### PR TITLE
 POC - RUMM-637 Condition the RUM context in the NDK crash Logs on the bundleWithRum option

### DIFF
--- a/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/NdkCrashReportsPlugin.kt
+++ b/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/NdkCrashReportsPlugin.kt
@@ -64,9 +64,10 @@ class NdkCrashReportsPlugin : DatadogPlugin {
     }
 
     override fun onContextChanged(context: DatadogContext) {
-        // TODO: RUMM-637 Only update the rum context if the `bundleWithRum` config attribute is true
         context.rum?.let {
-            updateRumContext(it.applicationId, it.sessionId, it.viewId)
+            if (it.bundleWithRum) {
+                updateRumContext(it.applicationId, it.sessionId, it.viewId)
+            }
         }
     }
 

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -30,6 +30,8 @@ class com.datadog.android.DatadogConfig
     fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
     fun addPlugin(com.datadog.android.plugin.DatadogPlugin, com.datadog.android.plugin.Feature): Builder
     fun sampleRumSessions(Float): Builder
+    fun setBundleWithTraceEnabled(Boolean): Builder
+    fun setBundleWithRumEnabled(Boolean): Builder
 object com.datadog.android.DatadogEndpoint
   const val LOGS_US: String
   const val LOGS_EU: String

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -15,6 +15,7 @@ import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.error.internal.CrashReportsFeature
 import com.datadog.android.log.EndpointUpdateStrategy
+import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.log.internal.domain.Log
 import com.datadog.android.log.internal.user.UserInfo
