### PR TITLE
RUMM-185 downgrade ok http

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,8 @@ tasks.register("checkAll") {
         "ktlintCheckAll",
         "detektAll",
         "unitTestAll",
-        "jacocoReportAll"
+        "jacocoReportAll",
+        "instrumentTestAll"
     )
 }
 
@@ -109,6 +110,12 @@ tasks.register("jacocoReportAll") {
         ":tools:unit:jacocoTestDebugUnitTestReport",
         ":tools:unit:jacocoTestReleaseUnitTestReport"
     )
+}
+
+tasks.register("instrumentTestAll") {
+    dependsOn(":instrumented:integration:connectedCheck")
+    dependsOn(":instrumented:benchmark:connectedCheck")
+    dependsOn(":dd-sdk-android:connectedCheck")
 }
 
 tasks.register("buildIntegrationTestsArtifacts") {

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -13,7 +13,7 @@ object Dependencies {
         const val Kotlin = "1.3.61"
         const val AndroidToolsPlugin = "3.5.3"
         const val Gson = "2.8.6"
-        const val OkHttp = "4.2.2"
+        const val OkHttp = "3.12.6"
         const val JetpackWorkManager = "2.2.0"
 
         // JUnit

--- a/dd-sdk-android/build.gradle.kts
+++ b/dd-sdk-android/build.gradle.kts
@@ -96,6 +96,12 @@ android {
             )
         }
     }
