### PR TITLE
RUMM-278 Prevent OutOfMemory crash

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileReader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileReader.kt
@@ -83,6 +83,9 @@ internal class FileReader(
         } catch (e: SecurityException) {
             sdkLogger.e("Couldn't access file ${file?.path}", e)
             ByteArray(0)
+        } catch (e: OutOfMemoryError) {
+            sdkLogger.e("Couldn't read file ${file?.path} (not enough memory)", e)
+            ByteArray(0)
         }
 
         return file to data

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileReaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/file/FileReaderTest.kt
@@ -177,6 +177,27 @@ internal class FileReaderTest {
     }
 
     @Test
+    fun `returns null when orchestrator throws OutOfMemoryError`(
+        @SystemOutStream outputStream: ByteArrayOutputStream,
+        forge: Forge
+    ) {
+        // given
+        val exception = OutOfMemoryError(forge.anAlphabeticalString())
+        doThrow(exception).whenever(mockOrchestrator).getReadableFile(any())
+
+        // when
+        val nextBatch = testedReader.readNextBatch()
+
+        // then
+        assertThat(nextBatch).isNull()
+        if (BuildConfig.DEBUG) {
+            val expectedTag = resolveTagName(testedReader, "DD_LOG")
+            assertThat(outputStream)
+                .hasLogLine(Log.ERROR, expectedTag, startsWith("Couldn't read file"))
+        }
+    }
+
+    @Test
     fun `drops the batch if the file exists`(
         forge: Forge,
         @SystemOutStream outputStream: ByteArrayOutputStream


### PR DESCRIPTION
### What does this PR do?

Prevent SDK from crashing when an OOM Error occurs. (#164)
This doesn't fix the root cause of the OOM of course, but will avoid crashing on our side.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

