### PR TITLE
RUMM-475 Provide integration with RxJava 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -180,6 +180,18 @@ publish:release-ndk:
     - git fetch --depth=1 origin master
     - ./gradlew :dd-sdk-android-ndk:bintrayUpload --stacktrace --no-daemon
 
+publish:release-rx:
+  tags: [ "runner:main", "size:large" ]
+  only:
+    - tags
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gradle-properties --with-decryption --query "Parameter.Value" --out text >> ./gradle.properties
+    - git fetch --depth=1 origin master
+    - ./gradlew :dd-sdk-android-rx:bintrayUpload --stacktrace --no-daemon
+
 publish:release-timber:
   tags: [ "runner:main", "size:large" ]
   only:

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,16 +3,7 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
-        </value>
-      </option>
-      <option name="PACKAGES_IMPORT_LAYOUT">
-        <value>
-          <package name="" alias="false" withSubpackages="true" />
-          <package name="java" alias="false" withSubpackages="true" />
-          <package name="javax" alias="false" withSubpackages="true" />
-          <package name="kotlin" alias="false" withSubpackages="true" />
-          <package name="" alias="true" withSubpackages="true" />
+          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -44,6 +44,8 @@ import,com.fasterxml.jackson,Apache-2.0,Copyright 2020 Datadog, Inc.
 import,com.datadoghq,Apache-2.0,Copyright 2017 Datadog, Inc
 import,io.opentracing,Apache-2.0,Copyright 2016-2017 The OpenTracing Authors
 import,io.opentracing.contrib,Apache-2.0,Copyright 2016-2017 The OpenTracing Authors
+import,io.reactivex.rxjava3,Apache-2.0,Copyright (c) 2016-present, RxJava Contributors
+import,io.reactivex.rxjava3.android,Apache-2.0,Copyright 2015 The RxAndroid authors
 import,org.jetbrains,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors
 import,org.jetbrains.kotlin,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors
 import,org.jetbrains.kotlinx,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,8 +54,9 @@ tasks.register("assembleAll") {
         ":dd-sdk-android-fresco:assemble",
         ":dd-sdk-android-glide:assemble",
         ":dd-sdk-android-ktx:assemble",
-        ":dd-sdk-android-timber:assemble",
-        ":dd-sdk-android-ndk:assemble"
+        ":dd-sdk-android-ndk:assemble",
+        ":dd-sdk-android-rx:assemble",
+        ":dd-sdk-android-timber:assemble"
     )
 }
 
@@ -66,8 +67,9 @@ tasks.register("unitTestRelease") {
         ":dd-sdk-android-fresco:testReleaseUnitTest",
         ":dd-sdk-android-glide:testReleaseUnitTest",
         ":dd-sdk-android-ktx:testReleaseUnitTest",
-        ":dd-sdk-android-timber:testReleaseUnitTest",
-        ":dd-sdk-android-ndk:testReleaseUnitTest"
+        ":dd-sdk-android-ndk:testReleaseUnitTest",
+        ":dd-sdk-android-rx:testReleaseUnitTest",
+        ":dd-sdk-android-timber:testReleaseUnitTest"
     )
 }
 
@@ -78,8 +80,9 @@ tasks.register("unitTestDebug") {
         ":dd-sdk-android-fresco:testDebugUnitTest",
         ":dd-sdk-android-glide:testDebugUnitTest",
         ":dd-sdk-android-ktx:testDebugUnitTest",
-        ":dd-sdk-android-timber:testDebugUnitTest",
-        ":dd-sdk-android-ndk:testDebugUnitTest"
+        ":dd-sdk-android-ndk:testDebugUnitTest",
+        ":dd-sdk-android-rx:testDebugUnitTest",
+        ":dd-sdk-android-timber:testDebugUnitTest"
     )
 }
 
@@ -107,8 +110,9 @@ tasks.register("ktlintCheckAll") {
         ":dd-sdk-android-fresco:ktlintCheck",
         ":dd-sdk-android-glide:ktlintCheck",
         ":dd-sdk-android-ktx:ktlintCheck",
-        ":dd-sdk-android-timber:ktlintCheck",
         ":dd-sdk-android-ndk:ktlintCheck",
+        ":dd-sdk-android-rx:ktlintCheck",
+        ":dd-sdk-android-timber:ktlintCheck",
         ":instrumented:integration:ktlintCheck",
         ":instrumented:benchmark:ktlintCheck",
         ":tools:detekt:ktlintCheck",
@@ -123,8 +127,9 @@ tasks.register("lintCheckAll") {
         ":dd-sdk-android-fresco:lintRelease",
         ":dd-sdk-android-glide:lintRelease",
         ":dd-sdk-android-ktx:lintRelease",
-        ":dd-sdk-android-timber:lintRelease",
-        ":dd-sdk-android-ndk:lintRelease"
+        ":dd-sdk-android-ndk:lintRelease",
+        ":dd-sdk-android-rx:lintRelease",
+        ":dd-sdk-android-timber:lintRelease"
     )
 }
 
