### PR TITLE
RUMM-187 Implement the Traces Uploader

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -4,8 +4,7 @@ object com.datadog.android.Datadog
   const val DATADOG_US_TRACES: String
   const val DATADOG_EU_TRACES: String
   fun initialize(android.content.Context, String, String? = null, String? = null)
-  fun setLogsEndpointUrl(String, com.datadog.android.log.EndpointUpdateStrategy)
-  fun setTracesEndpointUrl(String, com.datadog.android.log.EndpointUpdateStrategy)
+  fun setEndpointUrl(String, com.datadog.android.log.EndpointUpdateStrategy)
   fun setVerbosity(Int)
   fun setUserInfo(String? = null, String? = null, String? = null)
 enum com.datadog.android.log.EndpointUpdateStrategy

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1,13 +1,16 @@
 object com.datadog.android.Datadog
   const val DATADOG_US_LOGS: String
   const val DATADOG_EU_LOGS: String
-  fun initialize(android.content.Context, String, String? = null)
-  fun setEndpointUrl(String, com.datadog.android.log.EndpointUpdateStrategy)
+  const val DATADOG_US_TRACES: String
+  const val DATADOG_EU_TRACES: String
+  fun initialize(android.content.Context, String, String? = null, String? = null)
+  fun setLogsEndpointUrl(String, com.datadog.android.log.EndpointUpdateStrategy)
+  fun setTracesEndpointUrl(String, com.datadog.android.log.EndpointUpdateStrategy)
   fun setVerbosity(Int)
   fun setUserInfo(String? = null, String? = null, String? = null)
 enum com.datadog.android.log.EndpointUpdateStrategy
-  - DISCARD_OLD_LOGS
-  - SEND_OLD_LOGS_TO_NEW_ENDPOINT
+  - DISCARD_OLD_DATA
+  - SEND_OLD_DATA_TO_NEW_ENDPOINT
 class com.datadog.android.log.Logger
   fun v(String, Throwable? = null, Map<String, Any?> = emptyMap())
   fun d(String, Throwable? = null, Map<String, Any?> = emptyMap())

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1,6 +1,6 @@
 object com.datadog.android.Datadog
-  const val DATADOG_US: String
-  const val DATADOG_EU: String
+  const val DATADOG_US_LOGS: String
+  const val DATADOG_EU_LOGS: String
   fun initialize(android.content.Context, String, String? = null)
   fun setEndpointUrl(String, com.datadog.android.log.EndpointUpdateStrategy)
   fun setVerbosity(Int)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -13,7 +13,6 @@ import com.datadog.android.core.internal.data.upload.DataUploadHandlerThread
 import com.datadog.android.core.internal.domain.PersistenceStrategy
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleCallback
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
-import com.datadog.android.core.internal.net.DataOkHttpUploader
 import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.GzipRequestInterceptor
 import com.datadog.android.core.internal.net.NetworkTimeInterceptor
@@ -29,6 +28,7 @@ import com.datadog.android.error.internal.DatadogExceptionHandler
 import com.datadog.android.log.EndpointUpdateStrategy
 import com.datadog.android.log.internal.domain.Log
 import com.datadog.android.log.internal.domain.LogFileStrategy
+import com.datadog.android.log.internal.net.LogsOkHttpUploader
 import com.datadog.android.log.internal.user.DatadogUserInfoProvider
 import com.datadog.android.log.internal.user.MutableUserInfoProvider
 import com.datadog.android.log.internal.user.UserInfo
