### PR TITLE
RUMM-304 Share one single writer per feature

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/AsyncWriterFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/AsyncWriterFilePersistenceStrategy.kt
@@ -35,11 +35,15 @@ internal abstract class AsyncWriterFilePersistenceStrategy<T : Any>(
     payloadSuffix
 ) {
 
-    override fun getWriter(): Writer<T> {
-        return DeferredWriter(
+    val deferredWriter: DeferredWriter<T> by lazy {
+        DeferredWriter(
             writerThreadName,
             fileWriter,
             dataMigrator
         )
+    }
+
+    override fun getWriter(): Writer<T> {
+        return deferredWriter
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategyTest.kt
@@ -63,8 +63,10 @@ internal abstract class FilePersistenceStrategyTest<T : Any>(
 
     lateinit var testedWriter: Writer<T>
     lateinit var testedReader: Reader
+
     @Mock(lenient = true)
     lateinit var mockDeferredHandler: DeferredHandler
+
     @TempDir
     lateinit var tempDir: File
 
@@ -181,7 +183,7 @@ internal abstract class FilePersistenceStrategyTest<T : Any>(
     fun `don't write model if size is too big`(forge: Forge) {
         val bigModel = bigModel(forge)
         testedWriter.write(bigModel)
-            waitForNextBatch()
+        waitForNextBatch()
         val batch = testedReader.readNextBatch()
 
         assertThat(batch)
@@ -302,6 +304,16 @@ internal abstract class FilePersistenceStrategyTest<T : Any>(
 
         assertThat(batch2)
             .isNull()
+    }
+
+    @Test
+    fun `it will create and share one single writer instance`() {
+        // given
+        val persistenceStrategy = getStrategy()
+        val currentWriter = persistenceStrategy.getWriter()
+
+        // then
+        assertThat(persistenceStrategy.getWriter()).isSameAs(currentWriter)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

In this PR we make sure we're only creating and sharing one single Writer instance per feature inside fir the persistence layer.

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

