### PR TITLE
RUMM-641 Reset application startup time on resetSession

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -100,6 +100,7 @@ internal sealed class RumRawEvent {
     internal class KeepAlive : RumRawEvent()
 
     internal data class ApplicationStarted(
-        override val eventTime: Time
+        override val eventTime: Time,
+        val applicationStartupNanos: Long
     ) : RumRawEvent()
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import com.datadog.android.Datadog
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.domain.Time
 import com.datadog.android.core.internal.utils.loggableStackTrace
@@ -356,7 +355,7 @@ internal class RumViewScope(
 
     private fun getStartupTime(event: RumRawEvent.ApplicationStarted): Long {
         val now = event.eventTime.nanoTime
-        val startupTime = Datadog.startupTimeNs
+        val startupTime = event.applicationStartupNanos
         return max(now - startupTime, 1L)
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/domain/TimeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/domain/TimeTest.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+internal class TimeTest {
+
+    @Test
+    fun `creates Time with current millis and nanos`() {
+
+        val startMs = System.currentTimeMillis()
+        val startNs = System.nanoTime()
+
+        val time = Time()
+
+        val endNs = System.nanoTime()
+        val endMs = System.currentTimeMillis()
+
+        assertThat(time.timestamp).isBetween(startMs, endMs)
+        assertThat(time.nanoTime).isBetween(startNs, endNs)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
@@ -154,6 +154,16 @@ internal class ActionEventAssert(actual: ActionEvent) :
         return this
     }
 
+    fun hasDuration(expected: Long): ActionEventAssert {
+        assertThat(actual.action.loadingTime)
+            .overridingErrorMessage(
+                "Expected event data to have duration $expected " +
+                    "but was ${actual.action.loadingTime}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     fun hasDurationLowerThan(upperBound: Long): ActionEventAssert {
         assertThat(actual.action.loadingTime)
             .overridingErrorMessage(


### PR DESCRIPTION
### What does this PR do?

Resets the Application Start info when `resetSession` is called.

### Motivation

`resetSession` is called in our Ci environment to simulate multiple sessions in one single instrumented test run. To enhance the demo data, we want to reset the "application startup time" every time we simulate a new session.


### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

