### PR TITLE
RUMM-183 Correct traces timestamp

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -144,13 +144,12 @@ object Datadog {
 
         initNetworkInfoProvider(appContext)
 
-        logStrategy =
-            LogFileStrategy(appContext)
-
-        tracingStrategy = TracingFileStrategy(appContext)
-
         // prepare time management
         timeProvider = DatadogTimeProvider(appContext)
+
+        logStrategy = LogFileStrategy(appContext)
+
+        tracingStrategy = TracingFileStrategy(appContext, timeProvider)
 
         // Prepare user info management
         userInfoProvider = DatadogUserInfoProvider()
@@ -208,13 +207,13 @@ object Datadog {
                 tracingStrategy.getReader().dropAllBatches()
                 devLogger.w(
                     "$TAG: old traces targeted at $endpointUrl " +
-                            "will now be deleted"
+                        "will now be deleted"
                 )
             }
             EndpointUpdateStrategy.SEND_OLD_DATA_TO_NEW_ENDPOINT -> {
                 devLogger.w(
                     "$TAG: old traces targeted at $endpointUrl " +
-                            "will now be sent to $endpointUrl"
+                        "will now be sent to $endpointUrl"
                 )
             }
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/DatadogTimeProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/DatadogTimeProvider.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.time
 import android.content.Context
 import android.content.SharedPreferences
 import java.lang.ref.WeakReference
+import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 
 @Suppress("DEPRECATION")
@@ -66,6 +67,10 @@ internal class DatadogTimeProvider(
 
     override fun getServerTimestamp(): Long {
         return System.currentTimeMillis() + serverOffset
+    }
+
+    override fun getServerOffsetNanos(): Long {
+        return TimeUnit.MILLISECONDS.toNanos(serverOffset)
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/TimeProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/TimeProvider.kt
@@ -11,4 +11,6 @@ internal interface TimeProvider {
     fun getDeviceTimestamp(): Long
 
     fun getServerTimestamp(): Long
+
+    fun getServerOffsetNanos(): Long
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -1,24 +1,26 @@
 package com.datadog.android.tracing.internal.domain
 
 import com.datadog.android.core.internal.domain.Serializer
+import com.datadog.android.core.internal.time.TimeProvider
 import com.google.gson.JsonObject
 import datadog.opentracing.DDSpan
-import java.lang.Long
 
-internal class SpanSerializer : Serializer<DDSpan> {
+internal class SpanSerializer(
+    private val timeProvider: TimeProvider
+) : Serializer<DDSpan> {
 
     override fun serialize(model: DDSpan): String {
+        val serverOffset = timeProvider.getServerOffsetNanos()
         val jsonObject = JsonObject()
-        // it is save to convert to Long here from BigInteger...they are actually parsing this as
-        // Long also on server side.
-        jsonObject.addProperty(TRACE_ID_KEY, Long.toHexString(model.traceId.toLong()))
-        jsonObject.addProperty(SPAN_ID_KEY, Long.toHexString(model.spanId.toLong()))
-        jsonObject.addProperty(PARENT_ID_KEY, Long.toHexString(model.parentId.toLong()))
+        // it is safe to convert BigInteger IDs to Long as they are parsed as Long on the backend
+        jsonObject.addProperty(TRACE_ID_KEY, model.traceId.toLong().toString(16))
+        jsonObject.addProperty(SPAN_ID_KEY, model.spanId.toLong().toString(16))
+        jsonObject.addProperty(PARENT_ID_KEY, model.parentId.toLong().toString(16))
         jsonObject.addProperty(RESOURCE_KEY, model.resourceName)
         jsonObject.addProperty(OPERATION_NAME_KEY, model.operationName)
         jsonObject.addProperty(SERVICE_NAME_KEY, model.serviceName)
         jsonObject.addProperty(DURATION_KEY, model.durationNano)
-        jsonObject.addProperty(START_TIMESTAMP_KEY, model.startTime)
+        jsonObject.addProperty(START_TIMESTAMP_KEY, model.startTime + serverOffset)
         jsonObject.addProperty(TYPE_KEY, "object") // do not know yet what should be here
         addMeta(jsonObject, model)
         addMetrics(jsonObject, model)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategy.kt
@@ -2,11 +2,13 @@ package com.datadog.android.tracing.internal.domain
 
 import android.content.Context
 import com.datadog.android.core.internal.domain.FilePersistenceStrategy
+import com.datadog.android.core.internal.time.TimeProvider
 import datadog.opentracing.DDSpan
 import java.io.File
 
 internal class TracingFileStrategy(
     context: Context,
+    timeProvider: TimeProvider,
     recentDelayMs: Long = MAX_DELAY_BETWEEN_LOGS_MS,
     maxBatchSize: Long = MAX_BATCH_SIZE,
     maxLogPerBatch: Int = MAX_ITEMS_PER_BATCH,
@@ -17,7 +19,7 @@ internal class TracingFileStrategy(
         context.filesDir,
         TRACES_FOLDER
     ),
-    SpanSerializer(),
+    SpanSerializer(timeProvider),
     WRITER_THREAD_NAME,
     recentDelayMs,
     maxBatchSize,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/time/DatadogTimeProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/time/DatadogTimeProviderTest.kt
@@ -21,6 +21,7 @@ import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.concurrent.TimeUnit
 import kotlin.math.abs
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
@@ -103,10 +104,13 @@ internal class DatadogTimeProviderTest {
 
         val start = System.currentTimeMillis()
         val timestamp = testedProvider.getServerTimestamp()
+        val offsetNanos = testedProvider.getServerOffsetNanos()
         val end = System.currentTimeMillis()
 
         assertThat(timestamp)
             .isBetween(start + offset, end + offset)
+        assertThat(offsetNanos)
+            .isEqualTo(TimeUnit.MILLISECONDS.toNanos(offset))
     }
 
     @Test
@@ -126,12 +130,18 @@ internal class DatadogTimeProviderTest {
         val start = System.currentTimeMillis()
 
         val timestamp = testedProvider.getServerTimestamp()
+        val offsetNanos = testedProvider.getServerOffsetNanos()
         val end = System.currentTimeMillis()
 
         assertThat(timestamp)
             .isBetween(
                 start + averageOffset - deviation,
                 end + averageOffset + deviation
+            )
+        assertThat(offsetNanos)
+            .isBetween(
+                TimeUnit.MILLISECONDS.toNanos(averageOffset - deviation),
+                TimeUnit.MILLISECONDS.toNanos(averageOffset + deviation)
             )
     }
 
@@ -204,10 +214,13 @@ internal class DatadogTimeProviderTest {
 
         val start = System.currentTimeMillis()
         val timestamp = newProvider.getServerTimestamp()
+        val offsetNanos = newProvider.getServerOffsetNanos()
         val end = System.currentTimeMillis()
 
         assertThat(timestamp)
             .isBetween(start + offset, end + offset)
+        assertThat(offsetNanos)
+            .isEqualTo(TimeUnit.MILLISECONDS.toNanos(offset))
     }
 
     companion object {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializerTest.kt
@@ -1,17 +1,22 @@
 package com.datadog.android.tracing.internal.domain
 
-import com.datadog.android.utils.extension.assertMatches
+import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.utils.extension.toHexString
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.assertj.JsonObjectAssert.Companion.assertThat
 import com.google.gson.JsonParser
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.whenever
 import datadog.opentracing.DDSpan
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import org.assertj.core.api.Java6Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
@@ -25,26 +30,44 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(Configurator::class)
 internal class SpanSerializerTest {
 
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
     lateinit var underTest: SpanSerializer
 
     @BeforeEach
     fun `set up`() {
-        underTest = SpanSerializer()
+        underTest = SpanSerializer(mockTimeProvider)
     }
 
     @Test
-    fun `it will serialize a span to it Json string representation`(@Forgery span: DDSpan) {
-        // when
+    fun `serializes a span to a Json string representation`(
+        @Forgery span: DDSpan,
+        @LongForgery serverOffsetNanos: Long
+    ) {
+        // given
+        whenever(mockTimeProvider.getServerOffsetNanos()) doReturn serverOffsetNanos
         val serialized = underTest.serialize(span)
 
-        // then
+        // when
         val jsonObject = JsonParser.parseString(serialized).asJsonObject
-        jsonObject.assertMatches(span)
-        // check special metrics
-        val metricsObject = jsonObject.get(SpanSerializer.METRICS_KEY).asJsonObject
-        assertThat(metricsObject.getAsJsonPrimitive(SpanSerializer.METRICS_KEY_TOP_LEVEL).asInt)
-            .isEqualTo(1)
-        assertThat(metricsObject.getAsJsonPrimitive(SpanSerializer.METRICS_KEY_SAMPLING).asInt)
-            .isEqualTo(1)
+
+        // then
+        assertThat(jsonObject)
+            .hasField(SpanSerializer.START_TIMESTAMP_KEY, span.startTime + serverOffsetNanos)
+            .hasField(SpanSerializer.DURATION_KEY, span.durationNano)
+            .hasField(SpanSerializer.SERVICE_NAME_KEY, span.serviceName)
+            .hasField(SpanSerializer.TRACE_ID_KEY, span.traceId.toHexString())
+            .hasField(SpanSerializer.SPAN_ID_KEY, span.spanId.toHexString())
+            .hasField(SpanSerializer.PARENT_ID_KEY, span.parentId.toHexString())
+            .hasField(SpanSerializer.RESOURCE_KEY, span.resourceName)
+            .hasField(SpanSerializer.OPERATION_NAME_KEY, span.operationName)
+            .hasField(SpanSerializer.META_KEY, span.meta)
+            .hasField(SpanSerializer.METRICS_KEY, span.metrics)
+            .hasField(SpanSerializer.METRICS_KEY) {
+                // additional "magic" metrics key
+                hasField(SpanSerializer.METRICS_KEY_TOP_LEVEL, 1)
+                hasField(SpanSerializer.METRICS_KEY_SAMPLING, 1)
+            }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategyTest.kt
@@ -12,18 +12,22 @@ import com.datadog.android.core.internal.data.file.DeferredWriter
 import com.datadog.android.core.internal.domain.FilePersistenceStrategyTest
 import com.datadog.android.core.internal.domain.PersistenceStrategy
 import com.datadog.android.core.internal.threading.LazyHandlerThread
+import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.utils.copy
-import com.datadog.android.utils.extension.assertMatches
+import com.datadog.android.utils.extension.getString
+import com.datadog.android.utils.extension.hexToBigInteger
+import com.datadog.android.utils.extension.toHexString
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.SpanForgeryFactory
+import com.datadog.tools.unit.assertj.JsonObjectAssert.Companion.assertThat
 import com.datadog.tools.unit.invokeMethod
 import com.google.gson.JsonObject
-import com.google.gson.JsonPrimitive
 import datadog.opentracing.DDSpan
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import java.io.File
 import org.assertj.core.api.Assertions.assertThat
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
 
@@ -35,11 +39,15 @@ internal class TracingFileStrategyTest :
         modelClass = DDSpan::class.java
     ) {
 
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
     // region LogStrategyTest
 
     override fun getStrategy(): PersistenceStrategy<DDSpan> {
         return TracingFileStrategy(
             context = mockContext,
+            timeProvider = mockTimeProvider,
             recentDelayMs = RECENT_DELAY_MS,
             maxBatchSize = MAX_BATCH_SIZE,
             maxLogPerBatch = MAX_MESSAGES_PER_BATCH,
@@ -110,28 +118,35 @@ internal class TracingFileStrategyTest :
     }
 
     override fun assertHasMatches(jsonObject: JsonObject, models: List<DDSpan>) {
-        val serviceName = (jsonObject[SpanSerializer.SERVICE_NAME_KEY] as JsonPrimitive).asString
-        val spanIdHexa = (jsonObject[SpanSerializer.SPAN_ID_KEY] as JsonPrimitive).asString
-        val traceIdHexa = (jsonObject[SpanSerializer.TRACE_ID_KEY] as JsonPrimitive).asString
-        val parentIdHexa = (jsonObject[SpanSerializer.PARENT_ID_KEY] as JsonPrimitive).asString
-        val resourceName = (jsonObject[SpanSerializer.RESOURCE_KEY] as JsonPrimitive).asString
-        val traceId = java.lang.Long.parseLong(traceIdHexa, 16)
-        val spanId = java.lang.Long.parseLong(spanIdHexa, 16)
-        val parentId = java.lang.Long.parseLong(parentIdHexa, 16)
+        val serviceName = jsonObject.getString(SpanSerializer.SERVICE_NAME_KEY)
+        val resourceName = jsonObject.getString(SpanSerializer.RESOURCE_KEY)
+        val traceId = jsonObject.getString(SpanSerializer.TRACE_ID_KEY).hexToBigInteger()
+        val spanId = jsonObject.getString(SpanSerializer.SPAN_ID_KEY).hexToBigInteger()
+        val parentId = jsonObject.getString(SpanSerializer.PARENT_ID_KEY).hexToBigInteger()
 
         val roughMatches = models.filter {
             serviceName == it.serviceName &&
-                    traceId == it.traceId.toLong() &&
-                    parentId == it.parentId.toLong() &&
-                    spanId == it.spanId.toLong() &&
-                    resourceName == it.resourceName
+                traceId == it.traceId &&
+                parentId == it.parentId &&
+                spanId == it.spanId &&
+                resourceName == it.resourceName
         }
 
         assertThat(roughMatches).isNotEmpty()
     }
 
     override fun assertMatches(jsonObject: JsonObject, model: DDSpan) {
-        jsonObject.assertMatches(model)
+        assertThat(jsonObject)
+            .hasField(SpanSerializer.START_TIMESTAMP_KEY, model.startTime)
+            .hasField(SpanSerializer.DURATION_KEY, model.durationNano)
+            .hasField(SpanSerializer.SERVICE_NAME_KEY, model.serviceName)
+            .hasField(SpanSerializer.TRACE_ID_KEY, model.traceId.toHexString())
+            .hasField(SpanSerializer.SPAN_ID_KEY, model.spanId.toHexString())
+            .hasField(SpanSerializer.PARENT_ID_KEY, model.parentId.toHexString())
+            .hasField(SpanSerializer.RESOURCE_KEY, model.resourceName)
+            .hasField(SpanSerializer.OPERATION_NAME_KEY, model.operationName)
+            .hasField(SpanSerializer.META_KEY, model.meta)
+            .hasField(SpanSerializer.METRICS_KEY, model.metrics)
     }
 
     // endregion
@@ -139,5 +154,7 @@ internal class TracingFileStrategyTest :
     companion object {
         private const val RECENT_DELAY_MS = 150L
         private const val MAX_DISK_SPACE = 16 * 32 * 1024L
+
+        private const val HEX_RAD = 16
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/BigIntegetExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/BigIntegetExt.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-2020 Datadog, Inc.
+ */
+
+package com.datadog.android.utils.extension
+
+import java.math.BigInteger
+
+fun BigInteger.toHexString(): String {
+    return toLong().toString(16)
+}
+
+fun String.hexToBigInteger(): BigInteger {
+    return toLong(16).toBigInteger()
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/JsonObjectExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/JsonObjectExt.kt
@@ -1,21 +1,7 @@
 package com.datadog.android.utils.extension
 
-import com.datadog.android.tracing.internal.domain.SpanSerializer
-import com.datadog.tools.unit.assertj.JsonObjectAssert
 import com.google.gson.JsonObject
-import datadog.opentracing.DDSpan
-import java.lang.Long
 
-fun JsonObject.assertMatches(span: DDSpan) {
-    JsonObjectAssert.assertThat(this)
-        .hasField(SpanSerializer.START_TIMESTAMP_KEY, span.startTime)
-        .hasField(SpanSerializer.DURATION_KEY, span.durationNano)
-        .hasField(SpanSerializer.SERVICE_NAME_KEY, span.serviceName)
-        .hasField(SpanSerializer.TRACE_ID_KEY, Long.toHexString((span.traceId.toLong())))
-        .hasField(SpanSerializer.SPAN_ID_KEY, Long.toHexString((span.spanId.toLong())))
-        .hasField(SpanSerializer.PARENT_ID_KEY, Long.toHexString((span.parentId.toLong())))
-        .hasField(SpanSerializer.RESOURCE_KEY, span.resourceName)
-        .hasField(SpanSerializer.OPERATION_NAME_KEY, span.operationName)
-        .hasField(SpanSerializer.META_KEY, span.meta)
-        .hasField(SpanSerializer.METRICS_KEY, span.metrics)
+fun JsonObject.getString(key: String): String {
+    return get(key).asString
 }


### PR DESCRIPTION
### What does this PR do?

Correct the timestamp used in Spans for local device time offset. 

### Motivation

Some device which don't use NTP to sync the device Time and Date with the network can report bogus timestamps, That will result in weird or inconsistent data. This is an attempt to prevent that.

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

