### PR TITLE
RUMM-650 Implement link between RUM Resources and APM spans

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/gitclone/GitCloneDependenciesExtension.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/gitclone/GitCloneDependenciesExtension.kt
@@ -6,15 +6,17 @@
 
 package com.datadog.gradle.plugin.gitclone
 
-open class GitCloneDependenciesExtension {
+import java.io.Serializable
 
-    internal class Dependency(
+open class GitCloneDependenciesExtension : Serializable {
+
+    internal data class Dependency(
         var originRepository: String,
         var originSubFolder: String,
         var excludedPrefixes: List<String>,
         var originRef: String,
         var destinationFolder: String
-    )
+    ) : Serializable
 
     internal val dependencies: MutableList<Dependency> = mutableListOf()
 

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -182,6 +182,7 @@ object com.datadog.android.rum.RumAttributes
   const val SOURCE: String
   const val SDK_VERSION: String
   const val TRACE_ID: String
+  const val SPAN_ID: String
   const val ERROR_RESOURCE_METHOD: String
   const val ERROR_RESOURCE_STATUS_CODE: String
   const val ERROR_RESOURCE_URL: String

--- a/dd-sdk-android/clone_rum_schema.gradle.kts
+++ b/dd-sdk-android/clone_rum_schema.gradle.kts
@@ -11,7 +11,7 @@ tasks.register<GitCloneDependenciesTask>("cloneRumSchema") {
             "https://github.com/DataDog/rum-events-format.git",
             "schemas",
             destinationFolder = "src/main/json",
-            ref = "17b48d87db4734a2e1a7e551d3c3e1c566151a7f"
+            ref = "master"
         )
     }
 }

--- a/dd-sdk-android/src/main/json/_common-schema.json
+++ b/dd-sdk-android/src/main/json/_common-schema.json
@@ -136,8 +136,8 @@
       ],
       "properties": {
         "format_version": {
-          "const": 2,
           "type": "integer",
+          "const": 2,
           "description": "Version of the RUM event format"
         }
       }

