### PR TITLE
RUMM-273 Add End - to - End tests for ActivityViewTrackingStrategy

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -74,7 +74,7 @@ internal object LogsFeature {
 
     fun stop() {
         if (initialized.get()) {
-            uploadHandlerThread.quitSafely()
+            uploadHandlerThread.quit()
 
             persistenceStrategy = NoOpPersistenceStrategy()
             uploadHandlerThread = HandlerThread("NoOp")

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracesFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracesFeature.kt
@@ -70,14 +70,13 @@ internal object TracesFeature {
 
     fun stop() {
         if (initialized.get()) {
-            uploadHandlerThread.quitSafely()
+            uploadHandlerThread.quit()
 
             persistenceStrategy = NoOpPersistenceStrategy()
             uploadHandlerThread = HandlerThread("Test")
             clientToken = ""
             endpointUrl = DatadogEndpoint.TRACES_US
             serviceName = DatadogConfig.DEFAULT_SERVICE_NAME
-
             initialized.set(false)
         }
     }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/RumMockServerActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/RumMockServerActivityTestRule.kt
@@ -1,0 +1,74 @@
+package com.datadog.android.sdk.rules
+
+import android.app.Activity
+import android.app.Application
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.rum.ActivityViewTrackingStrategy
+import com.datadog.android.rum.GlobalRum
+import com.datadog.tools.unit.createInstance
+import com.datadog.tools.unit.getFieldValue
+import com.datadog.tools.unit.getStaticValue
+import com.datadog.tools.unit.setStaticValue
+import java.util.concurrent.atomic.AtomicBoolean
+import kotlin.collections.ArrayList
+
+internal class RumMockServerActivityTestRule<T : Activity>(
+    activityClass: Class<T>,
+    keepRequests: Boolean = false
+) : MockServerActivityTestRule<T>(activityClass, keepRequests) {
+
+    // region ActivityTestRule
+
+    override fun beforeActivityLaunched() {
+//        // This needs to be called here due to the way Espresso handles the activities.
+//        // There are cases when one activity is about to be finished and we are stopping the RumFeature
+//        // but in the same time another activity starts and wants to set the RumMonitor, in that moment
+//        // the Rum.Builder() returns NoOpMonitor because the RumFeature is disabled
+//        resetRumMonitor()
+        removeRumCallbacks()
+        super.beforeActivityLaunched()
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun removeRumCallbacks() {
+        val application =
+            InstrumentationRegistry
+                .getInstrumentation()
+                .targetContext
+                .applicationContext as Application
+        val lifecycleCallbacks: ArrayList<Application.ActivityLifecycleCallbacks> =
+            application.getFieldValue(
+                "mActivityLifecycleCallbacks",
+                Application::class.java
+            )
+        val activityViewTrackingStrategyClass = ActivityViewTrackingStrategy::class.java
+        // we need this because the lifecycle callbacks are modified concurrently from other
+        // unfinished tests
+        // (it can happen that one Espresso test to start while other it is about to start)
+        synchronized(lifecycleCallbacks) {
+            var pointer = lifecycleCallbacks.size - 1
+            while (pointer >= 0) {
+                val callback = lifecycleCallbacks[pointer]
+                if (activityViewTrackingStrategyClass.isAssignableFrom(callback::class.java)) {
+                    application.unregisterActivityLifecycleCallbacks(callback)
+                    pointer--
+                }
+                pointer--
+            }
+        }
+    }
+
+    private fun resetRumMonitor() {
+        val noOpMonitor = createInstance(
+            "com.datadog.android.rum.internal.monitor.NoOpRumMonitor"
+        )
+        GlobalRum::class.java.setStaticValue("monitor", noOpMonitor)
+        val isRegistered: AtomicBoolean = GlobalRum::class.java.getStaticValue("isRegistered")
+        isRegistered.set(false)
+    }
+
+    // endregion
+}

--- a/instrumented/integration/src/main/AndroidManifest.xml
+++ b/instrumented/integration/src/main/AndroidManifest.xml
@@ -28,7 +28,11 @@
             android:windowSoftInputMode="adjustResize"/>
         <activity
             android:name=".rum.RumGesturesTrackingPlaygroundActivity"
-            android:label="@string/activity_rum_gestures_end_to_end"
+            android:label="@string/rum_gestures_tracking_end_to_end"
+            android:windowSoftInputMode="adjustResize"/>
+        <activity
+            android:name=".rum.RumActivityTrackingPlaygroundActivity"
+            android:label="@string/rum_activity_view_tracking_end_to_end"
             android:windowSoftInputMode="adjustResize"/>
         <activity
             android:name="com.datadog.android.sdk.integrationtests.ActivityProfiling"

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/RumActivityTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/RumActivityTrackingPlaygroundActivity.kt
@@ -1,0 +1,30 @@
+package com.datadog.android.sdk.integration.rum
+
+import android.app.Activity
+import android.os.Bundle
+import com.datadog.android.Datadog
+import com.datadog.android.DatadogConfig
+import com.datadog.android.rum.ActivityViewTrackingStrategy
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumMonitor
+import com.datadog.android.sdk.integration.R
+import com.datadog.android.sdk.integration.RuntimeConfig
+
+internal class RumActivityTrackingPlaygroundActivity : Activity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.gestures_tracking_layout)
+
+        // use the activity view tracking strategy
+        val config = DatadogConfig.Builder(RuntimeConfig.DD_TOKEN, RuntimeConfig.APP_ID)
+            .useCustomLogsEndpoint(RuntimeConfig.logsEndpointUrl)
+            .useCustomTracesEndpoint(RuntimeConfig.tracesEndpointUrl)
+            .useCustomRumEndpoint(RuntimeConfig.rumEndpointUrl)
+            .useViewTrackingStrategy(ActivityViewTrackingStrategy())
+            .build()
+
+        Datadog.initialize(this, config)
+        GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
+    }
+}

--- a/instrumented/integration/src/main/res/values/strings.xml
+++ b/instrumented/integration/src/main/res/values/strings.xml
@@ -6,5 +6,6 @@
     <string name="activity_traces_end_to_end">Traces (End to End)</string>
     <string name="activity_logs_profiling">Logs (Profiling)</string>
     <string name="button1">Button1</string>
-    <string name="activity_rum_gestures_end_to_end">Rum Gestures (End to End)</string>
+    <string name="rum_gestures_tracking_end_to_end">Rum Gestures (End to End)</string>
+    <string name="rum_activity_view_tracking_end_to_end">Rum Activity View (End to End)</string>
 </resources>


### PR DESCRIPTION
### What does this PR do?

Adds the end - to - end tests for the Rum  Activity based view tracking strategy. It will assert the dispatched rum View events between the onPause and onResume Activity lifecycle events.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

