### PR TITLE
RUMM-692 Fix RUM events timing

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/ResourceTiming.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/ResourceTiming.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.rum.internal.domain.event
 
-import kotlin.math.max
-
 internal data class ResourceTiming(
     val dnsStart: Long = 0L,
     val dnsDuration: Long = 0L,
@@ -19,8 +17,4 @@ internal data class ResourceTiming(
     val firstByteDuration: Long = 0L,
     val downloadStart: Long = 0L,
     val downloadDuration: Long = 0L
-) {
-    fun totalDuration(): Long {
-        return max(downloadStart + downloadDuration, firstByteStart + firstByteDuration)
-    }
-}
+)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -15,46 +15,53 @@ import com.datadog.android.rum.internal.domain.model.ViewEvent
 
 internal sealed class RumRawEvent {
 
-    open val eventTime = Time()
+    abstract val eventTime: Time
 
     internal data class StartView(
         val key: Any,
         val name: String,
-        val attributes: Map<String, Any?>
+        val attributes: Map<String, Any?>,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class StopView(
         val key: Any,
-        val attributes: Map<String, Any?>
+        val attributes: Map<String, Any?>,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class StartAction(
         val type: RumActionType,
         val name: String,
         val waitForStop: Boolean,
-        val attributes: Map<String, Any?>
+        val attributes: Map<String, Any?>,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class StopAction(
         val type: RumActionType,
         val name: String,
-        val attributes: Map<String, Any?>
+        val attributes: Map<String, Any?>,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class StartResource(
         val key: String,
         val url: String,
         val method: String,
-        val attributes: Map<String, Any?>
+        val attributes: Map<String, Any?>,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class WaitForResourceTiming(
-        val key: String
+        val key: String,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class AddResourceTiming(
         val key: String,
-        val timing: ResourceTiming
+        val timing: ResourceTiming,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class StopResource(
@@ -62,7 +69,8 @@ internal sealed class RumRawEvent {
         val statusCode: Long?,
         val size: Long?,
         val kind: RumResourceKind,
-        val attributes: Map<String, Any?>
+        val attributes: Map<String, Any?>,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class StopResourceWithError(
@@ -70,7 +78,8 @@ internal sealed class RumRawEvent {
         val statusCode: Long?,
         val message: String,
         val source: RumErrorSource,
-        val throwable: Throwable
+        val throwable: Throwable,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class AddError(
@@ -79,28 +88,40 @@ internal sealed class RumRawEvent {
         val throwable: Throwable?,
         val stacktrace: String?,
         val isFatal: Boolean,
-        val attributes: Map<String, Any?>
+        val attributes: Map<String, Any?>,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class UpdateViewLoadingTime(
         val key: Any,
         val loadingTime: Long,
-        val loadingType: ViewEvent.LoadingType
+        val loadingType: ViewEvent.LoadingType,
+        override val eventTime: Time = Time()
     ) : RumRawEvent()
 
-    internal class SentResource : RumRawEvent()
+    internal data class SentResource(
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
 
-    internal class SentAction : RumRawEvent()
+    internal data class SentAction(
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
 
-    internal class SentError : RumRawEvent()
+    internal data class SentError(
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
 
     internal class ViewTreeChanged(
         override val eventTime: Time
     ) : RumRawEvent()
 
-    internal class ResetSession : RumRawEvent()
+    internal data class ResetSession(
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
 
-    internal class KeepAlive : RumRawEvent()
+    internal data class KeepAlive(
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
 
     internal data class ApplicationStarted(
         override val eventTime: Time,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -18,7 +18,6 @@ import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.internal.domain.model.ErrorEvent
 import com.datadog.android.rum.internal.domain.model.ResourceEvent
-import kotlin.math.max
 
 internal class RumResourceScope(
     internal val parentScope: RumScope,
@@ -122,13 +121,7 @@ internal class RumResourceScope(
         val user = RumFeature.userInfoProvider.getUserInfo()
 
         val finalTiming = timing
-        val duration = if (finalTiming == null) {
-            eventTime.nanoTime - startedNanos
-        } else {
-            // ensure we don't get weird graphs
-            // TODO RUMM-692 find out why we can have resource duration < timing.totalDuration()
-            max(eventTime.nanoTime - startedNanos, finalTiming.totalDuration())
-        }
+        val duration = eventTime.nanoTime - startedNanos
 
         val resourceEvent = ResourceEvent(
             date = eventTimestamp,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/resource/RumResourceInputStream.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/resource/RumResourceInputStream.kt
@@ -122,10 +122,8 @@ class RumResourceInputStream(
             (monitor as? AdvancedRumMonitor)?.addResourceTiming(
                 key,
                 ResourceTiming(
-                    firstByteStart = 1L,
-                    firstByteDuration = firstByte - callStart - 1L,
                     downloadStart = firstByte - callStart,
-                    downloadDuration = lastByte - firstByte - 1L
+                    downloadDuration = lastByte - firstByte
                 )
             )
             monitor.stopResource(
@@ -166,7 +164,7 @@ class RumResourceInputStream(
     // endregion
 
     companion object {
-        internal const val METHOD: String = "STREAM"
+        internal const val METHOD: String = "GET"
 
         internal const val ERROR_CLOSE = "Error closing input stream"
         internal const val ERROR_MARK = "Error marking input stream"

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -345,7 +345,9 @@ internal class DatadogRumMonitorTest {
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
 
-            assertThat(firstValue).isEqualTo(RumRawEvent.WaitForResourceTiming(key))
+            val event = firstValue
+            check(event is RumRawEvent.WaitForResourceTiming)
+            assertThat(event.key).isEqualTo(key)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)
     }
@@ -361,7 +363,10 @@ internal class DatadogRumMonitorTest {
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
 
-            assertThat(firstValue).isEqualTo(RumRawEvent.AddResourceTiming(key, timing))
+            val event = firstValue
+            check(event is RumRawEvent.AddResourceTiming)
+            assertThat(event.key).isEqualTo(key)
+            assertThat(event.timing).isEqualTo(timing)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)
     }
@@ -400,13 +405,11 @@ internal class DatadogRumMonitorTest {
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
 
-            assertThat(firstValue).isEqualTo(
-                RumRawEvent.UpdateViewLoadingTime(
-                    key,
-                    loadingTime,
-                    loadingType
-                )
-            )
+            val event = firstValue
+            check(event is RumRawEvent.UpdateViewLoadingTime)
+            assertThat(event.key).isEqualTo(key)
+            assertThat(event.loadingTime).isEqualTo(loadingTime)
+            assertThat(event.loadingType).isEqualTo(loadingType)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/resource/RumResourceInputStreamTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/resource/RumResourceInputStreamTest.kt
@@ -700,7 +700,8 @@ internal class RumResourceInputStreamTest {
                 assertThat(firstValue.connectDuration).isEqualTo(0L)
                 assertThat(firstValue.dnsDuration).isEqualTo(0L)
                 assertThat(firstValue.sslDuration).isEqualTo(0L)
-                assertThat(firstValue.firstByteDuration).isGreaterThan(
+                assertThat(firstValue.firstByteDuration).isEqualTo(0L)
+                assertThat(firstValue.downloadStart).isGreaterThan(
                     TimeUnit.MILLISECONDS.toNanos(500)
                 )
                 assertThat(firstValue.downloadDuration).isLessThanOrEqualTo(download)

--- a/sample/README.md
+++ b/sample/README.md
@@ -7,12 +7,14 @@ For each flavor you will have to provide a config file named `[flavorName].json`
 
 Example of a sample app configuration file:
 ```json
-   {
-     "logsEndpoint": "YOUR PREFERRED ENDPOINT",
-     "tracesEndpoint": "YOUR PREFERRED ENDPOINT",
-     "rumEndpoint": "YOUR PREFERRED ENDPOINT",
-     "token": "YOUR APP TOKEN",
-     "appId": "YOUR RUM APP ID"
-   }
+    {
+        "logsEndpoint": "YOUR PREFERRED ENDPOINT",
+        "tracesEndpoint": "YOUR PREFERRED ENDPOINT",
+        "rumEndpoint": "YOUR PREFERRED ENDPOINT",
+        "token": "YOUR APP TOKEN",
+        "rumApplicationId": "YOUR RUM APPLICATION ID",
+        "apiKey": "YOUR API ID",
+        "applicationKey": "YOUR APPLICATION KEY"
+    }
 ```
 **Note** `logsEndpoint`, `tracesEndpoint` and `rumEndpoint` are not mandatory attributes, so if you want to use the default endpoints (production ones) you just omit them in the configuration file.

--- a/sample/kotlin/src/main/res/layout/fragment_traces.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_traces.xml
@@ -29,6 +29,7 @@
         android:id="@+id/start_async_operation"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
+        android:layout_margin="16dp"
         android:text="@string/button_start"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"


### PR DESCRIPTION
### What does this PR do?

Fix the RUM events timing.

### Motivation

With each RUM raw event (start X, stop Y, …), we keep an `eventTime` value to know when the event occurred in the client's code. At some point, those raw events could be updated to include additional attributes, and since they are all immutable objects, we used the `copy()` method.

The main issue was that the `eventTime` attribute was part of the parent `sealed` class (`RumRawEvent`), and was not copied but recreated at the time of the copy, meaning that all our events' times were skewed by a few milliseconds, making each information slightly off.

This PR fixes that by making the parent `eventTime` attribute abstract, forcing implementations to have them (meaning that they are taken into account by the kotlin compiler, and indeed kept during a `copy()` call).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

