### PR TITLE
RUMM-180 Make a generic DataUploader

### DIFF
--- a/dd-sdk-android/src/androidTest/kotlin/com/datadog/android/internal/utils/utils.kt
+++ b/dd-sdk-android/src/androidTest/kotlin/com/datadog/android/internal/utils/utils.kt
@@ -1,7 +1,7 @@
 package com.datadog.android.internal.utils
 
+import com.datadog.android.core.internal.net.info.NetworkInfo
 import com.datadog.android.log.internal.domain.Log
-import com.datadog.android.log.internal.net.NetworkInfo
 import com.datadog.android.log.internal.user.UserInfo
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryException

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -20,6 +20,7 @@ import com.datadog.android.core.internal.net.NetworkTimeInterceptor
 import com.datadog.android.core.internal.net.info.BroadcastReceiverNetworkInfoProvider
 import com.datadog.android.core.internal.net.info.CallbackNetworkInfoProvider
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
+import com.datadog.android.core.internal.system.BroadcastReceiverSystemInfoProvider
 import com.datadog.android.core.internal.time.DatadogTimeProvider
 import com.datadog.android.core.internal.time.MutableTimeProvider
 import com.datadog.android.core.internal.time.TimeProvider
@@ -27,7 +28,6 @@ import com.datadog.android.error.internal.DatadogExceptionHandler
 import com.datadog.android.log.EndpointUpdateStrategy
 import com.datadog.android.log.internal.domain.Log
 import com.datadog.android.log.internal.domain.LogFileStrategy
-import com.datadog.android.log.internal.system.BroadcastReceiverSystemInfoProvider
 import com.datadog.android.log.internal.user.DatadogUserInfoProvider
 import com.datadog.android.log.internal.user.MutableUserInfoProvider
 import com.datadog.android.log.internal.user.UserInfo

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -17,6 +17,9 @@ import com.datadog.android.core.internal.net.DataOkHttpUploader
 import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.GzipRequestInterceptor
 import com.datadog.android.core.internal.net.NetworkTimeInterceptor
+import com.datadog.android.core.internal.net.info.BroadcastReceiverNetworkInfoProvider
+import com.datadog.android.core.internal.net.info.CallbackNetworkInfoProvider
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.DatadogTimeProvider
 import com.datadog.android.core.internal.time.MutableTimeProvider
 import com.datadog.android.core.internal.time.TimeProvider
@@ -24,9 +27,6 @@ import com.datadog.android.error.internal.DatadogExceptionHandler
 import com.datadog.android.log.EndpointUpdateStrategy
 import com.datadog.android.log.internal.domain.Log
 import com.datadog.android.log.internal.domain.LogFileStrategy
-import com.datadog.android.log.internal.net.BroadcastReceiverNetworkInfoProvider
-import com.datadog.android.log.internal.net.CallbackNetworkInfoProvider
-import com.datadog.android.log.internal.net.NetworkInfoProvider
 import com.datadog.android.log.internal.system.BroadcastReceiverSystemInfoProvider
 import com.datadog.android.log.internal.user.DatadogUserInfoProvider
 import com.datadog.android.log.internal.user.MutableUserInfoProvider

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -24,6 +24,7 @@ import com.datadog.android.core.internal.system.BroadcastReceiverSystemInfoProvi
 import com.datadog.android.core.internal.time.DatadogTimeProvider
 import com.datadog.android.core.internal.time.MutableTimeProvider
 import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.error.internal.DatadogExceptionHandler
 import com.datadog.android.log.EndpointUpdateStrategy
 import com.datadog.android.log.internal.domain.Log
@@ -32,7 +33,6 @@ import com.datadog.android.log.internal.user.DatadogUserInfoProvider
 import com.datadog.android.log.internal.user.MutableUserInfoProvider
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.log.internal.user.UserInfoProvider
-import com.datadog.android.log.internal.utils.devLogger
 import java.lang.IllegalStateException
 import java.lang.ref.WeakReference
 import java.util.concurrent.TimeUnit

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileExtensions.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileExtensions.kt
@@ -1,6 +1,6 @@
 package com.datadog.android.core.internal.data.file
 
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 import java.io.File
 
 internal fun File.readBytes(withPrefix: Char, withSuffix: Char): ByteArray =

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileOrchestrator.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.core.internal.data.file
 
 import com.datadog.android.core.internal.data.Orchestrator
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 import java.io.File
 import java.io.FileFilter
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileReader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileReader.kt
@@ -9,7 +9,7 @@ package com.datadog.android.core.internal.data.file
 import com.datadog.android.core.internal.data.Orchestrator
 import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.domain.Batch
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.IOException

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriter.kt
@@ -9,8 +9,8 @@ package com.datadog.android.core.internal.data.file
 import com.datadog.android.core.internal.data.Orchestrator
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.domain.Serializer
-import com.datadog.android.log.internal.utils.devLogger
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.devLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 import java.io.File
 import java.io.FileNotFoundException
 import java.io.FileOutputStream

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadHandlerThread.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadHandlerThread.kt
@@ -10,7 +10,7 @@ import android.os.Handler
 import android.os.HandlerThread
 import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.net.DataUploader
