### PR TITLE
RUMM-315 Add a benchmark on the SDK initialize

### DIFF
--- a/instrumented/benchmark/build.gradle.kts
+++ b/instrumented/benchmark/build.gradle.kts
@@ -101,6 +101,12 @@ ktLintConfig()
 
 reviewBenchmark {
 
+    // Global Benchmarks
+    addThreshold(
+        "benchmark_initialize",
+        TimeUnit.MILLISECONDS.toNanos(8)
+    )
+
     // Logs Benchmarks
     addThreshold(
         "benchmark_create_one_log",
@@ -141,8 +147,7 @@ reviewBenchmark {
         TimeUnit.MILLISECONDS.toNanos(250)
     )
 
-    // LogIo Benchmarks
-
+    // Logs I/O Benchmarks
     addThreshold(
         "benchmark_write_logs_on_disk",
         TimeUnit.MILLISECONDS.toNanos(60)

--- a/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/core/CoreInitBenchmark.kt
+++ b/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/core/CoreInitBenchmark.kt
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-2020 Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.benchmark.core
+
+import androidx.benchmark.junit4.BenchmarkRule
+import androidx.benchmark.junit4.measureRepeated
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.Datadog
+import com.datadog.android.DatadogConfig
+import com.datadog.tools.unit.invokeMethod
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class CoreInitBenchmark {
+    @get:Rule
+    val benchmark = BenchmarkRule()
+
+    @Test
+    fun benchmark_initialize() {
+        val context = InstrumentationRegistry.getInstrumentation().context
+        val config = DatadogConfig
+            .Builder("NO_TOKEN")
+            .setTracesEnabled(true)
+            .setLogsEnabled(true)
+            .setCrashReportsEnabled(true)
+            .build()
+
+        benchmark.measureRepeated {
+            Datadog.initialize(context, config)
+
+            runWithTimingDisabled {
+                Datadog.invokeMethod("stop")
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Write a simple benchmark test to ensure the initialize method doesn't slow an application's startup time

**Note** benchmark are not run on each PR, but it's still important to have this one in the lot.
