### PR TITLE
RUMM-235 LogcatHandler - add caller classname as tag when in debug

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -8,6 +8,7 @@ package com.datadog.android
 
 import android.app.Application
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.os.Build
 import com.datadog.android.core.internal.data.upload.DataUploadHandlerThread
 import com.datadog.android.core.internal.domain.PersistenceStrategy
@@ -84,6 +85,7 @@ object Datadog {
         private set
     internal var libraryVerbosity = Int.MAX_VALUE
         private set
+    internal var isDebug = false
 
     /**
      * Initializes the Datadog SDK.
@@ -133,6 +135,8 @@ object Datadog {
 
         // setup the process lifecycle monitor
         setupLifecycleMonitorCallback(appContext)
+
+        isDebug = resolveIsDebug(context)
 
         initialized = true
 
@@ -320,6 +324,10 @@ object Datadog {
             val callback = ProcessLifecycleCallback(networkInfoProvider, appContext)
             appContext.registerActivityLifecycleCallbacks(ProcessLifecycleMonitor(callback))
         }
+    }
+
+    private fun resolveIsDebug(context: Context): Boolean {
+        return (context.applicationInfo.flags.and(ApplicationInfo.FLAG_DEBUGGABLE)) != 0
     }
 
     internal const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized.\n" +

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -177,6 +177,7 @@ object Datadog {
         contextRef.get()?.let { networkInfoProvider.unregister(it) }
         contextRef.clear()
         initialized = false
+        isDebug = false
     }
 
     /**

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -328,7 +328,7 @@ object Datadog {
     }
 
     private fun resolveIsDebug(context: Context): Boolean {
-        return (context.applicationInfo.flags.and(ApplicationInfo.FLAG_DEBUGGABLE)) != 0
+        return (context.applicationInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE) != 0
     }
 
     internal const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized.\n" +

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileOrchestrator.kt
@@ -137,7 +137,7 @@ internal class FileOrchestrator(
         val sizeToFree = sizeOnDisk - maxDiskSpace
         if (sizeToFree > 0) {
             sdkLogger.w(
-                "$TAG: Too much disk space used ($sizeOnDisk / $maxDiskSpace): " +
+                "Too much disk space used ($sizeOnDisk / $maxDiskSpace): " +
                         "cleaning up to free $sizeToFree bytes…"
             )
             files.asSequence()
@@ -157,8 +157,4 @@ internal class FileOrchestrator(
     }
 
     // endregion
-
-    companion object {
-        private const val TAG = "FileOrchestrator"
-    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileReader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileReader.kt
@@ -40,14 +40,14 @@ internal class FileReader(
     }
 
     override fun releaseBatch(batchId: String) {
-        sdkLogger.i("$TAG: releaseBatch $batchId")
+        sdkLogger.i("releaseBatch $batchId")
         synchronized(readFiles) {
             readFiles.remove(batchId)
         }
     }
 
     override fun dropBatch(batchId: String) {
-        sdkLogger.i("$TAG: dropBatch $batchId")
+        sdkLogger.i("dropBatch $batchId")
         sentBatches.add(batchId)
         readFiles.remove(batchId)
         val fileToDelete = File(dataDirectory, batchId)
@@ -56,7 +56,7 @@ internal class FileReader(
     }
 
     override fun dropAllBatches() {
-        sdkLogger.i("$TAG: dropAllBatches")
+        sdkLogger.i("dropAllBatches")
         fileOrchestrator.getAllFiles().forEach { deleteFile(it) }
     }
 
@@ -75,13 +75,13 @@ internal class FileReader(
                 file.readBytes(withPrefix = '[', withSuffix = ']')
             }
         } catch (e: FileNotFoundException) {
-            sdkLogger.e("$TAG: Couldn't create an input stream from file ${file?.path}", e)
+            sdkLogger.e("Couldn't create an input stream from file ${file?.path}", e)
             ByteArray(0)
         } catch (e: IOException) {
-            sdkLogger.e("$TAG: Couldn't read messages from file ${file?.path}", e)
+            sdkLogger.e("Couldn't read messages from file ${file?.path}", e)
             ByteArray(0)
         } catch (e: SecurityException) {
-            sdkLogger.e("$TAG: Couldn't access file ${file?.path}", e)
+            sdkLogger.e("Couldn't access file ${file?.path}", e)
             ByteArray(0)
         }
 
@@ -91,18 +91,14 @@ internal class FileReader(
     private fun deleteFile(fileToDelete: File) {
         if (fileToDelete.exists()) {
             if (fileToDelete.delete()) {
-                sdkLogger.d("$TAG: File ${fileToDelete.path} deleted")
+                sdkLogger.d("File ${fileToDelete.path} deleted")
             } else {
-                sdkLogger.e("$TAG: Error deleting file ${fileToDelete.path}")
+                sdkLogger.e("Error deleting file ${fileToDelete.path}")
             }
         } else {
-            sdkLogger.w("$TAG: file ${fileToDelete.path} does not exist")
+            sdkLogger.w("file ${fileToDelete.path} does not exist")
         }
     }
 
     // endregion
-
-    companion object {
-        private const val TAG = "FileReader"
-    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriter.kt
@@ -47,14 +47,14 @@ internal class ImmediateFileWriter<T : Any>(
             if (file != null) {
                 writeDataToFile(file, dataAsByteArray)
             } else {
-                sdkLogger.e("$TAG: Could not get a valid file")
+                sdkLogger.e("Could not get a valid file")
             }
         } catch (e: FileNotFoundException) {
-            sdkLogger.e("$TAG: Couldn't create an output stream to file ${file?.path}", e)
+            sdkLogger.e("Couldn't create an output stream to file ${file?.path}", e)
         } catch (e: IOException) {
-            sdkLogger.e("$TAG: Couldn't write data to file ${file?.path}", e)
+            sdkLogger.e("Couldn't write data to file ${file?.path}", e)
         } catch (e: SecurityException) {
-            sdkLogger.e("$TAG: Couldn't access file ${file?.path}", e)
+            sdkLogger.e("Couldn't access file ${file?.path}", e)
         }
     }
 
@@ -72,7 +72,6 @@ internal class ImmediateFileWriter<T : Any>(
 
     companion object {
         private const val MAX_ITEM_SIZE = 256 * 1024 // 256 Kb
-        private const val TAG = "ImmediateFileWriter"
         private val separator = ByteArray(1) { ','.toByte() }
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
@@ -60,7 +60,7 @@ internal class DataUploadRunnable(
     }
 
     private fun delayTheRunnable() {
-        sdkLogger.i("$TAG: There was no batch to be sent")
+        sdkLogger.i("There was no batch to be sent")
         currentDelayInterval =
             DEFAULT_DELAY
         handler.removeCallbacks(this)
@@ -71,7 +71,7 @@ internal class DataUploadRunnable(
 
     private fun consumeBatch(batch: Batch) {
         val batchId = batch.id
-        sdkLogger.i("$TAG: Sending batch $batchId")
+        sdkLogger.i("Sending batch $batchId")
         val status = dataUploader.upload(batch.data)
         if (status in dropableBatchStatus) {
             reader.dropBatch(batchId)
@@ -108,6 +108,5 @@ internal class DataUploadRunnable(
         const val MIN_DELAY_MS = 1000L // 1 second
         const val MAX_DELAY = DEFAULT_DELAY * 4 // 20 seconds
         const val DELAY_PERCENT = 90 // as 90 percent of
-        private const val TAG = "DataUploadRunnable"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -46,13 +46,13 @@ internal class DataOkHttpUploader(
             val request = buildRequest(data)
             val response = client.newCall(request).execute()
             sdkLogger.i(
-                    "$TAG: Response code:${response.code()} " +
+                    "Response code:${response.code()} " +
                             "body:${response.body()?.string()} " +
                             "headers:${response.headers()}"
             )
             responseCodeToUploadStatus(response.code())
         } catch (e: IOException) {
-            sdkLogger.e("$TAG: unable to upload data", e)
+            sdkLogger.e("unable to upload data", e)
             UploadStatus.NETWORK_ERROR
         }
     }
@@ -62,12 +62,12 @@ internal class DataOkHttpUploader(
     // region Internal
 
     private fun buildUrl(endpoint: String, token: String): String {
-        sdkLogger.i("$TAG: using endpoint $endpoint")
+        sdkLogger.i("using endpoint $endpoint")
         return String.format(Locale.US, UPLOAD_URL, endpoint, token)
     }
 
     private fun buildRequest(data: ByteArray): Request {
-        sdkLogger.d("$TAG: Sending data to $url")
+        sdkLogger.d("Sending data to $url")
         return Request.Builder()
             .url(url)
             .post(RequestBody.create(null, data))
@@ -104,6 +104,5 @@ internal class DataOkHttpUploader(
         private const val DD_SOURCE_MOBILE = "mobile"
 
         const val UPLOAD_URL = "%s/v1/input/%s?$QP_SOURCE=$DD_SOURCE_MOBILE"
-        private const val TAG = "DataOkHttpUploader"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/NetworkTimeInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/NetworkTimeInterceptor.kt
@@ -45,12 +45,12 @@ internal class NetworkTimeInterceptor(
         val serverDate = try {
             formatter.parse(serverDateStr)
         } catch (e: ParseException) {
-            sdkLogger.w("$TAG: invalid date received \"$serverDateStr\"")
+            sdkLogger.w("invalid date received \"$serverDateStr\"")
             null
         }
 
         if (serverDate != null) {
-            sdkLogger.v("$TAG: updating offset with server time $serverDate")
+            sdkLogger.v("updating offset with server time $serverDate")
             val localTimestamp = (start + end) / 2
             val offset = serverDate.time - localTimestamp
             timeProvider.updateOffset(offset)
@@ -60,8 +60,4 @@ internal class NetworkTimeInterceptor(
     }
 
     // endregion
-
-    companion object {
-        private const val TAG = "NetworkTimeInterceptor"
-    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
@@ -29,7 +29,7 @@ internal class BroadcastReceiverNetworkInfoProvider :
     // region BroadcastReceiver
 
     override fun onReceive(context: Context, intent: Intent?) {
-        sdkLogger.d("$TAG: received network update")
+        sdkLogger.d("received network update")
         val connectivityMgr =
             context.getSystemService(Context.CONNECTIVITY_SERVICE) as? ConnectivityManager
         val activeNetworkInfo = connectivityMgr?.activeNetworkInfo
@@ -153,7 +153,5 @@ internal class BroadcastReceiverNetworkInfoProvider :
         )
 
         private const val UNKNOWN_CARRIER_NAME = "Unknown Carrier Name"
-
-        private const val TAG = "BroadcastReceiver"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
@@ -33,14 +33,14 @@ internal class BroadcastReceiverSystemInfoProvider :
         val action = intent?.action
         when (action) {
             Intent.ACTION_BATTERY_CHANGED -> {
-                sdkLogger.d("$TAG: received battery update")
+                sdkLogger.d("received battery update")
                 handleBatteryIntent(intent)
             }
             PowerManager.ACTION_POWER_SAVE_MODE_CHANGED -> {
-                sdkLogger.d("$TAG: received power save mode update")
+                sdkLogger.d("received power save mode update")
                 handlePowerSaveIntent(context)
             }
-            else -> sdkLogger.d("$TAG: received unknown update $action")
+            else -> sdkLogger.d("received unknown update $action")
         }
     }
 
@@ -88,8 +88,4 @@ internal class BroadcastReceiverSystemInfoProvider :
     }
 
     // endregion
-
-    companion object {
-        private const val TAG = "BroadcastReceiver"
-    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/RuntimeUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/RuntimeUtils.kt
@@ -18,7 +18,7 @@ internal val sdkLogger: Logger = buildSdkLogger()
 
 internal fun buildSdkLogger(): Logger {
     val handler = if (BuildConfig.LOGCAT_ENABLED) {
-        LogcatLogHandler(SDK_LOG_PREFIX, LogcatLogHandler.SDK_LOGGER_CALLER_STACK_INDEX)
+        LogcatLogHandler(SDK_LOG_PREFIX)
     } else {
         NoOpLogHandler
     }
@@ -33,7 +33,7 @@ internal val devLogger: Logger = buildDevLogger()
 
 private fun buildDevLogger(): Logger {
     val handler = ConditionalLogHandler(
-        LogcatLogHandler(DEV_LOG_PREFIX)
+        LogcatLogHandler(DEV_LOG_PREFIX, 1)
     ) { i, _ ->
         i >= Datadog.libraryVerbosity
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/RuntimeUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/RuntimeUtils.kt
@@ -18,7 +18,7 @@ internal val sdkLogger: Logger = buildSdkLogger()
 
 internal fun buildSdkLogger(): Logger {
     val handler = if (BuildConfig.LOGCAT_ENABLED) {
-        LogcatLogHandler(SDK_LOG_PREFIX)
+        LogcatLogHandler(SDK_LOG_PREFIX, LogcatLogHandler.SDK_LOGGER_CALLER_STACK_INDEX)
     } else {
         NoOpLogHandler
     }
@@ -32,7 +32,9 @@ internal fun buildSdkLogger(): Logger {
 internal val devLogger: Logger = buildDevLogger()
 
 private fun buildDevLogger(): Logger {
-    val handler = ConditionalLogHandler(LogcatLogHandler(DEV_LOG_PREFIX)) { i, _ ->
+    val handler = ConditionalLogHandler(
+        LogcatLogHandler(DEV_LOG_PREFIX)
+    ) { i, _ ->
         i >= Datadog.libraryVerbosity
     }
     return Logger(handler)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
@@ -9,7 +9,7 @@ import androidx.work.WorkManager
 import com.datadog.android.core.internal.data.upload.UploadWorker
 import java.lang.IllegalStateException
 
-internal const val TAG = "triggerUploadWorker"
+internal const val ERROR_MESSAGE = "Error while trying to setup the upload worker."
 internal const val UPLOAD_WORKER_TAG = "UploadWorker"
 
 internal fun triggerUploadWorker(context: Context) {
@@ -28,6 +28,6 @@ internal fun triggerUploadWorker(context: Context) {
                 uploadWorkRequest
             )
     } catch (e: IllegalStateException) {
-        sdkLogger.e(TAG, e)
+        sdkLogger.e(ERROR_MESSAGE, e)
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
@@ -9,7 +9,7 @@ import androidx.work.WorkManager
 import com.datadog.android.core.internal.data.upload.UploadWorker
 import java.lang.IllegalStateException
 
-internal const val TAG = "WorkManagerUtils"
+internal const val TAG = "triggerUploadWorker"
 internal const val UPLOAD_WORKER_TAG = "UploadWorker"
 
 internal fun triggerUploadWorker(context: Context) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -182,12 +182,12 @@ internal constructor(private val handler: LogHandler) {
                 datadogLogsEnabled && logcatLogsEnabled -> {
                     CombinedLogHandler(
                         buildDatadogHandler(),
-                        buildLogcatHandler()
+                        buildLogcatHandler(1)
                     )
                 }
                 datadogLogsEnabled -> buildDatadogHandler()
                 logcatLogsEnabled ->
-                    buildLogcatHandler(LogcatLogHandler.SDK_LOGGER_CALLER_STACK_INDEX)
+                    buildLogcatHandler()
                 else -> NoOpLogHandler
             }
 
@@ -243,9 +243,9 @@ internal constructor(private val handler: LogHandler) {
         // region Internal
 
         private fun buildLogcatHandler(
-            callerStackTraceIndex: Int = LogcatLogHandler.DEFAULT_LOGGER_CALLER_STACK_INDEX
+            nestedDepth: Int = 0
         ): LogHandler {
-            return LogcatLogHandler(serviceName, callerStackTraceIndex)
+            return LogcatLogHandler(serviceName, nestedDepth)
         }
 
         private fun buildDatadogHandler(): LogHandler {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -180,10 +180,14 @@ internal constructor(private val handler: LogHandler) {
 
             val handler = when {
                 datadogLogsEnabled && logcatLogsEnabled -> {
-                    CombinedLogHandler(buildDatadogHandler(), buildLogcatHandler())
+                    CombinedLogHandler(
+                        buildDatadogHandler(),
+                        buildLogcatHandler()
+                    )
                 }
                 datadogLogsEnabled -> buildDatadogHandler()
-                logcatLogsEnabled -> buildLogcatHandler()
+                logcatLogsEnabled ->
+                    buildLogcatHandler(LogcatLogHandler.SDK_LOGGER_CALLER_STACK_INDEX)
                 else -> NoOpLogHandler
             }
 
@@ -238,8 +242,10 @@ internal constructor(private val handler: LogHandler) {
 
         // region Internal
 
-        private fun buildLogcatHandler(): LogHandler {
-            return LogcatLogHandler(serviceName)
+        private fun buildLogcatHandler(
+            callerStackTraceIndex: Int = LogcatLogHandler.DEFAULT_LOGGER_CALLER_STACK_INDEX
+        ): LogHandler {
+            return LogcatLogHandler(serviceName, callerStackTraceIndex)
         }
 
         private fun buildDatadogHandler(): LogHandler {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/constraints/DatadogLogConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/constraints/DatadogLogConstraints.kt
@@ -19,15 +19,15 @@ internal class DatadogLogConstraints : LogConstraints {
         val convertedTags = tags.mapNotNull {
             val tag = convertTag(it)
             if (tag == null) {
-                devLogger.e("$TAG: \"$it\" is an invalid tag, and was ignored.")
+                devLogger.e("\"$it\" is an invalid tag, and was ignored.")
             } else if (tag != it) {
-                devLogger.w("$TAG: tag \"$it\" was modified to \"$tag\" to match our constraints.")
+                devLogger.w("tag \"$it\" was modified to \"$tag\" to match our constraints.")
             }
             tag
         }
         val discardedCount = convertedTags.size - MAX_TAG_COUNT
         if (discardedCount > 0) {
-            devLogger.w("$TAG: too many tags were added, $discardedCount had to be discarded.")
+            devLogger.w("too many tags were added, $discardedCount had to be discarded.")
         }
         return convertedTags.take(MAX_TAG_COUNT)
     }
@@ -36,12 +36,12 @@ internal class DatadogLogConstraints : LogConstraints {
         val convertedAttributes = attributes.mapNotNull {
             val key = convertAttributeKey(it.key)
             if (key == null) {
-                devLogger.e("$TAG: \"$it\" is an invalid attribute, and was ignored.")
+                devLogger.e("\"$it\" is an invalid attribute, and was ignored.")
                 null
             } else {
                 if (key != it.key) {
                     devLogger.w(
-                        "$TAG: attribute \"${it.key}\" " +
+                        "attribute \"${it.key}\" " +
                             "was modified to \"$key\" to match our constraints."
                     )
                 }
@@ -51,7 +51,7 @@ internal class DatadogLogConstraints : LogConstraints {
         val discardedCount = convertedAttributes.size - MAX_ATTR_COUNT
         if (discardedCount > 0) {
             devLogger.w(
-                "$TAG: too many attributes were added, " +
+                "too many attributes were added, " +
                     "$discardedCount had to be discarded."
             )
         }
@@ -120,7 +120,6 @@ internal class DatadogLogConstraints : LogConstraints {
     // endregion
 
     companion object {
-        private const val TAG = "DatadogLogConstraints"
 
         private const val MAX_TAG_LENGTH = 200
         private const val MAX_TAG_COUNT = 100

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
@@ -13,9 +13,14 @@ import java.util.regex.Pattern
 
 internal class LogcatLogHandler(
     internal val serviceName: String,
-    internal val callerNameStackIndex: Int = DEFAULT_LOGGER_CALLER_STACK_INDEX
+    nestedDepth: Int = 0
 ) : LogHandler {
 
+    private val callerNameStackIndex: Int
+
+    init {
+        callerNameStackIndex = DEFAULT_LOGGER_CALLER_STACK_INDEX + nestedDepth
+    }
     // region LogHandler
 
     override fun handleLog(
@@ -73,11 +78,7 @@ internal class LogcatLogHandler(
 
     private fun stripAnonymousPart(className: String): String {
         val matcher = ANONYMOUS_CLASS.matcher(className)
-        return if (matcher.find()) {
-            matcher.replaceAll("")
-        } else {
-            className
-        }
+        return matcher.replaceAll("")
     }
 
     // endregion
@@ -97,7 +98,6 @@ internal class LogcatLogHandler(
             Pattern.compile("(\\$\\d+)+$")
         private const val MAX_TAG_LENGTH = 23
 
-        internal const val SDK_LOGGER_CALLER_STACK_INDEX = 6
-        internal const val DEFAULT_LOGGER_CALLER_STACK_INDEX = 7
+        private const val DEFAULT_LOGGER_CALLER_STACK_INDEX = 6
     }
 }

--- a/dd-sdk-android/src/test/java/com/datadog/android/log/LoggerBuilderJavaTest.java
+++ b/dd-sdk-android/src/test/java/com/datadog/android/log/LoggerBuilderJavaTest.java
@@ -1,0 +1,133 @@
+package com.datadog.android.log;
+
+import android.app.Application;
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageInfo;
+import android.content.pm.PackageManager;
+import android.util.Log;
+
+import com.datadog.android.BuildConfig;
+import com.datadog.android.Datadog;
+import com.datadog.android.utils.DatadogExtKt;
+import com.datadog.tools.unit.ReflectUtilsKt;
+import com.datadog.tools.unit.annotations.SystemOutStream;
+import com.datadog.tools.unit.extensions.SystemOutputExtension;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.Extensions;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+
+import fr.xgouchet.elmyr.Forge;
+import fr.xgouchet.elmyr.annotation.Forgery;
+import fr.xgouchet.elmyr.junit5.ForgeExtension;
+
+import static android.content.pm.ApplicationInfo.FLAG_ALLOW_BACKUP;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Extensions(
+        {@ExtendWith(MockitoExtension.class),
+                @ExtendWith(ForgeExtension.class),
+                @ExtendWith(SystemOutputExtension.class)})
+@MockitoSettings()
+class LoggerBuilderJavaTest {
+
+    private Context mockContext;
+
+    private String packageName;
+
+    @BeforeEach
+    void setUp(@Forgery Forge forge) {
+        packageName = forge.anAlphabeticalString();
+        mockContext = mockContext(packageName);
+        Datadog.initialize(mockContext, forge.anHexadecimalString());
+        Datadog.setVerbosity(Log.VERBOSE);
+    }
+
+    @AfterEach
+    void tearDown() {
+        try {
+            ReflectUtilsKt.invokeMethod(Datadog.INSTANCE, "stop");
+        } catch (IllegalStateException e) {
+            // ignore
+        }
+    }
+
+    @Test
+    void builderCanEnableLogcatLogs(@Forgery Forge forge,
+                                    @SystemOutStream ByteArrayOutputStream outputStream) {
+
+        final boolean logcatLogsEnabled = true;
+        final String fakeMessage = forge.anAlphabeticalString();
+        final String fakeServiceName = forge.anAlphaNumericalString();
+
+        final Logger logger = new Logger.Builder()
+                .setLogcatLogsEnabled(logcatLogsEnabled)
+                .setServiceName(fakeServiceName)
+                .build();
+        logger.v(fakeMessage);
+        final String expectedTagName = DatadogExtKt.resolveTagName(this, fakeServiceName);
+
+        assertThat(outputStream.toString())
+                .isEqualTo(String.format("V/%s: %s\n", expectedTagName, fakeMessage));
+    }
+
+    @Test
+    void builderCanEnableOnlyLogcatLogs(@Forgery Forge forge,
+                                        @SystemOutStream ByteArrayOutputStream outputStream) {
+
+        final boolean logcatLogsEnabled = true;
+        final String fakeMessage = forge.anAlphabeticalString();
+        final String fakeServiceName = forge.anAlphaNumericalString();
+
+        final Logger logger = new Logger.Builder()
+                .setDatadogLogsEnabled(false)
+                .setLogcatLogsEnabled(logcatLogsEnabled)
+                .setServiceName(fakeServiceName)
+                .build();
+        logger.v(fakeMessage);
+        final String expectedTagName = DatadogExtKt.resolveTagName(this, fakeServiceName);
+
+        assertThat(outputStream.toString())
+                .isEqualTo(String.format("V/%s: %s\n", expectedTagName, fakeMessage));
+    }
+
+    private Context mockContext(String packageName) {
+        final int versionCode = BuildConfig.VERSION_CODE;
+        final String versionName = BuildConfig.VERSION_NAME;
+        final PackageInfo mockPackageInfo = new PackageInfo();
+        final PackageManager mockPackageMgr = mock(PackageManager.class);
+        final Context mockContext = mock(Application.class);
+
+        mockPackageInfo.versionName = versionName;
+        mockPackageInfo.versionCode = versionCode;
+        try {
+            when(mockPackageMgr.getPackageInfo(packageName, 0)).thenReturn(mockPackageInfo);
+        } catch (PackageManager.NameNotFoundException e) {
+            // ignore
+        }
+
+        when(mockContext.getApplicationContext()).thenReturn(mockContext);
+        when(mockContext.getPackageManager()).thenReturn(mockPackageMgr);
+        final ApplicationInfo mockApplicationInfo = mock(ApplicationInfo.class);
+        when(mockContext.getApplicationInfo()).thenReturn(mockApplicationInfo);
+        if (BuildConfig.DEBUG) {
+            mockApplicationInfo.flags =
+                    ApplicationInfo.FLAG_DEBUGGABLE | ApplicationInfo.FLAG_ALLOW_BACKUP;
+        }
+        when(mockContext.getPackageName()).thenReturn(packageName);
+        when(mockContext.getFilesDir()).thenReturn(new File("/dev/null"));
+        return mockContext;
+    }
+
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android
 import android.app.Application
 import android.content.BroadcastReceiver
 import android.content.Context
-import android.content.pm.ApplicationInfo
 import android.net.ConnectivityManager
 import android.os.Build
 import android.util.Log as AndroidLog
@@ -353,25 +352,14 @@ internal class DatadogTest {
 
     @Test
     fun `will update the isDebug flag if application is debuggable`() {
-        // given
-        val mockAppInfo = mock<ApplicationInfo>()
-        whenever(mockAppContext.applicationInfo).thenReturn(mockAppInfo)
-        mockAppInfo.flags = ApplicationInfo.FLAG_DEBUGGABLE
-            .or(ApplicationInfo.FLAG_ALLOW_BACKUP)
-
         // when
         Datadog.initialize(mockAppContext, fakeToken)
 
         // then
-        assertThat(Datadog.isDebug).isTrue()
-    }
-
-    @Test
-    fun `will update the isDebug flag if application is not`() {
-        // when
-        Datadog.initialize(mockAppContext, fakeToken)
-
-        // then
-        assertThat(Datadog.isDebug).isFalse()
+        if (BuildConfig.DEBUG) {
+            assertThat(Datadog.isDebug).isTrue()
+        } else {
+            assertThat(Datadog.isDebug).isFalse()
+        }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android
 import android.app.Application
 import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.net.ConnectivityManager
 import android.os.Build
 import android.util.Log as AndroidLog
@@ -220,8 +221,8 @@ internal class DatadogTest {
         assertThat(outputStream.lastLine())
             .isEqualTo(
                 "W/Datadog: setEndpointUrl() has been deprecated. " +
-                    "If you need it, submit an issue at " +
-                    "https://github.com/DataDog/dd-sdk-android/issues/"
+                        "If you need it, submit an issue at " +
+                        "https://github.com/DataDog/dd-sdk-android/issues/"
             )
     }
 
@@ -245,8 +246,8 @@ internal class DatadogTest {
         assertThat(outputStream.lastLine())
             .isEqualTo(
                 "W/Datadog: setEndpointUrl() has been deprecated. " +
-                    "If you need it, submit an issue at " +
-                    "https://github.com/DataDog/dd-sdk-android/issues/"
+                        "If you need it, submit an issue at " +
+                        "https://github.com/DataDog/dd-sdk-android/issues/"
             )
     }
 
@@ -348,5 +349,29 @@ internal class DatadogTest {
     fun `is initialized will return false if SDK was initialized`() {
         // then
         assertThat(Datadog.isInitialized()).isFalse()
+    }
+
+    @Test
+    fun `will update the isDebug flag if application is debuggable`() {
+        // given
+        val mockAppInfo = mock<ApplicationInfo>()
+        whenever(mockAppContext.applicationInfo).thenReturn(mockAppInfo)
+        mockAppInfo.flags = ApplicationInfo.FLAG_DEBUGGABLE
+            .or(ApplicationInfo.FLAG_ALLOW_BACKUP)
+
+        // when
+        Datadog.initialize(mockAppContext, fakeToken)
+
+        // then
+        assertThat(Datadog.isDebug).isTrue()
+    }
+
+    @Test
+    fun `will update the isDebug flag if application is not`() {
+        // when
+        Datadog.initialize(mockAppContext, fakeToken)
+
+        // then
+        assertThat(Datadog.isDebug).isFalse()
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileReaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileReaderTest.kt
@@ -170,7 +170,7 @@ internal class FileReaderTest {
             val expectedLogcatTag = resolveTagName(testedReader, "DD_LOG")
             val logMessages = systemOutStream.toString().trim().split("\n")
             assertThat(logMessages[0]).matches(
-                "E/$expectedLogcatTag: FileReader:" +
+                "E/$expectedLogcatTag:" +
                         " Couldn't access file .+"
             )
         }
@@ -196,7 +196,7 @@ internal class FileReaderTest {
             val expectedLogcatTag = resolveTagName(testedReader, "DD_LOG")
             val logMessages = systemOutStream.toString().trim().split("\n")
             assertThat(logMessages[0])
-                .matches("I/$expectedLogcatTag: FileReader: dropBatch $fileName")
+                .matches("I/$expectedLogcatTag: dropBatch $fileName")
         }
     }
 
@@ -221,7 +221,7 @@ internal class FileReaderTest {
             val logMessages = systemOutStream.toString().trim().split("\n")
             assertThat(logMessages[1])
                 .matches(
-                    "W/$expectedLogcatTag: FileReader: " +
+                    "W/$expectedLogcatTag: " +
                             "file ${notExistingFile.path} does not exist.*"
                 )
         }
@@ -250,7 +250,7 @@ internal class FileReaderTest {
             val expectedLogcatTag = resolveTagName(testedReader, "DD_LOG")
             val logMessages = systemOutStream.toString().trim().split("\n")
             assertThat(logMessages[0])
-                .matches("I/$expectedLogcatTag: FileReader: dropAllBatches.*")
+                .matches("I/$expectedLogcatTag: dropAllBatches.*")
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileReaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileReaderTest.kt
@@ -3,6 +3,7 @@ package com.datadog.android.core.internal.data.file
 import android.os.Build
 import com.datadog.android.core.internal.data.Orchestrator
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.resolveTagName
 import com.datadog.tools.unit.BuildConfig
 import com.datadog.tools.unit.annotations.SystemOutStream
 import com.datadog.tools.unit.annotations.TestTargetApi
@@ -166,8 +167,12 @@ internal class FileReaderTest {
         // then
         assertThat(nextBatch).isNull()
         if (BuildConfig.DEBUG) {
+            val expectedLogcatTag = resolveTagName(testedReader, "DD_LOG")
             val logMessages = systemOutStream.toString().trim().split("\n")
-            assertThat(logMessages[0]).matches("E/DD_LOG: FileReader: Couldn't access file .+")
+            assertThat(logMessages[0]).matches(
+                "E/$expectedLogcatTag: FileReader:" +
+                        " Couldn't access file .+"
+            )
         }
     }
 
@@ -188,9 +193,10 @@ internal class FileReaderTest {
         assertThat(rootDir.listFiles()).isEmpty()
         assertThat(sentBatches).contains(fileName)
         if (BuildConfig.DEBUG) {
+            val expectedLogcatTag = resolveTagName(testedReader, "DD_LOG")
             val logMessages = systemOutStream.toString().trim().split("\n")
             assertThat(logMessages[0])
-                .matches("I/DD_LOG: FileReader: dropBatch $fileName")
+                .matches("I/$expectedLogcatTag: FileReader: dropBatch $fileName")
         }
     }
 
@@ -211,9 +217,13 @@ internal class FileReaderTest {
         assertThat(rootDir.listFiles()).isEmpty()
         assertThat(sentBatches).contains(fileName)
         if (BuildConfig.DEBUG) {
+            val expectedLogcatTag = resolveTagName(testedReader, "DD_LOG")
             val logMessages = systemOutStream.toString().trim().split("\n")
             assertThat(logMessages[1])
-                .matches("W/DD_LOG: FileReader: file ${notExistingFile.path} does not exist.*")
+                .matches(
+                    "W/$expectedLogcatTag: FileReader: " +
+                            "file ${notExistingFile.path} does not exist.*"
+                )
         }
     }
 
@@ -237,9 +247,10 @@ internal class FileReaderTest {
         assertThat(rootDir.listFiles()).isEmpty()
         assertThat(sentBatches).isEmpty()
         if (BuildConfig.DEBUG) {
+            val expectedLogcatTag = resolveTagName(testedReader, "DD_LOG")
             val logMessages = systemOutStream.toString().trim().split("\n")
             assertThat(logMessages[0])
-                .matches("I/DD_LOG: FileReader: dropAllBatches.*")
+                .matches("I/$expectedLogcatTag: FileReader: dropAllBatches.*")
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriterTest.kt
@@ -118,7 +118,7 @@ internal class ImmediateFileWriterTest {
 
         if (BuildConfig.DEBUG) {
             val logMessages = outputStream.toString().trim().split("\n")
-            assertThat(logMessages[0]).matches("E/$expectedLogcatTag: ImmediateFileWriter: .*")
+            assertThat(logMessages[0]).matches("E/$expectedLogcatTag: Couldn't access file .*")
         }
     }
 
@@ -138,7 +138,7 @@ internal class ImmediateFileWriterTest {
         if (BuildConfig.DEBUG) {
             val logMessages = outputStream.toString().trim().split("\n")
             assertThat(logMessages[0])
-                .matches("E/$expectedLogcatTag: ImmediateFileWriter: Could not get a valid file")
+                .matches("E/$expectedLogcatTag: Could not get a valid file")
         }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/ImmediateFileWriterTest.kt
@@ -5,6 +5,7 @@ import com.datadog.android.core.internal.data.Orchestrator
 import com.datadog.android.core.internal.domain.Serializer
 import com.datadog.android.core.internal.threading.AndroidDeferredHandler
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.resolveTagName
 import com.datadog.tools.unit.BuildConfig
 import com.datadog.tools.unit.annotations.SystemOutStream
 import com.datadog.tools.unit.annotations.TestTargetApi
@@ -111,12 +112,13 @@ internal class ImmediateFileWriterTest {
         val modelValue = forge.anAlphabeticalString()
         val exception = SecurityException(forge.anAlphabeticalString())
         doThrow(exception).whenever(mockedOrchestrator).getWritableFile(any())
+        val expectedLogcatTag = resolveTagName(underTest, "DD_LOG")
 
         underTest.write(modelValue)
 
         if (BuildConfig.DEBUG) {
             val logMessages = outputStream.toString().trim().split("\n")
-            assertThat(logMessages[0]).matches("E/DD_LOG: ImmediateFileWriter: .*")
+            assertThat(logMessages[0]).matches("E/$expectedLogcatTag: ImmediateFileWriter: .*")
         }
     }
 
@@ -127,6 +129,7 @@ internal class ImmediateFileWriterTest {
     ) {
         val modelValue = forge.anAlphabeticalString()
         whenever(mockedOrchestrator.getWritableFile(any())).thenReturn(null)
+        val expectedLogcatTag = resolveTagName(underTest, "DD_LOG")
 
         // when
         underTest.write(modelValue)
@@ -135,7 +138,7 @@ internal class ImmediateFileWriterTest {
         if (BuildConfig.DEBUG) {
             val logMessages = outputStream.toString().trim().split("\n")
             assertThat(logMessages[0])
-                .matches("E/DD_LOG: ImmediateFileWriter: Could not get a valid file")
+                .matches("E/$expectedLogcatTag: ImmediateFileWriter: Could not get a valid file")
         }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -191,7 +191,7 @@ internal class DataUploadRunnableTest {
         if (BuildConfig.DEBUG) {
             val exptectedTag = resolveTagName(testedRunnable, "DD_LOG")
             assertThat(systemOutStream.toString().trim())
-                .matches("I/$exptectedTag: DataUploadRunnable: .+")
+                .matches("I/$exptectedTag: .+")
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.system.SystemInfo
 import com.datadog.android.core.internal.system.SystemInfoProvider
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.resolveTagName
 import com.datadog.tools.unit.annotations.SystemOutStream
 import com.datadog.tools.unit.extensions.SystemOutputExtension
 import com.nhaarman.mockitokotlin2.any
@@ -188,9 +189,9 @@ internal class DataUploadRunnableTest {
         verifyZeroInteractions(mockDataUploader)
         verify(mockHandler).postDelayed(testedRunnable, DataUploadRunnable.MAX_DELAY)
         if (BuildConfig.DEBUG) {
+            val exptectedTag = resolveTagName(testedRunnable, "DD_LOG")
             assertThat(systemOutStream.toString().trim())
-                .withFailMessage("We were expecting an info log message here")
-                .matches("I/DD_LOG: DataUploadRunnable: .+")
+                .matches("I/$exptectedTag: DataUploadRunnable: .+")
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.net
 import android.os.Build
 import com.datadog.android.BuildConfig
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.resolveTagName
 import com.datadog.tools.unit.annotations.SystemOutStream
 import com.datadog.tools.unit.extensions.SystemOutputExtension
 import com.datadog.tools.unit.setStaticValue
@@ -334,11 +335,11 @@ internal class DataOkHttpUploaderTest {
             // we need to set the Build.MODEL to null, to override the setup
             Build::class.java.setStaticValue("MODEL", null)
             mockWebServer.enqueue(mockResponse(forge.anInt(1000)))
-
+            val expectedTag = resolveTagName(testedUploader, "DD_LOG")
             testedUploader.upload(data)
             val logMessages = systemOutputStream.toString().trim().split("\n")
             assertThat(logMessages.last())
-                .isEqualTo("E/DD_LOG: DataOkHttpUploader: unable to upload data")
+                .isEqualTo("E/$expectedTag: unable to upload data")
         }
     }
 
@@ -353,11 +354,12 @@ internal class DataOkHttpUploaderTest {
             Build::class.java.setStaticValue("MODEL", null)
             val code = forge.anInt(500, 599)
             mockWebServer.enqueue(mockResponse(code))
+            val expectedTag = resolveTagName(testedUploader, "DD_LOG")
 
             testedUploader.upload(data)
             val logMessages = systemOutputStream.toString().trim().split("\n")
             assertThat(logMessages.last())
-                .matches("I/DD_LOG: DataOkHttpUploader: Response code:$code .+")
+                .matches("I/$expectedTag: Response code:$code .+")
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/RuntimeUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/RuntimeUtilsTest.kt
@@ -21,6 +21,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.ByteArrayOutputStream
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -51,6 +52,11 @@ class RuntimeUtilsTest {
         warning = forge.anAlphaNumericalString()
         error = forge.anAlphaNumericalString()
         wtf = forge.anAlphaNumericalString()
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        Datadog.setFieldValue("isDebug", false)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/RuntimeUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/RuntimeUtilsTest.kt
@@ -1,5 +1,6 @@
 package com.datadog.android.core.internal.utils
 
+import android.os.Build
 import android.util.Log
 import com.datadog.android.BuildConfig
 import com.datadog.android.Datadog
@@ -8,10 +9,14 @@ import com.datadog.android.log.internal.logger.LogcatLogHandler
 import com.datadog.android.log.internal.logger.NoOpLogHandler
 import com.datadog.android.utils.extension.EnableLogcat
 import com.datadog.android.utils.extension.EnableLogcatExtension
+import com.datadog.android.utils.resolveTagName
 import com.datadog.tools.unit.annotations.SystemErrorStream
 import com.datadog.tools.unit.annotations.SystemOutStream
+import com.datadog.tools.unit.annotations.TestTargetApi
+import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.SystemOutputExtension
 import com.datadog.tools.unit.getFieldValue
+import com.datadog.tools.unit.setFieldValue
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.ByteArrayOutputStream
@@ -26,7 +31,8 @@ import org.mockito.junit.jupiter.MockitoExtension
     ExtendWith(MockitoExtension::class),
     ExtendWith(EnableLogcatExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(SystemOutputExtension::class)
+    ExtendWith(SystemOutputExtension::class),
+    ExtendWith(ApiLevelExtension::class)
 )
 class RuntimeUtilsTest {
 
@@ -84,15 +90,15 @@ class RuntimeUtilsTest {
         devLogger.w(warning)
         devLogger.e(error)
         devLogger.wtf(wtf)
-
+        val expectedTagName = resolveTagName(this)
         assertThat(outputStream.toString())
             .isEqualTo(
-                "V/Datadog: $verbose\n" +
-                    "D/Datadog: $debug\n" +
-                    "I/Datadog: $info\n" +
-                    "W/Datadog: $warning\n" +
-                    "E/Datadog: $error\n" +
-                    "A/Datadog: $wtf\n"
+                "V/$expectedTagName: $verbose\n" +
+                        "D/$expectedTagName: $debug\n" +
+                        "I/$expectedTagName: $info\n" +
+                        "W/$expectedTagName: $warning\n" +
+                        "E/$expectedTagName: $error\n" +
+                        "A/$expectedTagName: $wtf\n"
             )
         assertThat(errorStream.toString())
             .isEmpty()
@@ -112,13 +118,14 @@ class RuntimeUtilsTest {
         devLogger.e(error)
         devLogger.wtf(wtf)
 
+        val expectedTagName = resolveTagName(this)
         assertThat(outputStream.toString())
             .isEqualTo(
-                "D/Datadog: $debug\n" +
-                    "I/Datadog: $info\n" +
-                    "W/Datadog: $warning\n" +
-                    "E/Datadog: $error\n" +
-                    "A/Datadog: $wtf\n"
+                "D/$expectedTagName: $debug\n" +
+                        "I/$expectedTagName: $info\n" +
+                        "W/$expectedTagName: $warning\n" +
+                        "E/$expectedTagName: $error\n" +
+                        "A/$expectedTagName: $wtf\n"
             )
         assertThat(errorStream.toString())
             .isEmpty()
@@ -138,12 +145,13 @@ class RuntimeUtilsTest {
         devLogger.e(error)
         devLogger.wtf(wtf)
 
+        val expectedTagName = resolveTagName(this)
         assertThat(outputStream.toString())
             .isEqualTo(
-                "I/Datadog: $info\n" +
-                    "W/Datadog: $warning\n" +
-                    "E/Datadog: $error\n" +
-                    "A/Datadog: $wtf\n"
+                "I/$expectedTagName: $info\n" +
+                        "W/$expectedTagName: $warning\n" +
+                        "E/$expectedTagName: $error\n" +
+                        "A/$expectedTagName: $wtf\n"
             )
         assertThat(errorStream.toString())
             .isEmpty()
@@ -163,11 +171,12 @@ class RuntimeUtilsTest {
         devLogger.e(error)
         devLogger.wtf(wtf)
 
+        val expectedTagName = resolveTagName(this)
         assertThat(outputStream.toString())
             .isEqualTo(
-                "W/Datadog: $warning\n" +
-                    "E/Datadog: $error\n" +
-                    "A/Datadog: $wtf\n"
+                "W/$expectedTagName: $warning\n" +
+                        "E/$expectedTagName: $error\n" +
+                        "A/$expectedTagName: $wtf\n"
             )
         assertThat(errorStream.toString())
             .isEmpty()
@@ -187,10 +196,11 @@ class RuntimeUtilsTest {
         devLogger.e(error)
         devLogger.wtf(wtf)
 
+        val expectedTagName = resolveTagName(this)
         assertThat(outputStream.toString())
             .isEqualTo(
-                "E/Datadog: $error\n" +
-                    "A/Datadog: $wtf\n"
+                "E/$expectedTagName: $error\n" +
+                        "A/$expectedTagName: $wtf\n"
             )
         assertThat(errorStream.toString())
             .isEmpty()
@@ -210,9 +220,10 @@ class RuntimeUtilsTest {
         devLogger.e(error)
         devLogger.wtf(wtf)
 
+        val expectedTagName = resolveTagName(this)
         assertThat(outputStream.toString())
             .isEqualTo(
-                "A/Datadog: $wtf\n"
+                "A/$expectedTagName: $wtf\n"
             )
         assertThat(errorStream.toString())
             .isEmpty()
@@ -236,5 +247,109 @@ class RuntimeUtilsTest {
             .isEmpty()
         assertThat(errorStream.toString())
             .isEmpty()
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.N)
+    fun `devLogger should use whole caller name as tag if inDebug and above N`(
+        forge: Forge,
+        @SystemOutStream outputStream: ByteArrayOutputStream,
+        @SystemErrorStream errorStream: ByteArrayOutputStream
+    ) {
+
+        // given
+        val fakeMessage = forge.anAlphabeticalString()
+        Datadog.setVerbosity(Log.VERBOSE)
+        Datadog.setFieldValue("isDebug", true)
+        val underTest = LogCaller()
+
+        // when
+        underTest.logMessage(fakeMessage)
+
+        // then
+        assertThat(outputStream.toString())
+            .isEqualTo(
+                "V/RuntimeUtilsTest\$LogCaller: $fakeMessage\n" +
+                        "D/RuntimeUtilsTest\$LogCaller: $fakeMessage\n" +
+                        "I/RuntimeUtilsTest\$LogCaller: $fakeMessage\n" +
+                        "W/RuntimeUtilsTest\$LogCaller: $fakeMessage\n" +
+                        "E/RuntimeUtilsTest\$LogCaller: $fakeMessage\n" +
+                        "A/RuntimeUtilsTest\$LogCaller: $fakeMessage\n"
+            )
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.M)
+    fun `devLogger will cut caller name to max accepted tag length if below N`(
+        forge: Forge,
+        @SystemOutStream outputStream: ByteArrayOutputStream,
+        @SystemErrorStream errorStream: ByteArrayOutputStream
+    ) {
+
+        // given
+        val fakeMessage = forge.anAlphabeticalString()
+        Datadog.setVerbosity(Log.VERBOSE)
+        Datadog.setFieldValue("isDebug", true)
+        val underTest = LogCaller()
+
+        // when
+        underTest.logMessage(fakeMessage)
+
+        // then
+        assertThat(outputStream.toString())
+            .isEqualTo(
+                "V/RuntimeUtilsTest\$LogCal: $fakeMessage\n" +
+                        "D/RuntimeUtilsTest\$LogCal: $fakeMessage\n" +
+                        "I/RuntimeUtilsTest\$LogCal: $fakeMessage\n" +
+                        "W/RuntimeUtilsTest\$LogCal: $fakeMessage\n" +
+                        "E/RuntimeUtilsTest\$LogCal: $fakeMessage\n" +
+                        "A/RuntimeUtilsTest\$LogCal: $fakeMessage\n"
+            )
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.N)
+    fun `devLogger will strip the anonymous part from caller name when resolving the tag`(
+        forge: Forge,
+        @SystemOutStream outputStream: ByteArrayOutputStream,
+        @SystemErrorStream errorStream: ByteArrayOutputStream
+    ) {
+
+        // given
+        val fakeMessage = forge.anAlphabeticalString()
+        Datadog.setVerbosity(Log.VERBOSE)
+        Datadog.setFieldValue("isDebug", true)
+        val underTest = object : Caller {
+            override fun logMessage(message: String) {
+                devLogger.v(message)
+            }
+        }
+
+        // when
+        underTest.logMessage(fakeMessage)
+
+        // then
+        assertThat(outputStream.toString())
+            .isEqualTo(
+                "V/RuntimeUtilsTest\$devLogger will strip " +
+                        "the anonymous part from caller name when " +
+                        "resolving the tag\$underTest: $fakeMessage\n"
+            )
+    }
+
+    open class LogCaller : Caller {
+
+        override fun logMessage(message: String) {
+            devLogger.v(message)
+            devLogger.d(message)
+            devLogger.i(message)
+            devLogger.w(message)
+            devLogger.e(message)
+            devLogger.wtf(message)
+        }
+    }
+
+    interface Caller {
+        fun logMessage(message: String)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -89,7 +89,7 @@ internal class WorkManagerUtilsTest {
         if (BuildConfig.DEBUG) {
             val expectedTagName = if (Datadog.isDebug) "WorkManagerUtilsKt" else "DD_LOG"
             val logMessages = outStream.toString().trim().split("\n")
-            assertThat(logMessages[0]).matches("E/$expectedTagName: $TAG.*")
+            assertThat(logMessages[0]).matches("E/$expectedTagName: $ERROR_MESSAGE.*")
         }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -87,8 +87,9 @@ internal class WorkManagerUtilsTest {
         // then
         verifyZeroInteractions(mockedWorkManager)
         if (BuildConfig.DEBUG) {
+            val expectedTagName = if (Datadog.isDebug) "WorkManagerUtilsKt" else "DD_LOG"
             val logMessages = outStream.toString().trim().split("\n")
-            assertThat(logMessages[0]).matches("E/DD_LOG: $TAG.*")
+            assertThat(logMessages[0]).matches("E/$expectedTagName: $TAG.*")
         }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/domain/FilePersistenceStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/domain/FilePersistenceStrategyTest.kt
@@ -273,7 +273,7 @@ internal abstract class FilePersistenceStrategyTest<T : Any>(
         if (BuildConfig.DEBUG) {
             val logMessages = outputStream.toString().trim().split("\n")
             assertThat(logMessages[logMessages.size - 1].trim())
-                .matches("W/$expectedTag: FileReader: .+")
+                .matches("W/$expectedTag: .+")
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/domain/FilePersistenceStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/domain/FilePersistenceStrategyTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.core.internal.threading.DeferredHandler
 import com.datadog.android.utils.asJsonArray
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext
+import com.datadog.android.utils.resolveTagName
 import com.datadog.tools.unit.annotations.SystemOutStream
 import com.datadog.tools.unit.annotations.TestTargetApi
 import com.datadog.tools.unit.extensions.ApiLevelExtension
@@ -267,12 +268,12 @@ internal abstract class FilePersistenceStrategyTest<T : Any>(
         forge: Forge,
         @SystemOutStream outputStream: ByteArrayOutputStream
     ) {
+        val expectedTag = resolveTagName(testedReader, "DD_LOG")
         testedReader.dropBatch(forge.aNumericalString())
         if (BuildConfig.DEBUG) {
             val logMessages = outputStream.toString().trim().split("\n")
             assertThat(logMessages[logMessages.size - 1].trim())
-                .withFailMessage("We were expecting a log message here")
-                .matches("W/DD_LOG: FileReader: .+")
+                .matches("W/$expectedTag: FileReader: .+")
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -18,7 +18,6 @@ import com.datadog.tools.unit.annotations.SystemOutStream
 import com.datadog.tools.unit.extensions.SystemOutputExtension
 import com.datadog.tools.unit.getFieldValue
 import com.datadog.tools.unit.invokeMethod
-import com.datadog.tools.unit.setFieldValue
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
@@ -53,8 +52,6 @@ internal class LoggerBuilderTest {
 
     @BeforeEach
     fun `set up Datadog`(forge: Forge) {
-        Datadog.setFieldValue("isDebug", true)
-
         packageName = forge.anAlphabeticalString()
         mockContext = mockContext(packageName, "")
         whenever(mockContext.filesDir) doReturn rootDir

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -9,16 +9,16 @@ package com.datadog.android.log
 import android.content.Context
 import android.util.Log as AndroidLog
 import com.datadog.android.Datadog
-import com.datadog.android.log.internal.logger.CombinedLogHandler
 import com.datadog.android.log.internal.logger.DatadogLogHandler
 import com.datadog.android.log.internal.logger.LogHandler
-import com.datadog.android.log.internal.logger.LogcatLogHandler
 import com.datadog.android.log.internal.logger.NoOpLogHandler
 import com.datadog.android.utils.mockContext
+import com.datadog.android.utils.resolveTagName
 import com.datadog.tools.unit.annotations.SystemOutStream
 import com.datadog.tools.unit.extensions.SystemOutputExtension
 import com.datadog.tools.unit.getFieldValue
 import com.datadog.tools.unit.invokeMethod
+import com.datadog.tools.unit.setFieldValue
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
@@ -53,6 +53,8 @@ internal class LoggerBuilderTest {
 
     @BeforeEach
     fun `set up Datadog`(forge: Forge) {
+        Datadog.setFieldValue("isDebug", true)
+
         packageName = forge.anAlphabeticalString()
         mockContext = mockContext(packageName, "")
         whenever(mockContext.filesDir) doReturn rootDir
@@ -127,17 +129,48 @@ internal class LoggerBuilderTest {
     }
 
     @Test
-    fun `builder can enable logcat logs`(@Forgery forge: Forge) {
+    fun `builder can enable logcat logs`(
+        @Forgery forge: Forge,
+        @SystemOutStream outputStream: ByteArrayOutputStream
+    ) {
         val logcatLogsEnabled = true
+        val fakeMessage = forge.anAlphabeticalString()
+        val fakeServiceName = forge.anAlphaNumericalString()
 
         val logger = Logger.Builder()
             .setLogcatLogsEnabled(logcatLogsEnabled)
+            .setServiceName(fakeServiceName)
             .build()
+        logger.v(fakeMessage)
+        val expectedTagName = resolveTagName(this, fakeServiceName)
 
-        val handler = logger.getFieldValue("handler") as CombinedLogHandler
-        assertThat(handler.handlers)
-            .hasAtLeastOneElementOfType(DatadogLogHandler::class.java)
-            .hasAtLeastOneElementOfType(LogcatLogHandler::class.java)
+        assertThat(outputStream.toString())
+            .isEqualTo(
+                "V/$expectedTagName: $fakeMessage\n"
+            )
+    }
+
+    @Test
+    fun `builder can enable only logcat logs`(
+        @Forgery forge: Forge,
+        @SystemOutStream outputStream: ByteArrayOutputStream
+    ) {
+        val logcatLogsEnabled = true
+        val fakeMessage = forge.anAlphabeticalString()
+        val fakeServiceName = forge.anAlphaNumericalString()
+
+        val logger = Logger.Builder()
+            .setDatadogLogsEnabled(false)
+            .setLogcatLogsEnabled(logcatLogsEnabled)
+            .setServiceName(fakeServiceName)
+            .build()
+        logger.v(fakeMessage)
+        val expectedTagName = resolveTagName(this, fakeServiceName)
+
+        assertThat(outputStream.toString())
+            .isEqualTo(
+                "V/$expectedTagName: $fakeMessage\n"
+            )
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/constraints/DatadogLogConstraintsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/constraints/DatadogLogConstraintsTest.kt
@@ -83,7 +83,7 @@ internal class DatadogLogConstraintsTest {
         val expectedTag = resolveTagName(testedConstraints)
         assertThat(outputStream.lastLine())
             .isEqualTo(
-                "E/$expectedTag: DatadogLogConstraints: \"$tag\" is an invalid tag, " +
+                "E/$expectedTag: \"$tag\" is an invalid tag, " +
                         "and was ignored."
             )
     }
@@ -110,7 +110,7 @@ internal class DatadogLogConstraintsTest {
 
         assertThat(outputStream.lastLine())
             .isEqualTo(
-                "W/$expectedLogcatTag: DatadogLogConstraints: tag \"$tag\" " +
+                "W/$expectedLogcatTag: tag \"$tag\" " +
                         "was modified to \"$expectedInnerTag\" to match our constraints."
             )
     }
@@ -131,7 +131,7 @@ internal class DatadogLogConstraintsTest {
             .containsOnly(expectedInnerTag)
         assertThat(outputStream.lastLine())
             .isEqualTo(
-                "W/$expectedLogcatTag: DatadogLogConstraints: tag \"$tag\" " +
+                "W/$expectedLogcatTag: tag \"$tag\" " +
                         "was modified to \"$expectedInnerTag\" to match our constraints."
             )
     }
@@ -150,7 +150,7 @@ internal class DatadogLogConstraintsTest {
             .containsOnly(expectedInnerTag)
         assertThat(outputStream.lastLine())
             .isEqualTo(
-                "W/$expectedLogcatTag: DatadogLogConstraints: tag \"$tag\" " +
+                "W/$expectedLogcatTag: tag \"$tag\" " +
                         "was modified to \"$expectedInnerTag\" to match our constraints."
             )
     }
@@ -171,7 +171,7 @@ internal class DatadogLogConstraintsTest {
         if (BuildConfig.DEBUG) {
             assertThat(outputStream.lastLine())
                 .isEqualTo(
-                    "W/$expectedLogcatTag: DatadogLogConstraints: tag \"$expectedInnerTag:\" " +
+                    "W/$expectedLogcatTag: tag \"$expectedInnerTag:\" " +
                             "was modified to \"$expectedInnerTag\" to match our constraints."
                 )
         }
@@ -193,7 +193,7 @@ internal class DatadogLogConstraintsTest {
             .isEmpty()
         assertThat(outputStream.lastLine())
             .isEqualTo(
-                "E/$expectedLogcatTag: DatadogLogConstraints: \"$expectedInnerTag\" " +
+                "E/$expectedLogcatTag: \"$expectedInnerTag\" " +
                         "is an invalid tag, " +
                         "and was ignored."
             )
@@ -215,7 +215,7 @@ internal class DatadogLogConstraintsTest {
             .isEmpty()
         assertThat(outputStream.lastLine())
             .isEqualTo(
-                "E/$expectedLogcatTag: DatadogLogConstraints: \"$expectedInnerTag\" " +
+                "E/$expectedLogcatTag: \"$expectedInnerTag\" " +
                         "is an invalid tag," +
                         " and was ignored."
             )
@@ -237,7 +237,7 @@ internal class DatadogLogConstraintsTest {
             .containsExactlyElementsOf(firstTags)
         assertThat(outputStream.lastLine())
             .isEqualTo(
-                "W/$expectedLogcatTag: DatadogLogConstraints: too many tags were added, " +
+                "W/$expectedLogcatTag: too many tags were added, " +
                         "$discardedCount had to be discarded."
             )
     }
@@ -280,7 +280,7 @@ internal class DatadogLogConstraintsTest {
         val expectedLogcatTag = resolveTagName(testedConstraints)
         assertThat(outputStream.lastLine())
             .isEqualTo(
-                "W/$expectedLogcatTag: DatadogLogConstraints: attribute \"$key\" " +
+                "W/$expectedLogcatTag: attribute \"$key\" " +
                         "was modified to \"$expectedKey\" to match our constraints."
             )
     }
@@ -302,7 +302,7 @@ internal class DatadogLogConstraintsTest {
         val expectedLogcatTag = resolveTagName(testedConstraints)
         assertThat(outputStream.lastLine())
             .isEqualTo(
-                "W/$expectedLogcatTag: DatadogLogConstraints: too many " +
+                "W/$expectedLogcatTag: too many " +
                         "attributes were added, " +
                         "$discardedCount had to be discarded."
             )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
@@ -48,8 +48,6 @@ internal class LogcatLogHandlerTest {
 
     var fakeLevel: Int = 0
 
-    var callerStackIndex = 3
-
     @Forgery
     lateinit var fakeThrowable: Throwable
 
@@ -62,7 +60,7 @@ internal class LogcatLogHandlerTest {
         fakeAttributes = forge.aMap { anAlphabeticalString() to anInt() }
         fakeTags = forge.aList { anAlphabeticalString() }.toSet()
 
-        testedHandler = LogcatLogHandler(fakeServiceName, callerStackIndex)
+        testedHandler = LogcatLogHandler(fakeServiceName, -3)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
@@ -6,10 +6,13 @@
 
 package com.datadog.android.log.internal.logger
 
+import com.datadog.android.Datadog
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.resolveTagName
 import com.datadog.tools.unit.annotations.SystemErrorStream
 import com.datadog.tools.unit.annotations.SystemOutStream
 import com.datadog.tools.unit.extensions.SystemOutputExtension
+import com.datadog.tools.unit.setFieldValue
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -45,6 +48,8 @@ internal class LogcatLogHandlerTest {
 
     var fakeLevel: Int = 0
 
+    var callerStackIndex = 3
+
     @Forgery
     lateinit var fakeThrowable: Throwable
 
@@ -57,7 +62,7 @@ internal class LogcatLogHandlerTest {
         fakeAttributes = forge.aMap { anAlphabeticalString() to anInt() }
         fakeTags = forge.aList { anAlphabeticalString() }.toSet()
 
-        testedHandler = LogcatLogHandler(fakeServiceName)
+        testedHandler = LogcatLogHandler(fakeServiceName, callerStackIndex)
     }
 
     @Test
@@ -73,9 +78,10 @@ internal class LogcatLogHandlerTest {
             fakeTags
         )
 
+        val exptectedTagName = resolveTagName(this, fakeServiceName)
         val prefix = levels[fakeLevel]
         assertThat(outputStream.toString())
-            .isEqualTo("$prefix/$fakeServiceName: $fakeMessage\n")
+            .isEqualTo("$prefix/$exptectedTagName: $fakeMessage\n")
         assertThat(errorStream.toString())
             .startsWith("${fakeThrowable.javaClass.canonicalName}: ${fakeThrowable.message}")
     }
@@ -88,6 +94,8 @@ internal class LogcatLogHandlerTest {
     ) {
         val threadName = forge.anAlphabeticalString()
         val countDownLatch = CountDownLatch(1)
+        val exptectedTagName = resolveTagName(this, fakeServiceName)
+        testedHandler = LogcatLogHandler(fakeServiceName, 4)
         val thread = Thread({
             testedHandler.handleLog(
                 fakeLevel,
@@ -104,7 +112,7 @@ internal class LogcatLogHandlerTest {
 
         val prefix = levels[fakeLevel]
         assertThat(outputStream.toString())
-            .isEqualTo("$prefix/$fakeServiceName: $fakeMessage\n")
+            .isEqualTo("$prefix/$exptectedTagName: $fakeMessage\n")
         assertThat(errorStream.toString())
             .startsWith("${fakeThrowable.javaClass.canonicalName}: ${fakeThrowable.message}")
     }
@@ -114,6 +122,8 @@ internal class LogcatLogHandlerTest {
         @SystemOutStream outputStream: ByteArrayOutputStream,
         @SystemErrorStream errorStream: ByteArrayOutputStream
     ) {
+        val exptectedTagName = resolveTagName(this, fakeServiceName)
+
         testedHandler.handleLog(
             fakeLevel,
             fakeMessage,
@@ -124,9 +134,37 @@ internal class LogcatLogHandlerTest {
 
         val prefix = levels[fakeLevel]
         assertThat(outputStream.toString())
-            .isEqualTo("$prefix/$fakeServiceName: $fakeMessage\n")
+            .isEqualTo("$prefix/$exptectedTagName: $fakeMessage\n")
         assertThat(errorStream.toString())
             .isEmpty()
+    }
+
+    @Test
+    fun `uses caller name as tag if inDebug`(
+        @SystemOutStream outputStream: ByteArrayOutputStream,
+        @SystemErrorStream errorStream: ByteArrayOutputStream
+    ) {
+        // given
+        val isDebug = Datadog.isDebug
+        Datadog.setFieldValue("isDebug", true)
+
+        // when
+        testedHandler.handleLog(
+            fakeLevel,
+            fakeMessage,
+            null,
+            emptyMap(),
+            emptySet()
+        )
+
+        // then
+        val prefix = levels[fakeLevel]
+        val expectedTagName = resolveTagName(this, fakeServiceName)
+        assertThat(outputStream.toString())
+            .isEqualTo("$prefix/$expectedTagName: $fakeMessage\n")
+        assertThat(errorStream.toString())
+            .isEmpty()
+        Datadog.setFieldValue("isDebug", isDebug)
     }
 
     companion object {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
@@ -7,9 +7,11 @@
 package com.datadog.android.utils
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import com.datadog.android.BuildConfig
+import com.datadog.android.Datadog
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
@@ -33,9 +35,26 @@ inline fun <reified T : Context> mockContext(
 
     whenever(mockContext.applicationContext) doReturn mockContext
     whenever(mockContext.packageManager) doReturn mockPackageMgr
-    whenever(mockContext.applicationInfo) doReturn mock()
+    val mockApplicationInfo = mock<ApplicationInfo>()
+    whenever(mockContext.applicationInfo) doReturn mockApplicationInfo
+    if (BuildConfig.DEBUG) {
+        mockApplicationInfo.flags =
+            ApplicationInfo.FLAG_DEBUGGABLE.or(ApplicationInfo.FLAG_ALLOW_BACKUP)
+    }
     whenever(mockContext.packageName) doReturn packageName
     whenever(mockContext.filesDir) doReturn File("/dev/null")
 
     return mockContext
+}
+
+/**
+ * Resolves the expected tag name for the logcat message depending on the application type
+ * (debug or release)
+ */
+fun resolveTagName(caller: Any, defaultIfNotDebug: String? = null): String {
+    return if (Datadog.isDebug) {
+        caller.javaClass.simpleName
+    } else {
+        defaultIfNotDebug ?: "Datadog"
+    }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
@@ -33,6 +33,7 @@ inline fun <reified T : Context> mockContext(
 
     whenever(mockContext.applicationContext) doReturn mockContext
     whenever(mockContext.packageManager) doReturn mockPackageMgr
+    whenever(mockContext.applicationInfo) doReturn mock()
     whenever(mockContext.packageName) doReturn packageName
     whenever(mockContext.filesDir) doReturn File("/dev/null")
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
@@ -39,7 +39,7 @@ inline fun <reified T : Context> mockContext(
     whenever(mockContext.applicationInfo) doReturn mockApplicationInfo
     if (BuildConfig.DEBUG) {
         mockApplicationInfo.flags =
-            ApplicationInfo.FLAG_DEBUGGABLE.or(ApplicationInfo.FLAG_ALLOW_BACKUP)
+            ApplicationInfo.FLAG_DEBUGGABLE or ApplicationInfo.FLAG_ALLOW_BACKUP
     }
     whenever(mockContext.packageName) doReturn packageName
     whenever(mockContext.filesDir) doReturn File("/dev/null")


### PR DESCRIPTION
### What does this PR do?

This PR addresses the issue #133 and adds a new capability to our LogcatHandler to be able to resolve and use as a TAG  the caller class name whenever using either the *sdkLogger*, *devLogger* or a simple logger having the *logcatOptionEnabled*. 

### Motivation

Was requested by some of our users and also brings a lot of value in our logs.

### Additional Notes

Please note that we are using 2 STACK_INDEX values to detect the right stack trace element due to the different place in the stack hierarchy if we are using the *sdkLogger* or the *devLogger* (which has one extra layer).

### Review checklist (to be filled by reviewers)

- [X] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [X] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [X] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

