### PR TITLE
RUMM-256 Add the UTC timestamp as query parameter

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataUploader.kt
@@ -8,7 +8,5 @@ package com.datadog.android.core.internal.net
 
 internal interface DataUploader {
 
-    fun setEndpoint(endpoint: String)
-
     fun upload(data: ByteArray): UploadStatus
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/NoOpDataUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/NoOpDataUploader.kt
@@ -14,9 +14,5 @@ internal class NoOpDataUploader : DataUploader {
         return UploadStatus.SUCCESS
     }
 
-    override fun setEndpoint(endpoint: String) {
-        // No Op
-    }
-
     // endregion
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
@@ -16,13 +16,19 @@ internal open class LogsOkHttpUploader(
         super.setEndpoint(buildUrl(endpoint, token))
     }
 
+    override fun buildQueryParams(): Map<String, Any> {
+        return mutableMapOf(
+            QP_SOURCE to DD_SOURCE_MOBILE
+        )
+    }
+
     // endregion
 
     companion object {
         private const val QP_SOURCE = "ddsource"
         private const val DD_SOURCE_MOBILE = "mobile"
         internal const val UPLOAD_URL =
-            "%s/v1/input/%s?$QP_SOURCE=$DD_SOURCE_MOBILE"
+            "%s/v1/input/%s"
 
         private fun buildUrl(endpoint: String, token: String): String {
             return String.format(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -9,7 +9,6 @@ package com.datadog.android.rum
 import android.app.Activity
 import android.app.Fragment
 import com.datadog.android.Datadog
-import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
@@ -138,7 +137,6 @@ interface RumMonitor {
                 NoOpRumMonitor()
             } else {
                 DatadogRumMonitor(
-                    timeProvider = CoreFeature.timeProvider,
                     writer = RumFeature.persistenceStrategy.getWriter()
                 )
             }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.internal.monitor
 
 import com.datadog.android.core.internal.data.Writer
+import com.datadog.android.core.internal.time.NoOpTimeProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.sdkLogger
@@ -20,8 +21,8 @@ import java.lang.ref.WeakReference
 import java.util.UUID
 
 internal class DatadogRumMonitor(
-    private val timeProvider: TimeProvider,
-    private val writer: Writer<RumEvent>
+    private val writer: Writer<RumEvent>,
+    private val timeProvider: TimeProvider = NoOpTimeProvider()
 ) : RumMonitor {
 
     @Volatile
@@ -49,7 +50,7 @@ internal class DatadogRumMonitor(
         val eventData = RumEventData.UserAction(action)
         val event = RumEvent(
             GlobalRum.getRumContext(),
-            timeProvider.getServerTimestamp(),
+            timeProvider.getDeviceTimestamp(),
             eventData,
             attributes
         )
@@ -75,7 +76,7 @@ internal class DatadogRumMonitor(
         val eventData = RumEventData.View(pathName, 0)
         val event = RumEvent(
             GlobalRum.getRumContext(),
-            timeProvider.getServerTimestamp(),
+            timeProvider.getDeviceTimestamp(),
             eventData,
             attributes
         )
@@ -100,12 +101,12 @@ internal class DatadogRumMonitor(
         when {
             startedEvent == null || startedEventData == null -> devLogger.w(
                 "Unable to end view with key <$key> (missing start). " +
-                    "This can mean that the view was not started or already ended."
+                        "This can mean that the view was not started or already ended."
             )
             startedKey == null -> {
                 devLogger.e(
                     "Unable to end view with key <$key> (missing key)." +
-                        "Closing previous view automatically."
+                            "Closing previous view automatically."
                 )
                 updateAndSendView(
                     mapOf(RumEventSerializer.TAG_EVENT_UNSTOPPED to true)
@@ -114,7 +115,7 @@ internal class DatadogRumMonitor(
             startedKey != key -> {
                 devLogger.e(
                     "Unable to end view with key <$key> (mismatched key). " +
-                        "Another view with key <$startedKey> has been started."
+                            "Another view with key <$startedKey> has been started."
                 )
             }
             else -> updateAndSendView(attributes)
@@ -138,7 +139,7 @@ internal class DatadogRumMonitor(
         )
         val event = RumEvent(
             GlobalRum.getRumContext(),
-            timeProvider.getServerTimestamp(),
+            timeProvider.getDeviceTimestamp(),
             eventData,
             attributes
         )
@@ -173,7 +174,7 @@ internal class DatadogRumMonitor(
         when {
             startedEvent == null -> devLogger.w(
                 "Unable to end resource with key <$key>. " +
-                    "This can mean that the resource was not started or already ended."
+                        "This can mean that the resource was not started or already ended."
             )
             startedEventData == null -> devLogger.e(
                 "Unable to end resource with key <$key>. The related data was inconsistent."
@@ -202,7 +203,7 @@ internal class DatadogRumMonitor(
         val eventData = RumEventData.Error(message, origin, throwable)
         val event = RumEvent(
             GlobalRum.getRumContext(),
-            timeProvider.getServerTimestamp(),
+            timeProvider.getDeviceTimestamp(),
             eventData,
             attributes
         )
@@ -254,7 +255,7 @@ internal class DatadogRumMonitor(
         when {
             startedEvent == null -> devLogger.w(
                 "Unable to end resource with key <$key>. " +
-                    "This can mean that the resource was not started or already ended."
+                        "This can mean that the resource was not started or already ended."
             )
             startedEventData == null -> devLogger.e(
                 "Unable to end resource with key <$key>. The related data was inconsistent."

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
@@ -22,13 +22,20 @@ internal open class RumOkHttpUploader(
         super.setEndpoint(buildUrl(endpoint, token))
     }
 
+    override fun buildQueryParams(): MutableMap<String, Any> {
+        return mutableMapOf(
+            BATCH_TIME to System.currentTimeMillis(),
+            QP_SOURCE to DD_SOURCE_MOBILE
+        )
+    }
+
     // endregion
 
     companion object {
         private const val QP_SOURCE = "ddsource"
         private const val DD_SOURCE_MOBILE = "mobile"
         internal const val UPLOAD_URL =
-            "%s/v1/input/%s?$QP_SOURCE=$DD_SOURCE_MOBILE"
+            "%s/v1/input/%s"
 
         private fun buildUrl(endpoint: String, token: String): String {
             return String.format(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploader.kt
@@ -16,6 +16,10 @@ internal open class TracesOkHttpUploader(
         super.setEndpoint(buildUrl(endpoint, token))
     }
 
+    override fun buildQueryParams(): Map<String, Any> {
+        return emptyMap()
+    }
+
     // endregion
 
     companion object {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
@@ -22,4 +22,8 @@ internal class LogsOkHttpUploaderTest : DataOkHttpUploaderTest<LogsOkHttpUploade
     override fun urlFormat(): String {
         return LogsOkHttpUploader.UPLOAD_URL
     }
+
+    override fun expectedPathRegex(): String {
+        return "\\/v1\\/input/${fakeToken}\\?ddsource=mobile$"
+    }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -66,7 +66,7 @@ internal class DatadogRumMonitorTest {
     @BeforeEach
     fun `set up`() {
         GlobalRum.updateApplicationId(fakeApplicationId)
-        testedMonitor = DatadogRumMonitor(mockTimeProvider, mockWriter)
+        testedMonitor = DatadogRumMonitor(mockWriter, mockTimeProvider)
     }
 
     @Test
@@ -93,7 +93,7 @@ internal class DatadogRumMonitorTest {
         val name = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
         val attributes = forge.exhaustiveAttributes()
         var viewId: UUID? = null
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         val duration = measureNanoTime {
             testedMonitor.startView(key, name, attributes)
@@ -165,7 +165,7 @@ internal class DatadogRumMonitorTest {
         val name = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
         val attributes = forge.exhaustiveAttributes()
         var viewId: UUID? = null
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         val duration = measureNanoTime {
             testedMonitor.startView(key, name, attributes)
@@ -203,7 +203,7 @@ internal class DatadogRumMonitorTest {
         val name = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
         val attributes = forge.exhaustiveAttributes()
         var viewId: UUID? = null
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         val duration = measureNanoTime {
             testedMonitor.startView(key, name, attributes)
@@ -242,7 +242,7 @@ internal class DatadogRumMonitorTest {
         val name = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
         val attributes = forge.exhaustiveAttributes()
         var viewId: UUID? = null
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         val duration = measureNanoTime {
             testedMonitor.startView(key, name, attributes)
@@ -285,7 +285,7 @@ internal class DatadogRumMonitorTest {
         val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
         val attributes = forge.exhaustiveAttributes()
         var viewId: UUID? = null
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         testedMonitor.startView(viewKey, viewName, attributes)
         testedMonitor.startResource(resourceKey, resourceUrl, attributes)
@@ -386,7 +386,7 @@ internal class DatadogRumMonitorTest {
         val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
         val resourceKind = forge.aValueFrom(RumResourceKind::class.java)
         val attributes = forge.exhaustiveAttributes()
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
         val viewId = GlobalRum.getRumContext().viewId
@@ -442,7 +442,7 @@ internal class DatadogRumMonitorTest {
         val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
         val attributes = forge.exhaustiveAttributes()
         val kind = forge.aValueFrom(RumResourceKind::class.java, listOf(RumResourceKind.UNKNOWN))
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
         val viewId = GlobalRum.getRumContext().viewId
@@ -515,7 +515,7 @@ internal class DatadogRumMonitorTest {
         val errorMessage = forge.anAlphabeticalString()
         val throwable = forge.aThrowable()
         val attributes = forge.exhaustiveAttributes()
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
         val viewId = GlobalRum.getRumContext().viewId
@@ -572,7 +572,7 @@ internal class DatadogRumMonitorTest {
         val errorOrigin = forge.anAlphabeticalString()
         val errorMessage = forge.anAlphabeticalString()
         val throwable = forge.aThrowable()
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
         val viewId = GlobalRum.getRumContext().viewId
@@ -629,7 +629,7 @@ internal class DatadogRumMonitorTest {
         val errorOrigin = forge.anAlphabeticalString()
         val errorMessage = forge.anAlphabeticalString()
         val throwable = forge.aThrowable()
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
         val viewId = GlobalRum.getRumContext().viewId
@@ -679,7 +679,7 @@ internal class DatadogRumMonitorTest {
         val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
         val actionNAme = forge.anAsciiString()
         val attributes = forge.exhaustiveAttributes()
-        whenever(mockTimeProvider.getServerTimestamp()) doReturn timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp()) doReturn timestamp
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
         val viewId = GlobalRum.getRumContext().viewId

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderTest.kt
@@ -21,4 +21,8 @@ internal class RumOkHttpUploaderTest : DataOkHttpUploaderTest<RumOkHttpUploader>
     override fun urlFormat(): String {
         return RumOkHttpUploader.UPLOAD_URL
     }
+
+    override fun expectedPathRegex(): String {
+        return "\\/v1\\/input/${fakeToken}\\?batch_time=\\d+&ddsource=mobile$"
+    }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderTest.kt
@@ -21,4 +21,8 @@ internal class TracesOkHttpUploaderTest : DataOkHttpUploaderTest<TracesOkHttpUpl
     override fun urlFormat(): String {
         return TracesOkHttpUploader.UPLOAD_URL
     }
+
+    override fun expectedPathRegex(): String {
+        return "\\/v1\\/input\\/$fakeToken$"
+    }
 }


### PR DESCRIPTION
### What does this PR do?

In this PR we add the UTC timestamp in milliseconds as a query parameter to each batch intake request:
*http://url?batch_time=System.currentTimeInMillis()*
This new query parameter will be needed to normalise the events timestamps on server side by computing the offset between the device UTC time and the server UTC time.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

