### PR TITLE
RUMM-893 Add variant tag

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -20,7 +20,7 @@ class com.datadog.android.Configuration
     fun setRumErrorEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ErrorEvent>): Builder
   companion object 
 class com.datadog.android.Credentials
-  constructor(String, String, String, String?, String?)
+  constructor(String, String, String, String?, String? = null)
 object com.datadog.android.Datadog
   DEPRECATED const val DATADOG_US: String
   DEPRECATED const val DATADOG_EU: String

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -185,7 +185,7 @@ interface com.datadog.android.plugin.DatadogPlugin : com.datadog.android.privacy
   fun register(DatadogPluginConfig)
   fun unregister()
   fun onContextChanged(DatadogContext)
-sealed class com.datadog.android.plugin.DatadogPluginConfig
+class com.datadog.android.plugin.DatadogPluginConfig
   constructor(android.content.Context, String, String, String, com.datadog.android.privacy.TrackingConsent)
 class com.datadog.android.plugin.DatadogRumContext
   constructor(String? = null, String? = null, String? = null)

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -190,6 +190,7 @@ class com.datadog.android.plugin.DatadogPluginConfig
 class com.datadog.android.plugin.DatadogRumContext
   constructor(String? = null, String? = null, String? = null)
 enum com.datadog.android.plugin.Feature
+  constructor(String)
   - LOG
   - CRASH
   - TRACE

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -218,6 +218,7 @@ object com.datadog.android.rum.RumAttributes
   const val ENV: String
   const val SERVICE_NAME: String
   const val SOURCE: String
+  const val VARIANT: String
   const val SDK_VERSION: String
   const val TRACE_ID: String
   const val SPAN_ID: String

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -25,15 +25,16 @@ object com.datadog.android.Datadog
   DEPRECATED const val DATADOG_US: String
   DEPRECATED const val DATADOG_EU: String
   DEPRECATED fun initialize(android.content.Context, DatadogConfig)
-  fun initialize(android.content.Context, com.datadog.android.privacy.TrackingConsent, DatadogConfig)
+  DEPRECATED fun initialize(android.content.Context, com.datadog.android.privacy.TrackingConsent, DatadogConfig)
+  fun initialize(android.content.Context, Credentials, Configuration, com.datadog.android.privacy.TrackingConsent)
   DEPRECATED fun setEndpointUrl(String, com.datadog.android.log.EndpointUpdateStrategy)
   fun isInitialized(): Boolean
   fun clearAllData()
   fun setVerbosity(Int)
   fun setTrackingConsent(com.datadog.android.privacy.TrackingConsent)
   fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
