### PR TITLE
RUMM-196 Let Crash logs use the EMERGENCY status

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.error.internal
 
 import android.content.Context
-import android.util.Log as AndroidLog
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
@@ -60,7 +59,7 @@ internal class DatadogExceptionHandler(
     private fun createLog(thread: Thread, throwable: Throwable): Log {
         return Log(
             serviceName = Logger.DEFAULT_SERVICE_NAME,
-            level = AndroidLog.ERROR,
+            level = Log.CRASH,
             loggerName = LOGGER_NAME,
             message = MESSAGE,
             threadName = thread.name,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/Log.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/Log.kt
@@ -24,4 +24,9 @@ internal data class Log(
     val userInfo: UserInfo,
     val loggerName: String,
     val threadName: String
-)
+) {
+
+    companion object {
+        internal const val CRASH: Int = 9
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.log.internal.domain
 
+import android.util.Log as AndroidLog
 import com.datadog.android.BuildConfig
 import com.datadog.android.Datadog
 import com.datadog.android.core.internal.domain.Serializer
@@ -204,12 +205,13 @@ internal class LogSerializer(private val logConstraints: LogConstraints = Datado
 
         internal fun resolveLogLevelStatus(level: Int): String {
             return when (level) {
-                android.util.Log.ASSERT -> "CRITICAL"
-                android.util.Log.ERROR -> "ERROR"
-                android.util.Log.WARN -> "WARN"
-                android.util.Log.INFO -> "INFO"
-                android.util.Log.DEBUG -> "DEBUG"
-                android.util.Log.VERBOSE -> "TRACE"
+                AndroidLog.ASSERT -> "CRITICAL"
+                AndroidLog.ERROR -> "ERROR"
+                AndroidLog.WARN -> "WARN"
+                AndroidLog.INFO -> "INFO"
+                AndroidLog.DEBUG -> "DEBUG"
+                AndroidLog.VERBOSE -> "TRACE"
+                Log.CRASH -> "EMERGENCY"
                 else -> "DEBUG"
             }
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/domain/LogSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/domain/LogSerializerTest.kt
@@ -261,7 +261,8 @@ internal class LogSerializerTest {
 
     companion object {
         internal val levels = arrayOf(
-            "DEBUG", "DEBUG", "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"
+            "DEBUG", "DEBUG", "TRACE", "DEBUG", "INFO", "WARN",
+            "ERROR", "CRITICAL", "DEBUG", "EMERGENCY"
         )
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.error.internal
 
 import android.app.Application
-import android.util.Log as AndroidLog
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.impl.WorkManagerImpl
@@ -125,7 +124,7 @@ internal class DatadogExceptionHandlerTest {
             assertThat(lastValue)
                 .hasThreadName(currentThread.name)
                 .hasMessage("Application crash detected")
-                .hasLevel(AndroidLog.ERROR)
+                .hasLevel(Log.CRASH)
                 .hasThrowable(fakeThrowable)
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
@@ -162,7 +161,7 @@ internal class DatadogExceptionHandlerTest {
             assertThat(lastValue)
                 .hasThreadName(currentThread.name)
                 .hasMessage("Application crash detected")
-                .hasLevel(AndroidLog.ERROR)
+                .hasLevel(Log.CRASH)
                 .hasThrowable(fakeThrowable)
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
@@ -188,7 +187,7 @@ internal class DatadogExceptionHandlerTest {
             assertThat(lastValue)
                 .hasThreadName(threadName)
                 .hasMessage("Application crash detected")
-                .hasLevel(AndroidLog.ERROR)
+                .hasLevel(Log.CRASH)
                 .hasThrowable(fakeThrowable)
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/file/LogFileStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/file/LogFileStrategyTest.kt
@@ -240,7 +240,8 @@ internal class LogFileStrategyTest :
         private const val RECENT_DELAY_MS = 150L
         private const val MAX_DISK_SPACE = 16 * 32 * 1024L
         private val levels = arrayOf(
-            "DEBUG", "DEBUG", "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"
+            "DEBUG", "DEBUG", "TRACE", "DEBUG", "INFO", "WARN",
+            "ERROR", "CRITICAL", "DEBUG", "EMERGENCY"
         )
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/LogForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/LogForgeryFactory.kt
@@ -23,7 +23,8 @@ internal class LogForgeryFactory : ForgeryFactory<Log> {
                 0, 1,
                 AndroidLog.VERBOSE, AndroidLog.DEBUG,
                 AndroidLog.INFO, AndroidLog.WARN,
-                AndroidLog.ERROR, AndroidLog.ASSERT
+                AndroidLog.ERROR, AndroidLog.ASSERT,
+                Log.CRASH
             ),
             message = forge.anAlphabeticalString(),
             timestamp = forge.aLong(),


### PR DESCRIPTION
### What does this PR do?

Let Crash logs use the `EMERGENCY` status

### Motivation

Because users can log `ERROR` message themselves, we need a way for crash to appear out of the list of non fatal error logs. 

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

