### PR TITLE
RUMM-219 Add activity screen tracker

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -24,6 +24,9 @@ class com.datadog.android.DatadogConfig
     fun useCustomTracesEndpoint(String): Builder
     fun useCustomCrashReportsEndpoint(String): Builder
     fun useCustomRumEndpoint(String): Builder
+    fun trackGestures(): Builder
+    fun trackActivitiesAsScreens(): Builder
+    fun trackFragmentsAsScreens(): Builder
   companion object
 object com.datadog.android.DatadogEndpoint
   const val LOGS_US: String

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -25,8 +25,11 @@ class com.datadog.android.DatadogConfig
     fun useCustomCrashReportsEndpoint(String): Builder
     fun useCustomRumEndpoint(String): Builder
     fun trackGestures(): Builder
-    fun trackActivitiesAsScreens(): Builder
-    fun trackFragmentsAsScreens(): Builder
+    fun trackViews(ViewTrackerStrategy): Builder
+  enum ViewTrackerStrategy
+    - TRACK_ACTIVITIES_AS_VIEWS
+    - TRACK_FRAGMENTS_AS_VIEWS
+    - NONE
   companion object
 object com.datadog.android.DatadogEndpoint
   const val LOGS_US: String

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -37,8 +37,8 @@ private constructor(
         val serviceName: String,
         val envName: String,
         val trackGestures: Boolean = false,
-        val trackActivityAsScreens: Boolean = false,
-        val trackFragmentAsScreens: Boolean = false
+        val trackActivitiesAsScreens: Boolean = false,
+        val trackFragmentsAsScreens: Boolean = false
     )
 
     // region Builder
