### PR TITLE
RUMM-207 Tracer - Add a configurable partial flush threshold

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -61,4 +61,5 @@ class com.datadog.android.tracing.Tracer : datadog.opentracing.DDTracer
   class Builder
     fun build(): Tracer
     fun setServiceName(String): Builder
+    fun setPartialFlushThreshold(Int): Builder
     companion object


### PR DESCRIPTION
### What does this PR do?

By default the **dd-trace-ot** SDK delivers the closed spans to the writer every time a trace is complete (the root span was closed) or whenever the threshold for partial flushing is reached which is by default 100 closed spans. To avoid too much memory consumption we lowered that default threshold to 5 and made that option configurable from the **Tracer.Builder**.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