--- a/dd-sdk-android/src/main/json/action-schema.json
+++ b/dd-sdk-android/src/main/json/action-schema.json
@@ -28,7 +28,7 @@
             "type": {
               "type": "string",
               "description": "Type of the action",
-              "enum": ["custom", "click", "tap", "scroll", "swipe", "application_start"]
+              "enum": ["custom", "click", "tap", "scroll", "swipe", "application_start", "back"]
             },
             "id": {
               "type": "string",

--- a/dd-sdk-android/src/main/json/resource-schema.json
+++ b/dd-sdk-android/src/main/json/resource-schema.json
@@ -27,6 +27,11 @@
             "duration"
           ],
           "properties": {
+            "id": {
+              "type": "string",
+              "description": "UUID of the resource",
+              "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+            },
             "type": {
               "type": "string",
               "description": "Resource type",
@@ -189,6 +194,22 @@
               "type": "string",
               "description": "UUID of the action",
               "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$"
+            }
+          }
+        },
+        "_dd": {
+          "type": "object",
+          "description": "Internal properties",
+          "properties": {
+            "span_id": {
+              "type": "string",
+              "description": "span identifier in decimal format",
+              "pattern": "^[0-9]+$"
+            },
+            "trace_id": {
+              "type": "string",
+              "description": "trace identifier in decimal format",
+              "pattern": "^[0-9]+$"
             }
           }
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
@@ -144,7 +144,10 @@ internal constructor(
         val attributes = if (span == null) {
             emptyMap<String, Any?>()
         } else {
-            mapOf(RumAttributes.TRACE_ID to span.context().toTraceId())
+            mapOf(
+                RumAttributes.TRACE_ID to span.context().toTraceId(),
+                RumAttributes.SPAN_ID to span.context().toSpanId()
+            )
         }
         GlobalRum.get().stopResource(
             requestId,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -57,7 +57,13 @@ object RumAttributes {
      * Trace Id related to the resource loading. (Number)
      * This value is filled automatically by the [DatadogInterceptor].
      */
-    const val TRACE_ID: String = "trace_id"
+    const val TRACE_ID: String = "_dd.trace_id"
+
+    /**
+     * Span Id related to the resource loading. (Number)
+     * This value is filled automatically by the [DatadogInterceptor].
+     */
+    const val SPAN_ID: String = "_dd.span_id"
 
     // endregion
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -208,7 +208,7 @@ internal class RumActionScope(
 
     companion object {
         internal const val ACTION_INACTIVITY_MS = 100L
-        internal const val ACTION_MAX_DURATION_MS = 10000L
+        internal const val ACTION_MAX_DURATION_MS = 5000L
         private val ACTION_INACTIVITY_NS = TimeUnit.MILLISECONDS.toNanos(ACTION_INACTIVITY_MS)
         internal val ACTION_MAX_DURATION_NS = TimeUnit.MILLISECONDS.toNanos(ACTION_MAX_DURATION_MS)
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -18,6 +18,7 @@ import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.internal.domain.model.ErrorEvent
 import com.datadog.android.rum.internal.domain.model.ResourceEvent
+import java.util.UUID
 
 internal class RumResourceScope(
     internal val parentScope: RumScope,
@@ -28,6 +29,7 @@ internal class RumResourceScope(
     initialAttributes: Map<String, Any?>
 ) : RumScope {
 
+    internal val resourceId: String = UUID.randomUUID().toString()
     internal val attributes: MutableMap<String, Any?> = initialAttributes.toMutableMap()
     private var timing: ResourceTiming? = null
     private val initialContext = parentScope.getRumContext()
@@ -126,6 +128,7 @@ internal class RumResourceScope(
         val resourceEvent = ResourceEvent(
             date = eventTimestamp,
             resource = ResourceEvent.Resource(
+                id = resourceId,
                 type = kind.toSchemaType(),
                 url = url,
                 duration = duration,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -10,6 +10,7 @@ import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.domain.Time
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.internal.RumFeature
@@ -118,6 +119,8 @@ internal class RumResourceScope(
         writer: Writer<RumEvent>
     ) {
         attributes.putAll(GlobalRum.globalAttributes)
+        val traceId = attributes.remove(RumAttributes.TRACE_ID)?.toString()
+        val spanId = attributes.remove(RumAttributes.SPAN_ID)?.toString()
 
         val context = getRumContext()
         val user = RumFeature.userInfoProvider.getUserInfo()
@@ -157,7 +160,10 @@ internal class RumResourceScope(
                 id = context.sessionId,
                 type = ResourceEvent.Type.USER
             ),
-            dd = ResourceEvent.Dd()
+            dd = ResourceEvent.Dd(
+                traceId = traceId,
+                spanId = spanId
+            )
         )
         val rumEvent = RumEvent(
             event = resourceEvent,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
@@ -55,7 +55,8 @@ internal class DatadogInterceptorTest : TracingInterceptorTest() {
         stubChain(mockChain, statusCode)
         val expectedStartAttrs = emptyMap<String, Any?>()
         val expectedStopAttrs = mapOf(
-            RumAttributes.TRACE_ID to fakeTraceId
+            RumAttributes.TRACE_ID to fakeTraceId,
+            RumAttributes.SPAN_ID to fakeSpanId
         )
         val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type()
@@ -94,7 +95,8 @@ internal class DatadogInterceptorTest : TracingInterceptorTest() {
         stubChain(mockChain, statusCode)
         val expectedStartAttrs = emptyMap<String, Any?>()
         val expectedStopAttrs = mapOf(
-            RumAttributes.TRACE_ID to fakeTraceId
+            RumAttributes.TRACE_ID to fakeTraceId,
+            RumAttributes.SPAN_ID to fakeSpanId
         )
         val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
@@ -8,6 +8,7 @@ package com.datadog.android.rum.assertj
 
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.model.ActionEvent
 import com.datadog.android.rum.internal.domain.scope.toSchemaType
 import org.assertj.core.api.AbstractObjectAssert
@@ -19,6 +20,28 @@ internal class ActionEventAssert(actual: ActionEvent) :
         actual,
         ActionEventAssert::class.java
     ) {
+
+    fun hasId(expected: String): ActionEventAssert {
+        assertThat(actual.action.id)
+            .overridingErrorMessage(
+                "Expected event data to have action.id $expected " +
+                    "but was ${actual.action.id}"
+            )
+            .isNotEqualTo(RumContext.NULL_UUID)
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasNonNullId(): ActionEventAssert {
+        assertThat(actual.action.id)
+            .overridingErrorMessage(
+                "Expected event data to have non null action.id " +
+                    "but was ${actual.action.id}"
+            )
+            .isNotNull()
+            .isNotEqualTo(RumContext.NULL_UUID)
+        return this
+    }
 
     fun hasTimestamp(
         expected: Long,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
@@ -348,6 +348,24 @@ internal class ResourceEventAssert(actual: ResourceEvent) :
         return this
     }
 
+    fun hasTraceId(expected: String?): ResourceEventAssert {
+        assertThat(actual.dd?.traceId)
+            .overridingErrorMessage(
+                "Expected event data to have _dd.trace_id $expected but was ${actual.dd?.traceId}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasSpanId(expected: String?): ResourceEventAssert {
+        assertThat(actual.dd?.spanId)
+            .overridingErrorMessage(
+                "Expected event data to have _dd.span_id $expected but was ${actual.dd?.spanId}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     companion object {
 
         internal const val DURATION_THRESHOLD_NANOS = 1000L

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.assertj
 import com.datadog.android.core.internal.net.info.NetworkInfo
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.domain.model.ResourceEvent
 import com.datadog.android.rum.internal.domain.model.ViewEvent
@@ -23,6 +24,17 @@ internal class ResourceEventAssert(actual: ResourceEvent) :
         actual,
         ResourceEventAssert::class.java
     ) {
+
+    fun hasId(expected: String): ResourceEventAssert {
+        assertThat(actual.resource.id)
+            .overridingErrorMessage(
+                "Expected event data to have resource.id $expected " +
+                    "but was ${actual.resource.id}"
+            )
+            .isNotEqualTo(RumContext.NULL_UUID)
+            .isEqualTo(expected)
+        return this
+    }
 
     fun hasTimestamp(
         expected: Long,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/RumEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/RumEventAssert.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.rum.assertj
 
-import com.datadog.android.core.internal.net.info.NetworkInfo
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.internal.domain.model.ActionEvent
 import com.datadog.android.rum.internal.domain.model.ErrorEvent
@@ -60,16 +59,6 @@ internal class RumEventAssert(actual: RumEvent) :
 
         ErrorEventAssert(actual.event as ErrorEvent).assert()
 
-        return this
-    }
-
-    fun hasNetworkInfo(expected: NetworkInfo?): RumEventAssert {
-        // assertThat(actual.networkInfo)
-        //     .overridingErrorMessage(
-        //         "Expected RUM event to have networkInfo $expected " +
-        //             "but was ${actual.networkInfo}"
-        //     )
-        //     .isEqualTo(expected)
         return this
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -147,6 +147,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -222,6 +223,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -244,6 +246,7 @@ internal class RumActionScopeTest {
         assertThat(result2).isSameAs(testedScope)
         assertThat(result3).isNull()
     }
+
     @Test
     fun `𝕄 do nothing 𝕎 handleEvent(StartResource+StopResourceWithError+any) {unknown key}`(
         @StringForgery(StringForgeryType.ALPHABETICAL) key: String,
@@ -295,6 +298,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -341,6 +345,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -385,6 +390,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -423,6 +429,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -459,6 +466,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -496,6 +504,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -533,6 +542,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -573,6 +583,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -611,6 +622,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -655,6 +667,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(expectedAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -693,6 +706,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -731,6 +745,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -771,6 +786,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -809,6 +825,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -916,6 +933,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -951,6 +969,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -991,6 +1010,7 @@ internal class RumActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -205,6 +205,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -255,6 +256,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(expectedAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasTargetName(name)
                     hasType(type)
@@ -303,6 +305,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -354,6 +357,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -403,6 +407,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -453,6 +458,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -499,6 +505,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -551,6 +558,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -589,6 +597,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -626,6 +635,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -663,6 +673,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -703,6 +714,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -743,6 +755,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -790,6 +803,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(expectedAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -831,6 +845,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -872,6 +887,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -915,6 +931,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -956,6 +973,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -1084,6 +1102,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -1127,6 +1146,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)
@@ -1171,6 +1191,7 @@ internal class RumContinuousActionScopeTest {
             assertThat(lastValue)
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
+                    hasId(testedScope.actionId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasType(fakeType)
                     hasTargetName(fakeName)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -16,6 +16,7 @@ import com.datadog.android.log.internal.user.NoOpMutableUserInfoProvider
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.assertj.RumEventAssert.Companion.assertThat
@@ -169,6 +170,60 @@ internal class RumResourceScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
+                    hasTraceId(null)
+                    hasSpanId(null)
+                }
+        }
+        verify(mockParentScope).handleEvent(
+            isA<RumRawEvent.SentResource>(),
+            same(mockWriter)
+        )
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isEqualTo(null)
+    }
+
+    @Test
+    fun `𝕄 send Resource with trace info 𝕎 handleEvent(StopResource)`(
+        @Forgery kind: RumResourceKind,
+        @LongForgery(200, 600) statusCode: Long,
+        @LongForgery(0, 1024) size: Long,
+        @StringForgery(StringForgeryType.HEXADECIMAL) fakeSpanId: String,
+        @StringForgery(StringForgeryType.HEXADECIMAL) fakeTraceId: String,
+        forge: Forge
+    ) {
+        // Given
+        val attributes = forge.exhaustiveAttributes().toMutableMap()
+        val expectedAttributes = mutableMapOf<String, Any?>()
+        expectedAttributes.putAll(fakeAttributes)
+        expectedAttributes.putAll(attributes)
+        attributes[RumAttributes.TRACE_ID] = fakeTraceId
+        attributes[RumAttributes.SPAN_ID] = fakeSpanId
+
+        // When
+        Thread.sleep(500)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        val result = testedScope.handleEvent(mockEvent, mockWriter)
+
+        // Then
+        argumentCaptor<RumEvent> {
+            verify(mockWriter).write(capture())
+            assertThat(lastValue)
+                .hasAttributes(expectedAttributes)
+                .hasResourceData {
+                    hasId(testedScope.resourceId)
+                    hasTimestamp(fakeEventTime.timestamp)
+                    hasUrl(fakeUrl)
+                    hasMethod(fakeMethod)
+                    hasKind(kind)
+                    hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(500))
+                    hasUserInfo(fakeUserInfo)
+                    hasConnectivityInfo(fakeNetworkInfo)
+                    hasView(fakeParentContext.viewId, fakeParentContext.viewUrl)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasActionId(fakeParentContext.actionId)
+                    hasTraceId(fakeTraceId)
+                    hasSpanId(fakeSpanId)
                 }
         }
         verify(mockParentScope).handleEvent(
@@ -217,6 +272,8 @@ internal class RumResourceScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
+                    hasTraceId(null)
+                    hasSpanId(null)
                 }
         }
         verify(mockParentScope).handleEvent(
@@ -264,6 +321,8 @@ internal class RumResourceScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
+                    hasTraceId(null)
+                    hasSpanId(null)
                 }
         }
         verify(mockParentScope).handleEvent(
@@ -314,6 +373,8 @@ internal class RumResourceScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
+                    hasTraceId(null)
+                    hasSpanId(null)
                 }
         }
         verify(mockParentScope).handleEvent(
@@ -365,6 +426,8 @@ internal class RumResourceScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
+                    hasTraceId(null)
+                    hasSpanId(null)
                 }
         }
         verify(mockParentScope).handleEvent(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -157,6 +157,7 @@ internal class RumResourceScopeTest {
             assertThat(lastValue)
                 .hasAttributes(expectedAttributes)
                 .hasResourceData {
+                    hasId(testedScope.resourceId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
@@ -204,6 +205,7 @@ internal class RumResourceScopeTest {
             assertThat(lastValue)
                 .hasAttributes(expectedAttributes)
                 .hasResourceData {
+                    hasId(testedScope.resourceId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
@@ -250,6 +252,7 @@ internal class RumResourceScopeTest {
             assertThat(lastValue)
                 .hasAttributes(expectedAttributes)
                 .hasResourceData {
+                    hasId(testedScope.resourceId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
@@ -298,6 +301,7 @@ internal class RumResourceScopeTest {
             assertThat(lastValue)
                 .hasAttributes(expectedAttributes)
                 .hasResourceData {
+                    hasId(testedScope.resourceId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
@@ -348,6 +352,7 @@ internal class RumResourceScopeTest {
             assertThat(lastValue)
                 .hasAttributes(expectedAttributes)
                 .hasResourceData {
+                    hasId(testedScope.resourceId)
                     hasTimestamp(fakeEventTime.timestamp)
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -774,7 +774,6 @@ internal class RumViewScopeTest {
             verify(mockWriter, times(2)).write(capture())
             assertThat(firstValue)
                 .hasAttributes(fakeGlobalAttributes)
-                .hasNetworkInfo(null)
                 .hasActionData {
                     hasNonNullId()
                     hasTimestamp(testedScope.eventTimestamp)
@@ -790,7 +789,6 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
             assertThat(lastValue)
-                .hasNetworkInfo(null)
                 .hasAttributes(fakeAttributes + fakeGlobalAttributes)
                 .hasViewData {
                     hasTimestamp(fakeEventTime.timestamp)
@@ -929,7 +927,6 @@ internal class RumViewScopeTest {
         argumentCaptor<RumEvent> {
             verify(mockWriter, times(2)).write(capture())
             assertThat(firstValue)
-                .hasNetworkInfo(null)
                 .hasActionData {
                     hasNonNullId()
                     hasTimestamp(testedScope.eventTimestamp)
@@ -945,7 +942,6 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
             assertThat(lastValue)
-                .hasNetworkInfo(null)
                 .hasAttributes(fakeAttributes)
                 .hasViewData {
                     hasTimestamp(fakeEventTime.timestamp)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -776,6 +776,7 @@ internal class RumViewScopeTest {
                 .hasAttributes(fakeGlobalAttributes)
                 .hasNetworkInfo(null)
                 .hasActionData {
+                    hasNonNullId()
                     hasTimestamp(testedScope.eventTimestamp)
                     hasType(ActionEvent.Type1.APPLICATION_START)
                     hasNoTarget()
@@ -930,6 +931,7 @@ internal class RumViewScopeTest {
             assertThat(firstValue)
                 .hasNetworkInfo(null)
                 .hasActionData {
+                    hasNonNullId()
                     hasTimestamp(testedScope.eventTimestamp)
                     hasType(ActionEvent.Type1.APPLICATION_START)
                     hasNoTarget()


### PR DESCRIPTION
### What does this PR do?

This is the first step into letting the backend generate spans for each RUM Resource: 
 - add a UUID `resource.id` attribute on RUM Resource
 - include the `_dd.trace_id` and `_dd.span_id` attributes to hold the identifiers of the span related to the request.

Step 2 will be performed once the backend can create the spans on our behalf

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

