### PR TITLE
RUMM-761  setTheme on activity

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -14,5 +14,5 @@ object AndroidConfig {
     const val MIN_SDK = 19
     const val BUILD_TOOLS_VERSION = "30.0.1"
 
-    val VERSION = Version(1, 5, 2, Version.Type.Release)
+    val VERSION = Version(1, 6, 0, Version.Type.Beta(1))
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -10,6 +10,7 @@ import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.widget.AbsListView
 import androidx.core.view.ScrollingView
 import com.datadog.android.core.internal.utils.devLogger
@@ -23,11 +24,9 @@ import java.util.LinkedList
 import kotlin.math.abs
 
 internal class GesturesListener(
-    private val decorViewReference: WeakReference<View>,
+    private val windowReference: WeakReference<Window>,
     private val attributesProviders: Array<ViewAttributesProvider> = emptyArray()
-
-) :
-    GestureDetector.OnGestureListener {
+) : GestureDetector.OnGestureListener {
 
     private val coordinatesContainer = IntArray(2)
     private var scrollEventType: RumActionType? = null
@@ -35,6 +34,7 @@ internal class GesturesListener(
     private var scrollTargetReference: WeakReference<View?> = WeakReference(null)
     private var onTouchDownXPos = 0f
     private var onTouchDownYPos = 0f
+
     // region GesturesListener
 
     override fun onShowPress(e: MotionEvent) {
@@ -42,7 +42,7 @@ internal class GesturesListener(
     }
 
     override fun onSingleTapUp(e: MotionEvent): Boolean {
-        val decorView: View? = decorViewReference.get()
+        val decorView = windowReference.get()?.decorView
         handleTapUp(decorView, e)
         return false
     }
@@ -55,7 +55,8 @@ internal class GesturesListener(
     }
 
     fun onUp(event: MotionEvent) {
-        closeScrollOrSwipeEventIfAny(decorViewReference.get(), event)
+        val decorView = windowReference.get()?.decorView
+        closeScrollOrSwipeEventIfAny(decorView, event)
         resetScrollEventParameters()
     }
 
@@ -65,7 +66,6 @@ internal class GesturesListener(
         velocityX: Float,
         velocityY: Float
     ): Boolean {
-
         scrollEventType = RumActionType.SWIPE
         return false
     }
@@ -77,7 +77,7 @@ internal class GesturesListener(
         distanceY: Float
     ): Boolean {
         val rumMonitor = GlobalRum.get()
-        val decorView = decorViewReference.get()
+        val decorView = windowReference.get()?.decorView
         if (decorView == null || rumMonitor !is DatadogRumMonitor) {
             return false
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AbstractGesturesListenerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AbstractGesturesListenerTest.kt
@@ -11,6 +11,7 @@ import android.content.res.Resources
 import android.util.Log
 import android.view.MotionEvent
 import android.view.View
+import android.view.Window
 import com.datadog.android.Datadog
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.rum.GlobalRum
@@ -18,6 +19,7 @@ import com.datadog.android.rum.NoOpRumMonitor
 import com.datadog.android.utils.forge.Configurator
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
@@ -54,6 +56,9 @@ internal abstract class AbstractGesturesListenerTest {
     @Mock
     lateinit var mockResources: Resources
 
+    @Mock
+    lateinit var mockWindow: Window
+
     // region Tests
 
     @BeforeEach
@@ -74,6 +79,20 @@ internal abstract class AbstractGesturesListenerTest {
     // endregion
 
     // region Internal
+
+    protected inline fun <reified T : View> mockDecorView(
+        id: Int,
+        forEvent: MotionEvent,
+        hitTest: Boolean,
+        clickable: Boolean = false,
+        visible: Boolean = true,
+        forge: Forge,
+        applyOthers: (T) -> Unit = {}
+    ): T {
+        val decorView = mockView<T>(id, forEvent, hitTest, clickable, visible, forge, applyOthers)
+        whenever(mockWindow.decorView) doReturn decorView
+        return decorView
+    }
 
     protected inline fun <reified T : View> mockView(
         id: Int,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesTrackerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesTrackerTest.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.app.Activity
-import android.view.View
 import android.view.Window
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
@@ -41,9 +40,6 @@ internal class DatadogGesturesTrackerTest {
     lateinit var mockWindow: Window
 
     @Mock
-    lateinit var mockDecorView: View
-
-    @Mock
     lateinit var mockGestureDetector: GesturesDetectorWrapper
 
     @BeforeEach
@@ -51,7 +47,6 @@ internal class DatadogGesturesTrackerTest {
         testedTracker =
             DatadogGesturesTracker(emptyArray())
         whenever(mockActivity.window).thenReturn(mockWindow)
-        whenever(mockWindow.decorView).thenReturn(mockDecorView)
     }
 
     @Test
@@ -60,7 +55,7 @@ internal class DatadogGesturesTrackerTest {
         val spyTest = spy(testedTracker)
         doReturn(mockGestureDetector)
             .whenever(spyTest)
-            .generateGestureDetector(mockActivity, mockDecorView)
+            .generateGestureDetector(mockActivity, mockWindow)
         spyTest.startTracking(mockWindow, mockActivity)
 
         // Then

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
@@ -83,7 +83,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             hitTest = true,
             forge = forge
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = endUpEvent,
             hitTest = true,
@@ -100,7 +100,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             RumAttributes.ACTION_GESTURE_DIRECTION to expectedDirection
         )
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -149,7 +149,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             hitTest = true,
             forge = forge
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = startDownEvent,
             hitTest = true,
@@ -166,7 +166,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             RumAttributes.ACTION_GESTURE_DIRECTION to expectedDirection
         )
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -219,7 +219,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             hitTest = true,
             forge = forge
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = startDownEvent,
             hitTest = true,
@@ -241,7 +241,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             RumAttributes.ACTION_GESTURE_DIRECTION to expectedDirection2
         )
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -298,7 +298,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             hitTest = false,
             forge = forge
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = startDownEvent,
             hitTest = true,
@@ -310,7 +310,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         val expectedResourceName = forge.anAlphabeticalString()
         mockResourcesForTarget(scrollingTarget, expectedResourceName)
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -341,7 +341,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             hitTest = true,
             forge = forge
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = startDownEvent,
             hitTest = true,
@@ -353,7 +353,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         val expectedResourceName = forge.anAlphabeticalString()
         mockResourcesForTarget(scrollingTarget, expectedResourceName)
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -392,7 +392,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             hitTest = true,
             forge = forge
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = startDownEvent,
             hitTest = true,
@@ -409,7 +409,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             RumAttributes.ACTION_GESTURE_DIRECTION to expectedDirection
         )
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -465,7 +465,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             hitTest = true,
             forge = forge
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = startDownEvent,
             hitTest = true,
@@ -487,7 +487,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             RumAttributes.ACTION_GESTURE_DIRECTION to expectedDirection2
         )
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -541,7 +541,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             hitTest = true,
             forge = forge
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = startDownEvent,
             hitTest = true,
@@ -552,7 +552,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         }
 
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
         testedListener.onUp(startDownEvent)
         testedListener.onDown(endUpEvent)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
@@ -105,7 +106,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             whenever(it.getChildAt(1)).thenReturn(notVisibleInvalidTarget)
             whenever(it.getChildAt(2)).thenReturn(target)
         }
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = mockEvent,
             hitTest = true,
@@ -118,7 +119,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         val expectedResourceName = forge.anAlphabeticalString()
         mockResourcesForTarget(target, expectedResourceName)
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -143,7 +144,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             whenever(it.getChildAt(0)).thenReturn(mock())
             whenever(it.getChildAt(1)).thenReturn(mock())
         }
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = mockEvent,
             hitTest = true,
@@ -155,7 +156,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         val expectedResourceName = forge.anAlphabeticalString()
         mockResourcesForTarget(target, expectedResourceName)
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -184,7 +185,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             forge = forge,
             clickable = true
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = mockEvent,
             hitTest = true,
@@ -197,7 +198,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         val expectedResourceName = forge.anAlphabeticalString()
         mockResourcesForTarget(validTarget, expectedResourceName)
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -225,7 +226,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             forge = forge,
             clickable = true
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = mockEvent,
             hitTest = true,
@@ -238,7 +239,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         val expectedResourceName = forge.anAlphabeticalString()
         mockResourcesForTarget(validTarget, expectedResourceName)
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -254,7 +255,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
     ) {
         // Given
         val mockEvent: MotionEvent = forge.getForgery()
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = mockEvent,
             hitTest = true,
@@ -263,7 +264,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             whenever(it.childCount).thenReturn(0)
         }
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -282,7 +283,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
     fun `onTap keeps decorView as target if visible and clickable`(forge: Forge) {
         // Given
         val mockEvent: MotionEvent = forge.getForgery()
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = mockEvent,
             hitTest = true,
@@ -292,7 +293,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             whenever(it.childCount).thenReturn(0)
         }
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
         val expectedResourceName = forge.anAlphabeticalString()
         mockResourcesForTarget(mockDecorView, expectedResourceName)
@@ -316,7 +317,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             forge = forge,
             clickable = true
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = mockEvent,
             hitTest = false,
@@ -331,7 +332,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             )
         )
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -353,7 +354,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             forge = forge,
             clickable = true
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = mockEvent,
             hitTest = false,
