### PR TITLE
RUMM-870 Make sure we get the current network state on start

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
@@ -20,8 +20,7 @@ internal class CallbackNetworkInfoProvider :
     ConnectivityManager.NetworkCallback(),
     NetworkInfoProvider {
 
-    private var networkInfo: NetworkInfo =
-        NetworkInfo()
+    private var networkInfo: NetworkInfo = NetworkInfo()
 
     // region NetworkCallback
 
@@ -54,6 +53,11 @@ internal class CallbackNetworkInfoProvider :
         val connMgr = context.getSystemService(Context.CONNECTIVITY_SERVICE) as ConnectivityManager
         try {
             connMgr.registerDefaultNetworkCallback(this)
+            val activeNetwork = connMgr.activeNetwork
+            val activeCaps = connMgr.getNetworkCapabilities(activeNetwork)
+            if (activeNetwork != null && activeCaps != null) {
+                onCapabilitiesChanged(activeNetwork, activeCaps)
+            }
         } catch (e: SecurityException) {
             // RUMM-852 On some devices we get a SecurityException with message
             // "package does not belong to 10411"

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProviderTest.kt
@@ -287,6 +287,33 @@ internal class CallbackNetworkInfoProviderTest {
     }
 
     @Test
+    fun `M get current network state W register()`(
+        @IntForgery(min = 1) upSpeed: Int,
+        @IntForgery(min = 1) downSpeed: Int
+    ) {
+        val context = mock<Context>()
+        val manager = mock<ConnectivityManager>()
+        whenever(context.getSystemService(Context.CONNECTIVITY_SERVICE)) doReturn manager
+        whenever(manager.activeNetwork) doReturn mockNetwork
+        whenever(manager.getNetworkCapabilities(mockNetwork)) doReturn mockCapabilities
+        whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) doReturn true
+        whenever(mockCapabilities.linkUpstreamBandwidthKbps) doReturn upSpeed
+        whenever(mockCapabilities.linkDownstreamBandwidthKbps) doReturn downSpeed
+
+        testedProvider.register(context)
+        val networkInfo = testedProvider.getLatestNetworkInfo()
+
+        verify(manager).registerDefaultNetworkCallback(testedProvider)
+        assertThat(networkInfo)
+            .hasConnectivity(NetworkInfo.Connectivity.NETWORK_WIFI)
+            .hasCarrierName(null)
+            .hasCarrierId(-1)
+            .hasUpSpeed(upSpeed)
+            .hasDownSpeed(downSpeed)
+            .hasStrength(Int.MIN_VALUE)
+    }
+
+    @Test
     fun `M register callback safely W register() with SecurityException`(
         @StringForgery message: String
     ) {


### PR DESCRIPTION
### What does this PR do?

Ensure we retrieve the current network status on start

### Motivation

One of our customer experiences a weird behavior on some (Samsung) devices : the inital value is never received, and only when turning the airplane mode on and off does the callback get triggered.
