### PR TITLE
Update gradle.properties

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,10 +4,5 @@
 # Copyright 2016-Present Datadog, Inc.
 #
 org.gradle.jvmargs=-Xmx2048m -XX:MaxPermSize=512m
-org.gradle.daemon=false
-org.gradle.parallel=false
-org.gradle.caching=false
-kotlin.incremental=false
-kotlin.compiler.execution.strategy=in-process
 android.useAndroidX=true
 # Leave the next line blank for CI


### PR DESCRIPTION
### What does this PR do?

Update the `gradle.properties` to only keep what's required for both devs and CI. The CI specific config is stored in a separate file hosted on the CI
