### PR TITLE
Update kronos-android to v0.0.1-alpha10

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -13,7 +13,7 @@ object Dependencies {
         const val Kotlin = "1.4.0"
         const val Gson = "2.8.6"
         const val OkHttp = "3.12.6"
-        const val KronosNTP = "0.0.1-alpha09"
+        const val KronosNTP = "0.0.1-alpha10"
 
         // Android
         const val AndroidToolsPlugin = "4.0.1"


### PR DESCRIPTION
### What does this PR do?
Simple dependency version bump for `kronos-android`. Fixes #408 

### Motivation
alpha10 version removes `com.android.support` dependencies, which helps library consumers migrate off of the AndroidX Jetifier.

### Additional Notes
N/A

### Review checklist (to be filled by reviewers)
- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

