### PR TITLE
RUMM-255 traces content type

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -16,7 +16,8 @@ import okhttp3.RequestBody
 
 internal abstract class DataOkHttpUploader(
     private var url: String,
-    private val client: OkHttpClient
+    private val client: OkHttpClient,
+    internal val contentType: String = CONTENT_TYPE_JSON
 ) : DataUploader {
 
     // region LogUploader
@@ -51,7 +52,7 @@ internal abstract class DataOkHttpUploader(
     private fun headers(): MutableMap<String, String> {
         return mutableMapOf(
             HEADER_UA to userAgent,
-            HEADER_CT to CONTENT_TYPE
+            HEADER_CT to contentType
         )
     }
 
@@ -66,12 +67,13 @@ internal abstract class DataOkHttpUploader(
     }
 
     private fun buildRequest(data: ByteArray): Request {
-        sdkLogger.d("$TAG: Sending data to $url")
+        sdkLogger.d("$TAG: Sending data to POST $url")
         val builder = Request.Builder()
             .url(url)
             .post(RequestBody.create(null, data))
         headers().forEach {
             builder.addHeader(it.key, it.value)
+            sdkLogger.d("$TAG: ${it.key}: ${it.value}")
         }
         return builder.build()
     }
@@ -90,10 +92,13 @@ internal abstract class DataOkHttpUploader(
     // endregion
 
     companion object {
+        internal const val CONTENT_TYPE_JSON = "application/json"
+        internal const val CONTENT_TYPE_TEXT_UTF8 = "text/plain;charset=UTF-8"
+
         private const val HEADER_CT = "Content-Type"
-        private const val CONTENT_TYPE = "application/json"
         private const val HEADER_UA = "User-Agent"
         const val SYSTEM_UA = "http.agent"
+
         private const val TAG = "DataOkHttpUploader"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -30,7 +30,7 @@ internal class SpanSerializer(
         jsonObject.addProperty(TAG_DURATION, model.durationNano)
         jsonObject.addProperty(TAG_START_TIMESTAMP, model.startTime + serverOffset)
         jsonObject.addProperty(TAG_ERROR, if (model.isError) 1 else 0)
-        jsonObject.addProperty(TAG_TYPE, "object") // do not know yet what should be here
+        jsonObject.addProperty(TAG_TYPE, "custom")
         addMeta(jsonObject, model)
         addMetrics(jsonObject, model)
         return jsonObject.toString()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploader.kt
@@ -8,7 +8,7 @@ internal open class TracesOkHttpUploader(
     endpoint: String,
     private val token: String,
     client: OkHttpClient
-) : DataOkHttpUploader(buildUrl(endpoint, token), client) {
+) : DataOkHttpUploader(buildUrl(endpoint, token), client, CONTENT_TYPE_TEXT_UTF8) {
 
     // region DataOkHttpUploader
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
@@ -401,7 +401,7 @@ internal abstract class DataOkHttpUploaderTest<T : DataOkHttpUploader> {
 
     fun assertHeaders(request: RecordedRequest) {
         assertThat(request.getHeader("Content-Type"))
-            .isEqualTo("application/json")
+            .isEqualTo(testedUploader.contentType)
         val expectedUserAgent = if (fakeUserAgent.isBlank()) {
             "Datadog/${BuildConfig.VERSION_NAME} " +
                     "(Linux; U; Android ${Build.VERSION.RELEASE}; " +


### PR DESCRIPTION
### What does this PR do?

The traces couldn't be sent on prod (and on staging it didn't work anymore) because the intake expects a `\n` separated list of json object sent with `Content-Type: text/plain;charset=UTF-8`.

Also the `type` field in a span is used to define the icon in the dashboard and can take the following values : `web`, `db`, `cache`, `custom`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

