### PR TITLE
RUMM-274 Add end - to - end tests for FragmentViewTrackingStrategy

### DIFF
--- a/dd-sdk-androidx-fragment/apiSurface
+++ b/dd-sdk-androidx-fragment/apiSurface
@@ -1,3 +1,3 @@
-class com.datadog.android.androidx.fragment.FragmentViewTrackingStrategy : com.datadog.android.rum.ActivityLifecycleTrackingStrategy
+class com.datadog.android.androidx.fragment.FragmentViewTrackingStrategy : com.datadog.android.rum.ActivityLifecycleTrackingStrategy, com.datadog.android.rum.ViewTrackingStrategy
   override fun onActivityResumed(android.app.Activity)
   override fun onActivityPaused(android.app.Activity)

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -67,6 +67,9 @@ repositories {
 }
 
 dependencies {
+    implementation(project(":dd-sdk-androidx-fragment")) {
+        exclude("com.google.guava", "listenablefuture")
+    }
     implementation(project(":dd-sdk-android")) {
         exclude("com.google.guava", "listenablefuture")
     }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/RumMockServerActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/RumMockServerActivityTestRule.kt
@@ -4,12 +4,7 @@ import android.app.Activity
 import android.app.Application
 import androidx.test.platform.app.InstrumentationRegistry
 import com.datadog.android.rum.ActivityViewTrackingStrategy
-import com.datadog.android.rum.GlobalRum
-import com.datadog.tools.unit.createInstance
 import com.datadog.tools.unit.getFieldValue
-import com.datadog.tools.unit.getStaticValue
-import com.datadog.tools.unit.setStaticValue
-import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.collections.ArrayList
 
 internal class RumMockServerActivityTestRule<T : Activity>(
@@ -20,13 +15,13 @@ internal class RumMockServerActivityTestRule<T : Activity>(
     // region ActivityTestRule
 
     override fun beforeActivityLaunched() {
-//        // This needs to be called here due to the way Espresso handles the activities.
-//        // There are cases when one activity is about to be finished and we are stopping the RumFeature
-//        // but in the same time another activity starts and wants to set the RumMonitor, in that moment
-//        // the Rum.Builder() returns NoOpMonitor because the RumFeature is disabled
-//        resetRumMonitor()
         removeRumCallbacks()
         super.beforeActivityLaunched()
+    }
+
+    override fun afterActivityFinished() {
+        removeRumCallbacks()
+        super.afterActivityFinished()
     }
 
     // endregion
@@ -59,15 +54,6 @@ internal class RumMockServerActivityTestRule<T : Activity>(
                 pointer--
             }
         }
-    }
-
-    private fun resetRumMonitor() {
-        val noOpMonitor = createInstance(
-            "com.datadog.android.rum.internal.monitor.NoOpRumMonitor"
-        )
-        GlobalRum::class.java.setStaticValue("monitor", noOpMonitor)
-        val isRegistered: AtomicBoolean = GlobalRum::class.java.getStaticValue("isRegistered")
-        isRegistered.set(false)
     }
 
     // endregion

--- a/instrumented/integration/src/main/AndroidManifest.xml
+++ b/instrumented/integration/src/main/AndroidManifest.xml
@@ -35,6 +35,10 @@
             android:label="@string/rum_activity_view_tracking_end_to_end"
             android:windowSoftInputMode="adjustResize"/>
         <activity
+            android:name=".rum.RumFragmentTrackingPlaygroundActivity"
+            android:label="@string/rum_activity_view_tracking_end_to_end"
+            android:windowSoftInputMode="adjustResize"/>
+        <activity
             android:name="com.datadog.android.sdk.integrationtests.ActivityProfiling"
             android:label="@string/activity_logs_profiling"
             android:windowSoftInputMode="adjustResize">

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentA.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentA.kt
@@ -1,0 +1,22 @@
+package com.datadog.android.sdk.integration.rum
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.datadog.android.sdk.integration.R
+
+internal class FragmentA : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_layout, container, false)
+        view.findViewById<TextView>(R.id.textView).setText(R.string.fragment_a)
+        return view
+    }
+}

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentB.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentB.kt
@@ -1,0 +1,22 @@
+package com.datadog.android.sdk.integration.rum
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.datadog.android.sdk.integration.R
+
+internal class FragmentB : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_layout, container, false)
+        view.findViewById<TextView>(R.id.textView).setText(R.string.fragment_b)
+        return view
+    }
+}

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentC.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentC.kt
@@ -1,0 +1,22 @@
+package com.datadog.android.sdk.integration.rum
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.TextView
+import androidx.fragment.app.Fragment
+import com.datadog.android.sdk.integration.R
+
+internal class FragmentC : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        val view = inflater.inflate(R.layout.fragment_layout, container, false)
+        view.findViewById<TextView>(R.id.textView).setText(R.string.fragment_c)
+        return view
+    }
+}

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/RumActivityTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/RumActivityTrackingPlaygroundActivity.kt
@@ -14,7 +14,7 @@ internal class RumActivityTrackingPlaygroundActivity : Activity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.gestures_tracking_layout)
+        setContentView(R.layout.fragment_tracking_layout)
 
         // use the activity view tracking strategy
         val config = DatadogConfig.Builder(RuntimeConfig.DD_TOKEN, RuntimeConfig.APP_ID)

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/RumFragmentTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/RumFragmentTrackingPlaygroundActivity.kt
@@ -1,0 +1,54 @@
+package com.datadog.android.sdk.integration.rum
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentPagerAdapter
+import androidx.viewpager.widget.ViewPager
+import com.datadog.android.Datadog
+import com.datadog.android.DatadogConfig
+import com.datadog.android.androidx.fragment.FragmentViewTrackingStrategy
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumMonitor
+import com.datadog.android.sdk.integration.R
+import com.datadog.android.sdk.integration.RuntimeConfig
+
+internal class RumFragmentTrackingPlaygroundActivity : AppCompatActivity() {
+    lateinit var viewPager: ViewPager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.fragment_tracking_layout)
+        viewPager = findViewById(R.id.pager)
+        viewPager.apply {
+            adapter = ViewPagerAdapter(supportFragmentManager)
+        }
+
+        // attach the fragment view tracking strategy
+        val config = DatadogConfig.Builder(RuntimeConfig.DD_TOKEN, RuntimeConfig.APP_ID)
+            .useCustomLogsEndpoint(RuntimeConfig.logsEndpointUrl)
+            .useCustomTracesEndpoint(RuntimeConfig.tracesEndpointUrl)
+            .useCustomRumEndpoint(RuntimeConfig.rumEndpointUrl)
+            .useViewTrackingStrategy(FragmentViewTrackingStrategy())
+            .build()
+
+        Datadog.initialize(this, config)
+        GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
+    }
+
+    internal inner class ViewPagerAdapter(fragmentManager: FragmentManager) :
+        FragmentPagerAdapter(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+        override fun getItem(position: Int): Fragment {
+            return when (position) {
+                0 -> FragmentA()
+                1 -> FragmentB()
+                else -> FragmentC()
+            }
+        }
+
+        override fun getCount(): Int {
+            return 3
+        }
+    }
+}

