### PR TITLE
RUMM-308 Make Logger methods Thread safe

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MapUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MapUtils.kt
@@ -1,0 +1,3 @@
+package com.datadog.android.core.internal.utils
+
+internal val NULL_MAP_VALUE = Object()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
@@ -10,6 +10,7 @@ import android.util.Log as AndroidLog
 import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.domain.Serializer
+import com.datadog.android.core.internal.utils.NULL_MAP_VALUE
 import com.datadog.android.log.internal.constraints.DatadogLogConstraints
 import com.datadog.android.log.internal.constraints.LogConstraints
 import com.google.gson.JsonArray
@@ -27,7 +28,7 @@ import java.util.TimeZone
  * The Logging feature implementation of the [Serializer] interface.
  */
 internal class LogSerializer(private val logConstraints: LogConstraints = DatadogLogConstraints()) :
-    Serializer<Log> {
+        Serializer<Log> {
 
     private val simpleDateFormat = SimpleDateFormat(ISO_8601, Locale.US).apply {
         timeZone = TimeZone.getTimeZone("UTC")
@@ -133,7 +134,7 @@ internal class LogSerializer(private val logConstraints: LogConstraints = Datado
         jsonLog: JsonObject
     ) {
         val tags = logConstraints.validateTags(log.tags)
-            .joinToString(",")
+                .joinToString(",")
         jsonLog.addProperty(TAG_DATADOG_TAGS, tags)
     }
 
@@ -142,24 +143,24 @@ internal class LogSerializer(private val logConstraints: LogConstraints = Datado
         jsonLog: JsonObject
     ) {
         logConstraints.validateAttributes(log.attributes)
-            .filter { it.key.isNotBlank() && it.key !in reservedAttributes }
-            .forEach {
-                val value = it.value
-                val jsonValue = when (value) {
-                    null -> JsonNull.INSTANCE
-                    is Boolean -> JsonPrimitive(value)
-                    is Int -> JsonPrimitive(value)
-                    is Long -> JsonPrimitive(value)
-                    is Float -> JsonPrimitive(value)
-                    is Double -> JsonPrimitive(value)
-                    is String -> JsonPrimitive(value)
-                    is Date -> JsonPrimitive(value.time)
-                    is JsonObject -> value
-                    is JsonArray -> value
-                    else -> JsonPrimitive(value.toString())
+                .filter { it.key.isNotBlank() && it.key !in reservedAttributes }
+                .forEach {
+                    val value = it.value
+                    val jsonValue = when (value) {
+                        NULL_MAP_VALUE -> JsonNull.INSTANCE
+                        is Boolean -> JsonPrimitive(value)
+                        is Int -> JsonPrimitive(value)
+                        is Long -> JsonPrimitive(value)
+                        is Float -> JsonPrimitive(value)
+                        is Double -> JsonPrimitive(value)
+                        is String -> JsonPrimitive(value)
+                        is Date -> JsonPrimitive(value.time)
+                        is JsonObject -> value
+                        is JsonArray -> value
+                        else -> JsonPrimitive(value.toString())
+                    }
+                    jsonLog.add(it.key, jsonValue)
                 }
-                jsonLog.add(it.key, jsonValue)
-            }
     }
 
     private fun addTraceInfo(log: Log, jsonLog: JsonObject) {
@@ -217,15 +218,15 @@ internal class LogSerializer(private val logConstraints: LogConstraints = Datado
         internal const val TAG_SPAN_ID = "dd.span_id"
 
         internal val reservedAttributes = arrayOf(
-            TAG_HOST,
-            TAG_MESSAGE,
-            TAG_STATUS,
-            TAG_SERVICE_NAME,
-            TAG_SOURCE,
-            TAG_ERROR_KIND,
-            TAG_ERROR_MESSAGE,
-            TAG_ERROR_STACK,
-            TAG_DATADOG_TAGS
+                TAG_HOST,
+                TAG_MESSAGE,
+                TAG_STATUS,
+                TAG_SERVICE_NAME,
+                TAG_SOURCE,
+                TAG_ERROR_KIND,
+                TAG_ERROR_MESSAGE,
+                TAG_ERROR_STACK,
+                TAG_DATADOG_TAGS
         )
 
         internal fun resolveLogLevelStatus(level: Int): String {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerTest.kt
@@ -7,20 +7,25 @@
 package com.datadog.android.log
 
 import android.util.Log
+import com.datadog.android.core.internal.utils.NULL_MAP_VALUE
 import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.utils.forge.Configurator
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.isNull
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.util.Date
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -30,8 +35,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 
 @Extensions(
-    ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class)
+        ExtendWith(MockitoExtension::class),
+        ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings()
 @ForgeConfiguration(Configurator::class)
@@ -58,13 +63,13 @@ internal class LoggerTest {
         testedLogger.v(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.VERBOSE,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.VERBOSE,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -74,14 +79,14 @@ internal class LoggerTest {
         testedLogger.internalLog(level, fakeMessage, null, emptyMap(), timestamp)
 
         verify(mockLogHandler)
-            .handleLog(
-                level,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet(),
-                timestamp
-            )
+                .handleLog(
+                        level,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet(),
+                        timestamp
+                )
     }
 
     @Test
@@ -89,13 +94,13 @@ internal class LoggerTest {
         testedLogger.d(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.DEBUG,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.DEBUG,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -103,13 +108,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -117,13 +122,13 @@ internal class LoggerTest {
         testedLogger.w(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.WARN,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.WARN,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -131,13 +136,13 @@ internal class LoggerTest {
         testedLogger.e(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.ERROR,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.ERROR,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -145,13 +150,13 @@ internal class LoggerTest {
         testedLogger.wtf(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.ASSERT,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.ASSERT,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     // endregion
@@ -162,13 +167,13 @@ internal class LoggerTest {
         testedLogger.v(fakeMessage, throwable)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.VERBOSE,
-                fakeMessage,
-                throwable,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.VERBOSE,
+                        fakeMessage,
+                        throwable,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -176,13 +181,13 @@ internal class LoggerTest {
         testedLogger.d(fakeMessage, throwable)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.DEBUG,
-                fakeMessage,
-                throwable,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.DEBUG,
+                        fakeMessage,
+                        throwable,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -190,13 +195,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage, throwable)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                throwable,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        throwable,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -204,13 +209,13 @@ internal class LoggerTest {
         testedLogger.w(fakeMessage, throwable)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.WARN,
-                fakeMessage,
-                throwable,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.WARN,
+                        fakeMessage,
+                        throwable,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -218,13 +223,13 @@ internal class LoggerTest {
         testedLogger.e(fakeMessage, throwable)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.ERROR,
-                fakeMessage,
-                throwable,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.ERROR,
+                        fakeMessage,
+                        throwable,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -232,13 +237,13 @@ internal class LoggerTest {
         testedLogger.wtf(fakeMessage, throwable)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.ASSERT,
-                fakeMessage,
-                throwable,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.ASSERT,
+                        fakeMessage,
+                        throwable,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     // endregion
@@ -254,13 +259,13 @@ internal class LoggerTest {
         testedLogger.v(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.VERBOSE,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.VERBOSE,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     @Test
@@ -272,13 +277,13 @@ internal class LoggerTest {
         testedLogger.d(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.DEBUG,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.DEBUG,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     @Test
@@ -290,13 +295,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     @Test
@@ -308,13 +313,13 @@ internal class LoggerTest {
         testedLogger.w(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.WARN,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.WARN,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     @Test
@@ -326,13 +331,13 @@ internal class LoggerTest {
         testedLogger.e(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.ERROR,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.ERROR,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     @Test
@@ -344,13 +349,13 @@ internal class LoggerTest {
         testedLogger.wtf(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.ASSERT,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.ASSERT,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     @Test
@@ -362,13 +367,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        mapOf(key to NULL_MAP_VALUE),
+                        emptySet()
+                )
     }
 
     @Test
@@ -379,13 +384,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     @Test
@@ -396,13 +401,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     @Test
@@ -413,13 +418,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     // endregion
@@ -436,13 +441,13 @@ internal class LoggerTest {
         testedLogger.v(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.VERBOSE,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.VERBOSE,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -455,13 +460,13 @@ internal class LoggerTest {
         testedLogger.d(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.DEBUG,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.DEBUG,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -474,13 +479,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -493,13 +498,13 @@ internal class LoggerTest {
         testedLogger.w(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.WARN,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.WARN,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -512,13 +517,13 @@ internal class LoggerTest {
         testedLogger.e(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.ERROR,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.ERROR,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -531,13 +536,13 @@ internal class LoggerTest {
         testedLogger.wtf(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.ASSERT,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.ASSERT,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -550,13 +555,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -568,13 +573,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     // endregion
@@ -590,13 +595,13 @@ internal class LoggerTest {
         testedLogger.v(fakeMessage, null, mapOf(key to value))
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.VERBOSE,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.VERBOSE,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     @Test
@@ -609,14 +614,14 @@ internal class LoggerTest {
         testedLogger.internalLog(level, fakeMessage, null, mapOf(key to value), timestamp)
 
         verify(mockLogHandler)
-            .handleLog(
-                level,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet(),
-                timestamp
-            )
+                .handleLog(
+                        level,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet(),
+                        timestamp
+                )
     }
 
     @Test
@@ -628,13 +633,13 @@ internal class LoggerTest {
         testedLogger.d(fakeMessage, null, mapOf(key to value))
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.DEBUG,
-                fakeMessage,
-                null,
-                mapOf(key to value),
-                emptySet()
-            )
+                .handleLog(
+                        Log.DEBUG,
+                        fakeMessage,
+                        null,
+                        mapOf(key to value),
+                        emptySet()
+                )
     }
 
     @Test
@@ -648,13 +653,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage, null, mapOf(key to localValue))
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                mapOf(key to localValue),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        mapOf(key to localValue),
+                        emptySet()
+                )
     }
 
     @Test
@@ -670,23 +675,23 @@ internal class LoggerTest {
 
         inOrder(mockLogHandler) {
             verify(mockLogHandler)
-                .handleLog(
-                    eq(Log.WARN),
-                    eq(message1),
-                    isNull(),
-                    eq(mapOf(key to value)),
-                    eq(emptySet()),
-                    isNull()
-                )
+                    .handleLog(
+                            eq(Log.WARN),
+                            eq(message1),
+                            isNull(),
+                            eq(mapOf(key to value)),
+                            eq(emptySet()),
+                            isNull()
+                    )
             verify(mockLogHandler)
-                .handleLog(
-                    eq(Log.ERROR),
-                    eq(message2),
-                    isNull(),
-                    eq(emptyMap()),
-                    eq(emptySet()),
-                    isNull()
-                )
+                    .handleLog(
+                            eq(Log.ERROR),
+                            eq(message2),
+                            isNull(),
+                            eq(emptyMap()),
+                            eq(emptySet()),
+                            isNull()
+                    )
         }
     }
 
@@ -702,13 +707,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                setOf("env:$envName")
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        setOf("env:$envName")
+                )
     }
 
     @Test
@@ -719,13 +724,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                setOf(tag)
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        setOf(tag)
+                )
     }
 
     @Test
@@ -737,13 +742,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                setOf("$key:$value")
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        setOf("$key:$value")
+                )
     }
 
     @Test
@@ -759,13 +764,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                setOf("$key:$value1", "$key:$value2", "$key:$value3")
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        setOf("$key:$value1", "$key:$value2", "$key:$value3")
+                )
     }
 
     // endregion
@@ -781,13 +786,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -800,13 +805,13 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
     }
 
     @Test
@@ -823,13 +828,165 @@ internal class LoggerTest {
         testedLogger.i(fakeMessage)
 
         verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                emptySet()
-            )
+                .handleLog(
+                        Log.INFO,
+                        fakeMessage,
+                        null,
+                        emptyMap(),
+                        emptySet()
+                )
+    }
+
+    // endregion
+
+    // region Multi Thread Access
+
+    @Test
+    fun `adding and removing tags is thread safe`(forge: Forge) {
+        val asyncOperations = 100
+        val syncOperations = 10
+        val randomTags =
+                forge.aList(asyncOperations) {
+                    "${forge.aString(syncOperations)}:${forge.aString(syncOperations)}"
+                }
+        val countDownLatch = CountDownLatch(asyncOperations)
+        var logDebugExecutionCalls = 0
+        repeat(asyncOperations) {
+
+            val closure = when (forge.anInt(min = 0, max = 3)) {
+                0 -> {
+                    {
+                        repeat(syncOperations) {
+                            repeat(syncOperations) {
+                                val randomTagIndex = forge.anInt(0, asyncOperations)
+                                testedLogger.addTag(randomTags[randomTagIndex])
+                            }
+                        }
+                    }
+                }
+                1 -> {
+                    {
+                        repeat(syncOperations) {
+                            val randomTagIndex = forge.anInt(0, asyncOperations)
+                            testedLogger.removeTag(randomTags[randomTagIndex])
+                        }
+                    }
+                }
+                2 -> {
+                    {
+                        repeat(syncOperations) {
+                            val randomTagIndex = forge.anInt(0, asyncOperations)
+                            val tagKey = randomTags[randomTagIndex].split(":").first()
+                            testedLogger.removeTagsWithKey(tagKey)
+                        }
+                    }
+                }
+                3 -> {
+                    logDebugExecutionCalls++
+                    {
+                        val attributes =
+                                forge.aMap<String, Any>(size = forge.anInt(min = 1, max = 5)) {
+                                    forge.aString(size = syncOperations) to
+                                            forge.aString(size = syncOperations)
+                                }
+                        testedLogger.d(
+                                forge.aString(size = syncOperations),
+                                attributes = attributes
+                        )
+                    }
+                }
+                else -> {
+                    { }
+                }
+            }
+            async(countDownLatch, closure)
+        }
+
+        countDownLatch.await(5, TimeUnit.SECONDS)
+        verify(mockLogHandler, times(logDebugExecutionCalls)).handleLog(
+                eq(Log.DEBUG),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull()
+        )
+    }
+
+    @Test
+    fun `adding and removing attributes is thread safe`(forge: Forge) {
+        val asyncOperations = 100
+        val syncedOperations = 10
+        val randomAttributes = forge.aList(size = asyncOperations) {
+            forge.aString(syncedOperations) to forge.aString(syncedOperations)
+        }
+        val countDownLatch = CountDownLatch(asyncOperations)
+        var logDebugExecutionCalls = 0
+        repeat(asyncOperations) {
+
+            val closure = when (forge.anInt(min = 0, max = 2)) {
+                0 -> {
+                    {
+                        repeat(syncedOperations) {
+                            val randomAttributeIndex = forge.anInt(0, asyncOperations)
+                            testedLogger.addAttribute(
+                                    randomAttributes[randomAttributeIndex].first,
+                                    randomAttributes[randomAttributeIndex].second
+                            )
+                        }
+                    }
+                }
+                1 -> {
+                    {
+                        repeat(syncedOperations) {
+                            val randomAttributeIndex = forge.anInt(0, asyncOperations)
+                            testedLogger.removeAttribute(
+                                    randomAttributes[randomAttributeIndex].first
+                            )
+                        }
+                    }
+                }
+                2 -> {
+                    logDebugExecutionCalls++
+                    {
+                        val attributes =
+                                forge.aMap<String, Any>(size = forge.anInt(min = 1, max = 5)) {
+                                    forge.aString(size = syncedOperations) to
+                                            forge.aString(size = syncedOperations)
+                                }
+                        testedLogger.d(
+                                forge.aString(size = syncedOperations),
+                                attributes = attributes
+                        )
+                    }
+                }
+                else -> {
+                    { }
+                }
+            }
+            async(countDownLatch, closure)
+        }
+
+        countDownLatch.await(5, TimeUnit.SECONDS)
+        verify(mockLogHandler, times(logDebugExecutionCalls)).handleLog(
+                eq(Log.DEBUG),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull()
+        )
+    }
+
+    // endregion
+
+    // region internal
+
+    private fun async(countDownLatch: CountDownLatch, closure: () -> Unit) {
+        Thread {
+            closure()
+            countDownLatch.countDown()
+        }.start()
     }
 
     // endregion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/LogSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/LogSerializerTest.kt
@@ -2,6 +2,7 @@ package com.datadog.android.log.internal.domain
 
 import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.CoreFeature
+import com.datadog.android.core.internal.utils.NULL_MAP_VALUE
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.assertj.JsonObjectAssert.Companion.assertThat
@@ -26,8 +27,8 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
 
 @Extensions(
-    ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class)
+        ExtendWith(MockitoExtension::class),
+        ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 @ForgeConfiguration(Configurator::class)
@@ -49,11 +50,11 @@ internal class LogSerializerTest {
     @Test
     fun `serializes minimal log as json`(@Forgery fakeLog: Log) {
         val minimalLog = fakeLog.copy(
-            throwable = null,
-            networkInfo = null,
-            userInfo = UserInfo(),
-            attributes = emptyMap(),
-            tags = emptyList()
+                throwable = null,
+                networkInfo = null,
+                userInfo = UserInfo(),
+                attributes = emptyMap(),
+                tags = emptyList()
         )
 
         val serialized = underTest.serialize(minimalLog)
@@ -64,8 +65,8 @@ internal class LogSerializerTest {
     @Test
     fun `serializes a log with trace id and span id`(@Forgery fakeLog: Log, forge: Forge) {
         val tracedLog = fakeLog.copy(
-            traceId = forge.aNumericalString(),
-            spanId = forge.aNumericalString()
+                traceId = forge.aNumericalString(),
+                spanId = forge.aNumericalString()
         )
 
         val serialized = underTest.serialize(tracedLog)
@@ -135,14 +136,14 @@ internal class LogSerializerTest {
     ) {
         val jsonObject = JsonParser.parseString(serializedObject).asJsonObject
         assertThat(jsonObject)
-            .hasField(LogSerializer.TAG_MESSAGE, log.message)
-            .hasField(LogSerializer.TAG_SERVICE_NAME, log.serviceName)
-            .hasField(LogSerializer.TAG_STATUS, levels[log.level])
-            .hasField(LogSerializer.TAG_LOGGER_NAME, log.loggerName)
-            .hasField(LogSerializer.TAG_THREAD_NAME, log.threadName)
-            .hasField(LogSerializer.TAG_VERSION_NAME, BuildConfig.VERSION_NAME)
-            .hasField(LogSerializer.TAG_APP_VERSION_NAME, CoreFeature.packageVersion)
-            .hasField(LogSerializer.TAG_APP_PACKAGE_NAME, CoreFeature.packageName)
+                .hasField(LogSerializer.TAG_MESSAGE, log.message)
+                .hasField(LogSerializer.TAG_SERVICE_NAME, log.serviceName)
+                .hasField(LogSerializer.TAG_STATUS, levels[log.level])
+                .hasField(LogSerializer.TAG_LOGGER_NAME, log.loggerName)
+                .hasField(LogSerializer.TAG_THREAD_NAME, log.threadName)
+                .hasField(LogSerializer.TAG_VERSION_NAME, BuildConfig.VERSION_NAME)
+                .hasField(LogSerializer.TAG_APP_VERSION_NAME, CoreFeature.packageVersion)
+                .hasField(LogSerializer.TAG_APP_PACKAGE_NAME, CoreFeature.packageName)
 
         if (log.traceId != null) {
             assertThat(jsonObject).hasField(LogSerializer.TAG_TRACE_ID, log.traceId)
@@ -157,8 +158,8 @@ internal class LogSerializerTest {
 
         // yyyy-mm-ddThh:mm:ss.SSSZ
         assertThat(jsonObject).hasStringFieldMatching(
-            LogSerializer.TAG_DATE,
-            "\\d+\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"
+                LogSerializer.TAG_DATE,
+                "\\d+\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"
         )
 
         assertNetworkInfoMatches(log, jsonObject)
@@ -202,31 +203,31 @@ internal class LogSerializerTest {
             }
         } else {
             assertThat(jsonObject)
-                .doesNotHaveField(LogSerializer.TAG_NETWORK_CONNECTIVITY)
-                .doesNotHaveField(LogSerializer.TAG_NETWORK_CARRIER_NAME)
-                .doesNotHaveField(LogSerializer.TAG_NETWORK_CARRIER_ID)
+                    .doesNotHaveField(LogSerializer.TAG_NETWORK_CONNECTIVITY)
+                    .doesNotHaveField(LogSerializer.TAG_NETWORK_CARRIER_NAME)
+                    .doesNotHaveField(LogSerializer.TAG_NETWORK_CARRIER_ID)
         }
     }
 
     private fun assertAttributesMatch(log: Log, jsonObject: JsonObject) {
         log.attributes
-            .filter { it.key.isNotBlank() }
-            .forEach {
-                val value = it.value
-                when (value) {
-                    null -> assertThat(jsonObject).hasNullField(it.key)
-                    is Boolean -> assertThat(jsonObject).hasField(it.key, value)
-                    is Int -> assertThat(jsonObject).hasField(it.key, value)
-                    is Long -> assertThat(jsonObject).hasField(it.key, value)
-                    is Float -> assertThat(jsonObject).hasField(it.key, value)
-                    is Double -> assertThat(jsonObject).hasField(it.key, value)
-                    is String -> assertThat(jsonObject).hasField(it.key, value)
-                    is Date -> assertThat(jsonObject).hasField(it.key, value.time)
-                    is JsonObject -> assertThat(jsonObject).hasField(it.key, value)
-                    is JsonArray -> assertThat(jsonObject).hasField(it.key, value)
-                    else -> assertThat(jsonObject).hasField(it.key, value.toString())
+                .filter { it.key.isNotBlank() }
+                .forEach {
+                    val value = it.value
+                    when (value) {
+                        NULL_MAP_VALUE -> assertThat(jsonObject).hasNullField(it.key)
+                        is Boolean -> assertThat(jsonObject).hasField(it.key, value)
+                        is Int -> assertThat(jsonObject).hasField(it.key, value)
+                        is Long -> assertThat(jsonObject).hasField(it.key, value)
+                        is Float -> assertThat(jsonObject).hasField(it.key, value)
+                        is Double -> assertThat(jsonObject).hasField(it.key, value)
+                        is String -> assertThat(jsonObject).hasField(it.key, value)
+                        is Date -> assertThat(jsonObject).hasField(it.key, value.time)
+                        is JsonObject -> assertThat(jsonObject).hasField(it.key, value)
+                        is JsonArray -> assertThat(jsonObject).hasField(it.key, value)
+                        else -> assertThat(jsonObject).hasField(it.key, value.toString())
+                    }
                 }
-            }
     }
 
     private fun assertTagsMatch(jsonObject: JsonObject, log: Log) {
@@ -234,14 +235,14 @@ internal class LogSerializerTest {
 
         if (jsonTagString.isNullOrBlank()) {
             Assertions.assertThat(log.tags)
-                .isEmpty()
+                    .isEmpty()
         } else {
             val tags = jsonTagString
-                .split(',')
-                .toList()
+                    .split(',')
+                    .toList()
 
             Assertions.assertThat(tags)
-                .containsExactlyInAnyOrder(*log.tags.toTypedArray())
+                    .containsExactlyInAnyOrder(*log.tags.toTypedArray())
         }
     }
 
@@ -252,14 +253,14 @@ internal class LogSerializerTest {
             throwable.printStackTrace(PrintWriter(sw))
 
             assertThat(jsonObject)
-                .hasField(LogSerializer.TAG_ERROR_KIND, throwable.javaClass.simpleName)
-                .hasField(LogSerializer.TAG_ERROR_MESSAGE, throwable.message)
-                .hasField(LogSerializer.TAG_ERROR_STACK, sw.toString())
+                    .hasField(LogSerializer.TAG_ERROR_KIND, throwable.javaClass.simpleName)
+                    .hasField(LogSerializer.TAG_ERROR_MESSAGE, throwable.message)
+                    .hasField(LogSerializer.TAG_ERROR_STACK, sw.toString())
         } else {
             assertThat(jsonObject)
-                .doesNotHaveField(LogSerializer.TAG_ERROR_KIND)
-                .doesNotHaveField(LogSerializer.TAG_ERROR_MESSAGE)
-                .doesNotHaveField(LogSerializer.TAG_ERROR_STACK)
+                    .doesNotHaveField(LogSerializer.TAG_ERROR_KIND)
+                    .doesNotHaveField(LogSerializer.TAG_ERROR_MESSAGE)
+                    .doesNotHaveField(LogSerializer.TAG_ERROR_STACK)
         }
     }
 
@@ -286,8 +287,8 @@ internal class LogSerializerTest {
 
     companion object {
         internal val levels = arrayOf(
-            "DEBUG", "DEBUG", "TRACE", "DEBUG", "INFO", "WARN",
-            "ERROR", "CRITICAL", "DEBUG", "EMERGENCY"
+                "DEBUG", "DEBUG", "TRACE", "DEBUG", "INFO", "WARN",
+                "ERROR", "CRITICAL", "DEBUG", "EMERGENCY"
         )
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/file/LogFileStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/file/LogFileStrategyTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.core.internal.data.file.DeferredWriter
 import com.datadog.android.core.internal.domain.FilePersistenceStrategyTest
 import com.datadog.android.core.internal.domain.PersistenceStrategy
 import com.datadog.android.core.internal.net.info.NetworkInfo
+import com.datadog.android.core.internal.utils.NULL_MAP_VALUE
 import com.datadog.android.log.internal.domain.Log
 import com.datadog.android.log.internal.domain.LogFileStrategy
 import com.datadog.android.log.internal.domain.LogSerializer
@@ -33,17 +34,18 @@ import org.junit.jupiter.api.Test
 
 @ForgeConfiguration(Configurator::class)
 internal class LogFileStrategyTest :
-    FilePersistenceStrategyTest<Log>(LogFileStrategy.LOGS_FOLDER, modelClass = Log::class.java) {
+        FilePersistenceStrategyTest<Log>(LogFileStrategy.LOGS_FOLDER,
+                modelClass = Log::class.java) {
 
     // region LogStrategyTest
 
     override fun getStrategy(): PersistenceStrategy<Log> {
         return LogFileStrategy(
-            context = mockContext,
-            recentDelayMs = RECENT_DELAY_MS,
-            maxBatchSize = MAX_BATCH_SIZE,
-            maxLogPerBatch = MAX_MESSAGES_PER_BATCH,
-            maxDiskSpace = MAX_DISK_SPACE
+                context = mockContext,
+                recentDelayMs = RECENT_DELAY_MS,
+                maxBatchSize = MAX_BATCH_SIZE,
+                maxLogPerBatch = MAX_MESSAGES_PER_BATCH,
+                maxDiskSpace = MAX_DISK_SPACE
         )
     }
 
@@ -78,45 +80,45 @@ internal class LogFileStrategyTest :
 
     override fun minimalCopy(of: Log): Log {
         return of.copy(
-            throwable = null,
-            networkInfo = null,
-            attributes = emptyMap(),
-            tags = emptyList()
+                throwable = null,
+                networkInfo = null,
+                attributes = emptyMap(),
+                tags = emptyList()
         )
     }
 
     override fun lightModel(forge: Forge): Log {
         return forge.getForgery<Log>().copy(
-            serviceName = forge.anAlphabeticalString(size = forge.aTinyInt()),
-            message = forge.anAlphabeticalString(size = forge.aTinyInt()),
-            throwable = null,
-            networkInfo = null,
-            attributes = emptyMap(),
-            tags = emptyList()
+                serviceName = forge.anAlphabeticalString(size = forge.aTinyInt()),
+                message = forge.anAlphabeticalString(size = forge.aTinyInt()),
+                throwable = null,
+                networkInfo = null,
+                attributes = emptyMap(),
+                tags = emptyList()
         )
     }
 
     override fun bigModel(forge: Forge): Log {
         return Log(
-            level = android.util.Log.ASSERT,
-            serviceName = forge.anAlphabeticalString(size = 65536),
-            message = forge.anAlphabeticalString(size = 131072),
-            tags = forge.aList(size = 256) { forge.anAlphabeticalString(size = 128) },
-            attributes = forge.aMap(size = 256) {
-                forge.anAlphabeticalString(size = 64) to forge.anAlphabeticalString(
-                    size = 128
-                )
-            },
-            networkInfo = NetworkInfo(
-                connectivity = NetworkInfo.Connectivity.NETWORK_MOBILE_OTHER,
-                carrierId = forge.aHugeInt(),
-                carrierName = forge.anAlphabeticalString(size = 256)
-            ),
-            userInfo = UserInfo(), // TODO !!!
-            throwable = ArrayIndexOutOfBoundsException(forge.anAlphabeticalString()),
-            timestamp = forge.aLong(),
-            loggerName = forge.anAlphabeticalString(),
-            threadName = forge.anAlphabeticalString()
+                level = android.util.Log.ASSERT,
+                serviceName = forge.anAlphabeticalString(size = 65536),
+                message = forge.anAlphabeticalString(size = 131072),
+                tags = forge.aList(size = 256) { forge.anAlphabeticalString(size = 128) },
+                attributes = forge.aMap(size = 256) {
+                    forge.anAlphabeticalString(size = 64) to forge.anAlphabeticalString(
+                            size = 128
+                    )
+                },
+                networkInfo = NetworkInfo(
+                        connectivity = NetworkInfo.Connectivity.NETWORK_MOBILE_OTHER,
+                        carrierId = forge.aHugeInt(),
+                        carrierName = forge.anAlphabeticalString(size = 256)
+                ),
+                userInfo = UserInfo(), // TODO !!!
+                throwable = ArrayIndexOutOfBoundsException(forge.anAlphabeticalString()),
+                timestamp = forge.aLong(),
+                loggerName = forge.anAlphabeticalString(),
+                threadName = forge.anAlphabeticalString()
         )
     }
 
@@ -134,16 +136,16 @@ internal class LogFileStrategyTest :
 
     override fun assertMatches(jsonObject: JsonObject, model: Log) {
         assertThat(jsonObject)
-            .hasField(LogSerializer.TAG_MESSAGE, model.message)
-            .hasField(LogSerializer.TAG_SERVICE_NAME, model.serviceName)
-            .hasField(LogSerializer.TAG_STATUS, levels[model.level])
-            .hasField(LogSerializer.TAG_LOGGER_NAME, model.loggerName)
-            .hasField(LogSerializer.TAG_THREAD_NAME, model.threadName)
+                .hasField(LogSerializer.TAG_MESSAGE, model.message)
+                .hasField(LogSerializer.TAG_SERVICE_NAME, model.serviceName)
+                .hasField(LogSerializer.TAG_STATUS, levels[model.level])
+                .hasField(LogSerializer.TAG_LOGGER_NAME, model.loggerName)
+                .hasField(LogSerializer.TAG_THREAD_NAME, model.threadName)
 
         // yyyy-mm-ddThh:mm:ss.SSSZ
         assertThat(jsonObject).hasStringFieldMatching(
-            LogSerializer.TAG_DATE,
-            "\\d+\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"
+                LogSerializer.TAG_DATE,
+                "\\d+\\-\\d{2}\\-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d{3}Z"
         )
 
         assertNetworkInfoMatches(model, jsonObject)
@@ -171,34 +173,34 @@ internal class LogFileStrategyTest :
             }
         } else {
             assertThat(jsonObject)
-                .doesNotHaveField(LogSerializer.TAG_NETWORK_CONNECTIVITY)
-                .doesNotHaveField(LogSerializer.TAG_NETWORK_CARRIER_NAME)
-                .doesNotHaveField(LogSerializer.TAG_NETWORK_CARRIER_ID)
+                    .doesNotHaveField(LogSerializer.TAG_NETWORK_CONNECTIVITY)
+                    .doesNotHaveField(LogSerializer.TAG_NETWORK_CARRIER_NAME)
+                    .doesNotHaveField(LogSerializer.TAG_NETWORK_CARRIER_ID)
         }
     }
 
     private fun assertFieldsMatch(log: Log, jsonObject: JsonObject) {
         log.attributes
-            .filter { it.key.isNotBlank() }
-            .forEach {
-                val value = it.value
-                when (value) {
-                    null -> assertThat(jsonObject).hasNullField(it.key)
-                    is Boolean -> assertThat(jsonObject).hasField(it.key, value)
-                    is Int -> assertThat(jsonObject).hasField(it.key, value)
-                    is Long -> assertThat(jsonObject).hasField(it.key, value)
-                    is Float -> assertThat(jsonObject).hasField(it.key, value)
-                    is Double -> assertThat(jsonObject).hasField(it.key, value)
-                    is String -> assertThat(jsonObject).hasField(it.key, value)
-                    is Date -> assertThat(jsonObject).hasField(it.key, value.time)
-                    is JsonObject -> assertThat(jsonObject).hasField(it.key, value)
-                    is JsonArray -> assertThat(jsonObject).hasField(it.key, value)
-                    else -> assertThat(jsonObject).hasField(
-                        it.key,
-                        value.toString()
-                    )
+                .filter { it.key.isNotBlank() }
+                .forEach {
+                    val value = it.value
+                    when (value) {
+                        NULL_MAP_VALUE -> assertThat(jsonObject).hasNullField(it.key)
+                        is Boolean -> assertThat(jsonObject).hasField(it.key, value)
+                        is Int -> assertThat(jsonObject).hasField(it.key, value)
+                        is Long -> assertThat(jsonObject).hasField(it.key, value)
+                        is Float -> assertThat(jsonObject).hasField(it.key, value)
+                        is Double -> assertThat(jsonObject).hasField(it.key, value)
+                        is String -> assertThat(jsonObject).hasField(it.key, value)
+                        is Date -> assertThat(jsonObject).hasField(it.key, value.time)
+                        is JsonObject -> assertThat(jsonObject).hasField(it.key, value)
+                        is JsonArray -> assertThat(jsonObject).hasField(it.key, value)
+                        else -> assertThat(jsonObject).hasField(
+                                it.key,
+                                value.toString()
+                        )
+                    }
                 }
-            }
     }
 
     private fun assertTagsMatch(jsonObject: JsonObject, log: Log) {
@@ -206,14 +208,14 @@ internal class LogFileStrategyTest :
 
         if (jsonTagString.isNullOrBlank()) {
             assertThat(log.tags)
-                .isEmpty()
+                    .isEmpty()
         } else {
             val tags = jsonTagString
-                .split(',')
-                .toList()
+                    .split(',')
+                    .toList()
 
             assertThat(tags)
-                .containsExactlyInAnyOrder(*log.tags.toTypedArray())
+                    .containsExactlyInAnyOrder(*log.tags.toTypedArray())
         }
     }
 
@@ -224,14 +226,14 @@ internal class LogFileStrategyTest :
             throwable.printStackTrace(PrintWriter(sw))
 
             assertThat(jsonObject)
-                .hasField(LogSerializer.TAG_ERROR_KIND, throwable.javaClass.simpleName)
-                .hasField(LogSerializer.TAG_ERROR_MESSAGE, throwable.message)
-                .hasField(LogSerializer.TAG_ERROR_STACK, sw.toString())
+                    .hasField(LogSerializer.TAG_ERROR_KIND, throwable.javaClass.simpleName)
+                    .hasField(LogSerializer.TAG_ERROR_MESSAGE, throwable.message)
+                    .hasField(LogSerializer.TAG_ERROR_STACK, sw.toString())
         } else {
             assertThat(jsonObject)
-                .doesNotHaveField(LogSerializer.TAG_ERROR_KIND)
-                .doesNotHaveField(LogSerializer.TAG_ERROR_MESSAGE)
-                .doesNotHaveField(LogSerializer.TAG_ERROR_STACK)
+                    .doesNotHaveField(LogSerializer.TAG_ERROR_KIND)
+                    .doesNotHaveField(LogSerializer.TAG_ERROR_MESSAGE)
+                    .doesNotHaveField(LogSerializer.TAG_ERROR_STACK)
         }
     }
 
@@ -241,8 +243,8 @@ internal class LogFileStrategyTest :
         private const val RECENT_DELAY_MS = 150L
         private const val MAX_DISK_SPACE = 16 * 32 * 1024L
         private val levels = arrayOf(
-            "DEBUG", "DEBUG", "TRACE", "DEBUG", "INFO", "WARN",
-            "ERROR", "CRITICAL", "DEBUG", "EMERGENCY"
+                "DEBUG", "DEBUG", "TRACE", "DEBUG", "INFO", "WARN",
+                "ERROR", "CRITICAL", "DEBUG", "EMERGENCY"
         )
     }
 }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/EndToEndLogTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/EndToEndLogTest.kt
@@ -31,8 +31,8 @@ internal class EndToEndLogTest {
 
     @get:Rule
     val mockServerRule = MockServerActivityTestRule(
-        ActivityLifecycleLogs::class.java,
-        keepRequests = true
+            ActivityLifecycleLogs::class.java,
+            keepRequests = true
     )
 
     @Test
@@ -47,9 +47,9 @@ internal class EndToEndLogTest {
         val logObjects = mutableListOf<JsonObject>()
         requests.forEach { request ->
             assertThat(request.headers)
-                .isNotNull
-                .hasHeader(HeadersAssert.HEADER_CT, RuntimeConfig.DD_CONTENT_TYPE)
-                .hasHeader(HeadersAssert.HEADER_UA, expectedUserAgent())
+                    .isNotNull
+                    .hasHeader(HeadersAssert.HEADER_CT, RuntimeConfig.DD_CONTENT_TYPE)
+                    .hasHeader(HeadersAssert.HEADER_UA, expectedUserAgent())
 
             request.jsonBody!!.asJsonArray.forEach {
                 Log.i("EndToEndLogTest", "adding log $it")
@@ -66,12 +66,12 @@ internal class EndToEndLogTest {
         messagesSent.forEachIndexed { i, m ->
             val log = logObjects[i]
             assertThat(log)
-                .hasField(TAG_STATUS, levels[m.first])
-                .hasField(TAG_MESSAGE, m.second)
-                .hasField(TAG_SERVICE, "android")
-                .hasField(TAG_LOGGER_NAME, expectedLoggerName())
-                .hasField(TAG_VERSION_NAME, com.datadog.android.BuildConfig.VERSION_NAME)
-                .hasField(TAG_APP_VERSION_NAME, BuildConfig.VERSION_NAME)
+                    .hasField(TAG_STATUS, levels[m.first])
+                    .hasField(TAG_MESSAGE, m.second)
+                    .hasField(TAG_SERVICE, "android")
+                    .hasField(TAG_LOGGER_NAME, expectedLoggerName())
+                    .hasField(TAG_VERSION_NAME, com.datadog.android.BuildConfig.VERSION_NAME)
+                    .hasField(TAG_APP_VERSION_NAME, BuildConfig.VERSION_NAME)
 
             val tags = log.get(TAG_DDTAGS)?.asString.orEmpty().split(',')
             assertThat(tags).containsOnlyElementsOf(globalTags)
@@ -99,16 +99,16 @@ internal class EndToEndLogTest {
 
     private fun expectedLoggerName(): String {
         return InstrumentationRegistry
-            .getInstrumentation()
-            .targetContext.packageName
+                .getInstrumentation()
+                .targetContext.packageName
     }
 
     private fun expectedUserAgent(): String {
         return System.getProperty("http.agent").let {
             if (it.isNullOrBlank()) {
                 "Datadog/${BuildConfig.VERSION_NAME} " +
-                    "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
-                    "${Build.MODEL} Build/${Build.ID})"
+                        "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
+                        "${Build.MODEL} Build/${Build.ID})"
             } else {
                 it
             }
@@ -124,14 +124,13 @@ internal class EndToEndLogTest {
         private const val TAG_DDTAGS = "ddtags"
 
         internal const val TAG_LOGGER_NAME = "logger.name"
-        internal const val TAG_THREAD_NAME = "logger.thread_name"
         internal const val TAG_VERSION_NAME = "logger.version"
         internal const val TAG_APP_VERSION_NAME = "application.version"
 
         private val INITIAL_WAIT_MS = TimeUnit.SECONDS.toMillis(30)
 
         internal val levels = arrayOf(
-            "DEBUG", "DEBUG", "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"
+                "DEBUG", "DEBUG", "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "CRITICAL"
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

In this PR we are fixing the Logger **remove/add** methods for tags or attributes by making them Thread safe. To achieve this we are switching from regular HashMap and HashSet implementations to a ConcurrentHashMap and a CopyOnWriteArraySet implementations.

### Additional Notes

Please note that the problem was also present in Android as I was able to reproduce the **ConcurrentModificationException** in my tests.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

