### PR TITLE
RUMM-209 Add user agent into traces intake request

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.core.internal.net
 
+import android.os.Build
+import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.utils.sdkLogger
 import java.io.IOException
 import okhttp3.OkHttpClient
@@ -46,8 +48,21 @@ internal abstract class DataOkHttpUploader(
 
     // region Internal
 
-    open fun headers(): MutableMap<String, String> {
-        return mutableMapOf(HEADER_CT to CONTENT_TYPE)
+    private fun headers(): MutableMap<String, String> {
+        return mutableMapOf(
+            HEADER_UA to userAgent,
+            HEADER_CT to CONTENT_TYPE
+        )
+    }
+
+    private val userAgent = System.getProperty(SYSTEM_UA).let {
+        if (it.isNullOrBlank()) {
+            "Datadog/${BuildConfig.VERSION_NAME} " +
+                    "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
+                    "${Build.MODEL} Build/${Build.ID})"
+        } else {
+            it
+        }
     }
 
     private fun buildRequest(data: ByteArray): Request {
@@ -76,6 +91,8 @@ internal abstract class DataOkHttpUploader(
     companion object {
         private const val HEADER_CT = "Content-Type"
         private const val CONTENT_TYPE = "application/json"
+        private const val HEADER_UA = "User-Agent"
+        const val SYSTEM_UA = "http.agent"
         private const val TAG = "DataOkHttpUploader"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
@@ -1,7 +1,5 @@
 package com.datadog.android.log.internal.net
 
-import android.os.Build
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.DataOkHttpUploader
 import java.util.Locale
 import okhttp3.OkHttpClient
@@ -14,35 +12,13 @@ internal open class LogsOkHttpUploader(
 
     // region DataOkHttpUploader
 
-    override fun headers(): MutableMap<String, String> {
-        val headers = super.headers()
-        headers[HEADER_UA] = userAgent
-        return headers
-    }
-
     override fun setEndpoint(endpoint: String) {
         super.setEndpoint(buildUrl(endpoint, token))
     }
 
     // endregion
 
-    // region Internal
-
-    private val userAgent = System.getProperty(SYSTEM_UA).let {
-        if (it.isNullOrBlank()) {
-            "Datadog/${BuildConfig.VERSION_NAME} " +
-                "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
-                "${Build.MODEL} Build/${Build.ID})"
-        } else {
-            it
-        }
-    }
-
-    // endregion
-
     companion object {
-        private const val HEADER_UA = "User-Agent"
-        const val SYSTEM_UA = "http.agent"
         private const val QP_SOURCE = "ddsource"
         private const val DD_SOURCE_MOBILE = "mobile"
         internal const val UPLOAD_URL =

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploader.kt
@@ -21,7 +21,6 @@ internal open class TracesOkHttpUploader(
     companion object {
         internal const val UPLOAD_URL = "%s/v1/input/%s"
         internal const val TAG = "TracesOkHttpUploader"
-
         private fun buildUrl(endpoint: String, token: String): String {
             return String.format(
                 Locale.US,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
@@ -387,9 +387,18 @@ internal abstract class DataOkHttpUploaderTest<T : DataOkHttpUploader> {
             .isEqualTo(data)
     }
 
-    open fun assertHeaders(request: RecordedRequest) {
+    fun assertHeaders(request: RecordedRequest) {
         assertThat(request.getHeader("Content-Type"))
             .isEqualTo("application/json")
+        val expectedUserAgent = if (fakeUserAgent.isBlank()) {
+            "Datadog/${BuildConfig.VERSION_NAME} " +
+                    "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
+                    "${Build.MODEL} Build/${Build.ID})"
+        } else {
+            fakeUserAgent
+        }
+        assertThat(request.getHeader("User-Agent"))
+            .isEqualTo(expectedUserAgent)
     }
 
     private fun mockResponse(code: Int): MockResponse {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
@@ -1,13 +1,9 @@
 package com.datadog.android.log.net
 
-import android.os.Build
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.DataOkHttpUploaderTest
 import com.datadog.android.log.internal.net.LogsOkHttpUploader
 import java.util.concurrent.TimeUnit
 import okhttp3.OkHttpClient
-import okhttp3.mockwebserver.RecordedRequest
-import org.assertj.core.api.Assertions.assertThat
 
 internal class LogsOkHttpUploaderTest : DataOkHttpUploaderTest<LogsOkHttpUploader>() {
 
@@ -21,19 +17,6 @@ internal class LogsOkHttpUploaderTest : DataOkHttpUploaderTest<LogsOkHttpUploade
                 .writeTimeout(TIMEOUT_TEST_MS, TimeUnit.MILLISECONDS)
                 .build()
         )
-    }
-
-    override fun assertHeaders(request: RecordedRequest) {
-        super.assertHeaders(request)
-        val expectedUserAgent = if (fakeUserAgent.isBlank()) {
-            "Datadog/${BuildConfig.VERSION_NAME} " +
-                    "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
-                    "${Build.MODEL} Build/${Build.ID})"
-        } else {
-            fakeUserAgent
-        }
-        assertThat(request.getHeader("User-Agent"))
-            .isEqualTo(expectedUserAgent)
     }
 
     override fun urlFormat(): String {

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -89,7 +89,7 @@ android {
 dependencies {
 
     api(project(":dd-sdk-android")) {
-        exclude("com.google.guava")
+        exclude("com.google.guava", module = "listenablefuture")
     }
 
     // Android dependencies


### PR DESCRIPTION
### What does this PR do?

When I first tried to use the Tracing intake there were some weird errors reported by the **logs-processing** service related with the user agent parsing. To make sure these are not the cause for which our traces were dropped I remove the user agent from header for this endpoint. Now when everything is stable I added it back and everything seems to work as expected so probably the assumption I made that the user agent format was not supported was wrong.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

