### PR TITLE
RUMM-208 Add top level metrics only for root span

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -44,7 +44,9 @@ internal class SpanSerializer(
         // we need this for sampling priority
         metricsObject.addProperty(METRICS_KEY_SAMPLING, 1)
         // same magic thing for sampling
-        metricsObject.addProperty(METRICS_KEY_TOP_LEVEL, 1)
+        if (model.parentId.toLong() == 0L) {
+            metricsObject.addProperty(METRICS_KEY_TOP_LEVEL, 1)
+        }
         jsonObject.add(METRICS_KEY, metricsObject)
     }
 


### PR DESCRIPTION
### What does this PR do?

We should only add the top level metrics for the root span in the trace. This will fix the way the traces are displayed on the dashboard by showing only the top level span that can be expanded on user action.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