+
+    packagingOptions {
+        exclude("META-INF/jvm.kotlin_module")
+        exclude("META-INF/LICENSE.md")
+        exclude("META-INF/LICENSE-notice.md")
+    }
 }
 
 dependencies {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -13,7 +13,7 @@ import java.io.IOException
 import java.util.Locale
 import okhttp3.OkHttpClient
 import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.RequestBody
 
 internal class DataOkHttpUploader(
     endpoint: String,
@@ -46,11 +46,11 @@ internal class DataOkHttpUploader(
             val request = buildRequest(data)
             val response = client.newCall(request).execute()
             sdkLogger.i(
-                    "$TAG: Response code:${response.code} " +
-                            "body:${response.body?.string()} " +
-                            "headers:${response.headers}"
+                    "$TAG: Response code:${response.code()} " +
+                            "body:${response.body()?.string()} " +
+                            "headers:${response.headers()}"
             )
-            responseCodeToUploadStatus(response.code)
+            responseCodeToUploadStatus(response.code())
         } catch (e: IOException) {
             sdkLogger.e("$TAG: unable to upload data", e)
             UploadStatus.NETWORK_ERROR
@@ -71,7 +71,7 @@ internal class DataOkHttpUploader(
         sdkLogger.d("$TAG: Sending data to $url")
         return Request.Builder()
             .url(url)
-            .post(data.toRequestBody())
+            .post(RequestBody.create(null, data))
             .addHeader(HEADER_UA, userAgent)
             .addHeader(
                 HEADER_CT,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -241,11 +241,11 @@ internal class DatadogTest {
         val uploader: DataOkHttpUploader = Datadog.javaClass.getStaticValue("uploader")
         val okHttpClient: OkHttpClient = uploader.getFieldValue("client")
 
-        assertThat(okHttpClient.protocols)
+        assertThat(okHttpClient.protocols())
             .containsExactly(Protocol.HTTP_2, Protocol.HTTP_1_1)
-        assertThat(okHttpClient.callTimeoutMillis)
+        assertThat(okHttpClient.callTimeoutMillis())
             .isEqualTo(Datadog.NETWORK_TIMEOUT_MS.toInt())
-        assertThat(okHttpClient.connectionSpecs)
+        assertThat(okHttpClient.connectionSpecs())
             .containsExactly(ConnectionSpec.RESTRICTED_TLS)
     }
 
@@ -258,11 +258,11 @@ internal class DatadogTest {
         val uploader: DataOkHttpUploader = Datadog.javaClass.getStaticValue("uploader")
         val okHttpClient: OkHttpClient = uploader.getFieldValue("client")
 
-        assertThat(okHttpClient.protocols)
+        assertThat(okHttpClient.protocols())
             .containsExactly(Protocol.HTTP_2, Protocol.HTTP_1_1)
-        assertThat(okHttpClient.callTimeoutMillis)
+        assertThat(okHttpClient.callTimeoutMillis())
             .isEqualTo(Datadog.NETWORK_TIMEOUT_MS.toInt())
-        assertThat(okHttpClient.connectionSpecs)
+        assertThat(okHttpClient.connectionSpecs())
             .containsExactly(ConnectionSpec.CLEARTEXT)
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/GzipRequestInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/GzipRequestInterceptorTest.kt
@@ -19,7 +19,7 @@ import java.io.ByteArrayOutputStream
 import okhttp3.Interceptor
 import okhttp3.Protocol
 import okhttp3.Request
-import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.RequestBody
 import okhttp3.Response
 import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
@@ -54,7 +54,7 @@ internal class GzipRequestInterceptorTest {
         fakeBody = forge.anAlphabeticalString()
         fakeRequest = Request.Builder()
             .url(fakeUrl)
-            .post(fakeBody.toByteArray().toRequestBody())
+            .post(RequestBody.create(null, fakeBody.toByteArray()))
             .build()
         testedInterceptor = GzipRequestInterceptor()
     }
@@ -69,7 +69,7 @@ internal class GzipRequestInterceptorTest {
             verify(mockChain).proceed(capture())
             val buffer = Buffer()
             val stream = ByteArrayOutputStream()
-            lastValue.body!!.writeTo(buffer)
+            lastValue.body()!!.writeTo(buffer)
             buffer.copyTo(stream)
 
             assertThat(stream.toString())
@@ -95,7 +95,7 @@ internal class GzipRequestInterceptorTest {
             verify(mockChain).proceed(capture())
             val buffer = Buffer()
             val stream = ByteArrayOutputStream()
-            lastValue.body!!.writeTo(buffer)
+            lastValue.body()!!.writeTo(buffer)
             buffer.copyTo(stream)
 
             assertThat(stream.toString())
@@ -118,7 +118,7 @@ internal class GzipRequestInterceptorTest {
 
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.body)
+            assertThat(lastValue.body())
                 .isNull()
             assertThat(lastValue.header("Content-Encoding"))
                 .isNull()

--- a/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/log/LogApiBenchmark.kt
+++ b/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/log/LogApiBenchmark.kt
@@ -45,11 +45,11 @@ class LogApiBenchmark {
             .apply {
                 start()
             }
-        mockWebServer.dispatcher = object : Dispatcher() {
+        mockWebServer.setDispatcher(object : Dispatcher() {
             override fun dispatch(request: RecordedRequest): MockResponse {
                 return mockResponse(200)
             }
-        }
+        })
         val fakeEndpoint = mockWebServer.url("/").toString().removeSuffix("/")
 
         val context = InstrumentationRegistry.getInstrumentation().context

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integrationtests/utils/AbstractProfilingRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integrationtests/utils/AbstractProfilingRule.kt
@@ -35,7 +35,12 @@ internal abstract class AbstractProfilingRule<T> : TestRule {
     abstract fun measureAfterAction(): T
     abstract fun compareWithThreshold(before: T, after: T, threshold: T)
 
-    fun profile(warmupAction: () -> Unit = noOpWarmUpFunction, action: () -> Unit, threshold: T) {
+    fun profile(
+        warmupAction: () -> Unit = noOpWarmUpFunction,
+        action: () -> Unit,
+        threshold: T,
+        repeatCount: Int = 64
+    ) {
         doBeforeWarmUp()
         warmupAction()
         doAfterWarmUp()


### PR DESCRIPTION
### What does this PR do?

Downgrade the OkHttp dependency from 4.* to 3.12

### Motivation

For customers writing apps with Kotlin+OkHttp3, our dependency breaks their Kotlin sources.
Mostly OkHttp4 is OkHttp3 with Kotlin sugar syntax.
Using OkHttp3 in our library is binary compatible with customers writing in either Kotlin or Java and using either OkHttp3 or OkHttp4.

We do miss on several fixes from later versions, but none that actually impact our limited use of OkHttp.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

