### PR TITLE
RUMM-240 Benchmark plugin - provide relative thresholds

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/benchmark/ReviewBenchmarkExtension.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/benchmark/ReviewBenchmarkExtension.kt
@@ -8,14 +8,20 @@ package com.datadog.gradle.plugin.benchmark
 
 open class ReviewBenchmarkExtension {
 
-    internal val thresholds = mutableMapOf<String, Long>()
-    internal val ignored = mutableSetOf<String>()
-
+    internal val benchmarkStrategies = mutableMapOf<String, BenchmarkStrategy>()
     fun addThreshold(name: String, threshold: Long) {
-        thresholds[name] = threshold
+        benchmarkStrategies[name] = BenchmarkStrategy.AbsoluteThreshold(name, threshold)
     }
 
     fun ignoreTest(name: String) {
-        ignored.add(name)
+        benchmarkStrategies[name] = BenchmarkStrategy.Ignore
+    }
+
+    fun relativeThreshold(betweenTest: String, andTest: String, shouldNotExceed: Long) {
+        benchmarkStrategies[betweenTest] =
+            BenchmarkStrategy.RelativeThreshold(betweenTest, andTest, shouldNotExceed)
+        // add an ignore strategy for the second in order to not be matched
+        // as a no - strategy benchmark
+        benchmarkStrategies[andTest] = BenchmarkStrategy.Ignore
     }
 }

--- a/instrumented/benchmark/build.gradle.kts
+++ b/instrumented/benchmark/build.gradle.kts
@@ -107,70 +107,59 @@ reviewBenchmark {
 
     // Logs Benchmarks
     addThreshold(
-        "benchmark_create_one_log",
-        TimeUnit.MICROSECONDS.toNanos(500)
+        "benchmark_create_one_log", 500
     )
     addThreshold(
-        "benchmark_create_one_log_with_throwable",
-        TimeUnit.MILLISECONDS.toNanos(1)
+        "benchmark_create_one_log_with_throwable", 1
     )
     addThreshold(
-        "benchmark_create_one_log_with_tags",
-        TimeUnit.MILLISECONDS.toNanos(1)
+        "benchmark_create_one_log_with_tags", 1
     )
     addThreshold(
-        "benchmark_create_one_log_with_attributes",
-        TimeUnit.MILLISECONDS.toNanos(1)
+        "benchmark_create_one_log_with_attributes", 1
     )
 
     // Traces Benchmarks
     addThreshold(
-        "benchmark_creating_span",
-        TimeUnit.MILLISECONDS.toNanos(1)
+        "benchmark_creating_span", 1
     )
     addThreshold(
-        "benchmark_creating_span_with_throwable",
-        TimeUnit.MILLISECONDS.toNanos(1)
+        "benchmark_creating_span_with_throwable", 1
     )
     addThreshold(
         "benchmark_creating_spans_with_baggage_items_and_logs",
-        TimeUnit.MILLISECONDS.toNanos(1)
+        1
     )
     addThreshold(
-        "benchmark_creating_heavy_load_of_spans",
-        TimeUnit.MILLISECONDS.toNanos(400)
+        "benchmark_creating_heavy_load_of_spans", 400
     )
     addThreshold(
-        "benchmark_creating_medium_load_of_spans",
-        TimeUnit.MILLISECONDS.toNanos(250)
+        "benchmark_creating_medium_load_of_spans", 250
     )
 
     // LogIo Benchmarks
 
     addThreshold(
-        "benchmark_write_logs_on_disk",
-        TimeUnit.MILLISECONDS.toNanos(60)
+        "benchmark_write_logs_on_disk", 60
     )
     addThreshold(
-        "benchmark_read_logs_from_disk",
-        TimeUnit.MILLISECONDS.toNanos(60)
+        "benchmark_read_logs_from_disk", 60
     )
 
-    // Ignore Gestures Tracker Benchmarks
-    // The thresholds are too high because of the Espresso instrumentation.
-    // The only reason we added those benchmarks is to see the diffs between running with or without
-    // the tracker attached.
-    // TODO RUMM-240 Add a plugin extension to be able to assert diffs in execution time
-    ignoreTest(
-        "benchmark_clicking_on_recycler_view_item_tracker_attached"
+    // Rum - Gesture Tracker Benchmarks
+
+    relativeThreshold(
+        "benchmark_clicking_on_simple_button_tracker_attached",
+        "benchmark_clicking_on_simple_button_tracker_not_attached",
+        250
     )
-    ignoreTest(
-        "benchmark_clicking_on_simple_button_tracker_attached"
+    relativeThreshold(
+        "benchmark_clicking_on_recycler_view_item_tracker_attached",
+        "benchmark_clicking_on_recycler_view_item_tracker_not_attached",
+        250
     )
-    ignoreTest(
-        "benchmark_clicking_on_recycler_view_item_tracker_not_attached"
-    )
-    ignoreTest(
-        "benchmark_clicking_on_simple_button_tracker_not_attached"
-    )
+
+    // those values are very big due to Bitrise emulator which is too slow. We will need to see
+    // how we can have same values as on local emulator. Have in mind that locally
+    // that difference threshold is somewhere around 7 millis
 }

--- a/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/rum/RumGesturesTrackerBenchmark.kt
+++ b/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/rum/RumGesturesTrackerBenchmark.kt
@@ -70,6 +70,7 @@ internal class RumGesturesTrackerBenchmark {
             "com.datadog.android.rum.gestures.DatadogGesturesTracker",
             testedTracer
         )
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
     }
 
     @After


### PR DESCRIPTION
### What does this PR do?

This PR adds an extension to the current Benchmark Plugin to be able to add relative thresholds as a measurement criteria.
We define the relative threshold as the threshold for the execution time difference between 2 defined tests.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