@@ -76,17 +76,18 @@ object Datadog {
     private lateinit var systemInfoProvider: BroadcastReceiverSystemInfoProvider
     private lateinit var handlerThread: DataUploadHandlerThread
     private lateinit var contextRef: WeakReference<Context>
-    private lateinit var uploader: DataUploader
+    private lateinit var logsUploader: LogsOkHttpUploader
     private lateinit var timeProvider: MutableTimeProvider
     private lateinit var userInfoProvider: MutableUserInfoProvider
     private lateinit var tracingStrategy: PersistenceStrategy<DDSpan>
-
     internal var packageName: String = ""
         private set
+
     internal var packageVersion: String = ""
         private set
     internal var libraryVerbosity = Int.MAX_VALUE
         private set
+    private var okHttpClient: OkHttpClient? = null
 
     /**
      * Initializes the Datadog SDK.
@@ -172,7 +173,7 @@ object Datadog {
                 )
             }
         }
-        uploader.setEndpoint(endpointUrl)
+        logsUploader.setEndpoint(endpointUrl)
     }
 
     // Stop all Datadog work (for test purposes).
@@ -182,6 +183,7 @@ object Datadog {
         handlerThread.quitSafely()
         contextRef.get()?.let { networkInfoProvider.unregister(it) }
         contextRef.clear()
+        okHttpClient = null
         initialized = false
     }
 
@@ -225,7 +227,7 @@ object Datadog {
 
     internal fun getLogUploader(): DataUploader {
         checkInitialized()
-        return uploader
+        return logsUploader
     }
 
     internal fun getNetworkInfoProvider(): NetworkInfoProvider {
@@ -268,12 +270,15 @@ object Datadog {
     }
 
     private fun buildOkHttpClient(endpoint: String): OkHttpClient {
+        var currentOkHttpClient = okHttpClient
+        if (currentOkHttpClient != null) return currentOkHttpClient
+
         val connectionSpec = when {
             endpoint.startsWith("http://") -> ConnectionSpec.CLEARTEXT
             Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP -> ConnectionSpec.RESTRICTED_TLS
             else -> ConnectionSpec.MODERN_TLS
         }
-        return OkHttpClient.Builder()
+        currentOkHttpClient = OkHttpClient.Builder()
             .addInterceptor(NetworkTimeInterceptor(timeProvider))
             .addInterceptor(GzipRequestInterceptor())
             .callTimeout(NETWORK_TIMEOUT_MS, TimeUnit.MILLISECONDS)
@@ -281,6 +286,9 @@ object Datadog {
             .protocols(listOf(Protocol.HTTP_2, Protocol.HTTP_1_1))
             .connectionSpecs(listOf(connectionSpec))
             .build()
+
+        okHttpClient = currentOkHttpClient
+        return currentOkHttpClient
     }
 
     private fun setupTheExceptionHandler(appContext: Context?) {
@@ -305,7 +313,7 @@ object Datadog {
         val endpoint = endpointUrl ?: DATADOG_US
         val okHttpClient = buildOkHttpClient(endpoint)
 
-        uploader = DataOkHttpUploader(
+        logsUploader = LogsOkHttpUploader(
             endpoint,
             clientToken,
             okHttpClient
@@ -314,7 +322,7 @@ object Datadog {
             DataUploadHandlerThread(
                 LOG_UPLOAD_THREAD_NAME,
                 logStrategy.getReader(),
-                uploader,
+                logsUploader,
                 networkInfoProvider,
                 systemInfoProvider
             )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -49,20 +49,20 @@ import okhttp3.Protocol
 object Datadog {
 
     /**
-     * The endpoint for our US based servers, used by default by the SDK.
+     * The endpoint for our Logs US based servers, used by default by the SDK.
      * @see [initialize]
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    const val DATADOG_US: String = "https://mobile-http-intake.logs.datadoghq.com"
+    const val DATADOG_US_LOGS: String = "https://mobile-http-intake.logs.datadoghq.com"
 
     /**
-     * The endpoint for our Europe based servers.
+     * The endpoint for our Europe Logs based servers.
      * Use this in your call to [initialize] if you log on
      * [app.datadoghq.eu](https://app.datadoghq.eu/) instead of
      * [app.datadoghq.com](https://app.datadoghq.com/)
      */
     @Suppress("MemberVisibilityCanBePrivate")
-    const val DATADOG_EU: String = "https://mobile-http-intake.logs.datadoghq.eu"
+    const val DATADOG_EU_LOGS: String = "https://mobile-http-intake.logs.datadoghq.eu"
 
     private const val TAG = "Datadog"
 
@@ -94,7 +94,7 @@ object Datadog {
      * @param context your application context
      * @param clientToken your API key of type Client Token
      * @param endpointUrl (optional) the endpoint url to target, or null to use the default. Possible values are
-     * [DATADOG_US], [DATADOG_EU] or a custom endpoint.
+     * [DATADOG_US_LOGS], [DATADOG_EU_LOGS] or a custom endpoint.
      */
     @JvmStatic
     @JvmOverloads
@@ -149,9 +149,9 @@ object Datadog {
     }
 
     /**
-     * Changes the endpoint to which data is sent.
+     * Changes the endpoint to which logging data is sent.
      * @param endpointUrl the endpoint url to target, or null to use the default.
-     * Possible values are [DATADOG_US], [DATADOG_EU] or a custom endpoint.
+     * Possible values are [DATADOG_US_LOGS], [DATADOG_EU_LOGS] or a custom endpoint.
      * @param strategy the strategy defining how to handle logs created previously.
      * Because logs are sent asynchronously, some logs intended for the previous endpoint
      * might still be yet to sent.
@@ -310,7 +310,7 @@ object Datadog {
         endpointUrl: String?
     ) {
         // Start handler to send logs
-        val endpoint = endpointUrl ?: DATADOG_US
+        val endpoint = endpointUrl ?: DATADOG_US_LOGS
         val okHttpClient = buildOkHttpClient(endpoint)
 
         logsUploader = LogsOkHttpUploader(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -34,6 +34,7 @@ import com.datadog.android.log.internal.user.MutableUserInfoProvider
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.tracing.internal.domain.TracingFileStrategy
+import com.datadog.android.tracing.internal.net.TracesOkHttpUploader
 import datadog.opentracing.DDSpan
 import java.lang.IllegalStateException
 import java.lang.ref.WeakReference
@@ -64,19 +65,38 @@ object Datadog {
     @Suppress("MemberVisibilityCanBePrivate")
     const val DATADOG_EU_LOGS: String = "https://mobile-http-intake.logs.datadoghq.eu"
 
+    /**
+     * The endpoint for our Traces US based servers, used by default by the SDK.
+     * @see [initialize]
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    const val DATADOG_US_TRACES: String = "https://public-trace-http-intake.logs.datadoghq.com"
+
+    /**
+     * The endpoint for our Europe Traces based servers.
+     * Use this in your call to [initialize] if you log on
+     * [app.datadoghq.eu](https://app.datadoghq.eu/) instead of
+     * [app.datadoghq.com](https://app.datadoghq.com/)
+     */
+    @Suppress("MemberVisibilityCanBePrivate")
+    const val DATADOG_EU_TRACES: String = "https://public-trace-http-intake.logs.datadoghq.eu"
+
     private const val TAG = "Datadog"
 
     internal const val NETWORK_TIMEOUT_MS = DatadogTimeProvider.MAX_OFFSET_DEVIATION / 2
     internal const val LOG_UPLOAD_THREAD_NAME = "ddog-logs-upload"
+    internal const val TRACES_UPLOAD_THREAD_NAME = "ddog-traces-upload"
 
     private var initialized: Boolean = false
     private lateinit var clientToken: String
     private lateinit var logStrategy: PersistenceStrategy<Log>
     private lateinit var networkInfoProvider: NetworkInfoProvider
     private lateinit var systemInfoProvider: BroadcastReceiverSystemInfoProvider
-    private lateinit var handlerThread: DataUploadHandlerThread
+    private lateinit var logsHandlerThread: DataUploadHandlerThread
+    private lateinit var tracesHandlerThread: DataUploadHandlerThread
     private lateinit var contextRef: WeakReference<Context>
     private lateinit var logsUploader: LogsOkHttpUploader
+    private lateinit var tracesUploader: TracesOkHttpUploader
     private lateinit var timeProvider: MutableTimeProvider
     private lateinit var userInfoProvider: MutableUserInfoProvider
     private lateinit var tracingStrategy: PersistenceStrategy<DDSpan>
@@ -89,19 +109,25 @@ object Datadog {
         private set
     private var okHttpClient: OkHttpClient? = null
 
+    // TODO: RUMM-193 Switch to the new way of initializing the SDK through using the DatadogConfig
     /**
      * Initializes the Datadog SDK.
      * @param context your application context
      * @param clientToken your API key of type Client Token
-     * @param endpointUrl (optional) the endpoint url to target, or null to use the default. Possible values are
-     * [DATADOG_US_LOGS], [DATADOG_EU_LOGS] or a custom endpoint.
+     * @param logsEndpointUrl (optional) the logs endpoint url to target,
+     * or null to use the default.
+     * Possible values are [DATADOG_US_LOGS], [DATADOG_EU_LOGS] or a custom endpoint.
+     * @param tracesEndpointUrl (optional) the traces endpoint url to target,
+     * or null to use the default.
+     * Possible values are [DATADOG_US_TRACES], [DATADOG_EU_TRACES] or a custom endpoint.
      */
     @JvmStatic
     @JvmOverloads
     fun initialize(
         context: Context,
         clientToken: String,
-        endpointUrl: String? = null
+        logsEndpointUrl: String? = null,
+        tracesEndpointUrl: String? = null
     ) {
         if (initialized) {
             devLogger.w(
@@ -135,7 +161,10 @@ object Datadog {
         setupTheSystemInfoProvider(appContext)
 
         // setup the logs uploader
-        setupLogsUploader(endpointUrl)
+        setupLogsUploader(logsEndpointUrl)
+
+        // setup the traces uploader
+        setupTracesUploader(tracesEndpointUrl)
 
         // setup the process lifecycle monitor
         setupLifecycleMonitorCallback(appContext)
@@ -157,30 +186,59 @@ object Datadog {
      * might still be yet to sent.
      */
     @JvmStatic
-    fun setEndpointUrl(endpointUrl: String, strategy: EndpointUpdateStrategy) {
+    fun setLogsEndpointUrl(endpointUrl: String, strategy: EndpointUpdateStrategy) {
         when (strategy) {
-            EndpointUpdateStrategy.DISCARD_OLD_LOGS -> {
+            EndpointUpdateStrategy.DISCARD_OLD_DATA -> {
                 logStrategy.getReader().dropAllBatches()
                 devLogger.w(
                     "$TAG: old logs targeted at $endpointUrl " +
-                        "will now be deleted"
+                            "will now be deleted"
                 )
             }
-            EndpointUpdateStrategy.SEND_OLD_LOGS_TO_NEW_ENDPOINT -> {
+            EndpointUpdateStrategy.SEND_OLD_DATA_TO_NEW_ENDPOINT -> {
                 devLogger.w(
                     "$TAG: old logs targeted at $endpointUrl " +
-                        "will now be sent to $endpointUrl"
+                            "will now be sent to $endpointUrl"
                 )
             }
         }
         logsUploader.setEndpoint(endpointUrl)
     }
 
+    /**
+     * Changes the endpoint to which tracing data is sent.
+     * @param endpointUrl the endpoint url to target, or null to use the default.
+     * Possible values are [DATADOG_US_TRACES], [DATADOG_EU_TRACES] or a custom endpoint.
+     * @param strategy the strategy defining how to handle traces created previously.
+     * Because traces are sent asynchronously, some traces intended for the previous endpoint
+     * might still be yet to sent.
+     */
+    @JvmStatic
+    fun setTracesEndpointUrl(endpointUrl: String, strategy: EndpointUpdateStrategy) {
+        when (strategy) {
+            EndpointUpdateStrategy.DISCARD_OLD_DATA -> {
+                tracingStrategy.getReader().dropAllBatches()
+                devLogger.w(
+                    "$TAG: old traces targeted at $endpointUrl " +
+                            "will now be deleted"
+                )
+            }
+            EndpointUpdateStrategy.SEND_OLD_DATA_TO_NEW_ENDPOINT -> {
+                devLogger.w(
+                    "$TAG: old traces targeted at $endpointUrl " +
+                            "will now be sent to $endpointUrl"
+                )
+            }
+        }
+        tracesUploader.setEndpoint(endpointUrl)
+    }
+
     // Stop all Datadog work (for test purposes).
     @Suppress("unused")
     private fun stop() {
         checkInitialized()
-        handlerThread.quitSafely()
+        logsHandlerThread.quitSafely()
+        tracesHandlerThread.quitSafely()
         contextRef.get()?.let { networkInfoProvider.unregister(it) }
         contextRef.clear()
         okHttpClient = null
@@ -309,7 +367,6 @@ object Datadog {
     private fun setupLogsUploader(
         endpointUrl: String?
     ) {
-        // Start handler to send logs
         val endpoint = endpointUrl ?: DATADOG_US_LOGS
         val okHttpClient = buildOkHttpClient(endpoint)
 
@@ -318,7 +375,7 @@ object Datadog {
             clientToken,
             okHttpClient
         )
-        handlerThread =
+        logsHandlerThread =
             DataUploadHandlerThread(
                 LOG_UPLOAD_THREAD_NAME,
                 logStrategy.getReader(),
@@ -326,7 +383,29 @@ object Datadog {
                 networkInfoProvider,
                 systemInfoProvider
             )
-        handlerThread.start()
+        logsHandlerThread.start()
+    }
+
+    private fun setupTracesUploader(
+        endpointUrl: String?
+    ) {
+        val endpoint = endpointUrl ?: DATADOG_US_TRACES
+        val okHttpClient = buildOkHttpClient(endpoint)
+
+        tracesUploader = TracesOkHttpUploader(
+            endpoint,
+            clientToken,
+            okHttpClient
+        )
+        tracesHandlerThread =
+            DataUploadHandlerThread(
+                TRACES_UPLOAD_THREAD_NAME,
+                tracingStrategy.getReader(),
+                tracesUploader,
+                networkInfoProvider,
+                systemInfoProvider
+            )
+        tracesHandlerThread.start()
     }
 
     private fun initSdkCredentials(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -186,7 +186,7 @@ object Datadog {
      * might still be yet to sent.
      */
     @JvmStatic
-    fun setLogsEndpointUrl(endpointUrl: String, strategy: EndpointUpdateStrategy) {
+    fun setEndpointUrl(endpointUrl: String, strategy: EndpointUpdateStrategy) {
         when (strategy) {
             EndpointUpdateStrategy.DISCARD_OLD_DATA -> {
                 logStrategy.getReader().dropAllBatches()
@@ -203,34 +203,6 @@ object Datadog {
             }
         }
         logsUploader.setEndpoint(endpointUrl)
-    }
-
-    /**
-     * Changes the endpoint to which tracing data is sent.
-     * @param endpointUrl the endpoint url to target, or null to use the default.
-     * Possible values are [DATADOG_US_TRACES], [DATADOG_EU_TRACES] or a custom endpoint.
-     * @param strategy the strategy defining how to handle traces created previously.
-     * Because traces are sent asynchronously, some traces intended for the previous endpoint
-     * might still be yet to sent.
-     */
-    @JvmStatic
-    fun setTracesEndpointUrl(endpointUrl: String, strategy: EndpointUpdateStrategy) {
-        when (strategy) {
-            EndpointUpdateStrategy.DISCARD_OLD_DATA -> {
-                tracingStrategy.getReader().dropAllBatches()
-                devLogger.w(
-                    "$TAG: old traces targeted at $endpointUrl " +
-                            "will now be deleted"
-                )
-            }
-            EndpointUpdateStrategy.SEND_OLD_DATA_TO_NEW_ENDPOINT -> {
-                devLogger.w(
-                    "$TAG: old traces targeted at $endpointUrl " +
-                            "will now be sent to $endpointUrl"
-                )
-            }
-        }
-        tracesUploader.setEndpoint(endpointUrl)
     }
 
     // Stop all Datadog work (for test purposes).

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileReader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileReader.kt
@@ -16,7 +16,9 @@ import java.io.IOException
 
 internal class FileReader(
     private val fileOrchestrator: Orchestrator,
-    private val dataDirectory: File
+    private val dataDirectory: File,
+    private val prefix: CharSequence = "",
+    private val suffix: CharSequence = ""
 ) : Reader {
 
     private val readFiles: MutableSet<String> = mutableSetOf()
@@ -72,7 +74,7 @@ internal class FileReader(
                 ByteArray(0)
             } else {
                 readFiles.add(file.name)
-                file.readBytes(withPrefix = '[', withSuffix = ']')
+                file.readBytes(withPrefix = prefix, withSuffix = suffix)
             }
         } catch (e: FileNotFoundException) {
             sdkLogger.e("$TAG: Couldn't create an input stream from file ${file?.path}", e)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategy.kt
@@ -22,9 +22,9 @@ internal abstract class FilePersistenceStrategy<T : Any>(
     maxItemsPerBatch: Int,
     oldFileThreshold: Long,
     maxDiskSpace: Long,
-    private val dataMigrator: DataMigrator,
     serializer: Serializer<T>,
-    private val writerThreadName: String
+    private val writerThreadName: String,
+    private val dataMigrator: DataMigrator? = null
 ) : PersistenceStrategy<T> {
 
     val fileOrchestrator = FileOrchestrator(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategy.kt
@@ -17,14 +17,14 @@ import java.io.File
 
 internal abstract class FilePersistenceStrategy<T : Any>(
     dataDirectory: File,
+    recentDelayMs: Long,
+    maxBatchSize: Long,
+    maxItemsPerBatch: Int,
+    oldFileThreshold: Long,
+    maxDiskSpace: Long,
+    private val dataMigrator: DataMigrator,
     serializer: Serializer<T>,
-    private val writerThreadName: String,
-    recentDelayMs: Long = MAX_DELAY_BETWEEN_MESSAGES_MS,
-    maxBatchSize: Long = MAX_BATCH_SIZE,
-    maxItemsPerBatch: Int = MAX_ITEMS_PER_BATCH,
-    oldFileThreshold: Long = OLD_FILE_THRESHOLD,
-    maxDiskSpace: Long = MAX_DISK_SPACE,
-    private val dataMigrator: DataMigrator? = null
+    private val writerThreadName: String
 ) : PersistenceStrategy<T> {
 
     val fileOrchestrator = FileOrchestrator(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategy.kt
@@ -17,13 +17,15 @@ import java.io.File
 
 internal abstract class FilePersistenceStrategy<T : Any>(
     dataDirectory: File,
-    recentDelayMs: Long,
-    maxBatchSize: Long,
-    maxItemsPerBatch: Int,
-    oldFileThreshold: Long,
-    maxDiskSpace: Long,
     serializer: Serializer<T>,
     private val writerThreadName: String,
+    recentDelayMs: Long = MAX_DELAY_BETWEEN_MESSAGES_MS,
+    maxBatchSize: Long = MAX_BATCH_SIZE,
+    maxItemsPerBatch: Int = MAX_ITEMS_PER_BATCH,
+    oldFileThreshold: Long = OLD_FILE_THRESHOLD,
+    maxDiskSpace: Long = MAX_DISK_SPACE,
+    payloadPrefix: CharSequence = "",
+    payloadSuffix: CharSequence = "",
     private val dataMigrator: DataMigrator? = null
 ) : PersistenceStrategy<T> {
 
@@ -38,7 +40,9 @@ internal abstract class FilePersistenceStrategy<T : Any>(
 
     private val fileReader = FileReader(
         fileOrchestrator,
-        dataDirectory
+        dataDirectory,
+        payloadPrefix,
+        payloadSuffix
     )
 
     // region Strategy methods

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -34,7 +34,8 @@ internal abstract class DataOkHttpUploader(
 
         return try {
             val request = buildRequest(data)
-            val response = client.newCall(request).execute()
+            val call = client.newCall(request)
+            val response = call.execute()
             sdkLogger.i(
                 "$tag: Response code:${response.code()} " +
                         "body:${response.body()?.string()} " +

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -102,10 +102,6 @@ internal abstract class DataOkHttpUploader(
         private const val HEADER_CT = "Content-Type"
 
         private const val CONTENT_TYPE = "application/json"
-
         const val SYSTEM_UA = "http.agent"
-
-        internal const val QP_SOURCE = "ddsource"
-        internal const val DD_SOURCE_MOBILE = "mobile"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/EndpointUpdateStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/EndpointUpdateStrategy.kt
@@ -7,17 +7,17 @@
 package com.datadog.android.log
 
 /**
- * The strategy on how to deal with older logs when the
+ * The strategy on how to deal with older data when the
  * endpoint needs to be changed.
  */
 enum class EndpointUpdateStrategy {
 
     /**
-     * All previous unsent log will be deleted and lost forever.
+     * All previous unsent data will be deleted and lost forever.
      */
-    DISCARD_OLD_LOGS,
+    DISCARD_OLD_DATA,
     /**
-     * All previous unsent log will be sent to the new endpoint.
+     * All previous unsent data will be sent to the new endpoint.
      */
-    SEND_OLD_LOGS_TO_NEW_ENDPOINT
+    SEND_OLD_DATA_TO_NEW_ENDPOINT
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFileStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFileStrategy.kt
@@ -27,9 +27,9 @@ internal class LogFileStrategy(
     maxLogPerBatch,
     oldFileThreshold,
     maxDiskSpace,
-    LogFileDataMigrator(context.filesDir),
     LogSerializer(),
-    WRITER_THREAD_NAME
+    WRITER_THREAD_NAME,
+    LogFileDataMigrator(context.filesDir)
 ) {
     // endregion
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFileStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFileStrategy.kt
@@ -22,14 +22,14 @@ internal class LogFileStrategy(
         context.filesDir,
         LOGS_FOLDER
     ),
-    LogSerializer(),
-    WRITER_THREAD_NAME,
     recentDelayMs,
     maxBatchSize,
     maxLogPerBatch,
     oldFileThreshold,
     maxDiskSpace,
-    LogFileDataMigrator(context.filesDir)
+    LogFileDataMigrator(context.filesDir),
+    LogSerializer(),
+    WRITER_THREAD_NAME
 ) {
     // endregion
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFileStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFileStrategy.kt
@@ -22,13 +22,15 @@ internal class LogFileStrategy(
         context.filesDir,
         LOGS_FOLDER
     ),
+    LogSerializer(),
+    WRITER_THREAD_NAME,
     recentDelayMs,
     maxBatchSize,
     maxLogPerBatch,
     oldFileThreshold,
     maxDiskSpace,
-    LogSerializer(),
-    WRITER_THREAD_NAME,
+    "[",
+    "]",
     LogFileDataMigrator(context.filesDir)
 ) {
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
@@ -1,0 +1,17 @@
+package com.datadog.android.log.internal.net
+
+import com.datadog.android.core.internal.net.DataOkHttpUploader
+import okhttp3.OkHttpClient
+
+internal open class LogsOkHttpUploader(
+    endpoint: String,
+    token: String,
+    client: OkHttpClient
+) : DataOkHttpUploader(endpoint, token, client, UPLOAD_URL, TAG) {
+
+    companion object {
+        internal const val UPLOAD_URL =
+            "%s/v1/input/%s?$QP_SOURCE=$DD_SOURCE_MOBILE"
+        internal const val TAG = "LogsOkHttpUploader"
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
@@ -3,13 +3,14 @@ package com.datadog.android.log.internal.net
 import android.os.Build
 import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.DataOkHttpUploader
+import java.util.Locale
 import okhttp3.OkHttpClient
 
 internal open class LogsOkHttpUploader(
     endpoint: String,
-    token: String,
+    private val token: String,
     client: OkHttpClient
-) : DataOkHttpUploader(endpoint, token, client, UPLOAD_URL, TAG) {
+) : DataOkHttpUploader(buildUrl(endpoint, token), client) {
 
     private val userAgent = System.getProperty(SYSTEM_UA).let {
         if (it.isNullOrBlank()) {
@@ -28,6 +29,10 @@ internal open class LogsOkHttpUploader(
         return headers
     }
 
+    override fun setEndpoint(endpoint: String) {
+        super.setEndpoint(buildUrl(endpoint, token))
+    }
+
     companion object {
         private const val HEADER_UA = "User-Agent"
         const val SYSTEM_UA = "http.agent"
@@ -35,6 +40,12 @@ internal open class LogsOkHttpUploader(
         private const val DD_SOURCE_MOBILE = "mobile"
         internal const val UPLOAD_URL =
             "%s/v1/input/%s?$QP_SOURCE=$DD_SOURCE_MOBILE"
-        internal const val TAG = "LogsOkHttpUploader"
+
+        private fun buildUrl(endpoint: String, token: String): String {
+            return String.format(
+                Locale.US,
+                UPLOAD_URL, endpoint, token
+            )
+        }
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
@@ -1,5 +1,7 @@
 package com.datadog.android.log.internal.net
 
+import android.os.Build
+import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.DataOkHttpUploader
 import okhttp3.OkHttpClient
 
@@ -9,7 +11,26 @@ internal open class LogsOkHttpUploader(
     client: OkHttpClient
 ) : DataOkHttpUploader(endpoint, token, client, UPLOAD_URL, TAG) {
 
+    private val userAgent = System.getProperty(SYSTEM_UA).let {
+        if (it.isNullOrBlank()) {
+            "Datadog/${BuildConfig.VERSION_NAME} " +
+                    "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
+                    "${Build.MODEL} Build/${Build.ID})"
+        } else {
+            it
+        }
+    }
+
+    override fun headers(): MutableMap<String, String> {
+        val headers = super.headers()
+        headers[HEADER_UA] = userAgent // traces intake doesn't support this type of user agent
+        // and crashes at message format
+        return headers
+    }
+
     companion object {
+        private const val HEADER_UA = "User-Agent"
+        const val SYSTEM_UA = "http.agent"
         private const val QP_SOURCE = "ddsource"
         private const val DD_SOURCE_MOBILE = "mobile"
         internal const val UPLOAD_URL =

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
@@ -10,6 +10,8 @@ internal open class LogsOkHttpUploader(
 ) : DataOkHttpUploader(endpoint, token, client, UPLOAD_URL, TAG) {
 
     companion object {
+        private const val QP_SOURCE = "ddsource"
+        private const val DD_SOURCE_MOBILE = "mobile"
         internal const val UPLOAD_URL =
             "%s/v1/input/%s?$QP_SOURCE=$DD_SOURCE_MOBILE"
         internal const val TAG = "LogsOkHttpUploader"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -15,7 +15,6 @@ internal class SpanSerializer : Serializer<DDSpan> {
         jsonObject.addProperty(SPAN_ID_KEY, Long.toHexString(model.spanId.toLong()))
         jsonObject.addProperty(PARENT_ID_KEY, Long.toHexString(model.parentId.toLong()))
         jsonObject.addProperty(RESOURCE_KEY, model.resourceName)
-        jsonObject.addProperty(RESOURCE_KEY, model.resourceName)
         jsonObject.addProperty(OPERATION_NAME_KEY, model.operationName)
         jsonObject.addProperty(SERVICE_NAME_KEY, model.serviceName)
         jsonObject.addProperty(DURATION_KEY, model.durationNano)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -59,7 +59,7 @@ internal class SpanSerializer : Serializer<DDSpan> {
         const val META_KEY = "meta"
         const val METRICS_KEY = "metrics"
         const val METRICS_KEY_TOP_LEVEL = "_top_level"
-        const val METRICS_KEY_SAMPLING = "_sampling_priority"
+        const val METRICS_KEY_SAMPLING = "_sampling_priority_v1"
     }
 
     companion object {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -61,15 +61,4 @@ internal class SpanSerializer : Serializer<DDSpan> {
         const val METRICS_KEY_TOP_LEVEL = "_top_level"
         const val METRICS_KEY_SAMPLING = "_sampling_priority_v1"
     }
-
-    companion object {
-        const val START_TIMESTAMP_KEY = "start"
-        const val DURATION_KEY = "duration"
-        const val SERVICE_NAME_KEY = "service"
-        const val TRACE_ID_KEY = "trace_id"
-        const val SPAN_ID_KEY = "span_id"
-        const val PARENT_ID_KEY = "parent_id"
-        const val RESOURCE_KEY = "resource"
-        const val OPERATION_NAME_KEY = "name"
-    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -1,15 +1,66 @@
 package com.datadog.android.tracing.internal.domain
 
 import com.datadog.android.core.internal.domain.Serializer
-import com.fasterxml.jackson.core.JsonFactory
-import com.fasterxml.jackson.databind.ObjectMapper
+import com.google.gson.JsonObject
 import datadog.opentracing.DDSpan
+import java.lang.Long
 
 internal class SpanSerializer : Serializer<DDSpan> {
-    private val mapper: ObjectMapper = ObjectMapper(JsonFactory())
 
     override fun serialize(model: DDSpan): String {
-        return mapper.writeValueAsString(model)
+        val jsonObject = JsonObject()
+        // it is save to convert to Long here from BigInteger...they are actually parsing this as
+        // Long also on server side.
+        jsonObject.addProperty(TRACE_ID_KEY, Long.toHexString(model.traceId.toLong()))
+        jsonObject.addProperty(SPAN_ID_KEY, Long.toHexString(model.spanId.toLong()))
+        jsonObject.addProperty(PARENT_ID_KEY, Long.toHexString(model.parentId.toLong()))
+        jsonObject.addProperty(RESOURCE_KEY, model.resourceName)
+        jsonObject.addProperty(RESOURCE_KEY, model.resourceName)
+        jsonObject.addProperty(OPERATION_NAME_KEY, model.operationName)
+        jsonObject.addProperty(SERVICE_NAME_KEY, model.serviceName)
+        jsonObject.addProperty(DURATION_KEY, model.durationNano)
+        jsonObject.addProperty(START_TIMESTAMP_KEY, model.startTime)
+        jsonObject.addProperty(TYPE_KEY, "object") // do not know yet what should be here
+        addMeta(jsonObject, model)
+        addMetrics(jsonObject, model)
+        return jsonObject.toString()
+    }
+
+    private fun addMeta(jsonObject: JsonObject, model: DDSpan) {
+        val metaObject = JsonObject()
+        model.meta.forEach {
+            metaObject.addProperty(it.key, it.value)
+        }
+        jsonObject.add(META_KEY, metaObject)
+    }
+
+    private fun addMetrics(jsonObject: JsonObject, model: DDSpan) {
+        val metricsObject = JsonObject()
+        model.metrics.forEach {
+            metricsObject.addProperty(it.key, it.value)
+        }
+        // add special keys
+        // we need this for sampling priority
+        metricsObject.addProperty(METRICS_KEY_SAMPLING, 1)
+        // same magic thing for sampling
+        metricsObject.addProperty(METRICS_KEY_TOP_LEVEL, 1)
+        jsonObject.add(METRICS_KEY, metricsObject)
+    }
+
+    companion object {
+        const val START_TIMESTAMP_KEY = "start"
+        const val DURATION_KEY = "duration"
+        const val SERVICE_NAME_KEY = "service"
+        const val TRACE_ID_KEY = "trace_id"
+        const val SPAN_ID_KEY = "span_id"
+        const val PARENT_ID_KEY = "parent_id"
+        const val RESOURCE_KEY = "resource"
+        const val OPERATION_NAME_KEY = "name"
+        const val TYPE_KEY = "type"
+        const val META_KEY = "meta"
+        const val METRICS_KEY = "metrics"
+        const val METRICS_KEY_TOP_LEVEL = "_top_level"
+        const val METRICS_KEY_SAMPLING = "_sampling_priority"
     }
 
     companion object {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -11,4 +11,15 @@ internal class SpanSerializer : Serializer<DDSpan> {
     override fun serialize(model: DDSpan): String {
         return mapper.writeValueAsString(model)
     }
+
+    companion object {
+        const val START_TIMESTAMP_KEY = "start"
+        const val DURATION_KEY = "duration"
+        const val SERVICE_NAME_KEY = "service"
+        const val TRACE_ID_KEY = "trace_id"
+        const val SPAN_ID_KEY = "span_id"
+        const val PARENT_ID_KEY = "parent_id"
+        const val RESOURCE_KEY = "resource"
+        const val OPERATION_NAME_KEY = "name"
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategy.kt
@@ -17,16 +17,20 @@ internal class TracingFileStrategy(
         context.filesDir,
         TRACES_FOLDER
     ),
-    SpanSerializer(),
-    WRITER_THREAD_NAME,
     recentDelayMs,
     maxBatchSize,
     maxLogPerBatch,
     oldFileThreshold,
-    maxDiskSpace
+    maxDiskSpace,
+    SpanSerializer(),
+    WRITER_THREAD_NAME
 ) {
 
     companion object {
+        private const val MAX_BATCH_SIZE: Long = 4 * 1024 * 1024 // 4 MB
+        private const val OLD_FILE_THRESHOLD: Long = 18L * 60L * 60L * 1000L // 18 hours
+        private const val MAX_DISK_SPACE: Long = 128 * MAX_BATCH_SIZE // 512 MB
+
         internal const val TRACES_DATA_VERSION = 1
         internal const val DATA_FOLDER_ROOT = "dd-tracing"
         internal const val TRACES_FOLDER = "$DATA_FOLDER_ROOT-v$TRACES_DATA_VERSION"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategy.kt
@@ -17,20 +17,18 @@ internal class TracingFileStrategy(
         context.filesDir,
         TRACES_FOLDER
     ),
+    SpanSerializer(),
+    WRITER_THREAD_NAME,
     recentDelayMs,
     maxBatchSize,
     maxLogPerBatch,
     oldFileThreshold,
     maxDiskSpace,
-    SpanSerializer(),
-    WRITER_THREAD_NAME
+    "{ \"spans\": [",
+    "]}"
 ) {
 
     companion object {
-        private const val MAX_BATCH_SIZE: Long = 4 * 1024 * 1024 // 4 MB
-        private const val OLD_FILE_THRESHOLD: Long = 18L * 60L * 60L * 1000L // 18 hours
-        private const val MAX_DISK_SPACE: Long = 128 * MAX_BATCH_SIZE // 512 MB
-
         internal const val TRACES_DATA_VERSION = 1
         internal const val DATA_FOLDER_ROOT = "dd-tracing"
         internal const val TRACES_FOLDER = "$DATA_FOLDER_ROOT-v$TRACES_DATA_VERSION"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploader.kt
@@ -1,0 +1,17 @@
+package com.datadog.android.tracing.internal.net
+
+import com.datadog.android.core.internal.net.DataOkHttpUploader
+import okhttp3.OkHttpClient
+
+internal open class TracesOkHttpUploader(
+    endpoint: String,
+    token: String,
+    client: OkHttpClient
+) : DataOkHttpUploader(endpoint, token, client, UPLOAD_URL, TAG) {
+
+    companion object {
+        internal const val UPLOAD_URL =
+            "%s/v1/input/%s"
+        internal const val TAG = "TracesOkHttpUploader"
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploader.kt
@@ -1,17 +1,29 @@
 package com.datadog.android.tracing.internal.net
 
 import com.datadog.android.core.internal.net.DataOkHttpUploader
+import java.util.Locale
 import okhttp3.OkHttpClient
 
 internal open class TracesOkHttpUploader(
     endpoint: String,
-    token: String,
+    private val token: String,
     client: OkHttpClient
-) : DataOkHttpUploader(endpoint, token, client, UPLOAD_URL, TAG) {
+) : DataOkHttpUploader(buildUrl(endpoint, token), client) {
 
     companion object {
         internal const val UPLOAD_URL =
             "%s/v1/input/%s"
         internal const val TAG = "TracesOkHttpUploader"
+
+        private fun buildUrl(endpoint: String, token: String): String {
+            return String.format(
+                Locale.US,
+                UPLOAD_URL, endpoint, token
+            )
+        }
+    }
+
+    override fun setEndpoint(endpoint: String) {
+        super.setEndpoint(buildUrl(endpoint, token))
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -11,7 +11,6 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.net.ConnectivityManager
 import android.os.Build
-import android.os.Trace
 import android.util.Log as AndroidLog
 import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.data.upload.DataUploadHandlerThread
@@ -82,8 +81,6 @@ internal class DatadogTest {
     lateinit var mockAppContext: Application
     @Mock
     lateinit var mockLogStrategy: PersistenceStrategy<Log>
-    @Mock
-    lateinit var mockTracesStrategy: PersistenceStrategy<Trace>
     @Mock
     lateinit var mockConnectivityMgr: ConnectivityManager
 
@@ -231,23 +228,7 @@ internal class DatadogTest {
         Datadog.javaClass.setStaticValue("logStrategy", mockLogStrategy)
         Datadog.javaClass.setStaticValue("logsUploader", mockUploader)
 
-        Datadog.setLogsEndpointUrl(newEndpoint, EndpointUpdateStrategy.DISCARD_OLD_DATA)
-
-        verify(mockReader).dropAllBatches()
-        verify(mockUploader).setEndpoint(newEndpoint)
-    }
-
-    @Test
-    fun `drop traces on setTracesEndpointUrl with Discard strategy`(forge: Forge) {
-        val mockReader: Reader = mock()
-        val mockUploader: TracesOkHttpUploader = mock()
-        whenever(mockTracesStrategy.getReader()) doReturn mockReader
-        val newEndpoint = forge.aStringMatching("https://[a-z]+\\.[a-z]{3}")
-        Datadog.initialize(mockAppContext, fakeToken)
-        Datadog.javaClass.setStaticValue("tracingStrategy", mockTracesStrategy)
-        Datadog.javaClass.setStaticValue("tracesUploader", mockUploader)
-
-        Datadog.setTracesEndpointUrl(newEndpoint, EndpointUpdateStrategy.DISCARD_OLD_DATA)
+        Datadog.setEndpointUrl(newEndpoint, EndpointUpdateStrategy.DISCARD_OLD_DATA)
 
         verify(mockReader).dropAllBatches()
         verify(mockUploader).setEndpoint(newEndpoint)
@@ -263,26 +244,7 @@ internal class DatadogTest {
         Datadog.javaClass.setStaticValue("logStrategy", mockLogStrategy)
         Datadog.javaClass.setStaticValue("logsUploader", mockUploader)
 
-        Datadog.setLogsEndpointUrl(
-            newEndpoint,
-            EndpointUpdateStrategy.SEND_OLD_DATA_TO_NEW_ENDPOINT
-        )
-
-        verify(mockReader, never()).dropAllBatches()
-        verify(mockUploader).setEndpoint(newEndpoint)
-    }
-
-    @Test
-    fun `keep traces on setTracesEndpointUrl with Update strategy`(forge: Forge) {
-        val mockReader: Reader = mock()
-        val mockUploader: TracesOkHttpUploader = mock()
-        whenever(mockTracesStrategy.getReader()) doReturn mockReader
-        val newEndpoint = forge.aStringMatching("https://[a-z]+\\.[a-z]{3}")
-        Datadog.initialize(mockAppContext, fakeToken)
-        Datadog.javaClass.setStaticValue("tracingStrategy", mockTracesStrategy)
-        Datadog.javaClass.setStaticValue("tracesUploader", mockUploader)
-
-        Datadog.setTracesEndpointUrl(
+        Datadog.setEndpointUrl(
             newEndpoint,
             EndpointUpdateStrategy.SEND_OLD_DATA_TO_NEW_ENDPOINT
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileExtensionsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileExtensionsTest.kt
@@ -9,6 +9,7 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.File
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -27,6 +28,15 @@ class FileExtensionsTest {
     @TempDir
     lateinit var tempDir: File
 
+    lateinit var prefix: String
+    lateinit var suffix: String
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        prefix = forge.anAsciiString(size = forge.anInt(min = 2, max = 8))
+        suffix = forge.anAsciiString(size = forge.anInt(min = 2, max = 8))
+    }
+
     @Test
     fun `adds the suffix and prefix to the file ByteArray`(forge: Forge) {
         val file = File(tempDir, "testFile")
@@ -34,8 +44,8 @@ class FileExtensionsTest {
         val dataToWrite = forge.anAlphaNumericalString()
         file.writeText(dataToWrite)
 
-        val readData = file.readBytes('[', ']')
-        assertThat(String(readData)).isEqualTo("[$dataToWrite]")
+        val readData = file.readBytes(prefix, suffix)
+        assertThat(String(readData)).isEqualTo("$prefix$dataToWrite$suffix")
     }
 
     @Test
@@ -43,8 +53,8 @@ class FileExtensionsTest {
         val file = File(tempDir, "testFile")
         file.createNewFile()
 
-        val readData = file.readBytes('[', ']')
-        assertThat(String(readData)).isEqualTo("[]")
+        val readData = file.readBytes(prefix, suffix)
+        assertThat(String(readData)).isEqualTo("$prefix$suffix")
     }
 
     @Test
@@ -54,7 +64,7 @@ class FileExtensionsTest {
         val spiedFile = spy(file)
         doReturn(Long.MAX_VALUE).whenever(spiedFile).length()
 
-        val readData = spiedFile.readBytes('[', ']')
+        val readData = spiedFile.readBytes(prefix, suffix)
         assertThat(readData).isEmpty()
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileReaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileReaderTest.kt
@@ -48,9 +48,14 @@ internal class FileReaderTest {
     @Mock
     lateinit var mockOrchestrator: Orchestrator
 
+    lateinit var prefix: String
+    lateinit var suffix: String
+
     @BeforeEach
-    fun `set up`() {
-        testedReader = FileReader(mockOrchestrator, rootDir)
+    fun `set up`(forge: Forge) {
+        prefix = forge.anAsciiString(size = forge.anInt(min = 2, max = 8))
+        suffix = forge.anAsciiString(size = forge.anInt(min = 2, max = 8))
+        testedReader = FileReader(mockOrchestrator, rootDir, prefix, suffix)
     }
 
     @Test
@@ -68,7 +73,7 @@ internal class FileReaderTest {
         val secondBatch = testedReader.readNextBatch()
         checkNotNull(firstBatch)
 
-        assertThat(String(firstBatch.data)).isEqualTo("[$data]")
+        assertThat(String(firstBatch.data)).isEqualTo("$prefix$data$suffix")
         assertThat(secondBatch).isNull()
         inOrder(mockOrchestrator) {
             verify(mockOrchestrator).getReadableFile(emptySet())
@@ -95,9 +100,9 @@ internal class FileReaderTest {
         val thirdBatch = testedReader.readNextBatch()
         checkNotNull(thirdBatch)
 
-        assertThat(String(firstBatch.data)).isEqualTo("[$data]")
+        assertThat(String(firstBatch.data)).isEqualTo("$prefix$data$suffix")
         assertThat(secondBatch).isNull()
-        assertThat(String(thirdBatch.data)).isEqualTo("[$data]")
+        assertThat(String(thirdBatch.data)).isEqualTo("$prefix$data$suffix")
         inOrder(mockOrchestrator) {
             verify(mockOrchestrator).getReadableFile(emptySet())
             verify(mockOrchestrator).getReadableFile(setOf(firstBatch.id))
@@ -124,7 +129,7 @@ internal class FileReaderTest {
 
         // then
         val persistedData = String(nextBatch.data)
-        assertThat(persistedData).isEqualTo("[$data]")
+        assertThat(persistedData).isEqualTo("$prefix$data$suffix")
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileReaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileReaderTest.kt
@@ -184,7 +184,7 @@ internal class FileReaderTest {
         testedReader.dropBatch(fileName)
 
         // then
-        val sentBatches = testedReader.getFieldValue<MutableSet<String>>("sentBatches")
+        val sentBatches: MutableSet<String> = testedReader.getFieldValue("sentBatches")
         assertThat(rootDir.listFiles()).isEmpty()
         assertThat(sentBatches).contains(fileName)
         if (BuildConfig.DEBUG) {
@@ -207,7 +207,7 @@ internal class FileReaderTest {
         testedReader.dropBatch(fileName)
 
         // then
-        val sentBatches = testedReader.getFieldValue<MutableSet<String>>("sentBatches")
+        val sentBatches: MutableSet<String> = testedReader.getFieldValue("sentBatches")
         assertThat(rootDir.listFiles()).isEmpty()
         assertThat(sentBatches).contains(fileName)
         if (BuildConfig.DEBUG) {
@@ -233,7 +233,7 @@ internal class FileReaderTest {
         testedReader.dropAllBatches()
 
         // then
-        val sentBatches = testedReader.getFieldValue<MutableSet<String>>("sentBatches")
+        val sentBatches: MutableSet<String> = testedReader.getFieldValue("sentBatches")
         assertThat(rootDir.listFiles()).isEmpty()
         assertThat(sentBatches).isEmpty()
         if (BuildConfig.DEBUG) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -14,9 +14,9 @@ import com.datadog.android.Datadog
 import com.datadog.android.core.internal.data.Reader
 import com.datadog.android.core.internal.domain.Batch
 import com.datadog.android.core.internal.domain.PersistenceStrategy
-import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.UploadStatus
 import com.datadog.android.log.internal.domain.Log
+import com.datadog.android.log.internal.net.LogsOkHttpUploader
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext
 import com.datadog.tools.unit.invokeMethod
@@ -58,7 +58,7 @@ internal class UploadWorkerTest {
     @Mock
     lateinit var mockLogReader: Reader
     @Mock
-    lateinit var mockDataUploader: DataUploader
+    lateinit var mockDataUploader: LogsOkHttpUploader
 
     @Forgery
     lateinit var fakeWorkerParameters: WorkerParameters
@@ -71,7 +71,7 @@ internal class UploadWorkerTest {
         Datadog.initialize(mockContext, "<CLIENT_TOKEN>")
 
         Datadog.setFieldValue("logStrategy", mockLogStrategy)
-        Datadog.setFieldValue("uploader", mockDataUploader)
+        Datadog.setFieldValue("logsUploader", mockDataUploader)
 
         testedWorker =
             UploadWorker(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategyTest.kt
@@ -177,7 +177,7 @@ internal abstract class FilePersistenceStrategyTest<T : Any>(
     fun `don't write model if size is too big`(forge: Forge) {
         val bigModel = bigModel(forge)
         testedWriter.write(bigModel)
-        waitForNextBatch()
+            waitForNextBatch()
         val batch = testedReader.readNextBatch()
 
         assertThat(batch)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
@@ -379,24 +379,19 @@ internal abstract class DataOkHttpUploaderTest<T : DataOkHttpUploader> {
         request: RecordedRequest,
         data: String
     ) {
-        val expectedUserAgent = if (fakeUserAgent.isBlank()) {
-            "Datadog/${BuildConfig.VERSION_NAME} " +
-                    "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
-                    "${Build.MODEL} Build/${Build.ID})"
-        } else {
-            fakeUserAgent
-        }
 
         val fullPath = String.format(Locale.US, urlFormat(), fakeEndpoint, fakeToken)
         val expectedPath = fullPath.substring(fakeEndpoint.length)
+        assertHeaders(request)
         assertThat(request.path)
             .isEqualTo(expectedPath)
-        assertThat(request.getHeader("User-Agent"))
-            .isEqualTo(expectedUserAgent)
-        assertThat(request.getHeader("Content-Type"))
-            .isEqualTo("application/json")
         assertThat(request.body.readUtf8())
             .isEqualTo(data)
+    }
+
+    open fun assertHeaders(request: RecordedRequest) {
+        assertThat(request.getHeader("Content-Type"))
+            .isEqualTo("application/json")
     }
 
     private fun mockResponse(code: Int): MockResponse {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
@@ -66,8 +66,6 @@ internal abstract class DataOkHttpUploaderTest<T : DataOkHttpUploader> {
 
     abstract fun uploader(): T
 
-    abstract fun tag(): String
-
     abstract fun urlFormat(): String
 
     @AfterEach
@@ -336,7 +334,7 @@ internal abstract class DataOkHttpUploaderTest<T : DataOkHttpUploader> {
             testedUploader.upload(data)
             val logMessages = systemOutputStream.toString().trim().split("\n")
             assertThat(logMessages.last())
-                .isEqualTo("E/DD_LOG: ${tag()}: unable to upload data")
+                .isEqualTo("E/DD_LOG: DataOkHttpUploader: unable to upload data")
         }
     }
 
@@ -355,7 +353,7 @@ internal abstract class DataOkHttpUploaderTest<T : DataOkHttpUploader> {
             testedUploader.upload(data)
             val logMessages = systemOutputStream.toString().trim().split("\n")
             assertThat(logMessages.last())
-                .matches("I/DD_LOG: ${tag()}: Response code:$code .+")
+                .matches("I/DD_LOG: DataOkHttpUploader: Response code:$code .+")
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/RuntimeUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/RuntimeUtilsTest.kt
@@ -50,7 +50,7 @@ class RuntimeUtilsTest {
     @Test
     fun `the sdk logger should always be disabled for remote logs`() {
         if (BuildConfig.LOGCAT_ENABLED) {
-            val handler = sdkLogger.getFieldValue<LogHandler>("handler") as LogcatLogHandler
+            val handler: LogcatLogHandler = sdkLogger.getFieldValue("handler")
             assertThat(handler.serviceName).isEqualTo(SDK_LOG_PREFIX)
         }
     }
@@ -59,7 +59,7 @@ class RuntimeUtilsTest {
     @EnableLogcat(isEnabled = false)
     fun `the sdk logger should disable the logcat logs if the BuildConfig flag is false`() {
         val logger = buildSdkLogger()
-        val handler = logger.getFieldValue<LogHandler>("handler")
+        val handler: LogHandler = logger.getFieldValue("handler")
         assertThat(handler).isInstanceOf(NoOpLogHandler::class.java)
     }
 
@@ -67,7 +67,7 @@ class RuntimeUtilsTest {
     @EnableLogcat(isEnabled = true)
     fun `the sdk logger should enable the logcat logs if the BuildConfig flag is true`() {
         val logger = buildSdkLogger()
-        val handler = logger.getFieldValue<LogHandler>("handler") as LogcatLogHandler
+        val handler: LogcatLogHandler = logger.getFieldValue("handler")
         assertThat(handler.serviceName).isEqualTo(SDK_LOG_PREFIX)
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -94,7 +94,7 @@ internal class LoggerBuilderTest {
         val logger = Logger.Builder()
             .build()
 
-        val handler = logger.getFieldValue("handler") as DatadogLogHandler
+        val handler: DatadogLogHandler = logger.getFieldValue("handler")
         assertThat(handler.serviceName).isEqualTo(Logger.DEFAULT_SERVICE_NAME)
         assertThat(handler.loggerName).isEqualTo(packageName)
         assertThat(handler.networkInfoProvider).isNull()
@@ -110,7 +110,7 @@ internal class LoggerBuilderTest {
             .setServiceName(serviceName)
             .build()
 
-        val handler = logger.getFieldValue("handler") as DatadogLogHandler
+        val handler: DatadogLogHandler = logger.getFieldValue("handler")
         assertThat(handler.serviceName).isEqualTo(serviceName)
     }
 
@@ -118,11 +118,11 @@ internal class LoggerBuilderTest {
     fun `builder can disable datadog logs`(@Forgery forge: Forge) {
         val datadogLogsEnabled = false
 
-        val logger = Logger.Builder()
+        val logger: Logger = Logger.Builder()
             .setDatadogLogsEnabled(datadogLogsEnabled)
             .build()
 
-        val handler = logger.getFieldValue("handler") as LogHandler
+        val handler: LogHandler = logger.getFieldValue("handler")
         assertThat(handler).isInstanceOf(NoOpLogHandler::class.java)
     }
 
@@ -134,7 +134,7 @@ internal class LoggerBuilderTest {
             .setLogcatLogsEnabled(logcatLogsEnabled)
             .build()
 
-        val handler = logger.getFieldValue("handler") as CombinedLogHandler
+        val handler: CombinedLogHandler = logger.getFieldValue("handler")
         assertThat(handler.handlers)
             .hasAtLeastOneElementOfType(DatadogLogHandler::class.java)
             .hasAtLeastOneElementOfType(LogcatLogHandler::class.java)
@@ -148,7 +148,7 @@ internal class LoggerBuilderTest {
             .setNetworkInfoEnabled(networkInfoEnabled)
             .build()
 
-        val handler = logger.getFieldValue("handler") as DatadogLogHandler
+        val handler: DatadogLogHandler = logger.getFieldValue("handler")
         assertThat(handler.networkInfoProvider).isNotNull()
     }
 
@@ -160,7 +160,7 @@ internal class LoggerBuilderTest {
             .setLoggerName(loggerName)
             .build()
 
-        val handler = logger.getFieldValue("handler") as DatadogLogHandler
+        val handler: DatadogLogHandler = logger.getFieldValue("handler")
         assertThat(handler.loggerName).isEqualTo(loggerName)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
@@ -36,10 +36,6 @@ internal class LogsOkHttpUploaderTest : DataOkHttpUploaderTest<LogsOkHttpUploade
             .isEqualTo(expectedUserAgent)
     }
 
-    override fun tag(): String {
-        return LogsOkHttpUploader.TAG
-    }
-
     override fun urlFormat(): String {
         return LogsOkHttpUploader.UPLOAD_URL
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
@@ -1,0 +1,29 @@
+package com.datadog.android.log.net
+
+import com.datadog.android.core.internal.net.DataOkHttpUploaderTest
+import com.datadog.android.log.internal.net.LogsOkHttpUploader
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+
+internal class LogsOkHttpUploaderTest : DataOkHttpUploaderTest<LogsOkHttpUploader>() {
+
+    override fun uploader(): LogsOkHttpUploader {
+        return LogsOkHttpUploader(
+            fakeEndpoint,
+            fakeToken,
+            OkHttpClient.Builder()
+                .connectTimeout(TIMEOUT_TEST_MS, TimeUnit.MILLISECONDS)
+                .readTimeout(TIMEOUT_TEST_MS, TimeUnit.MILLISECONDS)
+                .writeTimeout(TIMEOUT_TEST_MS, TimeUnit.MILLISECONDS)
+                .build()
+        )
+    }
+
+    override fun tag(): String {
+        return LogsOkHttpUploader.TAG
+    }
+
+    override fun urlFormat(): String {
+        return LogsOkHttpUploader.UPLOAD_URL
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
@@ -1,9 +1,13 @@
 package com.datadog.android.log.net
 
+import android.os.Build
+import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.DataOkHttpUploaderTest
 import com.datadog.android.log.internal.net.LogsOkHttpUploader
 import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
+import okhttp3.mockwebserver.RecordedRequest
+import org.assertj.core.api.Assertions.assertThat
 
 internal class LogsOkHttpUploaderTest : DataOkHttpUploaderTest<LogsOkHttpUploader>() {
 
@@ -17,6 +21,19 @@ internal class LogsOkHttpUploaderTest : DataOkHttpUploaderTest<LogsOkHttpUploade
                 .writeTimeout(TIMEOUT_TEST_MS, TimeUnit.MILLISECONDS)
                 .build()
         )
+    }
+
+    override fun assertHeaders(request: RecordedRequest) {
+        super.assertHeaders(request)
+        val expectedUserAgent = if (fakeUserAgent.isBlank()) {
+            "Datadog/${BuildConfig.VERSION_NAME} " +
+                    "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
+                    "${Build.MODEL} Build/${Build.ID})"
+        } else {
+            fakeUserAgent
+        }
+        assertThat(request.getHeader("User-Agent"))
+            .isEqualTo(expectedUserAgent)
     }
 
     override fun tag(): String {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializerTest.kt
@@ -7,6 +7,7 @@ import datadog.opentracing.DDSpan
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -39,5 +40,11 @@ internal class SpanSerializerTest {
         // then
         val jsonObject = JsonParser.parseString(serialized).asJsonObject
         jsonObject.assertMatches(span)
+        // check special metrics
+        val metricsObject = jsonObject.get(SpanSerializer.METRICS_KEY).asJsonObject
+        assertThat(metricsObject.getAsJsonPrimitive(SpanSerializer.METRICS_KEY_TOP_LEVEL).asInt)
+            .isEqualTo(1)
+        assertThat(metricsObject.getAsJsonPrimitive(SpanSerializer.METRICS_KEY_SAMPLING).asInt)
+            .isEqualTo(1)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategyTest.kt
@@ -22,7 +22,6 @@ import com.google.gson.JsonPrimitive
 import datadog.opentracing.DDSpan
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
-import io.opentracing.Tracer
 import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.junit.jupiter.MockitoSettings
@@ -81,12 +80,14 @@ internal class TracingFileStrategyTest :
 
     override fun bigModel(forge: Forge): DDSpan {
 
-        val operationName = forge.anAlphabeticalString(size = 65536)
-        val resourceName = forge.anAlphabeticalString(size = 65536)
-        val serviceName = forge.anAlphabeticalString(size = 65536)
-        val spanType = forge.anAlphabeticalString(size = 65536)
+        val maxBytesInSize = 256 * 1024
+        val maxBytesInSizeForKeyValye = maxBytesInSize / 3
+        val operationName = forge.anAlphabeticalString(size = maxBytesInSizeForKeyValye)
+        val resourceName = forge.anAlphabeticalString(size = maxBytesInSizeForKeyValye)
+        val serviceName = forge.anAlphabeticalString(size = maxBytesInSizeForKeyValye)
+        val spanType = forge.anAlphabeticalString(size = maxBytesInSizeForKeyValye)
         val isWithErrorFlag = forge.aBool()
-        val tags = forge.aMap(size = 256) {
+        val meta = forge.aMap(size = 256) {
             forge.anAlphabeticalString(size = 64) to forge.anAlphabeticalString(
                 size = 128
             )
@@ -100,12 +101,12 @@ internal class TracingFileStrategyTest :
         if (isWithErrorFlag) {
             spanBuilder.withErrorFlag()
         }
-        (spanBuilder as Tracer.SpanBuilder).apply {
-            tags.forEach {
-                this.withTag(it.key, it.value)
-            }
+        val span = spanBuilder.start()
+        meta.forEach {
+            span.context().setBaggageItem(it.key, it.value)
         }
-        return spanBuilder.start()
+
+        return span
     }
 
     override fun assertHasMatches(jsonObject: JsonObject, models: List<DDSpan>) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategyTest.kt
@@ -13,7 +13,6 @@ import com.datadog.android.core.internal.domain.FilePersistenceStrategyTest
 import com.datadog.android.core.internal.domain.PersistenceStrategy
 import com.datadog.android.core.internal.threading.LazyHandlerThread
 import com.datadog.android.utils.copy
-import com.datadog.android.utils.extension.SpanKeys
 import com.datadog.android.utils.extension.assertMatches
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.SpanForgeryFactory
@@ -110,10 +109,10 @@ internal class TracingFileStrategyTest :
     }
 
     override fun assertHasMatches(jsonObject: JsonObject, models: List<DDSpan>) {
-        val serviceName = (jsonObject[SpanKeys.SERVICE_NAME_KEY] as JsonPrimitive).asString
-        val traceId = (jsonObject[SpanKeys.TRACE_ID_KEY] as JsonPrimitive).asBigInteger
-        val parentId = (jsonObject[SpanKeys.PARENT_ID_KEY] as JsonPrimitive).asBigInteger
-        val resourceName = (jsonObject[SpanKeys.RESOURCE_KEY] as JsonPrimitive).asString
+        val serviceName = (jsonObject[SpanSerializer.SERVICE_NAME_KEY] as JsonPrimitive).asString
+        val traceId = (jsonObject[SpanSerializer.TRACE_ID_KEY] as JsonPrimitive).asBigInteger
+        val parentId = (jsonObject[SpanSerializer.PARENT_ID_KEY] as JsonPrimitive).asBigInteger
+        val resourceName = (jsonObject[SpanSerializer.RESOURCE_KEY] as JsonPrimitive).asString
 
         val roughMatches = models.filter {
             serviceName == it.serviceName &&

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategyTest.kt
@@ -110,14 +110,19 @@ internal class TracingFileStrategyTest :
 
     override fun assertHasMatches(jsonObject: JsonObject, models: List<DDSpan>) {
         val serviceName = (jsonObject[SpanSerializer.SERVICE_NAME_KEY] as JsonPrimitive).asString
-        val traceId = (jsonObject[SpanSerializer.TRACE_ID_KEY] as JsonPrimitive).asBigInteger
-        val parentId = (jsonObject[SpanSerializer.PARENT_ID_KEY] as JsonPrimitive).asBigInteger
+        val spanIdHexa = (jsonObject[SpanSerializer.SPAN_ID_KEY] as JsonPrimitive).asString
+        val traceIdHexa = (jsonObject[SpanSerializer.TRACE_ID_KEY] as JsonPrimitive).asString
+        val parentIdHexa = (jsonObject[SpanSerializer.PARENT_ID_KEY] as JsonPrimitive).asString
         val resourceName = (jsonObject[SpanSerializer.RESOURCE_KEY] as JsonPrimitive).asString
+        val traceId = java.lang.Long.parseLong(traceIdHexa, 16)
+        val spanId = java.lang.Long.parseLong(spanIdHexa, 16)
+        val parentId = java.lang.Long.parseLong(parentIdHexa, 16)
 
         val roughMatches = models.filter {
             serviceName == it.serviceName &&
-                    traceId == it.traceId &&
-                    parentId == it.parentId &&
+                    traceId == it.traceId.toLong() &&
+                    parentId == it.parentId.toLong() &&
+                    spanId == it.spanId.toLong() &&
                     resourceName == it.resourceName
         }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderTest.kt
@@ -18,10 +18,6 @@ internal class TracesOkHttpUploaderTest : DataOkHttpUploaderTest<TracesOkHttpUpl
         )
     }
 
-    override fun tag(): String {
-        return TracesOkHttpUploader.TAG
-    }
-
     override fun urlFormat(): String {
         return TracesOkHttpUploader.UPLOAD_URL
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderTest.kt
@@ -1,0 +1,28 @@
+package com.datadog.android.tracing.internal.net
+
+import com.datadog.android.core.internal.net.DataOkHttpUploaderTest
+import java.util.concurrent.TimeUnit
+import okhttp3.OkHttpClient
+
+internal class TracesOkHttpUploaderTest : DataOkHttpUploaderTest<TracesOkHttpUploader>() {
+
+    override fun uploader(): TracesOkHttpUploader {
+        return TracesOkHttpUploader(
+            fakeEndpoint,
+            fakeToken,
+            OkHttpClient.Builder()
+                .connectTimeout(TIMEOUT_TEST_MS, TimeUnit.MILLISECONDS)
+                .readTimeout(TIMEOUT_TEST_MS, TimeUnit.MILLISECONDS)
+                .writeTimeout(TIMEOUT_TEST_MS, TimeUnit.MILLISECONDS)
+                .build()
+        )
+    }
+
+    override fun tag(): String {
+        return TracesOkHttpUploader.TAG
+    }
+
+    override fun urlFormat(): String {
+        return TracesOkHttpUploader.UPLOAD_URL
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/BatchExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/BatchExt.kt
@@ -2,9 +2,17 @@ package com.datadog.android.utils
 
 import com.datadog.android.core.internal.domain.Batch
 import com.google.gson.JsonArray
+import com.google.gson.JsonObject
 import com.google.gson.JsonParser
 
 internal val Batch.asJsonArray: JsonArray
     get() {
-        return JsonParser.parseString(String(data)).asJsonArray
+        val jsonElement = JsonParser.parseString(String(data))
+        if (jsonElement is JsonArray) {
+            return jsonElement
+        } else if (jsonElement is JsonObject) {
+            return jsonElement.getAsJsonArray("spans")
+        } else {
+            return JsonArray()
+        }
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/SpanExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/SpanExt.kt
@@ -4,7 +4,7 @@ import com.datadog.android.utils.forge.SpanForgeryFactory
 import datadog.opentracing.DDSpan
 
 fun DDSpan.copy(): DDSpan {
-    return SpanForgeryFactory
+    val ddSpan = SpanForgeryFactory
         .generateSpanBuilder(
             operationName,
             spanType,
@@ -15,4 +15,11 @@ fun DDSpan.copy(): DDSpan {
         )
         .withStartTimestamp(startTime)
         .start()
+    metrics.forEach {
+        ddSpan.context().setMetric(it.key, it.value)
+    }
+    meta.forEach {
+        ddSpan.context().baggageItems.putIfAbsent(it.key, it.value)
+    }
+    return ddSpan
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/JsonObjectExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/JsonObjectExt.kt
@@ -1,7 +1,7 @@
 package com.datadog.android.utils.extension
 
-import com.datadog.android.log.assertj.JsonObjectAssert
 import com.datadog.android.tracing.internal.domain.SpanSerializer
+import com.datadog.tools.unit.assertj.JsonObjectAssert
 import com.google.gson.JsonObject
 import datadog.opentracing.DDSpan
 import java.lang.Long

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/JsonObjectExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/JsonObjectExt.kt
@@ -4,15 +4,18 @@ import com.datadog.android.log.assertj.JsonObjectAssert
 import com.datadog.android.tracing.internal.domain.SpanSerializer
 import com.google.gson.JsonObject
 import datadog.opentracing.DDSpan
+import java.lang.Long
 
 fun JsonObject.assertMatches(span: DDSpan) {
     JsonObjectAssert.assertThat(this)
         .hasField(SpanSerializer.START_TIMESTAMP_KEY, span.startTime)
         .hasField(SpanSerializer.DURATION_KEY, span.durationNano)
         .hasField(SpanSerializer.SERVICE_NAME_KEY, span.serviceName)
-        .hasField(SpanSerializer.TRACE_ID_KEY, span.traceId)
-        .hasField(SpanSerializer.SPAN_ID_KEY, span.spanId)
-        .hasField(SpanSerializer.PARENT_ID_KEY, span.parentId)
+        .hasField(SpanSerializer.TRACE_ID_KEY, Long.toHexString((span.traceId.toLong())))
+        .hasField(SpanSerializer.SPAN_ID_KEY, Long.toHexString((span.spanId.toLong())))
+        .hasField(SpanSerializer.PARENT_ID_KEY, Long.toHexString((span.parentId.toLong())))
         .hasField(SpanSerializer.RESOURCE_KEY, span.resourceName)
         .hasField(SpanSerializer.OPERATION_NAME_KEY, span.operationName)
+        .hasField(SpanSerializer.META_KEY, span.meta)
+        .hasField(SpanSerializer.METRICS_KEY, span.metrics)
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/JsonObjectExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/JsonObjectExt.kt
@@ -1,28 +1,18 @@
 package com.datadog.android.utils.extension
 
 import com.datadog.android.log.assertj.JsonObjectAssert
+import com.datadog.android.tracing.internal.domain.SpanSerializer
 import com.google.gson.JsonObject
 import datadog.opentracing.DDSpan
 
 fun JsonObject.assertMatches(span: DDSpan) {
     JsonObjectAssert.assertThat(this)
-        .hasField(SpanKeys.START_TIMESTAMP_KEY, span.startTime)
-        .hasField(SpanKeys.DURATION_KEY, span.durationNano)
-        .hasField(SpanKeys.SERVICE_NAME_KEY, span.serviceName)
-        .hasField(SpanKeys.TRACE_ID_KEY, span.traceId)
-        .hasField(SpanKeys.SPAN_ID_KEY, span.spanId)
-        .hasField(SpanKeys.PARENT_ID_KEY, span.parentId)
-        .hasField(SpanKeys.RESOURCE_KEY, span.resourceName)
-        .hasField(SpanKeys.OPERATION_NAME_KEY, span.operationName)
-}
-
-object SpanKeys {
-    const val START_TIMESTAMP_KEY = "start"
-    const val DURATION_KEY = "duration"
-    const val SERVICE_NAME_KEY = "service"
-    const val TRACE_ID_KEY = "trace_id"
-    const val SPAN_ID_KEY = "span_id"
-    const val PARENT_ID_KEY = "parent_id"
-    const val RESOURCE_KEY = "resource"
-    const val OPERATION_NAME_KEY = "name"
+        .hasField(SpanSerializer.START_TIMESTAMP_KEY, span.startTime)
+        .hasField(SpanSerializer.DURATION_KEY, span.durationNano)
+        .hasField(SpanSerializer.SERVICE_NAME_KEY, span.serviceName)
+        .hasField(SpanSerializer.TRACE_ID_KEY, span.traceId)
+        .hasField(SpanSerializer.SPAN_ID_KEY, span.spanId)
+        .hasField(SpanSerializer.PARENT_ID_KEY, span.parentId)
+        .hasField(SpanSerializer.RESOURCE_KEY, span.resourceName)
+        .hasField(SpanSerializer.OPERATION_NAME_KEY, span.operationName)
 }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
@@ -57,7 +57,7 @@ internal class MockServerActivityTestRule<T : Activity>(
         })
 
         val fakeEndpoint = mockWebServer.url("/").toString().removeSuffix("/")
-        Datadog.setEndpointUrl(fakeEndpoint, EndpointUpdateStrategy.DISCARD_OLD_LOGS)
+        Datadog.setEndpointUrl(fakeEndpoint, EndpointUpdateStrategy.DISCARD_OLD_DATA)
         super.beforeActivityLaunched()
     }
 

--- a/sample/java/src/main/java/com/datadog/android/sample/SampleApplication.java
+++ b/sample/java/src/main/java/com/datadog/android/sample/SampleApplication.java
@@ -24,7 +24,7 @@ public class SampleApplication extends Application {
         Datadog.initialize(
                 this,
                 BuildConfig.DD_CLIENT_TOKEN,
-                (BuildConfig.DD_OVERRIDE_URL == null) ? Datadog.DATADOG_US : BuildConfig.DD_OVERRIDE_URL
+                (BuildConfig.DD_OVERRIDE_URL == null) ? Datadog.DATADOG_US_LOGS : BuildConfig.DD_OVERRIDE_URL
         );
         Datadog.setVerbosity(Log.VERBOSE);
 

--- a/sample/kotlin-timber/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin-timber/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -21,7 +21,7 @@ class SampleApplication : Application() {
         Datadog.initialize(
             this,
             BuildConfig.DD_CLIENT_TOKEN,
-            if (BuildConfig.DD_OVERRIDE_URL.isEmpty()) Datadog.DATADOG_US else BuildConfig.DD_OVERRIDE_URL
+            if (BuildConfig.DD_OVERRIDE_URL.isEmpty()) Datadog.DATADOG_US_LOGS else BuildConfig.DD_OVERRIDE_URL
         )
         Datadog.setVerbosity(Log.VERBOSE)
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -18,7 +18,7 @@ class SampleApplication : Application() {
         Datadog.initialize(
             this,
             BuildConfig.DD_CLIENT_TOKEN,
-            if (BuildConfig.DD_OVERRIDE_URL.isEmpty()) Datadog.DATADOG_US else BuildConfig.DD_OVERRIDE_URL
+            if (BuildConfig.DD_OVERRIDE_URL.isEmpty()) Datadog.DATADOG_US_LOGS else BuildConfig.DD_OVERRIDE_URL
         )
         Datadog.setVerbosity(Log.VERBOSE)
     }

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
@@ -96,7 +96,7 @@ fun <T : Any> T.invokeMethod(
         if (params.isEmpty()) {
             method.invoke(this)
         } else {
-            method.invoke(this, params)
+            method.invoke(this, *params)
         }
     } catch (e: InvocationTargetException) {
         throw e.cause ?: e

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
@@ -65,8 +65,11 @@ inline fun <reified T> Any.setFieldValue(
  * Gets the field value from the target instance.
  * @param fieldName the name of the field
  */
-inline fun <reified T> Any.getFieldValue(fieldName: String): T {
-    val field = this.javaClass.getDeclaredField(fieldName)
+inline fun <reified T, R : Any> R.getFieldValue(
+    fieldName: String,
+    enclosingClass: Class<R> = this.javaClass
+): T {
+    val field = enclosingClass.getDeclaredField(fieldName)
     field.isAccessible = true
     return field.get(this) as T
 }

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
@@ -12,6 +12,7 @@ import com.google.gson.JsonPrimitive
 import java.math.BigInteger
 import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat
+import java.math.BigInteger
 
 /**
  * Assertion methods for [JsonObject].
@@ -268,6 +269,31 @@ class JsonObjectAssert(actual: JsonObject) :
             .overridingErrorMessage(
                 "Expected json object to have field $name value $expectedValue " +
                     "but was $value"
+            )
+            .isEqualTo(expectedValue)
+        return this
+    }
+
+    fun hasField(name: String, expectedValue: BigInteger): JsonObjectAssert {
+        assertThat(actual.has(name))
+            .overridingErrorMessage(
+                "Expected json object to have field named $name but couldn't find one"
+            )
+            .isTrue()
+
+        val element = actual.get(name)
+        assertThat(element is JsonPrimitive && element.isNumber)
+            .overridingErrorMessage(
+                "Expected json object to have field $name with BigInteger value " +
+                        "but was ${element.javaClass.simpleName}"
+            )
+            .isTrue()
+
+        val value = (element as JsonPrimitive).asBigInteger
+        assertThat(value)
+            .overridingErrorMessage(
+                "Expected json object to have field $name value $expectedValue " +
+                        "but was $value"
             )
             .isEqualTo(expectedValue)
         return this

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
@@ -298,31 +298,6 @@ class JsonObjectAssert(actual: JsonObject) :
         return this
     }
 
-    fun hasField(name: String, expectedValue: BigInteger): JsonObjectAssert {
-        assertThat(actual.has(name))
-            .overridingErrorMessage(
-                "Expected json object to have field named $name but couldn't find one"
-            )
-            .isTrue()
-
-        val element = actual.get(name)
-        assertThat(element is JsonPrimitive && element.isNumber)
-            .overridingErrorMessage(
-                "Expected json object to have field $name with BigInteger value " +
-                        "but was ${element.javaClass.simpleName}"
-            )
-            .isTrue()
-
-        val value = (element as JsonPrimitive).asBigInteger
-        assertThat(value)
-            .overridingErrorMessage(
-                "Expected json object to have field $name value $expectedValue " +
-                        "but was $value"
-            )
-            .isEqualTo(expectedValue)
-        return this
-    }
-
     /**
      *  Verifies that the actual jsonObject contains a field with the given name and JsonObject value.
      *  @param name the field name

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
@@ -16,7 +16,7 @@ import org.assertj.core.api.Assertions.assertThat
 /**
  * Assertion methods for [JsonObject].
  */
-@Suppress("StringLiteralDuplication", "MethodOverloading")
+@Suppress("StringLiteralDuplication", "MethodOverloading", "TooManyFunctions")
 class JsonObjectAssert(actual: JsonObject) :
     AbstractObjectAssert<JsonObjectAssert, JsonObject>(actual, JsonObjectAssert::class.java) {
 
@@ -273,6 +273,11 @@ class JsonObjectAssert(actual: JsonObject) :
         return this
     }
 
+    /**
+     *  Verifies that the actual jsonObject contains a field with the given name and BigInteger value.
+     *  @param name the field name
+     *  @param expectedValue the expected value of the field
+     */
     fun hasField(name: String, expectedValue: BigInteger): JsonObjectAssert {
         assertThat(actual.has(name))
             .overridingErrorMessage(
@@ -326,6 +331,12 @@ class JsonObjectAssert(actual: JsonObject) :
         return this
     }
 
+    /**
+     *  Verifies that the actual jsonObject contains a field with the given name and
+     *  Map<String,Any> value.
+     *  @param name the field name
+     *  @param expectedValue the expected value of the field
+     */
     fun hasField(name: String, map: Map<String, Any>): JsonObjectAssert {
         assertThat(actual.has(name))
             .overridingErrorMessage(

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
@@ -12,7 +12,6 @@ import com.google.gson.JsonPrimitive
 import java.math.BigInteger
 import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat
-import java.math.BigInteger
 
 /**
  * Assertion methods for [JsonObject].

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
@@ -49,7 +49,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(element is JsonNull)
             .overridingErrorMessage(
                 "Expected json object to have field $name with null value " +
-                    "but was ${element.javaClass.simpleName}"
+                        "but was ${element.javaClass.simpleName}"
             )
             .isTrue()
 
@@ -75,7 +75,7 @@ class JsonObjectAssert(actual: JsonObject) :
             assertThat(element is JsonPrimitive && element.isString)
                 .overridingErrorMessage(
                     "Expected json object to have field $name with String value " +
-                        "but was ${element.javaClass.simpleName}"
+                            "but was ${element.javaClass.simpleName}"
                 )
                 .isTrue()
 
@@ -83,7 +83,7 @@ class JsonObjectAssert(actual: JsonObject) :
             assertThat(value)
                 .overridingErrorMessage(
                     "Expected json object to have field $name with value \"%s\" " +
-                        "but was \"%s\"",
+                            "but was \"%s\"",
                     expectedValue, value
                 )
                 .isEqualTo(expectedValue)
@@ -107,7 +107,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat((element is JsonPrimitive && element.isString))
             .overridingErrorMessage(
                 "Expected json object to have field $name with String value " +
-                    "but was ${element.javaClass.simpleName}"
+                        "but was ${element.javaClass.simpleName}"
             )
             .isTrue()
 
@@ -115,7 +115,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(value)
             .overridingErrorMessage(
                 "Expected json object to have field $name with value matching \"%s\" " +
-                    "but was \"%s\"",
+                        "but was \"%s\"",
                 regex, value
             )
             .matches(regex)
@@ -139,7 +139,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(element is JsonPrimitive && element.isBoolean)
             .overridingErrorMessage(
                 "Expected json object to have field $name with Boolean value " +
-                    "but was ${element.javaClass.simpleName}"
+                        "but was ${element.javaClass.simpleName}"
             )
             .isTrue()
 
@@ -147,7 +147,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(value)
             .overridingErrorMessage(
                 "Expected json object to have field $name value $expectedValue " +
-                    "but was $value"
+                        "but was $value"
             )
             .isEqualTo(expectedValue)
         return this
@@ -169,7 +169,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(element is JsonPrimitive && element.isNumber)
             .overridingErrorMessage(
                 "Expected json object to have field $name with Int value " +
-                    "but was ${element.javaClass.simpleName}"
+                        "but was ${element.javaClass.simpleName}"
             )
             .isTrue()
 
@@ -177,7 +177,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(value)
             .overridingErrorMessage(
                 "Expected json object to have field $name value $expectedValue " +
-                    "but was $value"
+                        "but was $value"
             )
             .isEqualTo(expectedValue)
         return this
@@ -199,7 +199,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(element is JsonPrimitive && element.isNumber)
             .overridingErrorMessage(
                 "Expected json object to have field $name with Long value " +
-                    "but was ${element.javaClass.simpleName}"
+                        "but was ${element.javaClass.simpleName}"
             )
             .isTrue()
 
@@ -207,7 +207,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(value)
             .overridingErrorMessage(
                 "Expected json object to have field $name value $expectedValue " +
-                    "but was $value"
+                        "but was $value"
             )
             .isEqualTo(expectedValue)
         return this
@@ -229,7 +229,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(element is JsonPrimitive && element.isNumber)
             .overridingErrorMessage(
                 "Expected json object to have field $name with Float value " +
-                    "but was ${element.javaClass.simpleName}"
+                        "but was ${element.javaClass.simpleName}"
             )
             .isTrue()
 
@@ -237,7 +237,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(value)
             .overridingErrorMessage(
                 "Expected json object to have field $name value $expectedValue " +
-                    "but was $value"
+                        "but was $value"
             )
             .isEqualTo(expectedValue)
         return this
@@ -259,7 +259,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(element is JsonPrimitive && element.isNumber)
             .overridingErrorMessage(
                 "Expected json object to have field $name with Double value " +
-                    "but was ${element.javaClass.simpleName}"
+                        "but was ${element.javaClass.simpleName}"
             )
             .isTrue()
 
@@ -267,7 +267,7 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(value)
             .overridingErrorMessage(
                 "Expected json object to have field $name value $expectedValue " +
-                    "but was $value"
+                        "but was $value"
             )
             .isEqualTo(expectedValue)
         return this
@@ -342,12 +342,41 @@ class JsonObjectAssert(actual: JsonObject) :
         assertThat(element is JsonObject)
             .overridingErrorMessage(
                 "Expected json object to have object field $name " +
-                    "but was ${element.javaClass.simpleName}"
+                        "but was ${element.javaClass.simpleName}"
             )
             .isTrue()
 
         JsonObjectAssert(element as JsonObject).withAssertions()
 
+        return this
+    }
+
+    fun hasField(name: String, map: Map<String, Any>): JsonObjectAssert {
+        assertThat(actual.has(name))
+            .overridingErrorMessage(
+                "Expected json object to have field named $name but couldn't find one"
+            )
+            .isTrue()
+
+        val element = actual.get(name)
+        assertThat(element is JsonObject)
+            .overridingErrorMessage(
+                "Expected json object to have object field $name " +
+                        "but was ${element.javaClass.simpleName}"
+            )
+            .isTrue()
+        val jsonObject = element as JsonObject
+        map.forEach {
+            val keyValue = it.value
+            when (keyValue) {
+                is String -> assertThat(jsonObject).hasField(it.key, keyValue)
+                is Int -> assertThat(jsonObject).hasField(it.key, keyValue)
+                is Long -> assertThat(jsonObject).hasField(it.key, keyValue)
+                is Double -> assertThat(jsonObject).hasField(it.key, keyValue)
+                is Float -> assertThat(jsonObject).hasField(it.key, keyValue)
+                is BigInteger -> assertThat(jsonObject).hasField(it.key, keyValue)
+            }
+        }
         return this
     }
 


### PR DESCRIPTION
### What does this PR do?

We will extract the DataOkHttpUploader abstract class and provide 2 implementations:
* LogsOkHttpUploader (sending logs to the logs endpoint)
* TracesOkHttpUploader (sending traces to the traces endpoint)

### Additional Notes

Instrumentations tests are provided as the final commit of this PR where we are actually asserting that the spans are properly sent to the mock server once they are closed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

