### PR TITLE
Add reference to Application ID definition through RUM

### DIFF
--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -24,7 +24,7 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
     }
     ```
 
-2. Initialize the library with your application context and your [Datadog client token][2]. For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-android` library as they would be exposed client-side in the Android application APK byte code. For more information about setting up a client token, see the [client token documentation][2]:
+2. Initialize the library with your application context and your [Datadog client token][2]. You also need to provide an Application ID (see our [RUM Getting Started page][6]). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-android` library as they would be exposed client-side in the Android application APK byte code. For more information about setting up a client token, see the [client token documentation][2]:
 
     {{< tabs >}}
     {{% tab "US" %}}
@@ -243,3 +243,4 @@ If your existing codebase is using Timber, you can forward all those logs to  Da
 [3]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
 [4]: https://docs.datadoghq.com/logs/processing/attributes_naming_convention/
 [5]: https://docs.datadoghq.com/tagging/
+[6]" https://docs.datadoghq.com/real_user_monitoring/installation/?tab=us

--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -243,4 +243,4 @@ If your existing codebase is using Timber, you can forward all those logs to  Da
 [3]: https://docs.datadoghq.com/account_management/api-app-keys/#api-keys
 [4]: https://docs.datadoghq.com/logs/processing/attributes_naming_convention/
 [5]: https://docs.datadoghq.com/tagging/
-[6]" https://docs.datadoghq.com/real_user_monitoring/installation/?tab=us
+[6]: https://docs.datadoghq.com/real_user_monitoring/android/?tab=us

--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -24,7 +24,7 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
     }
     ```
 
-2. Initialize the library with your application context and your [Datadog client token][2]. You also need to provide an Application ID (see our [RUM Getting Started page][6]). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-android` library as they would be exposed client-side in the Android application APK byte code. For more information about setting up a client token, see the [client token documentation][2]:
+2. Initialize the library with your application context and the [Datadog client token][2] and Application ID generated when you create a new RUM applicaiton in the Datadog UI (see our [Getting Started with Android RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-android` library as they would be exposed client-side in the Android application APK byte code. For more information about setting up a client token, see the [client token documentation][2]:
 
     {{< tabs >}}
     {{% tab "US" %}}

--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -24,7 +24,7 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
     }
     ```
 
-2. Initialize the library with your application context and the [Datadog client token][2] and Application ID generated when you create a new RUM applicaiton in the Datadog UI (see our [Getting Started with Android RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-android` library as they would be exposed client-side in the Android application APK byte code. For more information about setting up a client token, see the [client token documentation][2]:
+2. Initialize the library with your application context and the [Datadog client token][2] and Application ID generated when you create a new RUM application in the Datadog UI (see our [Getting Started with Android RUM Collection][6] for more information). For security reasons, you must use a client token: you cannot use [Datadog API keys][3] to configure the `dd-sdk-android` library as they would be exposed client-side in the Android application APK byte code. For more information about setting up a client token, see the [client token documentation][2]:
 
     {{< tabs >}}
     {{% tab "US" %}}


### PR DESCRIPTION
### What does this PR do?

Adding reference to remove confusion around the APPLICATION_ID for getting logs set up with Android (whether it is the same as the APPLICATION_ID used to set up RUM for Android or it is the applicationId property defined in an Android application)

### Motivation

ticket: https://datadog.zendesk.com/agent/tickets/402817

### Additional Notes



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