--- a/instrumented/integration/src/main/res/layout/fragment_b_layout.xml
+++ b/instrumented/integration/src/main/res/layout/fragment_b_layout.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/fragment_b" />
+</LinearLayout>

--- a/instrumented/integration/src/main/res/layout/fragment_c_layout.xml
+++ b/instrumented/integration/src/main/res/layout/fragment_c_layout.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/fragment_c" />
+</LinearLayout>

--- a/instrumented/integration/src/main/res/layout/fragment_layout.xml
+++ b/instrumented/integration/src/main/res/layout/fragment_layout.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center">
+
+    <TextView
+        android:id="@+id/textView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/fragment_a" />
+</LinearLayout>

--- a/instrumented/integration/src/main/res/layout/fragment_tracking_layout.xml
+++ b/instrumented/integration/src/main/res/layout/fragment_tracking_layout.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.viewpager.widget.ViewPager
+        android:id="@+id/pager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </androidx.viewpager.widget.ViewPager>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/instrumented/integration/src/main/res/values/strings.xml
+++ b/instrumented/integration/src/main/res/values/strings.xml
@@ -8,4 +8,7 @@
     <string name="button1">Button1</string>
     <string name="rum_gestures_tracking_end_to_end">Rum Gestures (End to End)</string>
     <string name="rum_activity_view_tracking_end_to_end">Rum Activity View (End to End)</string>
+    <string name="fragment_a">Fragment A</string>
+    <string name="fragment_b">Fragment B</string>
+    <string name="fragment_c">Fragment C</string>
 </resources>


### PR DESCRIPTION
### What does this PR do?

Adds the end - to - end tests for FragmentViewTrackingStrategy. We are using a Fragments based ViewPager which we instrument (using swipe actions) and we assert the view events after each page change. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

We are not covering in this PR the corner case where the ViewPager is using same Fragment for displaying each page.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

