### PR TITLE
RUMM-969 Increment RUM ViewEvent error count and send ErrorEvent when NDK crash detected

### DIFF
--- a/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.cpp
+++ b/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.cpp
@@ -35,10 +35,10 @@ static const uint8_t tracking_consent_granted = 1;
 static uint8_t tracking_consent = tracking_consent_pending; // 0 - PENDING, 1 - GRANTED, 2 - NOT-GRANTED
 
 
-void crash_signal_intercepted(int signum,
-                              const char *signal_name,
-                              const char *error_message,
-                              const char *error_stacktrace) {
+void write_crash_report(int signum,
+                        const char *signal_name,
+                        const char *error_message,
+                        const char *error_stacktrace) {
     using namespace std;
     static const std::string crash_log_filename = "crash_log";
 

--- a/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.h
+++ b/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.h
@@ -19,10 +19,10 @@ void update_main_context(JNIEnv *env,
 
 void update_tracking_consent(jint consent);
 
-void crash_signal_intercepted(int signum,
-                              const char *signal_name,
-                              const char *error_message,
-                              const char *error_stacktrace);
+void write_crash_report(int signum,
+                        const char *signal_name,
+                        const char *error_message,
+                        const char *error_stacktrace);
 
 #ifdef __cplusplus
 }

--- a/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
@@ -56,22 +56,22 @@ namespace {
         return std::string(address_as_hexa);
     }
 
-    void get_info_from_address(const uintptr_t address, std::string *backtrace) {
-        backtrace->append(std::to_string(address));
+    void get_info_from_address(size_t index, const uintptr_t address, std::string *backtrace) {
+        backtrace->append(std::to_string(index));
         Dl_info info;
         int fetch_info_success = dladdr(reinterpret_cast<void *>(address), &info);
         if (fetch_info_success) {
 
             if (info.dli_fname) {
-                backtrace->append("  ");
+                backtrace->append(" ");
                 backtrace->append(info.dli_fname);
             }
 
-            backtrace->append("  ");
+            backtrace->append(" ");
             backtrace->append(address_to_hexa(address));
 
             if (info.dli_sname) {
-                backtrace->append("  ");
+                backtrace->append(" ");
                 backtrace->append(info.dli_sname);
             }
 
@@ -79,8 +79,7 @@ namespace {
                 backtrace->append(" ");
                 backtrace->append("+");
                 backtrace->append(" ");
-                const uintptr_t address_offset =
-                        address - reinterpret_cast<uintptr_t>(info.dli_fbase);
+                auto address_offset = reinterpret_cast<uintptr_t>(info.dli_fbase);
                 backtrace->append(std::to_string(address_offset));
             }
 
@@ -109,7 +108,7 @@ bool generate_backtrace(char *backtrace_ptr, size_t max_size) {
     for (size_t idx = 0; idx < number_of_captured_frames; ++idx) {
         // we will iterate through all the stack addresses and translate each address in
         // readable information
-        get_info_from_address(buffer[idx], &backtrace);
+        get_info_from_address(idx, buffer[idx], &backtrace);
     }
     return copyString(backtrace, backtrace_ptr, max_size);
 }

--- a/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
@@ -96,7 +96,7 @@ bool copyString(const std::string &str, char *ptr, size_t max_size) {
     size_t copy_size = std::min(str_size, max_size - 1);
     memcpy(ptr, str.data(), copy_size);
     ptr[str.size()] = '\0';
-    return copy_size < str_size;
+    return copy_size == str_size;
 }
 
 bool generate_backtrace(char *backtrace_ptr, size_t max_size) {

--- a/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
@@ -125,10 +125,10 @@ void handle_signal(int signum, siginfo_t *info, void *user_context) {
             char backtrace[max_stack_size];
             // in case the stacktrace is bigger than the required size it will be truncated
             generate_backtrace(backtrace, max_stack_size);
-            crash_signal_intercepted(signal,
-                                     handled_signals[i].signal_name,
-                                     handled_signals[i].signal_error_message,
-                                     backtrace);
+            write_crash_report(signal,
+                               handled_signals[i].signal_name,
+                               handled_signals[i].signal_error_message,
+                               backtrace);
 
             break;
         }

--- a/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
@@ -123,12 +123,13 @@ void handle_signal(int signum, siginfo_t *info, void *user_context) {
         const int signal = handled_signals[i].signal_value;
         if (signal == signum) {
             char backtrace[max_stack_size];
-            if (generate_backtrace(backtrace, max_stack_size)) {
-                crash_signal_intercepted(signal,
-                                         handled_signals[i].signal_name,
-                                         handled_signals[i].signal_error_message,
-                                         backtrace);
-            }
+            // in case the stacktrace is bigger than the required size it will be truncated
+            generate_backtrace(backtrace, max_stack_size);
+            crash_signal_intercepted(signal,
+                                     handled_signals[i].signal_name,
+                                     handled_signals[i].signal_error_message,
+                                     backtrace);
+
             break;
         }
     }

--- a/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/NdkCrashReportsPlugin.kt
+++ b/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/NdkCrashReportsPlugin.kt
@@ -49,6 +49,7 @@ class NdkCrashReportsPlugin : DatadogPlugin {
                 config.context.filesDir,
                 NDK_CRASH_REPORTS_FOLDER
             )
+        ndkCrashesDirs.mkdirs()
         registerSignalHandler(
             ndkCrashesDirs.absolutePath,
             consentToInt(config.trackingConsent)
@@ -96,7 +97,7 @@ class NdkCrashReportsPlugin : DatadogPlugin {
     // endregion
 
     companion object {
-        private const val NDK_CRASH_REPORTS_FOLDER = "ndk_crash_reports"
+        internal const val NDK_CRASH_REPORTS_FOLDER = "ndk_crash_reports"
         private const val TAG: String = "NdkCrashReportsPlugin"
         private const val ERROR_LOADING_NATIVE_MESSAGE: String =
             "We could not load the native library"

--- a/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/NdkCrashReportsPlugin.kt
+++ b/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/NdkCrashReportsPlugin.kt
@@ -46,9 +46,8 @@ class NdkCrashReportsPlugin : DatadogPlugin {
         }
         val ndkCrashesDirs =
             File(
-                config.context.filesDir.absolutePath +
-                    File.separator +
-                    NDK_CRASH_REPORTS_FOLDER
+                config.context.filesDir,
+                NDK_CRASH_REPORTS_FOLDER
             )
         registerSignalHandler(
             ndkCrashesDirs.absolutePath,

--- a/dd-sdk-android-ndk/src/test/cpp/integration-tests.cpp
+++ b/dd-sdk-android-ndk/src/test/cpp/integration-tests.cpp
@@ -62,7 +62,7 @@ void test_generate_log(
         const char *signal_name,
         const char *signal_error_message,
         const char *error_stack) {
-    crash_signal_intercepted(signal, signal_name, signal_error_message, error_stack);
+    write_crash_report(signal, signal_name, signal_error_message, error_stack);
 }
 
 

--- a/dd-sdk-android-ndk/src/test/cpp/test-generate-backtrace.cpp
+++ b/dd-sdk-android-ndk/src/test/cpp/test-generate-backtrace.cpp
@@ -9,13 +9,14 @@
 
 TEST test_generate_backtrace(void) {
     char backtrace[max_stack_size];
-    generate_backtrace(backtrace, max_stack_size);
+    const bool was_successful = generate_backtrace(backtrace, max_stack_size);
     std::list<std::string> backtrace_lines = testutils::split_backtrace_into_lines(
             backtrace);
     // we don't know if the stack is big enough to cover the required max size of 30
     unsigned int lines_count = backtrace_lines.size();
+            ASSERT(was_successful);
     const char *regex = "(\\d+)(.*)0[xX][0-9a-fA-F]+(.*)";
-            ASSERT(lines_count > 0 && lines_count <= 30);
+            ASSERT(lines_count > 0 && lines_count <= max_stack_frames);
     for (auto it = backtrace_lines.begin(); it != backtrace_lines.end(); ++it) {
                 ASSERT(std::regex_match(it->c_str(), std::regex(regex)));
     }
@@ -23,19 +24,20 @@ TEST test_generate_backtrace(void) {
 }
 
 TEST test_generate_backtrace_will_return_false_if_size_is_exceeded(void) {
-    const size_t backtrace_size = 0;
+    const size_t backtrace_size = 1;
     char backtrace[backtrace_size];
-    const bool was_generated = generate_backtrace(backtrace, backtrace_size);
-            ASSERT_FALSE(was_generated);
+    const bool was_successful = generate_backtrace(backtrace, backtrace_size);
+            ASSERT_FALSE(was_successful);
             PASS();
 }
 
 TEST test_generate_backtrace_will_return_truncated_string_if_size_is_exceeded(void) {
-    const size_t backtrace_size = 2;
+    const size_t backtrace_size = 3;
     char backtrace[backtrace_size];
-    generate_backtrace(backtrace, backtrace_size);
-            ASSERT(backtrace[0]!='\0');
-            ASSERT(backtrace[1]!='\0');
+    const bool was_successful = generate_backtrace(backtrace, backtrace_size);
+            ASSERT_FALSE(was_successful);
+            ASSERT(backtrace[0] != '\0');
+            ASSERT(backtrace[1] != '\0');
             PASS();
 }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/Deserializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/domain/Deserializer.kt
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.domain
+
+/**
+ * The Serializer<T> generic interface. Should be implemented by any custom serializer.
+ */
+internal interface Deserializer<T : Any> {
+
+    fun deserialize(model: String): T?
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogSerializer.kt
@@ -157,14 +157,6 @@ internal class LogSerializer(
         internal const val USER_EXTRA_GROUP_VERBOSE_NAME = "user extra information"
 
         internal val reservedAttributes = arrayOf(
-            LogAttributes.HOST,
-            LogAttributes.MESSAGE,
-            LogAttributes.STATUS,
-            LogAttributes.SERVICE_NAME,
-            LogAttributes.SOURCE,
-            LogAttributes.ERROR_KIND,
-            LogAttributes.ERROR_MESSAGE,
-            LogAttributes.ERROR_STACK,
             TAG_DATADOG_TAGS
         )
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/data/file/RumFileWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/data/file/RumFileWriter.kt
@@ -33,6 +33,9 @@ internal class RumFileWriter(
     override fun writeData(data: ByteArray, model: RumEvent) {
         super.writeData(data, model)
         if (model.event is ViewEvent) {
+            if (!lastViewEventFile.exists()) {
+                lastViewEventFile.createNewFile()
+            }
             // persist the serialised ViewEvent in the NDK crash data folder
             writeDataToFile(lastViewEventFile, data, false)
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumFileStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumFileStrategy.kt
@@ -15,6 +15,7 @@ import com.datadog.android.event.EventMapper
 import com.datadog.android.rum.internal.data.file.RumFileWriter
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.internal.domain.event.RumEventSerializer
+import com.datadog.android.rum.internal.ndk.DatadogNdkCrashHandler
 import java.io.File
 import java.util.concurrent.ExecutorService
 
@@ -35,7 +36,7 @@ internal class RumFileStrategy(
     eventMapper,
     fileWriterFactory = { fileOrchestrator, eventSerializer, eventSeparator ->
         RumFileWriter(
-            File(context.filesDir, NDK_CRASH_REPORTS_FOLDER_NAME),
+            File(context.filesDir, DatadogNdkCrashHandler.NDK_CRASH_REPORTS_FOLDER_NAME),
             fileOrchestrator,
             eventSerializer,
             eventSeparator
@@ -48,6 +49,5 @@ internal class RumFileStrategy(
         internal const val INTERMEDIATE_DATA_FOLDER =
             "$ROOT-pending-v$VERSION"
         internal const val AUTHORIZED_FOLDER = "$ROOT-v$VERSION"
-        internal const val NDK_CRASH_REPORTS_FOLDER_NAME = "ndk_crash_reports"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializer.kt
@@ -1,0 +1,103 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.event
+
+import com.datadog.android.core.internal.domain.Deserializer
+import com.datadog.android.core.internal.utils.sdkLogger
+import com.datadog.android.rum.model.ActionEvent
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.ViewEvent
+import com.google.gson.JsonObject
+import com.google.gson.JsonParser
+import com.google.gson.JsonSyntaxException
+
+internal class RumEventDeserializer : Deserializer<RumEvent> {
+
+    // region Deserializer
+
+    override fun deserialize(model: String): RumEvent? {
+        return try {
+            val jsonObject = JsonParser.parseString(model).asJsonObject
+            val userAttributes: MutableMap<String, Any?> = mutableMapOf()
+            val globalAttributes: MutableMap<String, Any?> = mutableMapOf()
+            val customTimings: MutableMap<String, Long> = mutableMapOf()
+            resolveAttributes(userAttributes, globalAttributes, customTimings, jsonObject)
+            RumEvent(
+                fromJson(jsonObject.getAsJsonPrimitive(EVENT_TYPE_KEY_NAME).asString, model),
+                globalAttributes,
+                userAttributes,
+                if (customTimings.isNotEmpty()) {
+                    customTimings
+                } else {
+                    null
+                }
+            )
+        } catch (e: JsonSyntaxException) {
+            sdkLogger.e("Error while trying to deserialize the serialized RumEvent: $model")
+            null
+        }
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun resolveAttributes(
+        userAttributes: MutableMap<String, Any?>,
+        globalAttributes: MutableMap<String, Any?>,
+        customTimings: MutableMap<String, Long>,
+        jsonObject: JsonObject
+    ) {
+        val customGlobalAttributesPrefix = RumEventSerializer.GLOBAL_ATTRIBUTE_PREFIX + '.'
+        val customUserAttributesPrefix = RumEventSerializer.USER_ATTRIBUTE_PREFIX + '.'
+        val customTimingsAttributesPrefix =
+            RumEventSerializer.VIEW_CUSTOM_TIMINGS_ATTRIBUTE_PREFIX + '.'
+        val customGlobalAttributesPrefixLength = customGlobalAttributesPrefix.length
+        val customUserAttributesPrefixLength = customUserAttributesPrefix.length
+        val customTimingsAttributesPrefixLength = customTimingsAttributesPrefix.length
+
+        jsonObject.keySet().forEach {
+            when {
+                it.startsWith(customUserAttributesPrefix) -> {
+                    userAttributes[it.substring(customUserAttributesPrefixLength)] =
+                        jsonObject.get(it)
+                }
+                it.startsWith(customGlobalAttributesPrefix) -> {
+                    globalAttributes[it.substring(customGlobalAttributesPrefixLength)] =
+                        jsonObject.get(it)
+                }
+                it.startsWith(customTimingsAttributesPrefix) -> {
+                    customTimings[it.substring(customTimingsAttributesPrefixLength)] =
+                        jsonObject.get(it).asLong
+                }
+            }
+        }
+    }
+
+    private fun fromJson(eventType: String, jsonString: String): Any {
+        return when (eventType) {
+            EVENT_TYPE_VIEW -> ViewEvent.fromJson(jsonString)
+            EVENT_TYPE_RESOURCE -> ResourceEvent.fromJson(jsonString)
+            EVENT_TYPE_ACTION -> ActionEvent.fromJson(jsonString)
+            EVENT_TYPE_ERROR -> ErrorEvent.fromJson(jsonString)
+            else -> JsonObject()
+        }
+    }
+
+    // endregion
+
+    companion object {
+        const val EVENT_TYPE_KEY_NAME = "type"
+
+        // Maybe we need to expose these as static constants in the POKOs from the Generator ??
+        const val EVENT_TYPE_VIEW = "view"
+        const val EVENT_TYPE_RESOURCE = "resource"
+        const val EVENT_TYPE_ACTION = "action"
+        const val EVENT_TYPE_ERROR = "error"
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
@@ -1,0 +1,231 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.ndk
+
+import com.datadog.android.core.internal.data.Writer
+import com.datadog.android.core.internal.domain.Deserializer
+import com.datadog.android.core.internal.utils.sdkLogger
+import com.datadog.android.log.LogAttributes
+import com.datadog.android.log.internal.domain.Log
+import com.datadog.android.log.internal.domain.LogGenerator
+import com.datadog.android.rum.internal.data.file.RumFileWriter
+import com.datadog.android.rum.internal.domain.event.RumEvent
+import com.datadog.android.rum.internal.domain.event.RumEventDeserializer
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.ViewEvent
+import com.google.gson.JsonSyntaxException
+import java.io.File
+import java.io.IOException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.TimeUnit
+
+internal class DatadogNdkCrashHandler(
+    private val ndkCrashDataDirectory: File,
+    private val dataPersistenceExecutorService: ExecutorService,
+    private val asyncLogWriter: Writer<Log>,
+    private val asyncRumWriter: Writer<RumEvent>,
+    private val logGenerator: LogGenerator,
+    private val rumEventDeserializer: Deserializer<RumEvent> = RumEventDeserializer()
+) : NdkCrashHandler {
+
+    override fun handleNdkCrash() {
+        dataPersistenceExecutorService.submit {
+            checkAndHandleNdkCrashReport()
+        }
+    }
+
+    private fun checkAndHandleNdkCrashReport() {
+        if (ndkCrashDataDirectory.exists()) {
+            // check if there is an NDK report
+            val crashLogFiles =
+                ndkCrashDataDirectory.listFiles { _, name -> name == CRASH_LOG_FILE_NAME }
+            if (crashLogFiles != null && crashLogFiles.isNotEmpty()) {
+                readFromFile(
+                    crashLogFiles[0],
+                    NdkCrashLog::class.java,
+                    "Malformed ndk crash error log",
+                    "Error while trying to read the ndk crash log"
+                )?.let {
+                    handleNdkCrashLog(it, searchLastRumViewEvent())
+                }
+            }
+            clearCrashLog()
+        }
+    }
+
+    private fun searchLastRumViewEvent(): RumEvent? {
+        val lastViewEventFiles =
+            ndkCrashDataDirectory.listFiles { _, name ->
+                name == RumFileWriter.LAST_VIEW_EVENT_FILE_NAME
+            }
+        if (lastViewEventFiles != null && lastViewEventFiles.isNotEmpty()) {
+            return readFromFile(
+                lastViewEventFiles[0],
+                RumEvent::class.java,
+                "Malformed RUM ViewEvent log",
+                "Error while trying to read the last rum view event log"
+            )
+        }
+        return null
+    }
+
+    private fun <T> readFromFile(
+        file: File,
+        type: Class<T>,
+        parsingErrorMessage: String,
+        ioErrorMessage: String
+    ): T? {
+        return try {
+            val serializedData = file.readText(Charsets.UTF_8)
+            @Suppress("UNCHECKED_CAST")
+            if (type == RumEvent::class.java) {
+                rumEventDeserializer.deserialize(serializedData) as? T
+            } else {
+                fromJson(serializedData) as T
+            }
+        } catch (e: JsonSyntaxException) {
+            sdkLogger.e(parsingErrorMessage, e)
+            null
+        } catch (e: IOException) {
+            sdkLogger.e(ioErrorMessage, e)
+            null
+        }
+    }
+
+    private fun handleNdkCrashLog(ndkCrashLog: NdkCrashLog, lastRumViewEvent: RumEvent?) {
+        val errorLogMessage = NDK_ERROR_LOG_MESSAGE.format(ndkCrashLog.signalName)
+        val bundledViewEvent = lastRumViewEvent?.event as? ViewEvent
+        val logAttributes: Map<String, String>
+        if (lastRumViewEvent != null && bundledViewEvent != null) {
+            logAttributes = mapOf(
+                LogAttributes.RUM_SESSION_ID to bundledViewEvent.session.id,
+                LogAttributes.RUM_APPLICATION_ID to bundledViewEvent.application.id,
+                LogAttributes.RUM_VIEW_ID to bundledViewEvent.view.id,
+                LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace
+            )
+            // update the error count
+            val toSendErrorEvent = resolveFromLastRumViewEvent(
+                errorLogMessage,
+                ndkCrashLog,
+                lastRumViewEvent,
+                bundledViewEvent
+            )
+            val sessionsTimeDifference = System.currentTimeMillis() - ndkCrashLog.timestamp
+            if (sessionsTimeDifference < VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD
+            ) {
+                val toSendRumEvent = resolveFromLastRumViewEvent(lastRumViewEvent, bundledViewEvent)
+                asyncRumWriter.write(toSendRumEvent)
+            }
+            asyncRumWriter.write(toSendErrorEvent)
+        } else {
+            logAttributes = mapOf(
+                LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace
+            )
+        }
+
+        val log = logGenerator.generateLog(
+            Log.CRASH,
+            errorLogMessage,
+            null,
+            logAttributes,
+            emptySet(),
+            ndkCrashLog.timestamp,
+            bundleWithTraces = false,
+            bundleWithRum = false
+        )
+
+        asyncLogWriter.write(log)
+    }
+
+    private fun resolveFromLastRumViewEvent(
+        lastRumViewEvent: RumEvent,
+        bundledViewEvent: ViewEvent
+    ): RumEvent {
+        return lastRumViewEvent.copy(
+            event = bundledViewEvent.copy(
+                view = bundledViewEvent.view.copy(
+                    error = bundledViewEvent.view.error
+                        .copy(count = bundledViewEvent.view.error.count + 1),
+                    isActive = false
+                ),
+                dd = bundledViewEvent.dd.copy(
+                    documentVersion = bundledViewEvent.dd.documentVersion + 1
+                )
+            )
+        )
+    }
+
+    private fun resolveFromLastRumViewEvent(
+        errorLogMessage: String,
+        ndkCrashLog: NdkCrashLog,
+        rumViewEvent: RumEvent,
+        bundledViewEvent: ViewEvent
+    ): RumEvent {
+        val connectivity = bundledViewEvent.connectivity?.let {
+            val connectivityStatus =
+                ErrorEvent.Status.valueOf(it.status.name)
+            val connectivityInterfaces = it.interfaces.map { ErrorEvent.Interface.valueOf(it.name) }
+            val cellular = ErrorEvent.Cellular(
+                it.cellular?.technology,
+                it.cellular?.carrierName
+            )
+            ErrorEvent.Connectivity(connectivityStatus, connectivityInterfaces, cellular)
+        }
+        return RumEvent(
+            ErrorEvent(
+                ndkCrashLog.timestamp,
+                ErrorEvent.Application(bundledViewEvent.application.id),
+                bundledViewEvent.service,
+                ErrorEvent.Session(bundledViewEvent.session.id, ErrorEvent.SessionType.USER),
+                ErrorEvent.View(
+                    bundledViewEvent.view.id,
+                    bundledViewEvent.view.referrer,
+                    bundledViewEvent.view.url
+                ),
+                ErrorEvent.Usr(
+                    bundledViewEvent.usr?.id,
+                    bundledViewEvent.usr?.name,
+                    bundledViewEvent.usr?.email
+                ),
+                connectivity,
+                ErrorEvent.Dd(),
+                ErrorEvent.Error(
+                    errorLogMessage,
+                    ErrorEvent.Source.SOURCE,
+                    ndkCrashLog.stacktrace,
+                    true
+                )
+            ),
+            rumViewEvent.globalAttributes,
+            rumViewEvent.userExtraAttributes,
+            rumViewEvent.customTimings
+        )
+    }
+
+    @SuppressWarnings("TooGenericExceptionCaught")
+    private fun clearCrashLog() {
+        if (ndkCrashDataDirectory.exists()) {
+            try {
+                ndkCrashDataDirectory.listFiles()?.forEach { it.deleteRecursively() }
+            } catch (e: Throwable) {
+                sdkLogger.e(
+                    "Unable to clear the NDK crash report file:" +
+                        " ${ndkCrashDataDirectory.absolutePath}",
+                    e
+                )
+            }
+        }
+    }
+
+    companion object {
+        internal val VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD = TimeUnit.HOURS.toMillis(4)
+        const val CRASH_LOG_FILE_NAME = "crash_log"
+        const val LOGGER_NAME = "ndk_crash"
+        const val NDK_ERROR_LOG_MESSAGE = "NDK crash detected with signal: %s"
+        internal const val NDK_CRASH_REPORTS_FOLDER_NAME = "ndk_crash_reports"
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashHandler.kt
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.ndk
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+@NoOpImplementation
+internal interface NdkCrashHandler {
+    fun handleNdkCrash()
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashLog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashLog.kt
@@ -16,34 +16,36 @@ internal data class NdkCrashLog(
     val signalName: String,
     val message: String,
     val stacktrace: String
+) {
 
-)
+    internal fun toJson(): String {
+        val jsonObject = JsonObject()
+        jsonObject.addProperty(SIGNAL_KEY_NAME, signal)
+        jsonObject.addProperty(SIGNAL_NAME_KEY_NAME, signalName)
+        jsonObject.addProperty(TIMESTAMP_KEY_NAME, timestamp)
+        jsonObject.addProperty(MESSAGE_KEY_NAME, message)
+        jsonObject.addProperty(STACKTRACE_KEY_NAME, stacktrace)
+        return jsonObject.toString()
+    }
 
-@Throws(JsonParseException::class)
-internal fun fromJson(jsonString: String): NdkCrashLog {
-    val jsonObject = JsonParser.parseString(jsonString).asJsonObject
-    return NdkCrashLog(
-        jsonObject.get(SIGNAL_KEY_NAME).asInt,
-        jsonObject.get(TIMESTAMP_KEY_NAME).asLong,
-        jsonObject.get(SIGNAL_NAME_KEY_NAME).asString,
-        jsonObject.get(MESSAGE_KEY_NAME).asString,
-        jsonObject.get(STACKTRACE_KEY_NAME).asString
+    companion object {
 
-    )
+        internal const val SIGNAL_KEY_NAME = "signal"
+        internal const val TIMESTAMP_KEY_NAME = "timestamp"
+        internal const val MESSAGE_KEY_NAME = "message"
+        internal const val SIGNAL_NAME_KEY_NAME = "signal_name"
+        internal const val STACKTRACE_KEY_NAME = "stacktrace"
+
+        @Throws(JsonParseException::class)
+        internal fun fromJson(jsonString: String): NdkCrashLog {
+            val jsonObject = JsonParser.parseString(jsonString).asJsonObject
+            return NdkCrashLog(
+                jsonObject.get(SIGNAL_KEY_NAME).asInt,
+                jsonObject.get(TIMESTAMP_KEY_NAME).asLong,
+                jsonObject.get(SIGNAL_NAME_KEY_NAME).asString,
+                jsonObject.get(MESSAGE_KEY_NAME).asString,
+                jsonObject.get(STACKTRACE_KEY_NAME).asString
+            )
+        }
+    }
 }
-
-internal fun NdkCrashLog.toJson(): String {
-    val jsonObject = JsonObject()
-    jsonObject.addProperty(SIGNAL_KEY_NAME, signal)
-    jsonObject.addProperty(SIGNAL_NAME_KEY_NAME, signalName)
-    jsonObject.addProperty(TIMESTAMP_KEY_NAME, timestamp)
-    jsonObject.addProperty(MESSAGE_KEY_NAME, message)
-    jsonObject.addProperty(STACKTRACE_KEY_NAME, stacktrace)
-    return jsonObject.toString()
-}
-
-internal const val SIGNAL_KEY_NAME = "signal"
-internal const val TIMESTAMP_KEY_NAME = "timestamp"
-internal const val MESSAGE_KEY_NAME = "message"
-internal const val SIGNAL_NAME_KEY_NAME = "signal_name"
-internal const val STACKTRACE_KEY_NAME = "stacktrace"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashLog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashLog.kt
@@ -1,0 +1,49 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.ndk
+
+import com.google.gson.JsonObject
+import com.google.gson.JsonParseException
+import com.google.gson.JsonParser
+
+internal data class NdkCrashLog(
+    val signal: Int,
+    val timestamp: Long,
+    val signalName: String,
+    val message: String,
+    val stacktrace: String
+
+)
+
+@Throws(JsonParseException::class)
+internal fun fromJson(jsonString: String): NdkCrashLog {
+    val jsonObject = JsonParser.parseString(jsonString).asJsonObject
+    return NdkCrashLog(
+        jsonObject.get(SIGNAL_KEY_NAME).asInt,
+        jsonObject.get(TIMESTAMP_KEY_NAME).asLong,
+        jsonObject.get(SIGNAL_NAME_KEY_NAME).asString,
+        jsonObject.get(MESSAGE_KEY_NAME).asString,
+        jsonObject.get(STACKTRACE_KEY_NAME).asString
+
+    )
+}
+
+internal fun NdkCrashLog.toJson(): String {
+    val jsonObject = JsonObject()
+    jsonObject.addProperty(SIGNAL_KEY_NAME, signal)
+    jsonObject.addProperty(SIGNAL_NAME_KEY_NAME, signalName)
+    jsonObject.addProperty(TIMESTAMP_KEY_NAME, timestamp)
+    jsonObject.addProperty(MESSAGE_KEY_NAME, message)
+    jsonObject.addProperty(STACKTRACE_KEY_NAME, stacktrace)
+    return jsonObject.toString()
+}
+
+internal const val SIGNAL_KEY_NAME = "signal"
+internal const val TIMESTAMP_KEY_NAME = "timestamp"
+internal const val MESSAGE_KEY_NAME = "message"
+internal const val SIGNAL_NAME_KEY_NAME = "signal_name"
+internal const val STACKTRACE_KEY_NAME = "stacktrace"

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
@@ -207,30 +207,6 @@ internal class ActionEventAssert(actual: ActionEvent) :
         return this
     }
 
-    fun isEqualTo(expectedActionEvent: ActionEvent): ActionEventAssert {
-        assertThat(actual.date).isEqualTo(expectedActionEvent.date)
-        assertThat(actual.service).isEqualTo(expectedActionEvent.service)
-        assertThat(actual.type).isEqualTo(expectedActionEvent.type)
-        assertThat(actual.action)
-            .isEqualToComparingFieldByField(expectedActionEvent.action)
-        assertThat(actual.application)
-            .isEqualToComparingFieldByField(expectedActionEvent.application)
-
-        assertThat(actual.dd).isEqualToComparingFieldByField(expectedActionEvent.dd)
-        assertThat(actual.session).isEqualToComparingFieldByField(expectedActionEvent.session)
-        // to avoid null comparisons which will fail
-        if (actual.connectivity != expectedActionEvent.connectivity) {
-            assertThat(actual.connectivity)
-                .isEqualToComparingFieldByField(expectedActionEvent.connectivity)
-        }
-        if (actual.usr != expectedActionEvent.usr) {
-            assertThat(actual.usr).isEqualToComparingFieldByField(expectedActionEvent.usr)
-        }
-        assertThat(actual.view).isEqualToComparingFieldByField(expectedActionEvent.view)
-
-        return this
-    }
-
     companion object {
 
         internal fun assertThat(actual: ActionEvent): ActionEventAssert =

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
@@ -207,6 +207,30 @@ internal class ActionEventAssert(actual: ActionEvent) :
         return this
     }
 
+    fun isEqualTo(expectedActionEvent: ActionEvent): ActionEventAssert {
+        assertThat(actual.date).isEqualTo(expectedActionEvent.date)
+        assertThat(actual.service).isEqualTo(expectedActionEvent.service)
+        assertThat(actual.type).isEqualTo(expectedActionEvent.type)
+        assertThat(actual.action)
+            .isEqualToComparingFieldByField(expectedActionEvent.action)
+        assertThat(actual.application)
+            .isEqualToComparingFieldByField(expectedActionEvent.application)
+
+        assertThat(actual.dd).isEqualToComparingFieldByField(expectedActionEvent.dd)
+        assertThat(actual.session).isEqualToComparingFieldByField(expectedActionEvent.session)
+        // to avoid null comparisons which will fail
+        if (actual.connectivity != expectedActionEvent.connectivity) {
+            assertThat(actual.connectivity)
+                .isEqualToComparingFieldByField(expectedActionEvent.connectivity)
+        }
+        if (actual.usr != expectedActionEvent.usr) {
+            assertThat(actual.usr).isEqualToComparingFieldByField(expectedActionEvent.usr)
+        }
+        assertThat(actual.view).isEqualToComparingFieldByField(expectedActionEvent.view)
+
+        return this
+    }
+
     companion object {
 
         internal fun assertThat(actual: ActionEvent): ActionEventAssert =

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -273,30 +273,6 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
-    fun isEqualTo(expectedErrorEvent: ErrorEvent): ErrorEventAssert {
-        assertThat(actual.date).isEqualTo(expectedErrorEvent.date)
-        assertThat(actual.service).isEqualTo(expectedErrorEvent.service)
-        assertThat(actual.type).isEqualTo(expectedErrorEvent.type)
-        if (actual.action != expectedErrorEvent.action) {
-            assertThat(actual.action).isEqualToComparingFieldByField(expectedErrorEvent.action)
-        }
-        assertThat(actual.application)
-            .isEqualToComparingFieldByField(expectedErrorEvent.application)
-        assertThat(actual.dd).isEqualToComparingFieldByField(expectedErrorEvent.dd)
-        assertThat(actual.session).isEqualToComparingFieldByField(expectedErrorEvent.session)
-        assertThat(actual.view).isEqualToComparingFieldByField(expectedErrorEvent.view)
-        assertThat(actual.error).isEqualToComparingFieldByField(expectedErrorEvent.error)
-        // to avoid null comparisons which will fail
-        if (actual.connectivity != expectedErrorEvent.connectivity) {
-            assertThat(actual.connectivity)
-                .isEqualToComparingFieldByField(expectedErrorEvent.connectivity)
-        }
-        if (actual.usr != expectedErrorEvent.usr) {
-            assertThat(actual.usr).isEqualToComparingFieldByField(expectedErrorEvent.usr)
-        }
-        return this
-    }
-
     companion object {
 
         internal fun assertThat(actual: ErrorEvent): ErrorEventAssert =

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -242,6 +242,61 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
+    fun hasConnectivityStatus(expected: ErrorEvent.Status?): ErrorEventAssert {
+        assertThat(actual.connectivity?.status)
+            .overridingErrorMessage(
+                "Expected event data to have connectivity status: $expected" +
+                    " but was: ${actual.connectivity?.status} "
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasConnectivityInterface(expected: List<ErrorEvent.Interface>?): ErrorEventAssert {
+        val interfaces = actual.connectivity?.interfaces
+        assertThat(interfaces)
+            .overridingErrorMessage(
+                "Expected event data to have connectivity interfaces: $expected" +
+                    " but was: $interfaces "
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasConnectivityCellular(expected: ErrorEvent.Cellular?): ErrorEventAssert {
+        assertThat(actual.connectivity?.cellular)
+            .overridingErrorMessage(
+                "Expected event data to have connectivity cellular: $expected" +
+                    " but was: ${actual.connectivity?.cellular} "
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun isEqualTo(expectedErrorEvent: ErrorEvent): ErrorEventAssert {
+        assertThat(actual.date).isEqualTo(expectedErrorEvent.date)
+        assertThat(actual.service).isEqualTo(expectedErrorEvent.service)
+        assertThat(actual.type).isEqualTo(expectedErrorEvent.type)
+        if (actual.action != expectedErrorEvent.action) {
+            assertThat(actual.action).isEqualToComparingFieldByField(expectedErrorEvent.action)
+        }
+        assertThat(actual.application)
+            .isEqualToComparingFieldByField(expectedErrorEvent.application)
+        assertThat(actual.dd).isEqualToComparingFieldByField(expectedErrorEvent.dd)
+        assertThat(actual.session).isEqualToComparingFieldByField(expectedErrorEvent.session)
+        assertThat(actual.view).isEqualToComparingFieldByField(expectedErrorEvent.view)
+        assertThat(actual.error).isEqualToComparingFieldByField(expectedErrorEvent.error)
+        // to avoid null comparisons which will fail
+        if (actual.connectivity != expectedErrorEvent.connectivity) {
+            assertThat(actual.connectivity)
+                .isEqualToComparingFieldByField(expectedErrorEvent.connectivity)
+        }
+        if (actual.usr != expectedErrorEvent.usr) {
+            assertThat(actual.usr).isEqualToComparingFieldByField(expectedErrorEvent.usr)
+        }
+        return this
+    }
+
     companion object {
 
         internal fun assertThat(actual: ErrorEvent): ErrorEventAssert =

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
@@ -393,31 +393,6 @@ internal class ResourceEventAssert(actual: ResourceEvent) :
         return this
     }
 
-    fun isEqualTo(expectedResourceEvent: ResourceEvent): ResourceEventAssert {
-        assertThat(actual.date).isEqualTo(expectedResourceEvent.date)
-        assertThat(actual.service).isEqualTo(expectedResourceEvent.service)
-        assertThat(actual.type).isEqualTo(expectedResourceEvent.type)
-        if (actual.action != expectedResourceEvent.action) {
-            assertThat(actual.action).isEqualToComparingFieldByField(expectedResourceEvent.action)
-        }
-        assertThat(actual.application).isEqualToComparingFieldByField(
-            expectedResourceEvent.application
-        )
-        assertThat(actual.dd).isEqualToComparingFieldByField(expectedResourceEvent.dd)
-        assertThat(actual.resource).isEqualToComparingFieldByField(expectedResourceEvent.resource)
-        assertThat(actual.session).isEqualToComparingFieldByField(expectedResourceEvent.session)
-        assertThat(actual.view).isEqualToComparingFieldByField(expectedResourceEvent.view)
-        // to avoid null comparisons which will fail
-        if (actual.connectivity != expectedResourceEvent.connectivity) {
-            assertThat(actual.connectivity)
-                .isEqualToComparingFieldByField(expectedResourceEvent.connectivity)
-        }
-        if (actual.usr != expectedResourceEvent.usr) {
-            assertThat(actual.usr).isEqualToComparingFieldByField(expectedResourceEvent.usr)
-        }
-        return this
-    }
-
     companion object {
 
         internal const val DURATION_THRESHOLD_NANOS = 1000L

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
@@ -14,7 +14,6 @@ import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.domain.scope.toMethod
 import com.datadog.android.rum.internal.domain.scope.toSchemaType
 import com.datadog.android.rum.model.ResourceEvent
-import com.datadog.android.rum.model.ViewEvent
 import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
@@ -25,7 +24,7 @@ internal class ResourceEventAssert(actual: ResourceEvent) :
         ResourceEventAssert::class.java
     ) {
 
-    fun hasId(expected: String): ResourceEventAssert {
+    fun hasId(expected: String?): ResourceEventAssert {
         assertThat(actual.resource.id)
             .overridingErrorMessage(
                 "Expected event data to have resource.id $expected " +
@@ -394,11 +393,36 @@ internal class ResourceEventAssert(actual: ResourceEvent) :
         return this
     }
 
+    fun isEqualTo(expectedResourceEvent: ResourceEvent): ResourceEventAssert {
+        assertThat(actual.date).isEqualTo(expectedResourceEvent.date)
+        assertThat(actual.service).isEqualTo(expectedResourceEvent.service)
+        assertThat(actual.type).isEqualTo(expectedResourceEvent.type)
+        if (actual.action != expectedResourceEvent.action) {
+            assertThat(actual.action).isEqualToComparingFieldByField(expectedResourceEvent.action)
+        }
+        assertThat(actual.application).isEqualToComparingFieldByField(
+            expectedResourceEvent.application
+        )
+        assertThat(actual.dd).isEqualToComparingFieldByField(expectedResourceEvent.dd)
+        assertThat(actual.resource).isEqualToComparingFieldByField(expectedResourceEvent.resource)
+        assertThat(actual.session).isEqualToComparingFieldByField(expectedResourceEvent.session)
+        assertThat(actual.view).isEqualToComparingFieldByField(expectedResourceEvent.view)
+        // to avoid null comparisons which will fail
+        if (actual.connectivity != expectedResourceEvent.connectivity) {
+            assertThat(actual.connectivity)
+                .isEqualToComparingFieldByField(expectedResourceEvent.connectivity)
+        }
+        if (actual.usr != expectedResourceEvent.usr) {
+            assertThat(actual.usr).isEqualToComparingFieldByField(expectedResourceEvent.usr)
+        }
+        return this
+    }
+
     companion object {
 
         internal const val DURATION_THRESHOLD_NANOS = 1000L
 
-        internal fun assertThat(actual: ViewEvent): ViewEventAssert =
-            ViewEventAssert(actual)
+        internal fun assertThat(actual: ResourceEvent): ResourceEventAssert =
+            ResourceEventAssert(actual)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -112,7 +112,7 @@ internal class ViewEventAssert(actual: ViewEvent) :
         return this
     }
 
-    fun hasCrashCount(expected: Long): ViewEventAssert {
+    fun hasCrashCount(expected: Long?): ViewEventAssert {
         assertThat(actual.view.crash?.count)
             .overridingErrorMessage(
                 "Expected event data to have view.crash.count $expected " +
@@ -204,6 +204,47 @@ internal class ViewEventAssert(actual: ViewEvent) :
                     "but was ${actual.usr?.email}"
             )
             .isEqualTo(expected?.email)
+        return this
+    }
+
+    fun hasUserInfo(expected: ViewEvent.Usr?): ViewEventAssert {
+        assertThat(actual.usr?.id)
+            .overridingErrorMessage(
+                "Expected RUM event to have usr.id ${expected?.id} " +
+                    "but was ${actual.usr?.id}"
+            )
+            .isEqualTo(expected?.id)
+        assertThat(actual.usr?.name)
+            .overridingErrorMessage(
+                "Expected RUM event to have usr.name ${expected?.name} " +
+                    "but was ${actual.usr?.name}"
+            )
+            .isEqualTo(expected?.name)
+        assertThat(actual.usr?.email)
+            .overridingErrorMessage(
+                "Expected RUM event to have usr.email ${expected?.email} " +
+                    "but was ${actual.usr?.email}"
+            )
+            .isEqualTo(expected?.email)
+        return this
+    }
+
+    fun isEqualTo(expectedViewEvent: ViewEvent): ViewEventAssert {
+        assertThat(actual.date).isEqualTo(expectedViewEvent.date)
+        assertThat(actual.service).isEqualTo(expectedViewEvent.service)
+        assertThat(actual.application).isEqualToComparingFieldByField(expectedViewEvent.application)
+        assertThat(actual.session).isEqualToComparingFieldByField(expectedViewEvent.session)
+        assertThat(actual.view).isEqualToComparingFieldByField(expectedViewEvent.view)
+        assertThat(actual.dd).isEqualToComparingFieldByField(expectedViewEvent.dd)
+        assertThat(actual.session).isEqualToComparingFieldByField(expectedViewEvent.session)
+        // to avoid null comparisons which will fail
+        if (actual.connectivity != expectedViewEvent.connectivity) {
+            assertThat(actual.connectivity)
+                .isEqualToComparingFieldByField(expectedViewEvent.connectivity)
+        }
+        if (actual.usr != expectedViewEvent.usr) {
+            assertThat(actual.usr).isEqualToComparingFieldByField(expectedViewEvent.usr)
+        }
         return this
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -229,25 +229,6 @@ internal class ViewEventAssert(actual: ViewEvent) :
         return this
     }
 
-    fun isEqualTo(expectedViewEvent: ViewEvent): ViewEventAssert {
-        assertThat(actual.date).isEqualTo(expectedViewEvent.date)
-        assertThat(actual.service).isEqualTo(expectedViewEvent.service)
-        assertThat(actual.application).isEqualToComparingFieldByField(expectedViewEvent.application)
-        assertThat(actual.session).isEqualToComparingFieldByField(expectedViewEvent.session)
-        assertThat(actual.view).isEqualToComparingFieldByField(expectedViewEvent.view)
-        assertThat(actual.dd).isEqualToComparingFieldByField(expectedViewEvent.dd)
-        assertThat(actual.session).isEqualToComparingFieldByField(expectedViewEvent.session)
-        // to avoid null comparisons which will fail
-        if (actual.connectivity != expectedViewEvent.connectivity) {
-            assertThat(actual.connectivity)
-                .isEqualToComparingFieldByField(expectedViewEvent.connectivity)
-        }
-        if (actual.usr != expectedViewEvent.usr) {
-            assertThat(actual.usr).isEqualToComparingFieldByField(expectedViewEvent.usr)
-        }
-        return this
-    }
-
     companion object {
 
         internal const val DURATION_THRESHOLD_NANOS = 1000L

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
@@ -1,0 +1,242 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.event
+
+import com.datadog.android.core.internal.utils.toJsonArray
+import com.datadog.android.rum.assertj.ActionEventAssert
+import com.datadog.android.rum.assertj.ErrorEventAssert
+import com.datadog.android.rum.assertj.ResourceEventAssert
+import com.datadog.android.rum.assertj.ViewEventAssert
+import com.datadog.android.rum.model.ActionEvent
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.utils.forge.Configurator
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.Date
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.api.fail
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RumEventDeserializerTest {
+
+    lateinit var testedDeserializer: RumEventDeserializer
+
+    // we use a NoOpDataConstraints to avoid flaky tests
+    private val serializer: RumEventSerializer = RumEventSerializer(
+        mock {
+            whenever(it.validateAttributes(any(), anyOrNull(), anyOrNull())).thenAnswer {
+                it.getArgument(0)
+            }
+            whenever(it.validateTags(any())).thenAnswer {
+                it.getArgument(0)
+            }
+        }
+    )
+
+    @BeforeEach
+    fun `set up`() {
+        testedDeserializer = RumEventDeserializer()
+    }
+
+    // region UnitTests
+
+    @Test
+    fun `𝕄 deserialize a serialized RUM ViewEvent 𝕎 deserialize()`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeViewEvent = forge.getForgery(ViewEvent::class.java)
+        val fakeEvent: RumEvent = forge.getForgery(RumEvent::class.java)
+            .copy(event = fakeViewEvent)
+        val serializedEvent = serializer.serialize(fakeEvent)
+
+        // WHEN
+        val deserializedEvent = testedDeserializer.deserialize(serializedEvent)
+
+        // THEN
+        assertThat(deserializedEvent).isNotNull()
+        assertThat(deserializedEvent?.customTimings).isEqualTo(fakeEvent.customTimings)
+        assertAttributes(fakeEvent.globalAttributes, deserializedEvent?.globalAttributes)
+        assertAttributes(fakeEvent.userExtraAttributes, deserializedEvent?.userExtraAttributes)
+        val deserializedViewEvent = deserializedEvent!!.event as ViewEvent
+        ViewEventAssert.assertThat(deserializedViewEvent)
+            .isEqualTo(fakeViewEvent)
+    }
+
+    @Test
+    fun `𝕄 deserialize a serialized RUM ResourceEvent 𝕎 deserialize()`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeResourceEvent = forge.getForgery(ResourceEvent::class.java)
+        val fakeEvent: RumEvent = forge.getForgery(RumEvent::class.java)
+            .copy(event = fakeResourceEvent)
+        val serializedEvent = serializer.serialize(fakeEvent)
+
+        // WHEN
+        val deserializedEvent = testedDeserializer.deserialize(serializedEvent)
+
+        // THEN
+        assertThat(deserializedEvent).isNotNull()
+        assertThat(deserializedEvent?.customTimings).isEqualTo(fakeEvent.customTimings)
+        assertAttributes(fakeEvent.globalAttributes, deserializedEvent?.globalAttributes)
+        assertAttributes(fakeEvent.userExtraAttributes, deserializedEvent?.userExtraAttributes)
+        val deserializedResourceEvent = deserializedEvent!!.event as ResourceEvent
+        ResourceEventAssert.assertThat(deserializedResourceEvent).isEqualTo(fakeResourceEvent)
+    }
+
+    @Test
+    fun `𝕄 deserialize a serialized RUM ActionEvent 𝕎 deserialize()`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeActionEvent = forge.getForgery(ActionEvent::class.java)
+        val fakeEvent: RumEvent = forge.getForgery(RumEvent::class.java)
+            .copy(event = fakeActionEvent)
+        val serializedEvent = serializer.serialize(fakeEvent)
+
+        // WHEN
+        val deserializedEvent = testedDeserializer.deserialize(serializedEvent)
+
+        // THEN
+        assertThat(deserializedEvent).isNotNull()
+        assertThat(deserializedEvent?.customTimings).isEqualTo(fakeEvent.customTimings)
+        assertAttributes(fakeEvent.globalAttributes, deserializedEvent?.globalAttributes)
+        assertAttributes(fakeEvent.userExtraAttributes, deserializedEvent?.userExtraAttributes)
+        val deserializedActionEvent = deserializedEvent!!.event as ActionEvent
+        ActionEventAssert.assertThat(deserializedActionEvent).isEqualTo(fakeActionEvent)
+    }
+
+    @Test
+    fun `𝕄 deserialize a serialized RUM ErrorEvent 𝕎 deserialize()`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeErrorEvent = forge.getForgery(ErrorEvent::class.java)
+        val fakeEvent: RumEvent = forge.getForgery(RumEvent::class.java)
+            .copy(event = fakeErrorEvent)
+        val serializedEvent = serializer.serialize(fakeEvent)
+
+        // WHEN
+        val deserializedEvent = testedDeserializer.deserialize(serializedEvent)
+
+        // THEN
+        assertThat(deserializedEvent).isNotNull()
+        assertThat(deserializedEvent?.customTimings).isEqualTo(fakeEvent.customTimings)
+        assertAttributes(fakeEvent.globalAttributes, deserializedEvent?.globalAttributes)
+        assertAttributes(fakeEvent.userExtraAttributes, deserializedEvent?.userExtraAttributes)
+        val deserializedErrorEvent = deserializedEvent!!.event as ErrorEvent
+        ErrorEventAssert.assertThat(deserializedErrorEvent).isEqualTo(fakeErrorEvent)
+    }
+
+    // @Test
+    // fun `𝕄 deserialize the user global attributes first  𝕎 deserialize()`(
+    //     forge: Forge
+    // ) {
+    //     // GIVEN
+    //     val fakeEvent: RumEvent = forge.getForgery(RumEvent::class.java)
+    //     fakeEvent.
+    //     val serializedEvent = serializer.serialize(fakeEvent)
+    //
+    //     // WHEN
+    //     val deserializedEvent = testedDeserializer.deserialize(serializedEvent)
+    //
+    //     // THEN
+    //     assertThat(deserializedEvent).isNotNull()
+    //     assertThat(deserializedEvent?.customTimings).isEqualTo(fakeEvent.customTimings)
+    //     assertAttributes(fakeEvent.globalAttributes, deserializedEvent?.globalAttributes)
+    //     assertAttributes(fakeEvent.userExtraAttributes, deserializedEvent?.userExtraAttributes)
+    //     val deserializedErrorEvent = deserializedEvent!!.event as ErrorEvent
+    //     ErrorEventAssert.assertThat(deserializedErrorEvent).isEqualTo(fakeErrorEvent)
+    // }
+
+    @Test
+    fun `𝕄 return null W deserialize { wrong Json format }`(
+        @Forgery fakeEvent: RumEvent
+    ) {
+        // WHEN
+        val deserializedEvent = testedDeserializer.deserialize("{]}")
+
+        // THEN
+        assertThat(deserializedEvent).isNull()
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun assertAttributes(
+        originalAttributes: Map<String, Any?>?,
+        deserializedAttributes: Map<String, Any?>?
+    ) {
+        if (originalAttributes == null && deserializedAttributes == null) {
+            return
+        }
+        if (originalAttributes != null && deserializedAttributes != null) {
+            originalAttributes.filter {
+                it.key.isNotBlank() && !RumEventSerializer.knownAttributes.contains(
+                    it.key
+                )
+            }
+                .forEach {
+                    val value = it.value
+                    val deserializedValue = deserializedAttributes[it.key] as JsonElement
+                    when (value) {
+                        null -> assertThat(deserializedValue).isEqualTo(
+                            JsonNull.INSTANCE
+                        )
+                        is Boolean -> assertThat(deserializedValue.asBoolean).isEqualTo(value)
+                        is Int -> assertThat(deserializedValue.asInt).isEqualTo(value)
+                        is Long -> assertThat(deserializedValue.asLong).isEqualTo(value)
+                        is Float -> assertThat(deserializedValue.asFloat).isEqualTo(value)
+                        is Double -> assertThat(deserializedValue.asDouble).isEqualTo(value)
+                        is String -> assertThat(deserializedValue.asString).isEqualTo(value)
+                        is Date -> assertThat(deserializedValue.asLong).isEqualTo(value.time)
+                        is JsonObject ->
+                            assertThat(deserializedValue.asJsonObject.toString())
+                                .isEqualTo(value.toString())
+                        is JsonArray -> assertThat(deserializedValue.asJsonArray).isEqualTo(value)
+                        is Iterable<*> -> assertThat(deserializedValue.asJsonArray).isEqualTo(
+                            value.toJsonArray()
+                        )
+                        else -> assertThat(deserializedValue.asString).isEqualTo(value.toString())
+                    }
+                }
+        } else {
+            fail(
+                "Original attributes:$originalAttributes are not the same " +
+                    "as deserialized attributes: $deserializedAttributes"
+            )
+        }
+    }
+
+    // endregion
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
@@ -7,10 +7,6 @@
 package com.datadog.android.rum.internal.domain.event
 
 import com.datadog.android.core.internal.utils.toJsonArray
-import com.datadog.android.rum.assertj.ActionEventAssert
-import com.datadog.android.rum.assertj.ErrorEventAssert
-import com.datadog.android.rum.assertj.ResourceEventAssert
-import com.datadog.android.rum.assertj.ViewEventAssert
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent
@@ -87,7 +83,7 @@ internal class RumEventDeserializerTest {
         assertAttributes(fakeEvent.globalAttributes, deserializedEvent?.globalAttributes)
         assertAttributes(fakeEvent.userExtraAttributes, deserializedEvent?.userExtraAttributes)
         val deserializedViewEvent = deserializedEvent!!.event as ViewEvent
-        ViewEventAssert.assertThat(deserializedViewEvent)
+        assertThat(deserializedViewEvent)
             .isEqualTo(fakeViewEvent)
     }
 
@@ -110,7 +106,7 @@ internal class RumEventDeserializerTest {
         assertAttributes(fakeEvent.globalAttributes, deserializedEvent?.globalAttributes)
         assertAttributes(fakeEvent.userExtraAttributes, deserializedEvent?.userExtraAttributes)
         val deserializedResourceEvent = deserializedEvent!!.event as ResourceEvent
-        ResourceEventAssert.assertThat(deserializedResourceEvent).isEqualTo(fakeResourceEvent)
+        assertThat(deserializedResourceEvent).isEqualTo(fakeResourceEvent)
     }
 
     @Test
@@ -132,7 +128,10 @@ internal class RumEventDeserializerTest {
         assertAttributes(fakeEvent.globalAttributes, deserializedEvent?.globalAttributes)
         assertAttributes(fakeEvent.userExtraAttributes, deserializedEvent?.userExtraAttributes)
         val deserializedActionEvent = deserializedEvent!!.event as ActionEvent
-        ActionEventAssert.assertThat(deserializedActionEvent).isEqualTo(fakeActionEvent)
+        assertThat(deserializedActionEvent).isEqualToIgnoringGivenFields(
+            fakeActionEvent,
+            "dd"
+        )
     }
 
     @Test
@@ -154,36 +153,31 @@ internal class RumEventDeserializerTest {
         assertAttributes(fakeEvent.globalAttributes, deserializedEvent?.globalAttributes)
         assertAttributes(fakeEvent.userExtraAttributes, deserializedEvent?.userExtraAttributes)
         val deserializedErrorEvent = deserializedEvent!!.event as ErrorEvent
-        ErrorEventAssert.assertThat(deserializedErrorEvent).isEqualTo(fakeErrorEvent)
+        assertThat(deserializedErrorEvent).isEqualToIgnoringGivenFields(
+            fakeErrorEvent,
+            "dd"
+        )
     }
 
-    // @Test
-    // fun `𝕄 deserialize the user global attributes first  𝕎 deserialize()`(
-    //     forge: Forge
-    // ) {
-    //     // GIVEN
-    //     val fakeEvent: RumEvent = forge.getForgery(RumEvent::class.java)
-    //     fakeEvent.
-    //     val serializedEvent = serializer.serialize(fakeEvent)
-    //
-    //     // WHEN
-    //     val deserializedEvent = testedDeserializer.deserialize(serializedEvent)
-    //
-    //     // THEN
-    //     assertThat(deserializedEvent).isNotNull()
-    //     assertThat(deserializedEvent?.customTimings).isEqualTo(fakeEvent.customTimings)
-    //     assertAttributes(fakeEvent.globalAttributes, deserializedEvent?.globalAttributes)
-    //     assertAttributes(fakeEvent.userExtraAttributes, deserializedEvent?.userExtraAttributes)
-    //     val deserializedErrorEvent = deserializedEvent!!.event as ErrorEvent
-    //     ErrorEventAssert.assertThat(deserializedErrorEvent).isEqualTo(fakeErrorEvent)
-    // }
-
     @Test
-    fun `𝕄 return null W deserialize { wrong Json format }`(
-        @Forgery fakeEvent: RumEvent
-    ) {
+    fun `𝕄 return null W deserialize { wrong Json format }`() {
         // WHEN
         val deserializedEvent = testedDeserializer.deserialize("{]}")
+
+        // THEN
+        assertThat(deserializedEvent).isNull()
+    }
+
+    @Test
+    fun `𝕄 return null W deserialize { wrong bundled RUM event type }`(
+        @Forgery fakeEvent: RumEvent
+    ) {
+        // GIVEN
+        val fakeBadFormatEvent = fakeEvent.copy(event = Any())
+        val serializedEvent = serializer.serialize(fakeBadFormatEvent)
+
+        // WHEN
+        val deserializedEvent = testedDeserializer.deserialize(serializedEvent)
 
         // THEN
         assertThat(deserializedEvent).isNull()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -4,13 +4,11 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum.internal.domain
+package com.datadog.android.rum.internal.domain.event
 
 import com.datadog.android.core.internal.constraints.DataConstraints
 import com.datadog.android.core.internal.utils.toJsonArray
 import com.datadog.android.log.internal.user.UserInfo
-import com.datadog.android.rum.internal.domain.event.RumEvent
-import com.datadog.android.rum.internal.domain.event.RumEventSerializer
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
@@ -1,0 +1,470 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.ndk
+
+import com.datadog.android.core.internal.data.Writer
+import com.datadog.android.log.LogAttributes
+import com.datadog.android.log.internal.domain.Log
+import com.datadog.android.log.internal.domain.LogGenerator
+import com.datadog.android.log.internal.logger.LogHandler
+import com.datadog.android.log.internal.user.UserInfo
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.assertj.ErrorEventAssert
+import com.datadog.android.rum.assertj.ViewEventAssert
+import com.datadog.android.rum.internal.data.file.RumFileWriter
+import com.datadog.android.rum.internal.domain.event.RumEvent
+import com.datadog.android.rum.internal.domain.event.RumEventSerializer
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.mockSdkLogHandler
+import com.datadog.android.utils.restoreSdkLogHandler
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.io.File
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Future
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.api.io.TempDir
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DatadogNdkCrashHandlerTest {
+
+    @Mock
+    lateinit var mockedExecutorService: ExecutorService
+
+    @TempDir
+    lateinit var fakeNdkCrashReportsDirectory: File
+
+    @Mock
+    lateinit var mockedAsyncLogWriter: Writer<Log>
+
+    @Mock
+    lateinit var mockedAsyncRumWriter: Writer<RumEvent>
+
+    @Mock
+    lateinit var mockedLockGenerator: LogGenerator
+
+    @Mock
+    lateinit var mockedGeneratedLog: Log
+
+    lateinit var testedHandler: DatadogNdkCrashHandler
+
+    @Forgery
+    lateinit var fakeNdkCrashLog: NdkCrashLog
+
+    lateinit var fakeRumViewEvent: RumEvent
+    lateinit var fakeSerializedNdkCrashLog: String
+    lateinit var fakeSerializedRumViewEvent: String
+
+    private var rumEventSerializer = RumEventSerializer()
+
+    // region Unit Tests
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        fakeRumViewEvent = forge.getForgery(RumEvent::class.java)
+            .copy(event = forge.getForgery(ViewEvent::class.java))
+        fakeSerializedNdkCrashLog = fakeNdkCrashLog.toJson()
+        fakeSerializedRumViewEvent = rumEventSerializer.serialize(fakeRumViewEvent)
+        whenever(
+            mockedLockGenerator.generateLog(
+                eq(Log.CRASH),
+                eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+                anyOrNull(),
+                eq(
+                    mapOf(
+                        LogAttributes.ERROR_STACK to fakeNdkCrashLog.stacktrace
+                    )
+                ),
+                anyOrNull(),
+                eq(fakeNdkCrashLog.timestamp),
+                anyOrNull(),
+                any(),
+                any()
+            )
+        ).thenReturn(mockedGeneratedLog)
+
+        whenever(mockedExecutorService.submit(any())).then {
+            val runnable = it.getArgument<Runnable>(0)
+            runnable.run()
+            mock<Future<Any>>()
+        }
+        testedHandler = DatadogNdkCrashHandler(
+            fakeNdkCrashReportsDirectory,
+            mockedExecutorService,
+            mockedAsyncLogWriter,
+            mockedAsyncRumWriter,
+            mockedLockGenerator
+        )
+    }
+
+    @Test
+    fun `M do nothing W handleNdkCrash { NDK crash reports directory does not exist }`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeNonExistingDir = File(forge.aStringMatching("[a-b]{3,10}"))
+        testedHandler = DatadogNdkCrashHandler(
+            fakeNonExistingDir,
+            mockedExecutorService,
+            mockedAsyncLogWriter,
+            mockedAsyncRumWriter,
+            mockedLockGenerator
+        )
+
+        // WHEN
+        testedHandler.handleNdkCrash()
+
+        // THEN
+        verifyZeroInteractions(mockedAsyncLogWriter)
+        verifyZeroInteractions(mockedAsyncRumWriter)
+    }
+
+    @Test
+    fun `M do nothing W handleNdkCrash { there was no NDK crash report persisted }`() {
+        // GIVEN
+        testedHandler = DatadogNdkCrashHandler(
+            fakeNdkCrashReportsDirectory,
+            mockedExecutorService,
+            mockedAsyncLogWriter,
+            mockedAsyncRumWriter,
+            mockedLockGenerator
+        )
+
+        // WHEN
+        testedHandler.handleNdkCrash()
+
+        // THEN
+        verifyZeroInteractions(mockedAsyncLogWriter)
+        verifyZeroInteractions(mockedAsyncRumWriter)
+    }
+
+    @Test
+    fun `M do nothing and log exception W handleNdkCrash { persisted crash report is broken }`(
+        forge: Forge
+    ) {
+        // GIVEN
+        val mockLogHandler: LogHandler = mock()
+        val originalLogHandler: LogHandler = mockSdkLogHandler(mockLogHandler)
+        val fakeBrokenJson = "{]"
+        val crashLogFile =
+            File(fakeNdkCrashReportsDirectory, DatadogNdkCrashHandler.CRASH_LOG_FILE_NAME)
+        crashLogFile.outputStream().use {
+            it.write(fakeBrokenJson.toByteArray())
+        }
+        testedHandler = DatadogNdkCrashHandler(
+            fakeNdkCrashReportsDirectory,
+            mockedExecutorService,
+            mockedAsyncLogWriter,
+            mockedAsyncRumWriter,
+            mockedLockGenerator
+        )
+
+        // WHEN
+        testedHandler.handleNdkCrash()
+
+        // THEN
+        verifyZeroInteractions(mockedAsyncLogWriter)
+        verifyZeroInteractions(mockedAsyncRumWriter)
+        verify(mockLogHandler).handleLog(
+            eq(android.util.Log.ERROR),
+            eq("Malformed ndk crash error log"),
+            any(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull()
+        )
+        restoreSdkLogHandler(originalLogHandler)
+    }
+
+    @Test
+    fun `M send an error log W handleNdkCrash { found a persisted crash report }`(forge: Forge) {
+        // GIVEN
+        val crashLogFile =
+            File(fakeNdkCrashReportsDirectory, DatadogNdkCrashHandler.CRASH_LOG_FILE_NAME)
+        crashLogFile.outputStream().use {
+            it.write(fakeSerializedNdkCrashLog.toByteArray())
+        }
+
+        // WHEN
+        testedHandler.handleNdkCrash()
+
+        // THEN
+        verify(mockedLockGenerator).generateLog(
+            eq(Log.CRASH),
+            eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+            anyOrNull(),
+            eq(
+                mapOf(
+                    LogAttributes.ERROR_STACK to fakeNdkCrashLog.stacktrace
+                )
+            ),
+            eq(emptySet()),
+            eq(fakeNdkCrashLog.timestamp),
+            anyOrNull(),
+            eq(false),
+            eq(false)
+        )
+        verify(mockedAsyncLogWriter).write(mockedGeneratedLog)
+    }
+
+    @Test
+    fun `M send an error log W RUM context handleNdkCrash { has last view event }`(forge: Forge) {
+        // GIVEN
+        val crashLogFile =
+            File(fakeNdkCrashReportsDirectory, DatadogNdkCrashHandler.CRASH_LOG_FILE_NAME)
+        val lastViewEventFile =
+            File(fakeNdkCrashReportsDirectory, RumFileWriter.LAST_VIEW_EVENT_FILE_NAME)
+
+        crashLogFile.outputStream().use {
+            it.write(fakeSerializedNdkCrashLog.toByteArray())
+        }
+        lastViewEventFile.outputStream().use {
+            it.write(fakeSerializedRumViewEvent.toByteArray())
+        }
+        val fakeBundledViewEvent = fakeRumViewEvent.event as ViewEvent
+        mockTheLogGenerator(fakeBundledViewEvent)
+
+        // WHEN
+        testedHandler.handleNdkCrash()
+
+        // THEN
+        verify(mockedLockGenerator).generateLog(
+            eq(Log.CRASH),
+            eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+            anyOrNull(),
+            eq(
+                mapOf(
+                    LogAttributes.RUM_VIEW_ID to fakeBundledViewEvent.view.id,
+                    LogAttributes.RUM_SESSION_ID to fakeBundledViewEvent.session.id,
+                    LogAttributes.RUM_APPLICATION_ID to fakeBundledViewEvent.application.id,
+                    LogAttributes.ERROR_STACK to fakeNdkCrashLog.stacktrace
+                )
+            ),
+            eq(emptySet()),
+            eq(fakeNdkCrashLog.timestamp),
+            anyOrNull(),
+            eq(false),
+            eq(false)
+        )
+        verify(mockedAsyncLogWriter).write(mockedGeneratedLog)
+    }
+
+    @Test
+    fun `M send the updated RUM ViewEvent W handleNdkCrash { has last view event }`(forge: Forge) {
+        // GIVEN
+        val crashLogFile =
+            File(fakeNdkCrashReportsDirectory, DatadogNdkCrashHandler.CRASH_LOG_FILE_NAME)
+        val lastViewEventFile =
+            File(fakeNdkCrashReportsDirectory, RumFileWriter.LAST_VIEW_EVENT_FILE_NAME)
+
+        crashLogFile.outputStream().use {
+            it.write(fakeSerializedNdkCrashLog.toByteArray())
+        }
+        lastViewEventFile.outputStream().use {
+            it.write(fakeSerializedRumViewEvent.toByteArray())
+        }
+        val fakeBundledViewEvent = fakeRumViewEvent.event as ViewEvent
+        mockTheLogGenerator(fakeBundledViewEvent)
+
+        // WHEN
+        testedHandler.handleNdkCrash()
+
+        // THEN
+        verify(mockedAsyncLogWriter).write(mockedGeneratedLog)
+        val argumentCaptor = argumentCaptor<RumEvent>()
+        verify(mockedAsyncRumWriter, times(2)).write(argumentCaptor.capture())
+        ViewEventAssert.assertThat(argumentCaptor.firstValue.event as ViewEvent)
+            .isEqualTo(
+                fakeBundledViewEvent.copy(
+                    view = fakeBundledViewEvent.view.copy(
+                        error = fakeBundledViewEvent.view.error.copy(
+                            count = fakeBundledViewEvent.view.error.count + 1
+                        ),
+                        isActive = false
+                    ),
+                    dd = fakeBundledViewEvent.dd.copy(
+                        documentVersion = fakeBundledViewEvent.dd.documentVersion + 1
+                    )
+                )
+            )
+    }
+
+    @Test
+    fun `M send the updated RUM ErrorEvent W handleNdkCrash { has last view event }`(forge: Forge) {
+        // GIVEN
+        val crashLogFile =
+            File(fakeNdkCrashReportsDirectory, DatadogNdkCrashHandler.CRASH_LOG_FILE_NAME)
+        val lastViewEventFile =
+            File(fakeNdkCrashReportsDirectory, RumFileWriter.LAST_VIEW_EVENT_FILE_NAME)
+
+        crashLogFile.outputStream().use {
+            it.write(fakeSerializedNdkCrashLog.toByteArray())
+        }
+        lastViewEventFile.outputStream().use {
+            it.write(fakeSerializedRumViewEvent.toByteArray())
+        }
+        val fakeBundledViewEvent = fakeRumViewEvent.event as ViewEvent
+        mockTheLogGenerator(fakeBundledViewEvent)
+
+        // WHEN
+        testedHandler.handleNdkCrash()
+
+        // THEN
+        verify(mockedAsyncLogWriter).write(mockedGeneratedLog)
+        val argumentCaptor = argumentCaptor<RumEvent>()
+        verify(mockedAsyncRumWriter, times(2)).write(argumentCaptor.capture())
+        ErrorEventAssert.assertThat(argumentCaptor.secondValue.event as ErrorEvent)
+            .hasApplicationId(fakeBundledViewEvent.application.id)
+            .hasSessionId(fakeBundledViewEvent.session.id)
+            .hasView(fakeBundledViewEvent.view.id, fakeBundledViewEvent.view.url)
+            .hasMessage(
+                DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)
+            )
+            .hasStackTrace(fakeNdkCrashLog.stacktrace)
+            .isCrash(true)
+            .hasSource(RumErrorSource.SOURCE)
+            .hasTimestamp(fakeNdkCrashLog.timestamp)
+            .hasUserInfo(
+                UserInfo(
+                    fakeBundledViewEvent.usr?.id,
+                    fakeBundledViewEvent.usr?.name,
+                    fakeBundledViewEvent.usr?.email
+                )
+            )
+            .hasConnectivityStatus(
+                fakeBundledViewEvent.connectivity?.status?.let {
+                    ErrorEvent.Status.valueOf(it.name)
+                }
+            )
+            .hasConnectivityCellular(
+                fakeBundledViewEvent.connectivity?.cellular?.let {
+                    ErrorEvent.Cellular(it.technology, it.carrierName)
+                }
+            )
+            .hasConnectivityInterface(
+                fakeBundledViewEvent.connectivity?.interfaces?.map {
+                    ErrorEvent.Interface.valueOf(
+                        it.name
+                    )
+                }
+            )
+    }
+
+    @Test
+    fun `M only send the RUM ErrorEvent W handleNdkCrash { last view event older than 4h }`(
+        forge: Forge
+    ) {
+        // GIVEN
+        fakeNdkCrashLog =
+            fakeNdkCrashLog.copy(
+                timestamp = System.currentTimeMillis() -
+                    DatadogNdkCrashHandler.VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD
+            )
+        fakeSerializedNdkCrashLog = fakeNdkCrashLog.toJson()
+        val crashLogFile =
+            File(fakeNdkCrashReportsDirectory, DatadogNdkCrashHandler.CRASH_LOG_FILE_NAME)
+        val lastViewEventFile =
+            File(fakeNdkCrashReportsDirectory, RumFileWriter.LAST_VIEW_EVENT_FILE_NAME)
+
+        crashLogFile.outputStream().use {
+            it.write(fakeSerializedNdkCrashLog.toByteArray())
+        }
+        lastViewEventFile.outputStream().use {
+            it.write(fakeSerializedRumViewEvent.toByteArray())
+        }
+        val fakeBundledViewEvent = fakeRumViewEvent.event as ViewEvent
+        mockTheLogGenerator(fakeBundledViewEvent)
+
+        // WHEN
+        testedHandler.handleNdkCrash()
+
+        // THEN
+        verify(mockedAsyncLogWriter).write(mockedGeneratedLog)
+        val argumentCaptor = argumentCaptor<RumEvent>()
+        verify(mockedAsyncRumWriter, times(1)).write(argumentCaptor.capture())
+        assertThat(argumentCaptor.firstValue.event).isInstanceOf(ErrorEvent::class.java)
+    }
+
+    @Test
+    fun `M clean the NDK crash reports folder`() {
+        // GIVEN
+        val crashLogFile =
+            File(fakeNdkCrashReportsDirectory, DatadogNdkCrashHandler.CRASH_LOG_FILE_NAME)
+        val lastViewEventFile =
+            File(fakeNdkCrashReportsDirectory, RumFileWriter.LAST_VIEW_EVENT_FILE_NAME)
+
+        crashLogFile.outputStream().use {
+            it.write(fakeSerializedNdkCrashLog.toByteArray())
+        }
+        lastViewEventFile.outputStream().use {
+            it.write(fakeSerializedRumViewEvent.toByteArray())
+        }
+        val fakeBundledViewEvent = fakeRumViewEvent.event as ViewEvent
+        mockTheLogGenerator(fakeBundledViewEvent)
+
+        // WHEN
+        testedHandler.handleNdkCrash()
+
+        // THEN
+        assertThat(fakeNdkCrashReportsDirectory.listFiles()).isEmpty()
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun mockTheLogGenerator(fakeBundledViewEvent: ViewEvent) {
+        whenever(
+            mockedLockGenerator.generateLog(
+                eq(Log.CRASH),
+                eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+                anyOrNull(),
+                eq(
+                    mapOf(
+                        LogAttributes.RUM_VIEW_ID to fakeBundledViewEvent.view.id,
+                        LogAttributes.RUM_SESSION_ID to fakeBundledViewEvent.session.id,
+                        LogAttributes.RUM_APPLICATION_ID to fakeBundledViewEvent.application.id,
+                        LogAttributes.ERROR_STACK to fakeNdkCrashLog.stacktrace
+                    )
+                ),
+                anyOrNull(),
+                eq(fakeNdkCrashLog.timestamp),
+                anyOrNull(),
+                any(),
+                any()
+            )
+        ).thenReturn(mockedGeneratedLog)
+    }
+
+    // endregion
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashLogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashLogTest.kt
@@ -32,7 +32,7 @@ internal class NdkCrashLogTest {
         val serializedLog = fakeNdkCrashLog.toJson()
 
         // WHEN
-        val deserializedLog: NdkCrashLog = fromJson(serializedLog)
+        val deserializedLog: NdkCrashLog = NdkCrashLog.fromJson(serializedLog)
 
         // THEN
         assertThat(deserializedLog).isEqualTo(fakeNdkCrashLog)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashLogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashLogTest.kt
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.ndk
+
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class NdkCrashLogTest {
+
+    @Test
+    fun `M deserialize an NdkCrashLog W required`(@Forgery fakeNdkCrashLog: NdkCrashLog) {
+        // GIVEN
+        val serializedLog = fakeNdkCrashLog.toJson()
+
+        // WHEN
+        val deserializedLog: NdkCrashLog = fromJson(serializedLog)
+
+        // THEN
+        assertThat(deserializedLog).isEqualTo(fakeNdkCrashLog)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -50,6 +50,9 @@ internal class Configurator :
         forge.addFactory(MotionEventForgeryFactory())
         forge.addFactory(RumEventMapperFactory())
 
+        // NDK Crash
+        forge.addFactory(NdkCrashLogForgeryFactory())
+
         // MISC
         forge.addFactory(BigIntegerFactory())
         forge.addFactory(JsonArrayForgeryFactory())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/NdkCrashLogForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/NdkCrashLogForgeryFactory.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.rum.internal.ndk.NdkCrashLog
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class NdkCrashLogForgeryFactory :
+    ForgeryFactory<NdkCrashLog> {
+    override fun getForgery(forge: Forge): NdkCrashLog {
+        return NdkCrashLog(
+            forge.anInt(min = 1),
+            System.currentTimeMillis(),
+            forge.anAlphabeticalString(),
+            forge.anAlphabeticalString(),
+            forge.anAlphabeticalString()
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumEventForgeryFactory.kt
@@ -27,7 +27,12 @@ internal class RumEventForgeryFactory : ForgeryFactory<RumEvent> {
         return RumEvent(
             event = eventData,
             globalAttributes = forge.exhaustiveAttributes(),
-            userExtraAttributes = forge.exhaustiveAttributes()
+            userExtraAttributes = forge.exhaustiveAttributes(),
+            customTimings = forge.aNullable {
+                forge.aMap {
+                    forge.anAlphabeticalString() to forge.aLong()
+                }
+            }
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

In this *PR* I am concluding the NDK crash reporting feature by adding the last missing piece: `DatadogNdkCrashHandler`
with the following responsibilities:

- check when the SDK is initialized if there is any crash report from previous session in the NDK crash reports folder.
- if a crash report is found the handler will send a related Crash Log based on the information found in the crash report
- if along with the crash report there is also a `last_view_event` stored in the NDK crash reports folder the handler will also increment the `error.count` attribute and update this `ViewEvent`. A RUM ErrorEvent will also be sent for this ViewEvent.
- to avoid data duplication the `DatadogNdkCrashHandler` will only be running in the Application main process.
- to avoid the duplication of the RUM `ErrorEvent` the Crash Log will be sent directly to the `ConsentAwareWriter` skipping this way the `LogHandler` logic.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

