### PR TITLE
Make generated names user friendly

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
@@ -7,11 +7,11 @@
 package com.datadog.gradle.plugin.apisurface
 
 import com.datadog.gradle.config.taskConfig
+import com.datadog.gradle.plugin.jsonschema.JsonSchemaPlugin
 import java.io.File
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import com.datadog.gradle.plugin.jsonschema.JsonSchemaPlugin
 
 class ApiSurfacePlugin : Plugin<Project> {
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGenerator.kt
@@ -7,7 +7,6 @@
 package com.datadog.gradle.plugin.jsonschema
 
 import android.databinding.tool.ext.joinToCamelCaseAsVar
-import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.CodeBlock

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
@@ -85,7 +85,7 @@ val Conflict = TypeDefinition.Class(
         TypeProperty(
             "type",
             TypeDefinition.Class(
-                name = "Type",
+                name = "ConflictType",
                 properties = listOf(
                     TypeProperty("id", TypeDefinition.Primitive(JsonType.STRING), true)
                 )
@@ -101,7 +101,7 @@ val Conflict = TypeDefinition.Class(
                     TypeProperty(
                         "type",
                         TypeDefinition.Enum(
-                            name = "Type",
+                            name = "UserType",
                             type = JsonType.STRING,
                             values = listOf("unknown", "customer", "partner")
                         ),

--- a/buildSrc/src/test/kotlin/com/example/forgery/ConflictForgeryFactory.kt
+++ b/buildSrc/src/test/kotlin/com/example/forgery/ConflictForgeryFactory.kt
@@ -14,7 +14,7 @@ internal class ConflictForgeryFactory : ForgeryFactory<Conflict> {
     override fun getForgery(forge: Forge): Conflict {
         return Conflict(
             type = forge.aNullable {
-                Conflict.Type(
+                Conflict.ConflictType(
                     aNullable { anAlphabeticalString() }
                 )
             },

--- a/buildSrc/src/test/kotlin/com/example/model/Conflict.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Conflict.kt
@@ -6,7 +6,7 @@ import com.google.gson.JsonPrimitive
 import kotlin.String
 
 data class Conflict(
-    val type: Type? = null,
+    val type: ConflictType? = null,
     val user: User? = null
 ) {
     fun toJson(): JsonElement {
@@ -16,7 +16,7 @@ data class Conflict(
         return json
     }
 
-    data class Type(
+    data class ConflictType(
         val id: String? = null
     ) {
         fun toJson(): JsonElement {
@@ -28,7 +28,7 @@ data class Conflict(
 
     data class User(
         val name: String? = null,
-        val type: Type1? = null
+        val type: UserType? = null
     ) {
         fun toJson(): JsonElement {
             val json = JsonObject()
@@ -38,7 +38,7 @@ data class Conflict(
         }
     }
 
-    enum class Type1 {
+    enum class UserType {
         UNKNOWN,
 
         CUSTOMER,

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -290,7 +290,7 @@ class com.datadog.android.rum.model.ActionEvent
     constructor(kotlin.String)
     fun toJson(): com.google.gson.JsonElement
   class Session
-    constructor(kotlin.String, Type)
+    constructor(kotlin.String, SessionType)
     fun toJson(): com.google.gson.JsonElement
   class View
     constructor(kotlin.String, kotlin.String? = null, kotlin.String)
@@ -305,7 +305,7 @@ class com.datadog.android.rum.model.ActionEvent
     val formatVersion: kotlin.Long
     fun toJson(): com.google.gson.JsonElement
   class Action
-    constructor(Type1, kotlin.String? = null, kotlin.Long? = null, Target? = null, Error? = null, Crash? = null, LongTask? = null, Resource? = null)
+    constructor(ActionType, kotlin.String? = null, kotlin.Long? = null, Target? = null, Error? = null, Crash? = null, LongTask? = null, Resource? = null)
     fun toJson(): com.google.gson.JsonElement
   class Cellular
     constructor(kotlin.String? = null, kotlin.String? = null)
@@ -325,7 +325,7 @@ class com.datadog.android.rum.model.ActionEvent
   class Resource
     constructor(kotlin.Long)
     fun toJson(): com.google.gson.JsonElement
-  enum Type
+  enum SessionType
     - USER
     - SYNTHETICS
     fun toJson(): com.google.gson.JsonElement
@@ -345,7 +345,7 @@ class com.datadog.android.rum.model.ActionEvent
     - UNKNOWN
     - NONE
     fun toJson(): com.google.gson.JsonElement
-  enum Type1
+  enum ActionType
     - CUSTOM
     - CLICK
     - TAP
@@ -362,7 +362,7 @@ class com.datadog.android.rum.model.ErrorEvent
     constructor(kotlin.String)
     fun toJson(): com.google.gson.JsonElement
   class Session
-    constructor(kotlin.String, Type)
+    constructor(kotlin.String, SessionType)
     fun toJson(): com.google.gson.JsonElement
   class View
     constructor(kotlin.String, kotlin.String? = null, kotlin.String)
@@ -389,9 +389,9 @@ class com.datadog.android.rum.model.ErrorEvent
     constructor(Method, kotlin.Long, kotlin.String, Provider? = null)
     fun toJson(): com.google.gson.JsonElement
   class Provider
-    constructor(kotlin.String? = null, kotlin.String? = null, Type1? = null)
+    constructor(kotlin.String? = null, kotlin.String? = null, ProviderType? = null)
     fun toJson(): com.google.gson.JsonElement
-  enum Type
+  enum SessionType
     - USER
     - SYNTHETICS
     fun toJson(): com.google.gson.JsonElement
@@ -428,7 +428,7 @@ class com.datadog.android.rum.model.ErrorEvent
     - DELETE
     - PATCH
     fun toJson(): com.google.gson.JsonElement
-  enum Type1
+  enum ProviderType
     - AD
     - ADVERTISING
     - ANALYTICS
@@ -452,7 +452,7 @@ class com.datadog.android.rum.model.ResourceEvent
     constructor(kotlin.String)
     fun toJson(): com.google.gson.JsonElement
   class Session
-    constructor(kotlin.String, Type)
+    constructor(kotlin.String, SessionType)
     fun toJson(): com.google.gson.JsonElement
   class View
     constructor(kotlin.String, kotlin.String? = null, kotlin.String)
@@ -468,7 +468,7 @@ class com.datadog.android.rum.model.ResourceEvent
     val formatVersion: kotlin.Long
     fun toJson(): com.google.gson.JsonElement
   class Resource
-    constructor(kotlin.String? = null, Type1, Method? = null, kotlin.String, kotlin.Long? = null, kotlin.Long, kotlin.Long? = null, Redirect? = null, Dns? = null, Connect? = null, Ssl? = null, FirstByte? = null, Download? = null, Provider? = null)
+    constructor(kotlin.String? = null, ResourceType, Method? = null, kotlin.String, kotlin.Long? = null, kotlin.Long, kotlin.Long? = null, Redirect? = null, Dns? = null, Connect? = null, Ssl? = null, FirstByte? = null, Download? = null, Provider? = null)
     fun toJson(): com.google.gson.JsonElement
   class Action
     constructor(kotlin.String)
@@ -495,9 +495,9 @@ class com.datadog.android.rum.model.ResourceEvent
     constructor(kotlin.Long, kotlin.Long)
     fun toJson(): com.google.gson.JsonElement
   class Provider
-    constructor(kotlin.String? = null, kotlin.String? = null, Type2? = null)
+    constructor(kotlin.String? = null, kotlin.String? = null, ProviderType? = null)
     fun toJson(): com.google.gson.JsonElement
-  enum Type
+  enum SessionType
     - USER
     - SYNTHETICS
     fun toJson(): com.google.gson.JsonElement
@@ -517,7 +517,7 @@ class com.datadog.android.rum.model.ResourceEvent
     - UNKNOWN
     - NONE
     fun toJson(): com.google.gson.JsonElement
-  enum Type1
+  enum ResourceType
     - DOCUMENT
     - XHR
     - BEACON
@@ -537,7 +537,7 @@ class com.datadog.android.rum.model.ResourceEvent
     - DELETE
     - PATCH
     fun toJson(): com.google.gson.JsonElement
-  enum Type2
+  enum ProviderType
     - AD
     - ADVERTISING
     - ANALYTICS

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -180,7 +180,7 @@ internal class RumActionScope(
                 application = ActionEvent.Application(context.applicationId),
                 session = ActionEvent.Session(
                     id = context.sessionId,
-                    type = ActionEvent.Type.USER
+                    type = ActionEvent.SessionType.USER
                 ),
                 usr = ActionEvent.Usr(
                     id = user.id,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
@@ -36,19 +36,19 @@ internal fun String.toErrorMethod(): ErrorEvent.Method {
     }
 }
 
-internal fun RumResourceKind.toSchemaType(): ResourceEvent.Type1 {
+internal fun RumResourceKind.toSchemaType(): ResourceEvent.ResourceType {
     return when (this) {
-        RumResourceKind.BEACON -> ResourceEvent.Type1.BEACON
-        RumResourceKind.FETCH -> ResourceEvent.Type1.FETCH
-        RumResourceKind.XHR -> ResourceEvent.Type1.XHR
-        RumResourceKind.DOCUMENT -> ResourceEvent.Type1.DOCUMENT
-        RumResourceKind.IMAGE -> ResourceEvent.Type1.IMAGE
-        RumResourceKind.JS -> ResourceEvent.Type1.JS
-        RumResourceKind.FONT -> ResourceEvent.Type1.FONT
-        RumResourceKind.CSS -> ResourceEvent.Type1.CSS
-        RumResourceKind.MEDIA -> ResourceEvent.Type1.MEDIA
+        RumResourceKind.BEACON -> ResourceEvent.ResourceType.BEACON
+        RumResourceKind.FETCH -> ResourceEvent.ResourceType.FETCH
+        RumResourceKind.XHR -> ResourceEvent.ResourceType.XHR
+        RumResourceKind.DOCUMENT -> ResourceEvent.ResourceType.DOCUMENT
+        RumResourceKind.IMAGE -> ResourceEvent.ResourceType.IMAGE
+        RumResourceKind.JS -> ResourceEvent.ResourceType.JS
+        RumResourceKind.FONT -> ResourceEvent.ResourceType.FONT
+        RumResourceKind.CSS -> ResourceEvent.ResourceType.CSS
+        RumResourceKind.MEDIA -> ResourceEvent.ResourceType.MEDIA
         RumResourceKind.UNKNOWN,
-        RumResourceKind.OTHER -> ResourceEvent.Type1.OTHER
+        RumResourceKind.OTHER -> ResourceEvent.ResourceType.OTHER
     }
 }
 
@@ -93,13 +93,13 @@ internal fun ResourceTiming.download(): ResourceEvent.Download? {
     } else null
 }
 
-internal fun RumActionType.toSchemaType(): ActionEvent.Type1 {
+internal fun RumActionType.toSchemaType(): ActionEvent.ActionType {
     return when (this) {
-        RumActionType.TAP -> ActionEvent.Type1.TAP
-        RumActionType.SCROLL -> ActionEvent.Type1.SCROLL
-        RumActionType.SWIPE -> ActionEvent.Type1.SWIPE
-        RumActionType.CLICK -> ActionEvent.Type1.CLICK
-        RumActionType.CUSTOM -> ActionEvent.Type1.CUSTOM
+        RumActionType.TAP -> ActionEvent.ActionType.TAP
+        RumActionType.SCROLL -> ActionEvent.ActionType.SCROLL
+        RumActionType.SWIPE -> ActionEvent.ActionType.SWIPE
+        RumActionType.CLICK -> ActionEvent.ActionType.CLICK
+        RumActionType.CUSTOM -> ActionEvent.ActionType.CUSTOM
     }
 }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -163,7 +163,7 @@ internal class RumResourceScope(
             application = ResourceEvent.Application(context.applicationId),
             session = ResourceEvent.Session(
                 id = context.sessionId,
-                type = ResourceEvent.Type.USER
+                type = ResourceEvent.SessionType.USER
             ),
             dd = ResourceEvent.Dd(
                 traceId = traceId,
@@ -182,7 +182,10 @@ internal class RumResourceScope(
 
     private fun resolveResourceProvider(): ResourceEvent.Provider? {
         return if (firstPartyHostDetector.isFirstPartyUrl(url)) {
-            ResourceEvent.Provider(resolveDomain(url), type = ResourceEvent.Type2.FIRST_PARTY)
+            ResourceEvent.Provider(
+                resolveDomain(url),
+                type = ResourceEvent.ProviderType.FIRST_PARTY
+            )
         } else {
             null
         }
@@ -225,7 +228,10 @@ internal class RumResourceScope(
             ),
             connectivity = networkInfo.toErrorConnectivity(),
             application = ErrorEvent.Application(context.applicationId),
-            session = ErrorEvent.Session(id = context.sessionId, type = ErrorEvent.Type.USER),
+            session = ErrorEvent.Session(
+                id = context.sessionId,
+                type = ErrorEvent.SessionType.USER
+            ),
             dd = ErrorEvent.Dd()
         )
         val rumEvent = RumEvent(
@@ -240,7 +246,10 @@ internal class RumResourceScope(
 
     private fun resolveErrorProvider(): ErrorEvent.Provider? {
         return if (firstPartyHostDetector.isFirstPartyUrl(url)) {
-            ErrorEvent.Provider(domain = resolveDomain(url), type = ErrorEvent.Type1.FIRST_PARTY)
+            ErrorEvent.Provider(
+                domain = resolveDomain(url),
+                type = ErrorEvent.ProviderType.FIRST_PARTY
+            )
         } else {
             null
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -205,7 +205,10 @@ internal class RumViewScope(
             ),
             connectivity = networkInfo.toErrorConnectivity(),
             application = ErrorEvent.Application(context.applicationId),
-            session = ErrorEvent.Session(id = context.sessionId, type = ErrorEvent.Type.USER),
+            session = ErrorEvent.Session(
+                id = context.sessionId,
+                type = ErrorEvent.SessionType.USER
+            ),
             dd = ErrorEvent.Dd()
         )
         val rumEvent = RumEvent(
@@ -341,7 +344,7 @@ internal class RumViewScope(
         val actionEvent = ActionEvent(
             date = eventTimestamp,
             action = ActionEvent.Action(
-                type = ActionEvent.Type1.APPLICATION_START,
+                type = ActionEvent.ActionType.APPLICATION_START,
                 id = UUID.randomUUID().toString(),
                 loadingTime = getStartupTime(event)
             ),
@@ -357,7 +360,7 @@ internal class RumViewScope(
             application = ActionEvent.Application(context.applicationId),
             session = ActionEvent.Session(
                 id = context.sessionId,
-                type = ActionEvent.Type.USER
+                type = ActionEvent.SessionType.USER
             ),
             dd = ActionEvent.Dd()
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
@@ -64,7 +64,7 @@ internal class ActionEventAssert(actual: ActionEvent) :
         return this
     }
 
-    fun hasType(expected: ActionEvent.Type1): ActionEventAssert {
+    fun hasType(expected: ActionEvent.ActionType): ActionEventAssert {
         assertThat(actual.action.type)
             .overridingErrorMessage(
                 "Expected event data to have action.type $expected but was ${actual.action.type}"

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -214,7 +214,7 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
-    fun hasProviderType(expected: ErrorEvent.Type1): ErrorEventAssert {
+    fun hasProviderType(expected: ErrorEvent.ProviderType): ErrorEventAssert {
         assertThat(actual.error.resource?.provider?.type)
             .overridingErrorMessage(
                 "Expected event data to have resource provider type $expected " +

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
@@ -366,7 +366,7 @@ internal class ResourceEventAssert(actual: ResourceEvent) :
         return this
     }
 
-    fun hasProviderType(expected: ResourceEvent.Type2): ResourceEventAssert {
+    fun hasProviderType(expected: ResourceEvent.ProviderType): ResourceEventAssert {
         assertThat(actual.resource.provider?.type)
             .overridingErrorMessage(
                 "Expected event data to have resource provider type $expected " +

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExtTest.kt
@@ -98,7 +98,7 @@ internal class RumEventExtTest {
 
         // Then
         if (kind == RumResourceKind.UNKNOWN) {
-            assertThat(result).isEqualTo(ResourceEvent.Type1.OTHER)
+            assertThat(result).isEqualTo(ResourceEvent.ResourceType.OTHER)
         } else {
             assertThat(kind.name).isEqualTo(result.name)
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -219,7 +219,7 @@ internal class RumResourceScopeTest {
                     hasActionId(fakeParentContext.actionId)
                     hasTraceId(null)
                     hasSpanId(null)
-                    hasProviderType(ResourceEvent.Type2.FIRST_PARTY)
+                    hasProviderType(ResourceEvent.ProviderType.FIRST_PARTY)
                     hasProviderDomain(URL(fakeUrl).host)
                 }
         }
@@ -281,7 +281,7 @@ internal class RumResourceScopeTest {
                     hasActionId(fakeParentContext.actionId)
                     hasTraceId(null)
                     hasSpanId(null)
-                    hasProviderType(ResourceEvent.Type2.FIRST_PARTY)
+                    hasProviderType(ResourceEvent.ProviderType.FIRST_PARTY)
                     hasProviderDomain(brokenUrl)
                 }
         }
@@ -692,7 +692,7 @@ internal class RumResourceScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
                     hasProviderDomain(brokenUrl)
-                    hasProviderType(ErrorEvent.Type1.FIRST_PARTY)
+                    hasProviderType(ErrorEvent.ProviderType.FIRST_PARTY)
                 }
         }
         verify(mockParentScope).handleEvent(
@@ -739,7 +739,7 @@ internal class RumResourceScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
                     hasProviderDomain(URL(fakeUrl).host)
-                    hasProviderType(ErrorEvent.Type1.FIRST_PARTY)
+                    hasProviderType(ErrorEvent.ProviderType.FIRST_PARTY)
                 }
         }
         verify(mockParentScope).handleEvent(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -820,7 +820,7 @@ internal class RumViewScopeTest {
                 .hasActionData {
                     hasNonNullId()
                     hasTimestamp(testedScope.eventTimestamp)
-                    hasType(ActionEvent.Type1.APPLICATION_START)
+                    hasType(ActionEvent.ActionType.APPLICATION_START)
                     hasNoTarget()
                     hasDuration(duration)
                     hasResourceCount(0)
@@ -980,7 +980,7 @@ internal class RumViewScopeTest {
                 .hasActionData {
                     hasNonNullId()
                     hasTimestamp(testedScope.eventTimestamp)
-                    hasType(ActionEvent.Type1.APPLICATION_START)
+                    hasType(ActionEvent.ActionType.APPLICATION_START)
                     hasNoTarget()
                     hasDuration(duration)
                     hasResourceCount(0)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ActionEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ActionEventForgeryFactory.kt
@@ -39,7 +39,7 @@ internal class ActionEventForgeryFactory :
             application = ActionEvent.Application(forge.getForgery<UUID>().toString()),
             session = ActionEvent.Session(
                 id = forge.getForgery<UUID>().toString(),
-                type = ActionEvent.Type.USER
+                type = ActionEvent.SessionType.USER
             ),
             dd = ActionEvent.Dd()
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
@@ -45,7 +45,7 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
             application = ErrorEvent.Application(forge.getForgery<UUID>().toString()),
             session = ErrorEvent.Session(
                 id = forge.getForgery<UUID>().toString(),
-                type = ErrorEvent.Type.USER
+                type = ErrorEvent.SessionType.USER
             ),
             dd = ErrorEvent.Dd()
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ResourceEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ResourceEventForgeryFactory.kt
@@ -52,7 +52,7 @@ internal class ResourceEventForgeryFactory :
             application = ResourceEvent.Application(forge.getForgery<UUID>().toString()),
             session = ResourceEvent.Session(
                 id = forge.getForgery<UUID>().toString(),
-                type = ResourceEvent.Type.USER
+                type = ResourceEvent.SessionType.USER
             ),
             dd = ResourceEvent.Dd()
         )


### PR DESCRIPTION
### What does this PR do?

When generated RUM Event types from Json schema, ensure that types with conflicting names use a user friendly name.

### Motivation

Because those types are public, it was a bit weird to have `Type1` or `Type2` classes. Now those classes will be named more accurately (e.g.: `SessionType` or `ResourceType`). 