### PR TITLE
RUMM-676 Log error messages for inconistent states of the SDK

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -31,6 +31,7 @@ class com.datadog.android.DatadogConfig
     fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
     fun addPlugin(com.datadog.android.plugin.DatadogPlugin, com.datadog.android.plugin.Feature): Builder
     fun sampleRumSessions(Float): Builder
+    companion object 
 object com.datadog.android.DatadogEndpoint
   const val LOGS_US: String
   const val LOGS_EU: String
@@ -218,6 +219,7 @@ interface com.datadog.android.rum.RumMonitor
   fun addError(String, RumErrorSource, Throwable?, Map<String, Any?>)
   class Builder
     fun build(): RumMonitor
+    companion object 
 enum com.datadog.android.rum.RumResourceKind
   constructor(String)
   - BEACON

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -275,11 +275,13 @@ object Datadog {
     internal const val MESSAGE_ALREADY_INITIALIZED =
         "The Datadog library has already been initialized."
     internal const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized.\n" +
-            "Please add the following code in your application's onCreate() method:\n" +
-            "Datadog.initialize(context, \"<CLIENT_TOKEN>\");"
+        "Please add the following code in your application's onCreate() method:\n" +
+        "val config = DatadogConfig.Builder(\"<CLIENT_TOKEN>\", \"<ENVIRONMENT>\", " +
+        "\"<APPLICATION_ID>\").build()\n" +
+        "Datadog.initialize(context, config);"
 
     internal const val MESSAGE_DEPRECATED = "%s has been deprecated. " +
-            "If you need it, submit an issue at https://github.com/DataDog/dd-sdk-android/issues/"
+        "If you need it, submit an issue at https://github.com/DataDog/dd-sdk-android/issues/"
 
     internal const val SHUTDOWN_THREAD = "datadog_shutdown"
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -7,6 +7,7 @@
 package com.datadog.android
 
 import android.os.Build
+import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.plugin.Feature
 import com.datadog.android.rum.internal.instrumentation.GesturesTrackingStrategy
@@ -179,6 +180,10 @@ private constructor(
          * @param enabled true by default
          */
         fun setRumEnabled(enabled: Boolean): Builder {
+            if (enabled && rumConfig.applicationId == UUID(0, 0)) {
+                devLogger.w(RUM_NOT_INITIALISED_WARNING_MESSAGE)
+                return this
+            }
             rumEnabled = enabled
             return this
         }
@@ -383,6 +388,15 @@ private constructor(
             val defaultProviders = arrayOf(JetpackViewAttributesProvider())
             val providers = customProviders + defaultProviders
             return DatadogGesturesTracker(providers)
+        }
+
+        companion object {
+            internal const val RUM_NOT_INITIALISED_WARNING_MESSAGE =
+                "You're trying to enable RUM but no Application Id was provided. " +
+                    "Please use the following line to create your DatadogConfig:\n" +
+                    "val config = " +
+                    "DatadogConfig.Builder" +
+                    "(\"<CLIENT_TOKEN>\", \"<ENVIRONMENT>\", \"<APPLICATION_ID>\").build()"
         }
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -10,7 +10,6 @@ import android.app.Activity
 import android.app.Fragment
 import android.os.Handler
 import android.os.Looper
-import com.datadog.android.Datadog
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
@@ -181,7 +180,7 @@ interface RumMonitor {
          */
         fun build(): RumMonitor {
             return if (!RumFeature.isInitialized()) {
-                devLogger.e(Datadog.MESSAGE_NOT_INITIALIZED)
+                devLogger.e(RUM_NOT_ENABLED_ERROR_MESSAGE)
                 NoOpRumMonitor()
             } else {
                 DatadogRumMonitor(
@@ -191,6 +190,13 @@ interface RumMonitor {
                     handler = Handler(Looper.getMainLooper())
                 )
             }
+        }
+
+        companion object {
+            internal const val RUM_NOT_ENABLED_ERROR_MESSAGE =
+                "You're trying to create a RumMonitor instance, " +
+                    "but the RUM feature was disabled in your DatadogConfig. " +
+                    "No RUM data will be sent."
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

In this PR we update some logs following the latest changes in the SDK initialisation and we provide an additional Log for the case where the `setRumEnabled` option is used without correctly initialising the `DatadogConfig.Builder` instance.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

