### PR TITLE
RUMM-884 Use JUnit5 assumptions

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/resource/RumResourceInputStreamTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/resource/RumResourceInputStreamTest.kt
@@ -36,8 +36,8 @@ import kotlin.math.max
 import kotlin.math.min
 import kotlin.system.measureNanoTime
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Assume.assumeTrue
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows


### PR DESCRIPTION
### What does this PR do?

Use JUnit5's `Assumptions` class instead of JUnit4's

### Motivation

Because the java-agent expect all our tests to be running with JUnit5, JUnit4 exceptions are not recognized.
