### PR TITLE
RUMM-331 Tracer - add helper methods for logging an error

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -68,5 +68,7 @@ class com.datadog.android.tracing.AndroidTracer : datadog.opentracing.DDTracer
     fun setServiceName(String): Builder
     fun setPartialFlushThreshold(Int): Builder
   companion object
+    fun logThrowable(io.opentracing.Span, Throwable)
+    fun logErrorMessage(io.opentracing.Span, String)
 class com.datadog.android.tracing.TracingInterceptor : okhttp3.Interceptor
   override fun intercept(okhttp3.Interceptor, Chain): okhttp3.Response

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt
@@ -15,6 +15,8 @@ import datadog.opentracing.LogHandler
 import datadog.opentracing.propagation.ExtractedContext
 import datadog.trace.api.Config
 import datadog.trace.api.sampling.PrioritySampling
+import io.opentracing.Span
+import io.opentracing.log.Fields
 import java.math.BigInteger
 import java.security.SecureRandom
 import java.util.Properties
@@ -137,5 +139,30 @@ class AndroidTracer internal constructor(
         internal const val TRACE_LOGGER_NAME = "trace"
 
         internal const val TRACE_ID_BIT_SIZE = 63
+
+        /**
+         * Helper method to attach a Throwable to a specific Span.
+         * The Throwable information (class name, message and stacktrace) will be added to the
+         * provided Span as standard Error Tags.
+         * @param span the active Span
+         * @param throwable the Throwable you wan to log
+         */
+        @JvmStatic
+        fun logThrowable(span: Span, throwable: Throwable) {
+            val fieldsMap = mapOf(Fields.ERROR_OBJECT to throwable)
+            span.log(fieldsMap)
+        }
+
+        /**
+         * Helper method to attach an error message to a specific Span.
+         * The error message will be added to the provided Span as a standard Error Tag.
+         * @param span the active Span
+         * @param message the error message you want to attach
+         */
+        @JvmStatic
+        fun logErrorMessage(span: Span, message: String) {
+            val fieldsMap = mapOf(Fields.MESSAGE to message)
+            span.log(fieldsMap)
+        }
     }
 }

--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -92,6 +92,24 @@ class SampleApplication : Application() {
     ```kotlin
     span.setTag("http.url", url)
     ```
+7. (Optional) Attach an error information to a Span:
+
+    If you want to mark a span as having an error, you can do so by logging it using the official OpenTracing tags
+
+    ```kotlin
+    span.log(mapOf(Fields.ERROR_OBJECT to throwable))
+    ```
+    ```kotlin
+    span.log(mapOf(Fields.MESSAGE to errorMessage))
+    ```
+    You can also use one of the following helper method in AndroidTracer
+
+    ```kotlin
+    AndroidTracer.logThrowable(span, throwable)
+    ```
+    ```kotlin
+    AndroidTracer.logErrorMessage(span, message)
+    ```
 
 ## Integrations
 


### PR DESCRIPTION
### What does this PR do?

In this PR we are adding 2 static helper methods for the AndroidTracer to be able to attach a Throwable or an error message to a specific Span.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

