### PR TITLE
Prevent crash on Runtime shutdown

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -68,7 +68,7 @@ test:unit:
   stage: test
   script:
     - git fetch --depth=1 origin master
-    - ./gradlew unitTestAll
+    - ./gradlew unitTestChanged
 
 publish:release:
   tags: [ "runner:docker", "size:large" ]

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,13 +41,16 @@ task<Delete>("clean") {
     delete(rootProject.buildDir)
 }
 
-gitDiffTask("unitTestAll") {
+gitDiffTask("unitTestChanged") {
     dependsOnDiff(
         "dd-sdk-android/.*",
         ":dd-sdk-android:testDebugUnitTest",
         ":dd-sdk-android:testReleaseUnitTest",
+        ":dd-sdk-android-timber:testDebugUnitTest",
+        ":dd-sdk-android-timber:testReleaseUnitTest",
         ":sample:java:assembleDebug",
-        ":sample:kotlin:assembleDebug"
+        ":sample:kotlin:assembleDebug",
+        ":sample:kotlin-timber:assembleDebug"
     )
     dependsOnDiff(
         "dd-sdk-android-timber/.*",
@@ -56,13 +59,40 @@ gitDiffTask("unitTestAll") {
         ":sample:kotlin-timber:assembleDebug"
     )
     dependsOnDiff(
-        "tools/.*",
-        ":tools:detekt:test",
+        "tools/detekt/.*",
+        ":tools:detekt:test"
+    )
+    dependsOnDiff(
+        "tools/unit/.*",
         ":tools:unit:testDebugUnitTest",
         ":tools:unit:testReleaseUnitTest"
     )
     dependsOnDiff(
-        "sample/.*",
+        "sample/java/.*",
+        ":sample:java:assembleDebug"
+    )
+    dependsOnDiff(
+        "sample/kotlin/.*",
+        ":sample:kotlin:assembleDebug"
+    )
+    dependsOnDiff(
+        "sample/kotlin/.*",
+        ":sample:kotlin-timber:assembleDebug"
+    )
+}
+
+gitDiffTask("unitTestAll") {
+    dependsOn(
+        ":dd-sdk-android:testDebugUnitTest",
+        ":dd-sdk-android:testReleaseUnitTest",
+        ":sample:java:assembleDebug",
+        ":sample:kotlin:assembleDebug",
+        ":dd-sdk-android-timber:testDebugUnitTest",
+        ":dd-sdk-android-timber:testReleaseUnitTest",
+        ":sample:kotlin-timber:assembleDebug",
+        ":tools:detekt:test",
+        ":tools:unit:testDebugUnitTest",
+        ":tools:unit:testReleaseUnitTest",
         ":sample:java:assembleDebug",
         ":sample:kotlin:assembleDebug",
         ":sample:kotlin-timber:assembleDebug"

--- a/dd-sdk-android-timber/src/test/kotlin/com/datadog/android/timber/DatadogTreeTest.kt
+++ b/dd-sdk-android-timber/src/test/kotlin/com/datadog/android/timber/DatadogTreeTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.timber
 
 import android.content.Context
+import android.content.pm.ApplicationInfo
 import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import com.datadog.android.Datadog
@@ -61,13 +62,18 @@ internal class DatadogTreeTest {
         val mockPackageInfo = PackageInfo()
         val mockPackageMgr = mock<PackageManager>()
         val mockContext: Context = mock()
+        val mockApplicationInfo: ApplicationInfo = mock()
         mockPackageInfo.versionName = forge.anAlphabeticalString()
         whenever(mockPackageMgr.getPackageInfo(fakePackageName, 0)) doReturn mockPackageInfo
         whenever(mockContext.filesDir).thenReturn(tempDir)
         whenever(mockContext.applicationContext) doReturn mockContext
         whenever(mockContext.packageManager) doReturn mockPackageMgr
         whenever(mockContext.packageName) doReturn fakePackageName
-
+        whenever(mockContext.applicationInfo) doReturn mockApplicationInfo
+        if (BuildConfig.DEBUG) {
+            mockApplicationInfo.flags =
+                ApplicationInfo.FLAG_DEBUGGABLE or ApplicationInfo.FLAG_ALLOW_BACKUP
+        }
         Datadog.initialize(mockContext, forge.anHexadecimalString())
 
         val builder = Logger.Builder()
@@ -147,8 +153,9 @@ internal class DatadogTreeTest {
         logCatPrefix: String,
         outputStream: ByteArrayOutputStream
     ) {
+        val tag = if (BuildConfig.DEBUG) "DatadogTree" else fakeServiceName
         assertThat(outputStream.lastLine())
-            .isEqualTo("$logCatPrefix/$fakeServiceName: $fakeMessage")
+            .isEqualTo("$logCatPrefix/$tag: $fakeMessage")
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -144,6 +144,13 @@ object Datadog {
         // We set this up last.
         // We don't want to catch any exception that might throw during the initialisation)
         setupTheExceptionHandler(appContext)
+
+        // Issue #154 (“Thread starting during runtime shutdown”)
+        // Make sure we stop Datadog when the Runtime shuts down
+        Runtime.getRuntime()
+            .addShutdownHook(
+                Thread(Runnable { stop() }, SHUTDOWN_THREAD)
+            )
     }
 
     /**
@@ -337,6 +344,8 @@ object Datadog {
 
     internal const val MESSAGE_DEPRECATED = "%s has been deprecated. " +
             "If you need it, submit an issue at https://github.com/DataDog/dd-sdk-android/issues/"
+
+    internal const val SHUTDOWN_THREAD = "datadog_shutdown"
 
     // endregion
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
@@ -64,7 +64,8 @@ internal class DataUploadRunnable(
         currentDelayInterval =
             DEFAULT_DELAY
         handler.removeCallbacks(this)
-        handler.postDelayed(this,
+        handler.postDelayed(
+            this,
             MAX_DELAY
         )
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -9,7 +9,6 @@ package com.datadog.android.core.internal.net
 import android.os.Build
 import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.utils.sdkLogger
-import java.io.IOException
 import java.util.Locale
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -51,7 +50,7 @@ internal class DataOkHttpUploader(
                             "headers:${response.headers()}"
             )
             responseCodeToUploadStatus(response.code())
-        } catch (e: IOException) {
+        } catch (e: Throwable) {
             sdkLogger.e("unable to upload data", e)
             UploadStatus.NETWORK_ERROR
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
@@ -9,7 +9,7 @@ package com.datadog.android.log.internal.logger
 import android.os.Build
 import android.util.Log
 import com.datadog.android.Datadog
-import java.util.logging.Logger
+import com.datadog.android.log.Logger
 import java.util.regex.Pattern
 
 internal class LogcatLogHandler(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -147,6 +147,25 @@ internal class DatadogTest {
     }
 
     @Test
+    fun `registers shutdown hooks`() {
+        Datadog.initialize(mockAppContext, fakeToken)
+
+        val shutdownHooks: Map<Thread, Thread> =
+            getStaticValue("java.lang.ApplicationShutdownHooks", "hooks")
+
+        val shutdownThread = shutdownHooks.keys
+            .first { it.name == Datadog.SHUTDOWN_THREAD }
+        assertThat(shutdownThread).isNotNull()
+
+        shutdownThread.start()
+        Thread.sleep(500L)
+        // check that stop was called by the shutdownThread
+        assertThrows<IllegalStateException> {
+            Datadog.invokeMethod("stop")
+        }
+    }
+
+    @Test
     @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
     fun `registers broadcast receivers on initialize (Lollipop)`() {
         Datadog.initialize(mockAppContext, fakeToken)

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
@@ -47,6 +47,23 @@ inline fun <reified T, R> Class<T>.setStaticValue(
 
 /**
  * Gets the static value from the target class.
+ * @param className the full name of the class
+ * @param fieldName the name of the field
+ */
+inline fun <reified R> getStaticValue(
+    className: String,
+    fieldName: String
+): R {
+    val clazz = Class.forName(className)
+    val field = clazz.getDeclaredField(fieldName)
+    // make it accessible
+    field.isAccessible = true
+
+    return field.get(null) as R
+}
+
+/**
+ * Gets the static value from the target class.
  * @param fieldName the name of the field
  */
 inline fun <reified T, reified R> Class<T>.getStaticValue(fieldName: String): R {


### PR DESCRIPTION
### What does this PR do?

Tries to prevent a crash happening on Runtime shutdown

### Motivation

Mostly motivated by issue #154: 

When the ART/JVM shuts down (either from a previous crash or when the app exits), new Thread are blocked from being spawned and will throw a `java.lang.InternalError`.
We add a shutdown hook to stop the Datadog SDK whenever the Runtime shuts down.

### Additional Notes

I wasn't able to reproduce this yet, but this fix should handle the issue.

@alparp27, if you can could you please build a local version of the Datadog library and see if this does indeed fix the issue?

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