@@ -275,11 +276,11 @@ object Datadog {
     internal const val MESSAGE_ALREADY_INITIALIZED =
         "The Datadog library has already been initialized."
     internal const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized.\n" +
-            "Please add the following code in your application's onCreate() method:\n" +
-            "Datadog.initialize(context, \"<CLIENT_TOKEN>\");"
+        "Please add the following code in your application's onCreate() method:\n" +
+        "Datadog.initialize(context, \"<CLIENT_TOKEN>\");"
 
     internal const val MESSAGE_DEPRECATED = "%s has been deprecated. " +
-            "If you need it, submit an issue at https://github.com/DataDog/dd-sdk-android/issues/"
+        "If you need it, submit an issue at https://github.com/DataDog/dd-sdk-android/issues/"
 
     internal const val SHUTDOWN_THREAD = "datadog_shutdown"
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -26,9 +26,9 @@ import java.util.UUID
  */
 class DatadogConfig
 private constructor(
-    internal val logsConfig: FeatureConfig?,
-    internal val tracesConfig: FeatureConfig?,
-    internal val crashReportConfig: FeatureConfig?,
+    internal val logsConfig: LogsConfig?,
+    internal val tracesConfig: TracesConfig?,
+    internal val crashReportConfig: CrashReportsConfig?,
     internal val rumConfig: RumConfig?,
     internal var coreConfig: CoreConfig
 ) {
@@ -38,9 +38,15 @@ private constructor(
         val serviceName: String? = null
     )
 
-    internal data class FeatureConfig(
+    internal data class CrashReportsConfig(
         val clientToken: String,
-        val applicationId: UUID,
+        val endpointUrl: String,
+        val envName: String,
+        val plugins: List<DatadogPlugin> = emptyList()
+    )
+
+    internal data class LogsConfig(
+        val clientToken: String,
         val endpointUrl: String,
         val envName: String,
         val plugins: List<DatadogPlugin> = emptyList()
@@ -55,6 +61,13 @@ private constructor(
         val gesturesTracker: GesturesTracker? = null,
         val userActionTrackingStrategy: UserActionTrackingStrategy? = null,
         val viewTrackingStrategy: ViewTrackingStrategy? = null,
+        val plugins: List<DatadogPlugin> = emptyList()
+    )
+
+    internal data class TracesConfig(
+        val clientToken: String,
+        val endpointUrl: String,
+        val envName: String,
         val plugins: List<DatadogPlugin> = emptyList()
     )
 
@@ -93,21 +106,18 @@ private constructor(
         constructor(clientToken: String, envName: String, applicationId: String) :
             this(clientToken, envName, UUID.fromString(applicationId))
 
-        private var logsConfig: FeatureConfig = FeatureConfig(
+        private var logsConfig: LogsConfig = LogsConfig(
             clientToken,
-            applicationId,
             DatadogEndpoint.LOGS_US,
             envName
         )
-        private var tracesConfig: FeatureConfig = FeatureConfig(
+        private var tracesConfig: TracesConfig = TracesConfig(
             clientToken,
-            applicationId,
             DatadogEndpoint.TRACES_US,
             envName
         )
-        private var crashReportConfig: FeatureConfig = FeatureConfig(
+        private var crashReportConfig: CrashReportsConfig = CrashReportsConfig(
             clientToken,
-            applicationId,
             DatadogEndpoint.LOGS_US,
             envName
         )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -7,6 +7,7 @@
 package com.datadog.android
 
 import android.os.Build
+import com.datadog.android.log.Logger
 import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.plugin.Feature
 import com.datadog.android.rum.internal.instrumentation.GesturesTrackingStrategy
@@ -49,6 +50,8 @@ private constructor(
         val clientToken: String,
         val endpointUrl: String,
         val envName: String,
+        val bundleWithTraces: Boolean = true,
+        val bundleWithRum: Boolean = true,
         val plugins: List<DatadogPlugin> = emptyList()
     )
 
@@ -354,6 +357,32 @@ private constructor(
          */
         fun sampleRumSessions(samplingRate: Float): Builder {
             rumConfig = rumConfig.copy(samplingRate = samplingRate)
+            return this
+        }
+
+        /**
+         * Enables the logs bundling with the current active trace. If the LOGGING feature is enabled
+         * all the logs sent from any [Logger] will be bundled with the current trace.
+         * @param enabled true by default
+         * Please note that this global configuration option can be overridden inside the
+         * [Logger.Builder].
+         * @see [Logger.Builder.setBundleWithTraceEnabled]
+         */
+        fun setBundleWithTraceEnabled(enabled: Boolean): Builder {
+            logsConfig = logsConfig.copy(bundleWithTraces = enabled)
+            return this
+        }
+
+        /**
+         * Enables the logs bundling with the current active View. If the LOGGING feature is enabled all
+         * the logs sent from any [Logger] will be bundled with the current view information.
+         * @param enabled true by default
+         * Please note that this global configuration option can be overridden inside the
+         * [Logger.Builder].
+         * @see [Logger.Builder.setBundleWithRumEnabled]
+         */
+        fun setBundleWithRumEnabled(enabled: Boolean): Builder {
+            logsConfig = logsConfig.copy(bundleWithRum = enabled)
             return this
         }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -55,7 +55,7 @@ internal object CrashReportsFeature {
     @Suppress("LongParameterList")
     fun initialize(
         appContext: Context,
-        config: DatadogConfig.FeatureConfig,
+        config: DatadogConfig.CrashReportsConfig,
         okHttpClient: OkHttpClient,
         networkInfoProvider: NetworkInfoProvider,
         userInfoProvider: UserInfoProvider,
@@ -144,7 +144,7 @@ internal object CrashReportsFeature {
         ).register()
     }
 
-    private fun registerPlugins(appContext: Context, config: DatadogConfig.FeatureConfig) {
+    private fun registerPlugins(appContext: Context, config: DatadogConfig.CrashReportsConfig) {
         plugins = config.plugins
         plugins.forEach {
             it.register(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -177,8 +177,8 @@ internal constructor(private val handler: LogHandler) {
         private var datadogLogsEnabled: Boolean = true
         private var logcatLogsEnabled: Boolean = false
         private var networkInfoEnabled: Boolean = false
-        private var bundleWithTraceEnabled: Boolean = true
-        private var bundleWithRumEnabled: Boolean = true
+        private var bundleWithTraceEnabled: Boolean = LogsFeature.bundleWithTracesEnabled
+        private var bundleWithRumEnabled: Boolean = LogsFeature.bundleWithRumEnabled
         private var loggerName: String = CoreFeature.packageName
         private var sampleRate: Float = 1.0f
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -63,6 +63,8 @@ internal object LogsFeature {
     internal var uploader: DataUploader = NoOpDataUploader()
     internal var dataUploadScheduler: UploadScheduler = NoOpUploadScheduler()
     internal var plugins: List<DatadogPlugin> = emptyList()
+    internal var bundleWithTracesEnabled = true
+    internal var bundleWithRumEnabled = true
 
     @Suppress("LongParameterList")
     fun initialize(
@@ -82,6 +84,8 @@ internal object LogsFeature {
         endpointUrl = config.endpointUrl
         envName = config.envName
         appVersion = CoreFeature.packageVersion
+        bundleWithRumEnabled = config.bundleWithRum
+        bundleWithTracesEnabled = config.bundleWithTraces
         persistenceStrategy = LogFileStrategy(
             appContext,
             dataPersistenceExecutorService = dataPersistenceExecutor

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -67,7 +67,7 @@ internal object LogsFeature {
     @Suppress("LongParameterList")
     fun initialize(
         appContext: Context,
-        config: DatadogConfig.FeatureConfig,
+        config: DatadogConfig.LogsConfig,
         okHttpClient: OkHttpClient,
         networkInfoProvider: NetworkInfoProvider,
         systemInfoProvider: SystemInfoProvider,
@@ -145,7 +145,7 @@ internal object LogsFeature {
         dataUploadScheduler.startScheduling()
     }
 
-    private fun registerPlugins(appContext: Context, config: DatadogConfig.FeatureConfig) {
+    private fun registerPlugins(appContext: Context, config: DatadogConfig.LogsConfig) {
         plugins = config.plugins
         plugins.forEach {
             it.register(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/DatadogRumContext.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/DatadogRumContext.kt
@@ -15,5 +15,7 @@ package com.datadog.android.plugin
 data class DatadogRumContext(
     val applicationId: String? = null,
     val sessionId: String? = null,
-    val viewId: String? = null
+    val viewId: String? = null,
+    val bundleWithRum: Boolean = true,
+    val bundleWithTraces: Boolean = true
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/GlobalRum.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/GlobalRum.kt
@@ -163,7 +163,9 @@ object GlobalRum {
             DatadogRumContext(
                 newContext.applicationId,
                 newContext.sessionId,
-                newContext.viewId
+                newContext.viewId,
+                bundleWithRum = LogsFeature.bundleWithRumEnabled,
+                bundleWithTraces = LogsFeature.bundleWithTracesEnabled
             )
         )
         updateContextInPlugins(pluginContext, RumFeature.plugins)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracesFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracesFeature.kt
@@ -46,7 +46,7 @@ internal object TracesFeature {
     @Suppress("LongParameterList")
     fun initialize(
         appContext: Context,
-        config: DatadogConfig.FeatureConfig,
+        config: DatadogConfig.TracesConfig,
         okHttpClient: OkHttpClient,
         networkInfoProvider: NetworkInfoProvider,
         userInfoProvider: UserInfoProvider,
@@ -124,7 +124,7 @@ internal object TracesFeature {
         dataUploadScheduler.startScheduling()
     }
 
-    private fun registerPlugins(appContext: Context, config: DatadogConfig.FeatureConfig) {
+    private fun registerPlugins(appContext: Context, config: DatadogConfig.TracesConfig) {
         plugins = config.plugins
         plugins.forEach {
             it.register(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
@@ -641,6 +641,90 @@ class DatadogConfigBuilderTest {
     }
 
     @Test
+    fun `M enable bundleWithRum by default in the Config W not provided in the builder`() {
+        // WHEN
+        val config = DatadogConfig.Builder(fakeClientToken, fakeEnvName, fakeApplicationId)
+            .build()
+
+        // THEN
+        assertThat(config.logsConfig)
+            .isEqualTo(
+                DatadogConfig.LogsConfig(
+                    fakeClientToken,
+                    DatadogEndpoint.LOGS_US,
+                    fakeEnvName,
+                    bundleWithRum = true,
+                    bundleWithTraces = true
+                )
+            )
+    }
+
+    @Test
+    fun `M enable bundleWithTrace by default in the Config W not provided in the builder`() {
+        // WHEN
+        val config = DatadogConfig.Builder(fakeClientToken, fakeEnvName, fakeApplicationId)
+            .build()
+
+        // THEN
+        assertThat(config.logsConfig)
+            .isEqualTo(
+                DatadogConfig.LogsConfig(
+                    fakeClientToken,
+                    DatadogEndpoint.LOGS_US,
+                    fakeEnvName,
+                    bundleWithRum = true,
+                    bundleWithTraces = true
+                )
+            )
+    }
+
+    @Test
+    fun `M update the bundleWithRum in the Config W provided in the builder`(forge: Forge) {
+        // GIVEN
+        val fakeBundleWithRumOption = forge.aBool()
+
+        // WHEN
+        val config = DatadogConfig.Builder(fakeClientToken, fakeEnvName, fakeApplicationId)
+            .setBundleWithRumEnabled(fakeBundleWithRumOption)
+            .build()
+
+        // THEN
+        assertThat(config.logsConfig)
+            .isEqualTo(
+                DatadogConfig.LogsConfig(
+                    fakeClientToken,
+                    DatadogEndpoint.LOGS_US,
+                    fakeEnvName,
+                    bundleWithRum = fakeBundleWithRumOption,
+                    bundleWithTraces = true
+                )
+            )
+    }
+
+    @Test
+    fun `M update the bundleWithTrace in the Config W provided in the builder`(forge: Forge) {
+        // GIVEN
+        val fakeBundleWithTraceOption = forge.aBool()
+
+        // WHEN
+        val config = DatadogConfig.Builder(fakeClientToken, fakeEnvName, fakeApplicationId)
+            .setBundleWithTraceEnabled(fakeBundleWithTraceOption)
+            .build()
+
+        // THEN
+        assertThat(config.logsConfig)
+            .isEqualTo(
+                DatadogConfig.LogsConfig(
+                    fakeClientToken,
+                    DatadogEndpoint.LOGS_US,
+                    fakeEnvName,
+                    bundleWithRum = true,
+                    bundleWithTraces = fakeBundleWithTraceOption
+                )
+            )
+    }
+
+    @Test
     fun `adding a plugin will register it to the specific feature`(forge: Forge) {
         val logsPlugin: DatadogPlugin = mock()
         val tracesPlugin: DatadogPlugin = mock()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
@@ -64,27 +64,24 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.logsConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.LogsConfig(
                     fakeClientToken,
-                    UUID(0, 0),
                     DatadogEndpoint.LOGS_US,
                     fakeEnvName
                 )
             )
         assertThat(config.tracesConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.TracesConfig(
                     fakeClientToken,
-                    UUID(0, 0),
                     DatadogEndpoint.TRACES_US,
                     fakeEnvName
                 )
             )
         assertThat(config.crashReportConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.CrashReportsConfig(
                     fakeClientToken,
-                    UUID(0, 0),
                     DatadogEndpoint.LOGS_US,
                     fakeEnvName
                 )
@@ -107,27 +104,24 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.logsConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.LogsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     fakeEnvName
                 )
             )
         assertThat(config.tracesConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.TracesConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.TRACES_US,
                     fakeEnvName
                 )
             )
         assertThat(config.crashReportConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.CrashReportsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     fakeEnvName
                 )
@@ -151,27 +145,24 @@ class DatadogConfigBuilderTest {
         assertThat(config.coreConfig)
         assertThat(config.logsConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.LogsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     fakeEnvName
                 )
             )
         assertThat(config.tracesConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.TracesConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.TRACES_US,
                     fakeEnvName
                 )
             )
         assertThat(config.crashReportConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.CrashReportsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     fakeEnvName
                 )
@@ -229,27 +220,24 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.logsConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.LogsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     envName
                 )
             )
         assertThat(config.tracesConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.TracesConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.TRACES_US,
                     envName
                 )
             )
         assertThat(config.crashReportConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.CrashReportsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     envName
                 )
@@ -287,27 +275,24 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.logsConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.LogsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     envName
                 )
             )
         assertThat(config.tracesConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.TracesConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.TRACES_US,
                     envName
                 )
             )
         assertThat(config.crashReportConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.CrashReportsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     envName
                 )
@@ -363,27 +348,24 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.logsConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.LogsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     fakeEnvName
                 )
             )
         assertThat(config.tracesConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.TracesConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.TRACES_US,
                     fakeEnvName
                 )
             )
         assertThat(config.crashReportConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.CrashReportsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     fakeEnvName
                 )
@@ -418,27 +400,24 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.logsConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.LogsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_EU,
                     fakeEnvName
                 )
             )
         assertThat(config.tracesConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.TracesConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.TRACES_EU,
                     fakeEnvName
                 )
             )
         assertThat(config.crashReportConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.CrashReportsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_EU,
                     fakeEnvName
                 )
@@ -481,27 +460,24 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.logsConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.LogsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     logsUrl,
                     fakeEnvName
                 )
             )
         assertThat(config.tracesConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.TracesConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     tracesUrl,
                     fakeEnvName
                 )
             )
         assertThat(config.crashReportConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.CrashReportsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     crashReportsUrl,
                     fakeEnvName
                 )
@@ -545,27 +521,24 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.logsConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.LogsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     logsUrl,
                     fakeEnvName
                 )
             )
         assertThat(config.tracesConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.TracesConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     tracesUrl,
                     fakeEnvName
                 )
             )
         assertThat(config.crashReportConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.CrashReportsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     crashReportsUrl,
                     fakeEnvName
                 )
@@ -686,9 +659,8 @@ class DatadogConfigBuilderTest {
 
         assertThat(config.logsConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.LogsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     fakeEnvName,
                     plugins = listOf(logsPlugin)
@@ -696,9 +668,8 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.tracesConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.TracesConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.TRACES_US,
                     fakeEnvName,
                     plugins = listOf(tracesPlugin)
@@ -706,9 +677,8 @@ class DatadogConfigBuilderTest {
             )
         assertThat(config.crashReportConfig)
             .isEqualTo(
-                DatadogConfig.FeatureConfig(
+                DatadogConfig.CrashReportsConfig(
                     fakeClientToken,
-                    fakeApplicationId,
                     DatadogEndpoint.LOGS_US,
                     fakeEnvName,
                     plugins = listOf(crashPlugin)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutTracesTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutTracesTest.kt
@@ -14,7 +14,6 @@ import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumResourceKind
-import com.datadog.android.tracing.TracedRequestListener
 import com.datadog.android.tracing.TracingInterceptor
 import com.datadog.android.tracing.TracingInterceptorTest
 import com.datadog.android.tracing.internal.TracesFeature
@@ -72,9 +71,6 @@ internal class DatadogInterceptorWithoutTracesTest {
     @Mock
     lateinit var mockChain: Interceptor.Chain
 
-    @Mock
-    lateinit var mockRequestListener: TracedRequestListener
-
     lateinit var mockDevLogHandler: LogHandler
 
     lateinit var mockAppContext: Context
@@ -102,7 +98,7 @@ internal class DatadogInterceptorWithoutTracesTest {
     lateinit var fakeUrl: String
 
     @Forgery
-    lateinit var fakeConfig: DatadogConfig.FeatureConfig
+    lateinit var fakeConfig: DatadogConfig.TracesConfig
 
     @StringForgery(StringForgeryType.ALPHABETICAL)
     lateinit var fakePackageName: String

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -78,7 +78,7 @@ internal class CrashReportsFeatureTest {
     @Mock
     lateinit var mockScheduledThreadPoolExecutor: ScheduledThreadPoolExecutor
 
-    lateinit var fakeConfig: DatadogConfig.FeatureConfig
+    lateinit var fakeConfig: DatadogConfig.CrashReportsConfig
 
     lateinit var fakePackageName: String
     lateinit var fakePackageVersion: String
@@ -89,9 +89,8 @@ internal class CrashReportsFeatureTest {
     @BeforeEach
     fun `set up`(forge: Forge) {
         CoreFeature.isMainProcess = true
-        fakeConfig = DatadogConfig.FeatureConfig(
+        fakeConfig = DatadogConfig.CrashReportsConfig(
             clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
             endpointUrl = forge.getForgery<URL>().toString(),
             envName = forge.anAlphabeticalString()
         )
@@ -226,9 +225,8 @@ internal class CrashReportsFeatureTest {
         val clientToken = CrashReportsFeature.clientToken
         val endpointUrl = CrashReportsFeature.endpointUrl
 
-        fakeConfig = DatadogConfig.FeatureConfig(
+        fakeConfig = DatadogConfig.CrashReportsConfig(
             clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
             endpointUrl = forge.getForgery<URL>().toString(),
             envName = forge.anAlphabeticalString()
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -188,7 +188,7 @@ internal class LoggerBuilderTest {
     }
 
     @Test
-    fun `buider can disable the bundle with trace feature`(@Forgery forge: Forge) {
+    fun `builder can disable the bundle with trace feature`(@Forgery forge: Forge) {
         val logger = Logger.Builder()
             .setBundleWithTraceEnabled(false)
             .build()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -316,4 +316,56 @@ internal class LogsFeatureTest {
         // Then
         assertThat(fakeFile).doesNotExist()
     }
+
+    @Test
+    fun `M set the bundle with RUM option from Config W initialized`(forge: Forge) {
+        // GIVEN
+        val fakeBundleWithRumOption = forge.aBool()
+        fakeConfig = DatadogConfig.LogsConfig(
+            clientToken = forge.anHexadecimalString(),
+            endpointUrl = forge.getForgery<URL>().toString(),
+            envName = forge.anAlphabeticalString(),
+            bundleWithRum = fakeBundleWithRumOption
+        )
+
+        // WHEN
+        LogsFeature.initialize(
+            mockAppContext,
+            fakeConfig,
+            mockOkHttpClient,
+            mockNetworkInfoProvider,
+            mockSystemInfoProvider,
+            mockScheduledThreadPoolExecutor,
+            mockPersistenceExecutorService
+        )
+
+        // THEN
+        assertThat(LogsFeature.bundleWithRumEnabled).isEqualTo(fakeBundleWithRumOption)
+    }
+
+    @Test
+    fun `M set the bundle with Traces option from Config W initialized`(forge: Forge) {
+        // GIVEN
+        val fakeBundleWithTracesOption = forge.aBool()
+        fakeConfig = DatadogConfig.LogsConfig(
+            clientToken = forge.anHexadecimalString(),
+            endpointUrl = forge.getForgery<URL>().toString(),
+            envName = forge.anAlphabeticalString(),
+            bundleWithTraces = fakeBundleWithTracesOption
+        )
+
+        // WHEN
+        LogsFeature.initialize(
+            mockAppContext,
+            fakeConfig,
+            mockOkHttpClient,
+            mockNetworkInfoProvider,
+            mockSystemInfoProvider,
+            mockScheduledThreadPoolExecutor,
+            mockPersistenceExecutorService
+        )
+
+        // THEN
+        assertThat(LogsFeature.bundleWithTracesEnabled).isEqualTo(fakeBundleWithTracesOption)
+    }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -74,7 +74,7 @@ internal class LogsFeatureTest {
     @Mock
     lateinit var mockPersistenceExecutorService: ExecutorService
 
-    lateinit var fakeConfig: DatadogConfig.FeatureConfig
+    lateinit var fakeConfig: DatadogConfig.LogsConfig
 
     lateinit var fakePackageName: String
     lateinit var fakePackageVersion: String
@@ -85,9 +85,8 @@ internal class LogsFeatureTest {
     @BeforeEach
     fun `set up`(forge: Forge) {
         CoreFeature.isMainProcess = true
-        fakeConfig = DatadogConfig.FeatureConfig(
+        fakeConfig = DatadogConfig.LogsConfig(
             clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
             endpointUrl = forge.getForgery<URL>().toString(),
             envName = forge.anAlphabeticalString()
         )
@@ -178,9 +177,8 @@ internal class LogsFeatureTest {
         val clientToken = LogsFeature.clientToken
         val endpointUrl = LogsFeature.endpointUrl
 
-        fakeConfig = DatadogConfig.FeatureConfig(
+        fakeConfig = DatadogConfig.LogsConfig(
             clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
             endpointUrl = forge.getForgery<URL>().toString(),
             envName = forge.anAlphabeticalString()
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
@@ -14,7 +14,6 @@ import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumMonitor
-import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.tracing.internal.TracesFeature
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext
@@ -130,7 +129,7 @@ internal open class TracingInterceptorTest {
     lateinit var fakeUrl: String
 
     @Forgery
-    lateinit var fakeConfig: DatadogConfig.FeatureConfig
+    lateinit var fakeConfig: DatadogConfig.TracesConfig
 
     @StringForgery(StringForgeryType.ALPHABETICAL)
     lateinit var fakePackageName: String
@@ -146,9 +145,6 @@ internal open class TracingInterceptorTest {
 
     @StringForgery(StringForgeryType.HEXADECIMAL)
     lateinit var fakeTraceId: String
-
-    @Forgery
-    lateinit var fakeRumContext: RumContext
 
     // endregion
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracesFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracesFeatureTest.kt
@@ -85,7 +85,7 @@ internal class TracesFeatureTest {
     @Mock
     lateinit var mockPersistenceExecutorService: ExecutorService
 
-    lateinit var fakeConfig: DatadogConfig.FeatureConfig
+    lateinit var fakeConfig: DatadogConfig.TracesConfig
 
     lateinit var fakePackageName: String
     lateinit var fakePackageVersion: String
@@ -96,9 +96,8 @@ internal class TracesFeatureTest {
     @BeforeEach
     fun `set up`(forge: Forge) {
         CoreFeature.isMainProcess = true
-        fakeConfig = DatadogConfig.FeatureConfig(
+        fakeConfig = DatadogConfig.TracesConfig(
             clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
             endpointUrl = forge.getForgery<URL>().toString(),
             envName = forge.anAlphabeticalString()
         )
@@ -226,9 +225,8 @@ internal class TracesFeatureTest {
         val clientToken = TracesFeature.clientToken
         val endpointUrl = TracesFeature.endpointUrl
 
-        fakeConfig = DatadogConfig.FeatureConfig(
+        fakeConfig = DatadogConfig.TracesConfig(
             clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
             endpointUrl = forge.getForgery<URL>().toString(),
             envName = forge.anAlphabeticalString()
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -13,7 +13,10 @@ import fr.xgouchet.elmyr.jvm.useJvmFactories
 internal class Configurator :
     ForgeConfigurator {
     override fun configure(forge: Forge) {
-        forge.addFactory(FeatureConfigForgeryFactory())
+        forge.addFactory(CrashReportsConfigForgeryFactory())
+        forge.addFactory(LogsConfigForgeryFactory())
+        forge.addFactory(RumConfigForgeryFactory())
+        forge.addFactory(TracesConfigForgeryFactory())
         forge.addFactory(LogForgeryFactory())
         forge.addFactory(BatchForgeryFactory())
         forge.addFactory(ThrowableForgeryFactory())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/CrashReportsConfigForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/CrashReportsConfigForgeryFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.DatadogConfig
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.net.URL
+
+internal class CrashReportsConfigForgeryFactory :
+    ForgeryFactory<DatadogConfig.CrashReportsConfig> {
+    override fun getForgery(forge: Forge): DatadogConfig.CrashReportsConfig {
+        return DatadogConfig.CrashReportsConfig(
+            clientToken = forge.anHexadecimalString(),
+            endpointUrl = forge.getForgery<URL>().toString(),
+            envName = forge.anAlphabeticalString()
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/LogsConfigForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/LogsConfigForgeryFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.DatadogConfig
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.net.URL
+
+internal class LogsConfigForgeryFactory :
+    ForgeryFactory<DatadogConfig.LogsConfig> {
+    override fun getForgery(forge: Forge): DatadogConfig.LogsConfig {
+        return DatadogConfig.LogsConfig(
+            clientToken = forge.anHexadecimalString(),
+            endpointUrl = forge.getForgery<URL>().toString(),
+            envName = forge.anAlphabeticalString()
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumConfigForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumConfigForgeryFactory.kt
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.DatadogConfig
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.net.URL
+import java.util.UUID
+
+internal class RumConfigForgeryFactory :
+    ForgeryFactory<DatadogConfig.RumConfig> {
+    override fun getForgery(forge: Forge): DatadogConfig.RumConfig {
+        return DatadogConfig.RumConfig(
+            clientToken = forge.anHexadecimalString(),
+            applicationId = forge.getForgery<UUID>(),
+            endpointUrl = forge.getForgery<URL>().toString(),
+            envName = forge.anAlphabeticalString(),
+            samplingRate = forge.aFloat(min = 0.0f, max = 1.0f)
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/TracesConfigForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/TracesConfigForgeryFactory.kt
@@ -11,12 +11,11 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 import java.net.URL
 
-internal class FeatureConfigForgeryFactory :
-    ForgeryFactory<DatadogConfig.FeatureConfig> {
-    override fun getForgery(forge: Forge): DatadogConfig.FeatureConfig {
-        return DatadogConfig.FeatureConfig(
+internal class TracesConfigForgeryFactory :
+    ForgeryFactory<DatadogConfig.TracesConfig> {
+    override fun getForgery(forge: Forge): DatadogConfig.TracesConfig {
+        return DatadogConfig.TracesConfig(
             clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
             endpointUrl = forge.getForgery<URL>().toString(),
             envName = forge.anAlphabeticalString()
         )


### PR DESCRIPTION
### What does this PR do?

This PR contains a POC for conditioning the NDK crash logs on the `bundleWithRum` option provided in the DatadogConfig.

IMHO I don't really think we need this as this information should always be available in the NDK crash logs as it is the case now for the Uncaught JVM exceptions. In any case if we consider to keep this then I will condition this information also in the `DatadogExceptionHandler`.

I am waiting for your thoughts.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

