### PR TITLE
RUMM-184 Give the Writer the capability to handle a list of models

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/Writer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/Writer.kt
@@ -13,4 +13,6 @@ package com.datadog.android.core.internal.data
 internal interface Writer<T : Any> {
 
     fun write(model: T)
+
+    fun write(models: List<T>)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/DeferredWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/DeferredWriter.kt
@@ -32,5 +32,11 @@ internal class DeferredWriter<T : Any>(
         })
     }
 
+    override fun write(models: List<T>) {
+        post(Runnable {
+            writer.write(models)
+        })
+    }
+
     // endregion
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriter.kt
@@ -24,6 +24,20 @@ internal class ImmediateFileWriter<T : Any>(
     // region Writer
 
     override fun write(model: T) {
+        consume(model)
+    }
+
+    override fun write(models: List<T>) {
+        models.forEach {
+            consume(it)
+        }
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun consume(model: T) {
         val data = serializer.serialize(model)
 
         if (data.length >= MAX_ITEM_SIZE) {
@@ -34,10 +48,6 @@ internal class ImmediateFileWriter<T : Any>(
             }
         }
     }
-
-    // endregion
-
-    // region Internal
 
     private fun writeData(data: String) {
         var file: File? = null

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/NoOpPersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/NoOpPersistenceStrategy.kt
@@ -17,6 +17,10 @@ internal class NoOpPersistenceStrategy<T : Any> :
             override fun write(model: T) {
                 // No Op
             }
+
+            override fun write(models: List<T>) {
+                // No Op
+            }
         }
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/data/TraceWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/data/TraceWriter.kt
@@ -12,8 +12,7 @@ internal class TraceWriter(
     }
 
     override fun write(trace: MutableList<DDSpan>?) {
-        // TODO: RUM-184 Modify the Writer to accept also a list of models
-        trace?.forEach {
+        trace?.let {
             writer.write(it)
         }
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/DeferredWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/DeferredWriterTest.kt
@@ -99,7 +99,7 @@ internal class DeferredWriterTest {
 
     @Test
     @TestTargetApi(Build.VERSION_CODES.O)
-    fun `run delegate in deferred handler`(forge: Forge) {
+    fun `run delegate in deferred handler when writing a model`(forge: Forge) {
         val model = forge.anAlphabeticalString()
         var runnable = Runnable {}
         whenever(mockDeferredHandler.handle(any())) doAnswer {
@@ -112,5 +112,22 @@ internal class DeferredWriterTest {
 
         runnable.run()
         verify(mockDelegate).write(model)
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.O)
+    fun `run delegate in deferred handler when writing a models list`(forge: Forge) {
+        val models: List<String> = forge.aList(size = 10) { forge.anAlphabeticalString() }
+        var runnable = Runnable {}
+        whenever(mockDeferredHandler.handle(any())) doAnswer {
+            runnable = it.arguments[0] as Runnable
+            Unit
+        }
+
+        underTest.write(models)
+        verifyZeroInteractions(mockDelegate)
+
+        runnable.run()
+        verify(mockDelegate).write(models)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriterTest.kt
@@ -88,6 +88,20 @@ internal class ImmediateFileWriterTest {
 
     @Test
     @TestTargetApi(Build.VERSION_CODES.O)
+    fun `writes a collection of models`(forge: Forge) {
+        val models: List<String> = forge.aList { forge.anAlphabeticalString() }
+        val fileNameToWriteTo = forge.anAlphaNumericalString()
+        val file = File(rootDir, fileNameToWriteTo)
+        whenever(mockedOrchestrator.getWritableFile(any())).thenReturn(file)
+
+        underTest.write(models)
+
+        assertThat(file.readText().split(","))
+            .isEqualTo(models)
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.O)
     fun `writes several models`(forge: Forge) {
         val models = forge.aList { anAlphabeticalString() }
         val fileNameToWriteTo = forge.anAlphaNumericalString()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
@@ -110,7 +110,7 @@ internal class TracingInterceptorTest {
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
-        }.whenever(mockTracer.inject<TextMapInject>(any(), any(), any()))
+        }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
 
         val response = testedInterceptor.intercept(mockChain)
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/data/TraceWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/data/TraceWriterTest.kt
@@ -2,7 +2,6 @@ package com.datadog.android.tracing.internal.data
 
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.utils.forge.Configurator
-import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
@@ -10,7 +9,6 @@ import datadog.opentracing.DDSpan
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -51,9 +49,7 @@ internal class TraceWriterTest {
         underTest.write(spansList)
 
         // then
-        val argumentCaptor = argumentCaptor<DDSpan>()
-        verify(mockedFilesWriter, times(spansList.size)).write(argumentCaptor.capture())
-        assertThat(argumentCaptor.allValues).containsExactlyElementsOf(spansList)
+        verify(mockedFilesWriter).write(spansList)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

In this PR we are providing the support for handling a list of model to our current FileWriter. This feature was needed in order to optimize the code around the TraceWriter which was scheduling a Runnable in the DefferedWriter for each model (Span). Due to the newly added feature we are able to consume all the list in one Runnable.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

