### PR TITLE
Fix .gitignore configuration for config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ build/
 # Local configuration file (sdk path, etc)
 local.properties
 repo/
-config/
+config/*
 
 # MacOS garbage
 .DS_Store


### PR DESCRIPTION
### What does this PR do?

Fixes the .gitignore configuration to exclude only the files in the `config` folder at the root level of the project. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

