### PR TITLE
Update the versioning model

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/utils/Version.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/utils/Version.kt
@@ -10,8 +10,33 @@ data class Version(
     val major: Int,
     val minor: Int,
     val hotfix: Int,
-    val suffix: String = ""
+    val type: Type = Type.Release
 ) {
+
+    // region Type
+
+    sealed class Type {
+
+        abstract val suffix: String
+
+        object Release : Type() {
+            override val suffix: String = ""
+        }
+
+        data class ReleaseCandidate(val number: Int) : Type() {
+            override val suffix: String = "-rc$number"
+        }
+
+        data class Beta(val number: Int) : Type() {
+            override val suffix: String = "-beta$number"
+        }
+
+        data class Alpha(val number: Int) : Type() {
+            override val suffix: String = "-alpha$number"
+        }
+    }
+
+    // endregion
 
     init {
         require(major < MAX_MAJOR) { "The minor component must be smaller than $MAX_MAJOR" }
@@ -26,14 +51,7 @@ data class Version(
      */
     val name: String
         get() {
-            return if (suffix.isBlank()) {
-                "$major.$minor.$hotfix"
-            } else {
-                val sanitized = suffix.trim()
-                    .toLowerCase()
-                    .replace(Regex("[^a-z0-9]"), "-")
-                "$major.$minor.$hotfix-$sanitized"
-            }
+            return "$major.$minor.$hotfix${type.suffix}"
         }
 
     /**

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/utils/VersionTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/utils/VersionTest.kt
@@ -55,16 +55,23 @@ class VersionTest {
     }
 
     @Test
-    fun addSuffix() {
-        val name = Version(3, 12, 7, "alpha1").name
-        val expected = "3.12.7-alpha1"
+    fun addSuffixForRC() {
+        val name = Version(3, 12, 7, Version.Type.ReleaseCandidate(1)).name
+        val expected = "3.12.7-rc1"
         assert(name == expected) { " expected name to be $expected but was $name" }
     }
 
     @Test
-    fun addSuffixSanitized() {
-        val name = Version(3, 12, 7, " Beta 1\t").name
-        val expected = "3.12.7-beta-1"
+    fun addSuffixForBeta() {
+        val name = Version(3, 12, 7, Version.Type.Beta(5)).name
+        val expected = "3.12.7-beta5"
+        assert(name == expected) { " expected name to be $expected but was $name" }
+    }
+
+    @Test
+    fun addSuffixForAlpha() {
+        val name = Version(3, 12, 7, Version.Type.Alpha(3)).name
+        val expected = "3.12.7-alpha3"
         assert(name == expected) { " expected name to be $expected but was $name" }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Avoids typo when releasing an `aphla` or `beat` version.