### PR TITLE
RUMM-684 Cleanup the NDK code

### DIFF
--- a/dd-sdk-android-ndk/src/main/cpp/CMakeLists.txt
+++ b/dd-sdk-android-ndk/src/main/cpp/CMakeLists.txt
@@ -27,3 +27,7 @@ target_link_libraries( # Specifies the target library.
         # Links the target library to the log library
         # included in the NDK.
         ${log-lib})
+set_target_properties(datadog-native-lib
+        PROPERTIES
+        COMPILE_OPTIONS
+        -Werror -Wall -pedantic)

--- a/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.cpp
+++ b/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.cpp
@@ -131,8 +131,11 @@ void crash_signal_intercepted(int signal, const char *signal_name, const char *e
 
     // dump the log into a new file
     char filename[200];
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wformat"
     snprintf(filename, sizeof(filename), "%s/%llu", main_context.storage_dir.c_str(),
              time_since_epoch());
+    #pragma clang diagnostic pop
     std::ofstream logs_file_output_stream(filename, std::ofstream::out | std::ofstream::app);
     const char *text = serialized_log.c_str();
     if (logs_file_output_stream.is_open()) {

--- a/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.cpp
+++ b/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.cpp
@@ -131,6 +131,8 @@ void crash_signal_intercepted(int signal, const char *signal_name, const char *e
 
     // dump the log into a new file
     char filename[200];
+     // The ARM_32 processors will use an unsigned long long to represent the uint_64. We will pick the
+    // String format that fits both ARM_32 and ARM_64 (llu).
     #pragma clang diagnostic push
     #pragma clang diagnostic ignored "-Wformat"
     snprintf(filename, sizeof(filename), "%s/%llu", main_context.storage_dir.c_str(),

--- a/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
@@ -41,7 +41,6 @@ namespace {
         return _URC_NO_REASON;
     }
 
-
     size_t capture_backtrace(uintptr_t *buffer, size_t max) {
         BacktraceState state = {buffer, buffer + max};
         // unwinds the backtrace and fills the buffer with stack lines addresses
@@ -49,47 +48,70 @@ namespace {
         return state.current - buffer;
     }
 
-    const char *get_line_symbol(const void *addr) {
-        const char *symbol = "";
-        Dl_info info;
-        if (dladdr(addr, &info) && info.dli_sname) {
-            symbol = info.dli_sname;
-        }
-        return symbol;
+    std::string address_to_hexa(uintptr_t address) {
+        char address_as_hexa[20];
+        // The ARM_32 processors will use an unsigned long long to represent a pointer so we will choose the
+        // String format that fits both ARM_32 and ARM_64 (lx).
+        #pragma clang diagnostic push
+        #pragma clang diagnostic ignored "-Wformat"
+        std::snprintf(address_as_hexa, sizeof(address_as_hexa), "0x%lx", address);
+        #pragma clang diagnostic pop
+        return std::string(address_as_hexa);
     }
+
+    void get_info_from_address(const uintptr_t address, std::string *backtrace) {
+        backtrace->append(std::to_string(address));
+        Dl_info info;
+        int fetch_info_success = dladdr(reinterpret_cast<void *>(address), &info);
+        if (fetch_info_success) {
+
+            if (info.dli_fname) {
+                backtrace->append("  ");
+                backtrace->append(info.dli_fname);
+            }
+
+            backtrace->append("  ");
+            backtrace->append(address_to_hexa(address));
+
+            if (info.dli_sname) {
+                backtrace->append("  ");
+                backtrace->append(info.dli_sname);
+            }
+
+            if (info.dli_fbase) {
+                backtrace->append(" ");
+                backtrace->append("+");
+                backtrace->append(" ");
+                const uintptr_t address_offset =
+                        address - reinterpret_cast<uintptr_t>(info.dli_fbase);
+                backtrace->append(std::to_string(address_offset));
+            }
+
+        }
+
+        backtrace->append("\\n");
+    }
+
 }
 
 namespace backtrace {
+
     std::string generate_backtrace() {
         // define the buffer which will hold pointers to stack memory addresses
         uintptr_t buffer[STACK_SIZE];
         // we will now unwind the stack and capture all the memory addresses up to STACK_SIZE in
         // the buffer
         const size_t captured_stacksize = capture_backtrace(buffer, STACK_SIZE);
-
         std::string backtrace;
         for (size_t idx = 0; idx < captured_stacksize; ++idx) {
             // we will iterate through all the stack addresses and translate each address in
-            // readable information
-            void *addr = reinterpret_cast<void *>(buffer[idx]);
-            const int hexa_address_buffer_size = 20;
-            char address_as_hexa[20];
-            // in ARM_64 that pointer will be considered uint_64 but in ARM_32 will be uint_32
-            // so we will choose the formatting that fits both (lx = unsigned long long).
-            #pragma clang diagnostic push
-            #pragma clang diagnostic ignored "-Wformat"
-            std::snprintf(address_as_hexa, hexa_address_buffer_size, "0x%lx", buffer[idx]);
-            #pragma clang diagnostic pop
-            const char *lineSymbol = get_line_symbol(addr);
-            backtrace.append(std::to_string(idx));
-            backtrace.append(":");
-            backtrace.append(address_as_hexa);
-            backtrace.append("  ");
-            backtrace.append(lineSymbol);
-            backtrace.append("\\n");
+            // readable informationdsadsa
+            get_info_from_address(buffer[idx], &backtrace);
+
         }
         return backtrace;
     }
+
 
 }
 

--- a/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
@@ -74,7 +74,12 @@ namespace backtrace {
             void *addr = reinterpret_cast<void *>(buffer[idx]);
             const int hexa_address_buffer_size = 20;
             char address_as_hexa[20];
-            std::snprintf(address_as_hexa, hexa_address_buffer_size, "0x%x", buffer[idx]);
+            // in ARM_64 that pointer will be considered uint_64 but in ARM_32 will be uint_32
+            // so we will choose the formatting that fits both (lx = unsigned long long).
+            #pragma clang diagnostic push
+            #pragma clang diagnostic ignored "-Wformat"
+            std::snprintf(address_as_hexa, hexa_address_buffer_size, "0x%lx", buffer[idx]);
+            #pragma clang diagnostic pop
             const char *lineSymbol = get_line_symbol(addr);
             backtrace.append(std::to_string(idx));
             backtrace.append(":");

--- a/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.h
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.h
@@ -9,16 +9,9 @@
 #ifndef BACKTRACE_HANDLER_H
 #define BACKTRACE_HANDLER_H
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 namespace backtrace {
 
     std::string generate_backtrace();
 }
 
-#ifdef __cplusplus
-}
-#endif
 #endif

--- a/dd-sdk-android-ndk/src/test/cpp/test_generate_backtrace.cpp
+++ b/dd-sdk-android-ndk/src/test/cpp/test_generate_backtrace.cpp
@@ -13,7 +13,7 @@ TEST test_generate_backtrace(void) {
             backtrace.c_str());
     // we don't know if the stack is big enough to cover the required max size of 30
     unsigned int lines_count = backtrace_lines.size();
-    const char *regex = "(\\d+):0[xX][0-9a-fA-F]+(\\s*)(.*)";
+    const char *regex = "(\\d+)(.*)0[xX][0-9a-fA-F]+(.*)";
             ASSERT(lines_count > 0 && lines_count <= 30);
     for (auto it = backtrace_lines.begin(); it != backtrace_lines.end(); ++it) {
                 ASSERT(std::regex_match(it->c_str(), std::regex(regex)));

--- a/dd-sdk-android-ndk/src/test/cpp/test_utils.h
+++ b/dd-sdk-android-ndk/src/test/cpp/test_utils.h
@@ -7,15 +7,7 @@
 #include <string>
 #include <list>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 namespace testutils {
 
     std::list<std::string> split_backtrace_into_lines(const char *buffer);
 }
-
-#ifdef __cplusplus
-}
-#endif


### PR DESCRIPTION
### What does this PR do?

The goal was this task was to research over the way we are currently constructing the backtrace in our NDK crash reporting code and if our current approach is good enough or we should use `libunwind` or `corkscrew` as seen in other SDKs. 
The resolution of this task is that what we have it is simple enough and covers all the processors as with other approaches we would have to use different APIs for each processor type bringing bigger complexity in our code.
In theory I was able to keep what we had so far and add an improvement where I enrich the crash stacktrace with more information and format it in a more readable structure following iOS approach. Right now we will have also the `shared object` file from which the executed line address was coming and also the memory offset for the address.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

