### PR TITLE
RUMM-165 Prevent crashing the app when the SDK is not Initialized

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -240,11 +240,11 @@ object Datadog {
 
     @Suppress("CheckInternal")
     private fun checkInitialized() {
-        check(initialized) {
-            "Datadog has not been initialized.\n" +
-                "Please add the following code in your application's onCreate() method:\n" +
-                "Datadog.initialize(context, \"<CLIENT_TOKEN>\");"
-        }
+        check(initialized) { MESSAGE_NOT_INITIALIZED }
+    }
+
+    internal fun isInitialized(): Boolean {
+        return initialized
     }
 
     private fun initNetworkInfoProvider(context: Context) {
@@ -329,6 +329,10 @@ object Datadog {
             appContext.registerActivityLifecycleCallbacks(ProcessLifecycleMonitor(callback))
         }
     }
+
+    internal const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized.\n" +
+        "Please add the following code in your application's onCreate() method:\n" +
+        "Datadog.initialize(context, \"<CLIENT_TOKEN>\");"
 
     // endregion
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
@@ -13,6 +13,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.core.internal.domain.Batch
 import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.UploadStatus
+import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.sdkLogger
 
 internal class UploadWorker(
@@ -23,6 +24,11 @@ internal class UploadWorker(
     // region Worker
 
     override fun doWork(): Result {
+        if (!Datadog.isInitialized()) {
+            devLogger.e(Datadog.MESSAGE_NOT_INITIALIZED)
+            return Result.success()
+        }
+
         val reader = Datadog.getLogStrategy().getReader()
         val uploader = Datadog.getLogUploader()
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -7,14 +7,16 @@
 package com.datadog.android.log
 
 import android.content.Context
+import android.util.Log as AndroidLog
 import com.datadog.android.Datadog
-import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.log.internal.logger.CombinedLogHandler
 import com.datadog.android.log.internal.logger.DatadogLogHandler
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.log.internal.logger.LogcatLogHandler
 import com.datadog.android.log.internal.logger.NoOpLogHandler
 import com.datadog.android.utils.mockContext
+import com.datadog.tools.unit.annotations.SystemOutStream
+import com.datadog.tools.unit.extensions.SystemOutputExtension
 import com.datadog.tools.unit.getFieldValue
 import com.datadog.tools.unit.invokeMethod
 import com.nhaarman.mockitokotlin2.doReturn
@@ -22,6 +24,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.io.ByteArrayOutputStream
 import java.io.File
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
@@ -30,19 +33,16 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.api.io.TempDir
-import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class)
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(SystemOutputExtension::class)
 )
 @MockitoSettings()
 internal class LoggerBuilderTest {
-
-    @Mock
-    lateinit var mockNetworkInfoProvider: NetworkInfoProvider
 
     lateinit var mockContext: Context
 
@@ -58,11 +58,35 @@ internal class LoggerBuilderTest {
         whenever(mockContext.filesDir) doReturn rootDir
 
         Datadog.initialize(mockContext, forge.anHexadecimalString())
+        Datadog.setVerbosity(AndroidLog.VERBOSE)
     }
 
     @AfterEach
     fun `tear down Datadog`() {
-        Datadog.invokeMethod("stop")
+        try {
+            Datadog.invokeMethod("stop")
+        } catch (e: IllegalStateException) {
+            // ignore
+        }
+    }
+
+    @Test
+    fun `builder returns no op if SDK is not initialized`(
+        @SystemOutStream outputStream: ByteArrayOutputStream
+    ) {
+        Datadog.invokeMethod("stop") // simulate non initialized SDK
+        val logger = Logger.Builder()
+            .build()
+
+        val handler: LogHandler = logger.getFieldValue("handler")
+
+        assertThat(handler).isSameAs(NoOpLogHandler)
+        assertThat(outputStream.toString())
+            .isEqualTo(
+                "E/Datadog: Datadog has not been initialized.\n" +
+                    "Please add the following code in your application's onCreate() method:\n" +
+                    "Datadog.initialize(context, \"<CLIENT_TOKEN>\");\n"
+            )
     }
 
     @Test


### PR DESCRIPTION

### What does this PR do?

Allow users to create Logger even if the SDK is not initialized. An error message will be logged if such a case occur. 

### Motivation

Avoid needless crashes on users' mistakes.

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

