### PR TITLE
RUMM-150 network speed

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
@@ -82,6 +82,15 @@ internal class LogSerializer(private val logConstraints: LogConstraints = Datado
             if (info.carrierId >= 0) {
                 jsonLog.addProperty(TAG_NETWORK_CARRIER_ID, info.carrierId)
             }
+            if (info.upKbps >= 0) {
+                jsonLog.addProperty(TAG_NETWORK_UP_KBPS, info.upKbps)
+            }
+            if (info.downKbps >= 0) {
+                jsonLog.addProperty(TAG_NETWORK_DOWN_KBPS, info.downKbps)
+            }
+            if (info.strength > Int.MIN_VALUE) {
+                jsonLog.addProperty(TAG_NETWORK_SIGNAL_STRENGTH, info.strength)
+            }
         }
     }
 
@@ -172,6 +181,9 @@ internal class LogSerializer(private val logConstraints: LogConstraints = Datado
         internal const val TAG_NETWORK_CONNECTIVITY = "network.client.connectivity"
         internal const val TAG_NETWORK_CARRIER_NAME = "network.client.sim_carrier.name"
         internal const val TAG_NETWORK_CARRIER_ID = "network.client.sim_carrier.id"
+        internal const val TAG_NETWORK_UP_KBPS = "network.client.uplink_kbps"
+        internal const val TAG_NETWORK_DOWN_KBPS = "network.client.downlink_kbps"
+        internal const val TAG_NETWORK_SIGNAL_STRENGTH = "network.client.signal_strength"
 
         // USER TAGS
         internal const val TAG_USER_ID = "usr.id"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/CallbackNetworkInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/CallbackNetworkInfoProvider.kt
@@ -27,17 +27,12 @@ internal class CallbackNetworkInfoProvider :
         super.onCapabilitiesChanged(network, networkCapabilities)
         sdkLogger.v("onCapabilitiesChanged $network $networkCapabilities")
 
-        val type = if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
-            NetworkInfo.Connectivity.NETWORK_WIFI
-        } else if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
-            NetworkInfo.Connectivity.NETWORK_ETHERNET
-        } else if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-            NetworkInfo.Connectivity.NETWORK_CELLULAR
-        } else {
-            NetworkInfo.Connectivity.NETWORK_OTHER
-        }
-
-        networkInfo = NetworkInfo(type)
+        networkInfo = NetworkInfo(
+            connectivity = getNetworkType(networkCapabilities),
+            upKbps = networkCapabilities.linkUpstreamBandwidthKbps,
+            downKbps = networkCapabilities.linkDownstreamBandwidthKbps,
+            strength = getStrength(networkCapabilities)
+        )
     }
 
     override fun onLost(network: Network) {
@@ -64,6 +59,30 @@ internal class CallbackNetworkInfoProvider :
 
     override fun getLatestNetworkInfo(): NetworkInfo {
         return networkInfo
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun getStrength(networkCapabilities: NetworkCapabilities): Int {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            networkCapabilities.signalStrength
+        } else {
+            Int.MIN_VALUE
+        }
+    }
+
+    private fun getNetworkType(networkCapabilities: NetworkCapabilities): NetworkInfo.Connectivity {
+        return if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
+            NetworkInfo.Connectivity.NETWORK_WIFI
+        } else if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_ETHERNET)) {
+            NetworkInfo.Connectivity.NETWORK_ETHERNET
+        } else if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+            NetworkInfo.Connectivity.NETWORK_CELLULAR
+        } else {
+            NetworkInfo.Connectivity.NETWORK_OTHER
+        }
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/NetworkInfo.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/NetworkInfo.kt
@@ -9,7 +9,10 @@ package com.datadog.android.log.internal.net
 internal data class NetworkInfo(
     val connectivity: Connectivity = Connectivity.NETWORK_NOT_CONNECTED,
     val carrierName: String? = null,
-    val carrierId: Int = -1
+    val carrierId: Int = -1,
+    val upKbps: Int = -1,
+    val downKbps: Int = -1,
+    val strength: Int = Int.MIN_VALUE
 ) {
 
     internal enum class Connectivity(val serialized: String) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/domain/LogSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/domain/LogSerializerTest.kt
@@ -161,6 +161,21 @@ internal class LogSerializerTest {
                 } else {
                     doesNotHaveField(LogSerializer.TAG_NETWORK_CARRIER_ID)
                 }
+                if (info.upKbps >= 0) {
+                    hasField(LogSerializer.TAG_NETWORK_UP_KBPS, info.upKbps)
+                } else {
+                    doesNotHaveField(LogSerializer.TAG_NETWORK_UP_KBPS)
+                }
+                if (info.downKbps >= 0) {
+                    hasField(LogSerializer.TAG_NETWORK_DOWN_KBPS, info.downKbps)
+                } else {
+                    doesNotHaveField(LogSerializer.TAG_NETWORK_DOWN_KBPS)
+                }
+                if (info.strength > Int.MIN_VALUE) {
+                    hasField(LogSerializer.TAG_NETWORK_SIGNAL_STRENGTH, info.strength)
+                } else {
+                    doesNotHaveField(LogSerializer.TAG_NETWORK_SIGNAL_STRENGTH)
+                }
             }
         } else {
             assertThat(jsonObject)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/NetworkInfoAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/NetworkInfoAssert.kt
@@ -40,6 +40,33 @@ internal class NetworkInfoAssert(actual: NetworkInfo) :
         return this
     }
 
+    fun hasUpSpeed(expected: Int): NetworkInfoAssert {
+        assertThat(actual.upKbps)
+            .overridingErrorMessage(
+                "Expected networkInfo to have upKbps $expected but was ${actual.upKbps}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasDownSpeed(expected: Int): NetworkInfoAssert {
+        assertThat(actual.downKbps)
+            .overridingErrorMessage(
+                "Expected networkInfo to have downKbps $expected but was ${actual.downKbps}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasStrength(expected: Int): NetworkInfoAssert {
+        assertThat(actual.strength)
+            .overridingErrorMessage(
+                "Expected networkInfo to have strength $expected but was ${actual.strength}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     companion object {
 
         internal fun assertThat(actual: NetworkInfo): NetworkInfoAssert =

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/forge/NetworkInfoForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/forge/NetworkInfoForgeryFactory.kt
@@ -14,13 +14,16 @@ internal class NetworkInfoForgeryFactory : ForgeryFactory<NetworkInfo> {
 
     override fun getForgery(forge: Forge): NetworkInfo {
         return NetworkInfo(
-            forge.aValueFrom(NetworkInfo.Connectivity::class.java),
-            forge.anElementFrom(
+            connectivity = forge.aValueFrom(NetworkInfo.Connectivity::class.java),
+            carrierName = forge.anElementFrom(
                 forge.anAlphabeticalString(),
                 forge.aWhitespaceString(),
                 null
             ),
-            if (forge.aBool()) forge.anInt(0, 10000) else -1
+            carrierId = if (forge.aBool()) forge.anInt(0, 10000) else -1,
+            upKbps = forge.anInt(0, Int.MAX_VALUE),
+            downKbps = forge.anInt(0, Int.MAX_VALUE),
+            strength = forge.anInt(-100, -30) // dBm for wifi signal
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

Include network speed and signal strength info into the `network.client` attributes

### Motivation

Get more information in logs

### Additional Notes

The new attributes are named: 

 - `network.client.uplink_kbps`: the peak upload speed (in kbps)
 - `network.client.downlink_kbps`: the peak download speed (in kbps)
 - `network.client.signal_strength`: the strength of the signal (in dBm, only available on Android 10 or more, and apparently only on Wifi networks)

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