@@ -264,7 +264,7 @@ private constructor(
          * events for you.
          */
         fun trackActivitiesAsScreens(): Builder {
-            rumConfig = rumConfig.copy(trackActivityAsScreens = true)
+            rumConfig = rumConfig.copy(trackActivitiesAsScreens = true)
             return this
         }
 
@@ -274,7 +274,7 @@ private constructor(
          * as RUM new View events for you.
          */
         fun trackFragmentsAsScreens(): Builder {
-            rumConfig = rumConfig.copy(trackFragmentAsScreens = true)
+            rumConfig = rumConfig.copy(trackFragmentsAsScreens = true)
             return this
         }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -37,8 +37,7 @@ private constructor(
         val serviceName: String,
         val envName: String,
         val trackGestures: Boolean = false,
-        val trackActivitiesAsScreens: Boolean = false,
-        val trackFragmentsAsScreens: Boolean = false
+        val viewTrackerStrategy: ViewTrackerStrategy = ViewTrackerStrategy.NONE
     )
 
     // region Builder
@@ -259,22 +258,15 @@ private constructor(
         }
 
         /**
-         * Enable the activities tracker. By enabling this feature the SDK will monitor the
-         * activities lifecycle and will automatically send them as RUM new View
-         * events for you.
+         * Sets the automatic view tracking strategy used by the SDK.
+         * By default this is NONE.
+         * @param strategy as the strategy to be used by the automatic view tracker.
+         * @see ViewTrackerStrategy.TRACK_ACTIVITIES_AS_VIEWS
+         * @see ViewTrackerStrategy.TRACK_FRAGMENTS_AS_VIEWS
+         * @see ViewTrackerStrategy.NONE
          */
-        fun trackActivitiesAsScreens(): Builder {
-            rumConfig = rumConfig.copy(trackActivitiesAsScreens = true)
-            return this
-        }
-
-        /**
-         * Enable the fragments tracker. By enabling this feature the SDK will monitor the
-         * FragmentManager operations and will automatically send newly added fragments
-         * as RUM new View events for you.
-         */
-        fun trackFragmentsAsScreens(): Builder {
-            rumConfig = rumConfig.copy(trackFragmentsAsScreens = true)
+        fun trackViews(strategy: ViewTrackerStrategy): Builder {
+            rumConfig = rumConfig.copy(viewTrackerStrategy = strategy)
             return this
         }
 
@@ -283,6 +275,26 @@ private constructor(
                 needsClearTextHttp = true
             }
         }
+    }
+
+    /**
+     * The available strategies for the automatic View tracker.
+     */
+    enum class ViewTrackerStrategy {
+        /**
+         * The SDK will monitor the FragmentManager operations
+         * and will automatically start and stop RUM View for each resumed/paused fragment.
+         */
+        TRACK_ACTIVITIES_AS_VIEWS,
+        /**
+         * The SDK will monitor the FragmentManager operations
+         * and will automatically start and stop RUM View for each resumed/paused fragment.
+         */
+        TRACK_FRAGMENTS_AS_VIEWS,
+        /**
+         * The SDK will not use any automatic view tracking mechanism.
+         */
+        NONE
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -19,7 +19,7 @@ private constructor(
     internal val logsConfig: FeatureConfig?,
     internal val tracesConfig: FeatureConfig?,
     internal val crashReportConfig: FeatureConfig?,
-    internal val rumConfig: FeatureConfig?
+    internal val rumConfig: RumConfig?
 ) {
 
     internal data class FeatureConfig(
@@ -28,6 +28,17 @@ private constructor(
         val endpointUrl: String,
         val serviceName: String,
         val envName: String
+    )
+
+    internal data class RumConfig(
+        val clientToken: String,
+        val applicationId: UUID,
+        val endpointUrl: String,
+        val serviceName: String,
+        val envName: String,
+        val trackGestures: Boolean = false,
+        val trackActivityAsScreens: Boolean = false,
+        val trackFragmentAsScreens: Boolean = false
     )
 
     // region Builder
@@ -45,7 +56,7 @@ private constructor(
          * @param clientToken your API key of type Client Token
          */
         constructor(clientToken: String) :
-            this(clientToken, UUID(0, 0))
+                this(clientToken, UUID(0, 0))
 
         /**
          * A Builder class for a [DatadogConfig].
@@ -53,7 +64,7 @@ private constructor(
          * @param applicationId your applicationId for RUM events
          */
         constructor(clientToken: String, applicationId: String) :
-            this(clientToken, UUID.fromString(applicationId))
+                this(clientToken, UUID.fromString(applicationId))
 
         private var logsConfig: FeatureConfig = FeatureConfig(
             clientToken,
@@ -76,7 +87,7 @@ private constructor(
             DEFAULT_SERVICE_NAME,
             DEFAULT_ENV_NAME
         )
-        private var rumConfig: FeatureConfig = FeatureConfig(
+        private var rumConfig: RumConfig = RumConfig(
             clientToken,
             applicationId,
             DatadogEndpoint.RUM_US,
@@ -235,6 +246,35 @@ private constructor(
         fun useCustomRumEndpoint(endpoint: String): Builder {
             rumConfig = rumConfig.copy(endpointUrl = endpoint)
             checkCustomEndpoint(endpoint)
+            return this
+        }
+
+        /**
+         * Enable the gestures auto tracker. By enabling this feature the SDK will intercept
+         * tap events and automatically send those as RUM UserActions for you.
+         */
+        fun trackGestures(): Builder {
+            rumConfig = rumConfig.copy(trackGestures = true)
+            return this
+        }
+
+        /**
+         * Enable the activities tracker. By enabling this feature the SDK will monitor the
+         * activities lifecycle and will automatically send them as RUM new View
+         * events for you.
+         */
+        fun trackActivitiesAsScreens(): Builder {
+            rumConfig = rumConfig.copy(trackActivityAsScreens = true)
+            return this
+        }
+
+        /**
+         * Enable the fragments tracker. By enabling this feature the SDK will monitor the
+         * FragmentManager operations and will automatically send newly added fragments
+         * as RUM new View events for you.
+         */
+        fun trackFragmentsAsScreens(): Builder {
+            rumConfig = rumConfig.copy(trackFragmentAsScreens = true)
             return this
         }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -42,7 +42,7 @@ internal object RumFeature {
     @Suppress("LongParameterList")
     fun initialize(
         appContext: Context,
-        config: DatadogConfig.FeatureConfig,
+        config: DatadogConfig.RumConfig,
         okHttpClient: OkHttpClient,
         networkInfoProvider: NetworkInfoProvider,
         systemInfoProvider: SystemInfoProvider

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -112,15 +112,18 @@ internal object RumFeature {
                     TrackingStrategy.GesturesTrackingStrategy
                 )
             }
-            if (config.trackActivitiesAsScreens) {
-                appContext.registerActivityLifecycleCallbacks(
-                    TrackingStrategy.ActivityTrackingStrategy
-                )
-            }
-            if (config.trackFragmentsAsScreens) {
-                appContext.registerActivityLifecycleCallbacks(
-                    TrackingStrategy.FragmentsTrackingStrategy
-                )
+
+            when (config.viewTrackerStrategy) {
+                DatadogConfig.ViewTrackerStrategy.TRACK_ACTIVITIES_AS_VIEWS ->
+                    appContext.registerActivityLifecycleCallbacks(
+                        TrackingStrategy.ActivityTrackingStrategy
+                    )
+                DatadogConfig.ViewTrackerStrategy.TRACK_FRAGMENTS_AS_VIEWS ->
+                    appContext.registerActivityLifecycleCallbacks(
+                        TrackingStrategy.FragmentsTrackingStrategy
+                    )
+                else -> { // Do Nothing }
+                }
             }
         } else {
             devLogger.e(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/TrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/TrackingStrategy.kt
@@ -3,6 +3,7 @@ package com.datadog.android.rum.internal.instrumentation
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
+import com.datadog.android.rum.GlobalRum
 
 internal sealed class TrackingStrategy : Application.ActivityLifecycleCallbacks {
 
@@ -35,10 +36,20 @@ internal sealed class TrackingStrategy : Application.ActivityLifecycleCallbacks 
     }
 
     // TODO RUMM-242
-    internal class GesturesTrackingStrategy : TrackingStrategy()
+    internal object GesturesTrackingStrategy : TrackingStrategy()
 
-    internal class ActivityTrackingStrategy : TrackingStrategy()
+    internal object ActivityTrackingStrategy : TrackingStrategy() {
+        override fun onActivityResumed(activity: Activity) {
+            super.onActivityResumed(activity)
+            GlobalRum.monitor.startView(activity, activity.javaClass.canonicalName!!)
+        }
+
+        override fun onActivityPaused(activity: Activity) {
+            super.onActivityPaused(activity)
+            GlobalRum.monitor.stopView(activity)
+        }
+    }
 
     // TODO RUMM-271
-    internal class FragmentsTrackingStrategy : TrackingStrategy()
+    internal object FragmentsTrackingStrategy : TrackingStrategy()
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/TrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/TrackingStrategy.kt
@@ -1,0 +1,44 @@
+package com.datadog.android.rum.internal.instrumentation
+
+import android.app.Activity
+import android.app.Application
+import android.os.Bundle
+
+internal sealed class TrackingStrategy : Application.ActivityLifecycleCallbacks {
+
+    override fun onActivityPaused(activity: Activity) {
+        // No Op
+    }
+
+    override fun onActivityStarted(activity: Activity) {
+        // No Op
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        // No Op
+    }
+
+    override fun onActivitySaveInstanceState(activity: Activity, outState: Bundle) {
+        // No Op
+    }
+
+    override fun onActivityStopped(activity: Activity) {
+        // No Op
+    }
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        // No Op
+    }
+
+    override fun onActivityResumed(activity: Activity) {
+        // No Op
+    }
+
+    // TODO RUMM-242
+    internal class GesturesTrackingStrategy : TrackingStrategy()
+
+    internal class ActivityTrackingStrategy : TrackingStrategy()
+
+    // TODO RUMM-271
+    internal class FragmentsTrackingStrategy : TrackingStrategy()
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesListener.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.rum.gestures
+package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.content.res.Resources
 import android.view.GestureDetector

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesTracker.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesTracker.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.rum.gestures
+package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.app.Activity
 import androidx.core.view.GestureDetectorCompat

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesTracker.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesTracker.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.rum.gestures
+package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.app.Activity
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/NoOpWindowCallback.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/NoOpWindowCallback.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.rum.gestures
+package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.view.ActionMode
 import android.view.KeyEvent

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.rum.gestures
+package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.view.MotionEvent
 import android.view.Window

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
@@ -585,6 +585,28 @@ class DatadogConfigBuilderTest {
     }
 
     @Test
+    fun `builder with all tracking instrumentation disabled`(forge: Forge) {
+        val rumUrl = forge.aStringMatching("http://[a-z]+\\.com")
+        val config = DatadogConfig.Builder(fakeClientToken, fakeApplicationId)
+            .useCustomRumEndpoint(rumUrl)
+            .build()
+
+        assertThat(config.rumConfig)
+            .isEqualTo(
+                DatadogConfig.RumConfig(
+                    fakeClientToken,
+                    fakeApplicationId,
+                    rumUrl,
+                    DatadogConfig.DEFAULT_SERVICE_NAME,
+                    DatadogConfig.DEFAULT_ENV_NAME,
+                    trackGestures = false,
+                    trackActivitiesAsScreens = false,
+                    trackFragmentsAsScreens = false
+                )
+            )
+    }
+
+    @Test
     fun `builder with track gestures enabled`(forge: Forge) {
         val rumUrl = forge.aStringMatching("http://[a-z]+\\.com")
         val config = DatadogConfig.Builder(fakeClientToken, fakeApplicationId)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
@@ -600,8 +600,7 @@ class DatadogConfigBuilderTest {
                     DatadogConfig.DEFAULT_SERVICE_NAME,
                     DatadogConfig.DEFAULT_ENV_NAME,
                     trackGestures = false,
-                    trackActivitiesAsScreens = false,
-                    trackFragmentsAsScreens = false
+                    viewTrackerStrategy = DatadogConfig.ViewTrackerStrategy.NONE
                 )
             )
     }
@@ -628,11 +627,11 @@ class DatadogConfigBuilderTest {
     }
 
     @Test
-    fun `builder with track activities as screens enabled`(forge: Forge) {
+    fun `builder with track activities as views enabled`(forge: Forge) {
         val rumUrl = forge.aStringMatching("http://[a-z]+\\.com")
         val config = DatadogConfig.Builder(fakeClientToken, fakeApplicationId)
             .useCustomRumEndpoint(rumUrl)
-            .trackActivitiesAsScreens()
+            .trackViews(DatadogConfig.ViewTrackerStrategy.TRACK_ACTIVITIES_AS_VIEWS)
             .build()
 
         assertThat(config.rumConfig)
@@ -643,17 +642,18 @@ class DatadogConfigBuilderTest {
                     rumUrl,
                     DatadogConfig.DEFAULT_SERVICE_NAME,
                     DatadogConfig.DEFAULT_ENV_NAME,
-                    trackActivitiesAsScreens = true
+                    viewTrackerStrategy =
+                    DatadogConfig.ViewTrackerStrategy.TRACK_ACTIVITIES_AS_VIEWS
                 )
             )
     }
 
     @Test
-    fun `builder with track fragments as screens enabled`(forge: Forge) {
+    fun `builder with track fragments as views enabled`(forge: Forge) {
         val rumUrl = forge.aStringMatching("http://[a-z]+\\.com")
         val config = DatadogConfig.Builder(fakeClientToken, fakeApplicationId)
             .useCustomRumEndpoint(rumUrl)
-            .trackFragmentsAsScreens()
+            .trackViews(DatadogConfig.ViewTrackerStrategy.TRACK_FRAGMENTS_AS_VIEWS)
             .build()
 
         assertThat(config.rumConfig)
@@ -664,7 +664,7 @@ class DatadogConfigBuilderTest {
                     rumUrl,
                     DatadogConfig.DEFAULT_SERVICE_NAME,
                     DatadogConfig.DEFAULT_ENV_NAME,
-                    trackFragmentsAsScreens = true
+                    viewTrackerStrategy = DatadogConfig.ViewTrackerStrategy.TRACK_FRAGMENTS_AS_VIEWS
                 )
             )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
@@ -621,7 +621,7 @@ class DatadogConfigBuilderTest {
                     rumUrl,
                     DatadogConfig.DEFAULT_SERVICE_NAME,
                     DatadogConfig.DEFAULT_ENV_NAME,
-                    trackActivityAsScreens = true
+                    trackActivitiesAsScreens = true
                 )
             )
     }
@@ -642,7 +642,7 @@ class DatadogConfigBuilderTest {
                     rumUrl,
                     DatadogConfig.DEFAULT_SERVICE_NAME,
                     DatadogConfig.DEFAULT_ENV_NAME,
-                    trackFragmentAsScreens = true
+                    trackFragmentsAsScreens = true
                 )
             )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
@@ -29,7 +29,8 @@ import org.mockito.junit.jupiter.MockitoSettings
 class DatadogConfigBuilderTest {
 
     lateinit var fakeClientToken: String
-    @Forgery lateinit var fakeApplicationId: UUID
+    @Forgery
+    lateinit var fakeApplicationId: UUID
 
     @BeforeEach
     fun `set up`(forge: Forge) {
@@ -114,7 +115,7 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.rumConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.RumConfig(
                     fakeClientToken,
                     fakeApplicationId,
                     DatadogEndpoint.RUM_US,
@@ -123,6 +124,7 @@ class DatadogConfigBuilderTest {
                 )
             )
     }
+
     @Test
     fun `builder returns sensible defaults with UUID applicationId`() {
         val config = DatadogConfig.Builder(fakeClientToken, fakeApplicationId)
@@ -161,7 +163,7 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.rumConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.RumConfig(
                     fakeClientToken,
                     fakeApplicationId,
                     DatadogEndpoint.RUM_US,
@@ -216,7 +218,7 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.rumConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.RumConfig(
                     fakeClientToken,
                     fakeApplicationId,
                     DatadogEndpoint.RUM_US,
@@ -272,7 +274,7 @@ class DatadogConfigBuilderTest {
 
         assertThat(config.rumConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.RumConfig(
                     fakeClientToken,
                     fakeApplicationId,
                     DatadogEndpoint.RUM_US,
@@ -328,7 +330,7 @@ class DatadogConfigBuilderTest {
 
         assertThat(config.rumConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.RumConfig(
                     fakeClientToken,
                     fakeApplicationId,
                     DatadogEndpoint.RUM_US,
@@ -397,7 +399,7 @@ class DatadogConfigBuilderTest {
 
         assertThat(config.rumConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.RumConfig(
                     fakeClientToken,
                     fakeApplicationId,
                     DatadogEndpoint.RUM_US,
@@ -449,7 +451,7 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.rumConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.RumConfig(
                     fakeClientToken,
                     fakeApplicationId,
                     DatadogEndpoint.RUM_EU,
@@ -511,7 +513,7 @@ class DatadogConfigBuilderTest {
 
         assertThat(config.rumConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.RumConfig(
                     fakeClientToken,
                     fakeApplicationId,
                     rumUrl,
@@ -572,12 +574,75 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.rumConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.RumConfig(
                     fakeClientToken,
                     fakeApplicationId,
                     rumUrl,
                     DatadogConfig.DEFAULT_SERVICE_NAME,
                     DatadogConfig.DEFAULT_ENV_NAME
+                )
+            )
+    }
+
+    @Test
+    fun `builder with track gestures enabled`(forge: Forge) {
+        val rumUrl = forge.aStringMatching("http://[a-z]+\\.com")
+        val config = DatadogConfig.Builder(fakeClientToken, fakeApplicationId)
+            .useCustomRumEndpoint(rumUrl)
+            .trackGestures()
+            .build()
+
+        assertThat(config.rumConfig)
+            .isEqualTo(
+                DatadogConfig.RumConfig(
+                    fakeClientToken,
+                    fakeApplicationId,
+                    rumUrl,
+                    DatadogConfig.DEFAULT_SERVICE_NAME,
+                    DatadogConfig.DEFAULT_ENV_NAME,
+                    trackGestures = true
+                )
+            )
+    }
+
+    @Test
+    fun `builder with track activities as screens enabled`(forge: Forge) {
+        val rumUrl = forge.aStringMatching("http://[a-z]+\\.com")
+        val config = DatadogConfig.Builder(fakeClientToken, fakeApplicationId)
+            .useCustomRumEndpoint(rumUrl)
+            .trackActivitiesAsScreens()
+            .build()
+
+        assertThat(config.rumConfig)
+            .isEqualTo(
+                DatadogConfig.RumConfig(
+                    fakeClientToken,
+                    fakeApplicationId,
+                    rumUrl,
+                    DatadogConfig.DEFAULT_SERVICE_NAME,
+                    DatadogConfig.DEFAULT_ENV_NAME,
+                    trackActivityAsScreens = true
+                )
+            )
+    }
+
+    @Test
+    fun `builder with track fragments as screens enabled`(forge: Forge) {
+        val rumUrl = forge.aStringMatching("http://[a-z]+\\.com")
+        val config = DatadogConfig.Builder(fakeClientToken, fakeApplicationId)
+            .useCustomRumEndpoint(rumUrl)
+            .trackFragmentsAsScreens()
+            .build()
+
+        assertThat(config.rumConfig)
+            .isEqualTo(
+                DatadogConfig.RumConfig(
+                    fakeClientToken,
+                    fakeApplicationId,
+                    rumUrl,
+                    DatadogConfig.DEFAULT_SERVICE_NAME,
+                    DatadogConfig.DEFAULT_ENV_NAME,
+                    trackFragmentAsScreens = true
                 )
             )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -22,7 +22,10 @@ import com.datadog.android.utils.mockContext
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.SystemOutputExtension
 import com.datadog.tools.unit.getFieldValue
+import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.never
+import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -180,9 +183,6 @@ internal class RumFeatureTest {
         val clientToken = RumFeature.clientToken
         val endpointUrl = RumFeature.endpointUrl
         val serviceName = RumFeature.serviceName
-        val gesturesTrackingStrategy = RumFeature.gesturesTrackingStrategy
-        val activityTrackingStrategy = RumFeature.activityTrackingStrategy
-        val fragmentsTrackingStrategy = RumFeature.fragmentsTrackingStrategy
 
         fakeConfig = DatadogConfig.RumConfig(
             clientToken = forge.anHexadecimalString(),
@@ -206,22 +206,20 @@ internal class RumFeatureTest {
         val clientToken2 = RumFeature.clientToken
         val endpointUrl2 = RumFeature.endpointUrl
         val serviceName2 = RumFeature.serviceName
-        val gesturesTrackingStrategy2 = RumFeature.gesturesTrackingStrategy
-        val activityTrackingStrategy2 = RumFeature.activityTrackingStrategy
-        val fragmentsTrackingStrategy2 = RumFeature.fragmentsTrackingStrategy
 
         assertThat(persistenceStrategy).isSameAs(persistenceStrategy2)
         assertThat(uploadHandlerThread).isSameAs(uploadHandlerThread2)
         assertThat(clientToken).isSameAs(clientToken2)
         assertThat(endpointUrl).isSameAs(endpointUrl2)
         assertThat(serviceName).isSameAs(serviceName2)
-        assertThat(gesturesTrackingStrategy).isSameAs(gesturesTrackingStrategy2)
-        assertThat(activityTrackingStrategy).isSameAs(activityTrackingStrategy2)
-        assertThat(fragmentsTrackingStrategy).isSameAs(fragmentsTrackingStrategy2)
+
+        verify(mockAppContext, never()).registerActivityLifecycleCallbacks(argThat {
+            TrackingStrategy::class.java.isAssignableFrom(this::class.java)
+        })
     }
 
     @Test
-    fun `will use default NoOpStrategy if no instrumentation feature enabled`() {
+    fun `will not register any callback if no instrumentation feature enabled`() {
         // when
         RumFeature.initialize(
             mockAppContext,
@@ -231,15 +229,12 @@ internal class RumFeatureTest {
             mockSystemInfoProvider
         )
 
-        val gesturesTrackingStrategy = RumFeature.gesturesTrackingStrategy
-        val activityTrackingStrategy = RumFeature.activityTrackingStrategy
-        val fragmentsTrackingStrategy = RumFeature.fragmentsTrackingStrategy
-
         // then
-        assertThat(gesturesTrackingStrategy).isNull()
-        assertThat(activityTrackingStrategy).isNull()
-        assertThat(fragmentsTrackingStrategy).isNull()
+        verify(mockAppContext, never()).registerActivityLifecycleCallbacks(argThat {
+            TrackingStrategy::class.java.isAssignableFrom(this::class.java)
+        })
     }
+
     @Test
     fun `will use the right Strategy when tracking gestures enabled`() {
         // given
@@ -254,15 +249,14 @@ internal class RumFeatureTest {
             mockSystemInfoProvider
         )
 
-        val gesturesTrackingStrategy = RumFeature.gesturesTrackingStrategy
-
         // then
-        assertThat(gesturesTrackingStrategy)
-            .isInstanceOf(TrackingStrategy.GesturesTrackingStrategy::class.java)
+        verify(mockAppContext).registerActivityLifecycleCallbacks(argThat {
+            this is TrackingStrategy.GesturesTrackingStrategy
+        })
     }
 
     @Test
-    fun `will use default right Strategy if track activities as screens enabled`() {
+    fun `will use the right Strategy if track activities as screens enabled`() {
         // given
         fakeConfig = fakeConfig.copy(trackActivitiesAsScreens = true)
 
@@ -275,15 +269,14 @@ internal class RumFeatureTest {
             mockSystemInfoProvider
         )
 
-        val activityTrackingStrategy = RumFeature.activityTrackingStrategy
-
         // then
-        assertThat(activityTrackingStrategy)
-            .isInstanceOf(TrackingStrategy.ActivityTrackingStrategy::class.java)
+        verify(mockAppContext).registerActivityLifecycleCallbacks(argThat {
+            this is TrackingStrategy.ActivityTrackingStrategy
+        })
     }
 
     @Test
-    fun `will use default right Strategy if track fragments as screens enabled`() {
+    fun `will use the right Strategy if track fragments as screens enabled`() {
         // given
         fakeConfig = fakeConfig.copy(trackFragmentsAsScreens = true)
 
@@ -296,10 +289,9 @@ internal class RumFeatureTest {
             mockSystemInfoProvider
         )
 
-        val fragmentsTrackingStrategy = RumFeature.fragmentsTrackingStrategy
-
         // then
-        assertThat(fragmentsTrackingStrategy)
-            .isInstanceOf(TrackingStrategy.FragmentsTrackingStrategy::class.java)
+        verify(mockAppContext).registerActivityLifecycleCallbacks(argThat {
+            this is TrackingStrategy.FragmentsTrackingStrategy
+        })
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -64,7 +64,7 @@ internal class RumFeatureTest {
     @Mock
     lateinit var mockOkHttpClient: OkHttpClient
 
-    lateinit var fakeConfig: DatadogConfig.FeatureConfig
+    lateinit var fakeConfig: DatadogConfig.RumConfig
 
     lateinit var fakePackageName: String
     lateinit var fakePackageVersion: String
@@ -74,7 +74,7 @@ internal class RumFeatureTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        fakeConfig = DatadogConfig.FeatureConfig(
+        fakeConfig = DatadogConfig.RumConfig(
             clientToken = forge.anHexadecimalString(),
             applicationId = forge.getForgery(),
             endpointUrl = forge.getForgery<URL>().toString(),
@@ -180,7 +180,7 @@ internal class RumFeatureTest {
         val endpointUrl = RumFeature.endpointUrl
         val serviceName = RumFeature.serviceName
 
-        fakeConfig = DatadogConfig.FeatureConfig(
+        fakeConfig = DatadogConfig.RumConfig(
             clientToken = forge.anHexadecimalString(),
             applicationId = forge.getForgery(),
             endpointUrl = forge.getForgery<URL>().toString(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -191,8 +191,7 @@ internal class RumFeatureTest {
             serviceName = forge.anAlphabeticalString(),
             envName = forge.anAlphabeticalString(),
             trackGestures = forge.aBool(),
-            trackActivitiesAsScreens = forge.aBool(),
-            trackFragmentsAsScreens = forge.aBool()
+            viewTrackerStrategy = forge.aValueFrom(DatadogConfig.ViewTrackerStrategy::class.java)
         )
         RumFeature.initialize(
             mockAppContext,
@@ -258,7 +257,10 @@ internal class RumFeatureTest {
     @Test
     fun `will use the right Strategy if track activities as screens enabled`() {
         // given
-        fakeConfig = fakeConfig.copy(trackActivitiesAsScreens = true)
+        fakeConfig = fakeConfig.copy(
+            viewTrackerStrategy =
+            DatadogConfig.ViewTrackerStrategy.TRACK_ACTIVITIES_AS_VIEWS
+        )
 
         // when
         RumFeature.initialize(
@@ -278,7 +280,8 @@ internal class RumFeatureTest {
     @Test
     fun `will use the right Strategy if track fragments as screens enabled`() {
         // given
-        fakeConfig = fakeConfig.copy(trackFragmentsAsScreens = true)
+        fakeConfig = fakeConfig.copy(viewTrackerStrategy =
+        DatadogConfig.ViewTrackerStrategy.TRACK_FRAGMENTS_AS_VIEWS)
 
         // when
         RumFeature.initialize(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/ActivityTrackingStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/ActivityTrackingStrategyTest.kt
@@ -1,0 +1,46 @@
+package com.datadog.android.rum.internal.instrumentation
+
+import com.datadog.android.utils.forge.Configurator
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class ActivityTrackingStrategyTest : TrackingStrategyTest() {
+
+    @Test
+    fun `when resumed it will start a view event`(forge: Forge) {
+        // when
+        underTest.onActivityResumed(mockActivity)
+        // then
+        verify(mockRumMonitor).startView(
+            eq(mockActivity),
+            eq(mockActivity::class.java.canonicalName!!),
+            eq(emptyMap())
+        )
+    }
+
+    @Test
+    fun `when paused it will stop a view event`(forge: Forge) {
+        // when
+        underTest.onActivityPaused(mockActivity)
+        // then
+        verify(mockRumMonitor).stopView(
+            eq(mockActivity),
+            eq(emptyMap())
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/TrackingStrategiesTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/TrackingStrategiesTest.kt
@@ -1,0 +1,87 @@
+package com.datadog.android.rum.internal.instrumentation
+
+import android.app.Activity
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumMonitor
+import com.datadog.android.rum.internal.monitor.NoOpRumMonitor
+import com.datadog.android.utils.forge.Configurator
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal open class TrackingStrategiesTest {
+    lateinit var underTest: TrackingStrategy
+    @Mock
+    lateinit var mockRumMonitor: RumMonitor
+    lateinit var mockActivity: Activity
+
+    @BeforeEach
+    open fun `set up`(forge: Forge) {
+        GlobalRum.registerIfAbsent(mockRumMonitor)
+        val mockActivity1 = mock<Test1Activity>()
+        val mockActivity2 = mock<Test2Activity>()
+        val mockActivity3 = mock<Test3Activity>()
+        mockActivity = forge.anElementFrom(mockActivity1, mockActivity2, mockActivity3)
+        underTest = TrackingStrategy.ActivityTrackingStrategy
+    }
+
+    @AfterEach
+    open fun `tear down`() {
+        GlobalRum.monitor = NoOpRumMonitor()
+        GlobalRum.isRegistered.set(false)
+    }
+
+    internal class Test1Activity() : Activity()
+    internal class Test2Activity() : Activity()
+    internal class Test3Activity() : Activity()
+}
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class ActivityTrackingStrategyTest : TrackingStrategiesTest() {
+
+    @Test
+    fun `when resumed it will start a view event`(forge: Forge) {
+        // when
+        underTest.onActivityResumed(mockActivity)
+        // then
+        verify(mockRumMonitor).startView(
+            eq(mockActivity),
+            eq(mockActivity::class.java.canonicalName!!),
+            eq(emptyMap())
+        )
+    }
+
+    @Test
+    fun `when paused it will stop a view event`(forge: Forge) {
+        // when
+        underTest.onActivityPaused(mockActivity)
+        // then
+        verify(mockRumMonitor).stopView(
+            eq(mockActivity),
+            eq(emptyMap())
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/TrackingStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/TrackingStrategyTest.kt
@@ -5,15 +5,12 @@ import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.internal.monitor.NoOpRumMonitor
 import com.datadog.android.utils.forge.Configurator
-import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
@@ -27,7 +24,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal open class TrackingStrategiesTest {
+internal abstract class TrackingStrategyTest {
     lateinit var underTest: TrackingStrategy
     @Mock
     lateinit var mockRumMonitor: RumMonitor
@@ -52,36 +49,4 @@ internal open class TrackingStrategiesTest {
     internal class Test1Activity() : Activity()
     internal class Test2Activity() : Activity()
     internal class Test3Activity() : Activity()
-}
-
-@Extensions(
-    ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class)
-)
-@MockitoSettings(strictness = Strictness.LENIENT)
-@ForgeConfiguration(Configurator::class)
-internal class ActivityTrackingStrategyTest : TrackingStrategiesTest() {
-
-    @Test
-    fun `when resumed it will start a view event`(forge: Forge) {
-        // when
-        underTest.onActivityResumed(mockActivity)
-        // then
-        verify(mockRumMonitor).startView(
-            eq(mockActivity),
-            eq(mockActivity::class.java.canonicalName!!),
-            eq(emptyMap())
-        )
-    }
-
-    @Test
-    fun `when paused it will stop a view event`(forge: Forge) {
-        // when
-        underTest.onActivityPaused(mockActivity)
-        // then
-        verify(mockRumMonitor).stopView(
-            eq(mockActivity),
-            eq(emptyMap())
-        )
-    }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesListenerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesListenerTest.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.rum.gestures
+package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.content.res.Resources
 import android.util.Log

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesTrackerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesTrackerTest.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.rum.gestures
+package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.app.Activity
 import android.view.Window

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapperTest.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.rum.gestures
+package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.view.MotionEvent
 import android.view.Window

--- a/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/rum/RumGesturesTrackerBenchmark.kt
+++ b/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/rum/RumGesturesTrackerBenchmark.kt
@@ -67,7 +67,7 @@ internal class RumGesturesTrackerBenchmark {
             .setPartialFlushThreshold(1)
             .build()
         datadogGesturesTracker = createInstance(
-            "com.datadog.android.rum.gestures.DatadogGesturesTracker",
+            "com.datadog.android.rum.internal.instrumentation.gestures.DatadogGesturesTracker",
             testedTracer
         )
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()

--- a/sample/java/src/main/java/com/datadog/android/sample/MainActivity.java
+++ b/sample/java/src/main/java/com/datadog/android/sample/MainActivity.java
@@ -84,7 +84,6 @@ public class MainActivity extends AppCompatActivity {
 
     @Override
     protected void onResume() {
-        mRumMonitor.startView(this, getComponentName().getClassName(), new HashMap<String, Object>());
         mResumePauseSpan = GlobalTracer.get()
                 .buildSpan("onResumeOnPause")
                 .asChildOf(mMainSpan)
@@ -98,7 +97,6 @@ public class MainActivity extends AppCompatActivity {
         super.onPause();
         mLogger.d("MainActivity/onPause");
         mResumePauseSpan.finish();
-        mRumMonitor.stopView(this, new HashMap<String, Object>());
     }
 
     @Override

--- a/sample/java/src/main/java/com/datadog/android/sample/SampleApplication.java
+++ b/sample/java/src/main/java/com/datadog/android/sample/SampleApplication.java
@@ -12,7 +12,9 @@ import android.content.SharedPreferences;
 import android.os.Build;
 import android.preference.PreferenceManager;
 import android.util.Log;
+
 import androidx.multidex.MultiDex;
+
 import com.datadog.android.Datadog;
 import com.datadog.android.DatadogConfig;
 import com.datadog.android.log.Logger;
@@ -23,6 +25,7 @@ import com.datadog.android.tracing.Tracer;
 import com.facebook.stetho.Stetho;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
+
 import io.opentracing.util.GlobalTracer;
 
 public class SampleApplication extends Application {
@@ -40,13 +43,22 @@ public class SampleApplication extends Application {
         super.onCreate();
         Stetho.initializeWithDefaults(this);
 
-        DatadogConfig.Builder configBuilder =
-                new DatadogConfig.Builder(
-                        BuildConfig.DD_CLIENT_TOKEN,
-                        BuildConfig.DD_RUM_APPLICATION_ID
-                )
-                        .setServiceName("android-sample-java")
-                        .setEnvironmentName("staging");
+        final DatadogConfig.Builder configBuilder;
+        if (BuildConfig.DD_RUM_APPLICATION_ID != null) {
+            configBuilder = new DatadogConfig.Builder(
+                    BuildConfig.DD_CLIENT_TOKEN,
+                    BuildConfig.DD_RUM_APPLICATION_ID
+            );
+
+        } else {
+            configBuilder = new DatadogConfig.Builder(
+                    BuildConfig.DD_CLIENT_TOKEN);
+        }
+
+        configBuilder.setServiceName("android-sample-java")
+                .trackActivitiesAsScreens()
+                .setEnvironmentName("staging");
+
 
         if (BuildConfig.DD_OVERRIDE_LOGS_URL != null) {
             configBuilder.useCustomLogsEndpoint(BuildConfig.DD_OVERRIDE_LOGS_URL);

--- a/sample/java/src/main/java/com/datadog/android/sample/SampleApplication.java
+++ b/sample/java/src/main/java/com/datadog/android/sample/SampleApplication.java
@@ -56,7 +56,7 @@ public class SampleApplication extends Application {
         }
 
         configBuilder.setServiceName("android-sample-java")
-                .trackActivitiesAsScreens()
+                .trackViews(DatadogConfig.ViewTrackerStrategy.TRACK_ACTIVITIES_AS_VIEWS)
                 .setEnvironmentName("staging");
 
 

--- a/sample/kotlin-timber/build.gradle.kts
+++ b/sample/kotlin-timber/build.gradle.kts
@@ -77,11 +77,23 @@ android {
                 "DD_OVERRIDE_TRACES_URL",
                 "\"${project.findProperty("DD_OVERRIDE_TRACES_URL") ?: ""}\""
             )
+            buildConfigField(
+                "String",
+                "DD_OVERRIDE_RUM_URL",
+                "\"${project.findProperty("DD_OVERRIDE_RUM_URL") ?: ""}\""
+            )
+            buildConfigField(
+                "String",
+                "DD_RUM_APPLICATION_ID",
+                "\"${project.findProperty("DD_RUM_APPLICATION_ID") ?: ""}\""
+            )
         }
         register("full") {
             dimension = "version"
             buildConfigField("String", "DD_OVERRIDE_LOGS_URL", "\"\"")
             buildConfigField("String", "DD_OVERRIDE_TRACES_URL", "\"\"")
+            buildConfigField("String", "DD_OVERRIDE_RUM_URL", "\"\"")
+            buildConfigField("String", "DD_RUM_APPLICATION_ID", "\"\"")
         }
     }
 }

--- a/sample/kotlin-timber/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin-timber/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -30,7 +30,7 @@ class SampleApplication : Application() {
         configBuilder
             .setServiceName("android-sample-kotlin-timber")
             .setEnvironmentName("staging")
-            .trackActivitiesAsScreens()
+            .trackViews(strategy = DatadogConfig.ViewTrackerStrategy.TRACK_ACTIVITIES_AS_VIEWS)
 
         if (BuildConfig.DD_OVERRIDE_LOGS_URL.isNotBlank()) {
             configBuilder.useCustomLogsEndpoint(BuildConfig.DD_OVERRIDE_LOGS_URL)

--- a/sample/kotlin-timber/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin-timber/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -18,9 +18,19 @@ class SampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        val configBuilder = DatadogConfig.Builder(BuildConfig.DD_CLIENT_TOKEN)
+        val configBuilder =
+            if (BuildConfig.DD_RUM_APPLICATION_ID.isNotBlank()) {
+                DatadogConfig.Builder(
+                    BuildConfig.DD_CLIENT_TOKEN,
+                    BuildConfig.DD_RUM_APPLICATION_ID
+                )
+            } else {
+                DatadogConfig.Builder(BuildConfig.DD_CLIENT_TOKEN)
+            }
+        configBuilder
             .setServiceName("android-sample-kotlin-timber")
             .setEnvironmentName("staging")
+            .trackActivitiesAsScreens()
 
         if (BuildConfig.DD_OVERRIDE_LOGS_URL.isNotBlank()) {
             configBuilder.useCustomLogsEndpoint(BuildConfig.DD_OVERRIDE_LOGS_URL)
@@ -29,7 +39,9 @@ class SampleApplication : Application() {
         if (BuildConfig.DD_OVERRIDE_TRACES_URL.isNotBlank()) {
             configBuilder.useCustomTracesEndpoint(BuildConfig.DD_OVERRIDE_TRACES_URL)
         }
-
+        if (BuildConfig.DD_OVERRIDE_RUM_URL.isNotBlank()) {
+            configBuilder.useCustomRumEndpoint(BuildConfig.DD_OVERRIDE_RUM_URL)
+        }
         // Initialise Datadog
         Datadog.initialize(this, configBuilder.build())
         Datadog.setVerbosity(Log.VERBOSE)

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -77,11 +77,23 @@ android {
                 "DD_OVERRIDE_TRACES_URL",
                 "\"${project.findProperty("DD_OVERRIDE_TRACES_URL") ?: ""}\""
             )
+            buildConfigField(
+                "String",
+                "DD_OVERRIDE_RUM_URL",
+                "\"${project.findProperty("DD_OVERRIDE_RUM_URL") ?: ""}\""
+            )
+            buildConfigField(
+                "String",
+                "DD_RUM_APPLICATION_ID",
+                "\"${project.findProperty("DD_RUM_APPLICATION_ID") ?: ""}\""
+            )
         }
         register("full") {
             dimension = "version"
             buildConfigField("String", "DD_OVERRIDE_LOGS_URL", "\"\"")
             buildConfigField("String", "DD_OVERRIDE_TRACES_URL", "\"\"")
+            buildConfigField("String", "DD_OVERRIDE_RUM_URL", "\"\"")
+            buildConfigField("String", "DD_RUM_APPLICATION_ID", "\"\"")
         }
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -31,7 +31,7 @@ class SampleApplication : Application() {
         configBuilder
             .setServiceName("android-sample-kotlin")
             .setEnvironmentName("staging")
-            .trackActivitiesAsScreens()
+            .trackViews(DatadogConfig.ViewTrackerStrategy.TRACK_ACTIVITIES_AS_VIEWS)
 
         if (BuildConfig.DD_OVERRIDE_LOGS_URL.isNotBlank()) {
             configBuilder.useCustomLogsEndpoint(BuildConfig.DD_OVERRIDE_LOGS_URL)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -9,6 +9,8 @@ import android.app.Application
 import android.util.Log
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogConfig
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumMonitor
 import com.datadog.android.tracing.Tracer
 import io.opentracing.util.GlobalTracer
 
@@ -17,9 +19,19 @@ class SampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        val configBuilder = DatadogConfig.Builder(BuildConfig.DD_CLIENT_TOKEN)
+        val configBuilder =
+            if (BuildConfig.DD_RUM_APPLICATION_ID.isNotBlank()) {
+                DatadogConfig.Builder(
+                    BuildConfig.DD_CLIENT_TOKEN,
+                    BuildConfig.DD_RUM_APPLICATION_ID
+                )
+            } else {
+                DatadogConfig.Builder(BuildConfig.DD_CLIENT_TOKEN)
+            }
+        configBuilder
             .setServiceName("android-sample-kotlin")
             .setEnvironmentName("staging")
+            .trackActivitiesAsScreens()
 
         if (BuildConfig.DD_OVERRIDE_LOGS_URL.isNotBlank()) {
             configBuilder.useCustomLogsEndpoint(BuildConfig.DD_OVERRIDE_LOGS_URL)
@@ -28,6 +40,9 @@ class SampleApplication : Application() {
         if (BuildConfig.DD_OVERRIDE_TRACES_URL.isNotBlank()) {
             configBuilder.useCustomTracesEndpoint(BuildConfig.DD_OVERRIDE_TRACES_URL)
         }
+        if (BuildConfig.DD_OVERRIDE_RUM_URL.isNotBlank()) {
+            configBuilder.useCustomRumEndpoint(BuildConfig.DD_OVERRIDE_RUM_URL)
+        }
 
         // Initialise Datadog
         Datadog.initialize(this, configBuilder.build())
@@ -35,5 +50,6 @@ class SampleApplication : Application() {
 
         // initialize the tracer here
         GlobalTracer.registerIfAbsent(Tracer.Builder().build())
+        GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds the Automatic ActivityScreenTracker as an optional feature to the SDK. By enabling this feature we will be able to detect activity changes and start/stop RumView events whenever on the Activity onResume/onPause lifecycle events.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

