### PR TITLE
RUMM-360 RumMonitor - add start/update user action methods

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorInternalMethodsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorInternalMethodsTest.kt
@@ -13,7 +13,6 @@ import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.rum.GlobalRum
-import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.assertj.RumEventAssert.Companion.assertThat
 import com.datadog.android.rum.internal.domain.RumEvent
@@ -21,7 +20,6 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.forge.aThrowable
-import com.datadog.tools.unit.setFieldValue
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.times
@@ -33,7 +31,6 @@ import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.lang.ref.WeakReference
 import java.util.UUID
 import kotlin.system.measureNanoTime
 import org.assertj.core.api.Assertions.assertThat
@@ -53,9 +50,9 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class DatadogRumMonitorTest {
+internal class DatadogRumMonitorInternalMethodsTest {
 
-    lateinit var testedMonitor: RumMonitor
+    lateinit var testedMonitor: DatadogRumMonitor
 
     @Mock
     lateinit var mockWriter: Writer<RumEvent>
@@ -84,646 +81,27 @@ internal class DatadogRumMonitorTest {
         testedMonitor = DatadogRumMonitor(mockWriter, mockTimeProvider, mockUserInfoProvider)
     }
 
-    // region View
-
-    @Test
-    fun `startView doesn't send anything without stopView and updates global context`(
-        forge: Forge
-    ) {
-        val key = forge.anAlphabeticalString()
-        val name = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-
-        testedMonitor.startView(key, name, emptyMap())
-
-        verifyZeroInteractions(mockWriter)
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isNotNull()
-            .isNotEqualTo(UUID(0, 0))
-    }
-
-    @Test
-    fun `startView sends previous unstopped view Rum Event`(
-        forge: Forge
-    ) {
-        val key = forge.anAlphabeticalString()
-        val name = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val attributes = forge.exhaustiveAttributes()
-        var viewId: UUID? = null
-
-        val duration = measureNanoTime {
-            testedMonitor.startView(key, name, attributes)
-            viewId = GlobalRum.getRumContext().viewId
-            testedMonitor.startView(
-                forge.anAlphabeticalString(),
-                forge.aStringMatching("[a-z]+(\\.[a-z]+)+"),
-                emptyMap()
-            )
-        }
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter).write(capture())
-
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasAttributes(attributes)
-                .hasViewData {
-                    hasName(name.replace('.', '/'))
-                    hasDurationLowerThan(duration)
-                    hasVersion(2)
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isNotNull()
-            .isNotEqualTo(viewId)
-    }
-
-    @Test
-    fun `stopView doesn't send anything without startView`(
-        forge: Forge
-    ) {
-        val key = forge.anAlphabeticalString()
-
-        testedMonitor.stopView(key, emptyMap())
-
-        verifyZeroInteractions(mockWriter)
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isNull()
-    }
-
-    @Test
-    fun `stopView doesn't send anything without matching startView`(
-        forge: Forge
-    ) {
-        val startKey = forge.anAlphabeticalString()
-        val name = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val stopKey = forge.anAlphabeticalString()
-
-        testedMonitor.startView(startKey, name, emptyMap())
-        testedMonitor.stopView(stopKey, emptyMap())
-
-        verifyZeroInteractions(mockWriter)
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isNull()
-    }
-
-    @Test
-    fun `stopView sends view Rum Event`(
-        forge: Forge
-    ) {
-        val key = forge.anAlphabeticalString()
-        val name = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val attributes = forge.exhaustiveAttributes()
-        var viewId: UUID? = null
-
-        val duration = measureNanoTime {
-            testedMonitor.startView(key, name, attributes)
-            viewId = GlobalRum.getRumContext().viewId
-            testedMonitor.stopView(key, emptyMap())
-        }
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter).write(capture())
-
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasViewData {
-                    hasName(name.replace('.', '/'))
-                    hasDurationLowerThan(duration)
-                    hasVersion(2)
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isNull()
-    }
-
-    @Test
-    fun `stopView sends view Rum Event only once`(
-        forge: Forge
-    ) {
-        val key = forge.anAlphabeticalString()
-        val name = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val attributes = forge.exhaustiveAttributes()
-        var viewId: UUID? = null
-
-        val duration = measureNanoTime {
-            testedMonitor.startView(key, name, attributes)
-            viewId = GlobalRum.getRumContext().viewId
-            testedMonitor.stopView(key, emptyMap())
-            testedMonitor.stopView(key, emptyMap())
-        }
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter).write(capture())
-
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasViewData {
-                    hasName(name.replace('.', '/'))
-                    hasDurationLowerThan(duration)
-                    hasVersion(2)
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isNull()
-    }
-
-    @Test
-    fun `stopView sends unclosed view Rum Event with missing key`(
-        forge: Forge
-    ) {
-        var key = forge.anAlphabeticalString().toByteArray()
-        val name = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val attributes = forge.exhaustiveAttributes()
-        var viewId: UUID? = null
-
-        val duration = measureNanoTime {
-            testedMonitor.startView(key, name, attributes)
-            viewId = GlobalRum.getRumContext().viewId
-            key = forge.anAlphabeticalString().toByteArray()
-            testedMonitor.setFieldValue("activeViewKey", WeakReference(null))
-            testedMonitor.stopView(key, emptyMap())
-        }
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter).write(capture())
-
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasAttributes(mapOf(DatadogRumMonitor.TAG_EVENT_UNSTOPPED to true))
-                .hasViewData {
-                    hasName(name.replace('.', '/'))
-                    hasDurationLowerThan(duration)
-                    hasVersion(2)
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isNull()
-    }
-
-    @Test
-    fun `stopView sends unclosed resource Rum Event with missing key`(
-        forge: Forge
-    ) {
-        val viewKey = forge.anAlphabeticalString()
-        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        var resourceKey = forge.anAlphabeticalString(size = 32).toByteArray()
-        val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
-        val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
-        val attributes = forge.exhaustiveAttributes()
-        var viewId: UUID? = null
-
-        testedMonitor.startView(viewKey, viewName, attributes)
-        testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
-        resourceKey = forge.anAlphabeticalString().toByteArray()
-        System.gc()
-        viewId = GlobalRum.getRumContext().viewId
-        testedMonitor.stopView(viewKey, emptyMap())
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter, times(3)).write(capture())
-            assertThat(firstValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasAttributes(mapOf(DatadogRumMonitor.TAG_EVENT_UNSTOPPED to true))
-                .hasResourceData {
-                    hasUrl(resourceUrl)
-                    hasMethod(resourceMethod)
-                    hasKind(RumResourceKind.UNKNOWN)
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-
-            assertThat(secondValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasViewData {
-                    hasName(viewName.replace('.', '/'))
-                    hasVersion(2)
-                    hasMeasures {
-                        hasErrorCount(0)
-                        hasResourceCount(1)
-                        hasUserActionCount(0)
-                    }
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasViewData {
-                    hasName(viewName.replace('.', '/'))
-                    hasVersion(3)
-                    hasMeasures {
-                        hasErrorCount(0)
-                        hasResourceCount(1)
-                        hasUserActionCount(0)
-                    }
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isNull()
-    }
-
-    // endregion
-
-    // region Resource
-
-    @Test
-    fun `startResource doesn't send anything without stopResource`(
-        forge: Forge
-    ) {
-        val viewKey = forge.anAlphabeticalString()
-        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val resourceKey = forge.anAlphabeticalString()
-        val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
-        val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
-
-        testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, emptyMap())
-
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `stopResource doesn't send anything without startResource`(
-        forge: Forge
-    ) {
-        val resourceKey = forge.anAlphabeticalString()
-        val resourceKind = forge.aValueFrom(RumResourceKind::class.java)
-
-        testedMonitor.stopResource(resourceKey, resourceKind, emptyMap())
-
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `stopResource sends resource Rum Event and updates view event`(
-        forge: Forge
-    ) {
-        val viewKey = forge.anAlphabeticalString()
-        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val resourceKey = forge.anAlphabeticalString()
-        val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
-        val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
-        val resourceKind = forge.aValueFrom(RumResourceKind::class.java)
-        val attributes = forge.exhaustiveAttributes()
-
-        testedMonitor.startView(viewKey, viewName, emptyMap())
-        val viewId = GlobalRum.getRumContext().viewId
-        val duration = measureNanoTime {
-            testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
-            testedMonitor.stopResource(resourceKey, resourceKind, emptyMap())
-        }
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
-
-            assertThat(firstValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasResourceData {
-                    hasUrl(resourceUrl)
-                    hasDurationLowerThan(duration)
-                    hasKind(resourceKind)
-                    hasMethod(resourceMethod)
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasViewData {
-                    hasName(viewName.replace('.', '/'))
-                    hasVersion(2)
-                    hasMeasures {
-                        hasErrorCount(0)
-                        hasResourceCount(1)
-                        hasUserActionCount(0)
-                    }
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isEqualTo(viewId)
-    }
-
-    @Test
-    fun `stopResource sends unclosed resource Rum Event automatically when key reference is null`(
-        forge: Forge
-    ) {
-        val viewKey = forge.anAlphabeticalString()
-        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        var resourceKey: Any = forge.anAlphabeticalString().toByteArray()
-        val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
-        val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
-        val attributes = forge.exhaustiveAttributes()
-        val kind = forge.aValueFrom(RumResourceKind::class.java, listOf(RumResourceKind.UNKNOWN))
-
-        testedMonitor.startView(viewKey, viewName, emptyMap())
-        val viewId = GlobalRum.getRumContext().viewId
-        testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
-        resourceKey = forge.anAlphabeticalString().toByteArray()
-        System.gc()
-        testedMonitor.stopResource(resourceKey, kind, attributes)
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
-
-            assertThat(firstValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasAttributes(mapOf(DatadogRumMonitor.TAG_EVENT_UNSTOPPED to true))
-                .hasResourceData {
-                    hasUrl(resourceUrl)
-                    hasMethod(resourceMethod)
-                    hasKind(RumResourceKind.UNKNOWN)
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasViewData {
-                    hasName(viewName.replace('.', '/'))
-                    hasVersion(2)
-                    hasMeasures {
-                        hasErrorCount(0)
-                        hasResourceCount(1)
-                        hasUserActionCount(0)
-                    }
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isEqualTo(viewId)
-    }
-
-    @Test
-    fun `stopResourceWithError doesn't send anything without startResource`(
-        forge: Forge
-    ) {
-        val resourceKey = forge.anAlphabeticalString()
-        val message = forge.anAlphabeticalString()
-        val origin = forge.anAlphabeticalString()
-        val error = forge.aThrowable()
-
-        testedMonitor.stopResourceWithError(resourceKey, message, origin, error)
-
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `stopResourceWithError sends error Rum Event and updates view`(
-        forge: Forge
-    ) {
-        val viewKey = forge.anAlphabeticalString()
-        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val resourceKey = forge.anAlphabeticalString()
-        val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
-        val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
-        val errorOrigin = forge.anAlphabeticalString()
-        val errorMessage = forge.anAlphabeticalString()
-        val throwable = forge.aThrowable()
-        val attributes = forge.exhaustiveAttributes()
-
-        testedMonitor.startView(viewKey, viewName, emptyMap())
-        val viewId = GlobalRum.getRumContext().viewId
-        testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
-        testedMonitor.stopResourceWithError(resourceKey, errorMessage, errorOrigin, throwable)
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
-
-            assertThat(firstValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasErrorData {
-                    hasOrigin(errorOrigin)
-                    hasMessage(errorMessage)
-                    hasThrowable(throwable)
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasViewData {
-                    hasName(viewName.replace('.', '/'))
-                    hasVersion(2)
-                    hasMeasures {
-                        hasErrorCount(1)
-                        hasResourceCount(0)
-                        hasUserActionCount(0)
-                    }
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isEqualTo(viewId)
-    }
-
-    @Test
-    fun `stopResourceWithError sends resource Rum Event automatically when key reference is null`(
-        forge: Forge
-    ) {
-        val viewKey = forge.anAlphabeticalString()
-        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        var resourceKey: Any = forge.anAlphabeticalString().toByteArray()
-        val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
-        val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
-        val attributes = forge.exhaustiveAttributes()
-        val errorOrigin = forge.anAlphabeticalString()
-        val errorMessage = forge.anAlphabeticalString()
-        val throwable = forge.aThrowable()
-
-        testedMonitor.startView(viewKey, viewName, emptyMap())
-        val viewId = GlobalRum.getRumContext().viewId
-        testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
-        resourceKey = forge.anAlphabeticalString().toByteArray()
-        System.gc()
-        testedMonitor.stopResourceWithError(resourceKey, errorMessage, errorOrigin, throwable)
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
-
-            assertThat(firstValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasAttributes(mapOf(DatadogRumMonitor.TAG_EVENT_UNSTOPPED to true))
-                .hasResourceData {
-                    hasUrl(resourceUrl)
-                    hasKind(RumResourceKind.UNKNOWN)
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasViewData {
-                    hasName(viewName.replace('.', '/'))
-                    hasVersion(2)
-                    hasMeasures {
-                        hasErrorCount(0)
-                        hasResourceCount(1)
-                        hasUserActionCount(0)
-                    }
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isEqualTo(viewId)
-    }
-
-    // endregion
-
-    // region Error
-
-    @Test
-    fun `addError sends error Rum Event and updates view`(
-        forge: Forge
-    ) {
-        val viewKey = forge.anAlphabeticalString()
-        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val attributes = forge.exhaustiveAttributes()
-        val errorOrigin = forge.anAlphabeticalString()
-        val errorMessage = forge.anAlphabeticalString()
-        val throwable = forge.aThrowable()
-
-        testedMonitor.startView(viewKey, viewName, emptyMap())
-        val viewId = GlobalRum.getRumContext().viewId
-        testedMonitor.addError(errorMessage, errorOrigin, throwable, attributes)
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
-
-            assertThat(firstValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasErrorData {
-                    hasMessage(errorMessage)
-                    hasOrigin(errorOrigin)
-                    hasThrowable(throwable)
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasViewData {
-                    hasMeasures {
-                        hasErrorCount(1)
-                        hasResourceCount(0)
-                        hasUserActionCount(0)
-                    }
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isEqualTo(viewId)
-    }
-
-    // endregion
-
     // region User action
 
     @Test
-    fun `addUserAction doesn't send anything`(
+    fun `startUserAction doesn't send anything`(
         forge: Forge
     ) {
         val viewKey = forge.anAlphabeticalString()
         val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val actionNAme = forge.anAlphabeticalString()
-        val attributes = forge.exhaustiveAttributes()
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.addUserAction(actionNAme, attributes)
+        testedMonitor.startUserAction()
 
         verifyZeroInteractions(mockWriter)
     }
 
     @Test
-    fun `resource started within userAction scope have action id`(
+    fun `resource started within started userAction scope have action id`(
         forge: Forge
     ) {
         val viewKey = forge.anAlphabeticalString()
         val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val actionNAme = forge.anAlphabeticalString()
         val resourceKey = forge.anAlphabeticalString()
         val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
         val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
@@ -731,7 +109,7 @@ internal class DatadogRumMonitorTest {
         val attributes = forge.exhaustiveAttributes()
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.addUserAction(actionNAme, attributes)
+        testedMonitor.startUserAction()
         val viewId = GlobalRum.getRumContext().viewId
         testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
         testedMonitor.stopResource(resourceKey, resourceKind, emptyMap())
@@ -776,7 +154,66 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `resource started outside userAction scope has no action and sends action`(
+    fun `resource started within started and closed userAction scope have action id`(
+        forge: Forge
+    ) {
+        val viewKey = forge.anAlphabeticalString()
+        val actionName = forge.anAlphabeticalString()
+        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
+        val resourceKey = forge.anAlphabeticalString()
+        val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
+        val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
+        val resourceKind = forge.aValueFrom(RumResourceKind::class.java)
+        val attributes = forge.exhaustiveAttributes()
+
+        testedMonitor.startView(viewKey, viewName, emptyMap())
+        testedMonitor.startUserAction()
+        val viewId = GlobalRum.getRumContext().viewId
+        testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
+        testedMonitor.stopUserAction(actionName, attributes)
+        testedMonitor.stopResource(resourceKey, resourceKind, emptyMap())
+
+        checkNotNull(viewId)
+        argumentCaptor<RumEvent> {
+            verify(mockWriter, times(2)).write(capture())
+
+            assertThat(firstValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasAttributes(attributes)
+                .hasUserActionAttribute()
+                .hasResourceData {
+                    hasUrl(resourceUrl)
+                    hasMethod(resourceMethod)
+                    hasKind(resourceKind)
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+            assertThat(lastValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasViewData {
+                    hasName(viewName.replace('.', '/'))
+                    hasVersion(2)
+                    hasMeasures {
+                        hasErrorCount(0)
+                        hasResourceCount(1)
+                        hasUserActionCount(0)
+                    }
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+        }
+        assertThat(GlobalRum.getRumContext().viewId)
+            .isEqualTo(viewId)
+    }
+
+    @Test
+    fun `resource started outside closed userAction scope has no action and sends action`(
         forge: Forge
     ) {
         val viewKey = forge.anAlphabeticalString()
@@ -789,10 +226,14 @@ internal class DatadogRumMonitorTest {
         val attributes = forge.exhaustiveAttributes()
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.addUserAction(actionName, attributes)
+        val userActionDuration = measureNanoTime {
+            testedMonitor.startUserAction()
+            Thread.sleep(1)
+            testedMonitor.stopUserAction(actionName, attributes)
+        }
         Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS)
         val viewId = GlobalRum.getRumContext().viewId
-        val duration = measureNanoTime {
+        val resourceDuration = measureNanoTime {
             testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
             testedMonitor.stopResource(resourceKey, resourceKind, emptyMap())
         }
@@ -807,7 +248,7 @@ internal class DatadogRumMonitorTest {
                 .hasUserActionData {
                     hasName(actionName)
                     hasNonDefaultId()
-                    hasDuration(1L)
+                    hasDurationLowerThan(userActionDuration)
                 }
                 .hasContext {
                     hasApplicationId(fakeApplicationId)
@@ -837,7 +278,7 @@ internal class DatadogRumMonitorTest {
                 .hasResourceData {
                     hasUrl(resourceUrl)
                     hasMethod(resourceMethod)
-                    hasDurationLowerThan(duration)
+                    hasDurationLowerThan(resourceDuration)
                     hasKind(resourceKind)
                 }
                 .hasContext {
@@ -867,12 +308,11 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `resource started within userAction scope and stopped later extends scope`(
+    fun `resource started outside opened userAction scope extends the scope`(
         forge: Forge
     ) {
         val viewKey = forge.anAlphabeticalString()
         val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val actionNAme = forge.anAlphabeticalString()
         val resourceKey = forge.anAlphabeticalString()
         val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
         val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
@@ -880,9 +320,74 @@ internal class DatadogRumMonitorTest {
         val attributes = forge.exhaustiveAttributes()
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.addUserAction(actionNAme, attributes)
+        testedMonitor.startUserAction()
+        Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS)
+        val viewId = GlobalRum.getRumContext().viewId
+        val resourceDuration = measureNanoTime {
+            testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
+            testedMonitor.stopResource(resourceKey, resourceKind, emptyMap())
+        }
+        val resourceKey2 = forge.anAlphabeticalString()
+        testedMonitor.startResource(resourceKey2, resourceMethod, resourceUrl, attributes)
+
+        checkNotNull(viewId)
+        argumentCaptor<RumEvent> {
+            verify(mockWriter, times(2)).write(capture())
+
+            assertThat(firstValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasAttributes(attributes)
+                .hasUserActionAttribute()
+                .hasResourceData {
+                    hasUrl(resourceUrl)
+                    hasMethod(resourceMethod)
+                    hasKind(resourceKind)
+                    hasDurationLowerThan(resourceDuration)
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+            assertThat(lastValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasViewData {
+                    hasName(viewName.replace('.', '/'))
+                    hasVersion(2)
+                    hasMeasures {
+                        hasErrorCount(0)
+                        hasResourceCount(1)
+                        hasUserActionCount(0)
+                    }
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+        }
+        assertThat(GlobalRum.getRumContext().viewId)
+            .isEqualTo(viewId)
+    }
+
+    @Test
+    fun `resource started within started userAction scope and stopped later extends scope`(
+        forge: Forge
+    ) {
+        val viewKey = forge.anAlphabeticalString()
+        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
+        val actionName = forge.anAlphabeticalString()
+        val resourceKey = forge.anAlphabeticalString()
+        val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
+        val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
+        val resourceKind = forge.aValueFrom(RumResourceKind::class.java)
+        val attributes = forge.exhaustiveAttributes()
+
+        testedMonitor.startView(viewKey, viewName, emptyMap())
+        testedMonitor.startUserAction()
         val viewId = GlobalRum.getRumContext().viewId
         testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
+        testedMonitor.stopUserAction(actionName, attributes)
         Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS * 5)
         testedMonitor.stopResource(resourceKey, resourceKind, emptyMap())
         val resourceKey2 = forge.anAlphabeticalString()
@@ -944,9 +449,10 @@ internal class DatadogRumMonitorTest {
         val attributes = forge.exhaustiveAttributes()
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.addUserAction(actionNAme, attributes)
+        testedMonitor.startUserAction()
         val viewId = GlobalRum.getRumContext().viewId
         testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
+        testedMonitor.stopUserAction(actionNAme, attributes)
         Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS * 5)
         testedMonitor.stopResource(resourceKey, resourceKind, emptyMap())
         Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS)
@@ -1066,10 +572,11 @@ internal class DatadogRumMonitorTest {
         val attributes = forge.exhaustiveAttributes()
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.addUserAction(actionNAme, attributes)
+        testedMonitor.startUserAction()
         val viewId = GlobalRum.getRumContext().viewId
         testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
         Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS * 5)
+        testedMonitor.stopUserAction(actionNAme, attributes)
         testedMonitor.stopResourceWithError(resourceKey, errorMessage, errorOrigin, errorThrowable)
         val resourceKey2 = forge.anAlphabeticalString()
         testedMonitor.startResource(resourceKey2, resourceMethod, resourceUrl, attributes)
@@ -1132,7 +639,7 @@ internal class DatadogRumMonitorTest {
         val attributes = forge.exhaustiveAttributes()
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.addUserAction(actionNAme, attributes)
+        testedMonitor.startUserAction()
         val viewId = GlobalRum.getRumContext().viewId
         testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
         Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS * 5)
@@ -1142,6 +649,7 @@ internal class DatadogRumMonitorTest {
             resErrorOrigin,
             resErrorThrowable
         )
+        testedMonitor.stopUserAction(actionNAme, attributes)
         Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS)
         testedMonitor.addError(errorMessage, errorOrigin, errorThrowable, attributes)
 
@@ -1260,8 +768,9 @@ internal class DatadogRumMonitorTest {
         val attributes = forge.exhaustiveAttributes()
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.addUserAction(actionNAme, attributes)
+        testedMonitor.startUserAction()
         val viewId = GlobalRum.getRumContext().viewId
+        testedMonitor.stopUserAction(actionNAme, attributes)
         testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
         Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS * 5)
         testedMonitor.addError(errorMessage, errorOrigin, throwable, attributes)
@@ -1306,7 +815,7 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `addError within userAction scope has action id`(
+    fun `addError within recently closed userAction scope has action id`(
         forge: Forge
     ) {
         val viewKey = forge.anAlphabeticalString()
@@ -1318,7 +827,9 @@ internal class DatadogRumMonitorTest {
         val throwable = forge.aThrowable()
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.addUserAction(actionNAme, emptyMap())
+        testedMonitor.startUserAction()
+        Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS)
+        testedMonitor.stopUserAction(actionNAme, attributes)
         val viewId = GlobalRum.getRumContext().viewId
         testedMonitor.addError(errorMessage, errorOrigin, throwable, attributes)
 
@@ -1362,7 +873,7 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `addError outside userAction scope has no action and sends action`(
+    fun `addError outside closed userAction scope has no action and sends action`(
         forge: Forge
     ) {
         val viewKey = forge.anAlphabeticalString()
@@ -1374,7 +885,10 @@ internal class DatadogRumMonitorTest {
         val throwable = forge.aThrowable()
 
         testedMonitor.startView(viewKey, viewName, emptyMap())
-        testedMonitor.addUserAction(actionNAme, attributes)
+        val userActionDuration = measureNanoTime {
+            testedMonitor.startUserAction()
+            testedMonitor.stopUserAction(actionNAme, attributes)
+        }
         val viewId = GlobalRum.getRumContext().viewId
         Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS)
         testedMonitor.addError(errorMessage, errorOrigin, throwable, attributes)
@@ -1389,7 +903,7 @@ internal class DatadogRumMonitorTest {
                 .hasUserActionData {
                     hasName(actionNAme)
                     hasNonDefaultId()
-                    hasDuration(1L)
+                    hasDurationLowerThan(userActionDuration)
                 }
                 .hasContext {
                     hasApplicationId(fakeApplicationId)
@@ -1456,8 +970,11 @@ internal class DatadogRumMonitorTest {
 
         testedMonitor.startView(viewKey, viewName, attributes)
         val viewId = GlobalRum.getRumContext().viewId
-        testedMonitor.addUserAction(actionName, attributes)
-        testedMonitor.stopView(viewKey, emptyMap())
+        val eventDuration = measureNanoTime {
+            testedMonitor.startUserAction()
+            testedMonitor.stopUserAction(actionName, attributes)
+            testedMonitor.stopView(viewKey, emptyMap())
+        }
 
         checkNotNull(viewId)
         argumentCaptor<RumEvent> {
@@ -1469,7 +986,7 @@ internal class DatadogRumMonitorTest {
                 .hasAttributes(attributes)
                 .hasUserActionData {
                     hasName(actionName)
-                    hasDuration(1)
+                    hasDurationLowerThan(eventDuration)
                     hasNonDefaultId()
                 }
                 .hasContext {
@@ -1516,123 +1033,16 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `addUserAction sends previous unclosed action`(
-        forge: Forge
-    ) {
-
-        val viewKey = forge.anAlphabeticalString()
-        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val actionName1 = forge.anAlphabeticalString()
-        val actionName2 = forge.anAlphabeticalString()
-        val attributes = forge.exhaustiveAttributes()
-
-        testedMonitor.startView(viewKey, viewName, attributes)
-        val viewId = GlobalRum.getRumContext().viewId
-        testedMonitor.addUserAction(actionName1, attributes)
-        Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS)
-        testedMonitor.addUserAction(actionName2, attributes)
-        testedMonitor.stopView(viewKey, emptyMap())
-
-        checkNotNull(viewId)
-        argumentCaptor<RumEvent> {
-            verify(mockWriter, times(5)).write(capture())
-
-            assertThat(firstValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasUserActionData {
-                    hasName(actionName1)
-                    hasDuration(1)
-                    hasNonDefaultId()
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-            assertThat(secondValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasViewData {
-                    hasName(viewName.replace('.', '/'))
-                    hasVersion(2)
-                    hasMeasures {
-                        hasResourceCount(0)
-                        hasErrorCount(0)
-                        hasUserActionCount(1)
-                    }
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-            assertThat(thirdValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasUserActionData {
-                    hasName(actionName2)
-                    hasDuration(1)
-                    hasNonDefaultId()
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-            assertThat(allValues[3])
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasViewData {
-                    hasName(viewName.replace('.', '/'))
-                    hasVersion(3)
-                    hasMeasures {
-                        hasResourceCount(0)
-                        hasErrorCount(0)
-                        hasUserActionCount(2)
-                    }
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-            assertThat(lastValue)
-                .hasTimestamp(fakeTimestamp)
-                .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
-                .hasViewData {
-                    hasName(viewName.replace('.', '/'))
-                    hasVersion(4)
-                    hasMeasures {
-                        hasResourceCount(0)
-                        hasErrorCount(0)
-                        hasUserActionCount(2)
-                    }
-                }
-                .hasContext {
-                    hasApplicationId(fakeApplicationId)
-                    hasViewId(viewId)
-                }
-        }
-        assertThat(GlobalRum.getRumContext().viewId)
-            .isNull()
-    }
-
-    @Test
-    fun `addUserAction ignored if previous action recent`(
+    fun `stopView sends last unclosed Action`(
         forge: Forge
     ) {
         val viewKey = forge.anAlphabeticalString()
         val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
-        val actionName1 = forge.anAlphabeticalString()
-        val actionName2 = forge.anAlphabeticalString()
         val attributes = forge.exhaustiveAttributes()
 
         testedMonitor.startView(viewKey, viewName, attributes)
         val viewId = GlobalRum.getRumContext().viewId
-        testedMonitor.addUserAction(actionName1, attributes)
-        testedMonitor.addUserAction(actionName2, attributes)
+        testedMonitor.startUserAction()
         testedMonitor.stopView(viewKey, emptyMap())
 
         checkNotNull(viewId)
@@ -1642,9 +1052,9 @@ internal class DatadogRumMonitorTest {
             assertThat(firstValue)
                 .hasTimestamp(fakeTimestamp)
                 .hasUserInfo(mockedUserInfo)
-                .hasAttributes(attributes)
+                .hasAttributes(emptyMap())
                 .hasUserActionData {
-                    hasName(actionName1)
+                    hasName("")
                     hasDuration(1)
                     hasNonDefaultId()
                 }
@@ -1692,7 +1102,194 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `addUserAction ignored if previous action active (unclosed resources)`(
+    fun `startUserAction sends previous unclosed action`(
+        forge: Forge
+    ) {
+
+        val viewKey = forge.anAlphabeticalString()
+        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
+        val attributes = forge.exhaustiveAttributes()
+
+        testedMonitor.startView(viewKey, viewName, attributes)
+        val viewId = GlobalRum.getRumContext().viewId
+        val actionDuration = measureNanoTime {
+            testedMonitor.startUserAction()
+            Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS)
+            testedMonitor.startUserAction()
+        }
+
+        checkNotNull(viewId)
+        argumentCaptor<RumEvent> {
+            verify(mockWriter, times(2)).write(capture())
+
+            assertThat(firstValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasAttributes(emptyMap())
+                .hasUserActionData {
+                    hasName("")
+                    hasDurationLowerThan(actionDuration)
+                    hasNonDefaultId()
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+            assertThat(secondValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasAttributes(attributes)
+                .hasViewData {
+                    hasName(viewName.replace('.', '/'))
+                    hasVersion(2)
+                    hasMeasures {
+                        hasResourceCount(0)
+                        hasErrorCount(0)
+                        hasUserActionCount(1)
+                    }
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+        }
+        assertThat(GlobalRum.getRumContext().viewId).isEqualTo(viewId)
+    }
+
+    @Test
+    fun `startUserAction ignored if previous action recent`(
+        forge: Forge
+    ) {
+        val viewKey = forge.anAlphabeticalString()
+        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
+        val attributes = forge.exhaustiveAttributes()
+
+        testedMonitor.startView(viewKey, viewName, attributes)
+        val viewId = GlobalRum.getRumContext().viewId
+        testedMonitor.startUserAction()
+        testedMonitor.startUserAction()
+        testedMonitor.stopView(viewKey, emptyMap())
+
+        checkNotNull(viewId)
+        argumentCaptor<RumEvent> {
+            verify(mockWriter, times(3)).write(capture())
+
+            assertThat(firstValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasAttributes(emptyMap())
+                .hasUserActionData {
+                    hasName("")
+                    hasDuration(1)
+                    hasNonDefaultId()
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+            assertThat(secondValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasAttributes(attributes)
+                .hasViewData {
+                    hasName(viewName.replace('.', '/'))
+                    hasVersion(2)
+                    hasMeasures {
+                        hasResourceCount(0)
+                        hasErrorCount(0)
+                        hasUserActionCount(1)
+                    }
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+            assertThat(lastValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasAttributes(attributes)
+                .hasViewData {
+                    hasName(viewName.replace('.', '/'))
+                    hasVersion(3)
+                    hasMeasures {
+                        hasResourceCount(0)
+                        hasErrorCount(0)
+                        hasUserActionCount(1)
+                    }
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+        }
+        assertThat(GlobalRum.getRumContext().viewId)
+            .isNull()
+    }
+
+    @Test
+    fun `startUserAction does not invalidate previous started action if too recent`(
+        forge: Forge
+    ) {
+        val viewKey = forge.anAlphabeticalString()
+        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
+        val resourceKey = forge.anAlphabeticalString()
+        val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
+        val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
+        val errorOrigin = forge.anAlphabeticalString()
+        val errorMessage = forge.anAlphabeticalString()
+        val errorThrowable = forge.aThrowable()
+        val attributes = forge.exhaustiveAttributes()
+
+        testedMonitor.startView(viewKey, viewName, emptyMap())
+        testedMonitor.startUserAction()
+        testedMonitor.startUserAction()
+        val viewId = GlobalRum.getRumContext().viewId
+        testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, attributes)
+        Thread.sleep(DatadogRumMonitor.ACTION_INACTIVITY_MS * 5)
+        testedMonitor.stopResourceWithError(resourceKey, errorMessage, errorOrigin, errorThrowable)
+        val resourceKey2 = forge.anAlphabeticalString()
+        testedMonitor.startResource(resourceKey2, resourceMethod, resourceUrl, attributes)
+
+        checkNotNull(viewId)
+        argumentCaptor<RumEvent> {
+            verify(mockWriter, times(2)).write(capture())
+
+            assertThat(firstValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasAttributes(attributes)
+                .hasUserActionAttribute()
+                .hasErrorData {
+                    hasMessage(errorMessage)
+                    hasOrigin(errorOrigin)
+                    hasThrowable(errorThrowable)
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+            assertThat(lastValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasViewData {
+                    hasName(viewName.replace('.', '/'))
+                    hasVersion(2)
+                    hasMeasures {
+                        hasErrorCount(1)
+                        hasResourceCount(0)
+                        hasUserActionCount(0)
+                    }
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+        }
+        assertThat(GlobalRum.getRumContext().viewId).isEqualTo(viewId)
+    }
+
+    @Test
+    fun `startUserAction ignored if previous action active (unclosed resources)`(
         forge: Forge
     ) {
         val viewKey = forge.anAlphabeticalString()
@@ -1701,15 +1298,13 @@ internal class DatadogRumMonitorTest {
         val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
         val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
         val resourceKind = forge.aValueFrom(RumResourceKind::class.java)
-        val actionName1 = forge.anAlphabeticalString()
-        val actionName2 = forge.anAlphabeticalString()
         val attributes = forge.exhaustiveAttributes()
 
         testedMonitor.startView(viewKey, viewName, attributes)
         val viewId = GlobalRum.getRumContext().viewId
-        testedMonitor.addUserAction(actionName1, attributes)
+        testedMonitor.startUserAction()
         testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, emptyMap())
-        testedMonitor.addUserAction(actionName2, attributes)
+        testedMonitor.startUserAction()
         testedMonitor.stopResource(resourceKey, resourceKind, emptyMap())
         testedMonitor.stopView(viewKey, emptyMap())
 
@@ -1751,7 +1346,7 @@ internal class DatadogRumMonitorTest {
                 .hasTimestamp(fakeTimestamp)
                 .hasUserInfo(mockedUserInfo)
                 .hasUserActionData {
-                    hasName(actionName1)
+                    hasName("")
                     hasNonDefaultId()
                 }
                 .hasContext {
@@ -1787,6 +1382,81 @@ internal class DatadogRumMonitorTest {
                         hasResourceCount(1)
                         hasErrorCount(0)
                         hasUserActionCount(1)
+                    }
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+        }
+        assertThat(GlobalRum.getRumContext().viewId)
+            .isNull()
+    }
+
+    @Test
+    fun `calling stopUserAction without starting an action will do nothing`(forge: Forge) {
+        val actionName = forge.aString()
+        val actionAttributes = forge.exhaustiveAttributes()
+        val viewKey = forge.anAlphabeticalString()
+        val viewName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+")
+        val resourceKey = forge.anAlphabeticalString()
+        val resourceMethod = forge.anElementFrom("GET", "PUT", "POST", "DELETE")
+        val resourceUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+")
+        val resourceKind = forge.aValueFrom(RumResourceKind::class.java)
+        val attributes = forge.exhaustiveAttributes()
+
+        testedMonitor.startView(viewKey, viewName, attributes)
+        val viewId = GlobalRum.getRumContext().viewId
+        testedMonitor.stopUserAction(actionName, actionAttributes)
+        testedMonitor.startResource(resourceKey, resourceMethod, resourceUrl, emptyMap())
+        testedMonitor.stopResource(resourceKey, resourceKind, emptyMap())
+        testedMonitor.stopUserAction(actionName, actionAttributes)
+        testedMonitor.stopView(viewKey, emptyMap())
+
+        checkNotNull(viewId)
+        argumentCaptor<RumEvent> {
+            verify(mockWriter, times(3)).write(capture())
+
+            assertThat(firstValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasResourceData {
+                    hasUrl(resourceUrl)
+                    hasMethod(resourceMethod)
+                    hasKind(resourceKind)
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+            assertThat(secondValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasAttributes(attributes)
+                .hasViewData {
+                    hasName(viewName.replace('.', '/'))
+                    hasVersion(2)
+                    hasMeasures {
+                        hasResourceCount(1)
+                        hasErrorCount(0)
+                        hasUserActionCount(0)
+                    }
+                }
+                .hasContext {
+                    hasApplicationId(fakeApplicationId)
+                    hasViewId(viewId)
+                }
+            assertThat(lastValue)
+                .hasTimestamp(fakeTimestamp)
+                .hasUserInfo(mockedUserInfo)
+                .hasAttributes(attributes)
+                .hasViewData {
+                    hasName(viewName.replace('.', '/'))
+                    hasVersion(3)
+                    hasMeasures {
+                        hasResourceCount(1)
+                        hasErrorCount(0)
+                        hasUserActionCount(0)
                     }
                 }
                 .hasContext {


### PR DESCRIPTION
### What does this PR do?

Provides 2 extra internal methods inside the Datadog RumMonitor implementation `startUserAction` and `stopUserAction(actionName, attributes)` needed by our Gestures instrumentation layer.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

