### PR TITLE
RUMM-906 Sanitise the custom attributes keys for all the events

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DataConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DataConstraints.kt
@@ -4,12 +4,12 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.constraints
+package com.datadog.android.core.internal.constraints
 
 /**
  * This interface allows sanitizing logs locally before uploading them to the servers.
  */
-internal interface LogConstraints {
+internal interface DataConstraints {
 
     fun validateAttributes(attributes: Map<String, Any?>): Map<String, Any?>
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DataConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DataConstraints.kt
@@ -11,7 +11,11 @@ package com.datadog.android.core.internal.constraints
  */
 internal interface DataConstraints {
 
-    fun validateAttributes(attributes: Map<String, Any?>): Map<String, Any?>
+    fun validateAttributes(
+        attributes: Map<String, Any?>,
+        keyPrefix: String? = null,
+        attributesGroupName: String? = null
+    ): Map<String, Any?>
 
     fun validateTags(tags: List<String>): List<String>
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraints.kt
@@ -4,16 +4,16 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.constraints
+package com.datadog.android.core.internal.constraints
 
 import com.datadog.android.core.internal.utils.devLogger
 import java.util.Locale
 
 internal typealias StringTransform = (String) -> String?
 
-internal class DatadogLogConstraints : LogConstraints {
+internal class DatadogDataConstraints : DataConstraints {
 
-    // region LogConstraints
+    // region DataConstraints
 
     override fun validateTags(tags: List<String>): List<String> {
         val convertedTags = tags.mapNotNull {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraints.kt
@@ -32,30 +32,52 @@ internal class DatadogDataConstraints : DataConstraints {
         return convertedTags.take(MAX_TAG_COUNT)
     }
 
-    override fun validateAttributes(attributes: Map<String, Any?>): Map<String, Any?> {
+    override fun validateAttributes(
+        attributes: Map<String, Any?>,
+        keyPrefix: String?,
+        attributesGroupName: String?
+    ): Map<String, Any?> {
+
+        // prefix = "a.b" => dotCount = 1+1 ("a.b." + key)
+        val prefixDotCount = keyPrefix?.let { it.count { character -> character == '.' } + 1 } ?: 0
         val convertedAttributes = attributes.mapNotNull {
-            val key = convertAttributeKey(it.key)
-            if (key == null) {
+            // We need this in case the attributes are added from JAVA code and a null key may be
+            // passed.
+            if (it.key == null) {
                 devLogger.e("\"$it\" is an invalid attribute, and was ignored.")
                 null
-            } else {
-                if (key != it.key) {
-                    devLogger.w(
-                        "attribute \"${it.key}\" " +
-                            "was modified to \"$key\" to match our constraints."
-                    )
-                }
-                key to it.value
             }
+            val key = convertAttributeKey(it.key, prefixDotCount)
+            if (key != it.key) {
+                devLogger.w(
+                    "Key \"${it.key}\" " +
+                        "was modified to \"$key\" to match our constraints."
+                )
+            }
+            key to it.value
         }
         val discardedCount = convertedAttributes.size - MAX_ATTR_COUNT
         if (discardedCount > 0) {
-            devLogger.w(
-                "too many attributes were added, " +
-                    "$discardedCount had to be discarded."
+            val warningMessage = resolveDiscardedAttrsWarning(
+                attributesGroupName,
+                discardedCount
             )
+            devLogger.w(warningMessage)
         }
         return convertedAttributes.take(MAX_ATTR_COUNT).toMap()
+    }
+
+    private fun resolveDiscardedAttrsWarning(
+        attributesGroupName: String?,
+        discardedCount: Int
+    ): String {
+        return if (attributesGroupName != null) {
+            "Too many attributes were added for [$attributesGroupName], " +
+                "$discardedCount had to be discarded."
+        } else {
+            "Too many attributes were added, " +
+                "$discardedCount had to be discarded."
+        }
     }
 
     // endregion
@@ -97,24 +119,15 @@ internal class DatadogDataConstraints : DataConstraints {
 
     // region Internal/Attribute
 
-    private val attributeKeyTransforms = listOf<StringTransform>(
-        // A key can only have 10 levels
-        { key ->
-            var dotCount = 0
-            val mapped = key.map {
-                if (it == '.') {
-                    dotCount++
-                    if (dotCount > 9) '_' else it
-                } else it
-            }
-            String(mapped.toCharArray())
+    private fun convertAttributeKey(rawKey: String, prefixDotCount: Int): String {
+        var dotCount = prefixDotCount
+        val mapped = rawKey.map {
+            if (it == '.') {
+                dotCount++
+                if (dotCount > MAX_DEPTH_LEVEL) '_' else it
+            } else it
         }
-    )
-
-    private fun convertAttributeKey(rawKey: String?): String? {
-        return attributeKeyTransforms.fold(rawKey) { key, transform ->
-            if (key == null) null else transform.invoke(key)
-        }
+        return String(mapped.toCharArray())
     }
 
     // endregion
@@ -124,7 +137,8 @@ internal class DatadogDataConstraints : DataConstraints {
         private const val MAX_TAG_LENGTH = 200
         private const val MAX_TAG_COUNT = 100
 
-        private const val MAX_ATTR_COUNT = 256
+        private const val MAX_ATTR_COUNT = 128
+        private const val MAX_DEPTH_LEVEL = 9
 
         private val reservedTagKeys = setOf(
             "host",

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
@@ -8,12 +8,12 @@ package com.datadog.android.log.internal.domain
 
 import android.util.Log as AndroidLog
 import com.datadog.android.BuildConfig
+import com.datadog.android.core.internal.constraints.DataConstraints
+import com.datadog.android.core.internal.constraints.DatadogDataConstraints
 import com.datadog.android.core.internal.domain.Serializer
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.internal.utils.toJsonElement
 import com.datadog.android.log.LogAttributes
-import com.datadog.android.log.internal.constraints.DatadogLogConstraints
-import com.datadog.android.log.internal.constraints.LogConstraints
 import com.google.gson.JsonObject
 import java.text.SimpleDateFormat
 import java.util.Date
@@ -23,7 +23,9 @@ import java.util.TimeZone
 /**
  * The Logging feature implementation of the [Serializer] interface.
  */
-internal class LogSerializer(private val logConstraints: LogConstraints = DatadogLogConstraints()) :
+internal class LogSerializer(
+    private val dataConstraints: DataConstraints = DatadogDataConstraints()
+) :
     Serializer<Log> {
 
     private val simpleDateFormat = SimpleDateFormat(ISO_8601, Locale.US).apply {
@@ -127,7 +129,7 @@ internal class LogSerializer(private val logConstraints: LogConstraints = Datado
         log: Log,
         jsonLog: JsonObject
     ) {
-        val tags = logConstraints.validateTags(log.tags)
+        val tags = dataConstraints.validateTags(log.tags)
             .joinToString(",")
         jsonLog.addProperty(TAG_DATADOG_TAGS, tags)
     }
@@ -136,7 +138,7 @@ internal class LogSerializer(private val logConstraints: LogConstraints = Datado
         log: Log,
         jsonLog: JsonObject
     ) {
-        logConstraints.validateAttributes(log.attributes)
+        dataConstraints.validateAttributes(log.attributes)
             .filter { it.key.isNotBlank() && it.key !in reservedAttributes }
             .forEach {
                 val jsonValue = it.value.toJsonElement()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
@@ -107,8 +107,12 @@ internal class LogSerializer(
         if (!userInfo.email.isNullOrEmpty()) {
             jsonLog.addProperty(LogAttributes.USR_EMAIL, userInfo.email)
         }
-        // add extra attributes
-        userInfo.extraInfo.forEach {
+        // add extra info
+        dataConstraints.validateAttributes(
+            userInfo.extraInfo,
+            keyPrefix = LogAttributes.USR_ATTRIBUTES_GROUP,
+            attributesGroupName = USER_EXTRA_GROUP_VERBOSE_NAME
+        ).forEach {
             val key = "${LogAttributes.USR_ATTRIBUTES_GROUP}.${it.key}"
             jsonLog.add(key, it.value.toJsonElement())
         }
@@ -150,6 +154,7 @@ internal class LogSerializer(
         private const val ISO_8601 = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"
 
         internal const val TAG_DATADOG_TAGS = "ddtags"
+        internal const val USER_EXTRA_GROUP_VERBOSE_NAME = "user extra information"
 
         internal val reservedAttributes = arrayOf(
             LogAttributes.HOST,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -8,6 +8,8 @@ package com.datadog.android.tracing.internal.domain
 
 import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.CoreFeature
+import com.datadog.android.core.internal.constraints.DataConstraints
+import com.datadog.android.core.internal.constraints.DatadogDataConstraints
 import com.datadog.android.core.internal.domain.Serializer
 import com.datadog.android.core.internal.net.info.NetworkInfo
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
@@ -26,7 +28,8 @@ internal class SpanSerializer(
     private val timeProvider: TimeProvider,
     private val networkInfoProvider: NetworkInfoProvider,
     private val userInfoProvider: UserInfoProvider,
-    private val envName: String
+    private val envName: String,
+    private val dataConstraints: DataConstraints = DatadogDataConstraints()
 ) : Serializer<DDSpan> {
 
     // region Serializer
@@ -149,7 +152,11 @@ internal class SpanSerializer(
             jsonLog.addProperty(LogAttributes.USR_EMAIL, userInfo.email)
         }
         // add extra attributes
-        userInfo.extraInfo.forEach {
+        dataConstraints.validateAttributes(
+            userInfo.extraInfo,
+            keyPrefix = LogAttributes.USR_ATTRIBUTES_GROUP,
+            attributesGroupName = USER_EXTRA_GROUP_VERBOSE_NAME
+        ).forEach {
             val key = "${LogAttributes.USR_ATTRIBUTES_GROUP}.${it.key}"
             toMetaString(it.value)?.apply {
                 jsonLog.addProperty(key, this)
@@ -197,5 +204,7 @@ internal class SpanSerializer(
         internal const val TAG_DD_SOURCE = "_dd.source"
         internal const val TAG_SPAN_KIND = "span.kind"
         internal const val TAG_TRACER_VERSION = "tracer.version"
+
+        internal const val USER_EXTRA_GROUP_VERBOSE_NAME = "user extra information"
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraintsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraintsTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.constraints
+package com.datadog.android.core.internal.constraints
 
 import android.os.Build
 import android.util.Log
@@ -35,9 +35,9 @@ import org.mockito.junit.jupiter.MockitoSettings
 )
 @MockitoSettings()
 @ForgeConfiguration(Configurator::class)
-internal class DatadogLogConstraintsTest {
+internal class DatadogDataConstraintsTest {
 
-    lateinit var testedConstraints: LogConstraints
+    lateinit var testedConstraints: DataConstraints
 
     lateinit var mockDevLogHandler: LogHandler
 
@@ -49,7 +49,7 @@ internal class DatadogLogConstraintsTest {
 
         mockDevLogHandler = mockDevLogHandler()
 
-        testedConstraints = DatadogLogConstraints()
+        testedConstraints = DatadogDataConstraints()
     }
 
     // region Tags

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraintsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraintsTest.kt
@@ -212,7 +212,7 @@ internal class DatadogDataConstraintsTest {
     }
 
     @Test
-    fun `convert nested attribute keys over 10 levels`(forge: Forge) {
+    fun `M convert nested attribute keys W over 10 levels`(forge: Forge) {
         val topLevels = forge.aList(10) { anAlphabeticalString() }
         val lowerLevels = forge.aList { anAlphabeticalString() }
         val key = (topLevels + lowerLevels).joinToString(".")
@@ -225,24 +225,68 @@ internal class DatadogDataConstraintsTest {
             .containsEntry(expectedKey, value)
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            "attribute \"$key\" was modified to \"$expectedKey\" to match our constraints."
+            "Key \"$key\" was modified to \"$expectedKey\" to match our constraints."
         )
     }
 
     @Test
-    fun `ignore attribute if adding more than 256`(forge: Forge) {
-        val attributes = forge.aList(300) { anAlphabeticalString() to anInt() }.toMap()
-        val firstAttributes = attributes.toList().take(256).toMap()
+    fun `M convert nested attribute keys W over 10 levels and using prefix`(forge: Forge) {
+        val keyPrefix = forge
+            .aList(5) { forge.anAlphabeticalString() }
+            .joinToString(".")
+        val topLevels = forge.aList(5) { anAlphabeticalString() }
+        val lowerLevels = forge.aList { anAlphabeticalString() }
+        val key = (topLevels + lowerLevels).joinToString(".")
+        val value = forge.aNumericalString()
+        val result =
+            testedConstraints.validateAttributes(mapOf(key to value), keyPrefix = keyPrefix)
+
+        val expectedKey = topLevels.joinToString(".") + "_" + lowerLevels.joinToString("_")
+        assertThat(result)
+            .containsEntry(expectedKey, value)
+        verify(mockDevLogHandler).handleLog(
+            Log.WARN,
+            "Key \"$key\" was modified to \"$expectedKey\" to match our constraints."
+        )
+    }
+
+    @Test
+    fun `ignore attribute if adding more than 128`(forge: Forge) {
+        val attributes = forge.aList(202) { anAlphabeticalString() to anInt() }.toMap()
+        val firstAttributes = attributes.toList().take(128).toMap()
 
         val result = testedConstraints.validateAttributes(attributes)
 
-        val discardedCount = attributes.size - 256
+        val discardedCount = attributes.size - 128
         assertThat(result)
-            .hasSize(256)
+            .hasSize(128)
             .containsAllEntriesOf(firstAttributes)
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            "too many attributes were added, $discardedCount had to be discarded."
+            "Too many attributes were added, $discardedCount had to be discarded."
+        )
+    }
+
+    @Test
+    fun `M use a custom error format W validateAttributes`(forge: Forge) {
+        val attributes = forge.aList(202) { anAlphabeticalString() to anInt() }.toMap()
+        val firstAttributes = attributes.toList().take(128).toMap()
+        val fakeAttributesGroup = forge
+            .aList(size = 10) { forge.anAlphabeticalString() }
+            .joinToString(".")
+        val result = testedConstraints.validateAttributes(
+            attributes,
+            attributesGroupName = fakeAttributesGroup
+        )
+
+        val discardedCount = attributes.size - 128
+        assertThat(result)
+            .hasSize(128)
+            .containsAllEntriesOf(firstAttributes)
+        verify(mockDevLogHandler).handleLog(
+            Log.WARN,
+            "Too many attributes were added for [$fakeAttributesGroup]," +
+                " $discardedCount had to be discarded."
         )
     }
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/user/UserFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/user/UserFragment.kt
@@ -50,6 +50,7 @@ class UserFragment : Fragment(), View.OnClickListener {
         nameField.setText(preferences.getUserName())
         emailField.setText(preferences.getUserEmail())
         userGenderField.setText(preferences.getUserGender())
+        userAgeField.setText(preferences.getUserAge().toString())
     }
 
     // endregion

--- a/sample/kotlin/src/main/res/layout/fragment_user.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_user.xml
@@ -77,6 +77,6 @@
         android:layout_margin="8dp"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/user_gender"
+        app:layout_constraintTop_toBottomOf="@id/user_age"
     />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### What does this PR do?

In this *PR* we are aligning the logic used for sanitising the keys for all the provided custom attributes (custom timings, custom user extra information, custom attributes) inside our events Serialisers. We are following the previously used rules for sanitising the Log custom attributes and we are applying these for each type of custom attribute.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

