### PR TITLE
RUMM-270 Build tools and SDK dependencies update

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -38,7 +38,7 @@ dependencies {
     implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.61")
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.1.1")
     implementation("org.jlleitschuh.gradle:ktlint-gradle:9.1.0")
-    implementation("com.android.tools.build:gradle:3.5.3")
+    implementation("com.android.tools.build:gradle:3.6.1")
     implementation("com.github.ben-manes:gradle-versions-plugin:0.27.0")
     implementation("me.xdrop:fuzzywuzzy:1.2.0")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:0.10.0")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -11,10 +11,10 @@ object Dependencies {
     object Versions {
         // Commons
         const val Kotlin = "1.3.61"
-        const val AndroidToolsPlugin = "3.5.3"
+        const val AndroidToolsPlugin = "3.6.1"
         const val Gson = "2.8.6"
         const val OkHttp = "3.12.6"
-        const val JetpackWorkManager = "2.2.0"
+        const val JetpackWorkManager = "2.3.3"
         const val AndroidXMultidex = "2.0.1"
 
         // JUnit
@@ -31,7 +31,7 @@ object Dependencies {
         const val JetpackBenchmark = "1.0.0"
 
         // Tools
-        const val Detekt = "1.2.1"
+        const val Detekt = "1.6.0"
         const val KtLint = "8.2.0"
         const val DependencyVersion = "0.27.0"
         const val Dokka = "0.10.0"
@@ -41,11 +41,11 @@ object Dependencies {
         const val AndroidJunitRunner = "1.2.0"
         const val AndroidExtJunit = "1.1.1"
         const val AndroidJunitCore = "1.2.0"
-        const val Espresso = "3.1.0"
+        const val Espresso = "3.1.1"
 
         // Sample Apps
         const val AppCompatVersion = "1.1.0"
-        const val ConstraintLayoutVersion = "2.0.0-beta3"
+        const val ConstraintLayoutVersion = "2.0.0-beta4"
         const val GoogleMaterialVersion = "1.0.0"
 
         // Integrations

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -187,13 +187,14 @@ object Datadog {
     // Stop all Datadog work (for test purposes).
     @Suppress("unused")
     private fun stop() {
-        checkInitialized()
-        LogsFeature.stop()
-        TracesFeature.stop()
-        CrashReportsFeature.stop()
-        CoreFeature.stop()
-        isDebug = false
-        initialized.set(false)
+        if (initialized.get()) {
+            LogsFeature.stop()
+            TracesFeature.stop()
+            CrashReportsFeature.stop()
+            CoreFeature.stop()
+            isDebug = false
+            initialized.set(false)
+        }
     }
 
     /**
@@ -229,11 +230,6 @@ object Datadog {
 
     // region Internal Initialization
 
-    @Suppress("CheckInternal")
-    private fun checkInitialized() {
-        check(initialized.get()) { MESSAGE_NOT_INITIALIZED }
-    }
-
     private fun setupLifecycleMonitorCallback(appContext: Context) {
         if (appContext is Application) {
             val callback = ProcessLifecycleCallback(CoreFeature.networkInfoProvider, appContext)
@@ -248,11 +244,11 @@ object Datadog {
     internal const val MESSAGE_ALREADY_INITIALIZED =
         "The Datadog library has already been initialized."
     internal const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized.\n" +
-        "Please add the following code in your application's onCreate() method:\n" +
-        "Datadog.initialize(context, \"<CLIENT_TOKEN>\");"
+            "Please add the following code in your application's onCreate() method:\n" +
+            "Datadog.initialize(context, \"<CLIENT_TOKEN>\");"
 
     internal const val MESSAGE_DEPRECATED = "%s has been deprecated. " +
-        "If you need it, submit an issue at https://github.com/DataDog/dd-sdk-android/issues/"
+            "If you need it, submit an issue at https://github.com/DataDog/dd-sdk-android/issues/"
 
     internal const val SHUTDOWN_THREAD = "datadog_shutdown"
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -26,6 +26,7 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -37,7 +38,6 @@ import org.hamcrest.CoreMatchers.startsWith
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.api.io.TempDir
@@ -103,10 +103,9 @@ internal class DatadogTest {
     }
 
     @Test
-    fun `fails if stop called without initialize`() {
-        assertThrows<IllegalStateException> {
-            Datadog.invokeMethod("stop")
-        }
+    fun `stop called without initialize will do nothing`() {
+        Datadog.invokeMethod("stop")
+        verifyZeroInteractions(mockAppContext)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ListenableFutureFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ListenableFutureFactory.kt
@@ -1,0 +1,42 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-2019 Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.google.common.util.concurrent.ListenableFuture
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.concurrent.Executor
+import java.util.concurrent.TimeUnit
+
+internal class ListenableFutureFactory : ForgeryFactory<ListenableFuture<Void>> {
+    override fun getForgery(forge: Forge): ListenableFuture<Void> {
+        return object : ListenableFuture<Void> {
+            override fun addListener(listener: Runnable, executor: Executor) {
+            }
+
+            override fun isDone(): Boolean {
+                return false
+            }
+
+            override fun get(): Void? {
+                return null
+            }
+
+            override fun get(timeout: Long, unit: TimeUnit): Void? {
+                return null
+            }
+
+            override fun cancel(mayInterruptIfRunning: Boolean): Boolean {
+                return false
+            }
+
+            override fun isCancelled(): Boolean {
+                return false
+            }
+        }
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/WorkerParametersForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/WorkerParametersForgeryFactory.kt
@@ -8,13 +8,16 @@ package com.datadog.android.utils.forge
 
 import android.content.Context
 import androidx.work.Data
+import androidx.work.ForegroundUpdater
 import androidx.work.ListenableWorker
+import androidx.work.ProgressUpdater
 import androidx.work.WorkerFactory
 import androidx.work.WorkerParameters
 import androidx.work.impl.utils.SerialExecutor
 import androidx.work.impl.utils.taskexecutor.TaskExecutor
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
@@ -25,7 +28,7 @@ class WorkerParametersForgeryFactory : ForgeryFactory<WorkerParameters> {
     override fun getForgery(forge: Forge): WorkerParameters {
         val threadExecutor = Executors.newSingleThreadExecutor()
         return WorkerParameters(
-            forge.getForgery(),
+            forge.getForgery<UUID>(),
             Data.EMPTY,
             forge.aList { anAlphabeticalString() },
             WorkerParameters.RuntimeExtras(),
@@ -54,7 +57,9 @@ class WorkerParametersForgeryFactory : ForgeryFactory<WorkerParameters> {
                 ): ListenableWorker? {
                     return null
                 }
-            }
+            },
+            ProgressUpdater { context, id, data -> forge.getForgery() },
+            ForegroundUpdater { context, id, foregroundInfo -> forge.getForgery() }
         )
     }
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -118,7 +118,7 @@ empty-blocks:
     active: true
   EmptyFunctionBlock:
     active: true
-    ignoreOverriddenFunctions: true
+    ignoreOverridden: true
   EmptyIfBlock:
     active: true
   EmptyInitBlock:
@@ -325,7 +325,7 @@ naming:
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
     parameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
-    ignoreOverriddenFunctions: true
+    ignoreOverridden: true
   InvalidPackageDeclaration:
     active: true
     rootPackage: ''
@@ -333,7 +333,7 @@ naming:
     active: true
   MemberNameEqualsClassName:
     active: true
-    ignoreOverriddenFunction: true
+    ignoreOverridden: true
   ObjectPropertyNaming:
     active: true
     excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+android.useAndroidX=true


### PR DESCRIPTION
### Additional Notes

Please not that in this PR I added also a fix for the IllegalStateException that was thrown by the `Datadog#stop` method when being called without initialising the SDK upfront. This was not a problem before as this method was only meant for tests but recently we added a fix and we are calling this method from the **Runtime ShutdownHook Thread** which can introduce unwanted Crashes in our clients applications.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

