### PR TITLE
RUMM-170 Allow Datadog.initialize() to be called more than once

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -30,6 +30,7 @@ import com.datadog.android.log.internal.user.MutableUserInfoProvider
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.log.internal.utils.devLogger
+import java.lang.IllegalStateException
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit
 import okhttp3.ConnectionSpec
@@ -92,7 +93,13 @@ object Datadog {
         clientToken: String,
         endpointUrl: String? = null
     ) {
-        check(!initialized) { "Datadog has already been initialized." }
+        if (initialized) {
+            devLogger.w(
+                "The Datadog library has already been initialized.",
+                IllegalStateException("The Datadog library has already been initialized.")
+            )
+            return
+        }
 
         val appContext = context.applicationContext
         packageName = context.packageName

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -10,6 +10,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.net.ConnectivityManager
 import android.os.Build
+import android.util.Log
 import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.error.internal.DatadogExceptionHandler
 import com.datadog.android.log.EndpointUpdateStrategy
@@ -22,11 +23,14 @@ import com.datadog.android.log.internal.net.LogOkHttpUploader
 import com.datadog.android.log.internal.net.LogUploader
 import com.datadog.android.log.internal.system.BroadcastReceiverSystemInfoProvider
 import com.datadog.android.utils.mockContext
+import com.datadog.tools.unit.annotations.SystemOutStream
 import com.datadog.tools.unit.annotations.TestTargetApi
 import com.datadog.tools.unit.extensions.ApiLevelExtension
+import com.datadog.tools.unit.extensions.SystemOutputExtension
 import com.datadog.tools.unit.getFieldValue
 import com.datadog.tools.unit.getStaticValue
 import com.datadog.tools.unit.invokeMethod
+import com.datadog.tools.unit.lastLine
 import com.datadog.tools.unit.setStaticValue
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
@@ -41,6 +45,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.io.ByteArrayOutputStream
 import java.io.File
 import okhttp3.ConnectionSpec
 import okhttp3.OkHttpClient
@@ -61,7 +66,8 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class)
+    ExtendWith(ApiLevelExtension::class),
+    ExtendWith(SystemOutputExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
@@ -165,12 +171,23 @@ internal class DatadogTest {
     }
 
     @Test
-    fun `fails if initialize called twice`() {
+    fun `ignores if initialize called more than once`(
+        @SystemOutStream outputStream: ByteArrayOutputStream
+    ) {
         Datadog.initialize(mockContext, fakeToken)
+        Datadog.setVerbosity(Log.VERBOSE)
+        val strategy = Datadog.getLogStrategy()
+        val networkInfoProvider = Datadog.getNetworkInfoProvider()
+        val userInfoProvider = Datadog.getUserInfoProvider()
+        val timeProvider = Datadog.getTimeProvider()
 
-        assertThrows<IllegalStateException> {
-            Datadog.initialize(mockContext, fakeToken)
-        }
+        Datadog.initialize(mockContext, fakeToken)
+        assertThat(strategy).isSameAs(Datadog.getLogStrategy())
+        assertThat(networkInfoProvider).isSameAs(Datadog.getNetworkInfoProvider())
+        assertThat(userInfoProvider).isSameAs(Datadog.getUserInfoProvider())
+        assertThat(timeProvider).isSameAs(Datadog.getTimeProvider())
+        assertThat(outputStream.lastLine())
+            .isEqualTo("W/Datadog: The Datadog library has already been initialized.")
     }
 
     @Test


### PR DESCRIPTION

### What does this PR do?

When calling `Datadog.initialize` more than once, all calls after the first one are ignored, and a warning message will be printed to the Logcat to warn the dev.

### Motivation

Resolves #86

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

