### PR TITLE
RUMM-167 Add slack notification on publish task

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,6 @@
+include:
+  - 'https://gitlab-templates.ddbuild.io/slack-notifier/v1/template.yml'
+
 variables:
   CURRENT_CI_IMAGE: "1"
   CI_IMAGE_DOCKER: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/dd-sdk-android:$CURRENT_CI_IMAGE
@@ -7,6 +10,7 @@ stages:
   - analysis
   - test
   - publish
+  - notify
 
 ci-image:
   stage: ci-image
@@ -40,7 +44,7 @@ analysis:licenses:
   stage: analysis
   script:
     - git fetch --depth=1 origin master
-    - ./gradlew :dd-sdk-android:checkThirdPartyLicences 
+    - ./gradlew :dd-sdk-android:checkThirdPartyLicences
 
 test:benchmark:
   tags: [ "runner:docker", "size:large" ]
@@ -77,4 +81,27 @@ publish:release-timber:
   stage: publish
   script:
     - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gradle-properties --with-decryption --query "Parameter.Value" --out text > ./gradle.properties
+    - git fetch --depth=1 origin master
     - ./gradlew :dd-sdk-android-timber:bintrayUpload
+
+notify:release:
+  extends: .slack-notifier-base
+  stage: notify
+  when: on_success
+  only:
+    - tags
+  script:
+    - BINTRAY_URL="https://bintray.com/datadog/datadog-maven/dd-sdk-android"
+    - 'MESSAGE_TEXT=":package: `$CI_PROJECT_NAME` $CI_COMMIT_TAG published on :bintray: ($BINTRAY_URL)."'
+    - postmessage "#mobile-rum" "$MESSAGE_TEXT"
+
+notify:failure:
+  extends: .slack-notifier-base
+  stage: notify
+  when: on_failure
+  only:
+    - tags
+  script:
+    - BUILD_URL="$CI_PROJECT_URL/pipelines/$CI_PIPELINE_ID"
+    - 'MESSAGE_TEXT=":status_alert: `$CI_PROJECT_NAME` $CI_COMMIT_TAG publish pipeline <$BUILD_URL|$COMMIT_MESSAGE> failed."'
+    - postmessage "#mobile-rum" "$MESSAGE_TEXT"


### PR DESCRIPTION
### What does this PR do?

Adds a slack step during CI builds to notify slack when the publication on Bintray succeeded or failed

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