-import com.datadog.android.log.internal.net.NetworkInfoProvider
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.log.internal.system.SystemInfoProvider
 
 internal class DataUploadHandlerThread(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadHandlerThread.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadHandlerThread.kt
@@ -11,7 +11,7 @@ import android.os.HandlerThread
 import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
-import com.datadog.android.log.internal.system.SystemInfoProvider
+import com.datadog.android.core.internal.system.SystemInfoProvider
 
 internal class DataUploadHandlerThread(
     threadName: String,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadHandlerThread.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadHandlerThread.kt
@@ -4,38 +4,36 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal
+package com.datadog.android.core.internal.data.upload
 
 import android.os.Handler
 import android.os.HandlerThread
 import com.datadog.android.core.internal.data.Reader
-import com.datadog.android.log.internal.net.LogUploader
+import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.log.internal.net.NetworkInfoProvider
 import com.datadog.android.log.internal.system.SystemInfoProvider
 
-internal class LogHandlerThread(
+internal class DataUploadHandlerThread(
+    threadName: String,
     private val reader: Reader,
-    private val logUploader: LogUploader,
+    private val dataUploader: DataUploader,
     private val networkInfoProvider: NetworkInfoProvider,
     private val systemInfoProvider: SystemInfoProvider
-) : HandlerThread(THREAD_NAME) {
+) : HandlerThread(threadName) {
 
     private lateinit var handler: Handler
 
     override fun onLooperPrepared() {
         super.onLooperPrepared()
         handler = Handler(looper)
-        val runnable = LogUploadRunnable(
-            handler,
-            reader,
-            logUploader,
-            networkInfoProvider,
-            systemInfoProvider
-        )
-        handler.postDelayed(runnable, LogUploadRunnable.DEFAULT_DELAY)
-    }
-
-    companion object {
-        private const val THREAD_NAME = "ddog"
+        val runnable =
+            DataUploadRunnable(
+                handler,
+                reader,
+                dataUploader,
+                networkInfoProvider,
+                systemInfoProvider
+            )
+        handler.postDelayed(runnable, DataUploadRunnable.DEFAULT_DELAY)
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
@@ -4,13 +4,13 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal
+package com.datadog.android.core.internal.data.upload
 
 import android.os.Handler
 import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.domain.Batch
-import com.datadog.android.log.internal.net.LogUploadStatus
-import com.datadog.android.log.internal.net.LogUploader
+import com.datadog.android.core.internal.net.DataUploader
+import com.datadog.android.core.internal.net.UploadStatus
 import com.datadog.android.log.internal.net.NetworkInfo
 import com.datadog.android.log.internal.net.NetworkInfoProvider
 import com.datadog.android.log.internal.system.SystemInfo
@@ -18,15 +18,16 @@ import com.datadog.android.log.internal.system.SystemInfoProvider
 import com.datadog.android.log.internal.utils.sdkLogger
 import kotlin.math.max
 
-internal class LogUploadRunnable(
+internal class DataUploadRunnable(
     private val handler: Handler,
     private val reader: Reader,
-    private val logUploader: LogUploader,
+    private val dataUploader: DataUploader,
     private val networkInfoProvider: NetworkInfoProvider,
     private val systemInfoProvider: SystemInfoProvider
 ) : UploadRunnable {
 
-    private var currentDelayInterval = DEFAULT_DELAY
+    private var currentDelayInterval =
+        DEFAULT_DELAY
 
     //  region Runnable
 
@@ -60,15 +61,18 @@ internal class LogUploadRunnable(
 
     private fun delayTheRunnable() {
         sdkLogger.i("$TAG: There was no batch to be sent")
-        currentDelayInterval = DEFAULT_DELAY
+        currentDelayInterval =
+            DEFAULT_DELAY
         handler.removeCallbacks(this)
-        handler.postDelayed(this, MAX_DELAY)
+        handler.postDelayed(this,
+            MAX_DELAY
+        )
     }
 
     private fun consumeBatch(batch: Batch) {
         val batchId = batch.id
         sdkLogger.i("$TAG: Sending batch $batchId")
-        val status = logUploader.upload(batch.data)
+        val status = dataUploader.upload(batch.data)
         if (status in dropableBatchStatus) {
             reader.dropBatch(batchId)
         } else {
@@ -87,10 +91,10 @@ internal class LogUploadRunnable(
     companion object {
 
         private val dropableBatchStatus = setOf(
-            LogUploadStatus.SUCCESS,
-            LogUploadStatus.HTTP_REDIRECTION,
-            LogUploadStatus.HTTP_CLIENT_ERROR,
-            LogUploadStatus.UNKNOWN_ERROR
+            UploadStatus.SUCCESS,
+            UploadStatus.HTTP_REDIRECTION,
+            UploadStatus.HTTP_CLIENT_ERROR,
+            UploadStatus.UNKNOWN_ERROR
         )
 
         private val batteryFullOrChargingStatus = setOf(
@@ -104,6 +108,6 @@ internal class LogUploadRunnable(
         const val MIN_DELAY_MS = 1000L // 1 second
         const val MAX_DELAY = DEFAULT_DELAY * 4 // 20 seconds
         const val DELAY_PERCENT = 90 // as 90 percent of
-        private const val TAG = "LogUploadRunnable"
+        private const val TAG = "DataUploadRunnable"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
@@ -15,7 +15,7 @@ import com.datadog.android.core.internal.net.info.NetworkInfo
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.system.SystemInfo
 import com.datadog.android.core.internal.system.SystemInfoProvider
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 import kotlin.math.max
 
 internal class DataUploadRunnable(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
@@ -13,8 +13,8 @@ import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.UploadStatus
 import com.datadog.android.core.internal.net.info.NetworkInfo
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
-import com.datadog.android.log.internal.system.SystemInfo
-import com.datadog.android.log.internal.system.SystemInfoProvider
+import com.datadog.android.core.internal.system.SystemInfo
+import com.datadog.android.core.internal.system.SystemInfoProvider
 import com.datadog.android.log.internal.utils.sdkLogger
 import kotlin.math.max
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
@@ -11,8 +11,8 @@ import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.domain.Batch
 import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.UploadStatus
-import com.datadog.android.log.internal.net.NetworkInfo
-import com.datadog.android.log.internal.net.NetworkInfoProvider
+import com.datadog.android.core.internal.net.info.NetworkInfo
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.log.internal.system.SystemInfo
 import com.datadog.android.log.internal.system.SystemInfoProvider
 import com.datadog.android.log.internal.utils.sdkLogger

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadRunnable.kt
@@ -1,0 +1,3 @@
+package com.datadog.android.core.internal.data.upload
+
+internal interface UploadRunnable : Runnable

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
@@ -13,7 +13,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.core.internal.domain.Batch
 import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.UploadStatus
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 
 internal class UploadWorker(
     appContext: Context,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
@@ -4,15 +4,15 @@
  * Copyright 2016-2020 Datadog, Inc.
  */
 
-package com.datadog.android.core.internal.data
+package com.datadog.android.core.internal.data.upload
 
 import android.content.Context
 import androidx.work.Worker
 import androidx.work.WorkerParameters
 import com.datadog.android.Datadog
 import com.datadog.android.core.internal.domain.Batch
-import com.datadog.android.log.internal.net.LogUploadStatus
-import com.datadog.android.log.internal.net.LogUploader
+import com.datadog.android.core.internal.net.DataUploader
+import com.datadog.android.core.internal.net.UploadStatus
 import com.datadog.android.log.internal.utils.sdkLogger
 
 internal class UploadWorker(
@@ -52,12 +52,12 @@ internal class UploadWorker(
 
     private fun consumeBatch(
         batch: Batch,
-        uploader: LogUploader
+        uploader: DataUploader
     ): Boolean {
         val batchId = batch.id
         sdkLogger.i("$TAG: Sending batch $batchId")
         val status = uploader.upload(batch.data)
-        return status == LogUploadStatus.SUCCESS
+        return status == UploadStatus.SUCCESS
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
@@ -1,9 +1,9 @@
 package com.datadog.android.core.internal.lifecycle
 
 import android.content.Context
+import com.datadog.android.core.internal.net.info.NetworkInfo
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.utils.triggerUploadWorker
-import com.datadog.android.log.internal.net.NetworkInfo
-import com.datadog.android.log.internal.net.NetworkInfoProvider
 import java.lang.ref.WeakReference
 
 internal class ProcessLifecycleCallback(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -8,7 +8,7 @@ package com.datadog.android.core.internal.net
 
 import android.os.Build
 import com.datadog.android.BuildConfig
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 import java.io.IOException
 import java.util.Locale
 import okhttp3.OkHttpClient

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataUploader.kt
@@ -4,13 +4,11 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.net
+package com.datadog.android.core.internal.net
 
-internal enum class LogUploadStatus {
-    SUCCESS,
-    NETWORK_ERROR,
-    HTTP_REDIRECTION,
-    HTTP_CLIENT_ERROR,
-    HTTP_SERVER_ERROR,
-    UNKNOWN_ERROR
+internal interface DataUploader {
+
+    fun setEndpoint(endpoint: String)
+
+    fun upload(data: ByteArray): UploadStatus
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/NetworkTimeInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/NetworkTimeInterceptor.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.core.internal.net
 
 import com.datadog.android.core.internal.time.MutableTimeProvider
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 import java.text.ParseException
 import java.text.SimpleDateFormat
 import java.util.Date

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/UploadStatus.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/UploadStatus.kt
@@ -4,11 +4,13 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.net
+package com.datadog.android.core.internal.net
 
-internal interface LogUploader {
-
-    fun setEndpoint(endpoint: String)
-
-    fun upload(data: ByteArray): LogUploadStatus
+internal enum class UploadStatus {
+    SUCCESS,
+    NETWORK_ERROR,
+    HTTP_REDIRECTION,
+    HTTP_CLIENT_ERROR,
+    HTTP_SERVER_ERROR,
+    UNKNOWN_ERROR
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
@@ -14,7 +14,7 @@ import android.net.ConnectivityManager
 import android.net.NetworkInfo as AndroidNetworkInfo
 import android.os.Build
 import android.telephony.TelephonyManager
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 
 @Suppress("DEPRECATION")
 internal class BroadcastReceiverNetworkInfoProvider :

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.net
+package com.datadog.android.core.internal.net.info
 
 import android.content.BroadcastReceiver
 import android.content.Context
@@ -18,9 +18,11 @@ import com.datadog.android.log.internal.utils.sdkLogger
 
 @Suppress("DEPRECATION")
 internal class BroadcastReceiverNetworkInfoProvider :
-    BroadcastReceiver(), NetworkInfoProvider {
+    BroadcastReceiver(),
+    NetworkInfoProvider {
 
-    private var networkInfo: NetworkInfo = NetworkInfo()
+    private var networkInfo: NetworkInfo =
+        NetworkInfo()
 
     // region BroadcastReceiver
 
@@ -60,15 +62,23 @@ internal class BroadcastReceiverNetworkInfoProvider :
         activeNetworkInfo: AndroidNetworkInfo?
     ): NetworkInfo {
         return if (activeNetworkInfo == null || !activeNetworkInfo.isConnected) {
-            NetworkInfo(NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED)
+            NetworkInfo(
+                NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
+            )
         } else if (activeNetworkInfo.type == ConnectivityManager.TYPE_WIFI) {
-            NetworkInfo(NetworkInfo.Connectivity.NETWORK_WIFI)
+            NetworkInfo(
+                NetworkInfo.Connectivity.NETWORK_WIFI
+            )
         } else if (activeNetworkInfo.type == ConnectivityManager.TYPE_ETHERNET) {
-            NetworkInfo(NetworkInfo.Connectivity.NETWORK_ETHERNET)
+            NetworkInfo(
+                NetworkInfo.Connectivity.NETWORK_ETHERNET
+            )
         } else if (activeNetworkInfo.type in knownMobileTypes) {
             buildMobileNetworkInfo(context, activeNetworkInfo.subtype)
         } else {
-            NetworkInfo(NetworkInfo.Connectivity.NETWORK_OTHER)
+            NetworkInfo(
+                NetworkInfo.Connectivity.NETWORK_OTHER
+            )
         }
     }
 
@@ -86,7 +96,11 @@ internal class BroadcastReceiverNetworkInfoProvider :
                 context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
             val carrierName = telephonyMgr?.simCarrierIdName ?: UNKNOWN_CARRIER_NAME
             val carrierId = telephonyMgr?.simCarrierId ?: -1
-            NetworkInfo(connectivity, carrierName.toString(), carrierId)
+            NetworkInfo(
+                connectivity,
+                carrierName.toString(),
+                carrierId
+            )
         } else {
             NetworkInfo(connectivity)
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
@@ -12,7 +12,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.os.Build
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 
 @TargetApi(Build.VERSION_CODES.N)
 internal class CallbackNetworkInfoProvider :

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.net
+package com.datadog.android.core.internal.net.info
 
 import android.annotation.TargetApi
 import android.content.Context
@@ -19,7 +19,8 @@ internal class CallbackNetworkInfoProvider :
     ConnectivityManager.NetworkCallback(),
     NetworkInfoProvider {
 
-    private var networkInfo: NetworkInfo = NetworkInfo()
+    private var networkInfo: NetworkInfo =
+        NetworkInfo()
 
     // region NetworkCallback
 
@@ -38,7 +39,10 @@ internal class CallbackNetworkInfoProvider :
     override fun onLost(network: Network) {
         super.onLost(network)
         sdkLogger.i("onLost $network")
-        networkInfo = NetworkInfo(NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED)
+        networkInfo =
+            NetworkInfo(
+                NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
+            )
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/NetworkInfo.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/NetworkInfo.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.net
+package com.datadog.android.core.internal.net.info
 
 internal data class NetworkInfo(
     val connectivity: Connectivity = Connectivity.NETWORK_NOT_CONNECTED,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/NetworkInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/NetworkInfoProvider.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.net
+package com.datadog.android.core.internal.net.info
 
 import android.content.Context
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
@@ -12,7 +12,7 @@ import android.content.Intent
 import android.content.IntentFilter
 import android.os.BatteryManager
 import android.os.PowerManager
-import com.datadog.android.log.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.sdkLogger
 
 internal class BroadcastReceiverSystemInfoProvider :
     BroadcastReceiver(), SystemInfoProvider {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.system
+package com.datadog.android.core.internal.system
 
 import android.content.BroadcastReceiver
 import android.content.Context

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/SystemInfo.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/SystemInfo.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.system
+package com.datadog.android.core.internal.system
 
 import android.os.BatteryManager
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/SystemInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/SystemInfoProvider.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.system
+package com.datadog.android.core.internal.system
 
 internal interface SystemInfoProvider {
     fun getLatestSystemInfo(): SystemInfo

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ByteArrayExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ByteArrayExt.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.utils
+package com.datadog.android.core.internal.utils
 
 /**
  * Splits this [ByteArray] to a list of [ByteArray] around occurrences of the specified [delimiter].

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/RuntimeUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/RuntimeUtils.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.log.internal.utils
+package com.datadog.android.core.internal.utils
 
 import com.datadog.android.BuildConfig
 import com.datadog.android.Datadog

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
@@ -6,7 +6,7 @@ import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
-import com.datadog.android.core.internal.data.UploadWorker
+import com.datadog.android.core.internal.data.upload.UploadWorker
 import com.datadog.android.log.internal.utils.sdkLogger
 import java.lang.IllegalStateException
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
@@ -7,7 +7,6 @@ import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.datadog.android.core.internal.data.upload.UploadWorker
-import com.datadog.android.log.internal.utils.sdkLogger
 import java.lang.IllegalStateException
 
 internal const val TAG = "WorkManagerUtils"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -9,11 +9,11 @@ package com.datadog.android.error.internal
 import android.content.Context
 import android.util.Log as AndroidLog
 import com.datadog.android.core.internal.data.Writer
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.triggerUploadWorker
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.domain.Log
-import com.datadog.android.log.internal.net.NetworkInfoProvider
 import com.datadog.android.log.internal.user.UserInfoProvider
 import java.lang.ref.WeakReference
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/DataStorageCallback.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/DataStorageCallback.kt
@@ -1,6 +1,0 @@
-package com.datadog.android.log.internal
-
-internal interface DataStorageCallback {
-
-    fun onDataAdded()
-}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/UploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/UploadRunnable.kt
@@ -1,3 +1,0 @@
-package com.datadog.android.log.internal
-
-internal interface UploadRunnable : Runnable

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/constraints/DatadogLogConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/constraints/DatadogLogConstraints.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.log.internal.constraints
 
-import com.datadog.android.log.internal.utils.devLogger
+import com.datadog.android.core.internal.utils.devLogger
 import java.util.Locale
 
 internal typealias StringTransform = (String) -> String?

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/Log.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/Log.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.log.internal.domain
 
-import com.datadog.android.log.internal.net.NetworkInfo
+import com.datadog.android.core.internal.net.info.NetworkInfo
 import com.datadog.android.log.internal.user.UserInfo
 
 /**

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -7,9 +7,9 @@
 package com.datadog.android.log.internal.logger
 
 import com.datadog.android.core.internal.data.Writer
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.log.internal.domain.Log
-import com.datadog.android.log.internal.net.NetworkInfoProvider
 import com.datadog.android.log.internal.user.UserInfoProvider
 
 internal class DatadogLogHandler(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -17,12 +17,12 @@ import com.datadog.android.core.internal.domain.PersistenceStrategy
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.net.DataOkHttpUploader
 import com.datadog.android.core.internal.net.DataUploader
+import com.datadog.android.core.internal.net.info.BroadcastReceiverNetworkInfoProvider
+import com.datadog.android.core.internal.net.info.CallbackNetworkInfoProvider
 import com.datadog.android.error.internal.DatadogExceptionHandler
 import com.datadog.android.log.EndpointUpdateStrategy
 import com.datadog.android.log.assertj.containsInstanceOf
 import com.datadog.android.log.internal.domain.Log
-import com.datadog.android.log.internal.net.BroadcastReceiverNetworkInfoProvider
-import com.datadog.android.log.internal.net.CallbackNetworkInfoProvider
 import com.datadog.android.log.internal.system.BroadcastReceiverSystemInfoProvider
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -15,14 +15,14 @@ import android.util.Log as AndroidLog
 import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.domain.PersistenceStrategy
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
+import com.datadog.android.core.internal.net.DataOkHttpUploader
+import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.error.internal.DatadogExceptionHandler
 import com.datadog.android.log.EndpointUpdateStrategy
 import com.datadog.android.log.assertj.containsInstanceOf
 import com.datadog.android.log.internal.domain.Log
 import com.datadog.android.log.internal.net.BroadcastReceiverNetworkInfoProvider
 import com.datadog.android.log.internal.net.CallbackNetworkInfoProvider
-import com.datadog.android.log.internal.net.LogOkHttpUploader
-import com.datadog.android.log.internal.net.LogUploader
 import com.datadog.android.log.internal.system.BroadcastReceiverSystemInfoProvider
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext
@@ -203,7 +203,7 @@ internal class DatadogTest {
     @Test
     fun `drop logs on setEndpointUrl with Discard strategy`(forge: Forge) {
         val mockReader: Reader = mock()
-        val mockUploader: LogUploader = mock()
+        val mockUploader: DataUploader = mock()
         whenever(mockLogStrategy.getReader()) doReturn mockReader
         val newEndpoint = forge.aStringMatching("https://[a-z]+\\.[a-z]{3}")
         Datadog.initialize(mockAppContext, fakeToken)
@@ -219,7 +219,7 @@ internal class DatadogTest {
     @Test
     fun `keep logs on setEndpointUrl with Update strategy`(forge: Forge) {
         val mockReader: Reader = mock()
-        val mockUploader: LogUploader = mock()
+        val mockUploader: DataUploader = mock()
         whenever(mockLogStrategy.getReader()) doReturn mockReader
         val newEndpoint = forge.aStringMatching("https://[a-z]+\\.[a-z]{3}")
         Datadog.initialize(mockAppContext, fakeToken)
@@ -238,7 +238,7 @@ internal class DatadogTest {
 
         Datadog.initialize(mockAppContext, fakeToken, endpoint)
 
-        val uploader: LogOkHttpUploader = Datadog.javaClass.getStaticValue("uploader")
+        val uploader: DataOkHttpUploader = Datadog.javaClass.getStaticValue("uploader")
         val okHttpClient: OkHttpClient = uploader.getFieldValue("client")
 
         assertThat(okHttpClient.protocols)
@@ -255,7 +255,7 @@ internal class DatadogTest {
 
         Datadog.initialize(mockAppContext, fakeToken, endpoint)
 
-        val uploader: LogOkHttpUploader = Datadog.javaClass.getStaticValue("uploader")
+        val uploader: DataOkHttpUploader = Datadog.javaClass.getStaticValue("uploader")
         val okHttpClient: OkHttpClient = uploader.getFieldValue("client")
 
         assertThat(okHttpClient.protocols)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -19,11 +19,11 @@ import com.datadog.android.core.internal.net.DataOkHttpUploader
 import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.info.BroadcastReceiverNetworkInfoProvider
 import com.datadog.android.core.internal.net.info.CallbackNetworkInfoProvider
+import com.datadog.android.core.internal.system.BroadcastReceiverSystemInfoProvider
 import com.datadog.android.error.internal.DatadogExceptionHandler
 import com.datadog.android.log.EndpointUpdateStrategy
 import com.datadog.android.log.assertj.containsInstanceOf
 import com.datadog.android.log.internal.domain.Log
-import com.datadog.android.log.internal.system.BroadcastReceiverSystemInfoProvider
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext
 import com.datadog.tools.unit.annotations.SystemOutStream

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -14,8 +14,8 @@ import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.UploadStatus
 import com.datadog.android.core.internal.net.info.NetworkInfo
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
-import com.datadog.android.log.internal.system.SystemInfo
-import com.datadog.android.log.internal.system.SystemInfoProvider
+import com.datadog.android.core.internal.system.SystemInfo
+import com.datadog.android.core.internal.system.SystemInfoProvider
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.annotations.SystemOutStream
 import com.datadog.tools.unit.extensions.SystemOutputExtension

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -12,8 +12,8 @@ import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.domain.Batch
 import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.UploadStatus
-import com.datadog.android.log.internal.net.NetworkInfo
-import com.datadog.android.log.internal.net.NetworkInfoProvider
+import com.datadog.android.core.internal.net.info.NetworkInfo
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.log.internal.system.SystemInfo
 import com.datadog.android.log.internal.system.SystemInfoProvider
 import com.datadog.android.utils.forge.Configurator
@@ -69,12 +69,13 @@ internal class DataUploadRunnableTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        val fakeNetworkInfo = NetworkInfo(
-            forge.aValueFrom(
-                enumClass = NetworkInfo.Connectivity::class.java,
-                exclude = listOf(NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED)
+        val fakeNetworkInfo =
+            NetworkInfo(
+                forge.aValueFrom(
+                    enumClass = NetworkInfo.Connectivity::class.java,
+                    exclude = listOf(NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED)
+                )
             )
-        )
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
         val fakeSystemInfo = SystemInfo(
             batteryStatus = forge.aValueFrom(SystemInfo.BatteryStatus::class.java),
@@ -94,7 +95,10 @@ internal class DataUploadRunnableTest {
 
     @Test
     fun `doesn't send batch when offline`(@Forgery batch: Batch) {
-        val networkInfo = NetworkInfo(NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED)
+        val networkInfo =
+            NetworkInfo(
+                NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
+            )
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn networkInfo
 
         testedRunnable.run()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -4,14 +4,14 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal
+package com.datadog.android.core.internal.data.upload
 
 import android.os.Handler
 import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.domain.Batch
-import com.datadog.android.log.internal.net.LogUploadStatus
-import com.datadog.android.log.internal.net.LogUploader
+import com.datadog.android.core.internal.net.DataUploader
+import com.datadog.android.core.internal.net.UploadStatus
 import com.datadog.android.log.internal.net.NetworkInfo
 import com.datadog.android.log.internal.net.NetworkInfoProvider
 import com.datadog.android.log.internal.system.SystemInfo
@@ -52,20 +52,20 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class LogUploadRunnableTest {
+internal class DataUploadRunnableTest {
 
     @Mock
     lateinit var mockHandler: Handler
     @Mock
     lateinit var mockReader: Reader
     @Mock
-    lateinit var mockLogUploader: LogUploader
+    lateinit var mockDataUploader: DataUploader
     @Mock
     lateinit var mockNetworkInfoProvider: NetworkInfoProvider
     @Mock
     lateinit var mockSystemInfoProvider: SystemInfoProvider
 
-    lateinit var testedRunnable: LogUploadRunnable
+    lateinit var testedRunnable: DataUploadRunnable
 
     @BeforeEach
     fun `set up`(forge: Forge) {
@@ -82,13 +82,14 @@ internal class LogUploadRunnableTest {
         )
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
 
-        testedRunnable = LogUploadRunnable(
-            mockHandler,
-            mockReader,
-            mockLogUploader,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider
-        )
+        testedRunnable =
+            DataUploadRunnable(
+                mockHandler,
+                mockReader,
+                mockDataUploader,
+                mockNetworkInfoProvider,
+                mockSystemInfoProvider
+            )
     }
 
     @Test
@@ -100,7 +101,7 @@ internal class LogUploadRunnableTest {
 
         verify(mockReader, never()).dropBatch(batch.id)
         verify(mockReader, never()).releaseBatch(batch.id)
-        verify(mockLogUploader, never()).upload(batch.data)
+        verify(mockDataUploader, never()).upload(batch.data)
         verify(mockHandler).postDelayed(same(testedRunnable), any())
     }
 
@@ -123,7 +124,7 @@ internal class LogUploadRunnableTest {
 
         verify(mockReader, never()).dropBatch(anyOrNull())
         verify(mockReader, never()).releaseBatch(batch.id)
-        verify(mockLogUploader, never()).upload(anyOrNull())
+        verify(mockDataUploader, never()).upload(anyOrNull())
         verify(mockHandler).postDelayed(same(testedRunnable), any())
     }
 
@@ -147,7 +148,7 @@ internal class LogUploadRunnableTest {
 
         verify(mockReader, never()).dropBatch(anyOrNull())
         verify(mockReader, never()).releaseBatch(batch.id)
-        verify(mockLogUploader, never()).upload(anyOrNull())
+        verify(mockDataUploader, never()).upload(anyOrNull())
         verify(mockHandler).postDelayed(same(testedRunnable), any())
     }
 
@@ -162,13 +163,13 @@ internal class LogUploadRunnableTest {
         )
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn systemInfo
         whenever(mockReader.readNextBatch()) doReturn batch
-        whenever(mockLogUploader.upload(batch.data)) doReturn LogUploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
 
         testedRunnable.run()
 
         verify(mockReader).dropBatch(batch.id)
         verify(mockReader, never()).releaseBatch(batch.id)
-        verify(mockLogUploader).upload(batch.data)
+        verify(mockDataUploader).upload(batch.data)
         verify(mockHandler).postDelayed(same(testedRunnable), any())
     }
 
@@ -180,38 +181,38 @@ internal class LogUploadRunnableTest {
 
         verify(mockReader, never()).dropBatch(anyOrNull())
         verify(mockReader, never()).releaseBatch(anyOrNull())
-        verifyZeroInteractions(mockLogUploader)
-        verify(mockHandler).postDelayed(testedRunnable, LogUploadRunnable.MAX_DELAY)
+        verifyZeroInteractions(mockDataUploader)
+        verify(mockHandler).postDelayed(testedRunnable, DataUploadRunnable.MAX_DELAY)
         if (BuildConfig.DEBUG) {
             assertThat(systemOutStream.toString().trim())
                 .withFailMessage("We were expecting an info log message here")
-                .matches("I/DD_LOG: LogUploadRunnable: .+")
+                .matches("I/DD_LOG: DataUploadRunnable: .+")
         }
     }
 
     @Test
     fun `batch sent successfully`(@Forgery batch: Batch) {
         whenever(mockReader.readNextBatch()) doReturn batch
-        whenever(mockLogUploader.upload(batch.data)) doReturn LogUploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
 
         testedRunnable.run()
 
         verify(mockReader).dropBatch(batch.id)
         verify(mockReader, never()).releaseBatch(batch.id)
-        verify(mockLogUploader).upload(batch.data)
+        verify(mockDataUploader).upload(batch.data)
         verify(mockHandler).postDelayed(same(testedRunnable), any())
     }
 
     @Test
     fun `batch kept on Network Error`(@Forgery batch: Batch) {
         whenever(mockReader.readNextBatch()) doReturn batch
-        whenever(mockLogUploader.upload(batch.data)) doReturn LogUploadStatus.NETWORK_ERROR
+        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.NETWORK_ERROR
 
         testedRunnable.run()
 
         verify(mockReader, never()).dropBatch(batch.id)
         verify(mockReader).releaseBatch(batch.id)
-        verify(mockLogUploader).upload(batch.data)
+        verify(mockDataUploader).upload(batch.data)
         verify(mockHandler).postDelayed(same(testedRunnable), any())
     }
 
@@ -221,12 +222,12 @@ internal class LogUploadRunnableTest {
         @IntForgery(min = 3, max = 42) runCount: Int
     ) {
         whenever(mockReader.readNextBatch()) doReturn batch
-        whenever(mockLogUploader.upload(batch.data)) doReturn LogUploadStatus.NETWORK_ERROR
+        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.NETWORK_ERROR
 
         for (i in 0 until runCount) {
             testedRunnable.run()
         }
-        verify(mockLogUploader, times(runCount)).upload(batch.data)
+        verify(mockDataUploader, times(runCount)).upload(batch.data)
         verify(mockReader, never()).dropBatch(batch.id)
         verify(mockReader, times(runCount)).releaseBatch(batch.id)
         verify(mockHandler, times(runCount)).postDelayed(same(testedRunnable), any())
@@ -235,39 +236,39 @@ internal class LogUploadRunnableTest {
     @Test
     fun `batch dropped on Redirection`(@Forgery batch: Batch) {
         whenever(mockReader.readNextBatch()) doReturn batch
-        whenever(mockLogUploader.upload(batch.data)) doReturn LogUploadStatus.HTTP_REDIRECTION
+        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.HTTP_REDIRECTION
 
         testedRunnable.run()
 
         verify(mockReader).dropBatch(batch.id)
         verify(mockReader, never()).releaseBatch(batch.id)
-        verify(mockLogUploader).upload(batch.data)
+        verify(mockDataUploader).upload(batch.data)
         verify(mockHandler).postDelayed(same(testedRunnable), any())
     }
 
     @Test
     fun `batch dropped on Client Error`(@Forgery batch: Batch) {
         whenever(mockReader.readNextBatch()) doReturn batch
-        whenever(mockLogUploader.upload(batch.data)) doReturn LogUploadStatus.HTTP_CLIENT_ERROR
+        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.HTTP_CLIENT_ERROR
 
         testedRunnable.run()
 
         verify(mockReader).dropBatch(batch.id)
         verify(mockReader, never()).releaseBatch(batch.id)
-        verify(mockLogUploader).upload(batch.data)
+        verify(mockDataUploader).upload(batch.data)
         verify(mockHandler).postDelayed(same(testedRunnable), any())
     }
 
     @Test
     fun `batch kept on Server Error`(@Forgery batch: Batch) {
         whenever(mockReader.readNextBatch()) doReturn batch
-        whenever(mockLogUploader.upload(batch.data)) doReturn LogUploadStatus.HTTP_SERVER_ERROR
+        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.HTTP_SERVER_ERROR
 
         testedRunnable.run()
 
         verify(mockReader, never()).dropBatch(batch.id)
         verify(mockReader).releaseBatch(batch.id)
-        verify(mockLogUploader).upload(batch.data)
+        verify(mockDataUploader).upload(batch.data)
         verify(mockHandler).postDelayed(same(testedRunnable), any())
     }
 
@@ -277,13 +278,13 @@ internal class LogUploadRunnableTest {
         @IntForgery(min = 3, max = 42) runCount: Int
     ) {
         whenever(mockReader.readNextBatch()) doReturn batch
-        whenever(mockLogUploader.upload(batch.data)) doReturn LogUploadStatus.HTTP_SERVER_ERROR
+        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.HTTP_SERVER_ERROR
 
         for (i in 0 until runCount) {
             testedRunnable.run()
         }
 
-        verify(mockLogUploader, times(runCount)).upload(batch.data)
+        verify(mockDataUploader, times(runCount)).upload(batch.data)
         verify(mockReader, never()).dropBatch(batch.id)
         verify(mockReader, times(runCount)).releaseBatch(batch.id)
         verify(mockHandler, times(runCount)).postDelayed(same(testedRunnable), any())
@@ -292,13 +293,13 @@ internal class LogUploadRunnableTest {
     @Test
     fun `batch dropped on Unknown error`(@Forgery batch: Batch) {
         whenever(mockReader.readNextBatch()) doReturn batch
-        whenever(mockLogUploader.upload(batch.data)) doReturn LogUploadStatus.UNKNOWN_ERROR
+        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.UNKNOWN_ERROR
 
         testedRunnable.run()
 
         verify(mockReader).dropBatch(batch.id)
         verify(mockReader, never()).releaseBatch(batch.id)
-        verify(mockLogUploader).upload(batch.data)
+        verify(mockDataUploader).upload(batch.data)
         verify(mockHandler).postDelayed(same(testedRunnable), any())
     }
 
@@ -331,8 +332,8 @@ internal class LogUploadRunnableTest {
         verify(mockHandler, times(30))
             .postDelayed(same(testedRunnable), captor.capture())
         captor.allValues.reduce { previous, next ->
-            assertThat(next).isGreaterThanOrEqualTo(LogUploadRunnable.MIN_DELAY_MS)
-            assertThat(next).isLessThan(LogUploadRunnable.DEFAULT_DELAY)
+            assertThat(next).isGreaterThanOrEqualTo(DataUploadRunnable.MIN_DELAY_MS)
+            assertThat(next).isLessThan(DataUploadRunnable.DEFAULT_DELAY)
             next
         }
     }
@@ -353,6 +354,6 @@ internal class LogUploadRunnableTest {
         verify(mockHandler, times(2))
             .postDelayed(same(testedRunnable), captor.capture())
         verify(mockHandler).removeCallbacks(same(testedRunnable))
-        assertThat(captor.lastValue).isEqualTo(LogUploadRunnable.MAX_DELAY)
+        assertThat(captor.lastValue).isEqualTo(DataUploadRunnable.MAX_DELAY)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
@@ -4,9 +4,9 @@ import android.content.Context
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.impl.WorkManagerImpl
+import com.datadog.android.core.internal.net.info.NetworkInfo
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.utils.UPLOAD_WORKER_TAG
-import com.datadog.android.log.internal.net.NetworkInfo
-import com.datadog.android.log.internal.net.NetworkInfoProvider
 import com.datadog.android.utils.mockContext
 import com.datadog.tools.unit.setFieldValue
 import com.datadog.tools.unit.setStaticValue
@@ -58,7 +58,11 @@ internal class ProcessLifecycleCallbackTest {
         // given
         WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo())
-            .thenReturn(NetworkInfo(NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED))
+            .thenReturn(
+                NetworkInfo(
+                    NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
+                )
+            )
 
         // when
         underTest.onStopped()
@@ -76,7 +80,11 @@ internal class ProcessLifecycleCallbackTest {
     fun `when process stopped and work manager is not present will not throw exception`() {
         // given
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo())
-            .thenReturn(NetworkInfo(NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED))
+            .thenReturn(
+                NetworkInfo(
+                    NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
+                )
+            )
 
         // when
         underTest.onStopped()
@@ -87,7 +95,11 @@ internal class ProcessLifecycleCallbackTest {
         // given
         WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo())
-            .thenReturn(NetworkInfo(NetworkInfo.Connectivity.NETWORK_WIFI))
+            .thenReturn(
+                NetworkInfo(
+                    NetworkInfo.Connectivity.NETWORK_WIFI
+                )
+            )
 
         // when
         underTest.onStopped()
@@ -101,7 +113,11 @@ internal class ProcessLifecycleCallbackTest {
         underTest.setFieldValue("contextWeakRef", WeakReference<Context>(null))
         WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo())
-            .thenReturn(NetworkInfo(NetworkInfo.Connectivity.NETWORK_WIFI))
+            .thenReturn(
+                NetworkInfo(
+                    NetworkInfo.Connectivity.NETWORK_WIFI
+                )
+            )
 
         // when
         underTest.onStopped()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProviderTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.net
+package com.datadog.android.core.internal.net.info
 
 // import org.assertj.core.api.Assertions.assertThat
 import android.content.Context
@@ -61,7 +61,8 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
         whenever(mockContext.getSystemService(Context.TELEPHONY_SERVICE))
             .doReturn(mockTelephonyManager)
 
-        testedProvider = BroadcastReceiverNetworkInfoProvider()
+        testedProvider =
+            BroadcastReceiverNetworkInfoProvider()
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProviderTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.net
+package com.datadog.android.core.internal.net.info
 
 import android.content.Context
 import android.net.ConnectivityManager
@@ -52,7 +52,8 @@ internal class CallbackNetworkInfoProviderTest {
     fun `set up`() {
         whenever(mockCapabilities.hasTransport(any())) doReturn false
 
-        testedProvider = CallbackNetworkInfoProvider()
+        testedProvider =
+            CallbackNetworkInfoProvider()
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProviderTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.system
+package com.datadog.android.core.internal.system
 
 import android.content.Context
 import android.content.Intent

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/ByteArrayExtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/ByteArrayExtTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.utils
+package com.datadog.android.core.internal.utils
 
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeExtension

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/RuntimeUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/RuntimeUtilsTest.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.log.internal.utils
+package com.datadog.android.core.internal.utils
 
 import android.util.Log
 import com.datadog.android.BuildConfig

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -6,7 +6,7 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.impl.WorkManagerImpl
 import com.datadog.android.BuildConfig
 import com.datadog.android.Datadog
-import com.datadog.android.core.internal.data.UploadWorker
+import com.datadog.android.core.internal.data.upload.UploadWorker
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext
 import com.datadog.tools.unit.annotations.SystemOutStream

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -13,12 +13,12 @@ import androidx.work.OneTimeWorkRequest
 import androidx.work.impl.WorkManagerImpl
 import com.datadog.android.Datadog
 import com.datadog.android.core.internal.data.Writer
+import com.datadog.android.core.internal.net.info.NetworkInfo
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.UPLOAD_WORKER_TAG
 import com.datadog.android.log.assertj.LogAssert.Companion.assertThat
 import com.datadog.android.log.internal.domain.Log
-import com.datadog.android.log.internal.net.NetworkInfo
-import com.datadog.android.log.internal.net.NetworkInfoProvider
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.utils.forge.Configurator

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -8,12 +8,12 @@ package com.datadog.android.log
 
 import android.content.Context
 import com.datadog.android.Datadog
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.log.internal.logger.CombinedLogHandler
 import com.datadog.android.log.internal.logger.DatadogLogHandler
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.log.internal.logger.LogcatLogHandler
 import com.datadog.android.log.internal.logger.NoOpLogHandler
-import com.datadog.android.log.internal.net.NetworkInfoProvider
 import com.datadog.android.utils.mockContext
 import com.datadog.tools.unit.getFieldValue
 import com.datadog.tools.unit.invokeMethod

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/LogAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/LogAssert.kt
@@ -6,8 +6,8 @@
 
 package com.datadog.android.log.assertj
 
+import com.datadog.android.core.internal.net.info.NetworkInfo
 import com.datadog.android.log.internal.domain.Log
-import com.datadog.android.log.internal.net.NetworkInfo
 import com.datadog.android.log.internal.user.UserInfo
 import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/NetworkInfoAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/NetworkInfoAssert.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.log.assertj
 
-import com.datadog.android.log.internal.net.NetworkInfo
+import com.datadog.android.core.internal.net.info.NetworkInfo
 import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/SystemInfoAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/SystemInfoAssert.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.log.assertj
 
-import com.datadog.android.log.internal.system.SystemInfo
+import com.datadog.android.core.internal.system.SystemInfo
 import kotlin.math.max
 import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/file/LogFileStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/file/LogFileStrategyTest.kt
@@ -10,13 +10,13 @@ import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.data.file.DeferredWriter
 import com.datadog.android.core.internal.domain.PersistenceStrategy
+import com.datadog.android.core.internal.net.info.NetworkInfo
 import com.datadog.android.core.internal.threading.LazyHandlerThread
 import com.datadog.android.domain.FilePersistenceStrategyTest
 import com.datadog.android.log.assertj.JsonObjectAssert
 import com.datadog.android.log.internal.domain.Log
 import com.datadog.android.log.internal.domain.LogFileStrategy
 import com.datadog.android.log.internal.domain.LogSerializer
-import com.datadog.android.log.internal.net.NetworkInfo
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.invokeMethod

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -7,11 +7,11 @@
 package com.datadog.android.log.internal.logger
 
 import com.datadog.android.core.internal.data.Writer
+import com.datadog.android.core.internal.net.info.NetworkInfo
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.log.assertj.LogAssert.Companion.assertThat
 import com.datadog.android.log.internal.domain.Log
-import com.datadog.android.log.internal.net.NetworkInfo
-import com.datadog.android.log.internal.net.NetworkInfoProvider
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.utils.forge.Configurator

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/NetworkInfoForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/NetworkInfoForgeryFactory.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.utils.forge
 
-import com.datadog.android.log.internal.net.NetworkInfo
+import com.datadog.android.core.internal.net.info.NetworkInfo
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to have a generic **DataUploader** and a generic **DataUploadHandlerThread** to be reused by all the new SDK features (e.g. tracing, logs, etc). All the previous Log related classes were cleaned, renamed, restructured and moved in the **core** package.
All the dependencies in those classes were also moved in the **core** package.
### Motivation

SDK Scalability.

### Additional Notes

Do not be scared about all the changes, most of them are package renaming and relocation. I've split the PR by relevant commits in order to be easy to review it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

