### PR TITLE
:bug: (RUMM-708): Prevent frequent retry on network layer error

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadScheduler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadScheduler.kt
@@ -33,7 +33,7 @@ internal class DataUploadScheduler(
     override fun startScheduling() {
         scheduledThreadPoolExecutor.schedule(
             runnable,
-            DataUploadRunnable.DEFAULT_DELAY,
+            DataUploadRunnable.DEFAULT_DELAY_MS,
             TimeUnit.MILLISECONDS
         )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -448,7 +448,7 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `𝕄 reduce delay between runs 𝕎 no batch availabled`(
+    fun `𝕄 increase delay between runs 𝕎 no batch available`(
         @IntForgery(16, 64) runCount: Int
     ) {
         // Given
@@ -479,7 +479,7 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `𝕄 reduce delay between runs 𝕎 batch fails and should be retried`(
+    fun `𝕄 increase delay between runs 𝕎 batch fails and should be retried`(
         @IntForgery(16, 64) runCount: Int,
         forge: Forge
     ) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -18,6 +18,7 @@ import com.datadog.android.utils.forge.Configurator
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.never
@@ -195,7 +196,7 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `no batch to send`() {
+    fun `𝕄 do nothing 𝕎 no batch to send`() {
         whenever(mockReader.readNextBatch()) doReturn null
 
         testedRunnable.run()
@@ -204,9 +205,9 @@ internal class DataUploadRunnableTest {
         verify(mockReader, never()).releaseBatch(anyOrNull())
         verifyZeroInteractions(mockDataUploader)
         verify(mockThreadPoolExecutor).schedule(
-            testedRunnable,
-            DataUploadRunnable.MAX_DELAY,
-            TimeUnit.MILLISECONDS
+            eq(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
         )
     }
 
@@ -376,43 +377,145 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `when has batches will increase the frequency up to a specific max`(
-        @Forgery batch: Batch
+    fun `𝕄 reduce delay between runs 𝕎 upload is successful`(
+        @Forgery batch: Batch,
+        @IntForgery(16, 64) runCount: Int
     ) {
+        // Given
         whenever(mockDataUploader.upload(any())) doReturn UploadStatus.SUCCESS
         whenever(mockReader.readNextBatch()).doReturn(batch)
 
-        repeat(30) {
+        // When
+        repeat(runCount) {
             testedRunnable.run()
         }
 
-        val captor = argumentCaptor<Long>()
-        verify(mockThreadPoolExecutor, times(30))
-            .schedule(same(testedRunnable), captor.capture(), eq(TimeUnit.MILLISECONDS))
-        captor.allValues.reduce { previous, next ->
-            assertThat(next).isGreaterThanOrEqualTo(DataUploadRunnable.MIN_DELAY_MS)
-            assertThat(next).isLessThan(DataUploadRunnable.DEFAULT_DELAY)
-            next
+        // Then
+        argumentCaptor<Long> {
+            verify(mockThreadPoolExecutor, times(runCount))
+                .schedule(
+                    same(testedRunnable),
+                    capture(),
+                    eq(TimeUnit.MILLISECONDS)
+                )
+
+            allValues.reduce { previous, next ->
+                assertThat(next)
+                    .isLessThanOrEqualTo(previous)
+                    .isBetween(DataUploadRunnable.MIN_DELAY_MS, DataUploadRunnable.MAX_DELAY_MS)
+                next
+            }
         }
     }
 
     @Test
-    fun `when no more batches available the scheduler delay will be increased`(
-        @Forgery batch: Batch
+    fun `𝕄 reduce delay between runs 𝕎 batch fails and should be dropped`(
+        @Forgery batch: Batch,
+        @IntForgery(16, 64) runCount: Int,
+        forge: Forge
     ) {
-        whenever(mockDataUploader.upload(any())) doReturn UploadStatus.SUCCESS
-        whenever(mockReader.readNextBatch())
-            .doReturn(batch)
-            .doReturn(null)
+        // Given
+        whenever(mockDataUploader.upload(any())) doAnswer {
+            forge.anElementFrom(
+                UploadStatus.HTTP_REDIRECTION,
+                UploadStatus.HTTP_CLIENT_ERROR,
+                UploadStatus.UNKNOWN_ERROR
+            )
+        }
+        whenever(mockReader.readNextBatch()).doReturn(batch)
 
-        repeat(2) {
+        // When
+        repeat(runCount) {
             testedRunnable.run()
         }
 
-        val captor = argumentCaptor<Long>()
-        verify(mockThreadPoolExecutor, times(2))
-            .schedule(same(testedRunnable), captor.capture(), eq(TimeUnit.MILLISECONDS))
-        verify(mockThreadPoolExecutor).remove(same(testedRunnable))
-        assertThat(captor.lastValue).isEqualTo(DataUploadRunnable.MAX_DELAY)
+        // Then
+        argumentCaptor<Long> {
+            verify(mockThreadPoolExecutor, times(runCount))
+                .schedule(
+                    same(testedRunnable),
+                    capture(),
+                    eq(TimeUnit.MILLISECONDS)
+                )
+
+            allValues.reduce { previous, next ->
+                assertThat(next)
+                    .isLessThanOrEqualTo(previous)
+                    .isBetween(DataUploadRunnable.MIN_DELAY_MS, DataUploadRunnable.MAX_DELAY_MS)
+                next
+            }
+        }
+    }
+
+    @Test
+    fun `𝕄 reduce delay between runs 𝕎 no batch availabled`(
+        @IntForgery(16, 64) runCount: Int
+    ) {
+        // Given
+        whenever(mockDataUploader.upload(any())) doReturn UploadStatus.SUCCESS
+        whenever(mockReader.readNextBatch()) doReturn null
+
+        // When
+        repeat(runCount) {
+            testedRunnable.run()
+        }
+
+        // Then
+        argumentCaptor<Long> {
+            verify(mockThreadPoolExecutor, times(runCount))
+                .schedule(
+                    same(testedRunnable),
+                    capture(),
+                    eq(TimeUnit.MILLISECONDS)
+                )
+
+            allValues.reduce { previous, next ->
+                assertThat(next)
+                    .isGreaterThanOrEqualTo(previous)
+                    .isBetween(DataUploadRunnable.MIN_DELAY_MS, DataUploadRunnable.MAX_DELAY_MS)
+                next
+            }
+        }
+    }
+
+    @Test
+    fun `𝕄 reduce delay between runs 𝕎 batch fails and should be retried`(
+        @IntForgery(16, 64) runCount: Int,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockDataUploader.upload(any())) doAnswer {
+            forge.aValueFrom(
+                UploadStatus::class.java, exclude = listOf(
+                    UploadStatus.SUCCESS,
+                    UploadStatus.HTTP_REDIRECTION,
+                    UploadStatus.HTTP_CLIENT_ERROR,
+                    UploadStatus.UNKNOWN_ERROR
+                )
+            )
+        }
+        whenever(mockReader.readNextBatch()) doReturn null
+
+        // When
+        repeat(runCount) {
+            testedRunnable.run()
+        }
+
+        // Then
+        argumentCaptor<Long> {
+            verify(mockThreadPoolExecutor, times(runCount))
+                .schedule(
+                    same(testedRunnable),
+                    capture(),
+                    eq(TimeUnit.MILLISECONDS)
+                )
+
+            allValues.reduce { previous, next ->
+                assertThat(next)
+                    .isGreaterThanOrEqualTo(previous)
+                    .isBetween(DataUploadRunnable.MIN_DELAY_MS, DataUploadRunnable.MAX_DELAY_MS)
+                next
+            }
+        }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadSchedulerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadSchedulerTest.kt
@@ -52,7 +52,7 @@ internal class DataUploadSchedulerTest {
         // Then
         verify(mockExecutor).schedule(
             any(),
-            eq(DataUploadRunnable.DEFAULT_DELAY),
+            eq(DataUploadRunnable.DEFAULT_DELAY_MS),
             eq(TimeUnit.MILLISECONDS)
         )
     }
@@ -69,7 +69,7 @@ internal class DataUploadSchedulerTest {
         val argumentCaptor = argumentCaptor<Runnable>()
         verify(mockExecutor).schedule(
             argumentCaptor.capture(),
-            eq(DataUploadRunnable.DEFAULT_DELAY),
+            eq(DataUploadRunnable.DEFAULT_DELAY_MS),
             eq(TimeUnit.MILLISECONDS)
         )
         verify(mockExecutor).remove(argumentCaptor.firstValue)


### PR DESCRIPTION
### What does this PR do?

Increase the delay between batch uploads when an error is detected.

### Motivation

When an app using the SDK is ran behind some firewalls/proxy, the data intake request can fail. This means that the workers are going to retry up to every 2 seconds to send the same batch, leading in more CPU consumption. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

