### PR TITLE
RUMM-388 NavigationViewTrackingStrategy - fix start/stop view behaviour

### DIFF
--- a/dd-sdk-android-navigation/src/main/kotlin/com/datadog/android/androidx/navigation/NavigationViewTrackingStrategy.kt
+++ b/dd-sdk-android-navigation/src/main/kotlin/com/datadog/android/androidx/navigation/NavigationViewTrackingStrategy.kt
@@ -67,11 +67,8 @@ class NavigationViewTrackingStrategy(
         destination: NavDestination,
         arguments: Bundle?
     ) {
-        controller.currentDestination?.let { GlobalRum.get().stopView(it) }
-
         val attributes = if (trackArguments) convertToRumAttributes(arguments) else emptyMap()
         val name = destination.getRumViewName()
-
         GlobalRum.get().startView(destination, name, attributes)
     }
 

--- a/dd-sdk-android-navigation/src/test/kotlin/com/datadog/android/androidx/navigation/NavigationViewTrackingStrategyTest.kt
+++ b/dd-sdk-android-navigation/src/test/kotlin/com/datadog/android/androidx/navigation/NavigationViewTrackingStrategyTest.kt
@@ -228,19 +228,7 @@ internal class NavigationViewTrackingStrategyTest {
     }
 
     @Test
-    fun `starts view onDestinationChanged with unknown destination type`() {
-        mockNavDestination = mock()
-        testedStrategy.onDestinationChanged(mockNavController, mockNavDestination, null)
-
-        verify(mockRumMonitor).startView(
-            mockNavDestination,
-            NavigationViewTrackingStrategy.UNKNOWN_DESTINATION_NAME,
-            emptyMap()
-        )
-    }
-
-    @Test
-    fun `stops previous view onDestinationChanged`(
+    fun `start new view onDestinationChanged`(
         forge: Forge,
         @StringForgery(StringForgeryType.ALPHABETICAL) newDestinationName: String
     ) {
@@ -251,7 +239,6 @@ internal class NavigationViewTrackingStrategyTest {
 
         inOrder(mockRumMonitor) {
             verify(mockRumMonitor).startView(mockNavDestination, fakeDestinationName, emptyMap())
-            verify(mockRumMonitor).stopView(mockNavDestination, emptyMap())
             verify(mockRumMonitor).startView(newDestination, newDestinationName, emptyMap())
         }
     }


### PR DESCRIPTION
### What does this PR do?

In some applications the way the Navigation pattern is implemented creates problems with the way our NavigationViewTrackingStrategy is starting/stoping Views. More exactly the `currentDestination` attribute in the NavigationController component returns the wrong destination (usually is the destination before previous one) and therefore it will no be able to close the right view.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

