### PR TITLE
RUMM-537 POC to explore the WindowManager capabilities

### DIFF
--- a/dd-sdk-android/build.gradle.kts
+++ b/dd-sdk-android/build.gradle.kts
@@ -119,6 +119,9 @@ dependencies {
     implementation(Dependencies.Libraries.AndroidXRecyclerView)
     implementation(Dependencies.Libraries.AndroidXNavigation)
 
+    // WindowManager
+    implementation("androidx.window:window:1.0.0-alpha01")
+
     api(Dependencies.Libraries.TracingOt)
     kapt(project(":tools:noopfactory"))
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -263,6 +263,9 @@ internal class RumViewScope(
         val updatedDurationNs = event.eventTime.nanoTime - startedNanos
         val context = getRumContext()
         val user = RumFeature.userInfoProvider.getUserInfo()
+        val deviceStateInfo = RumFeature.deviceInfoProvider.getLastDeviceStateInfo()
+        attributes["device_posture"] = deviceStateInfo.state.serializedName
+        attributes["display_type"] = deviceStateInfo.displayType?.serializedName
 
         val viewEvent = ViewEvent(
             date = eventTimestamp,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/DeviceInfo.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/DeviceInfo.kt
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.tracking
+
+import androidx.window.DeviceState
+import androidx.window.DisplayFeature
+
+internal data class DeviceInfo(
+    val state: Posture = Posture.UNKNOWN,
+    val displayType: DisplayType? = null
+) {
+
+    internal enum class Posture(val serializedName:String) {
+        UNKNOWN("unknown"),
+        CLOSED("closed"),
+        HALF_OPENED("half_opened"),
+        OPENED("opened"),
+        FLIPPED("flipped");
+
+        companion object {
+            fun fromPosture(posture: Int): Posture {
+                return when (posture) {
+                    DeviceState.POSTURE_CLOSED -> CLOSED
+                    DeviceState.POSTURE_FLIPPED -> FLIPPED
+                    DeviceState.POSTURE_HALF_OPENED -> HALF_OPENED
+                    DeviceState.POSTURE_OPENED -> OPENED
+                    else -> UNKNOWN
+                }
+            }
+        }
+    }
+
+    internal enum class DisplayType(val serializedName: String) {
+        UNKNOWN("unknown"),
+        HINGED("hinged"),
+        FOLD("fold");
+
+        companion object {
+            fun fromType(type: Int): DisplayType {
+                return when (type) {
+                    DisplayFeature.TYPE_FOLD -> FOLD
+                    DisplayFeature.TYPE_HINGE -> HINGED
+                    else -> UNKNOWN
+                }
+            }
+        }
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/DeviceInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/DeviceInfoProvider.kt
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.tracking
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+@NoOpImplementation
+internal interface DeviceInfoProvider {
+
+    fun getLastDeviceStateInfo(): DeviceInfo
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/DeviceInfoTrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/DeviceInfoTrackingStrategy.kt
@@ -1,0 +1,55 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.tracking
+
+import android.app.Activity
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import com.datadog.android.rum.tracking.ActivityLifecycleTrackingStrategy
+import java.util.concurrent.Executor
+
+internal class DeviceInfoTrackingStrategy : ActivityLifecycleTrackingStrategy(),
+    DeviceInfoProvider {
+
+    var deviceInfo = DeviceInfo()
+
+    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
+        activity.window?.callback?.let {
+            activity.window.callback = DeviceInfoWindowCallbackWrapper(
+                it,
+                activity
+            ) {
+                deviceInfo = it
+            }
+        }
+        super.onActivityCreated(activity, savedInstanceState)
+    }
+
+    override fun onActivityDestroyed(activity: Activity) {
+        (activity.window.callback as? DeviceInfoWindowCallbackWrapper)?.let {
+            it.detach(activity)
+        }
+        super.onActivityDestroyed(activity)
+    }
+
+    companion object {
+        val MAIN_THREAD_EXECUTOR: Executor =
+            object : Executor {
+                private val handler =
+                    Handler(Looper.getMainLooper())
+
+                override fun execute(command: Runnable) {
+                    handler.post(command)
+                }
+            }
+    }
+
+    override fun getLastDeviceStateInfo(): DeviceInfo {
+        return deviceInfo
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/DeviceInfoWindowCallbackWrapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/DeviceInfoWindowCallbackWrapper.kt
@@ -1,0 +1,96 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.tracking
+
+import android.app.Activity
+import android.content.Context
+import android.view.Window
+import androidx.core.util.Consumer
+import androidx.window.DeviceState
+import androidx.window.WindowLayoutInfo
+import androidx.window.WindowManager
+
+internal class DeviceInfoWindowCallbackWrapper(
+    val wrapped: Window.Callback,
+    val context: Context,
+    val callback: (DeviceInfo) -> Unit
+) :
+    Window.Callback by wrapped {
+
+    var deviceInfo = DeviceInfo()
+    var windowManager: WindowManager? = null
+
+    private val deviceStateCallback: Consumer<DeviceState> by lazy {
+        Consumer<DeviceState> {
+            it?.let {
+                deviceInfo = deviceInfo.copy(state = DeviceInfo.Posture.fromPosture(it.posture))
+                callback(deviceInfo)
+
+            }
+        }
+    }
+
+    private val windowLayoutCallback: Consumer<WindowLayoutInfo> by lazy {
+        Consumer<WindowLayoutInfo> {
+            it?.let {
+                // For testing purposes we're just going to get the first display for now
+                it.displayFeatures.getOrNull(0)?.let { displayFeature ->
+                    deviceInfo =
+                        deviceInfo.copy(displayType = DeviceInfo.DisplayType.fromType(displayFeature.type))
+                    callback(deviceInfo)
+
+                }
+            }
+        }
+    }
+
+
+    override fun onAttachedToWindow() {
+        val windowManager = WindowManager(context, null)
+        updateDeviceInfo(windowManager)
+        windowManager.registerDeviceStateChangeCallback(
+            DeviceInfoTrackingStrategy.MAIN_THREAD_EXECUTOR,
+            deviceStateCallback
+        )
+        windowManager.registerLayoutChangeCallback(
+            DeviceInfoTrackingStrategy.MAIN_THREAD_EXECUTOR,
+            windowLayoutCallback
+        )
+        windowManager.windowLayoutInfo
+        this.windowManager = windowManager
+        wrapped.onAttachedToWindow()
+    }
+
+    private fun updateDeviceInfo(windowManager: WindowManager) {
+        // For testing purposes we're just going to get the first display for now
+        val displayFeature = windowManager.windowLayoutInfo.displayFeatures.getOrNull(0)
+        deviceInfo =
+            DeviceInfo(
+                state = DeviceInfo.Posture.fromPosture(
+                    windowManager.deviceState.posture
+                ),
+                displayType = if (displayFeature != null) DeviceInfo.DisplayType.fromType(
+                    displayFeature.type
+                ) else null
+            )
+        callback(deviceInfo)
+    }
+
+    override fun onDetachedFromWindow() {
+        wrapped.onDetachedFromWindow()
+        unregisterCallbacks()
+    }
+
+    fun detach(activity: Activity) {
+        activity.window.callback = wrapped
+    }
+
+    private fun unregisterCallbacks() {
+        windowManager?.unregisterDeviceStateChangeCallback(deviceStateCallback)
+        windowManager?.unregisterLayoutChangeCallback(windowLayoutCallback)
+    }
+}

--- a/sample/kotlin/src/main/AndroidManifest.xml
+++ b/sample/kotlin/src/main/AndroidManifest.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.datadog.android.sample">
+          xmlns:tools="http://schemas.android.com/tools"
+          package="com.datadog.android.sample">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
 
     <application
         android:name=".SampleApplication"
@@ -17,28 +17,30 @@
         tools:ignore="GoogleAppIndexingWarning">
         <receiver android:name=".widget.DatadogWidgetsProvider">
             <intent-filter>
-                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
             </intent-filter>
 
             <meta-data
                 android:name="android.appwidget.provider"
-                android:resource="@xml/datadog_widget_info" />
+                android:resource="@xml/datadog_widget_info"/>
         </receiver>
 
         <activity
             android:name=".NavActivity"
-            android:label="@string/title_main">
+            android:label="@string/title_main"
+            android:configChanges="screenSize|screenLayout"
+            android:resizeableActivity="true">
             <intent-filter>
-                <action android:name="android.intent.action.MAIN" />
+                <action android:name="android.intent.action.MAIN"/>
 
-                <category android:name="android.intent.category.LAUNCHER" />
+                <category android:name="android.intent.category.LAUNCHER"/>
             </intent-filter>
         </activity>
-        <activity android:name=".ViewPagerActivity" />
+        <activity android:name=".ViewPagerActivity"/>
 
         <service
             android:name=".service.LogsForegroundService"
-            android:process=":logsService" />
+            android:process=":logsService"/>
         <service android:name=".widget.WidgetIntentService"/>
     </application>
 


### PR DESCRIPTION
### What does this PR do?

The purpose of this POC was to test the capabilities of the new WindowManager API for foldable devices.
The idea was to find a way to use this APIs features to provide more information related with those devices in our RUM View events for example.
I was able to grab their project together with their sample apps and following their implementation to be able to extract the following information and add it as special attributes in the View event:
```
internal enum class Posture {
    UNKNOWN,
    CLOSED,
    HALF_OPENED,
    OPENED,
    FLIPPED;
}

internal enum class DisplayType {
    UNKNOWN,
    HINGED,
    FOLD;
}

```

Unfortunately this API is in its first Alpha version and there was no active contribution on it in the last 8 months.
[Window Manager API](https://android.googlesource.com/platform/frameworks/support/+log/fca183fb525b93d2002528fbafdb042f2bffdf36/window)
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

