### PR TITLE
RUMM-909 Prevent coupling between assemble and publishMapping tasks

### DIFF
--- a/dd-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
+++ b/dd-android-gradle-plugin/src/main/kotlin/com/datadog/gradle/plugin/DdAndroidGradlePlugin.kt
@@ -53,7 +53,6 @@ class DdAndroidGradlePlugin : Plugin<Project> {
     ) {
         val flavorName = variant.name.removeSuffix("Release")
         val uploadTaskName = UPLOAD_TASK_NAME + flavorName.capitalize()
-        val assembleTaskName = "assemble${variant.name.capitalize()}"
 
         val uploadTask = target.tasks.create(
             uploadTaskName,
@@ -70,8 +69,6 @@ class DdAndroidGradlePlugin : Plugin<Project> {
         val mappingDir = File(outputsDir, "mapping")
         val flavorDir = File(mappingDir, variant.name)
         uploadTask.mappingFilePath = File(flavorDir, "mapping.txt").path
-
-        target.tasks.findByName(assembleTaskName)?.finalizedBy(uploadTaskName)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Prevent coupling between assemble and publishMapping tasks. 

### Motivation

Once uploaded, mapping files can't be overriden. Uncoupling those tasks ensure we don't block a release by mistake
