### PR TITLE
RUMM-214 Correctly handle the trace sampling

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -56,9 +56,6 @@ internal class SpanSerializer(
         model.metrics.forEach {
             metricsObject.addProperty(it.key, it.value)
         }
-        // For now disable the sampling on server
-        metricsObject.addProperty(TAG_METRICS_SAMPLING_PRIORITY, 1)
-
         if (model.parentId.toLong() == 0L) {
             // mark this span as top level
             metricsObject.addProperty(TAG_METRICS_TOP_LEVEL, 1)
@@ -118,7 +115,6 @@ internal class SpanSerializer(
         const val TAG_META = "meta"
         const val TAG_METRICS = "metrics"
         const val TAG_METRICS_TOP_LEVEL = "_top_level"
-        const val TAG_METRICS_SAMPLING_PRIORITY = "_sampling_priority_v1"
 
         // GLOBAL TAGS
         internal const val TAG_VERSION_NAME = "logger.version"

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializerTest.kt
@@ -57,7 +57,6 @@ internal class SpanSerializerTest {
     fun `set up`() {
         whenever(mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
-
         underTest = SpanSerializer(mockTimeProvider, mockNetworkInfoProvider, mockUserInfoProvider)
     }
 
@@ -100,7 +99,7 @@ internal class SpanSerializerTest {
 
         // then
         assertThat(serializedParent).hasField(SpanSerializer.TAG_METRICS) {
-            hasField(SpanSerializer.TAG_METRICS_SAMPLING_PRIORITY, 1)
+            hasField(SpanSerializer.TAG_METRICS_TOP_LEVEL, 1)
         }
         assertThat(serializedChild).hasField(SpanSerializer.TAG_METRICS) {
             doesNotHaveField(SpanSerializer.TAG_METRICS_TOP_LEVEL)
@@ -137,7 +136,6 @@ internal class SpanSerializerTest {
                 if (span.parentId.toLong() == 0L) {
                     hasField(SpanSerializer.TAG_METRICS_TOP_LEVEL, 1)
                 }
-                hasField(SpanSerializer.TAG_METRICS_SAMPLING_PRIORITY, 1)
             }
     }
 


### PR DESCRIPTION
### What does this PR do?

Not knowing exactly the *dd-trace-ot* Sampling mechanism under the hood we were adding the **_sampling_priority_v1:1** key - value property in all the spans metrics. Right now we are correcting this by following the *dd-trace-ot* logic which adds this only to the "parent" span as default. Furthermore once the sampling mechanism on their end will be validated we don't have to do anything on our end as this property is correctly managed on their end and we will only serialize it on our end.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