@@ -364,7 +365,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         }
         whenever(mockResources.getResourceEntryName(validTarget.id)).thenReturn(null)
         testedListener = GesturesListener(
-            WeakReference(mockDecorView)
+            WeakReference(mockWindow)
         )
 
         // When
@@ -378,7 +379,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
     fun `will not send any span if decor view view reference is null`(forge: Forge) {
         // Given
         val mockEvent: MotionEvent = forge.getForgery()
-        testedListener = GesturesListener(WeakReference<View>(null))
+        testedListener = GesturesListener(WeakReference<Window>(null))
 
         // When
         testedListener.onSingleTapUp(mockEvent)
@@ -398,7 +399,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
             forge = forge,
             clickable = true
         )
-        mockDecorView = mockView<ViewGroup>(
+        mockDecorView = mockDecorView<ViewGroup>(
             id = forge.anInt(),
             forEvent = mockEvent,
             hitTest = false,
@@ -425,7 +426,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         }
 
         testedListener = GesturesListener(
-            WeakReference(mockDecorView),
+            WeakReference(mockWindow),
             providers
         )
         // When

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/NavActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/NavActivity.kt
@@ -29,6 +29,8 @@ class NavActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         Timber.d("onStart")
 
+        setTheme(R.style.Sample_Theme_Custom)
+
         setContentView(R.layout.activity_nav)
         rootView = findViewById(R.id.frame_container)
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -95,8 +95,8 @@ class SampleApplication : Application() {
         )
 
         configBuilder
-            .useViewTrackingStrategy(NavigationViewTrackingStrategy(R.id.nav_host_fragment, true))
             .addPlugin(NdkCrashReportsPlugin(), Feature.CRASH)
+            .useViewTrackingStrategy(NavigationViewTrackingStrategy(R.id.nav_host_fragment, true))
             .trackInteractions()
 
         if (BuildConfig.DD_OVERRIDE_LOGS_URL.isNotBlank()) {

--- a/sample/kotlin/src/main/res/values-v21/themes.xml
+++ b/sample/kotlin/src/main/res/values-v21/themes.xml
@@ -8,8 +8,18 @@
 <resources>
     <style name="Sample.Theme" parent="Theme.AppCompat.Light.DarkActionBar">
         <item name="android:windowBackground">@color/white</item>
-        <item name="android:statusBarColor">@color/datadog_violet</item>
+        <item name="android:statusBarColor">@color/datadog_violet_dark</item>
 
         <item name="colorPrimary">@color/datadog_violet</item>
+        <item name="colorPrimaryDark">@color/datadog_violet_dark</item>
     </style>
+
+    <style name="Sample.Theme.Custom" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="android:windowBackground">@color/white</item>
+        <item name="android:statusBarColor">@color/datadog_violet_darkest</item>
+
+        <item name="colorPrimary">@color/datadog_violet</item>
+        <item name="colorPrimaryDark">@color/datadog_violet_darkest</item>
+    </style>
+
 </resources>

--- a/sample/kotlin/src/main/res/values/colors.xml
+++ b/sample/kotlin/src/main/res/values/colors.xml
@@ -12,6 +12,8 @@
     <color name="black">#000000</color>
 
     <!-- Main Palette -->
-    <color name="datadog_violet">#632CA6</color>
+    <color name="datadog_violet">#A538AF</color>
+    <color name="datadog_violet_dark">#5B34A0</color>
+    <color name="datadog_violet_darkest">#0F0616</color>
 
 </resources>

--- a/sample/kotlin/src/main/res/values/themes.xml
+++ b/sample/kotlin/src/main/res/values/themes.xml
@@ -11,6 +11,16 @@
         <item name="android:windowBackground">@color/white</item>
 
         <item name="colorPrimary">@color/datadog_violet</item>
+        <item name="colorPrimaryDark">@color/datadog_violet_dark</item>
+    </style>
+
+
+
+    <style name="Sample.Theme.Custom" parent="Theme.AppCompat.Light.DarkActionBar">
+        <item name="android:windowBackground">@color/white</item>
+
+        <item name="colorPrimary">@color/datadog_violet</item>
+        <item name="colorPrimaryDark">@color/datadog_violet_darkest</item>
     </style>
 
 </resources>


### PR DESCRIPTION
### What does this PR do?

Fix a but preventing user to call the Activity's `setTheme()` method.

### Motivation

When the gesture tracking is enabled, we are calling the window's `getDecorView()` early, which forces the generation of the decorView state. This state is (partly) immutable, meaning that when a customer calls `setTheme()` from the Activity's `onCreate()` method, some style attributes can't be changed, meaning that the app's (or OS's) default style is applied.


### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