@@ -135,8 +140,9 @@ tasks.register("detektAll") {
         ":dd-sdk-android-fresco:detekt",
         ":dd-sdk-android-glide:detekt",
         ":dd-sdk-android-ktx:detekt",
-        ":dd-sdk-android-timber:detekt",
         ":dd-sdk-android-ndk:detekt",
+        ":dd-sdk-android-rx:detekt",
+        ":dd-sdk-android-timber:detekt",
         ":instrumented:integration:detekt",
         ":instrumented:benchmark:detekt",
         ":tools:unit:detekt"
@@ -157,6 +163,8 @@ tasks.register("jacocoReportAll") {
         ":dd-sdk-android-ktx:jacocoTestReleaseUnitTestReport",
         ":dd-sdk-android-ndk:jacocoTestDebugUnitTestReport",
         ":dd-sdk-android-ndk:jacocoTestReleaseUnitTestReport",
+        ":dd-sdk-android-rx:jacocoTestDebugUnitTestReport",
+        ":dd-sdk-android-rx:jacocoTestReleaseUnitTestReport",
         ":dd-sdk-android-timber:jacocoTestDebugUnitTestReport",
         ":dd-sdk-android-timber:jacocoTestReleaseUnitTestReport",
         ":tools:detekt:jacocoTestReport",

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -63,6 +63,7 @@ object Dependencies {
         const val Coil = "0.12.0"
         const val Fresco = "2.3.0"
         const val Glide = "4.11.0"
+        const val RxJava = "3.0.0"
         const val Timber = "4.7.1"
 
         // NDK
@@ -153,8 +154,7 @@ object Dependencies {
             "com.google.android.material:material:${Versions.GoogleMaterial}"
         )
 
-        // INTEGRATIONS
-
+        // Integrations
         const val Coil = "io.coil-kt:coil:${Versions.Coil}"
 
         val Fresco = arrayOf(
@@ -168,14 +168,14 @@ object Dependencies {
             "com.github.bumptech.glide:okhttp3-integration:${Versions.Glide}"
         )
 
+        const val RxJava = "io.reactivex.rxjava3:rxjava:${Versions.RxJava}"
         const val Timber = "com.jakewharton.timber:timber:${Versions.Timber}"
 
-        const val OkHttpMock = "com.squareup.okhttp3:mockwebserver:${Versions.OkHttp}"
-
+        // Tools
         const val DetektCli = "io.gitlab.arturbosch.detekt:detekt-cli:${Versions.Detekt}"
         const val DetektApi = "io.gitlab.arturbosch.detekt:detekt-api:${Versions.Detekt}"
         const val DetektTest = "io.gitlab.arturbosch.detekt:detekt-test:${Versions.Detekt}"
-
+        const val OkHttpMock = "com.squareup.okhttp3:mockwebserver:${Versions.OkHttp}"
         const val Robolectric = "org.robolectric:android-all:${Versions.Robolectric}"
     }
 

--- a/dd-sdk-android-coil/src/main/kotlin/com/datadog/android/coil/DatadogCoilRequestListener.kt
+++ b/dd-sdk-android-coil/src/main/kotlin/com/datadog/android/coil/DatadogCoilRequestListener.kt
@@ -24,7 +24,7 @@ class DatadogCoilRequestListener : ImageRequest.Listener {
 
     // region Listener
 
-    /** @inheritdoc */
+    /** @inheritDoc */
     override fun onError(request: ImageRequest, throwable: Throwable) {
         GlobalRum.get().addError(
             REQUEST_ERROR_MESSAGE,

--- a/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/DatadogCoilRequestListenerTest.kt
+++ b/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/DatadogCoilRequestListenerTest.kt
@@ -4,14 +4,13 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.fresco
+package com.datadog.android.coil
 
 import android.graphics.Bitmap
 import android.graphics.drawable.Drawable
 import android.net.Uri
 import coil.request.ImageRequest
-import com.datadog.android.coil.DatadogCoilRequestListener
-import com.datadog.android.fresco.utils.Configurator
+import com.datadog.android.coil.utils.Configurator
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor

--- a/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/utils/Configurator.kt
+++ b/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/utils/Configurator.kt
@@ -1,10 +1,10 @@
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
  * This product includes software developed at Datadog (https://www.datadoghq.com/).
- * Copyright 2016-2020 Datadog, Inc.
+ * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.fresco.utils
+package com.datadog.android.coil.utils
 
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeConfigurator

--- a/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/utils/ThrowableForgeryFactory.kt
+++ b/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/utils/ThrowableForgeryFactory.kt
@@ -1,4 +1,4 @@
-package com.datadog.android.fresco.utils
+package com.datadog.android.coil.utils
 
 import com.datadog.tools.unit.forge.aThrowable
 import fr.xgouchet.elmyr.Forge

--- a/dd-sdk-android-fresco/src/main/kotlin/com/datadog/android/fresco/DatadogFrescoCacheListener.kt
+++ b/dd-sdk-android-fresco/src/main/kotlin/com/datadog/android/fresco/DatadogFrescoCacheListener.kt
@@ -23,7 +23,7 @@ class DatadogFrescoCacheListener : CacheEventListener {
 
     // region CacheEventListener
 
-    /** @inheritdoc */
+    /** @inheritDoc */
     override fun onMiss(cacheEvent: CacheEvent) {
         // NoOp
     }
@@ -39,32 +39,32 @@ class DatadogFrescoCacheListener : CacheEventListener {
         )
     }
 
-    /** @inheritdoc */
+    /** @inheritDoc */
     override fun onEviction(cacheEvent: CacheEvent) {
         // NoOp
     }
 
-    /** @inheritdoc */
+    /** @inheritDoc */
     override fun onHit(cacheEvent: CacheEvent) {
         // NoOp
     }
 
-    /** @inheritdoc */
+    /** @inheritDoc */
     override fun onCleared() {
         // NoOp
     }
 
-    /** @inheritdoc */
+    /** @inheritDoc */
     override fun onWriteAttempt(cacheEvent: CacheEvent) {
         // NoOp
     }
 
-    /** @inheritdoc */
+    /** @inheritDoc */
     override fun onWriteSuccess(cacheEvent: CacheEvent) {
         // NoOp
     }
 
-    /** @inheritdoc */
+    /** @inheritDoc */
     override fun onWriteException(cacheEvent: CacheEvent) {
         GlobalRum.get().addError(
             CACHE_ERROR_WRITE_MESSAGE,

--- a/dd-sdk-android-rx/.gitignore
+++ b/dd-sdk-android-rx/.gitignore
@@ -1,0 +1,18 @@
+# Built application files
+*.apk
+*.ap_
+*.aab
+
+# Files for the ART/Dalvik VM
+*.dex
+
+# Java class files
+*.class
+
+# Generated files
+bin/
+gen/
+out/
+
+# Gradle files
+build/

--- a/dd-sdk-android-rx/README.md
+++ b/dd-sdk-android-rx/README.md
@@ -1,0 +1,77 @@
+# Datadog Integration for RxJava
+
+## Getting Started 
+
+To include the Datadog integration for [RxJava][1] in your project, simply add the
+following to your application's `build.gradle` file.
+
+```
+repositories {
+    maven { url "https://dl.bintray.com/datadog/datadog-maven" }
+}
+
+dependencies {
+    implementation "com.datadoghq:dd-sdk-android:<latest-version>"
+    implementation "com.datadoghq:dd-sdk-android-rx:<latest-version>"
+}
+```
+
+### Initial Setup
+
+Before you can use the SDK, you need to setup the library with your application
+context, your Client token and your Application ID. 
+To generate a Client token and an Application ID please check **UX Monitoring > RUM Applications > New Application**
+in the Datadog dashboard.
+
+```kotlin
+class SampleApplication : Application() {
+
+    override fun onCreate() {
+        super.onCreate()
+        val config = DatadogConfig.Builder("<CLIENT_TOKEN>", "<ENVIRONMENT_NAME>", "<APPLICATION_ID>").build()
+        Datadog.initialize(this, config)
+
+        val  logger = Logger.Builder()
+                .setNetworkInfoEnabled(true)
+                .setLogcatLogsEnabled(true)
+                .setDatadogLogsEnabled(true)
+                .build();
+    }
+}
+```
+
+Following RxJava's [Generated API documentation][2], you just have to apply the `doOnError` operator on your `Observable`,
+`Flowable`, `Single`, `Maybe` or `Completable` and pass an instance of `DatadogErrorConsumer`.
+
+Doing so will automatically intercept any Exception thrown in the upper stream by creating RUM Error events.
+
+**Note** : If you are using `Kotlin` in your codebase you could also use the extension: `sendErrorToDatadog()`.
+
+Java: 
+
+```java
+    Observable.create<T>{...}
+    .doOnError(new DatadogErrorConsumer())
+    ...
+```
+
+Kotlin: 
+
+```java
+    Observable.create<T>{...}
+    .publishErrorsToRum()
+    ...
+```
+
+## Contributing
+
+Pull requests are welcome, but please open an issue first to discuss what you
+would like to change. For more information, read the 
+[Contributing Guide](../CONTRIBUTING.md).
+
+## License
+
+[Apache License, v2.0](../LICENSE)
+
+[1]: https://github.com/ReactiveX/RxJava
+[2]: https://github.com/ReactiveX/RxJava/wiki

--- a/dd-sdk-android-rx/apiSurface
+++ b/dd-sdk-android-rx/apiSurface
@@ -1,0 +1,8 @@
+class com.datadog.android.rx.DatadogRumErrorConsumer : io.reactivex.rxjava3.functions.Consumer<Throwable>
+  override fun accept(Throwable)
+  companion object 
+fun <T> sendErrorToDatadog(): io.reactivex.rxjava3.core.Observable<T>
+fun <T> sendErrorToDatadog(): io.reactivex.rxjava3.core.Single<T>
+fun <T> sendErrorToDatadog(): io.reactivex.rxjava3.core.Flowable<T>
+fun <T> sendErrorToDatadog(): io.reactivex.rxjava3.core.Maybe<T>
+fun sendErrorToDatadog(): io.reactivex.rxjava3.core.Completable

--- a/dd-sdk-android-rx/build.gradle.kts
+++ b/dd-sdk-android-rx/build.gradle.kts
@@ -1,0 +1,94 @@
+/*
+ * Unless explicitly stated otherwise all pomFilesList in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-2019 Datadog, Inc.
+ */
+
+import com.datadog.gradle.Dependencies
+import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.bintrayConfig
+import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.detektConfig
+import com.datadog.gradle.config.jacocoConfig
+import com.datadog.gradle.config.javadocConfig
+import com.datadog.gradle.config.junitConfig
+import com.datadog.gradle.config.kotlinConfig
+import com.datadog.gradle.config.ktLintConfig
+import com.datadog.gradle.config.publishingConfig
+import com.datadog.gradle.implementation
+import com.datadog.gradle.testImplementation
+
+plugins {
+    id("com.android.library")
+    id("androidx.benchmark")
+    kotlin("android")
+    kotlin("android.extensions")
+    kotlin("kapt")
+    `maven-publish`
+    id("com.github.ben-manes.versions")
+    id("io.gitlab.arturbosch.detekt")
+    id("org.jlleitschuh.gradle.ktlint")
+    id("thirdPartyLicences")
+    id("apiSurface")
+    id("org.jetbrains.dokka")
+    id("com.jfrog.bintray")
+    jacoco
+}
+
+android {
+    compileSdkVersion(AndroidConfig.TARGET_SDK)
+    buildToolsVersion(AndroidConfig.BUILD_TOOLS_VERSION)
+
+    defaultConfig {
+        minSdkVersion(AndroidConfig.MIN_SDK)
+        targetSdkVersion(AndroidConfig.TARGET_SDK)
+        versionCode = AndroidConfig.VERSION.code
+        versionName = AndroidConfig.VERSION.name
+    }
+
+    sourceSets.named("main") {
+        java.srcDir("src/main/kotlin")
+    }
+    sourceSets.named("test") {
+        java.srcDir("src/test/kotlin")
+    }
+    sourceSets.named("androidTest") {
+        java.srcDir("src/androidTest/kotlin")
+    }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+
+    lintOptions {
+        isWarningsAsErrors = true
+        isAbortOnError = true
+        isCheckReleaseBuilds = false
+        isCheckGeneratedSources = true
+    }
+}
+
+dependencies {
+    api(project(":dd-sdk-android"))
+    implementation(Dependencies.Libraries.Kotlin)
+    implementation(Dependencies.Libraries.OkHttp)
+    implementation(Dependencies.Libraries.RxJava)
+
+    testImplementation(project(":tools:unit"))
+    testImplementation(Dependencies.Libraries.JUnit5)
+    testImplementation(Dependencies.Libraries.TestTools)
+    testImplementation(Dependencies.Libraries.OkHttpMock)
+
+    detekt(project(":tools:detekt"))
+    detekt(Dependencies.Libraries.DetektCli)
+}
+
+kotlinConfig()
+detektConfig()
+ktLintConfig()
+junitConfig()
+jacocoConfig()
+javadocConfig()
+dependencyUpdateConfig()
+publishingConfig("${rootDir.canonicalPath}/repo")
+bintrayConfig()

--- a/dd-sdk-android-rx/src/main/AndroidManifest.xml
+++ b/dd-sdk-android-rx/src/main/AndroidManifest.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-2019 Datadog, Inc.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+          package="com.datadog.android.rx">
+
+</manifest>

--- a/dd-sdk-android-rx/src/main/kotlin/com/datadog/android/rx/DatadogRumErrorConsumer.kt
+++ b/dd-sdk-android-rx/src/main/kotlin/com/datadog/android/rx/DatadogRumErrorConsumer.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rx
+
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumErrorSource
+import io.reactivex.rxjava3.functions.Consumer
+
+/**
+ * Provides an implementation of [Consumer<Throwable>] already set up to send relevant information
+ * to Datadog.
+ *
+ * It will automatically send RUM error events whenever a RxJava Stream throws any [Exception].
+ */
+class DatadogRumErrorConsumer : Consumer<Throwable> {
+
+    /** @inheritDoc */
+    override fun accept(error: Throwable) {
+        GlobalRum.get().addError(REQUEST_ERROR_MESSAGE, RumErrorSource.SOURCE, error, emptyMap())
+    }
+
+    companion object {
+        internal const val REQUEST_ERROR_MESSAGE = "RxJava stream error"
+    }
+}

--- a/dd-sdk-android-rx/src/main/kotlin/com/datadog/android/rx/DatadogRxExt.kt
+++ b/dd-sdk-android-rx/src/main/kotlin/com/datadog/android/rx/DatadogRxExt.kt
@@ -1,0 +1,58 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rx
+
+import io.reactivex.rxjava3.core.Completable
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.core.Maybe
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.core.Single
+
+/**
+ *  Returns an [Observable<T>] that will send a RUM Error event
+ *  if this [Observable<T>] emits an error.
+ *  Note that the error will also be emitted by the returned [Observable<T>]
+ */
+fun <T> Observable<T>.sendErrorToDatadog(): Observable<T> {
+    return this.doOnError(DatadogRumErrorConsumer())
+}
+
+/**
+ *  Returns a [Single<T>] that will send a RUM Error event
+ *  if this [Single<T>] emits an error.
+ *  Note that the error will also be emitted by the returned [Single<T>]
+ */
+fun <T> Single<T>.sendErrorToDatadog(): Single<T> {
+    return this.doOnError(DatadogRumErrorConsumer())
+}
+
+/**
+ *  Returns a [Flowable<T>] that will send a RUM Error event
+ *  if this [Flowable<T>] emits an error.
+ *  Note that the error will also be emitted by the returned [Flowable<T>]
+ */
+fun <T> Flowable<T>.sendErrorToDatadog(): Flowable<T> {
+    return this.doOnError(DatadogRumErrorConsumer())
+}
+
+/**
+ *  Returns an [Maybe<T>] that will send a RUM Error event
+ *  if this [Maybe<T>] emits an error.
+ *  Note that the error will also be emitted by the returned [Maybe<T>]
+ */
+fun <T> Maybe<T>.sendErrorToDatadog(): Maybe<T> {
+    return this.doOnError(DatadogRumErrorConsumer())
+}
+
+/**
+ *  Returns a [Completable] that will send a RUM Error event
+ *  if this [Completable] emits an error.
+ *  Note that the error will also be emitted by the returned [Completable]
+ */
+fun Completable.sendErrorToDatadog(): Completable {
+    return this.doOnError(DatadogRumErrorConsumer())
+}

--- a/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRumErrorConsumerTest.kt
+++ b/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRumErrorConsumerTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rx
+
+import com.datadog.android.fresco.utils.Configurator
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumMonitor
+import com.datadog.tools.unit.getStaticValue
+import com.nhaarman.mockitokotlin2.verify
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.concurrent.atomic.AtomicBoolean
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(
+        MockitoExtension::class,
+        ForgeExtension::class
+    )
+)
+@ForgeConfiguration(value = Configurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DatadogRumErrorConsumerTest {
+
+    lateinit var testedConsumer: DatadogRumErrorConsumer
+
+    @Mock
+    lateinit var mockRumMonitor: RumMonitor
+
+    @Forgery
+    lateinit var fakeException: Throwable
+
+    @BeforeEach
+    fun `set up`() {
+        GlobalRum.registerIfAbsent(mockRumMonitor)
+        testedConsumer = DatadogRumErrorConsumer()
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        val isRegistered: AtomicBoolean = GlobalRum::class.java.getStaticValue("isRegistered")
+        isRegistered.set(false)
+    }
+
+    @Test
+    fun `M send an error event W intercepting an exception`(forge: Forge) {
+        // WHEN
+        testedConsumer.accept(fakeException)
+
+        // THEN
+        verify(mockRumMonitor).addError(
+            DatadogRumErrorConsumer.REQUEST_ERROR_MESSAGE,
+            RumErrorSource.SOURCE,
+            fakeException,
+            emptyMap()
+        )
+    }
+}

--- a/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRxExtTest.kt
+++ b/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRxExtTest.kt
@@ -1,0 +1,155 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rx
+
+import com.datadog.android.fresco.utils.Configurator
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumMonitor
+import com.datadog.tools.unit.getStaticValue
+import com.nhaarman.mockitokotlin2.verify
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.reactivex.rxjava3.core.Flowable
+import io.reactivex.rxjava3.core.Observable
+import io.reactivex.rxjava3.internal.operators.completable.CompletableError
+import io.reactivex.rxjava3.internal.operators.flowable.FlowableError
+import io.reactivex.rxjava3.internal.operators.maybe.MaybeError
+import io.reactivex.rxjava3.internal.operators.observable.ObservableError
+import io.reactivex.rxjava3.internal.operators.single.SingleError
+import java.util.concurrent.atomic.AtomicBoolean
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(
+        MockitoExtension::class,
+        ForgeExtension::class
+    )
+)
+@ForgeConfiguration(value = Configurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class DatadogRxExtTest {
+
+    @Mock
+    lateinit var mockRumMonitor: RumMonitor
+
+    @Forgery
+    lateinit var fakeException: Throwable
+
+    @BeforeEach
+    fun `set up`() {
+        GlobalRum.registerIfAbsent(mockRumMonitor)
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        val isRegistered: AtomicBoolean = GlobalRum::class.java.getStaticValue("isRegistered")
+        isRegistered.set(false)
+    }
+
+    @Test
+    fun `M send an error event W exception in the stream {Observable}`(forge: Forge) {
+        // GIVEN
+        val testObservable = Observable
+            .just(0, 1, 2)
+            .concatWith(ObservableError.error(fakeException))
+
+        // WHEN
+        val testSubscriber = testObservable.sendErrorToDatadog().test()
+
+        // THEN
+        testSubscriber.assertValues(0, 1, 2)
+        testSubscriber.assertError(fakeException)
+        verify(mockRumMonitor).addError(
+            DatadogRumErrorConsumer.REQUEST_ERROR_MESSAGE,
+            RumErrorSource.SOURCE,
+            fakeException,
+            emptyMap()
+        )
+    }
+
+    @Test
+    fun `M send an error event W exception in the stream {Single}`(forge: Forge) {
+        // GIVEN
+        val testSingle = SingleError.error<Int>(fakeException)
+
+        // WHEN
+        val testSubscriber = testSingle.sendErrorToDatadog().test()
+
+        // THEN
+        testSubscriber.assertError(fakeException)
+        verify(mockRumMonitor).addError(
+            DatadogRumErrorConsumer.REQUEST_ERROR_MESSAGE,
+            RumErrorSource.SOURCE,
+            fakeException,
+            emptyMap()
+        )
+    }
+
+    @Test
+    fun `M send an error event W exception in the stream {Maybe}`(forge: Forge) {
+        // GIVEN
+        val testMaybe = MaybeError.error<Int>(fakeException)
+
+        // WHEN
+        val testSubscriber = testMaybe.sendErrorToDatadog().test()
+
+        // THEN
+        testSubscriber.assertError(fakeException)
+        verify(mockRumMonitor).addError(
+            DatadogRumErrorConsumer.REQUEST_ERROR_MESSAGE,
+            RumErrorSource.SOURCE,
+            fakeException,
+            emptyMap()
+        )
+    }
+
+    @Test
+    fun `M send an error event W exception in the stream {Completable}`(forge: Forge) {
+        // WHEN
+        CompletableError.error(fakeException).sendErrorToDatadog().test()
+
+        // THEN
+        verify(mockRumMonitor).addError(
+            DatadogRumErrorConsumer.REQUEST_ERROR_MESSAGE,
+            RumErrorSource.SOURCE,
+            fakeException,
+            emptyMap()
+        )
+    }
+
+    @Test
+    fun `M send an error event W exception in the stream {Flowable}`(forge: Forge) {
+        // GIVEN
+        val testFlowable = Flowable
+            .just(0, 1, 2)
+            .concatWith(FlowableError.error(fakeException))
+
+        // WHEN
+        val testSubscriber = testFlowable.sendErrorToDatadog().test()
+
+        // THEN
+        testSubscriber.assertValues(0, 1, 2)
+        testSubscriber.assertError(fakeException)
+        verify(mockRumMonitor).addError(
+            DatadogRumErrorConsumer.REQUEST_ERROR_MESSAGE,
+            RumErrorSource.SOURCE,
+            fakeException,
+            emptyMap()
+        )
+    }
+}

--- a/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/utils/Configurator.kt
+++ b/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/utils/Configurator.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-2020 Datadog, Inc.
+ */
+
+package com.datadog.android.fresco.utils
+
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeConfigurator
+import fr.xgouchet.elmyr.jvm.useJvmFactories
+
+internal class Configurator :
+    ForgeConfigurator {
+    override fun configure(forge: Forge) {
+        forge.addFactory(ThrowableForgeryFactory())
+        forge.useJvmFactories()
+    }
+}

--- a/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/utils/ThrowableForgeryFactory.kt
+++ b/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/utils/ThrowableForgeryFactory.kt
@@ -1,0 +1,12 @@
+package com.datadog.android.fresco.utils
+
+import com.datadog.tools.unit.forge.aThrowable
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class ThrowableForgeryFactory :
+    ForgeryFactory<Throwable> {
+    override fun getForgery(forge: Forge): Throwable {
+        return forge.aThrowable()
+    }
+}

--- a/dd-sdk-android-rx/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/dd-sdk-android-rx/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -172,6 +172,10 @@ dependencies {
     // Picasso
     "picassoImplementation"("com.squareup.picasso:picasso:2.8")
 
+    // RxJava
+    implementation(Dependencies.Libraries.RxJava)
+    implementation("com.squareup.retrofit2:adapter-rxjava3:2.9.0")
+    implementation("io.reactivex.rxjava3:rxandroid:${Dependencies.Versions.RxJava}")
     implementation(Dependencies.Libraries.Kotlin)
     implementation(Dependencies.Libraries.OkHttp)
     implementation(Dependencies.Libraries.Gson)

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -131,6 +131,7 @@ dependencies {
     api(project(":dd-sdk-android"))
     api(project(":dd-sdk-android-ktx"))
     api(project(":dd-sdk-android-ndk"))
+    api(project(":dd-sdk-android-rx"))
     api(project(":dd-sdk-android-timber"))
     "coilApi"(project(":dd-sdk-android-coil"))
     "glideApi"(project(":dd-sdk-android-glide"))

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -34,6 +34,7 @@ import com.google.gson.JsonObject
 import io.opentracing.util.GlobalTracer
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
+import retrofit2.adapter.rxjava3.RxJava3CallAdapterFactory
 import retrofit2.converter.gson.GsonConverterFactory
 import timber.log.Timber
 
@@ -53,6 +54,7 @@ class SampleApplication : Application() {
     private val retrofitClient = Retrofit.Builder()
         .baseUrl("https://api.datadoghq.com/api/v2/")
         .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
+        .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
         .client(okHttpClient)
         .build()
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/data/DataRepository.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/data/DataRepository.kt
@@ -6,50 +6,12 @@
 
 package com.datadog.android.sample.data
 
-import com.datadog.android.sample.data.model.Log
 import com.datadog.android.sample.data.model.LogsCollection
-import retrofit2.Call
-import retrofit2.Response
+import io.reactivex.rxjava3.core.Single
 
 class DataRepository(private val remoteDataSource: RemoteDataSource) {
 
-    fun getLogs(query: String, callback: Callback<List<Log>>) {
-        val call = remoteDataSource.getLogs(query)
-        call.enqueue(object : retrofit2.Callback<LogsCollection> {
-
-            override fun onFailure(call: Call<LogsCollection>, t: Throwable) {
-                callback.onFailure(Result.Failure(throwable = t))
-            }
-
-            override fun onResponse(
-                call: Call<LogsCollection>,
-                response: Response<LogsCollection>
-            ) {
-                handleResponse(response)
-            }
-
-            private fun handleResponse(response: Response<LogsCollection>) {
-                val body = response.body()
-                if (response.isSuccessful && body != null) {
-                    callback.onSuccess(Result.Success(body.data))
-                } else {
-                    callback.onFailure(
-                        Result.Failure(resolveErrorMessage(response))
-                    )
-                }
-            }
-
-            private fun resolveErrorMessage(response: Response<LogsCollection>): String? {
-                return response.errorBody()?.string() ?: "Request (${call.request().url()
-                    .url().path}) failed (${response.code()})"
-            }
-        })
-    }
-
-    interface Callback<T> {
-
-        fun onSuccess(result: Result.Success<T>)
-
-        fun onFailure(failure: Result.Failure)
+    fun getLogs(query: String): Single<LogsCollection> {
+        return remoteDataSource.getLogs(query)
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/data/RemoteDataSource.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/data/RemoteDataSource.kt
@@ -8,7 +8,7 @@ package com.datadog.android.sample.data
 
 import com.datadog.android.sample.BuildConfig
 import com.datadog.android.sample.data.model.LogsCollection
-import retrofit2.Call
+import io.reactivex.rxjava3.core.Single
 import retrofit2.http.GET
 import retrofit2.http.Headers
 import retrofit2.http.Query
@@ -21,5 +21,5 @@ interface RemoteDataSource {
         "DD-APPLICATION-KEY:${BuildConfig.DD_APPLICATION_KEY}"
     )
     @GET("logs/events")
-    fun getLogs(@Query("filter[query]") query: String): Call<LogsCollection>
+    fun getLogs(@Query("filter[query]") query: String): Single<LogsCollection>
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/datalist/DataListFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/datalist/DataListFragment.kt
@@ -28,7 +28,7 @@ class DataListFragment : Fragment() {
     override fun onActivityCreated(savedInstanceState: Bundle?) {
         super.onActivityCreated(savedInstanceState)
         viewModel =
-            SampleApplication.getViewModelFactory(context!!).create(DataListViewModel::class.java)
+            SampleApplication.getViewModelFactory(requireContext()).create(DataListViewModel::class.java)
 
         viewModel.observeLiveData().observe(viewLifecycleOwner, Observer {
             when (it) {
@@ -52,7 +52,7 @@ class DataListFragment : Fragment() {
         recyclerView.layoutManager = LinearLayoutManager(context)
         recyclerView.adapter = adapter
         fab = rootView.findViewById(R.id.fab)
-        fab.setOnClickListener { viewModel.onAddData() }
+        fab.setOnClickListener { viewModel.performRequest(DataListViewModel.UIRequest.FetchData) }
         return rootView
     }
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/logs/LogsFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/logs/LogsFragment.kt
@@ -78,17 +78,4 @@ class LogsFragment :
             return label
         }
     }
-
-    companion object {
-
-        // NDK Crash signals
-        const val SIGILL = 4 // "Illegal instruction
-        const val SIGABRT = 6 // "Abort program"
-        const val SIGSEGV = 11 // "Segmentation violation (invalid memory reference)"
-        const val SIGQUIT = 3 // Application Non Responsive (ANR)
-
-        fun newInstance(): LogsFragment {
-            return LogsFragment()
-        }
-    }
 }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -10,6 +10,7 @@ include(":dd-sdk-android-fresco")
 include(":dd-sdk-android-glide")
 include(":dd-sdk-android-ktx")
 include(":dd-sdk-android-ndk")
+include(":dd-sdk-android-rx")
 include(":dd-sdk-android-timber")
 
 include(":instrumented:benchmark")


### PR DESCRIPTION
### What does this PR do?

This PR provides helper methods/consumers for RxJava streams to intercept and send the potential Exception as RUM error events to Datadog.
For **Kotlin** codebase we are also providing extensions methods to go along with the proposed `DatadogErrorConsumer`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

