### PR TITLE
RUMM-639 clear data

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -5,6 +5,7 @@ object com.datadog.android.Datadog
   DEPRECATED fun initialize(android.content.Context, String, String, String? = null)
   DEPRECATED fun setEndpointUrl(String, com.datadog.android.log.EndpointUpdateStrategy)
   fun isInitialized(): Boolean
+  fun clearAllData()
   fun setVerbosity(Int)
   fun setUserInfo(String? = null, String? = null, String? = null)
 class com.datadog.android.DatadogConfig

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -205,6 +205,16 @@ object Datadog {
         return initialized.get()
     }
 
+    /**
+     * Clears all data that has not already been sent to Datadog servers.
+     */
+    fun clearAllData() {
+        LogsFeature.clearAllData()
+        CrashReportsFeature.clearAllData()
+        RumFeature.clearAllData()
+        TracesFeature.clearAllData()
+    }
+
     // Stop all Datadog work (for test purposes).
     @Suppress("unused")
     private fun stop() {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/file/FileOrchestrator.kt
@@ -26,8 +26,7 @@ internal class FileOrchestrator(
         rootDirectory.isDirectory
     }
 
-    private val fileFilter: FileFilter =
-        FileFilter()
+    private val fileFilter: FileFilter = FileFilter()
 
     private var previousFile: File? = null
     private var previousFileLogCount: Int = 0

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategy.kt
@@ -40,13 +40,13 @@ internal open class FilePersistenceStrategy<T : Any>(
         payloadDecoration.suffix
     )
 
-    // region Strategy methods
-
     protected val fileWriter = ImmediateFileWriter(
         fileOrchestrator,
         serializer,
         payloadDecoration.separator
     )
+
+    // region PersistenceStrategy
 
     override fun getWriter(): Writer<T> {
         return fileWriter
@@ -54,6 +54,10 @@ internal open class FilePersistenceStrategy<T : Any>(
 
     override fun getReader(): Reader {
         return fileReader
+    }
+
+    override fun clearAllData() {
+        fileReader.dropAllBatches()
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/PersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/PersistenceStrategy.kt
@@ -16,4 +16,6 @@ internal interface PersistenceStrategy<T : Any> {
     fun getWriter(): Writer<T>
 
     fun getReader(): Reader
+
+    fun clearAllData()
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -87,6 +87,10 @@ internal object CrashReportsFeature {
         initialized.set(true)
     }
 
+    fun clearAllData() {
+        persistenceStrategy.clearAllData()
+    }
+
     fun stop() {
         if (initialized.get()) {
             unregisterPlugins()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -102,6 +102,10 @@ internal object LogsFeature {
         return initialized.get()
     }
 
+    fun clearAllData() {
+        persistenceStrategy.clearAllData()
+    }
+
     fun stop() {
         if (initialized.get()) {
             unregisterPlugins()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -114,6 +114,10 @@ internal object RumFeature {
         return initialized.get()
     }
 
+    fun clearAllData() {
+        persistenceStrategy.clearAllData()
+    }
+
     fun stop() {
         if (initialized.get()) {
             unregisterPlugins()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracesFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracesFeature.kt
@@ -82,6 +82,10 @@ internal object TracesFeature {
         initialized.set(true)
     }
 
+    fun clearAllData() {
+        persistenceStrategy.clearAllData()
+    }
+
     fun stop() {
         if (initialized.get()) {
             unregisterPlugins()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -27,6 +27,8 @@ import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.File
@@ -289,5 +291,31 @@ internal class LogsFeatureTest {
 
         // then
         assertThat(LogsFeature.dataUploadScheduler).isInstanceOf(NoOpUploadScheduler::class.java)
+    }
+
+    @Test
+    fun `clears all files on local storage on request`(
+        @StringForgery(StringForgeryType.NUMERICAL) fileName: String,
+        @StringForgery(StringForgeryType.ALPHABETICAL) content: String
+    ) {
+        val fakeDir = File(rootDir, LogFileStrategy.LOGS_FOLDER)
+        fakeDir.mkdirs()
+        val fakeFile = File(fakeDir, fileName)
+        fakeFile.writeText(content)
+
+        // when
+        LogsFeature.initialize(
+            mockAppContext,
+            fakeConfig,
+            mockOkHttpClient,
+            mockNetworkInfoProvider,
+            mockSystemInfoProvider,
+            mockScheduledThreadPoolExecutor,
+            mockPersistenceExecutorService
+        )
+        LogsFeature.clearAllData()
+
+        // Then
+        assertThat(fakeFile).doesNotExist()
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -37,6 +37,8 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.File
@@ -462,5 +464,32 @@ internal class RumFeatureTest {
                 verify(it).unregister()
             }
         }
+    }
+
+    @Test
+    fun `clears all files on local storage on request`(
+        @StringForgery(StringForgeryType.NUMERICAL) fileName: String,
+        @StringForgery(StringForgeryType.ALPHABETICAL) content: String
+    ) {
+        val fakeDir = File(rootDir, RumFileStrategy.RUM_FOLDER)
+        fakeDir.mkdirs()
+        val fakeFile = File(fakeDir, fileName)
+        fakeFile.writeText(content)
+
+        // when
+        RumFeature.initialize(
+            mockAppContext,
+            fakeConfig,
+            mockOkHttpClient,
+            mockNetworkInfoProvider,
+            mockSystemInfoProvider,
+            mockScheduledThreadPoolExecutor,
+            mockPersistenceExecutorService,
+            mockUserInfoProvider
+        )
+        RumFeature.clearAllData()
+
+        // Then
+        assertThat(fakeFile).doesNotExist()
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracesFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracesFeatureTest.kt
@@ -32,6 +32,8 @@ import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.File
@@ -346,5 +348,33 @@ internal class TracesFeatureTest {
 
         // then
         assertThat(TracesFeature.dataUploadScheduler).isInstanceOf(NoOpUploadScheduler::class.java)
+    }
+
+    @Test
+    fun `clears all files on local storage on request`(
+        @StringForgery(StringForgeryType.NUMERICAL) fileName: String,
+        @StringForgery(StringForgeryType.ALPHABETICAL) content: String
+    ) {
+        val fakeDir = File(rootDir, TracingFileStrategy.TRACES_FOLDER)
+        fakeDir.mkdirs()
+        val fakeFile = File(fakeDir, fileName)
+        fakeFile.writeText(content)
+
+        // when
+        TracesFeature.initialize(
+            mockAppContext,
+            fakeConfig,
+            mockOkHttpClient,
+            mockNetworkInfoProvider,
+            mockUserInfoProvider,
+            mockSystemInfoProvider,
+            mockTimeProvider,
+            mockScheduledThreadPoolExecutor,
+            mockPersistenceExecutorService
+        )
+        TracesFeature.clearAllData()
+
+        // Then
+        assertThat(fakeFile).doesNotExist()
     }
 }


### PR DESCRIPTION
### What does this PR do?

Some users want/need to be able to clear any unsent data we gather. This PR implements this feature as a single method that will wipe any remaining file from the application folders.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