-class com.datadog.android.DatadogConfig
-  class Builder
+DEPRECATED class com.datadog.android.DatadogConfig
+  DEPRECATED class Builder
     constructor(String, String, java.util.UUID)
     constructor(String, String)
     constructor(String, String, String)

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1,3 +1,26 @@
+class com.datadog.android.Configuration
+  class Builder
+    constructor(Boolean = false, Boolean = false, Boolean = false, Boolean = false)
+    fun build(): Configuration
+    fun setFirstPartyHosts(List<String>): Builder
+    fun useEUEndpoints(): Builder
+    fun useUSEndpoints(): Builder
+    fun useGovEndpoints(): Builder
+    fun useCustomLogsEndpoint(String): Builder
+    fun useCustomTracesEndpoint(String): Builder
+    fun useCustomCrashReportsEndpoint(String): Builder
+    fun useCustomRumEndpoint(String): Builder
+    fun trackInteractions(Array<com.datadog.android.rum.tracking.ViewAttributesProvider> = emptyArray()): Builder
+    fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
+    fun addPlugin(com.datadog.android.plugin.DatadogPlugin, com.datadog.android.plugin.Feature): Builder
+    fun sampleRumSessions(Float): Builder
+    fun setRumViewEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ViewEvent>): Builder
+    fun setRumResourceEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ResourceEvent>): Builder
+    fun setRumActionEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ActionEvent>): Builder
+    fun setRumErrorEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ErrorEvent>): Builder
+  companion object 
+class com.datadog.android.Credentials
+  constructor(String, String, String, String?, String?)
 object com.datadog.android.Datadog
   DEPRECATED const val DATADOG_US: String
   DEPRECATED const val DATADOG_EU: String

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Configuration.kt
@@ -1,0 +1,403 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android
+
+import android.os.Build
+import com.datadog.android.core.internal.event.NoOpEventMapper
+import com.datadog.android.event.EventMapper
+import com.datadog.android.plugin.DatadogPlugin
+import com.datadog.android.plugin.Feature as PluginFeature
+import com.datadog.android.rum.internal.domain.event.RumEvent
+import com.datadog.android.rum.internal.domain.event.RumEventMapper
+import com.datadog.android.rum.internal.instrumentation.GesturesTrackingStrategy
+import com.datadog.android.rum.internal.instrumentation.GesturesTrackingStrategyApi29
+import com.datadog.android.rum.internal.instrumentation.gestures.DatadogGesturesTracker
+import com.datadog.android.rum.internal.instrumentation.gestures.GesturesTracker
+import com.datadog.android.rum.internal.tracking.JetpackViewAttributesProvider
+import com.datadog.android.rum.internal.tracking.UserActionTrackingStrategy
+import com.datadog.android.rum.model.ActionEvent
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.rum.tracking.ViewAttributesProvider
+import com.datadog.android.rum.tracking.ViewTrackingStrategy
+
+/**
+ * An object describing the configuration of the Datadog SDK.
+ *
+ * This is necessary to initialize the SDK with the [Datadog.initialize] method.
+ */
+class Configuration
+internal constructor(
+    internal var coreConfig: Core,
+    internal val logsConfig: Feature.Logs?,
+    internal val tracesConfig: Feature.Tracing?,
+    internal val crashReportConfig: Feature.CrashReport?,
+    internal val rumConfig: Feature.RUM?
+) {
+
+    internal data class Core(
+        var needsClearTextHttp: Boolean,
+        val hosts: List<String>
+    )
+
+    internal sealed class Feature {
+        abstract val endpointUrl: String
+        abstract val plugins: List<DatadogPlugin>
+
+        internal data class Logs(
+            override val endpointUrl: String,
+            override val plugins: List<DatadogPlugin>
+        ) : Feature()
+
+        internal data class CrashReport(
+            override val endpointUrl: String,
+            override val plugins: List<DatadogPlugin>
+        ) : Feature()
+
+        internal data class Tracing(
+            override val endpointUrl: String,
+            override val plugins: List<DatadogPlugin>
+        ) : Feature()
+
+        internal data class RUM(
+            override val endpointUrl: String,
+            override val plugins: List<DatadogPlugin>,
+            val samplingRate: Float,
+            val gesturesTracker: GesturesTracker?,
+            val userActionTrackingStrategy: UserActionTrackingStrategy?,
+            val viewTrackingStrategy: ViewTrackingStrategy?,
+            val rumEventMapper: EventMapper<RumEvent>
+        ) : Feature()
+    }
+
+    // region Builder
+
+    /**
+     * A Builder class for a [Configuration].
+     * @param logsEnabled whether Logs are tracked and sent to Datadog (default: false)
+     * @param tracesEnabled whether Spans are tracked and sent to Datadog (default: false)
+     * @param crashReportsEnabled whether crashes are tracked and sent to Datadog (default: false)
+     * @param rumEnabled whether RUM events are tracked and sent to Datadog (default: false)
+     */
+    @Suppress("TooManyFunctions")
+    class Builder(
+        val logsEnabled: Boolean = false,
+        val tracesEnabled: Boolean = false,
+        val crashReportsEnabled: Boolean = false,
+        val rumEnabled: Boolean = false
+    ) {
+        private var logsConfig: Feature.Logs = DEFAULT_LOGS_CONFIG
+        private var tracesConfig: Feature.Tracing = DEFAULT_TRACING_CONFIG
+        private var crashReportConfig: Feature.CrashReport = DEFAULT_CRASH_CONFIG
+        private var rumConfig: Feature.RUM = DEFAULT_RUM_CONFIG
+
+        private var coreConfig = DEFAULT_CORE_CONFIG
+
+        /**
+         * Builds a [Configuration] based on the current state of this Builder.
+         */
+        fun build(): Configuration {
+            return Configuration(
+                coreConfig = coreConfig,
+                logsConfig = if (logsEnabled) logsConfig else null,
+                tracesConfig = if (tracesEnabled) tracesConfig else null,
+                crashReportConfig = if (crashReportsEnabled) crashReportConfig else null,
+                rumConfig = if (rumEnabled) rumConfig else null
+            )
+        }
+
+        /**
+         * Sets the list of first party hosts.
+         * Requests made to a URL with any one of these hosts (or any subdomain) will:
+         * - be considered a first party resource and categorised as such in your RUM dashboard;
+         * - be wrapped in a Span and have trace id injected to get a full flame-graph in APM.
+         * @param hosts a list of all the hosts that you own.
+         * See [DatadogInterceptor]
+         */
+        fun setFirstPartyHosts(hosts: List<String>): Builder {
+            coreConfig = coreConfig.copy(hosts = hosts)
+            return this
+        }
+
+        /**
+         * Let the SDK target Datadog's Europe server.
+         *
+         * Call this if you log on [app.datadoghq.eu](https://app.datadoghq.eu/).
+         */
+        fun useEUEndpoints(): Builder {
+            logsConfig = logsConfig.copy(endpointUrl = DatadogEndpoint.LOGS_EU)
+            tracesConfig = tracesConfig.copy(endpointUrl = DatadogEndpoint.TRACES_EU)
+            crashReportConfig = crashReportConfig.copy(endpointUrl = DatadogEndpoint.LOGS_EU)
+            rumConfig = rumConfig.copy(endpointUrl = DatadogEndpoint.RUM_EU)
+            coreConfig = coreConfig.copy(needsClearTextHttp = false)
+            return this
+        }
+
+        /**
+         * Let the SDK target Datadog's US server.
+         *
+         * Call this if you log on [app.datadoghq.com](https://app.datadoghq.com/).
+         */
+        fun useUSEndpoints(): Builder {
+            logsConfig = logsConfig.copy(endpointUrl = DatadogEndpoint.LOGS_US)
+            tracesConfig = tracesConfig.copy(endpointUrl = DatadogEndpoint.TRACES_US)
+            crashReportConfig = crashReportConfig.copy(endpointUrl = DatadogEndpoint.LOGS_US)
+            rumConfig = rumConfig.copy(endpointUrl = DatadogEndpoint.RUM_US)
+            coreConfig = coreConfig.copy(needsClearTextHttp = false)
+            return this
+        }
+
+        /**
+         * Let the SDK target Datadog's Gov server.
+         *
+         * Call this if you log on [app.ddog-gov.com/](https://app.ddog-gov.com/).
+         */
+        fun useGovEndpoints(): Builder {
+            logsConfig = logsConfig.copy(endpointUrl = DatadogEndpoint.LOGS_GOV)
+            tracesConfig = tracesConfig.copy(endpointUrl = DatadogEndpoint.TRACES_GOV)
+            crashReportConfig = crashReportConfig.copy(endpointUrl = DatadogEndpoint.LOGS_GOV)
+            rumConfig = rumConfig.copy(endpointUrl = DatadogEndpoint.RUM_GOV)
+            coreConfig = coreConfig.copy(needsClearTextHttp = false)
+            return this
+        }
+
+        /**
+         * Let the SDK target a custom server for the logs feature.
+         */
+        fun useCustomLogsEndpoint(endpoint: String): Builder {
+            logsConfig = logsConfig.copy(endpointUrl = endpoint)
+            checkCustomEndpoint(endpoint)
+            return this
+        }
+
+        /**
+         * Let the SDK target a custom server for the tracing feature.
+         */
+        fun useCustomTracesEndpoint(endpoint: String): Builder {
+            tracesConfig = tracesConfig.copy(endpointUrl = endpoint)
+            checkCustomEndpoint(endpoint)
+            return this
+        }
+
+        /**
+         * Let the SDK target a custom server for the crash reports feature.
+         */
+        fun useCustomCrashReportsEndpoint(endpoint: String): Builder {
+            crashReportConfig = crashReportConfig.copy(endpointUrl = endpoint)
+            checkCustomEndpoint(endpoint)
+            return this
+        }
+
+        /**
+         * Let the SDK target a custom server for the RUM feature.
+         */
+        fun useCustomRumEndpoint(endpoint: String): Builder {
+            rumConfig = rumConfig.copy(endpointUrl = endpoint)
+            checkCustomEndpoint(endpoint)
+            return this
+        }
+
+        /**
+         * Enable the user interaction automatic tracker. By enabling this feature the SDK will intercept
+         * UI interaction events (e.g.: taps, scrolls, swipes) and automatically send those as RUM UserActions for you.
+         * @param touchTargetExtraAttributesProviders an array with your own implementation of the
+         * target attributes provider.
+         * @see [ViewAttributesProvider]
+         */
+        @JvmOverloads
+        fun trackInteractions(
+            touchTargetExtraAttributesProviders: Array<ViewAttributesProvider> = emptyArray()
+        ): Builder {
+            val gesturesTracker = gestureTracker(touchTargetExtraAttributesProviders)
+            rumConfig = rumConfig.copy(
+                gesturesTracker = gesturesTracker,
+                userActionTrackingStrategy = provideUserTrackingStrategy(
+                    gesturesTracker
+                )
+            )
+            return this
+        }
+
+        /**
+         * Sets the automatic view tracking strategy used by the SDK.
+         * By default no view will be tracked.
+         * @param strategy as the [ViewTrackingStrategy]
+         * Note: By default, the RUM Monitor will let you handle View events manually.
+         * This means that you should call [RumMonitor.startView] and [RumMonitor.stopView]
+         * yourself. A view should be started when it becomes visible and interactive
+         * (equivalent to `onResume`) and be stopped when it's paused (equivalent to `onPause`).
+         * @see [com.datadog.android.rum.tracking.ActivityViewTrackingStrategy]
+         * @see [com.datadog.android.rum.tracking.FragmentViewTrackingStrategy]
+         * @see [com.datadog.android.rum.tracking.MixedViewTrackingStrategy]
+         * @see [com.datadog.android.rum.tracking.NavigationViewTrackingStrategy]
+
+         */
+        fun useViewTrackingStrategy(strategy: ViewTrackingStrategy): Builder {
+            rumConfig = rumConfig.copy(viewTrackingStrategy = strategy)
+            return this
+        }
+
+        /**
+         * Adds a plugin to a specific feature. This plugin will only be registered if the feature
+         * was enabled.
+         * @param plugin a [DatadogPlugin]
+         * @param feature the feature for which this plugin should be registered
+         * @see [Feature.LOG]
+         * @see [Feature.CRASH]
+         * @see [Feature.TRACE]
+         * @see [Feature.RUM]
+         */
+        fun addPlugin(plugin: DatadogPlugin, feature: PluginFeature): Builder {
+            when (feature) {
+                PluginFeature.RUM -> rumConfig = rumConfig.copy(
+                    plugins = rumConfig.plugins + plugin
+                )
+                PluginFeature.TRACE -> tracesConfig = tracesConfig.copy(
+                    plugins = tracesConfig.plugins + plugin
+                )
+                PluginFeature.LOG -> logsConfig = logsConfig.copy(
+                    plugins = logsConfig.plugins + plugin
+                )
+                PluginFeature.CRASH -> crashReportConfig = crashReportConfig.copy(
+                    plugins = crashReportConfig.plugins + plugin
+                )
+            }
+
+            return this
+        }
+
+        /**
+         * Sets the sampling rate for RUM Sessions.
+         *
+         * @param samplingRate the sampling rate must be a value between 0 and 100. A value of 0
+         * means no RUM event will be sent, 100 means all sessions will be kept.
+         *
+         */
+        fun sampleRumSessions(samplingRate: Float): Builder {
+            rumConfig = rumConfig.copy(samplingRate = samplingRate)
+            return this
+        }
+
+        /**
+         * Sets the [EventMapper] for the RUM [ViewEvent]. You can use this interface implementation
+         * to modify the [ViewEvent] attributes before serialisation.
+         *
+         * @param eventMapper the [EventMapper] implementation.
+         */
+        fun setRumViewEventMapper(eventMapper: EventMapper<ViewEvent>): Builder {
+            rumConfig = rumConfig.copy(
+                rumEventMapper = getRumEventMapper().copy(viewEventMapper = eventMapper)
+            )
+            return this
+        }
+
+        /**
+         * Sets the [EventMapper] for the RUM [ResourceEvent]. You can use this interface implementation
+         * to modify the [ResourceEvent] attributes before serialisation.
+         *
+         * @param eventMapper the [EventMapper] implementation.
+         */
+        fun setRumResourceEventMapper(eventMapper: EventMapper<ResourceEvent>): Builder {
+            rumConfig = rumConfig.copy(
+                rumEventMapper = getRumEventMapper().copy(resourceEventMapper = eventMapper)
+            )
+            return this
+        }
+
+        /**
+         * Sets the [EventMapper] for the RUM [ActionEvent]. You can use this interface implementation
+         * to modify the [ActionEvent] attributes before serialisation.
+         *
+         * @param eventMapper the [EventMapper] implementation.
+         */
+        fun setRumActionEventMapper(eventMapper: EventMapper<ActionEvent>): Builder {
+            rumConfig = rumConfig.copy(
+                rumEventMapper = getRumEventMapper().copy(actionEventMapper = eventMapper)
+            )
+            return this
+        }
+
+        /**
+         * Sets the [EventMapper] for the RUM [ErrorEvent]. You can use this interface implementation
+         * to modify the [ErrorEvent] attributes before serialisation.
+         *
+         * @param eventMapper the [EventMapper] implementation.
+         */
+        fun setRumErrorEventMapper(eventMapper: EventMapper<ErrorEvent>): Builder {
+            rumConfig = rumConfig.copy(
+                rumEventMapper = getRumEventMapper().copy(errorEventMapper = eventMapper)
+            )
+            return this
+        }
+
+        private fun checkCustomEndpoint(endpoint: String) {
+            if (endpoint.startsWith("http://")) {
+                coreConfig = coreConfig.copy(needsClearTextHttp = true)
+            }
+        }
+
+        private fun provideUserTrackingStrategy(
+            gesturesTracker: GesturesTracker
+        ): UserActionTrackingStrategy {
+            return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                GesturesTrackingStrategyApi29(gesturesTracker)
+            } else {
+                GesturesTrackingStrategy(gesturesTracker)
+            }
+        }
+
+        private fun getRumEventMapper(): RumEventMapper {
+            val rumEventMapper = rumConfig.rumEventMapper
+            return if (rumEventMapper is RumEventMapper) {
+                rumEventMapper
+            } else {
+                RumEventMapper()
+            }
+        }
+
+        private fun gestureTracker(
+            customProviders: Array<ViewAttributesProvider>
+        ): DatadogGesturesTracker {
+            val defaultProviders = arrayOf(JetpackViewAttributesProvider())
+            val providers = customProviders + defaultProviders
+            return DatadogGesturesTracker(providers)
+        }
+    }
+
+    // endregion
+
+    companion object {
+        internal const val DEFAULT_SAMPLING_RATE: Float = 100f
+
+        internal val DEFAULT_CORE_CONFIG = Core(
+            needsClearTextHttp = false,
+            hosts = emptyList()
+        )
+        internal val DEFAULT_LOGS_CONFIG = Feature.Logs(
+            endpointUrl = DatadogEndpoint.LOGS_US,
+            plugins = emptyList()
+        )
+        internal val DEFAULT_CRASH_CONFIG = Feature.CrashReport(
+            endpointUrl = DatadogEndpoint.LOGS_US,
+            plugins = emptyList()
+        )
+        internal val DEFAULT_TRACING_CONFIG = Feature.Tracing(
+            endpointUrl = DatadogEndpoint.TRACES_US,
+            plugins = emptyList()
+        )
+        internal val DEFAULT_RUM_CONFIG = Feature.RUM(
+            endpointUrl = DatadogEndpoint.RUM_US,
+            plugins = emptyList(),
+            samplingRate = DEFAULT_SAMPLING_RATE,
+            gesturesTracker = null,
+            userActionTrackingStrategy = null,
+            viewTrackingStrategy = null,
+            rumEventMapper = NoOpEventMapper()
+        )
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Credentials.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Credentials.kt
@@ -22,5 +22,5 @@ data class Credentials(
     val envName: String,
     val variant: String,
     val rumApplicationId: String?,
-    val serviceName: String?
+    val serviceName: String? = null
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Credentials.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Credentials.kt
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android
+
+/**
+ * Provides the credentials and identifying information for all the data tracked with the SDK.
+ * @param clientToken your API key of type Client Token
+ * @param envName the environment name that will be sent with each event. This can be used to
+ * filter your events on different environments (e.g.: "staging" vs. "production").
+ * @param variant the variant of your application, which should be the value from your
+ * `BuildConfig.FLAVOR` constant
+ * @param rumApplicationId your applicationId for RUM events
+ * @param serviceName the service name (if set to null, it'll be set to your application's
+ * package name, e.g.: com.example.android)
+ */
+data class Credentials(
+    val clientToken: String,
+    val envName: String,
+    val variant: String,
+    val rumApplicationId: String?,
+    val serviceName: String?
+)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -76,7 +76,7 @@ private constructor(
         return Configuration(
             coreConfig = Configuration.Core(
                 needsClearTextHttp = coreConfig.needsClearTextHttp,
-                hosts = coreConfig.hosts
+                firstPartyHosts = coreConfig.hosts
             ),
             logsConfig = logsConfig?.let {
                 Configuration.Feature.Logs(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -96,7 +96,7 @@ internal object CoreFeature {
         initializeClockSync(appContext)
         setupInfoProviders(appContext, consent)
         setupOkHttpClient(configuration.needsClearTextHttp)
-        firstPartyHostDetector = FirstPartyHostDetector(configuration.hosts)
+        firstPartyHostDetector = FirstPartyHostDetector(configuration.firstPartyHosts)
         setupExecutors()
 
         initialized.set(true)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -76,6 +76,7 @@ internal object CoreFeature {
     internal var rumApplicationId: String? = null
     internal var isMainProcess: Boolean = true
     internal var envName: String = ""
+    internal var variant: String = ""
 
     internal lateinit var uploadExecutorService: ScheduledThreadPoolExecutor
     internal lateinit var persistenceExecutorService: ExecutorService
@@ -144,6 +145,7 @@ internal object CoreFeature {
         serviceName = credentials.serviceName ?: appContext.packageName
         rumApplicationId = credentials.rumApplicationId
         envName = credentials.envName
+        variant = credentials.variant
         contextRef = WeakReference(appContext)
     }
 
@@ -223,6 +225,7 @@ internal object CoreFeature {
         rumApplicationId = null
         isMainProcess = true
         envName = ""
+        variant = ""
     }
 
     private fun cleanupProviders() {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -6,33 +6,141 @@
 
 package com.datadog.android.core.internal
 
+import android.content.Context
+import com.datadog.android.Configuration
+import com.datadog.android.core.internal.data.upload.DataUploadScheduler
+import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
+import com.datadog.android.core.internal.data.upload.UploadScheduler
+import com.datadog.android.core.internal.domain.NoOpPersistenceStrategy
+import com.datadog.android.core.internal.domain.PersistenceStrategy
+import com.datadog.android.core.internal.net.DataUploader
+import com.datadog.android.core.internal.net.NoOpDataUploader
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.plugin.DatadogPluginConfig
+import java.util.concurrent.atomic.AtomicBoolean
 
-internal abstract class SdkFeature {
-    private var featurePlugins: MutableList<DatadogPlugin> = mutableListOf()
+internal abstract class SdkFeature<T : Any, C : Configuration.Feature>(
+    internal val authorizedFolderName: String
+) {
 
-    protected fun registerPlugins(
+    internal val initialized = AtomicBoolean(false)
+
+    internal var endpointUrl: String = ""
+
+    internal var persistenceStrategy: PersistenceStrategy<T> = NoOpPersistenceStrategy()
+    internal var uploader: DataUploader = NoOpDataUploader()
+    internal var uploadScheduler: UploadScheduler = NoOpUploadScheduler()
+    internal val featurePlugins: MutableList<DatadogPlugin> = mutableListOf()
+
+    // region SDK Feature
+
+    fun initialize(context: Context, configuration: C) {
+        if (initialized.get()) {
+            return
+        }
+
+        endpointUrl = configuration.endpointUrl
+        persistenceStrategy = createPersistenceStrategy(context, configuration)
+
+        setupUploader()
+
+        registerPlugins(
+            configuration.plugins,
+            DatadogPluginConfig(
+                context = context,
+                envName = CoreFeature.envName,
+                serviceName = CoreFeature.serviceName,
+                featurePersistenceDirName = authorizedFolderName,
+                trackingConsent = CoreFeature.trackingConsentProvider.getConsent()
+            ),
+            CoreFeature.trackingConsentProvider
+        )
+
+        onInitialize(context, configuration)
+
+        initialized.set(true)
+    }
+
+    fun isInitialized(): Boolean {
+        return initialized.get()
+    }
+
+    fun clearAllData() {
+        persistenceStrategy.clearAllData()
+    }
+
+    fun stop() {
+        if (initialized.get()) {
+            unregisterPlugins()
+            uploadScheduler.stopScheduling()
+            persistenceStrategy = NoOpPersistenceStrategy()
+            uploadScheduler = NoOpUploadScheduler()
+            endpointUrl = ""
+
+            onStop()
+
+            initialized.set(false)
+        }
+    }
+
+    fun getPlugins(): List<DatadogPlugin> {
+        return featurePlugins
+    }
+
+    // endregion
+
+    // region Abstract
+
+    open fun onInitialize(context: Context, configuration: C) {}
+
+    open fun onStop() {}
+
+    abstract fun createPersistenceStrategy(
+        context: Context,
+        configuration: C
+    ): PersistenceStrategy<T>
+
+    abstract fun createUploader(): DataUploader
+
+    // endregion
+
+    // region Internal
+
+    private fun registerPlugins(
         plugins: List<DatadogPlugin>,
         config: DatadogPluginConfig,
         trackingConsentProvider: ConsentProvider
     ) {
-        this.featurePlugins = plugins.toMutableList()
         plugins.forEach {
+            featurePlugins.add(it)
             it.register(config)
             trackingConsentProvider.registerCallback(it)
         }
     }
 
-    protected fun unregisterPlugins() {
+    private fun unregisterPlugins() {
         featurePlugins.forEach {
             it.unregister()
         }
         featurePlugins.clear()
     }
 
-    fun getPlugins(): List<DatadogPlugin> {
-        return featurePlugins
+    private fun setupUploader() {
+        uploadScheduler = if (CoreFeature.isMainProcess) {
+            uploader = createUploader()
+            DataUploadScheduler(
+                persistenceStrategy.getReader(),
+                uploader,
+                CoreFeature.networkInfoProvider,
+                CoreFeature.systemInfoProvider,
+                CoreFeature.uploadExecutorService
+            )
+        } else {
+            NoOpUploadScheduler()
+        }
+        uploadScheduler.startScheduling()
     }
+
+    // endregion
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/event/NoOpEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/event/NoOpEventMapper.kt
@@ -13,4 +13,12 @@ internal class NoOpEventMapper<T : Any> : EventMapper<T> {
     override fun map(event: T): T {
         return event
     }
+
+    override fun equals(other: Any?): Boolean {
+        return other is NoOpEventMapper<*>
+    }
+
+    override fun hashCode(): Int {
+        return 0
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -14,8 +14,8 @@ import okhttp3.Request
 import okhttp3.RequestBody
 
 internal abstract class DataOkHttpUploader(
-    private var url: String,
-    private val client: OkHttpClient,
+    internal var url: String,
+    internal val client: OkHttpClient,
     internal val contentType: String = CONTENT_TYPE_JSON
 ) : DataUploader {
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/DatadogPluginConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/DatadogPluginConfig.kt
@@ -7,76 +7,15 @@
 package com.datadog.android.plugin
 
 import android.content.Context
-import com.datadog.android.error.internal.CrashLogFileStrategy
-import com.datadog.android.log.internal.domain.LogFileStrategy
 import com.datadog.android.privacy.TrackingConsent
-import com.datadog.android.rum.internal.domain.RumFileStrategy
-import com.datadog.android.tracing.internal.domain.TracingFileStrategy
 
 /**
  * Used to deliver the context from the SDK internals to a [DatadogPlugin] implementation.
  */
-sealed class DatadogPluginConfig(
+class DatadogPluginConfig(
     val context: Context,
     val envName: String,
     val serviceName: String,
     val featurePersistenceDirName: String,
     val trackingConsent: TrackingConsent
-) {
-
-    internal class CrashReportsPluginConfig(
-        context: Context,
-        envName: String,
-        serviceName: String,
-        trackingConsent: TrackingConsent
-    ) :
-        DatadogPluginConfig(
-            context,
-            envName,
-            serviceName,
-            CrashLogFileStrategy.AUTHORIZED_FOLDER,
-            trackingConsent
-        )
-
-    internal class LogsPluginConfig(
-        context: Context,
-        envName: String,
-        serviceName: String,
-        trackingConsent: TrackingConsent
-    ) :
-        DatadogPluginConfig(
-            context,
-            envName,
-            serviceName,
-            LogFileStrategy.AUTHORIZED_FOLDER,
-            trackingConsent
-        )
-
-    internal class TracingPluginConfig(
-        context: Context,
-        envName: String,
-        serviceName: String,
-        trackingConsent: TrackingConsent
-    ) :
-        DatadogPluginConfig(
-            context,
-            envName,
-            serviceName,
-            TracingFileStrategy.AUTHORIZED_FOLDER,
-            trackingConsent
-        )
-
-    internal class RumPluginConfig(
-        context: Context,
-        envName: String,
-        serviceName: String,
-        trackingConsent: TrackingConsent
-    ) :
-        DatadogPluginConfig(
-            context,
-            envName,
-            serviceName,
-            RumFileStrategy.AUTHORIZED_FOLDER,
-            trackingConsent
-        )
-}
+)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/Feature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/Feature.kt
@@ -9,9 +9,9 @@ package com.datadog.android.plugin
 /**
  * Provides the available feature for which a [DatadogPlugin] can be assigned.
  */
-enum class Feature {
-    LOG,
-    CRASH,
-    TRACE,
-    RUM
+enum class Feature(val featureName: String) {
+    LOG("Logging"),
+    CRASH("Crash Reporting"),
+    TRACE("Tracing"),
+    RUM("RUM")
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -45,6 +45,12 @@ object RumAttributes {
     const val SOURCE: String = "source"
 
     /**
+     * The application variant. (String)
+     * This value is filled automatically by the [RumMonitor].
+     */
+    const val VARIANT: String = "variant"
+
+    /**
      * Version of the current Datadog SDK.
      */
     const val SDK_VERSION: String = "sdk_version"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -213,12 +213,16 @@ interface RumMonitor {
          * Builds a [RumMonitor] based on the current state of this Builder.
          */
         fun build(): RumMonitor {
+            val rumApplicationId = CoreFeature.rumApplicationId
             return if (!RumFeature.isInitialized()) {
+                devLogger.e(RUM_NOT_ENABLED_ERROR_MESSAGE)
+                NoOpRumMonitor()
+            } else if (rumApplicationId.isNullOrBlank()) {
                 devLogger.e(RUM_NOT_ENABLED_ERROR_MESSAGE)
                 NoOpRumMonitor()
             } else {
                 DatadogRumMonitor(
-                    applicationId = RumFeature.applicationId,
+                    applicationId = rumApplicationId,
                     samplingRate = samplingRate,
                     writer = RumFeature.persistenceStrategy.getWriter(),
                     handler = Handler(Looper.getMainLooper()),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -6,12 +6,12 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.domain.Time
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
-import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.model.ActionEvent
@@ -160,7 +160,7 @@ internal class RumActionScope(
             attributes.putAll(GlobalRum.globalAttributes)
 
             val context = getRumContext()
-            val user = RumFeature.userInfoProvider.getUserInfo()
+            val user = CoreFeature.userInfoProvider.getUserInfo()
 
             val actionEvent = ActionEvent(
                 date = eventTimestamp,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -10,10 +10,9 @@ import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.RumEvent
-import java.util.UUID
 
 internal class RumApplicationScope(
-    applicationId: UUID,
+    applicationId: String,
     internal val samplingRate: Float,
     private val firstPartyHostDetector: FirstPartyHostDetector
 ) : RumScope {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.domain.Time
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
@@ -14,7 +15,6 @@ import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
-import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.domain.event.RumEvent
@@ -41,7 +41,7 @@ internal class RumResourceScope(
 
     private val eventTimestamp = eventTime.timestamp
     private val startedNanos: Long = eventTime.nanoTime
-    private val networkInfo = RumFeature.networkInfoProvider.getLatestNetworkInfo()
+    private val networkInfo = CoreFeature.networkInfoProvider.getLatestNetworkInfo()
 
     private var sent = false
     private var waitForTiming = false
@@ -128,7 +128,7 @@ internal class RumResourceScope(
         val spanId = attributes.remove(RumAttributes.SPAN_ID)?.toString()
 
         val context = getRumContext()
-        val user = RumFeature.userInfoProvider.getUserInfo()
+        val user = CoreFeature.userInfoProvider.getUserInfo()
 
         val finalTiming = timing
         val duration = eventTime.nanoTime - startedNanos
@@ -198,7 +198,7 @@ internal class RumResourceScope(
         attributes.putAll(GlobalRum.globalAttributes)
 
         val context = getRumContext()
-        val user = RumFeature.userInfoProvider.getUserInfo()
+        val user = CoreFeature.userInfoProvider.getUserInfo()
         val errorEvent = ErrorEvent(
             date = eventTimestamp,
             error = ErrorEvent.Error(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -6,12 +6,12 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.domain.Time
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRum
-import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.model.ActionEvent
@@ -181,9 +181,9 @@ internal class RumViewScope(
         if (stopped) return
 
         val context = getRumContext()
-        val user = RumFeature.userInfoProvider.getUserInfo()
+        val user = CoreFeature.userInfoProvider.getUserInfo()
         val updatedAttributes = addExtraAttributes(event.attributes)
-        val networkInfo = RumFeature.networkInfoProvider.getLatestNetworkInfo()
+        val networkInfo = CoreFeature.networkInfoProvider.getLatestNetworkInfo()
 
         val errorEvent = ErrorEvent(
             date = eventTimestamp,
@@ -276,7 +276,7 @@ internal class RumViewScope(
         version++
         val updatedDurationNs = event.eventTime.nanoTime - startedNanos
         val context = getRumContext()
-        val user = RumFeature.userInfoProvider.getUserInfo()
+        val user = CoreFeature.userInfoProvider.getUserInfo()
 
         val viewEvent = ViewEvent(
             date = eventTimestamp,
@@ -336,7 +336,7 @@ internal class RumViewScope(
         writer: Writer<RumEvent>
     ) {
         val context = getRumContext()
-        val user = RumFeature.userInfoProvider.getUserInfo()
+        val user = CoreFeature.userInfoProvider.getUserInfo()
 
         val actionEvent = ActionEvent(
             date = eventTimestamp,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/GesturesTrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/GesturesTrackingStrategy.kt
@@ -16,6 +16,11 @@ internal class GesturesTrackingStrategy(
 ) :
     ActivityLifecycleTrackingStrategy(),
     UserActionTrackingStrategy {
+
+    override fun getGesturesTracker(): GesturesTracker {
+        return gesturesTracker
+    }
+
     override fun onActivityResumed(activity: Activity) {
         super.onActivityResumed(activity)
         gesturesTracker.startTracking(activity.window, activity)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/GesturesTrackingStrategyApi29.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/GesturesTrackingStrategyApi29.kt
@@ -17,6 +17,10 @@ internal class GesturesTrackingStrategyApi29(
 ) : ActivityLifecycleTrackingStrategy(),
     UserActionTrackingStrategy {
 
+    override fun getGesturesTracker(): GesturesTracker {
+        return gesturesTracker
+    }
+
     override fun onActivityPreCreated(activity: Activity, savedInstanceState: Bundle?) {
         gesturesTracker.startTracking(activity.window, activity)
         super.onActivityPreCreated(activity, savedInstanceState)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -20,13 +20,12 @@ import com.datadog.android.rum.internal.domain.scope.RumApplicationScope
 import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.domain.scope.RumScope
 import com.datadog.android.rum.model.ViewEvent
-import java.util.UUID
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 
 internal class DatadogRumMonitor(
-    applicationId: UUID,
+    applicationId: String,
     internal val samplingRate: Float,
     private val writer: Writer<RumEvent>,
     internal val handler: Handler,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
@@ -10,7 +10,6 @@ import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.DataOkHttpUploader
 import com.datadog.android.rum.RumAttributes
-import com.datadog.android.rum.internal.RumFeature
 import java.util.Locale
 import okhttp3.OkHttpClient
 
@@ -25,7 +24,7 @@ internal open class RumOkHttpUploader(
             "${RumAttributes.SERVICE_NAME}:${CoreFeature.serviceName}",
             "${RumAttributes.APPLICATION_VERSION}:${CoreFeature.packageVersion}",
             "${RumAttributes.SDK_VERSION}:${BuildConfig.VERSION_NAME}",
-            "${RumAttributes.ENV}:${RumFeature.envName}"
+            "${RumAttributes.ENV}:${CoreFeature.envName}"
         ).joinToString(",")
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
@@ -24,7 +24,8 @@ internal open class RumOkHttpUploader(
             "${RumAttributes.SERVICE_NAME}:${CoreFeature.serviceName}",
             "${RumAttributes.APPLICATION_VERSION}:${CoreFeature.packageVersion}",
             "${RumAttributes.SDK_VERSION}:${BuildConfig.VERSION_NAME}",
-            "${RumAttributes.ENV}:${CoreFeature.envName}"
+            "${RumAttributes.ENV}:${CoreFeature.envName}",
+            "${RumAttributes.VARIANT}:${CoreFeature.variant}"
         ).joinToString(",")
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/UserActionTrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/UserActionTrackingStrategy.kt
@@ -5,6 +5,7 @@
  */
 package com.datadog.android.rum.internal.tracking
 
+import com.datadog.android.rum.internal.instrumentation.gestures.GesturesTracker
 import com.datadog.android.rum.tracking.TrackingStrategy
 import com.datadog.tools.annotation.NoOpImplementation
 
@@ -12,5 +13,6 @@ import com.datadog.tools.annotation.NoOpImplementation
  * A TrackingStrategy dedicated to user actions tracking.
  */
 @NoOpImplementation
-internal interface UserActionTrackingStrategy :
-    TrackingStrategy
+internal interface UserActionTrackingStrategy : TrackingStrategy {
+    fun getGesturesTracker(): GesturesTracker
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracingFileStrategy.kt
@@ -40,8 +40,7 @@ internal class TracingFileStrategy(
     companion object {
         internal const val VERSION = 1
         internal const val ROOT = "dd-tracing"
-        internal const val INTERMEDIATE_DATA_FOLDER =
-            "$ROOT-pending-v$VERSION"
+        internal const val INTERMEDIATE_DATA_FOLDER = "$ROOT-pending-v$VERSION"
         internal const val AUTHORIZED_FOLDER = "$ROOT-v$VERSION"
         internal const val MAX_DELAY_BETWEEN_SPANS_MS = 5000L
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/ConfigurationBuilderTest.kt
@@ -1,0 +1,446 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android
+
+import android.os.Build
+import com.datadog.android.core.internal.event.NoOpEventMapper
+import com.datadog.android.event.EventMapper
+import com.datadog.android.log.internal.logger.LogHandler
+import com.datadog.android.plugin.DatadogPlugin
+import com.datadog.android.plugin.Feature
+import com.datadog.android.rum.assertj.ConfigurationRumAssert.Companion.assertThat
+import com.datadog.android.rum.internal.domain.event.RumEventMapper
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.rum.tracking.ViewAttributesProvider
+import com.datadog.android.rum.tracking.ViewTrackingStrategy
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.mockDevLogHandler
+import com.datadog.tools.unit.annotations.TestTargetApi
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import com.nhaarman.mockitokotlin2.mock
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings()
+@ForgeConfiguration(value = Configurator::class)
+internal class ConfigurationBuilderTest {
+
+    lateinit var testedBuilder: Configuration.Builder
+
+    @StringForgery(type = StringForgeryType.HEXADECIMAL)
+    lateinit var fakeClientToken: String
+
+    @StringForgery
+    lateinit var fakeEnvName: String
+
+    @Forgery
+    lateinit var fakeApplicationId: UUID
+
+    lateinit var mockDevLogHandler: LogHandler
+
+    @BeforeEach
+    fun `set up`() {
+        mockDevLogHandler = mockDevLogHandler()
+        testedBuilder = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+    }
+
+    @Test
+    fun `𝕄 disable all features by default 𝕎 build()`() {
+        // Given
+        val builder = Configuration.Builder()
+
+        // When
+        val config = builder.build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(
+            Configuration.Core(
+                needsClearTextHttp = false,
+                hosts = emptyList()
+            )
+        )
+        assertThat(config.logsConfig).isNull()
+        assertThat(config.tracesConfig).isNull()
+        assertThat(config.crashReportConfig).isNull()
+        assertThat(config.rumConfig).isNull()
+    }
+
+    @Test
+    fun `𝕄 use sensible defaults 𝕎 build()`() {
+        // When
+        val config = testedBuilder.build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(
+            Configuration.Core(
+                needsClearTextHttp = false,
+                hosts = emptyList()
+            )
+        )
+        assertThat(config.logsConfig).isEqualTo(
+            Configuration.Feature.Logs(
+                endpointUrl = DatadogEndpoint.LOGS_US,
+                plugins = emptyList()
+            )
+        )
+        assertThat(config.tracesConfig).isEqualTo(
+            Configuration.Feature.Tracing(
+                endpointUrl = DatadogEndpoint.TRACES_US,
+                plugins = emptyList()
+            )
+        )
+        assertThat(config.crashReportConfig).isEqualTo(
+            Configuration.Feature.CrashReport(
+                endpointUrl = DatadogEndpoint.LOGS_US,
+                plugins = emptyList()
+            )
+        )
+        assertThat(config.rumConfig).isEqualTo(
+            Configuration.Feature.RUM(
+                endpointUrl = DatadogEndpoint.RUM_US,
+                plugins = emptyList(),
+                samplingRate = Configuration.DEFAULT_SAMPLING_RATE,
+                gesturesTracker = null,
+                userActionTrackingStrategy = null,
+                viewTrackingStrategy = null,
+                rumEventMapper = NoOpEventMapper()
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with US endpoints 𝕎 useUSEndpoints() and build()`() {
+        // When
+        val config = testedBuilder.useUSEndpoints().build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(
+            Configuration.DEFAULT_LOGS_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_US)
+        )
+        assertThat(config.tracesConfig).isEqualTo(
+            Configuration.DEFAULT_TRACING_CONFIG.copy(endpointUrl = DatadogEndpoint.TRACES_US)
+        )
+        assertThat(config.crashReportConfig).isEqualTo(
+            Configuration.DEFAULT_CRASH_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_US)
+        )
+        assertThat(config.rumConfig).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = DatadogEndpoint.RUM_US)
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with EU endpoints 𝕎 useEUEndpoints() and build()`() {
+        // When
+        val config = testedBuilder.useEUEndpoints().build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(
+            Configuration.DEFAULT_LOGS_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_EU)
+        )
+        assertThat(config.tracesConfig).isEqualTo(
+            Configuration.DEFAULT_TRACING_CONFIG.copy(endpointUrl = DatadogEndpoint.TRACES_EU)
+        )
+        assertThat(config.crashReportConfig).isEqualTo(
+            Configuration.DEFAULT_CRASH_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_EU)
+        )
+        assertThat(config.rumConfig).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = DatadogEndpoint.RUM_EU)
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with GOV endpoints 𝕎 useGOVEndpoints() and build()`() {
+        // When
+        val config = testedBuilder.useGovEndpoints().build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(
+            Configuration.DEFAULT_LOGS_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_GOV)
+        )
+        assertThat(config.tracesConfig).isEqualTo(
+            Configuration.DEFAULT_TRACING_CONFIG.copy(endpointUrl = DatadogEndpoint.TRACES_GOV)
+        )
+        assertThat(config.crashReportConfig).isEqualTo(
+            Configuration.DEFAULT_CRASH_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_GOV)
+        )
+        assertThat(config.rumConfig).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = DatadogEndpoint.RUM_GOV)
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with custom endpoints 𝕎 useCustomXXXEndpoint() and build()`(
+        @StringForgery(regex = "https://[a-z]+\\.com") logsUrl: String,
+        @StringForgery(regex = "https://[a-z]+\\.com") tracesUrl: String,
+        @StringForgery(regex = "https://[a-z]+\\.com") crashReportsUrl: String,
+        @StringForgery(regex = "https://[a-z]+\\.com") rumUrl: String
+    ) {
+        // When
+        val config = testedBuilder
+            .useCustomLogsEndpoint(logsUrl)
+            .useCustomTracesEndpoint(tracesUrl)
+            .useCustomCrashReportsEndpoint(crashReportsUrl)
+            .useCustomRumEndpoint(rumUrl)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(
+            Configuration.DEFAULT_CORE_CONFIG.copy(
+                needsClearTextHttp = false
+            )
+        )
+        assertThat(config.logsConfig).isEqualTo(
+            Configuration.DEFAULT_LOGS_CONFIG.copy(endpointUrl = logsUrl)
+        )
+        assertThat(config.tracesConfig).isEqualTo(
+            Configuration.DEFAULT_TRACING_CONFIG.copy(endpointUrl = tracesUrl)
+        )
+        assertThat(config.crashReportConfig).isEqualTo(
+            Configuration.DEFAULT_CRASH_CONFIG.copy(endpointUrl = crashReportsUrl)
+        )
+        assertThat(config.rumConfig).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = rumUrl)
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with custom cleartext endpoints 𝕎 useCustomXXXEndpoint() and build()`(
+        @StringForgery(regex = "http://[a-z]+\\.com") logsUrl: String,
+        @StringForgery(regex = "http://[a-z]+\\.com") tracesUrl: String,
+        @StringForgery(regex = "http://[a-z]+\\.com") crashReportsUrl: String,
+        @StringForgery(regex = "http://[a-z]+\\.com") rumUrl: String
+    ) {
+        // When
+        val config = testedBuilder
+            .useCustomLogsEndpoint(logsUrl)
+            .useCustomTracesEndpoint(tracesUrl)
+            .useCustomCrashReportsEndpoint(crashReportsUrl)
+            .useCustomRumEndpoint(rumUrl)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(
+            Configuration.DEFAULT_CORE_CONFIG.copy(
+                needsClearTextHttp = true
+            )
+        )
+        assertThat(config.logsConfig).isEqualTo(
+            Configuration.DEFAULT_LOGS_CONFIG.copy(endpointUrl = logsUrl)
+        )
+        assertThat(config.tracesConfig).isEqualTo(
+            Configuration.DEFAULT_TRACING_CONFIG.copy(endpointUrl = tracesUrl)
+        )
+        assertThat(config.crashReportConfig).isEqualTo(
+            Configuration.DEFAULT_CRASH_CONFIG.copy(endpointUrl = crashReportsUrl)
+        )
+        assertThat(config.rumConfig).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = rumUrl)
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with first party hosts 𝕎 setFirstPartyHosts() and build()`(
+        @StringForgery(regex = "([a-zA-Z0-9]{3,9}\\.){1,4}[a-z]{3}") hosts: List<String>
+    ) {
+        // When
+        val config = testedBuilder
+            .setFirstPartyHosts(hosts)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(
+            Configuration.DEFAULT_CORE_CONFIG.copy(hosts = hosts)
+        )
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
+    }
+
+    @Test
+    fun `𝕄 build config with gestures enabled 𝕎 trackInteractions() and build()`(
+        @IntForgery(0, 10) attributesCount: Int
+    ) {
+        // Given
+        val mockProviders = Array<ViewAttributesProvider>(attributesCount) {
+            mock()
+        }
+
+        // When
+        val config = testedBuilder
+            .trackInteractions(mockProviders)
+            .build()
+
+        // Then
+
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig!!)
+            .hasGesturesTrackingStrategy()
+            .hasViewAttributeProviders(mockProviders)
+            .doesNotHaveViewTrackingStrategy()
+    }
+
+    @TestTargetApi(value = Build.VERSION_CODES.Q)
+    @Test
+    fun `𝕄 build config with gestures enabled 𝕎 trackInteractions() and build() {Android Q}`(
+        @IntForgery(0, 10) attributesCount: Int
+    ) {
+        // Given
+        val mockProviders = Array<ViewAttributesProvider>(attributesCount) {
+            mock()
+        }
+
+        // When
+        val config = testedBuilder
+            .trackInteractions(mockProviders)
+            .build()
+
+        // Then
+
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig!!)
+            .hasGesturesTrackingStrategyApi29()
+            .hasViewAttributeProviders(mockProviders)
+            .doesNotHaveViewTrackingStrategy()
+    }
+
+    @Test
+    fun `𝕄 build config with view strategy enabled 𝕎 useViewTrackingStrategy() and build()`() {
+        // Given
+        val strategy: ViewTrackingStrategy = mock()
+
+        // When
+        val config = testedBuilder
+            .useViewTrackingStrategy(strategy)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig!!)
+            .doesNotHaveGesturesTrackingStrategy()
+            .hasViewTrackingStrategy(strategy)
+    }
+
+    @Test
+    fun `𝕄 build config with sampling rate 𝕎 sampleRumSessions() and build()`(
+        @FloatForgery(min = 0f, max = 100f) sampling: Float
+    ) {
+        // When
+        val config = testedBuilder
+            .sampleRumSessions(sampling)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig!!).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(
+                samplingRate = sampling
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with RUM View eventMapper 𝕎 setRumViewEventMapper() and build()`() {
+        // Given
+        val eventMapper: EventMapper<ViewEvent> = mock()
+
+        // When
+        val config = testedBuilder
+            .setRumViewEventMapper(eventMapper)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        val expectedRumEventMapper = RumEventMapper(viewEventMapper = eventMapper)
+        assertThat(config.rumConfig!!).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(
+                rumEventMapper = expectedRumEventMapper
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with plugin 𝕎 addPlugin() and build()`() {
+        // Given
+        val logsPlugin: DatadogPlugin = mock()
+        val tracesPlugin: DatadogPlugin = mock()
+        val rumPlugin: DatadogPlugin = mock()
+        val crashPlugin: DatadogPlugin = mock()
+
+        // When
+        val config = testedBuilder
+            .addPlugin(logsPlugin, Feature.LOG)
+            .addPlugin(tracesPlugin, Feature.TRACE)
+            .addPlugin(rumPlugin, Feature.RUM)
+            .addPlugin(crashPlugin, Feature.CRASH)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(
+            Configuration.DEFAULT_LOGS_CONFIG.copy(
+                plugins = listOf(logsPlugin)
+            )
+        )
+        assertThat(config.tracesConfig).isEqualTo(
+            Configuration.DEFAULT_TRACING_CONFIG.copy(
+                plugins = listOf(tracesPlugin)
+            )
+        )
+        assertThat(config.crashReportConfig).isEqualTo(
+            Configuration.DEFAULT_CRASH_CONFIG.copy(
+                plugins = listOf(crashPlugin)
+            )
+        )
+        assertThat(config.rumConfig!!).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(
+                plugins = listOf(rumPlugin)
+            )
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutTracesTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutTracesTest.kt
@@ -8,9 +8,9 @@ package com.datadog.android
 
 import android.content.Context
 import android.util.Log
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.net.identifyRequest
-import com.datadog.android.core.internal.privacy.TrackingConsentProvider
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumErrorSource
@@ -22,12 +22,12 @@ import com.datadog.android.tracing.TracingInterceptorTest
 import com.datadog.android.tracing.internal.TracesFeature
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext
+import com.datadog.android.utils.mockCoreFeature
 import com.datadog.android.utils.mockDevLogHandler
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.inOrder
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -104,7 +104,7 @@ internal class DatadogInterceptorWithoutTracesTest {
     lateinit var fakeUrl: String
 
     @Forgery
-    lateinit var fakeConfig: DatadogConfig.FeatureConfig
+    lateinit var fakeConfig: Configuration.Feature.Tracing
 
     @StringForgery
     lateinit var fakePackageName: String
@@ -122,6 +122,7 @@ internal class DatadogInterceptorWithoutTracesTest {
         mockDevLogHandler = mockDevLogHandler()
         mockAppContext = mockContext(fakePackageName, fakePackageVersion)
         Datadog.setVerbosity(Log.VERBOSE)
+        mockCoreFeature()
 
         val mediaType = forge.anElementFrom("application", "image", "text", "model") +
             "/" + forge.anAlphabeticalString()
@@ -134,8 +135,7 @@ internal class DatadogInterceptorWithoutTracesTest {
         ) { mockLocalTracer }
         TracesFeature.initialize(
             mockAppContext,
-            fakeConfig,
-            mock(), mock(), mock(), mock(), mock(), mock(), mock(), TrackingConsentProvider()
+            fakeConfig
         )
 
         GlobalRum.registerIfAbsent(mockRumMonitor)
@@ -143,6 +143,7 @@ internal class DatadogInterceptorWithoutTracesTest {
 
     @AfterEach
     fun `tear down`() {
+        CoreFeature.stop()
         GlobalRum.isRegistered.set(false)
         TracesFeature.stop()
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -75,11 +75,17 @@ internal class DatadogTest {
     @StringForgery
     lateinit var fakePackageName: String
 
+    @StringForgery
+    lateinit var fakeVariant: String
+
     @StringForgery(regex = "\\d(\\.\\d){3}")
     lateinit var fakePackageVersion: String
 
     @StringForgery(regex = "[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]")
     lateinit var fakeEnvName: String
+
+    @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+    lateinit var fakeApplicationId: String
 
     @TempDir
     lateinit var tempRootDir: File
@@ -339,6 +345,28 @@ internal class DatadogTest {
 
         // When
         Datadog.initialize(mockAppContext, config)
+
+        // Then
+        assertThat(CoreFeature.initialized.get()).isTrue()
+        assertThat(LogsFeature.initialized.get()).isTrue()
+        assertThat(CrashReportsFeature.initialized.get()).isTrue()
+        assertThat(TracesFeature.initialized.get()).isTrue()
+        assertThat(RumFeature.initialized.get()).isTrue()
+    }
+
+    @Test
+    fun `𝕄 initialize features 𝕎 initialize(context, config) deprecated method`() {
+        // Given
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, fakeApplicationId, null)
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        ).build()
+
+        // When
+        Datadog.initialize(mockAppContext, credentials, configuration, fakeConsent)
 
         // Then
         assertThat(CoreFeature.initialized.get()).isTrue()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -262,6 +262,7 @@ internal class CoreFeatureTest {
         assertThat(CoreFeature.packageVersion).isEqualTo(fakePackageVersion)
         assertThat(CoreFeature.serviceName).isEqualTo(fakeCredentials.serviceName)
         assertThat(CoreFeature.envName).isEqualTo(fakeCredentials.envName)
+        assertThat(CoreFeature.variant).isEqualTo(fakeCredentials.variant)
         assertThat(CoreFeature.rumApplicationId).isEqualTo(fakeCredentials.rumApplicationId)
         assertThat(CoreFeature.contextRef.get()).isEqualTo(mockAppContext)
     }
@@ -282,6 +283,7 @@ internal class CoreFeatureTest {
         assertThat(CoreFeature.packageVersion).isEqualTo(fakePackageVersion)
         assertThat(CoreFeature.serviceName).isEqualTo(fakePackageName)
         assertThat(CoreFeature.envName).isEqualTo(fakeCredentials.envName)
+        assertThat(CoreFeature.variant).isEqualTo(fakeCredentials.variant)
         assertThat(CoreFeature.rumApplicationId).isEqualTo(fakeCredentials.rumApplicationId)
         assertThat(CoreFeature.contextRef.get()).isEqualTo(mockAppContext)
     }
@@ -302,6 +304,7 @@ internal class CoreFeatureTest {
         assertThat(CoreFeature.packageVersion).isEqualTo(fakePackageVersion)
         assertThat(CoreFeature.serviceName).isEqualTo(fakeCredentials.serviceName)
         assertThat(CoreFeature.envName).isEqualTo(fakeCredentials.envName)
+        assertThat(CoreFeature.variant).isEqualTo(fakeCredentials.variant)
         assertThat(CoreFeature.rumApplicationId).isNull()
         assertThat(CoreFeature.contextRef.get()).isEqualTo(mockAppContext)
     }
@@ -330,6 +333,7 @@ internal class CoreFeatureTest {
         assertThat(CoreFeature.packageVersion).isEqualTo(versionCode.toString())
         assertThat(CoreFeature.serviceName).isEqualTo(fakeCredentials.serviceName)
         assertThat(CoreFeature.envName).isEqualTo(fakeCredentials.envName)
+        assertThat(CoreFeature.variant).isEqualTo(fakeCredentials.variant)
         assertThat(CoreFeature.rumApplicationId).isNull()
         assertThat(CoreFeature.contextRef.get()).isEqualTo(mockAppContext)
     }
@@ -437,6 +441,7 @@ internal class CoreFeatureTest {
         assertThat(CoreFeature.packageVersion).isEqualTo(fakePackageVersion)
         assertThat(CoreFeature.serviceName).isEqualTo(fakeCredentials.serviceName)
         assertThat(CoreFeature.envName).isEqualTo(fakeCredentials.envName)
+        assertThat(CoreFeature.variant).isEqualTo(fakeCredentials.variant)
         assertThat(CoreFeature.rumApplicationId).isEqualTo(fakeCredentials.rumApplicationId)
         assertThat(CoreFeature.contextRef.get()).isEqualTo(mockAppContext)
     }
@@ -537,6 +542,7 @@ internal class CoreFeatureTest {
         assertThat(CoreFeature.packageVersion).isEqualTo("")
         assertThat(CoreFeature.serviceName).isEqualTo("")
         assertThat(CoreFeature.envName).isEqualTo("")
+        assertThat(CoreFeature.variant).isEqualTo("")
         assertThat(CoreFeature.rumApplicationId).isNull()
         assertThat(CoreFeature.contextRef.get()).isNull()
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -243,7 +243,7 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(CoreFeature.firstPartyHostDetector.knownHosts)
-            .containsAll(fakeConfig.hosts.map { it.toLowerCase(Locale.US) })
+            .containsAll(fakeConfig.firstPartyHosts.map { it.toLowerCase(Locale.US) })
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -71,7 +71,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
     @Mock
     lateinit var mockUploader: DataUploader
 
-    lateinit var fakeConfig: C
+    lateinit var fakeConfigurationFeature: C
 
     @StringForgery
     lateinit var fakePackageName: String
@@ -102,7 +102,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
         whenever(mockAppContext.applicationContext) doReturn mockAppContext
         whenever(mockPersistenceStrategy.getReader()) doReturn mockReader
 
-        fakeConfig = forgeConfiguration(forge)
+        fakeConfigurationFeature = forgeConfiguration(forge)
         testedFeature = createTestedFeature()
     }
 
@@ -119,7 +119,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
     @Test
     fun `𝕄 mark itself as initialized 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         assertThat(testedFeature.isInitialized()).isTrue()
@@ -128,16 +128,16 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
     @Test
     fun `𝕄 store upload url 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
-        assertThat(testedFeature.endpointUrl).isEqualTo(fakeConfig.endpointUrl)
+        assertThat(testedFeature.endpointUrl).isEqualTo(fakeConfigurationFeature.endpointUrl)
     }
 
     @Test
     fun `𝕄 initialize uploader 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         assertThat(testedFeature.uploadScheduler)
@@ -154,14 +154,14 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
     @Test
     fun `𝕄 register plugins 𝕎 initialize()`() {
         // Given
-        assumeTrue(fakeConfig.plugins.isNotEmpty())
+        assumeTrue(fakeConfigurationFeature.plugins.isNotEmpty())
 
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         argumentCaptor<DatadogPluginConfig> {
-            fakeConfig.plugins.forEach {
+            fakeConfigurationFeature.plugins.forEach {
                 verify(it).register(capture())
             }
             allValues.forEach {
@@ -179,13 +179,13 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
     @Test
     fun `𝕄 register plugins as TrackingConsentCallback 𝕎 initialize()`() {
         // Given
-        assumeTrue(fakeConfig.plugins.isNotEmpty())
+        assumeTrue(fakeConfigurationFeature.plugins.isNotEmpty())
 
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
-        fakeConfig.plugins.forEach {
+        fakeConfigurationFeature.plugins.forEach {
             verify(CoreFeature.trackingConsentProvider).registerCallback(it)
         }
     }
@@ -193,9 +193,9 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
     @Test
     fun `𝕄 unregister plugins 𝕎 stop()`() {
         // Given
-        assumeTrue(fakeConfig.plugins.isNotEmpty())
-        testedFeature.initialize(mockAppContext, fakeConfig)
-        fakeConfig.plugins.forEach {
+        assumeTrue(fakeConfigurationFeature.plugins.isNotEmpty())
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
+        fakeConfigurationFeature.plugins.forEach {
             verify(it).register(any())
         }
 
@@ -203,7 +203,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
         testedFeature.stop()
 
         // Then
-        fakeConfig.plugins.forEach {
+        fakeConfigurationFeature.plugins.forEach {
             verify(it).unregister()
             verifyNoMoreInteractions(it)
         }
@@ -214,7 +214,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
         @IntForgery(1, 10) pluginsCount: Int
     ) {
         // Given
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
         val mockUploadScheduler: UploadScheduler = mock()
         testedFeature.uploadScheduler = mockUploadScheduler
 
@@ -230,7 +230,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
         @IntForgery(1, 10) pluginsCount: Int
     ) {
         // Given
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // When
         testedFeature.stop()
@@ -246,7 +246,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
     @Test
     fun `𝕄 mark itself as not initialized 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // When
         testedFeature.stop()
@@ -261,7 +261,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
     ) {
         // Given
         val otherConfig = forgeConfiguration(forge)
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
         val persistenceStrategy = testedFeature.persistenceStrategy
         val uploadScheduler = testedFeature.uploadScheduler
 
@@ -269,7 +269,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
         testedFeature.initialize(mockAppContext, otherConfig)
 
         // Then
-        assertThat(testedFeature.endpointUrl).isEqualTo(fakeConfig.endpointUrl)
+        assertThat(testedFeature.endpointUrl).isEqualTo(fakeConfigurationFeature.endpointUrl)
         assertThat(testedFeature.persistenceStrategy).isSameAs(persistenceStrategy)
         assertThat(testedFeature.uploadScheduler).isSameAs(uploadScheduler)
     }
@@ -280,7 +280,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
         CoreFeature.isMainProcess = false
 
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         assertThat(testedFeature.uploadScheduler).isInstanceOf(NoOpUploadScheduler::class.java)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -1,0 +1,300 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal
+
+import android.app.Application
+import com.datadog.android.Configuration
+import com.datadog.android.core.internal.data.Reader
+import com.datadog.android.core.internal.data.upload.DataUploadRunnable
+import com.datadog.android.core.internal.data.upload.DataUploadScheduler
+import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
+import com.datadog.android.core.internal.data.upload.UploadScheduler
+import com.datadog.android.core.internal.domain.NoOpPersistenceStrategy
+import com.datadog.android.core.internal.domain.PersistenceStrategy
+import com.datadog.android.core.internal.net.DataUploader
+import com.datadog.android.plugin.DatadogPluginConfig
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.mockContext
+import com.datadog.android.utils.mockCoreFeature
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.concurrent.TimeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assumptions.assumeTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : SdkFeature<T, C>> {
+
+    lateinit var testedFeature: F
+
+    lateinit var mockAppContext: Application
+
+    @Mock
+    lateinit var mockPersistenceStrategy: PersistenceStrategy<T>
+
+    @Mock
+    lateinit var mockReader: Reader
+
+    @Mock
+    lateinit var mockUploader: DataUploader
+
+    lateinit var fakeConfig: C
+
+    @StringForgery
+    lateinit var fakePackageName: String
+
+    @StringForgery
+    lateinit var fakeEnvName: String
+
+    @StringForgery(regex = "\\d(\\.\\d){3}")
+    lateinit var fakePackageVersion: String
+
+    @Forgery
+    lateinit var fakeConsent: TrackingConsent
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+
+        mockCoreFeature(
+            packageName = fakePackageName,
+            packageVersion = fakePackageVersion,
+            envName = fakeEnvName,
+            trackingConsent = fakeConsent
+        )
+
+        fakePackageName = forge.anAlphabeticalString()
+        fakePackageVersion = forge.aStringMatching("\\d(\\.\\d){3}")
+
+        mockAppContext = mockContext(fakePackageName, fakePackageVersion)
+        whenever(mockAppContext.applicationContext) doReturn mockAppContext
+        whenever(mockPersistenceStrategy.getReader()) doReturn mockReader
+
+        fakeConfig = forgeConfiguration(forge)
+        testedFeature = createTestedFeature()
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        testedFeature.stop()
+        CoreFeature.stop()
+    }
+
+    abstract fun createTestedFeature(): F
+
+    abstract fun forgeConfiguration(forge: Forge): C
+
+    @Test
+    fun `𝕄 mark itself as initialized 𝕎 initialize()`() {
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
+
+        // Then
+        assertThat(testedFeature.isInitialized()).isTrue()
+    }
+
+    @Test
+    fun `𝕄 store upload url 𝕎 initialize()`() {
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
+
+        // Then
+        assertThat(testedFeature.endpointUrl).isEqualTo(fakeConfig.endpointUrl)
+    }
+
+    @Test
+    fun `𝕄 initialize uploader 𝕎 initialize()`() {
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
+
+        // Then
+        assertThat(testedFeature.uploadScheduler)
+            .isInstanceOf(DataUploadScheduler::class.java)
+        argumentCaptor<Runnable> {
+            verify(CoreFeature.uploadExecutorService).schedule(
+                any(),
+                eq(DataUploadRunnable.DEFAULT_DELAY_MS),
+                eq(TimeUnit.MILLISECONDS)
+            )
+        }
+    }
+
+    @Test
+    fun `𝕄 register plugins 𝕎 initialize()`() {
+        // Given
+        assumeTrue(fakeConfig.plugins.isNotEmpty())
+
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
+
+        // Then
+        argumentCaptor<DatadogPluginConfig> {
+            fakeConfig.plugins.forEach {
+                verify(it).register(capture())
+            }
+            allValues.forEach {
+                assertThat(it.context).isEqualTo(mockAppContext)
+                assertThat(it.serviceName).isEqualTo(CoreFeature.serviceName)
+                assertThat(it.envName).isEqualTo(CoreFeature.envName)
+                assertThat(it.featurePersistenceDirName)
+                    .isEqualTo(testedFeature.authorizedFolderName)
+                assertThat(it.context).isEqualTo(mockAppContext)
+                assertThat(it.trackingConsent).isEqualTo(fakeConsent)
+            }
+        }
+    }
+
+    @Test
+    fun `𝕄 register plugins as TrackingConsentCallback 𝕎 initialize()`() {
+        // Given
+        assumeTrue(fakeConfig.plugins.isNotEmpty())
+
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
+
+        // Then
+        fakeConfig.plugins.forEach {
+            verify(CoreFeature.trackingConsentProvider).registerCallback(it)
+        }
+    }
+
+    @Test
+    fun `𝕄 unregister plugins 𝕎 stop()`() {
+        // Given
+        assumeTrue(fakeConfig.plugins.isNotEmpty())
+        testedFeature.initialize(mockAppContext, fakeConfig)
+        fakeConfig.plugins.forEach {
+            verify(it).register(any())
+        }
+
+        // When
+        testedFeature.stop()
+
+        // Then
+        fakeConfig.plugins.forEach {
+            verify(it).unregister()
+            verifyNoMoreInteractions(it)
+        }
+    }
+
+    @Test
+    fun `𝕄 stop scheduler 𝕎 stop()`(
+        @IntForgery(1, 10) pluginsCount: Int
+    ) {
+        // Given
+        testedFeature.initialize(mockAppContext, fakeConfig)
+        val mockUploadScheduler: UploadScheduler = mock()
+        testedFeature.uploadScheduler = mockUploadScheduler
+
+        // When
+        testedFeature.stop()
+
+        // Then
+        verify(mockUploadScheduler).stopScheduling()
+    }
+
+    @Test
+    fun `𝕄 cleanup data 𝕎 stop()`(
+        @IntForgery(1, 10) pluginsCount: Int
+    ) {
+        // Given
+        testedFeature.initialize(mockAppContext, fakeConfig)
+
+        // When
+        testedFeature.stop()
+
+        // Then
+        assertThat(testedFeature.persistenceStrategy)
+            .isInstanceOf(NoOpPersistenceStrategy::class.java)
+        assertThat(testedFeature.uploadScheduler)
+            .isInstanceOf(NoOpUploadScheduler::class.java)
+        assertThat(testedFeature.endpointUrl).isEqualTo("")
+    }
+
+    @Test
+    fun `𝕄 mark itself as not initialized 𝕎 stop()`() {
+        // Given
+        testedFeature.initialize(mockAppContext, fakeConfig)
+
+        // When
+        testedFeature.stop()
+
+        // Then
+        assertThat(testedFeature.isInitialized()).isFalse()
+    }
+
+    @Test
+    fun `𝕄 initialize only once 𝕎 initialize() twice`(
+        forge: Forge
+    ) {
+        // Given
+        val otherConfig = forgeConfiguration(forge)
+        testedFeature.initialize(mockAppContext, fakeConfig)
+        val persistenceStrategy = testedFeature.persistenceStrategy
+        val uploadScheduler = testedFeature.uploadScheduler
+
+        // When
+        testedFeature.initialize(mockAppContext, otherConfig)
+
+        // Then
+        assertThat(testedFeature.endpointUrl).isEqualTo(fakeConfig.endpointUrl)
+        assertThat(testedFeature.persistenceStrategy).isSameAs(persistenceStrategy)
+        assertThat(testedFeature.uploadScheduler).isSameAs(uploadScheduler)
+    }
+
+    @Test
+    fun `𝕄 not setup uploader 𝕎 initialize() in secondary process`() {
+        // Given
+        CoreFeature.isMainProcess = false
+
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
+
+        // Then
+        assertThat(testedFeature.uploadScheduler).isInstanceOf(NoOpUploadScheduler::class.java)
+    }
+
+    @Test
+    fun `𝕄 clear local storage 𝕎 clearAllData()`() {
+        // Given
+        testedFeature.persistenceStrategy = mock()
+
+        // When
+        testedFeature.clearAllData()
+
+        // Then
+        verify(testedFeature.persistenceStrategy).clearAllData()
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -6,49 +6,23 @@
 
 package com.datadog.android.error.internal
 
-import android.app.Application
-import com.datadog.android.Datadog
-import com.datadog.android.DatadogConfig
+import com.datadog.android.Configuration
 import com.datadog.android.core.internal.CoreFeature
-import com.datadog.android.core.internal.data.upload.DataUploadScheduler
-import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
-import com.datadog.android.core.internal.domain.FilePersistenceStrategy
-import com.datadog.android.core.internal.net.DataOkHttpUploader
-import com.datadog.android.core.internal.net.info.NetworkInfoProvider
-import com.datadog.android.core.internal.privacy.ConsentProvider
-import com.datadog.android.core.internal.privacy.TrackingConsentProvider
-import com.datadog.android.core.internal.system.SystemInfoProvider
-import com.datadog.android.log.internal.user.UserInfoProvider
-import com.datadog.android.plugin.DatadogPlugin
-import com.datadog.android.plugin.DatadogPluginConfig
-import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.core.internal.SdkFeatureTest
+import com.datadog.android.log.internal.domain.Log
+import com.datadog.android.log.internal.net.LogsOkHttpUploader
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.utils.mockContext
 import com.datadog.tools.unit.extensions.ApiLevelExtension
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.StringForgery
-import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.io.File
-import java.net.URL
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.ScheduledThreadPoolExecutor
-import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.junit.jupiter.api.io.TempDir
-import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
@@ -60,380 +34,77 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class CrashReportsFeatureTest {
+internal class CrashReportsFeatureTest :
+    SdkFeatureTest<Log, Configuration.Feature.CrashReport, CrashReportsFeature>() {
 
-    lateinit var mockAppContext: Application
-
-    @Mock
-    lateinit var mockNetworkInfoProvider: NetworkInfoProvider
-
-    @Mock
-    lateinit var mockUserInfoProvider: UserInfoProvider
-
-    @Mock
-    lateinit var mockSystemInfoProvider: SystemInfoProvider
-
-    @Mock
-    lateinit var mockOkHttpClient: OkHttpClient
-
-    @Mock
-    lateinit var mockScheduledThreadPoolExecutor: ScheduledThreadPoolExecutor
-
-    @Mock
-    lateinit var mockedPersistenceExecutorService: ExecutorService
-
-    lateinit var trackingConsentProvider: ConsentProvider
-
-    lateinit var fakeConfig: DatadogConfig.FeatureConfig
-
-    lateinit var fakePackageName: String
-    lateinit var fakePackageVersion: String
-
-    @TempDir
-    lateinit var tempRootDir: File
+    var jvmExceptionHandler: Thread.UncaughtExceptionHandler? = null
 
     @BeforeEach
-    fun `set up`(forge: Forge) {
-        CoreFeature.isMainProcess = true
-        trackingConsentProvider = TrackingConsentProvider()
-        fakeConfig = DatadogConfig.FeatureConfig(
-            clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
-            endpointUrl = forge.getForgery<URL>().toString(),
-            envName = forge.anAlphabeticalString()
-        )
-
-        fakePackageName = forge.anAlphabeticalString()
-        fakePackageVersion = forge.aStringMatching("\\d(\\.\\d){3}")
-
-        mockAppContext = mockContext(fakePackageName, fakePackageVersion)
-        whenever(mockAppContext.filesDir).thenReturn(tempRootDir)
-        whenever(mockAppContext.applicationContext) doReturn mockAppContext
+    fun `set up crash reports`() {
+        jvmExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
     }
 
     @AfterEach
-    fun `tear down`() {
-        CoreFeature.stop()
-        CrashReportsFeature.stop()
+    fun `tear down crash reports`() {
+        Thread.setDefaultUncaughtExceptionHandler(jvmExceptionHandler)
+    }
+
+    override fun createTestedFeature(): CrashReportsFeature {
+        return CrashReportsFeature
+    }
+
+    override fun forgeConfiguration(forge: Forge): Configuration.Feature.CrashReport {
+        return forge.getForgery()
     }
 
     @Test
-    fun `initializes persistence strategy`() {
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            trackingConsentProvider
-        )
+    fun `𝕄 initialize persistence strategy 𝕎 initialize()`() {
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
 
-        val persistenceStrategy = CrashReportsFeature.persistenceStrategy
-
-        assertThat(persistenceStrategy)
-            .isInstanceOf(FilePersistenceStrategy::class.java)
+        // Then
+        assertThat(testedFeature.persistenceStrategy)
+            .isInstanceOf(CrashLogFileStrategy::class.java)
     }
 
     @Test
-    fun `initializes uploader thread`() {
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            trackingConsentProvider
-        )
+    fun `𝕄 create a crash reports uploader 𝕎 createUploader()`() {
+        // Given
+        testedFeature.endpointUrl = fakeConfig.endpointUrl
 
-        val uploader = CrashReportsFeature.uploader
-        val dataUploadScheduler = CrashReportsFeature.dataUploadScheduler
+        // When
+        val uploader = testedFeature.createUploader()
 
-        assertThat(uploader)
-            .isInstanceOf(DataOkHttpUploader::class.java)
-        assertThat(dataUploadScheduler)
-            .isInstanceOf(DataUploadScheduler::class.java)
+        // Then
+        assertThat(uploader).isInstanceOf(LogsOkHttpUploader::class.java)
+        val logsUploader = uploader as LogsOkHttpUploader
+        assertThat(logsUploader.url).startsWith(fakeConfig.endpointUrl)
+        assertThat(logsUploader.client).isSameAs(CoreFeature.okHttpClient)
     }
 
     @Test
-    fun `initializes from configuration`() {
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            trackingConsentProvider
-        )
+    fun `𝕄 register crash handler 𝕎 initialize`() {
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
 
-        val clientToken = CrashReportsFeature.clientToken
-        val endpointUrl = CrashReportsFeature.endpointUrl
-
-        assertThat(clientToken).isEqualTo(fakeConfig.clientToken)
-        assertThat(endpointUrl).isEqualTo(fakeConfig.endpointUrl)
-    }
-
-    @Test
-    fun `initializes crash reporter`() {
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
+        // Then
         val handler = Thread.getDefaultUncaughtExceptionHandler()
-
         assertThat(handler)
             .isInstanceOf(DatadogExceptionHandler::class.java)
     }
 
     @Test
-    fun `restores original crash reporter on stop`() {
-        val originalHandler = Thread.getDefaultUncaughtExceptionHandler()
-        val handler: Thread.UncaughtExceptionHandler = mock()
-        Thread.setDefaultUncaughtExceptionHandler(handler)
+    fun `𝕄 restore original crash handler 𝕎 stop()`() {
+        // Given
+        val mockOriginalHandler: Thread.UncaughtExceptionHandler = mock()
+        Thread.setDefaultUncaughtExceptionHandler(mockOriginalHandler)
 
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        CrashReportsFeature.stop()
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.stop()
 
+        // Then
         val finalHandler = Thread.getDefaultUncaughtExceptionHandler()
-        assertThat(finalHandler)
-            .isSameAs(handler)
-        Thread.setDefaultUncaughtExceptionHandler(originalHandler)
-    }
-
-    @Test
-    fun `ignores if initialize called more than once`(forge: Forge) {
-        Datadog.setVerbosity(android.util.Log.VERBOSE)
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        val persistenceStrategy = CrashReportsFeature.persistenceStrategy
-        val uploader = CrashReportsFeature.uploader
-        val clientToken = CrashReportsFeature.clientToken
-        val endpointUrl = CrashReportsFeature.endpointUrl
-
-        fakeConfig = DatadogConfig.FeatureConfig(
-            clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
-            endpointUrl = forge.getForgery<URL>().toString(),
-            envName = forge.anAlphabeticalString()
-        )
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        val persistenceStrategy2 = CrashReportsFeature.persistenceStrategy
-        val uploader2 = CrashReportsFeature.uploader
-        val clientToken2 = CrashReportsFeature.clientToken
-        val endpointUrl2 = CrashReportsFeature.endpointUrl
-
-        assertThat(persistenceStrategy).isSameAs(persistenceStrategy2)
-        assertThat(uploader).isSameAs(uploader2)
-        assertThat(clientToken).isSameAs(clientToken2)
-        assertThat(endpointUrl).isSameAs(endpointUrl2)
-    }
-
-    @Test
-    fun `it will register the provided plugin when feature is initialized`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeConsent = forge.aValueFrom(TrackingConsent::class.java)
-        val mockedTrackingConsentProvider: TrackingConsentProvider = mock() {
-            whenever(it.getConsent()).thenReturn(fakeConsent)
-        }
-        val plugins: List<DatadogPlugin> = forge.aList(forge.anInt(min = 1, max = 10)) {
-            mock<DatadogPlugin>()
-        }
-
-        // When
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig.copy(plugins = plugins),
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            mockedTrackingConsentProvider
-        )
-
-        val argumentCaptor = argumentCaptor<DatadogPluginConfig>()
-
-        // Then
-        val mockPlugins = plugins.toTypedArray()
-        inOrder(*mockPlugins) {
-            mockPlugins.forEach {
-                verify(it).register(argumentCaptor.capture())
-            }
-        }
-
-        argumentCaptor.allValues.forEach {
-            assertThat(it).isInstanceOf(DatadogPluginConfig.CrashReportsPluginConfig::class.java)
-            assertThat(it.context).isEqualTo(mockAppContext)
-            assertThat(it.serviceName).isEqualTo(CoreFeature.serviceName)
-            assertThat(it.envName).isEqualTo(fakeConfig.envName)
-            assertThat(it.featurePersistenceDirName)
-                .isEqualTo(CrashLogFileStrategy.AUTHORIZED_FOLDER)
-            assertThat(it.context).isEqualTo(mockAppContext)
-            assertThat(it.trackingConsent).isEqualTo(fakeConsent)
-        }
-    }
-
-    @Test
-    fun `M register the plugins as TrackingConsentProvideCallback W initialized`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeConsent = forge.aValueFrom(TrackingConsent::class.java)
-        val plugins: List<DatadogPlugin> = forge.aList(forge.anInt(min = 1, max = 10)) {
-            mock<DatadogPlugin>()
-        }
-        val mockedTrackingConsentProvider: TrackingConsentProvider = mock() {
-            whenever(it.getConsent()).thenReturn(fakeConsent)
-        }
-
-        // When
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig.copy(plugins = plugins),
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            mockedTrackingConsentProvider
-        )
-
-        // Then
-        val mockPlugins = plugins.toTypedArray()
-        mockPlugins.forEach {
-            verify(mockedTrackingConsentProvider).registerCallback(it)
-        }
-    }
-
-    @Test
-    fun `M unregister the provided plugin W stop called`(
-        forge: Forge
-    ) {
-        // Given
-        val plugins: List<DatadogPlugin> = forge.aList(forge.anInt(min = 1, max = 10)) {
-            mock<DatadogPlugin>()
-        }
-
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig.copy(plugins = plugins),
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        // When
-        CrashReportsFeature.stop()
-
-        // Then
-        val mockPlugins = plugins.toTypedArray()
-        inOrder(*mockPlugins) {
-            mockPlugins.forEach {
-                verify(it).unregister()
-            }
-        }
-    }
-
-    @Test
-    fun `will use a NoOpUploadScheduler if this is not the application main process`() {
-        // Given
-        CoreFeature.isMainProcess = false
-
-        // When
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
-        // Then
-        assertThat(CrashReportsFeature.dataUploadScheduler)
-            .isInstanceOf(NoOpUploadScheduler::class.java)
-    }
-
-    @Test
-    fun `clears all files on local storage on request`(
-        @StringForgery(type = StringForgeryType.NUMERICAL) fileName: String,
-        @StringForgery content: String
-    ) {
-        val fakeDir = File(tempRootDir, CrashLogFileStrategy.AUTHORIZED_FOLDER)
-        fakeDir.mkdirs()
-        val fakeFile = File(fakeDir, fileName)
-        fakeFile.writeText(content)
-
-        // When
-        CrashReportsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockedPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        CrashReportsFeature.clearAllData()
-
-        // Then
-        assertThat(fakeFile).doesNotExist()
+        assertThat(finalHandler).isSameAs(mockOriginalHandler)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -60,7 +60,7 @@ internal class CrashReportsFeatureTest :
     @Test
     fun `𝕄 initialize persistence strategy 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         assertThat(testedFeature.persistenceStrategy)
@@ -70,7 +70,7 @@ internal class CrashReportsFeatureTest :
     @Test
     fun `𝕄 create a crash reports uploader 𝕎 createUploader()`() {
         // Given
-        testedFeature.endpointUrl = fakeConfig.endpointUrl
+        testedFeature.endpointUrl = fakeConfigurationFeature.endpointUrl
 
         // When
         val uploader = testedFeature.createUploader()
@@ -78,14 +78,14 @@ internal class CrashReportsFeatureTest :
         // Then
         assertThat(uploader).isInstanceOf(LogsOkHttpUploader::class.java)
         val logsUploader = uploader as LogsOkHttpUploader
-        assertThat(logsUploader.url).startsWith(fakeConfig.endpointUrl)
+        assertThat(logsUploader.url).startsWith(fakeConfigurationFeature.endpointUrl)
         assertThat(logsUploader.client).isSameAs(CoreFeature.okHttpClient)
     }
 
     @Test
     fun `𝕄 register crash handler 𝕎 initialize`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         val handler = Thread.getDefaultUncaughtExceptionHandler()
@@ -100,7 +100,7 @@ internal class CrashReportsFeatureTest :
         Thread.setDefaultUncaughtExceptionHandler(mockOriginalHandler)
 
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
         testedFeature.stop()
 
         // Then

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -6,47 +6,21 @@
 
 package com.datadog.android.log.internal
 
-import android.app.Application
-import com.datadog.android.Datadog
-import com.datadog.android.DatadogConfig
+import com.datadog.android.Configuration
 import com.datadog.android.core.internal.CoreFeature
-import com.datadog.android.core.internal.data.upload.DataUploadScheduler
-import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
-import com.datadog.android.core.internal.net.info.NetworkInfoProvider
-import com.datadog.android.core.internal.privacy.ConsentProvider
-import com.datadog.android.core.internal.privacy.TrackingConsentProvider
-import com.datadog.android.core.internal.system.SystemInfoProvider
+import com.datadog.android.core.internal.SdkFeatureTest
+import com.datadog.android.log.internal.domain.Log
 import com.datadog.android.log.internal.domain.LogFileStrategy
-import com.datadog.android.plugin.DatadogPlugin
-import com.datadog.android.plugin.DatadogPluginConfig
-import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.log.internal.net.LogsOkHttpUploader
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.utils.mockContext
 import com.datadog.tools.unit.extensions.ApiLevelExtension
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.inOrder
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.StringForgery
-import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.io.File
-import java.net.URL
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.ScheduledThreadPoolExecutor
-import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.junit.jupiter.api.io.TempDir
-import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
@@ -58,315 +32,38 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class LogsFeatureTest {
+internal class LogsFeatureTest : SdkFeatureTest<Log, Configuration.Feature.Logs, LogsFeature>() {
 
-    lateinit var mockAppContext: Application
-
-    @Mock
-    lateinit var mockNetworkInfoProvider: NetworkInfoProvider
-
-    @Mock
-    lateinit var mockSystemInfoProvider: SystemInfoProvider
-
-    @Mock
-    lateinit var mockOkHttpClient: OkHttpClient
-
-    @Mock
-    lateinit var mockScheduledThreadPoolExecutor: ScheduledThreadPoolExecutor
-
-    @Mock
-    lateinit var mockPersistenceExecutorService: ExecutorService
-
-    lateinit var trackingConsentProvider: ConsentProvider
-
-    lateinit var fakeConfig: DatadogConfig.FeatureConfig
-
-    lateinit var fakePackageName: String
-    lateinit var fakePackageVersion: String
-
-    @TempDir
-    lateinit var tempRootDir: File
-
-    @BeforeEach
-    fun `set up`(forge: Forge) {
-        trackingConsentProvider = TrackingConsentProvider()
-        CoreFeature.isMainProcess = true
-        fakeConfig = DatadogConfig.FeatureConfig(
-            clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
-            endpointUrl = forge.getForgery<URL>().toString(),
-            envName = forge.anAlphabeticalString()
-        )
-
-        fakePackageName = forge.anAlphabeticalString()
-        fakePackageVersion = forge.aStringMatching("\\d(\\.\\d){3}")
-
-        mockAppContext = mockContext(fakePackageName, fakePackageVersion)
-        whenever(mockAppContext.filesDir).thenReturn(tempRootDir)
-        whenever(mockAppContext.applicationContext) doReturn mockAppContext
+    override fun createTestedFeature(): LogsFeature {
+        return LogsFeature
     }
 
-    @AfterEach
-    fun `tear down`() {
-        LogsFeature.stop()
-        CoreFeature.stop()
+    override fun forgeConfiguration(forge: Forge): Configuration.Feature.Logs {
+        return forge.getForgery()
     }
 
     @Test
-    fun `initializes persistence strategy`() {
-        LogsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
+    fun `𝕄 initialize persistence strategy 𝕎 initialize()`() {
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
 
-        val persistenceStrategy = LogsFeature.persistenceStrategy
-
-        assertThat(persistenceStrategy)
+        // Then
+        assertThat(testedFeature.persistenceStrategy)
             .isInstanceOf(LogFileStrategy::class.java)
     }
 
     @Test
-    fun `initializes uploader thread`() {
-        LogsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
-        val dataUploadScheduler = LogsFeature.dataUploadScheduler
-
-        assertThat(dataUploadScheduler)
-            .isInstanceOf(DataUploadScheduler::class.java)
-    }
-
-    @Test
-    fun `initializes from configuration`() {
-        LogsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
-        val clientToken = LogsFeature.clientToken
-        val endpointUrl = LogsFeature.endpointUrl
-
-        assertThat(clientToken).isEqualTo(fakeConfig.clientToken)
-        assertThat(endpointUrl).isEqualTo(fakeConfig.endpointUrl)
-    }
-
-    @Test
-    fun `ignores if initialize called more than once`(forge: Forge) {
-        Datadog.setVerbosity(android.util.Log.VERBOSE)
-        LogsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        val persistenceStrategy = LogsFeature.persistenceStrategy
-        val dataUploadScheduler = LogsFeature.dataUploadScheduler
-        val clientToken = LogsFeature.clientToken
-        val endpointUrl = LogsFeature.endpointUrl
-
-        fakeConfig = DatadogConfig.FeatureConfig(
-            clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
-            endpointUrl = forge.getForgery<URL>().toString(),
-            envName = forge.anAlphabeticalString()
-        )
-        LogsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        val persistenceStrategy2 = LogsFeature.persistenceStrategy
-        val dataUploadScheduler2 = LogsFeature.dataUploadScheduler
-        val clientToken2 = LogsFeature.clientToken
-        val endpointUrl2 = LogsFeature.endpointUrl
-
-        assertThat(persistenceStrategy).isSameAs(persistenceStrategy2)
-        assertThat(dataUploadScheduler).isSameAs(dataUploadScheduler2)
-        assertThat(clientToken).isSameAs(clientToken2)
-        assertThat(endpointUrl).isSameAs(endpointUrl2)
-    }
-
-    @Test
-    fun `M register the plugins as TrackingConsentProvideCallback W initialized`(
-        forge: Forge
-    ) {
+    fun `𝕄 create a logs uploader 𝕎 createUploader()`() {
         // Given
-        val fakeConsent = forge.aValueFrom(TrackingConsent::class.java)
-        val plugins: List<DatadogPlugin> = forge.aList(forge.anInt(min = 1, max = 10)) {
-            mock<DatadogPlugin>()
-        }
-        val mockedTrackingConsentProvider: TrackingConsentProvider = mock() {
-            whenever(it.getConsent()).thenReturn(fakeConsent)
-        }
+        testedFeature.endpointUrl = fakeConfig.endpointUrl
 
         // When
-        LogsFeature.initialize(
-            mockAppContext,
-            fakeConfig.copy(plugins = plugins),
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            mockedTrackingConsentProvider
-        )
-        // Then
-        val mockPlugins = plugins.toTypedArray()
-        mockPlugins.forEach {
-            verify(mockedTrackingConsentProvider).registerCallback(it)
-        }
-    }
-
-    @Test
-    fun `it will register the provided plugin when feature was initialized`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeConsent = forge.aValueFrom(TrackingConsent::class.java)
-        val mockedTrackingConsentProvider: TrackingConsentProvider = mock() {
-            whenever(it.getConsent()).thenReturn(fakeConsent)
-        }
-        val plugins: List<DatadogPlugin> = forge.aList(forge.anInt(min = 1, max = 10)) {
-            mock<DatadogPlugin>()
-        }
-
-        // When
-        LogsFeature.initialize(
-            mockAppContext,
-            fakeConfig.copy(plugins = plugins),
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            mockedTrackingConsentProvider
-        )
-
-        val argumentCaptor = argumentCaptor<DatadogPluginConfig>()
-        // Then
-        val mockPlugins = plugins.toTypedArray()
-        inOrder(*mockPlugins) {
-            mockPlugins.forEach {
-                verify(it).register(argumentCaptor.capture())
-            }
-        }
-
-        argumentCaptor.allValues.forEach {
-            assertThat(it).isInstanceOf(DatadogPluginConfig.LogsPluginConfig::class.java)
-            assertThat(it.context).isEqualTo(mockAppContext)
-            assertThat(it.serviceName).isEqualTo(CoreFeature.serviceName)
-            assertThat(it.envName).isEqualTo(fakeConfig.envName)
-            assertThat(it.featurePersistenceDirName).isEqualTo(LogFileStrategy.AUTHORIZED_FOLDER)
-            assertThat(it.context).isEqualTo(mockAppContext)
-            assertThat(it.trackingConsent).isEqualTo(fakeConsent)
-        }
-    }
-
-    @Test
-    fun `it will unregister the provided plugin when stop called`(
-        forge: Forge
-    ) {
-        // Given
-        val plugins: List<DatadogPlugin> = forge.aList(forge.anInt(min = 1, max = 10)) {
-            mock<DatadogPlugin>()
-        }
-        LogsFeature.initialize(
-            mockAppContext,
-            fakeConfig.copy(plugins = plugins),
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
-        // When
-        LogsFeature.stop()
+        val uploader = testedFeature.createUploader()
 
         // Then
-        val mockPlugins = plugins.toTypedArray()
-        inOrder(*mockPlugins) {
-            mockPlugins.forEach {
-                verify(it).unregister()
-            }
-        }
-    }
-
-    @Test
-    fun `will use a NoOpUploadScheduler if this is not the application main process`() {
-        // Given
-        CoreFeature.isMainProcess = false
-
-        // When
-        LogsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
-        // Then
-        assertThat(LogsFeature.dataUploadScheduler).isInstanceOf(NoOpUploadScheduler::class.java)
-    }
-
-    @Test
-    fun `clears all files on local storage on request`(
-        @StringForgery(type = StringForgeryType.NUMERICAL) fileName: String,
-        @StringForgery content: String
-    ) {
-        val fakeDir = File(tempRootDir, LogFileStrategy.AUTHORIZED_FOLDER)
-        fakeDir.mkdirs()
-        val fakeFile = File(fakeDir, fileName)
-        fakeFile.writeText(content)
-
-        // When
-        LogsFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockSystemInfoProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        LogsFeature.clearAllData()
-
-        // Then
-        assertThat(fakeFile).doesNotExist()
+        assertThat(uploader).isInstanceOf(LogsOkHttpUploader::class.java)
+        val logsUploader = uploader as LogsOkHttpUploader
+        assertThat(logsUploader.url).startsWith(fakeConfig.endpointUrl)
+        assertThat(logsUploader.client).isSameAs(CoreFeature.okHttpClient)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -45,7 +45,7 @@ internal class LogsFeatureTest : SdkFeatureTest<Log, Configuration.Feature.Logs,
     @Test
     fun `𝕄 initialize persistence strategy 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         assertThat(testedFeature.persistenceStrategy)
@@ -55,7 +55,7 @@ internal class LogsFeatureTest : SdkFeatureTest<Log, Configuration.Feature.Logs,
     @Test
     fun `𝕄 create a logs uploader 𝕎 createUploader()`() {
         // Given
-        testedFeature.endpointUrl = fakeConfig.endpointUrl
+        testedFeature.endpointUrl = fakeConfigurationFeature.endpointUrl
 
         // When
         val uploader = testedFeature.createUploader()
@@ -63,7 +63,7 @@ internal class LogsFeatureTest : SdkFeatureTest<Log, Configuration.Feature.Logs,
         // Then
         assertThat(uploader).isInstanceOf(LogsOkHttpUploader::class.java)
         val logsUploader = uploader as LogsOkHttpUploader
-        assertThat(logsUploader.url).startsWith(fakeConfig.endpointUrl)
+        assertThat(logsUploader.url).startsWith(fakeConfigurationFeature.endpointUrl)
         assertThat(logsUploader.client).isSameAs(CoreFeature.okHttpClient)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ConfigurationRumAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ConfigurationRumAssert.kt
@@ -1,0 +1,95 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.assertj
+
+import com.datadog.android.Configuration
+import com.datadog.android.rum.internal.instrumentation.GesturesTrackingStrategy
+import com.datadog.android.rum.internal.instrumentation.GesturesTrackingStrategyApi29
+import com.datadog.android.rum.internal.instrumentation.gestures.DatadogGesturesTracker
+import com.datadog.android.rum.internal.tracking.UserActionTrackingStrategy
+import com.datadog.android.rum.tracking.TrackingStrategy
+import com.datadog.android.rum.tracking.ViewAttributesProvider
+import org.assertj.core.api.AbstractObjectAssert
+import org.assertj.core.api.Assertions.assertThat
+
+internal class ConfigurationRumAssert(actual: Configuration.Feature.RUM) :
+    AbstractObjectAssert<ConfigurationRumAssert, Configuration.Feature.RUM>(
+        actual,
+        ConfigurationRumAssert::class.java
+    ) {
+
+    // region Assertions
+
+    fun doesNotHaveGesturesTrackingStrategy(): ConfigurationRumAssert {
+        assertThat(actual.userActionTrackingStrategy).isNull()
+        return this
+    }
+
+    fun doesNotHaveViewTrackingStrategy(): ConfigurationRumAssert {
+        assertThat(actual.viewTrackingStrategy).isNull()
+        return this
+    }
+
+    fun hasGesturesTrackingStrategyApi29(): ConfigurationRumAssert {
+        assertThat(actual.userActionTrackingStrategy)
+            .isInstanceOf(GesturesTrackingStrategyApi29::class.java)
+        return this
+    }
+
+    fun hasGesturesTrackingStrategy(): ConfigurationRumAssert {
+        assertThat(actual.userActionTrackingStrategy)
+            .isInstanceOf(GesturesTrackingStrategy::class.java)
+        return this
+    }
+
+    fun hasViewAttributeProviders(
+        providers: Array<ViewAttributesProvider> = emptyArray()
+    ): ConfigurationRumAssert {
+        val gesturesTracker = actual.userActionTrackingStrategy?.getGesturesTracker()
+        assertThat(gesturesTracker).isInstanceOf(DatadogGesturesTracker::class.java)
+        RumGestureTrackerAssert.assertThat(gesturesTracker as DatadogGesturesTracker)
+            .hasCustomTargetAttributesProviders(providers)
+            .hasDefaultTargetAttributesProviders()
+        return this
+    }
+
+    fun hasViewTrackingStrategy(viewTrackingStrategy: TrackingStrategy): ConfigurationRumAssert {
+        assertThat(actual.viewTrackingStrategy)
+            .overridingErrorMessage(
+                "Expected the viewTrackingStrategy to " +
+                    "be $viewTrackingStrategy" +
+                    " but was ${actual.viewTrackingStrategy}"
+            )
+            .isEqualTo(viewTrackingStrategy)
+        return this
+    }
+
+    // endregion
+
+    // region Internal
+
+    private inline fun <reified Strategy : UserActionTrackingStrategy> isInstanceOf(): Strategy {
+        val userActionTrackingStrategy = actual.userActionTrackingStrategy as? Strategy
+        assertThat(userActionTrackingStrategy).isNotNull()
+        assertThat(userActionTrackingStrategy)
+            .overridingErrorMessage(
+                "Expected the trackGesturesStrategy " +
+                    "to be instance of ${Strategy::class.java.canonicalName}" +
+                    " but was ${userActionTrackingStrategy!!::class.java.canonicalName}"
+            )
+            .isInstanceOf(Strategy::class.java)
+        return userActionTrackingStrategy
+    }
+
+    // endregion
+
+    companion object {
+
+        internal fun assertThat(actual: Configuration.Feature.RUM): ConfigurationRumAssert =
+            ConfigurationRumAssert(actual)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -55,7 +55,7 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     @Test
     fun `𝕄 initialize persistence strategy 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         assertThat(testedFeature.persistenceStrategy)
@@ -65,7 +65,7 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     @Test
     fun `𝕄 create a logs uploader 𝕎 createUploader()`() {
         // Given
-        testedFeature.endpointUrl = fakeConfig.endpointUrl
+        testedFeature.endpointUrl = fakeConfigurationFeature.endpointUrl
 
         // When
         val uploader = testedFeature.createUploader()
@@ -73,54 +73,55 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
         // Then
         assertThat(uploader).isInstanceOf(RumOkHttpUploader::class.java)
         val logsUploader = uploader as RumOkHttpUploader
-        assertThat(logsUploader.url).startsWith(fakeConfig.endpointUrl)
+        assertThat(logsUploader.url).startsWith(fakeConfigurationFeature.endpointUrl)
         assertThat(logsUploader.client).isSameAs(CoreFeature.okHttpClient)
     }
 
     @Test
     fun `𝕄 store sampling rate 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
-        assertThat(testedFeature.samplingRate).isEqualTo(fakeConfig.samplingRate)
+        assertThat(testedFeature.samplingRate).isEqualTo(fakeConfigurationFeature.samplingRate)
     }
 
     @Test
     fun `𝕄 store gesturesTracker 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
-        assertThat(testedFeature.gesturesTracker).isEqualTo(fakeConfig.gesturesTracker)
+        assertThat(testedFeature.gesturesTracker)
+            .isEqualTo(fakeConfigurationFeature.gesturesTracker)
     }
 
     @Test
     fun `𝕄 store and register viewTrackingStrategy 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         assertThat(testedFeature.viewTrackingStrategy)
-            .isEqualTo(fakeConfig.viewTrackingStrategy)
-        verify(fakeConfig.viewTrackingStrategy!!).register(mockAppContext)
+            .isEqualTo(fakeConfigurationFeature.viewTrackingStrategy)
+        verify(fakeConfigurationFeature.viewTrackingStrategy!!).register(mockAppContext)
     }
 
     @Test
     fun `𝕄 store userActionTrackingStrategy 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         assertThat(testedFeature.actionTrackingStrategy)
-            .isEqualTo(fakeConfig.userActionTrackingStrategy)
-        verify(fakeConfig.userActionTrackingStrategy!!).register(mockAppContext)
+            .isEqualTo(fakeConfigurationFeature.userActionTrackingStrategy)
+        verify(fakeConfigurationFeature.userActionTrackingStrategy!!).register(mockAppContext)
     }
 
     @Test
     fun `𝕄 use noop gesturesTracker 𝕎 initialize()`() {
         // Given
-        val config = fakeConfig.copy(gesturesTracker = null)
+        val config = fakeConfigurationFeature.copy(gesturesTracker = null)
 
         // When
         testedFeature.initialize(mockAppContext, config)
@@ -133,7 +134,7 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     @Test
     fun `𝕄 use noop viewTrackingStrategy 𝕎 initialize()`() {
         // Given
-        val config = fakeConfig.copy(viewTrackingStrategy = null)
+        val config = fakeConfigurationFeature.copy(viewTrackingStrategy = null)
 
         // When
         testedFeature.initialize(mockAppContext, config)
@@ -146,7 +147,7 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     @Test
     fun `𝕄 use noop userActionTrackingStrategy 𝕎 initialize()`() {
         // Given
-        val config = fakeConfig.copy(userActionTrackingStrategy = null)
+        val config = fakeConfigurationFeature.copy(userActionTrackingStrategy = null)
 
         // When
         testedFeature.initialize(mockAppContext, config)
@@ -161,7 +162,7 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
         // When
         val mockViewTreeStrategy: TrackingStrategy = mock()
         testedFeature.viewTreeTrackingStrategy = mockViewTreeStrategy
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         verify(mockViewTreeStrategy).register(mockAppContext)
@@ -170,16 +171,16 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     @Test
     fun `𝕄 store eventMapper 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
-        assertThat(testedFeature.rumEventMapper).isSameAs(fakeConfig.rumEventMapper)
+        assertThat(testedFeature.rumEventMapper).isSameAs(fakeConfigurationFeature.rumEventMapper)
     }
 
     @Test
     fun `𝕄 use noop gesturesTracker 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // When
         testedFeature.stop()
@@ -192,7 +193,7 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     @Test
     fun `𝕄 use noop viewTrackingStrategy 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // When
         testedFeature.stop()
@@ -205,7 +206,7 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     @Test
     fun `𝕄 use noop userActionTrackingStrategy 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // When
         testedFeature.stop()
@@ -218,7 +219,7 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     @Test
     fun `𝕄 unregister strategies 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
         CoreFeature.contextRef = WeakReference(mockAppContext)
         val mockActionTrackingStrategy: UserActionTrackingStrategy = mock()
         val mockViewTrackingStrategy: ViewTrackingStrategy = mock()
@@ -239,7 +240,7 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     @Test
     fun `𝕄 reset eventMapper 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // When
         testedFeature.stop()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -6,22 +6,20 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.domain.Time
-import com.datadog.android.log.internal.user.NoOpMutableUserInfoProvider
 import com.datadog.android.log.internal.user.UserInfo
-import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.assertj.RumEventAssert.Companion.assertThat
-import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
-import com.datadog.tools.unit.setStaticValue
+import com.datadog.android.utils.mockCoreFeature
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.isA
@@ -66,9 +64,6 @@ internal class RumActionScopeTest {
     lateinit var mockParentScope: RumScope
 
     @Mock
-    lateinit var mockUserInfoProvider: UserInfoProvider
-
-    @Mock
     lateinit var mockWriter: Writer<RumEvent>
 
     @Forgery
@@ -94,12 +89,11 @@ internal class RumActionScopeTest {
     fun `set up`(forge: Forge) {
         fakeEventTime = Time()
 
-        RumFeature::class.java.setStaticValue("userInfoProvider", mockUserInfoProvider)
-
         fakeAttributes = forge.exhaustiveAttributes()
         fakeKey = forge.anAsciiString().toByteArray()
 
-        whenever(mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
+        mockCoreFeature()
+        whenever(CoreFeature.userInfoProvider.getUserInfo()) doReturn fakeUserInfo
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
 
         testedScope = RumActionScope(
@@ -114,7 +108,7 @@ internal class RumActionScopeTest {
 
     @AfterEach
     fun `tear down`() {
-        RumFeature::class.java.setStaticValue("userInfoProvider", NoOpMutableUserInfoProvider())
+        CoreFeature.stop()
         GlobalRum.globalAttributes.clear()
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -14,10 +14,9 @@ import com.datadog.tools.unit.setFieldValue
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import fr.xgouchet.elmyr.annotation.FloatForgery
-import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -51,8 +50,8 @@ internal class RumApplicationScopeTest {
     @Mock
     lateinit var mockDetector: FirstPartyHostDetector
 
-    @Forgery
-    lateinit var fakeApplicationId: UUID
+    @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+    lateinit var fakeApplicationId: String
 
     @FloatForgery(min = 0f, max = 100f)
     var fakeSamplingRate: Float = 0f

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -6,23 +6,21 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.domain.Time
 import com.datadog.android.core.internal.time.TimeProvider
-import com.datadog.android.log.internal.user.NoOpMutableUserInfoProvider
 import com.datadog.android.log.internal.user.UserInfo
-import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.assertj.RumEventAssert.Companion.assertThat
-import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
-import com.datadog.tools.unit.setStaticValue
+import com.datadog.android.utils.mockCoreFeature
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.isA
@@ -71,9 +69,6 @@ internal class RumContinuousActionScopeTest {
     lateinit var mockTimeProvider: TimeProvider
 
     @Mock
-    lateinit var mockUserInfoProvider: UserInfoProvider
-
-    @Mock
     lateinit var mockWriter: Writer<RumEvent>
 
     @Forgery
@@ -99,12 +94,11 @@ internal class RumContinuousActionScopeTest {
     fun `set up`(forge: Forge) {
         fakeEventTime = Time()
 
-        RumFeature::class.java.setStaticValue("userInfoProvider", mockUserInfoProvider)
-
         fakeAttributes = forge.exhaustiveAttributes()
         fakeKey = forge.anAsciiString().toByteArray()
 
-        whenever(mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
+        mockCoreFeature()
+        whenever(CoreFeature.userInfoProvider.getUserInfo()) doReturn fakeUserInfo
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
 
         testedScope = RumActionScope(
@@ -119,7 +113,7 @@ internal class RumContinuousActionScopeTest {
 
     @AfterEach
     fun `tear down`() {
-        RumFeature::class.java.setStaticValue("userInfoProvider", NoOpMutableUserInfoProvider())
+        CoreFeature.stop()
         GlobalRum.globalAttributes.clear()
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -43,7 +43,6 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -78,8 +77,8 @@ internal class DatadogRumMonitorTest {
     @Mock
     lateinit var mockDetector: FirstPartyHostDetector
 
-    @Forgery
-    lateinit var fakeApplicationId: UUID
+    @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
+    lateinit var fakeApplicationId: String
 
     lateinit var fakeAttributes: Map<String, Any?>
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderTest.kt
@@ -46,13 +46,17 @@ internal class RumOkHttpUploaderTest : DataOkHttpUploaderTest<RumOkHttpUploader>
 
     @StringForgery
     lateinit var fakeEnvName: String
+
+    @StringForgery
+    lateinit var fakeVariant: String
+
     lateinit var mockAppContext: Application
 
     @BeforeEach
     override fun `set up`(forge: Forge) {
         super.`set up`(forge)
         mockAppContext = mockContext(fakePackageName, fakePackageVersion)
-        mockCoreFeature(fakePackageName, fakePackageVersion, fakeEnvName)
+        mockCoreFeature(fakePackageName, fakePackageVersion, fakeEnvName, fakeVariant)
     }
 
     @AfterEach
@@ -85,7 +89,8 @@ internal class RumOkHttpUploaderTest : DataOkHttpUploaderTest<RumOkHttpUploader>
             "${RumAttributes.SERVICE_NAME}:$fakePackageName," +
             "${RumAttributes.APPLICATION_VERSION}:$fakePackageVersion," +
             "${RumAttributes.SDK_VERSION}:${BuildConfig.VERSION_NAME}," +
-            "${RumAttributes.ENV}:$fakeEnvName" +
+            "${RumAttributes.ENV}:$fakeEnvName," +
+            "${RumAttributes.VARIANT}:$fakeVariant" +
             "$"
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderTest.kt
@@ -8,15 +8,13 @@ package com.datadog.android.rum.internal.net
 
 import android.app.Application
 import com.datadog.android.BuildConfig
-import com.datadog.android.DatadogConfig
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.DataOkHttpUploader
 import com.datadog.android.core.internal.net.DataOkHttpUploaderTest
-import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.RumAttributes
-import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext
+import com.datadog.android.utils.mockCoreFeature
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.RegexForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -53,15 +51,8 @@ internal class RumOkHttpUploaderTest : DataOkHttpUploaderTest<RumOkHttpUploader>
     @BeforeEach
     override fun `set up`(forge: Forge) {
         super.`set up`(forge)
-        RumFeature.envName = fakeEnvName
         mockAppContext = mockContext(fakePackageName, fakePackageVersion)
-        CoreFeature.initialize(
-            mockAppContext,
-            forge.aValueFrom(TrackingConsent::class.java),
-            DatadogConfig.CoreConfig(
-                needsClearTextHttp = forge.aBool()
-            )
-        )
+        mockCoreFeature(fakePackageName, fakePackageVersion, fakeEnvName)
     }
 
     @AfterEach

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.tracing.internal
 
 import android.app.Application
 import com.datadog.android.Datadog
-import com.datadog.android.DatadogConfig
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.rum.GlobalRum
@@ -17,6 +16,7 @@ import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.tracing.AndroidTracer
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext
+import com.datadog.android.utils.mockCoreFeature
 import com.datadog.opentracing.DDSpan
 import com.datadog.opentracing.LogHandler
 import com.datadog.opentracing.scopemanager.ContextualScopeManager
@@ -58,7 +58,7 @@ import org.mockito.quality.Strictness
     ExtendWith(ForgeExtension::class)
 )
 
-@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+@MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
 internal class AndroidTracerTest {
 
@@ -79,7 +79,7 @@ internal class AndroidTracerTest {
         fakeEnvName = forge.anAlphabeticalString()
         fakeToken = forge.anHexadecimalString()
         mockAppContext = mockContext()
-        Datadog.initialize(mockAppContext, DatadogConfig.Builder(fakeToken, fakeEnvName).build())
+        mockCoreFeature()
         testedTracerBuilder = AndroidTracer.Builder()
         testedTracerBuilder.setFieldValue("logsHandler", mockLogsHandler)
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracesFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracesFeatureTest.kt
@@ -6,52 +6,21 @@
 
 package com.datadog.android.tracing.internal
 
-import android.app.Application
-import com.datadog.android.Datadog
-import com.datadog.android.DatadogConfig
+import com.datadog.android.Configuration
 import com.datadog.android.core.internal.CoreFeature
-import com.datadog.android.core.internal.data.upload.DataUploadScheduler
-import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
-import com.datadog.android.core.internal.domain.Serializer
-import com.datadog.android.core.internal.domain.batching.ConsentAwareDataWriter
-import com.datadog.android.core.internal.net.info.NetworkInfoProvider
-import com.datadog.android.core.internal.privacy.ConsentProvider
-import com.datadog.android.core.internal.privacy.TrackingConsentProvider
-import com.datadog.android.core.internal.system.SystemInfoProvider
-import com.datadog.android.core.internal.time.TimeProvider
-import com.datadog.android.log.internal.user.UserInfoProvider
-import com.datadog.android.plugin.DatadogPlugin
-import com.datadog.android.plugin.DatadogPluginConfig
-import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.core.internal.SdkFeatureTest
 import com.datadog.android.tracing.internal.domain.TracingFileStrategy
+import com.datadog.android.tracing.internal.net.TracesOkHttpUploader
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.utils.mockContext
+import com.datadog.opentracing.DDSpan
 import com.datadog.tools.unit.extensions.ApiLevelExtension
-import com.datadog.tools.unit.getFieldValue
-import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.inOrder
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.StringForgery
-import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.io.File
-import java.net.URL
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.ScheduledThreadPoolExecutor
-import okhttp3.OkHttpClient
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.junit.jupiter.api.io.TempDir
-import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
@@ -63,375 +32,39 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class TracesFeatureTest {
+internal class TracesFeatureTest :
+    SdkFeatureTest<DDSpan, Configuration.Feature.Tracing, TracesFeature>() {
 
-    lateinit var mockAppContext: Application
-
-    @Mock
-    lateinit var mockNetworkInfoProvider: NetworkInfoProvider
-
-    @Mock
-    lateinit var mockSystemInfoProvider: SystemInfoProvider
-
-    @Mock
-    lateinit var mockTimeProvider: TimeProvider
-
-    @Mock
-    lateinit var mockUserInfoProvider: UserInfoProvider
-
-    @Mock
-    lateinit var mockOkHttpClient: OkHttpClient
-
-    @Mock
-    lateinit var mockScheduledThreadPoolExecutor: ScheduledThreadPoolExecutor
-
-    @Mock
-    lateinit var mockPersistenceExecutorService: ExecutorService
-
-    lateinit var trackingConsentProvider: ConsentProvider
-
-    lateinit var fakeConfig: DatadogConfig.FeatureConfig
-
-    lateinit var fakePackageName: String
-    lateinit var fakePackageVersion: String
-
-    @TempDir
-    lateinit var tempRootDir: File
-
-    @BeforeEach
-    fun `set up`(forge: Forge) {
-        CoreFeature.isMainProcess = true
-        trackingConsentProvider = TrackingConsentProvider()
-        fakeConfig = DatadogConfig.FeatureConfig(
-            clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
-            endpointUrl = forge.getForgery<URL>().toString(),
-            envName = forge.anAlphabeticalString()
-        )
-
-        fakePackageName = forge.anAlphabeticalString()
-        fakePackageVersion = forge.aStringMatching("\\d(\\.\\d){3}")
-
-        mockAppContext = mockContext(fakePackageName, fakePackageVersion)
-        whenever(mockAppContext.filesDir).thenReturn(tempRootDir)
-        whenever(mockAppContext.applicationContext) doReturn mockAppContext
+    override fun createTestedFeature(): TracesFeature {
+        return TracesFeature
     }
 
-    @AfterEach
-    fun `tear down`() {
-        TracesFeature.stop()
-        CoreFeature.stop()
+    override fun forgeConfiguration(forge: Forge): Configuration.Feature.Tracing {
+        return forge.getForgery()
     }
 
     @Test
-    fun `initializes persistence strategy with env`() {
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
+    fun `𝕄 initialize persistence strategy 𝕎 initialize()`() {
+        // When
+        testedFeature.initialize(mockAppContext, fakeConfig)
 
-        val persistenceStrategy = TracesFeature.persistenceStrategy
-        assertThat(persistenceStrategy)
+        // Then
+        assertThat(testedFeature.persistenceStrategy)
             .isInstanceOf(TracingFileStrategy::class.java)
-        val consentAwareDataWriter =
-            TracesFeature.persistenceStrategy.getWriter() as ConsentAwareDataWriter
-        val writer = consentAwareDataWriter.getInternalWriter()
-        val serializer: Serializer<*> = writer.getFieldValue("serializer")
-        val envName: String = serializer.getFieldValue("envName")
-        assertThat(envName).isEqualTo(fakeConfig.envName)
     }
 
     @Test
-    fun `initializes persistence strategy without env`() {
-        fakeConfig = fakeConfig.copy(envName = "")
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
-        val persistenceStrategy = TracesFeature.persistenceStrategy
-        assertThat(persistenceStrategy)
-            .isInstanceOf(TracingFileStrategy::class.java)
-        val consentAwareDataWriter =
-            TracesFeature.persistenceStrategy.getWriter() as ConsentAwareDataWriter
-        val writer = consentAwareDataWriter.getInternalWriter()
-        val serializer: Serializer<*> = writer.getFieldValue("serializer")
-        val envName: String = serializer.getFieldValue("envName")
-        assertThat(envName).isEqualTo("")
-    }
-
-    @Test
-    fun `initializes uploader thread`() {
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
-        val dataUploadScheduler = TracesFeature.dataUploadScheduler
-
-        assertThat(dataUploadScheduler)
-            .isInstanceOf(DataUploadScheduler::class.java)
-    }
-
-    @Test
-    fun `initializes from configuration`() {
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
-        val clientToken = TracesFeature.clientToken
-        val endpointUrl = TracesFeature.endpointUrl
-
-        assertThat(clientToken).isEqualTo(fakeConfig.clientToken)
-        assertThat(endpointUrl).isEqualTo(fakeConfig.endpointUrl)
-    }
-
-    @Test
-    fun `ignores if initialize called more than once`(forge: Forge) {
-        Datadog.setVerbosity(android.util.Log.VERBOSE)
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        val persistenceStrategy = TracesFeature.persistenceStrategy
-        val dataUploadScheduler = TracesFeature.dataUploadScheduler
-        val clientToken = TracesFeature.clientToken
-        val endpointUrl = TracesFeature.endpointUrl
-
-        fakeConfig = DatadogConfig.FeatureConfig(
-            clientToken = forge.anHexadecimalString(),
-            applicationId = forge.getForgery(),
-            endpointUrl = forge.getForgery<URL>().toString(),
-            envName = forge.anAlphabeticalString()
-        )
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        val persistenceStrategy2 = TracesFeature.persistenceStrategy
-        val dataUploadScheduler2 = TracesFeature.dataUploadScheduler
-        val clientToken2 = TracesFeature.clientToken
-        val endpointUrl2 = TracesFeature.endpointUrl
-
-        assertThat(persistenceStrategy).isSameAs(persistenceStrategy2)
-        assertThat(dataUploadScheduler).isSameAs(dataUploadScheduler2)
-        assertThat(clientToken).isSameAs(clientToken2)
-        assertThat(endpointUrl).isSameAs(endpointUrl2)
-    }
-
-    @Test
-    fun `M register the plugins as TrackingConsentProvideCallback W initialized`(
-        forge: Forge
-    ) {
+    fun `𝕄 create a tracing uploader 𝕎 createUploader()`() {
         // Given
-        val fakeConsent = forge.aValueFrom(TrackingConsent::class.java)
-        val plugins: List<DatadogPlugin> = forge.aList(forge.anInt(min = 1, max = 10)) {
-            mock<DatadogPlugin>()
-        }
-        val mockedTrackingConsentProvider: TrackingConsentProvider = mock() {
-            whenever(it.getConsent()).thenReturn(fakeConsent)
-        }
+        testedFeature.endpointUrl = fakeConfig.endpointUrl
 
         // When
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig.copy(plugins = plugins),
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            mockedTrackingConsentProvider
-        )
-        // Then
-        val mockPlugins = plugins.toTypedArray()
-        mockPlugins.forEach {
-            verify(mockedTrackingConsentProvider).registerCallback(it)
-        }
-    }
-
-    @Test
-    fun `it will register the provided plugin when feature is initialized`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeConsent = forge.aValueFrom(TrackingConsent::class.java)
-        val mockedTrackingConsentProvider: TrackingConsentProvider = mock() {
-            whenever(it.getConsent()).thenReturn(fakeConsent)
-        }
-        val plugins: List<DatadogPlugin> = forge.aList(forge.anInt(min = 1, max = 10)) {
-            mock<DatadogPlugin>()
-        }
-
-        // When
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig.copy(plugins = plugins),
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            mockedTrackingConsentProvider
-        )
-
-        val argumentCaptor = argumentCaptor<DatadogPluginConfig>()
-        // Then
-        val mockPlugins = plugins.toTypedArray()
-        inOrder(*mockPlugins) {
-            mockPlugins.forEach {
-                verify(it).register(argumentCaptor.capture())
-            }
-        }
-
-        argumentCaptor.allValues.forEach {
-            assertThat(it).isInstanceOf(DatadogPluginConfig.TracingPluginConfig::class.java)
-            assertThat(it.context).isEqualTo(mockAppContext)
-            assertThat(it.serviceName).isEqualTo(CoreFeature.serviceName)
-            assertThat(it.envName).isEqualTo(fakeConfig.envName)
-            assertThat(it.featurePersistenceDirName)
-                .isEqualTo(TracingFileStrategy.AUTHORIZED_FOLDER)
-            assertThat(it.context).isEqualTo(mockAppContext)
-            assertThat(it.trackingConsent).isEqualTo(fakeConsent)
-        }
-    }
-
-    @Test
-    fun `it unregister the provided plugin when stop called`(
-        forge: Forge
-    ) {
-        // Given
-        val plugins: List<DatadogPlugin> = forge.aList(forge.anInt(min = 1, max = 10)) {
-            mock<DatadogPlugin>()
-        }
-
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig.copy(plugins = plugins),
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
-        // When
-        TracesFeature.stop()
+        val uploader = testedFeature.createUploader()
 
         // Then
-        val mockPlugins = plugins.toTypedArray()
-        inOrder(*mockPlugins) {
-            mockPlugins.forEach {
-                verify(it).unregister()
-            }
-        }
-    }
-
-    @Test
-    fun `will use a NoOpUploadScheduler if this is not the application main process`() {
-        // Given
-        CoreFeature.isMainProcess = false
-
-        // When
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-
-        // Then
-        assertThat(TracesFeature.dataUploadScheduler).isInstanceOf(NoOpUploadScheduler::class.java)
-    }
-
-    @Test
-    fun `clears all files on local storage on request`(
-        @StringForgery(type = StringForgeryType.NUMERICAL) fileName: String,
-        @StringForgery content: String
-    ) {
-        val fakeDir = File(tempRootDir, TracingFileStrategy.AUTHORIZED_FOLDER)
-        fakeDir.mkdirs()
-        val fakeFile = File(fakeDir, fileName)
-        fakeFile.writeText(content)
-
-        // When
-        TracesFeature.initialize(
-            mockAppContext,
-            fakeConfig,
-            mockOkHttpClient,
-            mockNetworkInfoProvider,
-            mockUserInfoProvider,
-            mockSystemInfoProvider,
-            mockTimeProvider,
-            mockScheduledThreadPoolExecutor,
-            mockPersistenceExecutorService,
-            trackingConsentProvider
-        )
-        TracesFeature.clearAllData()
-
-        // Then
-        assertThat(fakeFile).doesNotExist()
+        assertThat(uploader).isInstanceOf(TracesOkHttpUploader::class.java)
+        val tracesUploader = uploader as TracesOkHttpUploader
+        assertThat(tracesUploader.url).startsWith(fakeConfig.endpointUrl)
+        assertThat(tracesUploader.client).isSameAs(CoreFeature.okHttpClient)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracesFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracesFeatureTest.kt
@@ -46,7 +46,7 @@ internal class TracesFeatureTest :
     @Test
     fun `𝕄 initialize persistence strategy 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockAppContext, fakeConfig)
+        testedFeature.initialize(mockAppContext, fakeConfigurationFeature)
 
         // Then
         assertThat(testedFeature.persistenceStrategy)
@@ -56,7 +56,7 @@ internal class TracesFeatureTest :
     @Test
     fun `𝕄 create a tracing uploader 𝕎 createUploader()`() {
         // Given
-        testedFeature.endpointUrl = fakeConfig.endpointUrl
+        testedFeature.endpointUrl = fakeConfigurationFeature.endpointUrl
 
         // When
         val uploader = testedFeature.createUploader()
@@ -64,7 +64,7 @@ internal class TracesFeatureTest :
         // Then
         assertThat(uploader).isInstanceOf(TracesOkHttpUploader::class.java)
         val tracesUploader = uploader as TracesOkHttpUploader
-        assertThat(tracesUploader.url).startsWith(fakeConfig.endpointUrl)
+        assertThat(tracesUploader.url).startsWith(fakeConfigurationFeature.endpointUrl)
         assertThat(tracesUploader.client).isSameAs(CoreFeature.okHttpClient)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
@@ -108,6 +108,7 @@ internal fun mockCoreFeature(
     packageName: String = BuildConfig.LIBRARY_PACKAGE_NAME,
     packageVersion: String = BuildConfig.VERSION_NAME,
     envName: String = BuildConfig.BUILD_TYPE,
+    variant : String = BuildConfig.VERSION_NAME + BuildConfig.BUILD_TYPE,
     trackingConsent: TrackingConsent = TrackingConsent.PENDING,
     rumApplicationId: String = UUID.randomUUID().toString()
 ) {
@@ -116,6 +117,7 @@ internal fun mockCoreFeature(
     CoreFeature.serviceName = packageName
     CoreFeature.packageName = packageName
     CoreFeature.packageVersion = packageVersion
+    CoreFeature.variant = variant
     CoreFeature.rumApplicationId = rumApplicationId
     CoreFeature.persistenceExecutorService = mock()
     CoreFeature.uploadExecutorService = mock()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
@@ -13,10 +13,12 @@ import android.content.pm.PackageManager
 import android.os.Build
 import com.datadog.android.BuildConfig
 import com.datadog.android.Datadog
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.logger.LogHandler
+import com.datadog.android.privacy.TrackingConsent
 import com.datadog.tools.unit.getFieldValue
 import com.datadog.tools.unit.setFieldValue
 import com.nhaarman.mockitokotlin2.any
@@ -24,6 +26,7 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import java.io.File
+import java.util.UUID
 import kotlin.math.min
 
 /**
@@ -99,4 +102,26 @@ internal fun mockDevLogHandler(): LogHandler {
     devLogger.setFieldValue("handler", mockHandler)
 
     return mockHandler
+}
+
+internal fun mockCoreFeature(
+    packageName: String = BuildConfig.LIBRARY_PACKAGE_NAME,
+    packageVersion: String = BuildConfig.VERSION_NAME,
+    envName: String = BuildConfig.BUILD_TYPE,
+    trackingConsent: TrackingConsent = TrackingConsent.PENDING,
+    rumApplicationId: String = UUID.randomUUID().toString()
+) {
+    CoreFeature.isMainProcess = true
+    CoreFeature.envName = envName
+    CoreFeature.serviceName = packageName
+    CoreFeature.packageName = packageName
+    CoreFeature.packageVersion = packageVersion
+    CoreFeature.rumApplicationId = rumApplicationId
+    CoreFeature.persistenceExecutorService = mock()
+    CoreFeature.uploadExecutorService = mock()
+    CoreFeature.timeProvider = mock()
+    CoreFeature.networkInfoProvider = mock()
+    CoreFeature.trackingConsentProvider = mock()
+    CoreFeature.userInfoProvider = mock()
+    whenever(CoreFeature.trackingConsentProvider.getConsent()) doReturn trackingConsent
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/DatadogExt.kt
@@ -108,7 +108,7 @@ internal fun mockCoreFeature(
     packageName: String = BuildConfig.LIBRARY_PACKAGE_NAME,
     packageVersion: String = BuildConfig.VERSION_NAME,
     envName: String = BuildConfig.BUILD_TYPE,
-    variant : String = BuildConfig.VERSION_NAME + BuildConfig.BUILD_TYPE,
+    variant: String = BuildConfig.VERSION_NAME + BuildConfig.BUILD_TYPE,
     trackingConsent: TrackingConsent = TrackingConsent.PENDING,
     rumApplicationId: String = UUID.randomUUID().toString()
 ) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
@@ -16,7 +16,7 @@ internal class ConfigurationCoreForgeryFactory :
     override fun getForgery(forge: Forge): Configuration.Core {
         return Configuration.Core(
             needsClearTextHttp = forge.aBool(),
-            hosts = forge.aList { getForgery<URL>().host }
+            firstPartyHosts = forge.aList { getForgery<URL>().host }
         )
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.Configuration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.net.URL
+
+internal class ConfigurationCoreForgeryFactory :
+    ForgeryFactory<Configuration.Core> {
+    override fun getForgery(forge: Forge): Configuration.Core {
+        return Configuration.Core(
+            needsClearTextHttp = forge.aBool(),
+            hosts = forge.aList { getForgery<URL>().host }
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCrashReportForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCrashReportForgeryFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.Configuration
+import com.datadog.android.plugin.DatadogPlugin
+import com.nhaarman.mockitokotlin2.mock
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class ConfigurationCrashReportForgeryFactory :
+    ForgeryFactory<Configuration.Feature.CrashReport> {
+    override fun getForgery(forge: Forge): Configuration.Feature.CrashReport {
+        return Configuration.Feature.CrashReport(
+            endpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
+            plugins = forge.aList { mock<DatadogPlugin>() }
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationFeatureForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationFeatureForgeryFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.Configuration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class ConfigurationFeatureForgeryFactory :
+    ForgeryFactory<Configuration.Feature> {
+    override fun getForgery(forge: Forge): Configuration.Feature {
+        return forge.anElementFrom(
+            forge.getForgery<Configuration.Feature.Logs>(),
+            forge.getForgery<Configuration.Feature.CrashReport>(),
+            forge.getForgery<Configuration.Feature.Tracing>(),
+            forge.getForgery<Configuration.Feature.RUM>()
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationLogForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationLogForgeryFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.Configuration
+import com.datadog.android.plugin.DatadogPlugin
+import com.nhaarman.mockitokotlin2.mock
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class ConfigurationLogForgeryFactory :
+    ForgeryFactory<Configuration.Feature.Logs> {
+    override fun getForgery(forge: Forge): Configuration.Feature.Logs {
+        return Configuration.Feature.Logs(
+            endpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
+            plugins = forge.aList { mock<DatadogPlugin>() }
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.Configuration
+import com.datadog.android.plugin.DatadogPlugin
+import com.nhaarman.mockitokotlin2.mock
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class ConfigurationRumForgeryFactory :
+    ForgeryFactory<Configuration.Feature.RUM> {
+    override fun getForgery(forge: Forge): Configuration.Feature.RUM {
+        return Configuration.Feature.RUM(
+            endpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
+            plugins = forge.aList { mock<DatadogPlugin>() },
+            samplingRate = forge.aFloat(0f, 100f),
+            gesturesTracker = mock(),
+            userActionTrackingStrategy = mock(),
+            viewTrackingStrategy = mock(),
+            rumEventMapper = mock()
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationTracingForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationTracingForgeryFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.Configuration
+import com.datadog.android.plugin.DatadogPlugin
+import com.nhaarman.mockitokotlin2.mock
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class ConfigurationTracingForgeryFactory :
+    ForgeryFactory<Configuration.Feature.Tracing> {
+    override fun getForgery(forge: Forge): Configuration.Feature.Tracing {
+        return Configuration.Feature.Tracing(
+            endpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
+            plugins = forge.aList { mock<DatadogPlugin>() }
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -13,27 +13,45 @@ import fr.xgouchet.elmyr.jvm.useJvmFactories
 internal class Configurator :
     ForgeConfigurator {
     override fun configure(forge: Forge) {
-        forge.addFactory(FeatureConfigForgeryFactory())
-        forge.addFactory(LogForgeryFactory())
-        forge.addFactory(BatchForgeryFactory())
-        forge.addFactory(ThrowableForgeryFactory())
+
+        // Datadog Core
+        forge.addFactory(ConfigurationCoreForgeryFactory())
+        forge.addFactory(ConfigurationFeatureForgeryFactory())
+        forge.addFactory(ConfigurationLogForgeryFactory())
+        forge.addFactory(ConfigurationCrashReportForgeryFactory())
+        forge.addFactory(ConfigurationTracingForgeryFactory())
+        forge.addFactory(ConfigurationRumForgeryFactory())
+        forge.addFactory(CredentialsForgeryFactory())
         forge.addFactory(NetworkInfoForgeryFactory())
         forge.addFactory(UserInfoForgeryFactory())
+
+        // IO
+        forge.addFactory(BatchForgeryFactory())
         forge.addFactory(WorkerParametersForgeryFactory())
-        forge.addFactory(JsonObjectForgeryFactory())
-        forge.addFactory(JsonPrimitiveForgeryFactory())
-        forge.addFactory(JsonArrayForgeryFactory())
+
+        // LOG
+        forge.addFactory(LogForgeryFactory())
+
+        // APM
         forge.addFactory(SpanForgeryFactory())
+
+        // RUM
+        forge.addFactory(ActionEventForgeryFactory())
         forge.addFactory(RumEventForgeryFactory())
         forge.addFactory(RumContextForgeryFactory())
-        forge.addFactory(ResourceTimingForgeryFactory())
-        forge.addFactory(ViewEventForgeryFactory())
-        forge.addFactory(ActionEventForgeryFactory())
         forge.addFactory(ResourceEventForgeryFactory())
+        forge.addFactory(ResourceTimingForgeryFactory())
         forge.addFactory(ErrorEventForgeryFactory())
+        forge.addFactory(ViewEventForgeryFactory())
         forge.addFactory(MotionEventForgeryFactory())
-        forge.addFactory(BigIntegerFactory())
         forge.addFactory(RumEventMapperFactory())
+
+        // MISC
+        forge.addFactory(BigIntegerFactory())
+        forge.addFactory(JsonArrayForgeryFactory())
+        forge.addFactory(JsonObjectForgeryFactory())
+        forge.addFactory(JsonPrimitiveForgeryFactory())
+        forge.addFactory(ThrowableForgeryFactory())
         forge.useJvmFactories()
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/CredentialsForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/CredentialsForgeryFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.Credentials
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
+
+internal class CredentialsForgeryFactory :
+    ForgeryFactory<Credentials> {
+    override fun getForgery(forge: Forge): Credentials {
+        return Credentials(
+            clientToken = forge.anHexadecimalString(),
+            envName = forge.anAlphabeticalString(),
+            variant = forge.anAlphabeticalString(),
+            serviceName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+"),
+            rumApplicationId = forge.getForgery<UUID>().toString()
+        )
+    }
+}

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -10,9 +10,10 @@ import android.content.Context
 import android.os.Build
 import android.util.Log
 import androidx.lifecycle.ViewModelProvider
+import com.datadog.android.Configuration
+import com.datadog.android.Credentials
 import com.datadog.android.Datadog
 import com.datadog.android.Datadog.setUserInfo
-import com.datadog.android.DatadogConfig
 import com.datadog.android.DatadogEventListener
 import com.datadog.android.log.Logger
 import com.datadog.android.ndk.NdkCrashReportsPlugin
@@ -82,10 +83,12 @@ class SampleApplication : Application() {
 
     private fun initializeDatadog() {
         val preferences = Preferences.defaultPreferences(this)
+
         Datadog.initialize(
             this,
-            preferences.getTrackingConsent(),
-            createDatadogConfig()
+            createDatadogCredentials(),
+            createDatadogConfiguration(),
+            preferences.getTrackingConsent()
         )
         Datadog.setVerbosity(Log.VERBOSE)
         setUserInfo(
@@ -102,14 +105,22 @@ class SampleApplication : Application() {
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
     }
 
-    private fun createDatadogConfig(): DatadogConfig {
-        val configBuilder = DatadogConfig.Builder(
-            BuildConfig.DD_CLIENT_TOKEN,
-            BuildConfig.FLAVOR,
-            BuildConfig.DD_RUM_APPLICATION_ID
+    private fun createDatadogCredentials(): Credentials {
+        return Credentials(
+            clientToken = BuildConfig.DD_CLIENT_TOKEN,
+            envName = BuildConfig.BUILD_TYPE,
+            variant = BuildConfig.FLAVOR,
+            rumApplicationId = BuildConfig.DD_RUM_APPLICATION_ID
         )
+    }
 
-        configBuilder
+    private fun createDatadogConfiguration(): Configuration {
+        val configBuilder = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
             .setFirstPartyHosts(tracedHosts)
             .addPlugin(NdkCrashReportsPlugin(), Feature.CRASH)
             .useViewTrackingStrategy(NavigationViewTrackingStrategy(R.id.nav_host_fragment, true))


### PR DESCRIPTION
### What does this PR do?

Adds a `variant` tag to the RUM events.

Because the DatadogConfig class gets a bit messy, I split it into two classes: `Credentials` (to store info that will rarely change) and `Configuration` for features parameters.
