### PR TITLE
RUMM-134 Fix typos and remove unused constant

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -323,7 +323,7 @@ internal constructor(private val handler: LogHandler) {
 
     /**
      * Remove a custom attribute from all future logs sent by this logger.
-     * Previous log won't lose the attribute value associated with this key if they were created
+     * Previous logs won't lose the attribute value associated with this key if they were created
      * prior to this call.
      * @param key the key of the attribute to remove
      */
@@ -333,14 +333,13 @@ internal constructor(private val handler: LogHandler) {
 
     /**
      * Add a tag to all future logs sent by this logger.
-     * The tag will take the form "key:value"
+     * The tag will take the form "key:value".
      *
      * Tags must start with a letter and after that may contain the following characters:
-     * Alphanumerics, Underscores, Minuses, Colons, Periods,Slashes. Other special characters
+     * Alphanumerics, Underscores, Minuses, Colons, Periods, Slashes. Other special characters
      * are converted to underscores.
      * Tags must be lowercase, and can be at most 200 characters. If the tag you provide is
      * longer, only the first 200 characters will be used.
-     *
      *
      * @param key the key for this tag
      * @param value the (non null) value of this tag
@@ -354,7 +353,7 @@ internal constructor(private val handler: LogHandler) {
      * Add a tag to all future logs sent by this logger.
      *
      * Tags must start with a letter and after that may contain the following characters:
-     * Alphanumerics, Underscores, Minuses, Colons, Periods,Slashes. Other special characters
+     * Alphanumerics, Underscores, Minuses, Colons, Periods, Slashes. Other special characters
      * are converted to underscores.
      * Tags must be lowercase, and can be at most 200 characters. If the tag you provide is
      * longer, only the first 200 characters will be used.
@@ -368,7 +367,7 @@ internal constructor(private val handler: LogHandler) {
 
     /**
      * Remove a tag from all future logs sent by this logger.
-     * Previous log won't lose the this tag if they were created prior to this call.
+     * Previous logs won't lose the this tag if they were created prior to this call.
      * @param tag the tag to remove
      */
     fun removeTag(tag: String) {
@@ -377,7 +376,7 @@ internal constructor(private val handler: LogHandler) {
 
     /**
      * Remove all tags with the given key from all future logs sent by this logger.
-     * Previous log won't lose the this tag if they were created prior to this call.
+     * Previous logs won't lose the this tag if they were created prior to this call.
      * @param key the key of the tags to remove
      */
     fun removeTagsWithKey(key: String) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/constraints/DatadogLogConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/constraints/DatadogLogConstraints.kt
@@ -125,7 +125,6 @@ internal class DatadogLogConstraints : LogConstraints {
         private const val MAX_TAG_LENGTH = 200
         private const val MAX_TAG_COUNT = 100
 
-        private const val MAX_ATTR_KEY_LENGTH = 50
         private const val MAX_ATTR_COUNT = 256
 
         private val reservedTagKeys = setOf(


### PR DESCRIPTION
### What does this PR do?

Fixes few typos I spotted while working on `RUMM-134`.

### Additional Notes

💡 I also noticed that `date` is not a reserved attribute in Android SDK. Is this correct @mariusc83 @xgouchet ? Means, users can now overwrite it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

