### PR TITLE
RUMM-736 Add app version as tag into the Crash logs

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -65,6 +65,7 @@ internal object CoreFeature {
     internal var packageVersion: String = ""
     internal var serviceName: String = ""
     internal var isMainProcess: Boolean = true
+    internal var envName: String = ""
 
     internal lateinit var dataUploadScheduledExecutor: ScheduledThreadPoolExecutor
     internal lateinit var dataPersistenceExecutorService: ExecutorService
@@ -93,6 +94,7 @@ internal object CoreFeature {
         serviceName = config.serviceName ?: appContext.packageName
         contextRef = WeakReference(appContext)
         isMainProcess = resolveIsMainProcess(appContext)
+        envName = config.envName
 
         readApplicationInformation(appContext)
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -14,6 +14,7 @@ import com.datadog.android.core.internal.sampling.RateBasedSampler
 import com.datadog.android.core.internal.utils.NULL_MAP_VALUE
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.log.internal.LogsFeature
+import com.datadog.android.log.internal.domain.LogGenerator
 import com.datadog.android.log.internal.logger.CombinedLogHandler
 import com.datadog.android.log.internal.logger.DatadogLogHandler
 import com.datadog.android.log.internal.logger.LogHandler
@@ -298,11 +299,15 @@ internal constructor(private val handler: LogHandler) {
                     null
                 }
                 DatadogLogHandler(
-                    serviceName = serviceName,
-                    loggerName = loggerName,
+                    logGenerator = LogGenerator(
+                        serviceName,
+                        loggerName,
+                        netInfoProvider,
+                        CoreFeature.userInfoProvider,
+                        CoreFeature.envName,
+                        CoreFeature.packageVersion
+                    ),
                     writer = LogsFeature.persistenceStrategy.getWriter(),
-                    networkInfoProvider = netInfoProvider,
-                    userInfoProvider = CoreFeature.userInfoProvider,
                     bundleWithTraces = bundleWithTraceEnabled,
                     bundleWithRum = bundleWithRumEnabled,
                     sampler = RateBasedSampler(sampleRate)
@@ -477,17 +482,7 @@ internal constructor(private val handler: LogHandler) {
         val combinedAttributes = mutableMapOf<String, Any?>()
         combinedAttributes.putAll(attributes)
         combinedAttributes.putAll(localAttributes)
-
-        val combinedTags = mutableSetOf<String>()
-        combinedTags.addAll(tags)
-        if (LogsFeature.envTag.isNotEmpty()) {
-            combinedTags.add(LogsFeature.envTag)
-        }
-        if (LogsFeature.appVersionTag.isNotEmpty()) {
-            combinedTags.add(LogsFeature.appVersionTag)
-        }
-
-        handler.handleLog(level, message, throwable, combinedAttributes, combinedTags, timestamp)
+        handler.handleLog(level, message, throwable, combinedAttributes, tags, timestamp)
     }
 
     private fun addTagInternal(tag: String) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -19,7 +19,6 @@ import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.net.NoOpDataUploader
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.system.SystemInfoProvider
-import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.internal.domain.Log
 import com.datadog.android.log.internal.domain.LogFileStrategy
 import com.datadog.android.log.internal.net.LogsOkHttpUploader
@@ -36,29 +35,6 @@ internal object LogsFeature {
 
     internal var clientToken: String = ""
     internal var endpointUrl: String = DatadogEndpoint.LOGS_US
-    internal var envName: String = ""
-        set(value) {
-            field = value
-            envTag = if (value.isEmpty()) {
-                ""
-            } else {
-                "${LogAttributes.ENV}:$value"
-            }
-        }
-    internal var envTag: String = ""
-        private set
-
-    internal var appVersion: String = ""
-        set(value) {
-            field = value
-            appVersionTag = if (value.isEmpty()) {
-                ""
-            } else {
-                "${LogAttributes.APPLICATION_VERSION}:$value"
-            }
-        }
-    internal var appVersionTag = ""
-
     internal var persistenceStrategy: PersistenceStrategy<Log> = NoOpPersistenceStrategy()
     internal var uploader: DataUploader = NoOpDataUploader()
     internal var dataUploadScheduler: UploadScheduler = NoOpUploadScheduler()
@@ -80,8 +56,6 @@ internal object LogsFeature {
 
         clientToken = config.clientToken
         endpointUrl = config.endpointUrl
-        envName = config.envName
-        appVersion = CoreFeature.packageVersion
         persistenceStrategy = LogFileStrategy(
             appContext,
             dataPersistenceExecutorService = dataPersistenceExecutor
@@ -113,8 +87,6 @@ internal object LogsFeature {
             persistenceStrategy = NoOpPersistenceStrategy()
             dataUploadScheduler = NoOpUploadScheduler()
             clientToken = ""
-            envName = ""
-            appVersion = ""
             endpointUrl = DatadogEndpoint.LOGS_US
 
             initialized.set(false)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogGenerator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogGenerator.kt
@@ -1,0 +1,101 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.log.internal.domain
+
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
+import com.datadog.android.log.LogAttributes
+import com.datadog.android.log.internal.user.UserInfoProvider
+import com.datadog.android.rum.GlobalRum
+import io.opentracing.util.GlobalTracer
+
+internal class LogGenerator(
+    internal val serviceName: String,
+    internal val loggerName: String,
+    internal val networkInfoProvider: NetworkInfoProvider?,
+    internal val userInfoProvider: UserInfoProvider,
+    envName: String,
+    appVersion: String
+) {
+
+    private val envTag: String? = if (envName.isNotEmpty()) {
+        "${LogAttributes.ENV}:$envName"
+    } else {
+        null
+    }
+
+    private val appVersionTag = if (appVersion.isNotEmpty()) {
+        "${LogAttributes.APPLICATION_VERSION}:$appVersion"
+    } else {
+        null
+    }
+
+    @Suppress("LongParameterList")
+    fun generateLog(
+        level: Int,
+        message: String,
+        throwable: Throwable?,
+        attributes: Map<String, Any?>,
+        tags: Set<String>,
+        timestamp: Long,
+        threadName: String? = null,
+        bundleWithTraces: Boolean = true,
+        bundleWithRum: Boolean = true
+    ): Log {
+        val combinedAttributes = resolveAttributes(attributes, bundleWithTraces, bundleWithRum)
+        val combinedTags = resolveTags(tags)
+        return Log(
+            serviceName = serviceName,
+            level = level,
+            message = message,
+            timestamp = timestamp,
+            throwable = throwable,
+            attributes = combinedAttributes,
+            tags = combinedTags.toList(),
+            networkInfo = networkInfoProvider?.getLatestNetworkInfo(),
+            userInfo = userInfoProvider.getUserInfo(),
+            loggerName = loggerName,
+            threadName = threadName ?: Thread.currentThread().name
+        )
+    }
+
+    private fun resolveTags(
+        tags: Set<String>
+    ): MutableSet<String> {
+        val combinedTags = mutableSetOf<String>().apply { addAll(tags) }
+        envTag?.let {
+            combinedTags.add(it)
+        }
+        appVersionTag?.let {
+            combinedTags.add(it)
+        }
+
+        return combinedTags
+    }
+
+    private fun resolveAttributes(
+        attributes: Map<String, Any?>,
+        bundleWithTraces: Boolean,
+        bundleWithRum: Boolean
+    ): MutableMap<String, Any?> {
+        val combinedAttributes = mutableMapOf<String, Any?>().apply { putAll(attributes) }
+        if (bundleWithTraces && GlobalTracer.isRegistered()) {
+            val tracer = GlobalTracer.get()
+            val activeContext = tracer.activeSpan()?.context()
+            if (activeContext != null) {
+                combinedAttributes[LogAttributes.DD_TRACE_ID] = activeContext.toTraceId()
+                combinedAttributes[LogAttributes.DD_SPAN_ID] = activeContext.toSpanId()
+            }
+        }
+        if (bundleWithRum && GlobalRum.isRegistered()) {
+            val activeContext = GlobalRum.getRumContext()
+            combinedAttributes[LogAttributes.RUM_APPLICATION_ID] = activeContext.applicationId
+            combinedAttributes[LogAttributes.RUM_SESSION_ID] = activeContext.sessionId
+            combinedAttributes[LogAttributes.RUM_VIEW_ID] = activeContext.viewId
+        }
+        return combinedAttributes
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -8,22 +8,16 @@ package com.datadog.android.log.internal.logger
 
 import android.util.Log as AndroidLog
 import com.datadog.android.core.internal.data.Writer
-import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.sampling.RateBasedSampler
 import com.datadog.android.core.internal.sampling.Sampler
-import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.internal.domain.Log
-import com.datadog.android.log.internal.user.UserInfoProvider
+import com.datadog.android.log.internal.domain.LogGenerator
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumErrorSource
-import io.opentracing.util.GlobalTracer
 
 internal class DatadogLogHandler(
-    internal val serviceName: String,
-    internal val loggerName: String,
+    internal val logGenerator: LogGenerator,
     internal val writer: Writer<Log>,
-    internal val networkInfoProvider: NetworkInfoProvider?,
-    internal val userInfoProvider: UserInfoProvider,
     internal val bundleWithTraces: Boolean = true,
     internal val bundleWithRum: Boolean = true,
     internal val sampler: Sampler = RateBasedSampler(1.0f)
@@ -63,33 +57,15 @@ internal class DatadogLogHandler(
         tags: Set<String>,
         timestamp: Long
     ): Log {
-        val logAttrs = attributes.toMutableMap()
-        if (bundleWithTraces && GlobalTracer.isRegistered()) {
-            val tracer = GlobalTracer.get()
-            val activeContext = tracer.activeSpan()?.context()
-            if (activeContext != null) {
-                logAttrs[LogAttributes.DD_TRACE_ID] = activeContext.toTraceId()
-                logAttrs[LogAttributes.DD_SPAN_ID] = activeContext.toSpanId()
-            }
-        }
-        if (bundleWithRum && GlobalRum.isRegistered()) {
-            val activeContext = GlobalRum.getRumContext()
-            logAttrs[LogAttributes.RUM_APPLICATION_ID] = activeContext.applicationId
-            logAttrs[LogAttributes.RUM_SESSION_ID] = activeContext.sessionId
-            logAttrs[LogAttributes.RUM_VIEW_ID] = activeContext.viewId
-        }
-        return Log(
-            serviceName = serviceName,
-            level = level,
-            message = message,
-            timestamp = timestamp,
-            throwable = throwable,
-            attributes = logAttrs,
-            tags = tags.toList(),
-            networkInfo = networkInfoProvider?.getLatestNetworkInfo(),
-            userInfo = userInfoProvider.getUserInfo(),
-            loggerName = loggerName,
-            threadName = Thread.currentThread().name
+        return logGenerator.generateLog(
+            level,
+            message,
+            throwable,
+            attributes,
+            tags,
+            timestamp,
+            bundleWithRum = bundleWithRum,
+            bundleWithTraces = bundleWithTraces
         )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -15,7 +15,6 @@ import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.error.internal.CrashReportsFeature
 import com.datadog.android.log.EndpointUpdateStrategy
-import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.log.internal.user.MutableUserInfoProvider
@@ -283,11 +282,7 @@ internal class DatadogTest {
         verify(mockDevLogHandler)
             .handleLog(
                 AndroidLog.WARN,
-                String.format(Locale.US, Datadog.MESSAGE_DEPRECATED, "setEndpointUrl()"),
-                tags = setOf(
-                    "${LogAttributes.ENV}:$fakeEnvName",
-                    "${LogAttributes.APPLICATION_VERSION}:$fakePackageVersion"
-                )
+                String.format(Locale.US, Datadog.MESSAGE_DEPRECATED, "setEndpointUrl()")
             )
     }
 
@@ -306,11 +301,7 @@ internal class DatadogTest {
         verify(mockDevLogHandler)
             .handleLog(
                 AndroidLog.WARN,
-                String.format(Locale.US, Datadog.MESSAGE_DEPRECATED, "setEndpointUrl()"),
-                tags = setOf(
-                    "${LogAttributes.ENV}:$fakeEnvName",
-                    "${LogAttributes.APPLICATION_VERSION}:$fakePackageVersion"
-                )
+                String.format(Locale.US, Datadog.MESSAGE_DEPRECATED, "setEndpointUrl()")
             )
     }
 
@@ -339,11 +330,7 @@ internal class DatadogTest {
         verify(mockDevLogHandler)
             .handleLog(
                 AndroidLog.WARN,
-                Datadog.MESSAGE_ALREADY_INITIALIZED,
-                tags = setOf(
-                    "${LogAttributes.ENV}:$fakeEnvName",
-                    "${LogAttributes.APPLICATION_VERSION}:$fakePackageVersion"
-                )
+                Datadog.MESSAGE_ALREADY_INITIALIZED
             )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -35,6 +35,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.RegexForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.util.concurrent.ScheduledThreadPoolExecutor
@@ -67,6 +68,9 @@ internal class CoreFeatureTest {
     lateinit var mockConnectivityMgr: ConnectivityManager
     lateinit var fakePackageName: String
     lateinit var fakePackageVersion: String
+
+    @RegexForgery("[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]")
+    lateinit var fakeEnvName: String
 
     @BeforeEach
     fun `set up`(forge: Forge) {
@@ -262,6 +266,7 @@ internal class CoreFeatureTest {
         assertThat(CoreFeature.isMainProcess).isTrue()
     }
 
+    @Test
     fun `if this process does not match the package name it will be marked as secondary process`(
         forge: Forge
     ) {
@@ -315,6 +320,15 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(CoreFeature.isMainProcess).isTrue()
+    }
+
+    @Test
+    fun `M initialise the env name W provided from Config`() {
+        // WHEN
+        CoreFeature.initialize(mockAppContext, DatadogConfig.CoreConfig(envName = fakeEnvName))
+
+        // THEN
+        assertThat(CoreFeature.envName).isEqualTo(fakeEnvName)
     }
 
     // region internal

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -160,8 +160,8 @@ internal class DatadogExceptionHandlerTest {
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
                 .hasTimestampAround(now)
-                .hasTags(listOf("env:$envName"))
-                .hasAttributes(emptyMap())
+                .hasExactlyTags(listOf("env:$envName"))
+                .hasExactlyAttributes(emptyMap())
         }
         verifyZeroInteractions(mockPreviousHandler)
     }
@@ -205,8 +205,8 @@ internal class DatadogExceptionHandlerTest {
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
                 .hasTimestampAround(now)
-                .hasTags(listOf("env:$envName"))
-                .hasAttributes(emptyMap())
+                .hasExactlyTags(listOf("env:$envName"))
+                .hasExactlyAttributes(emptyMap())
         }
         verify(mockPreviousHandler).uncaughtException(currentThread, fakeThrowable)
     }
@@ -229,8 +229,8 @@ internal class DatadogExceptionHandlerTest {
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
                 .hasTimestampAround(now)
-                .hasTags(emptyList())
-                .hasAttributes(emptyMap())
+                .hasExactlyTags(emptyList())
+                .hasExactlyAttributes(emptyMap())
         }
         verify(mockPreviousHandler).uncaughtException(currentThread, fakeThrowable)
     }
@@ -260,8 +260,8 @@ internal class DatadogExceptionHandlerTest {
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
                 .hasTimestampAround(now)
-                .hasTags(listOf("env:$envName"))
-                .hasAttributes(emptyMap())
+                .hasExactlyTags(listOf("env:$envName"))
+                .hasExactlyAttributes(emptyMap())
         }
         verify(mockPreviousHandler).uncaughtException(thread, fakeThrowable)
     }
@@ -282,7 +282,7 @@ internal class DatadogExceptionHandlerTest {
             verify(mockLogWriter).write(capture())
 
             assertThat(lastValue)
-                .hasAttributes(
+                .hasExactlyAttributes(
                     mapOf(
                         LogAttributes.DD_TRACE_ID to tracer.traceId,
                         LogAttributes.DD_SPAN_ID to tracer.spanId
@@ -321,7 +321,7 @@ internal class DatadogExceptionHandlerTest {
             verify(mockLogWriter).write(capture())
 
             assertThat(lastValue)
-                .hasAttributes(
+                .hasExactlyAttributes(
                     mapOf(
                         LogAttributes.RUM_APPLICATION_ID to rumContext.applicationId,
                         LogAttributes.RUM_SESSION_ID to rumContext.sessionId,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -10,8 +10,10 @@ import android.app.Application
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.impl.WorkManagerImpl
+import com.datadog.android.BuildConfig
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogConfig
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.data.upload.UploadWorker
 import com.datadog.android.core.internal.net.info.NetworkInfo
@@ -21,6 +23,7 @@ import com.datadog.android.core.internal.utils.UPLOAD_WORKER_NAME
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.assertj.LogAssert.Companion.assertThat
 import com.datadog.android.log.internal.domain.Log
+import com.datadog.android.log.internal.domain.LogGenerator
 import com.datadog.android.log.internal.user.UserInfo
 import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.rum.GlobalRum
@@ -44,6 +47,7 @@ import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.RegexForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -102,28 +106,33 @@ internal class DatadogExceptionHandlerTest {
     @Forgery
     lateinit var fakeUserInfo: UserInfo
 
-    @StringForgery(StringForgeryType.ALPHABETICAL)
-    lateinit var fakeEnv: String
-
     @StringForgery(StringForgeryType.HEXADECIMAL)
     lateinit var fakeToken: String
+
+    @RegexForgery("[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]")
+    lateinit var fakeEnvName: String
 
     @BeforeEach
     fun `set up`() {
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
         whenever(mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
-
         val mockContext: Application = mockContext()
-        val config = DatadogConfig.Builder(fakeToken, fakeEnv).build()
+        val config = DatadogConfig.Builder(fakeToken, fakeEnvName).build()
         Datadog.initialize(mockContext(), config)
 
         originalHandler = Thread.getDefaultUncaughtExceptionHandler()
         Thread.setDefaultUncaughtExceptionHandler(mockPreviousHandler)
         testedHandler = DatadogExceptionHandler(
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockLogWriter,
-            mockContext
+            LogGenerator(
+                CoreFeature.serviceName,
+                DatadogExceptionHandler.LOGGER_NAME,
+                mockNetworkInfoProvider,
+                mockUserInfoProvider,
+                CoreFeature.envName,
+                CoreFeature.packageVersion
+            ),
+            writer = mockLogWriter,
+            appContext = mockContext
         )
         testedHandler.register()
     }
@@ -140,9 +149,7 @@ internal class DatadogExceptionHandlerTest {
     }
 
     @Test
-    fun `log exception when caught with no previous handler`(forge: Forge) {
-        val envName = forge.anAlphaNumericalString()
-        CrashReportsFeature.envName = envName
+    fun `M log exception W caught with no previous handler`(forge: Forge) {
         Thread.setDefaultUncaughtExceptionHandler(null)
         testedHandler.register()
         val currentThread = Thread.currentThread()
@@ -160,14 +167,19 @@ internal class DatadogExceptionHandlerTest {
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
                 .hasTimestampAround(now)
-                .hasExactlyTags(listOf("env:$envName"))
+                .hasExactlyTags(
+                    listOf(
+                        "${LogAttributes.ENV}:$fakeEnvName",
+                        "${LogAttributes.APPLICATION_VERSION}:${BuildConfig.VERSION_NAME}"
+                    )
+                )
                 .hasExactlyAttributes(emptyMap())
         }
         verifyZeroInteractions(mockPreviousHandler)
     }
 
     @Test
-    fun `schedules the worker when logging an exception`(forge: Forge) {
+    fun `M schedule the worker W logging an exception`(forge: Forge) {
         WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
         Thread.setDefaultUncaughtExceptionHandler(null)
         testedHandler.register()
@@ -187,9 +199,7 @@ internal class DatadogExceptionHandlerTest {
     }
 
     @Test
-    fun `log exception when caught`(forge: Forge) {
-        val envName = forge.anAlphaNumericalString()
-        CrashReportsFeature.envName = envName
+    fun `M log exception W caught`(forge: Forge) {
         val currentThread = Thread.currentThread()
 
         val now = System.currentTimeMillis()
@@ -205,40 +215,19 @@ internal class DatadogExceptionHandlerTest {
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
                 .hasTimestampAround(now)
-                .hasExactlyTags(listOf("env:$envName"))
+                .hasExactlyTags(
+                    listOf(
+                        "${LogAttributes.ENV}:$fakeEnvName",
+                        "${LogAttributes.APPLICATION_VERSION}:${BuildConfig.VERSION_NAME}"
+                    )
+                )
                 .hasExactlyAttributes(emptyMap())
         }
         verify(mockPreviousHandler).uncaughtException(currentThread, fakeThrowable)
     }
 
     @Test
-    fun `log exception when caught without env name`(forge: Forge) {
-        CrashReportsFeature.envName = ""
-        val currentThread = Thread.currentThread()
-
-        val now = System.currentTimeMillis()
-        testedHandler.uncaughtException(currentThread, fakeThrowable)
-
-        argumentCaptor<Log> {
-            verify(mockLogWriter).write(capture())
-            assertThat(lastValue)
-                .hasThreadName(currentThread.name)
-                .hasMessage("Application crash detected")
-                .hasLevel(Log.CRASH)
-                .hasThrowable(fakeThrowable)
-                .hasNetworkInfo(fakeNetworkInfo)
-                .hasUserInfo(fakeUserInfo)
-                .hasTimestampAround(now)
-                .hasExactlyTags(emptyList())
-                .hasExactlyAttributes(emptyMap())
-        }
-        verify(mockPreviousHandler).uncaughtException(currentThread, fakeThrowable)
-    }
-
-    @Test
-    fun `log exception when caught on background thread`(forge: Forge) {
-        val envName = forge.anAlphaNumericalString()
-        CrashReportsFeature.envName = envName
+    fun `M log exception W caught on background thread`(forge: Forge) {
         val latch = CountDownLatch(1)
         val threadName = forge.anAlphabeticalString()
         val thread = Thread({
@@ -260,14 +249,19 @@ internal class DatadogExceptionHandlerTest {
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
                 .hasTimestampAround(now)
-                .hasExactlyTags(listOf("env:$envName"))
+                .hasExactlyTags(
+                    listOf(
+                        "${LogAttributes.ENV}:$fakeEnvName",
+                        "${LogAttributes.APPLICATION_VERSION}:${BuildConfig.VERSION_NAME}"
+                    )
+                )
                 .hasExactlyAttributes(emptyMap())
         }
         verify(mockPreviousHandler).uncaughtException(thread, fakeThrowable)
     }
 
     @Test
-    fun `add current span information when tracer is active`(
+    fun `M add current span information W tracer is active`(
         @StringForgery(StringForgeryType.ALPHABETICAL) operation: String
     ) {
         val currentThread = Thread.currentThread()
@@ -293,7 +287,7 @@ internal class DatadogExceptionHandlerTest {
     }
 
     @Test
-    fun `register RUM Error with crash when RumMonitor registered`() {
+    fun `M register RUM Error with crash W RumMonitor registered`() {
         val currentThread = Thread.currentThread()
         GlobalRum.registerIfAbsent(mockRumMonitor)
 
@@ -308,7 +302,7 @@ internal class DatadogExceptionHandlerTest {
     }
 
     @Test
-    fun `add current RUM information when GlobalRum is active`(
+    fun `M add current RUM information W GlobalRum is active`(
         @Forgery rumContext: RumContext
     ) {
         val currentThread = Thread.currentThread()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -90,9 +90,9 @@ internal class LoggerBuilderTest {
             .build()
 
         val handler: DatadogLogHandler = logger.getFieldValue("handler")
-        assertThat(handler.serviceName).isEqualTo(CoreFeature.serviceName)
-        assertThat(handler.loggerName).isEqualTo(fakePackageName)
-        assertThat(handler.networkInfoProvider).isNull()
+        assertThat(handler.logGenerator.serviceName).isEqualTo(CoreFeature.serviceName)
+        assertThat(handler.logGenerator.loggerName).isEqualTo(fakePackageName)
+        assertThat(handler.logGenerator.networkInfoProvider).isNull()
         assertThat(handler.writer).isNotNull()
         assertThat(handler.bundleWithTraces).isTrue()
         assertThat(handler.sampler).isInstanceOf(RateBasedSampler::class.java)
@@ -108,7 +108,7 @@ internal class LoggerBuilderTest {
             .build()
 
         val handler: DatadogLogHandler = logger.getFieldValue("handler")
-        assertThat(handler.serviceName).isEqualTo(serviceName)
+        assertThat(handler.logGenerator.serviceName).isEqualTo(serviceName)
     }
 
     @Test
@@ -172,7 +172,7 @@ internal class LoggerBuilderTest {
             .build()
 
         val handler: DatadogLogHandler = logger.getFieldValue("handler")
-        assertThat(handler.networkInfoProvider).isNotNull()
+        assertThat(handler.logGenerator.networkInfoProvider).isNotNull()
     }
 
     @Test
@@ -184,7 +184,7 @@ internal class LoggerBuilderTest {
             .build()
 
         val handler: DatadogLogHandler = logger.getFieldValue("handler")
-        assertThat(handler.loggerName).isEqualTo(loggerName)
+        assertThat(handler.logGenerator.loggerName).isEqualTo(loggerName)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.log
 
 import android.util.Log
 import com.datadog.android.core.internal.utils.NULL_MAP_VALUE
-import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.utils.forge.Configurator
 import com.google.gson.JsonArray
@@ -26,7 +25,6 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -52,16 +50,8 @@ internal class LoggerTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        LogsFeature.envName = ""
-        LogsFeature.appVersion = ""
         fakeMessage = forge.anAlphabeticalString()
         testedLogger = Logger(mockLogHandler)
-    }
-
-    @AfterEach
-    fun `tear down`() {
-        LogsFeature.envName = ""
-        LogsFeature.appVersion = ""
     }
 
     // region Log
@@ -706,62 +696,6 @@ internal class LoggerTest {
     // endregion
 
     // region Tags
-
-    @Test
-    fun `adds env tag if present`(forge: Forge) {
-        val envName = forge.anAlphabeticalString()
-        LogsFeature.envName = envName
-
-        testedLogger.i(fakeMessage)
-
-        verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                setOf("${LogAttributes.ENV}:$envName")
-            )
-    }
-
-    @Test
-    fun `adds app version tag if present`(forge: Forge) {
-        val appVersion = forge.aStringMatching("[0-9]\\.[0-9]\\.[0-9]")
-        LogsFeature.appVersion = appVersion
-
-        testedLogger.i(fakeMessage)
-
-        verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                setOf("${LogAttributes.APPLICATION_VERSION}:$appVersion")
-            )
-    }
-
-    @Test
-    fun `adds app version tag and env tag if both present`(forge: Forge) {
-        val appVersion = forge.aStringMatching("[0-9]\\.[0-9]\\.[0-9]")
-        LogsFeature.appVersion = appVersion
-        val envName = forge.anAlphabeticalString()
-        LogsFeature.envName = envName
-
-        testedLogger.i(fakeMessage)
-
-        verify(mockLogHandler)
-            .handleLog(
-                Log.INFO,
-                fakeMessage,
-                null,
-                emptyMap(),
-                setOf(
-                    "${LogAttributes.ENV}:$envName",
-                    "${LogAttributes.APPLICATION_VERSION}:$appVersion"
-                )
-            )
-    }
 
     @Test
     fun `add simple tag to logger`(forge: Forge) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/LogAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/LogAssert.kt
@@ -61,6 +61,15 @@ internal class LogAssert(actual: Log) :
         return this
     }
 
+    fun hasTimestamp(expected: Long): LogAssert {
+        assertThat(actual.timestamp)
+            .overridingErrorMessage(
+                "Expected log to have timestamp $expected but was ${actual.timestamp}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     fun hasExactlyAttributes(attributes: Map<String, Any?>): LogAssert {
         assertThat(actual.attributes)
             .hasSameSizeAs(attributes)
@@ -93,6 +102,16 @@ internal class LogAssert(actual: Log) :
                     "but was ${actual.networkInfo}"
             )
             .isEqualTo(expected)
+        return this
+    }
+
+    fun doesNotHaveNetworkInfo(): LogAssert {
+        assertThat(actual.networkInfo)
+            .overridingErrorMessage(
+                "Expected log to not have a networkInfo " +
+                    "but instead it had ${actual.networkInfo}"
+            )
+            .isNull()
         return this
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/LogAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/LogAssert.kt
@@ -61,16 +61,28 @@ internal class LogAssert(actual: Log) :
         return this
     }
 
-    fun hasAttributes(attributes: Map<String, Any?>): LogAssert {
+    fun hasExactlyAttributes(attributes: Map<String, Any?>): LogAssert {
         assertThat(actual.attributes)
             .hasSameSizeAs(attributes)
             .containsAllEntriesOf(attributes)
         return this
     }
 
-    fun hasTags(tags: Collection<String>): LogAssert {
+    fun hasExactlyTags(tags: Collection<String>): LogAssert {
         assertThat(actual.tags)
             .containsExactlyInAnyOrder(*tags.toTypedArray())
+        return this
+    }
+
+    fun containsTags(tags: Collection<String>): LogAssert {
+        assertThat(actual.tags)
+            .contains(*tags.toTypedArray())
+        return this
+    }
+
+    fun containsAttributes(attributes: Map<String, Any?>): LogAssert {
+        assertThat(actual.attributes)
+            .containsAllEntriesOf(attributes)
         return this
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/LogGeneratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/LogGeneratorTest.kt
@@ -1,0 +1,572 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.log.internal.domain
+
+import com.datadog.android.core.internal.net.info.NetworkInfo
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
+import com.datadog.android.log.LogAttributes
+import com.datadog.android.log.assertj.LogAssert.Companion.assertThat
+import com.datadog.android.log.internal.user.UserInfo
+import com.datadog.android.log.internal.user.UserInfoProvider
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumMonitor
+import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.forge.aThrowable
+import com.datadog.tools.unit.setStaticValue
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.whenever
+import datadog.opentracing.DDSpanContext
+import datadog.trace.api.interceptor.MutableSpan
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.opentracing.Span
+import io.opentracing.Tracer
+import io.opentracing.util.GlobalTracer
+import java.util.UUID
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class LogGeneratorTest {
+
+    lateinit var testedLogGenerator: LogGenerator
+
+    @Mock
+    lateinit var mockNetworkInfoProvider: NetworkInfoProvider
+
+    @Mock
+    lateinit var mockRumMonitor: RumMonitor
+
+    @Mock
+    lateinit var mockTracer: Tracer
+
+    @Mock
+    lateinit var mockSpanContext: DDSpanContext
+
+    @Mock(extraInterfaces = [MutableSpan::class])
+    lateinit var mockSpan: Span
+
+    @Mock
+    lateinit var mockUserInfoProvider: UserInfoProvider
+    lateinit var fakeServiceName: String
+    lateinit var fakeLoggerName: String
+    lateinit var fakeAttributes: Map<String, Any?>
+    lateinit var fakeTags: Set<String>
+    lateinit var fakeAppVersion: String
+    lateinit var fakeEnvName: String
+    lateinit var fakeLogMessage: String
+    lateinit var fakeThrowable: Throwable
+
+    @StringForgery(StringForgeryType.HEXADECIMAL)
+    lateinit var fakeSpanId: String
+
+    @StringForgery(StringForgeryType.HEXADECIMAL)
+    lateinit var fakeTraceId: String
+
+    @Forgery
+    lateinit var fakeNetworkInfo: NetworkInfo
+
+    @Forgery
+    lateinit var fakeUserInfo: UserInfo
+    var fakeTimestamp = 0L
+    var fakeLevel: Int = 0
+    lateinit var fakeAppId: String
+    lateinit var fakeSessionId: String
+    lateinit var fakeViewId: String
+    lateinit var fakeThreadName: String
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        fakeServiceName = forge.anAlphabeticalString()
+        fakeLoggerName = forge.anAlphabeticalString()
+        fakeLogMessage = forge.anAlphabeticalString()
+        fakeLevel = forge.anInt(2, 8)
+        fakeAttributes = forge.aMap { anAlphabeticalString() to anInt() }
+        fakeTags = forge.aList { anAlphabeticalString() }.toSet()
+        fakeAppVersion = forge.aStringMatching("^[0-9]\\.[0-9]\\.[0-9]")
+        fakeEnvName = forge.aStringMatching("[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]")
+        fakeThrowable = forge.aThrowable()
+        fakeTimestamp = System.currentTimeMillis()
+        fakeAppId = UUID.randomUUID().toString()
+        fakeSessionId = UUID.randomUUID().toString()
+        fakeViewId = forge.anAlphabeticalString()
+        fakeThreadName = forge.anAlphabeticalString()
+
+        whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
+        whenever(mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
+        whenever(mockTracer.activeSpan()).thenReturn(mockSpan)
+        whenever(mockSpan.context()) doReturn mockSpanContext
+        whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
+        whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
+        GlobalRum.updateRumContext(RumContext(fakeAppId, fakeSessionId, fakeViewId))
+        GlobalRum.registerIfAbsent(mockRumMonitor)
+        GlobalTracer.registerIfAbsent(mockTracer)
+        testedLogGenerator = LogGenerator(
+            fakeServiceName,
+            fakeLoggerName,
+            mockNetworkInfoProvider,
+            mockUserInfoProvider,
+            fakeEnvName,
+            fakeAppVersion
+        )
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        GlobalRum.isRegistered.set(false)
+        GlobalTracer::class.java.setStaticValue("isRegistered", false)
+    }
+
+    @Test
+    fun `M add log message W creating the Log`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).hasMessage(fakeLogMessage)
+    }
+
+    @Test
+    fun `M add the log level W creating the Log`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).hasLevel(fakeLevel)
+    }
+
+    @Test
+    fun `M add the service name W creating the Log`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).hasServiceName(fakeServiceName)
+    }
+
+    @Test
+    fun `M add the logger name W creating the Log`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).hasLoggerName(fakeLoggerName)
+    }
+
+    @Test
+    fun `M add the thread name W creating the Log`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp,
+            fakeThreadName
+        )
+
+        // THEN
+        assertThat(log).hasThreadName(fakeThreadName)
+    }
+
+    @Test
+    fun `M add the thread name as current thread W creating the Log {threadName not provided}`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).hasThreadName(Thread.currentThread().name)
+    }
+
+    @Test
+    fun `M add the log timestamp W creating the Log`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).hasTimestamp(fakeTimestamp)
+    }
+
+    @Test
+    fun `M add the throwable W creating the Log`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).hasThrowable(fakeThrowable)
+    }
+
+    @Test
+    fun `M add the userNetworkInfo W creating the Log`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).hasUserInfo(fakeUserInfo)
+    }
+
+    @Test
+    fun `M add the networkInfo W creating the Log`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).hasNetworkInfo(fakeNetworkInfo)
+    }
+
+    @Test
+    fun `M not add the networkInfo W creating Log {networkInfoProvider is null}`() {
+        // GIVEN
+        testedLogGenerator = LogGenerator(
+            fakeServiceName,
+            fakeLoggerName,
+            null,
+            mockUserInfoProvider,
+            fakeEnvName,
+            fakeAppVersion
+        )
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).doesNotHaveNetworkInfo()
+    }
+
+    @Test
+    fun `M add the envNameTag W not empty`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).containsTags(listOf("${LogAttributes.ENV}:$fakeEnvName"))
+    }
+
+    @Test
+    fun `M not add the envNameTag W empty`() {
+        // GIVEN
+        testedLogGenerator = LogGenerator(
+            fakeServiceName,
+            fakeLoggerName,
+            mockNetworkInfoProvider,
+            mockUserInfoProvider,
+            "",
+            fakeAppVersion
+        )
+
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        val expectedTags = fakeTags + "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"
+        assertThat(log).hasExactlyTags(expectedTags)
+    }
+
+    @Test
+    fun `M add the appVersionTag W not empty`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).containsTags(listOf("${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"))
+    }
+
+    @Test
+    fun `M not add the appVersionTag W not empty`() {
+        // GIVEN
+        testedLogGenerator = LogGenerator(
+            fakeServiceName,
+            fakeLoggerName,
+            mockNetworkInfoProvider,
+            mockUserInfoProvider,
+            fakeEnvName,
+            ""
+        )
+
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        val expectedTags = fakeTags + "${LogAttributes.ENV}:$fakeEnvName"
+        assertThat(log).hasExactlyTags(expectedTags)
+    }
+
+    @Test
+    fun `M bundle the trace information W required`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).containsAttributes(
+            mapOf(
+                LogAttributes.DD_TRACE_ID to fakeTraceId,
+                LogAttributes.DD_SPAN_ID to fakeSpanId
+            )
+        )
+    }
+
+    @Test
+    fun `M do nothing W required to bundle the trace information {no active Span}`() {
+        // GIVEN
+        whenever(mockTracer.activeSpan()).doReturn(null)
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        val expectedAttributes = fakeAttributes + mapOf(
+            LogAttributes.RUM_APPLICATION_ID to fakeAppId,
+            LogAttributes.RUM_SESSION_ID to fakeSessionId,
+            LogAttributes.RUM_VIEW_ID to fakeViewId
+        )
+        assertThat(log).hasExactlyAttributes(expectedAttributes)
+    }
+
+    @Test
+    fun `M do nothing W required to bundle the trace information {AndroidTracer not registered}`() {
+        // GIVEN
+        GlobalTracer::class.java.setStaticValue("isRegistered", false)
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        val expectedAttributes = fakeAttributes + mapOf(
+            LogAttributes.RUM_APPLICATION_ID to fakeAppId,
+            LogAttributes.RUM_SESSION_ID to fakeSessionId,
+            LogAttributes.RUM_VIEW_ID to fakeViewId
+        )
+        assertThat(log).hasExactlyAttributes(expectedAttributes)
+    }
+
+    @Test
+    fun `M do nothing W not required to bundle the trace information`() {
+        // GIVEN
+        GlobalTracer::class.java.setStaticValue("isRegistered", false)
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp,
+            bundleWithTraces = false
+        )
+
+        // THEN
+        val expectedAttributes = fakeAttributes + mapOf(
+            LogAttributes.RUM_APPLICATION_ID to fakeAppId,
+            LogAttributes.RUM_SESSION_ID to fakeSessionId,
+            LogAttributes.RUM_VIEW_ID to fakeViewId
+        )
+        assertThat(log).hasExactlyAttributes(expectedAttributes)
+    }
+
+    @Test
+    fun `M bundle the RUM information W required`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        assertThat(log).containsAttributes(
+            mapOf(
+                LogAttributes.RUM_APPLICATION_ID to fakeAppId,
+                LogAttributes.RUM_SESSION_ID to fakeSessionId,
+                LogAttributes.RUM_VIEW_ID to fakeViewId
+            )
+        )
+    }
+
+    @Test
+    fun `M do nothing W required to bundle the rum information {RumMonitor not registered}`() {
+        // GIVEN
+        GlobalRum.isRegistered.set(false)
+
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        val expectedAttributes = fakeAttributes + mapOf(
+            LogAttributes.DD_TRACE_ID to fakeTraceId,
+            LogAttributes.DD_SPAN_ID to fakeSpanId
+        )
+        assertThat(log).hasExactlyAttributes(expectedAttributes)
+    }
+
+    @Test
+    fun `M do nothing W not required to bundle the rum information`() {
+        // GIVEN
+        GlobalRum.isRegistered.set(false)
+
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp,
+            bundleWithRum = false
+        )
+
+        // THEN
+        val expectedAttributes = fakeAttributes + mapOf(
+            LogAttributes.DD_TRACE_ID to fakeTraceId,
+            LogAttributes.DD_SPAN_ID to fakeSpanId
+        )
+        assertThat(log).hasExactlyAttributes(expectedAttributes)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -147,8 +147,8 @@ internal class DatadogLogHandlerTest {
                 .hasTimestampAround(now)
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
-                .hasAttributes(fakeAttributes)
-                .hasTags(fakeTags)
+                .hasExactlyAttributes(fakeAttributes)
+                .hasExactlyTags(fakeTags)
                 .hasThrowable(null)
         }
     }
@@ -177,8 +177,8 @@ internal class DatadogLogHandlerTest {
                 .hasTimestampAround(now)
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
-                .hasAttributes(fakeAttributes)
-                .hasTags(fakeTags)
+                .hasExactlyAttributes(fakeAttributes)
+                .hasExactlyTags(fakeTags)
                 .hasThrowable(fakeThrowable)
         }
     }
@@ -266,8 +266,8 @@ internal class DatadogLogHandlerTest {
                 .hasTimestampAround(customTimestamp)
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
-                .hasAttributes(fakeAttributes)
-                .hasTags(fakeTags)
+                .hasExactlyAttributes(fakeAttributes)
+                .hasExactlyTags(fakeTags)
         }
     }
 
@@ -302,8 +302,8 @@ internal class DatadogLogHandlerTest {
                 .hasTimestampAround(now)
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
-                .hasAttributes(fakeAttributes)
-                .hasTags(fakeTags)
+                .hasExactlyAttributes(fakeAttributes)
+                .hasExactlyTags(fakeTags)
         }
     }
 
@@ -332,8 +332,8 @@ internal class DatadogLogHandlerTest {
                 .hasTimestampAround(now)
                 .hasNetworkInfo(null)
                 .hasUserInfo(fakeUserInfo)
-                .hasAttributes(fakeAttributes)
-                .hasTags(fakeTags)
+                .hasExactlyAttributes(fakeAttributes)
+                .hasExactlyTags(fakeTags)
         }
     }
 
@@ -363,8 +363,8 @@ internal class DatadogLogHandlerTest {
                 .hasTimestampAround(now)
                 .hasNetworkInfo(null)
                 .hasUserInfo(fakeUserInfo)
-                .hasAttributes(emptyMap())
-                .hasTags(emptyList())
+                .hasExactlyAttributes(emptyMap())
+                .hasExactlyTags(emptyList())
                 .hasThrowable(null)
         }
     }
@@ -550,8 +550,8 @@ internal class DatadogLogHandlerTest {
                 .hasTimestampAround(now)
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasUserInfo(fakeUserInfo)
-                .hasAttributes(fakeAttributes)
-                .hasTags(fakeTags)
+                .hasExactlyAttributes(fakeAttributes)
+                .hasExactlyTags(fakeTags)
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

The scope of this PR is to add the application version information as a tag into the **Crash** logs by complying with the default log creation rules. 
Getting to the bottom of the issue I realised that we had 2 sources of true regarding the rules we are using for a Log creation: 
1. From the DatadogExceptionHandler
2. From the DatadogLogHandler

To fix this problem and to avoid similar problems in the future I introduced the `LogGenerator` class which will handle the `Log` object creation through all the SDK and will contain all the required rules. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

