### PR TITLE
RUMM-912 Json schema read only properties

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonDefinition.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonDefinition.kt
@@ -21,5 +21,6 @@ data class JsonDefinition(
     @SerializedName("items") val items: JsonDefinition?,
     @SerializedName("allOf") val allOf: List<JsonDefinition>?,
     @SerializedName("properties") val properties: Map<String, JsonDefinition>?,
-    @SerializedName("definitions") val definitions: Map<String, JsonDefinition>?
+    @SerializedName("definitions") val definitions: Map<String, JsonDefinition>?,
+    @SerializedName("readOnly") val readOnly: Boolean?
 )

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReader.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReader.kt
@@ -247,11 +247,12 @@ class JsonSchemaReader(
         val properties = mutableListOf<TypeProperty>()
         definition.properties?.forEach { (name, property) ->
             val required = (definition.required != null) && (name in definition.required)
+            val readOnly = (property.readOnly == null) || (property.readOnly)
             val propertyType = transform(
                 property,
                 name.toCamelCase()
             )
-            properties.add(TypeProperty(name, propertyType, !required))
+            properties.add(TypeProperty(name, propertyType, !required, readOnly))
         }
 
         return TypeDefinition.Class(

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGenerator.kt
@@ -166,6 +166,7 @@ class PokoGenerator(
 
         typeBuilder.addProperty(
             PropertySpec.builder(varName, type)
+                .mutable(!property.readOnly)
                 .initializer(varName)
                 .build()
         )
@@ -341,10 +342,9 @@ class PokoGenerator(
     ) {
         if (property.optional) {
             funBuilder.addStatement(
-                "if (%L != null) json.add(%S, %L.%L())",
+                "%L?.let { json.add(%S, it.%L()) }",
                 varName,
                 property.name,
-                varName,
                 TO_JSON
             )
         } else {
@@ -362,21 +362,24 @@ class PokoGenerator(
         varName: String,
         funBuilder: FunSpec.Builder
     ) {
-        if (property.optional) {
-            funBuilder.beginControlFlow("if (%L != null)", varName)
+        val arrayVar = if (property.optional) {
+            funBuilder.beginControlFlow("%L?.let { temp ->", varName)
+            "temp"
+        } else {
+            varName
         }
 
-        funBuilder.addStatement("val %LArray = %T(%L.size)", varName, JSON_ARRAY, varName)
+        funBuilder.addStatement("val %LArray = %T(%L.size)", varName, JSON_ARRAY, arrayVar)
         when (type.items) {
             is TypeDefinition.Primitive -> funBuilder.addStatement(
                 "%L.forEach { %LArray.add(it) }",
-                varName,
+                arrayVar,
                 varName
             )
             is TypeDefinition.Class,
             is TypeDefinition.Enum -> funBuilder.addStatement(
                 "%L.forEach { %LArray.add(it.%L()) }",
-                varName,
+                arrayVar,
                 varName,
                 TO_JSON
             )
@@ -409,10 +412,9 @@ class PokoGenerator(
             JsonType.INTEGER ->
                 if (property.optional) {
                     funBuilder.addStatement(
-                        "if (%L != null) json.addProperty(%S, %L)",
+                        "%L?.let { json.addProperty(%S, it) }",
                         varName,
-                        property.name,
-                        varName
+                        property.name
                     )
                 } else {
                     funBuilder.addStatement(

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGenerator.kt
@@ -127,7 +127,7 @@ class PokoGenerator(
 
         definition.values.forEach { value ->
             enumBuilder.addEnumConstant(
-                value.toUpperCase(Locale.US),
+                value.enumConstantName(),
                 TypeSpec.anonymousClassBuilder()
                     .build()
             )
@@ -288,7 +288,7 @@ class PokoGenerator(
         definition.values.forEach { value ->
             funBuilder.addStatement(
                 "%L -> %T(%S)",
-                value.toUpperCase(Locale.US),
+                value.enumConstantName(),
                 JSON_PRIMITIVE,
                 value
             )
@@ -465,6 +465,10 @@ class PokoGenerator(
         }
         knownTypes.add(uniqueName)
         return uniqueName
+    }
+
+    private fun String.enumConstantName(): String {
+        return toUpperCase(Locale.US).replace(Regex("[^A-Z0-9]+"), "_")
     }
 
     private fun TypeDefinition.Enum.withUniqueTypeName(): TypeDefinition.Enum {

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/TypeProperty.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/TypeProperty.kt
@@ -9,7 +9,8 @@ package com.datadog.gradle.plugin.jsonschema
 data class TypeProperty(
     val name: String,
     val type: TypeDefinition,
-    val optional: Boolean
+    val optional: Boolean,
+    val readOnly: Boolean = true
 ) {
     fun mergedWith(other: TypeProperty): TypeProperty {
         return if (this == other) {

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReaderTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReaderTest.kt
@@ -64,7 +64,8 @@ class JsonSchemaReaderTest(
                 arrayOf("all_of_merged", UserMerged),
                 arrayOf("external_description", Delivery),
                 arrayOf("external_nested_description", Shipping),
-                arrayOf("definition_name_conflict", Conflict)
+                arrayOf("definition_name_conflict", Conflict),
+                arrayOf("read_only", Message)
             )
         }
     }

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelValidationTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelValidationTest.kt
@@ -85,7 +85,8 @@ class ModelValidationTest(
                 arrayOf("all_of", "User"),
                 arrayOf("external_description", "Delivery"),
                 arrayOf("external_nested_description", "Shipping"),
-                arrayOf("definition_name_conflict", "Conflict")
+                arrayOf("definition_name_conflict", "Conflict"),
+                arrayOf("read_only", "Message")
             )
         }
     }

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGeneratorTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGeneratorTest.kt
@@ -71,6 +71,7 @@ class PokoGeneratorTest(
                 arrayOf(Foo, "Foo"),
                 arrayOf(Person, "Person"),
                 arrayOf(Location, "Location"),
+                arrayOf(Message, "Message"),
                 arrayOf(Opus, "Opus"),
                 arrayOf(Product, "Product"),
                 arrayOf(Shipping, "Shipping"),

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
@@ -338,7 +338,7 @@ val Style = TypeDefinition.Class(
             TypeDefinition.Enum(
                 "Color",
                 JsonType.STRING,
-                listOf("red", "amber", "green", "dark_blue")
+                listOf("red", "amber", "green", "dark_blue", "lime green", "sunburst-yellow")
             ),
             false
         )

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
@@ -203,6 +203,54 @@ val Location = TypeDefinition.Class(
     )
 )
 
+val Message = TypeDefinition.Class(
+    name = "Message",
+    properties = listOf(
+        TypeProperty(
+            "destination",
+            TypeDefinition.Array(TypeDefinition.Primitive(JsonType.STRING)),
+            optional = false,
+            readOnly = true
+        ),
+        TypeProperty(
+            "origin",
+            TypeDefinition.Primitive(JsonType.STRING),
+            optional = false,
+            readOnly = true
+        ),
+        TypeProperty(
+            "subject",
+            TypeDefinition.Primitive(JsonType.STRING),
+            optional = true,
+            readOnly = true
+        ),
+        TypeProperty(
+            "message",
+            TypeDefinition.Primitive(JsonType.STRING),
+            optional = true,
+            readOnly = true
+        ),
+        TypeProperty(
+            "labels",
+            TypeDefinition.Array(TypeDefinition.Primitive(JsonType.STRING)),
+            optional = true,
+            readOnly = false
+        ),
+        TypeProperty(
+            "read",
+            TypeDefinition.Primitive(JsonType.BOOLEAN),
+            optional = true,
+            readOnly = false
+        ),
+        TypeProperty(
+            "important",
+            TypeDefinition.Primitive(JsonType.BOOLEAN),
+            optional = true,
+            readOnly = false
+        )
+    )
+)
+
 val Opus = TypeDefinition.Class(
     name = "Opus",
     description = "A musical opus.",

--- a/buildSrc/src/test/kotlin/com/example/forgery/ForgeryConfiguration.kt
+++ b/buildSrc/src/test/kotlin/com/example/forgery/ForgeryConfiguration.kt
@@ -20,6 +20,7 @@ internal class ForgeryConfiguration : ForgeConfigurator {
         forge.addFactory(DemoForgeryFactory())
         forge.addFactory(FooForgeryFactory())
         forge.addFactory(LocationForgeryFactory())
+        forge.addFactory(MessageForgeryFactory())
         forge.addFactory(OpusForgeryFactory())
         forge.addFactory(PersonForgeryFactory())
         forge.addFactory(ProductForgeryFactory())

--- a/buildSrc/src/test/kotlin/com/example/forgery/MessageForgeryFactory.kt
+++ b/buildSrc/src/test/kotlin/com/example/forgery/MessageForgeryFactory.kt
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.example.forgery
+
+import com.example.model.Message
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class MessageForgeryFactory : ForgeryFactory<Message> {
+
+    override fun getForgery(forge: Forge): Message {
+        return Message(
+            destination = forge.aList { aStringMatching(EMAIL_REGEX) },
+            origin = forge.aStringMatching(EMAIL_REGEX),
+            subject = forge.aNullable { anAlphabeticalString() },
+            message = forge.aNullable { anAlphabeticalString() },
+            labels = forge.aNullable { forge.aList { anAlphabeticalString() } },
+            read = forge.aNullable { forge.aBool() },
+            important = forge.aNullable { forge.aBool() }
+        )
+    }
+
+    companion object {
+        const val EMAIL_REGEX = "[a-z]{3,9}\\.[a-z]{3,9}@[a-z]{3,9}\\.[a-z]{3}"
+    }
+}

--- a/buildSrc/src/test/kotlin/com/example/model/Article.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Article.kt
@@ -14,9 +14,9 @@ internal data class Article(
     fun toJson(): JsonElement {
         val json = JsonObject()
         json.addProperty("title", title)
-        if (tags != null) {
-            val tagsArray = JsonArray(tags.size)
-            tags.forEach { tagsArray.add(it) }
+        tags?.let { temp ->
+            val tagsArray = JsonArray(temp.size)
+            temp.forEach { tagsArray.add(it) }
             json.add("tags", tagsArray)
         }
         val authorsArray = JsonArray(authors.size)

--- a/buildSrc/src/test/kotlin/com/example/model/Book.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Book.kt
@@ -41,8 +41,8 @@ internal data class Book(
     ) {
         fun toJson(): JsonElement {
             val json = JsonObject()
-            if (phone != null) json.addProperty("phone", phone)
-            if (email != null) json.addProperty("email", email)
+            phone?.let { json.addProperty("phone", it) }
+            email?.let { json.addProperty("email", it) }
             return json
         }
     }

--- a/buildSrc/src/test/kotlin/com/example/model/Conflict.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Conflict.kt
@@ -11,8 +11,8 @@ internal data class Conflict(
 ) {
     fun toJson(): JsonElement {
         val json = JsonObject()
-        if (type != null) json.add("type", type.toJson())
-        if (user != null) json.add("user", user.toJson())
+        type?.let { json.add("type", it.toJson()) }
+        user?.let { json.add("user", it.toJson()) }
         return json
     }
 
@@ -21,7 +21,7 @@ internal data class Conflict(
     ) {
         fun toJson(): JsonElement {
             val json = JsonObject()
-            if (id != null) json.addProperty("id", id)
+            id?.let { json.addProperty("id", it) }
             return json
         }
     }
@@ -32,8 +32,8 @@ internal data class Conflict(
     ) {
         fun toJson(): JsonElement {
             val json = JsonObject()
-            if (name != null) json.addProperty("name", name)
-            if (type != null) json.add("type", type.toJson())
+            name?.let { json.addProperty("name", it) }
+            type?.let { json.add("type", it.toJson()) }
             return json
         }
     }

--- a/buildSrc/src/test/kotlin/com/example/model/Customer.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Customer.kt
@@ -11,9 +11,9 @@ internal data class Customer(
 ) {
     fun toJson(): JsonElement {
         val json = JsonObject()
-        if (name != null) json.addProperty("name", name)
-        if (billingAddress != null) json.add("billing_address", billingAddress.toJson())
-        if (shippingAddress != null) json.add("shipping_address", shippingAddress.toJson())
+        name?.let { json.addProperty("name", it) }
+        billingAddress?.let { json.add("billing_address", it.toJson()) }
+        shippingAddress?.let { json.add("shipping_address", it.toJson()) }
         return json
     }
 

--- a/buildSrc/src/test/kotlin/com/example/model/DateTime.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/DateTime.kt
@@ -11,8 +11,8 @@ internal data class DateTime(
 ) {
     fun toJson(): JsonElement {
         val json = JsonObject()
-        if (date != null) json.add("date", date.toJson())
-        if (time != null) json.add("time", time.toJson())
+        date?.let { json.add("date", it.toJson()) }
+        time?.let { json.add("time", it.toJson()) }
         return json
     }
 
@@ -23,9 +23,9 @@ internal data class DateTime(
     ) {
         fun toJson(): JsonElement {
             val json = JsonObject()
-            if (year != null) json.addProperty("year", year)
-            if (month != null) json.add("month", month.toJson())
-            if (day != null) json.addProperty("day", day)
+            year?.let { json.addProperty("year", it) }
+            month?.let { json.add("month", it.toJson()) }
+            day?.let { json.addProperty("day", it) }
             return json
         }
     }
@@ -37,9 +37,9 @@ internal data class DateTime(
     ) {
         fun toJson(): JsonElement {
             val json = JsonObject()
-            if (hour != null) json.addProperty("hour", hour)
-            if (minute != null) json.addProperty("minute", minute)
-            if (seconds != null) json.addProperty("seconds", seconds)
+            hour?.let { json.addProperty("hour", it) }
+            minute?.let { json.addProperty("minute", it) }
+            seconds?.let { json.addProperty("seconds", it) }
             return json
         }
     }

--- a/buildSrc/src/test/kotlin/com/example/model/Delivery.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Delivery.kt
@@ -22,9 +22,9 @@ internal data class Delivery(
     ) {
         fun toJson(): JsonElement {
             val json = JsonObject()
-            if (name != null) json.addProperty("name", name)
-            if (billingAddress != null) json.add("billing_address", billingAddress.toJson())
-            if (shippingAddress != null) json.add("shipping_address", shippingAddress.toJson())
+            name?.let { json.addProperty("name", it) }
+            billingAddress?.let { json.add("billing_address", it.toJson()) }
+            shippingAddress?.let { json.add("shipping_address", it.toJson()) }
             return json
         }
     }

--- a/buildSrc/src/test/kotlin/com/example/model/Demo.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Demo.kt
@@ -27,10 +27,10 @@ internal data class Demo(
         json.addProperty("n", n)
         json.addProperty("b", b)
         json.add("l", null)
-        if (ns != null) json.addProperty("ns", ns)
-        if (ni != null) json.addProperty("ni", ni)
-        if (nn != null) json.addProperty("nn", nn)
-        if (nb != null) json.addProperty("nb", nb)
+        ns?.let { json.addProperty("ns", it) }
+        ni?.let { json.addProperty("ni", it) }
+        nn?.let { json.addProperty("nn", it) }
+        nb?.let { json.addProperty("nb", it) }
         return json
     }
 }

--- a/buildSrc/src/test/kotlin/com/example/model/Foo.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Foo.kt
@@ -11,8 +11,8 @@ internal data class Foo(
 ) {
     fun toJson(): JsonElement {
         val json = JsonObject()
-        if (bar != null) json.addProperty("bar", bar)
-        if (baz != null) json.addProperty("baz", baz)
+        bar?.let { json.addProperty("bar", it) }
+        baz?.let { json.addProperty("baz", it) }
         return json
     }
 }

--- a/buildSrc/src/test/kotlin/com/example/model/Message.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Message.kt
@@ -1,0 +1,36 @@
+package com.example.model
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import kotlin.Boolean
+import kotlin.String
+import kotlin.collections.List
+
+internal data class Message(
+    val destination: List<String>,
+    val origin: String,
+    val subject: String? = null,
+    val message: String? = null,
+    var labels: List<String>? = null,
+    var read: Boolean? = null,
+    var important: Boolean? = null
+) {
+    fun toJson(): JsonElement {
+        val json = JsonObject()
+        val destinationArray = JsonArray(destination.size)
+        destination.forEach { destinationArray.add(it) }
+        json.add("destination", destinationArray)
+        json.addProperty("origin", origin)
+        subject?.let { json.addProperty("subject", it) }
+        message?.let { json.addProperty("message", it) }
+        labels?.let { temp ->
+            val labelsArray = JsonArray(temp.size)
+            temp.forEach { labelsArray.add(it) }
+            json.add("labels", labelsArray)
+        }
+        read?.let { json.addProperty("read", it) }
+        important?.let { json.addProperty("important", it) }
+        return json
+    }
+}

--- a/buildSrc/src/test/kotlin/com/example/model/Opus.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Opus.kt
@@ -23,14 +23,14 @@ internal data class Opus(
 ) {
     fun toJson(): JsonElement {
         val json = JsonObject()
-        if (title != null) json.addProperty("title", title)
-        if (composer != null) json.addProperty("composer", composer)
-        if (artists != null) {
-            val artistsArray = JsonArray(artists.size)
-            artists.forEach { artistsArray.add(it.toJson()) }
+        title?.let { json.addProperty("title", it) }
+        composer?.let { json.addProperty("composer", it) }
+        artists?.let { temp ->
+            val artistsArray = JsonArray(temp.size)
+            temp.forEach { artistsArray.add(it.toJson()) }
             json.add("artists", artistsArray)
         }
-        if (duration != null) json.addProperty("duration", duration)
+        duration?.let { json.addProperty("duration", it) }
         return json
     }
 
@@ -45,8 +45,8 @@ internal data class Opus(
     ) {
         fun toJson(): JsonElement {
             val json = JsonObject()
-            if (name != null) json.addProperty("name", name)
-            if (role != null) json.add("role", role.toJson())
+            name?.let { json.addProperty("name", it) }
+            role?.let { json.add("role", it.toJson()) }
             return json
         }
     }

--- a/buildSrc/src/test/kotlin/com/example/model/Person.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Person.kt
@@ -12,9 +12,9 @@ internal data class Person(
 ) {
     fun toJson(): JsonElement {
         val json = JsonObject()
-        if (firstName != null) json.addProperty("firstName", firstName)
-        if (lastName != null) json.addProperty("lastName", lastName)
-        if (age != null) json.addProperty("age", age)
+        firstName?.let { json.addProperty("firstName", it) }
+        lastName?.let { json.addProperty("lastName", it) }
+        age?.let { json.addProperty("age", it) }
         return json
     }
 }

--- a/buildSrc/src/test/kotlin/com/example/model/Style.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Style.kt
@@ -20,13 +20,19 @@ internal data class Style(
 
         GREEN,
 
-        DARK_BLUE;
+        DARK_BLUE,
+
+        LIME_GREEN,
+
+        SUNBURST_YELLOW;
 
         fun toJson(): JsonElement = when (this) {
             RED -> JsonPrimitive("red")
             AMBER -> JsonPrimitive("amber")
             GREEN -> JsonPrimitive("green")
             DARK_BLUE -> JsonPrimitive("dark_blue")
+            LIME_GREEN -> JsonPrimitive("lime green")
+            SUNBURST_YELLOW -> JsonPrimitive("sunburst-yellow")
         }
     }
 }

--- a/buildSrc/src/test/kotlin/com/example/model/User.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/User.kt
@@ -16,7 +16,7 @@ internal data class User(
         val json = JsonObject()
         json.addProperty("username", username)
         json.addProperty("host", host)
-        if (firstname != null) json.addProperty("firstname", firstname)
+        firstname?.let { json.addProperty("firstname", it) }
         json.addProperty("lastname", lastname)
         json.add("contact_type", contactType.toJson())
         return json

--- a/buildSrc/src/test/kotlin/com/example/model/UserMerged.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/UserMerged.kt
@@ -13,10 +13,10 @@ internal data class UserMerged(
 ) {
     fun toJson(): JsonElement {
         val json = JsonObject()
-        if (email != null) json.addProperty("email", email)
-        if (phone != null) json.addProperty("phone", phone)
-        if (info != null) json.add("info", info.toJson())
-        if (firstname != null) json.addProperty("firstname", firstname)
+        email?.let { json.addProperty("email", it) }
+        phone?.let { json.addProperty("phone", it) }
+        info?.let { json.add("info", it.toJson()) }
+        firstname?.let { json.addProperty("firstname", it) }
         json.addProperty("lastname", lastname)
         return json
     }
@@ -27,8 +27,8 @@ internal data class UserMerged(
     ) {
         fun toJson(): JsonElement {
             val json = JsonObject()
-            if (notes != null) json.addProperty("notes", notes)
-            if (source != null) json.addProperty("source", source)
+            notes?.let { json.addProperty("notes", it) }
+            source?.let { json.addProperty("source", it) }
             return json
         }
     }

--- a/buildSrc/src/test/kotlin/com/example/model/Video.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Video.kt
@@ -14,14 +14,14 @@ internal data class Video(
     fun toJson(): JsonElement {
         val json = JsonObject()
         json.addProperty("title", title)
-        if (tags != null) {
-            val tagsArray = JsonArray(tags.size)
-            tags.forEach { tagsArray.add(it) }
+        tags?.let { temp ->
+            val tagsArray = JsonArray(temp.size)
+            temp.forEach { tagsArray.add(it) }
             json.add("tags", tagsArray)
         }
-        if (links != null) {
-            val linksArray = JsonArray(links.size)
-            links.forEach { linksArray.add(it) }
+        links?.let { temp ->
+            val linksArray = JsonArray(temp.size)
+            temp.forEach { linksArray.add(it) }
             json.add("links", linksArray)
         }
         return json

--- a/buildSrc/src/test/resources/input/enum.json
+++ b/buildSrc/src/test/resources/input/enum.json
@@ -5,7 +5,7 @@
   "properties": {
     "color": {
       "type": "string",
-      "enum": ["red", "amber", "green", "dark_blue"]
+      "enum": ["red", "amber", "green", "dark_blue", "lime green", "sunburst-yellow"]
     }
   },
   "required": [ "color"]

--- a/buildSrc/src/test/resources/input/read_only.json
+++ b/buildSrc/src/test/resources/input/read_only.json
@@ -1,0 +1,45 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Message",
+  "type": "object",
+  "properties": {
+    "destination": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "readOnly": true
+    },
+    "origin": {
+      "type": "string",
+      "readOnly": true
+    },
+    "subject": {
+      "type": "string",
+      "readOnly": true
+    },
+    "message": {
+      "type": "string",
+      "readOnly": true
+    },
+    "labels": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "readOnly": false
+    },
+    "read": {
+      "type": "boolean",
+      "readOnly": false
+    },
+    "important": {
+      "type": "boolean",
+      "readOnly": false
+    }
+  },
+  "required": [
+    "destination",
+    "origin"
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

Add support to the JSON Schema `readOnly` property. When generated, non readOnly properties will be `var` properties, and readOnly will become `val`. This ensures that when the object is passed to the customer for data scrubbing, they can only modify a subset of properties.