### PR TITLE
RUMM-258 TraceInterceptor - fallback to local tracer if no global

### DIFF
--- a/dd-sdk-android/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/dd-sdk-android/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
### What does this PR do?

For now the TraceInterceptor was doing nothing if there was no Global Tracer registered. With this PR we introduced the **localTracer** fallback in case there's was no Tracer registered yet by the user.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

