### PR TITLE
RUMM-754 Allow Span decoration from the SQLiteDatabase#transactionTraced

### DIFF
--- a/dd-sdk-android-ktx/README.md
+++ b/dd-sdk-android-ktx/README.md
@@ -126,8 +126,12 @@ If you're using Kotlin Coroutine Flow, you can propagate Flow errors to your RUM
 If you are using SQLiteDatabase to persist data locally, you can trace the database transaction using the following method:
 
 ```kotlin
-   sqliteDatabase.transactionTraced("<SPAN_NAME>",isExclusive){
+   sqliteDatabase.transactionTraced("<SPAN_NAME>",isExclusive){ database ->
         // Your queries here
+        database.insert("<TABLE_NAME>", null, contentValues)
+
+        // Decorate the Span
+        setTag("<TAG_KEY>", "<TAG_VALUE>")
    } 
 ```
 It behaves like the `SQLiteDatabase.transaction` method provided in the `core-ktx` AndroidX package and only requires a span operation name.

--- a/dd-sdk-android-ktx/apiSurface
+++ b/dd-sdk-android-ktx/apiSurface
@@ -9,7 +9,8 @@ fun <T: java.io.Closeable, R> useMonitored((T) -> R): R
 fun getAssetAsRumResource(String, Int = AssetManager.ACCESS_STREAMING): java.io.InputStream
 fun getRawResAsRumResource(Int): java.io.InputStream
 fun asRumResource(String): java.io.InputStream
-fun <T> transactionTraced(String, Boolean = true, android.database.sqlite.SQLiteDatabase.() -> T): T
+fun <T> transactionTraced(String, Boolean = true, io.opentracing.Span.(android.database.sqlite.SQLiteDatabase) -> T): T
+interface com.datadog.android.ktx.sqlite.SQLite
 fun parentSpan(io.opentracing.Span): okhttp3.Request.Builder
 fun setError(Throwable)
 fun setError(String)

--- a/dd-sdk-android-ktx/src/main/kotlin/com/datadog/android/ktx/sqlite/SqliteDatabaseExt.kt
+++ b/dd-sdk-android-ktx/src/main/kotlin/com/datadog/android/ktx/sqlite/SqliteDatabaseExt.kt
@@ -23,7 +23,7 @@ import io.opentracing.util.GlobalTracer
 inline fun <T> SQLiteDatabase.transactionTraced(
     operationName: String,
     exclusive: Boolean = true,
-    body: SQLiteDatabase.() -> T
+    body: Span.(SQLiteDatabase) -> T
 ): T {
     val parentSpan = GlobalTracer.get().activeSpan()
     withinSpan(operationName, parentSpan, true) {
@@ -33,7 +33,7 @@ inline fun <T> SQLiteDatabase.transactionTraced(
             beginTransactionNonExclusive()
         }
         try {
-            val result = body()
+            val result = this.body(this@transactionTraced)
             setTransactionSuccessful()
             return result
         } finally {
@@ -41,3 +41,5 @@ inline fun <T> SQLiteDatabase.transactionTraced(
         }
     }
 }
+
+// endregion

--- a/sample/kotlin/src/sqlite/kotlin/com/datadog/android/sample/data/contentprovider/DatadogContentProvider.kt
+++ b/sample/kotlin/src/sqlite/kotlin/com/datadog/android/sample/data/contentprovider/DatadogContentProvider.kt
@@ -101,15 +101,16 @@ class DatadogContentProvider : ContentProvider() {
     // region internal
 
     private fun insertLogs(db: SQLiteDatabase, contentValues: Array<out ContentValues>): Int {
-        db.transactionTraced("Adding data to Logs DB") {
+        db.transactionTraced("Adding data to Logs DB") { database ->
             contentValues.forEach { value ->
-                db.insertWithOnConflict(
+                database.insertWithOnConflict(
                     DatadogDbContract.Logs.TABLE_NAME,
                     null,
                     value,
                     SQLiteDatabase.CONFLICT_REPLACE
                 )
             }
+            setTag("logs_count", contentValues.size)
             return contentValues.size
         }
     }


### PR DESCRIPTION
### What does this PR do?

The scope of this PR was to allow update the recently introduced SQLiteDatabase extension -> `transactionTraced` in order to allow the Span decoration from inside the provided lambda:

```
sqliteDabase.transactionTraced("<SPAN_NAME>", isExclusive) { database -> 
         database.insert("<TABLE_NAME>", null, contentValues)
         setTag("<TAG_KEY>", "<TAG_VALUE>")
}

```
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

