### PR TITLE
RUMM-962 Send the 'error.type' attribute in the RUM ErrorEvent

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -439,7 +439,7 @@ class com.datadog.android.rum.model.ErrorEvent
     companion object 
       fun fromJson(kotlin.String): Dd
   class Error
-    constructor(kotlin.String, Source, kotlin.String? = null, kotlin.Boolean? = null, Resource? = null)
+    constructor(kotlin.String, Source, kotlin.String? = null, kotlin.Boolean? = null, kotlin.String? = null, Resource? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Error

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -229,6 +229,7 @@ object com.datadog.android.rum.RumAttributes
   const val SOURCE: String
   const val VARIANT: String
   const val SDK_VERSION: String
+  const val INTERNAL_ERROR_TYPE: String
   const val INTERNAL_TIMESTAMP: String
   const val TRACE_ID: String
   const val SPAN_ID: String

--- a/dd-sdk-android/src/main/json/error-schema.json
+++ b/dd-sdk-android/src/main/json/error-schema.json
@@ -49,6 +49,11 @@
               "description": "Whether this error crashed the host application",
               "readOnly": true
             },
+            "type": {
+              "type": "string",
+              "description": "The type of the error",
+              "readOnly": true
+            },
             "resource": {
               "type": "object",
               "description": "Resource properties of the error",

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -60,6 +60,11 @@ object RumAttributes {
     // region Internal
 
     /**
+     * Overrides the automatic RUM error event type with a custom one.
+     */
+    const val INTERNAL_ERROR_TYPE: String = "_dd.error_type"
+
+    /**
      * Overrides the automatic RUM event timestamp with a custom one.
      */
     const val INTERNAL_TIMESTAMP: String = "_dd.timestamp"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
@@ -97,7 +97,8 @@ internal class RumEventSerializer(
         )
 
         internal val ignoredAttributes = setOf(
-            RumAttributes.INTERNAL_TIMESTAMP
+            RumAttributes.INTERNAL_TIMESTAMP,
+            RumAttributes.INTERNAL_ERROR_TYPE
         )
 
         internal const val GLOBAL_ATTRIBUTE_PREFIX: String = "context"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -89,7 +89,8 @@ internal sealed class RumRawEvent {
         val stacktrace: String?,
         val isFatal: Boolean,
         val attributes: Map<String, Any?>,
-        override val eventTime: Time = Time()
+        override val eventTime: Time = Time(),
+        val type: String? = null
     ) : RumRawEvent()
 
     internal data class UpdateViewLoadingTime(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -214,7 +214,8 @@ internal class RumResourceScope(
                     method = method.toErrorMethod(),
                     statusCode = statusCode ?: 0,
                     provider = resolveErrorProvider()
-                )
+                ),
+                type = throwable.javaClass.canonicalName
             ),
             action = context.actionId?.let { ErrorEvent.Action(it) },
             view = ErrorEvent.View(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -184,14 +184,15 @@ internal class RumViewScope(
         val user = CoreFeature.userInfoProvider.getUserInfo()
         val updatedAttributes = addExtraAttributes(event.attributes)
         val networkInfo = CoreFeature.networkInfoProvider.getLatestNetworkInfo()
-
+        val errorType = event.type ?: event.throwable?.javaClass?.canonicalName
         val errorEvent = ErrorEvent(
             date = event.eventTime.timestamp,
             error = ErrorEvent.Error(
                 message = event.message,
                 source = event.source.toSchemaSource(),
                 stack = event.stacktrace ?: event.throwable?.loggableStackTrace(),
-                isCrash = event.isFatal
+                isCrash = event.isFatal,
+                type = errorType
             ),
             action = context.actionId?.let { ErrorEvent.Action(it) },
             view = ErrorEvent.View(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -141,8 +141,18 @@ internal class DatadogRumMonitor(
         attributes: Map<String, Any?>
     ) {
         val eventTime = getEventTime(attributes)
+        val errorType = getErrorType(attributes)
         handleEvent(
-            RumRawEvent.AddError(message, source, throwable, null, false, attributes, eventTime)
+            RumRawEvent.AddError(
+                message,
+                source,
+                throwable,
+                null,
+                false,
+                attributes,
+                eventTime,
+                errorType
+            )
         )
     }
 
@@ -153,8 +163,18 @@ internal class DatadogRumMonitor(
         attributes: Map<String, Any?>
     ) {
         val eventTime = getEventTime(attributes)
+        val errorType = getErrorType(attributes)
         handleEvent(
-            RumRawEvent.AddError(message, source, null, stacktrace, false, attributes, eventTime)
+            RumRawEvent.AddError(
+                message,
+                source,
+                null,
+                stacktrace,
+                false,
+                attributes,
+                eventTime,
+                errorType
+            )
         )
     }
 
@@ -228,6 +248,10 @@ internal class DatadogRumMonitor(
 
     private fun getEventTime(attributes: Map<String, Any?>): Time {
         return (attributes[RumAttributes.INTERNAL_TIMESTAMP] as? Long)?.asTime() ?: Time()
+    }
+
+    private fun getErrorType(attributes: Map<String, Any?>): String? {
+        return attributes[RumAttributes.INTERNAL_ERROR_TYPE] as? String
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
@@ -228,7 +228,8 @@ internal class DatadogNdkCrashHandler(
                     errorLogMessage,
                     ErrorEvent.Source.SOURCE,
                     ndkCrashLog.stacktrace,
-                    true
+                    true,
+                    ndkCrashLog.signalName
                 )
             ),
             rumViewEvent.globalAttributes,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -273,6 +273,15 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
+    fun hasErrorType(expected: String?): ErrorEventAssert {
+        assertThat(actual.error.type)
+            .overridingErrorMessage(
+                "Expected event data to have error type $expected" +
+                    " but was ${actual.error.type}"
+            ).isEqualTo(expected)
+        return this
+    }
+
     companion object {
 
         internal fun assertThat(actual: ErrorEvent): ErrorEventAssert =

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -636,6 +636,7 @@ internal class RumResourceScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
+                    hasErrorType(throwable.javaClass.canonicalName)
                 }
         }
         verify(mockParentScope).handleEvent(
@@ -693,6 +694,7 @@ internal class RumResourceScopeTest {
                     hasActionId(fakeParentContext.actionId)
                     hasProviderDomain(brokenUrl)
                     hasProviderType(ErrorEvent.ProviderType.FIRST_PARTY)
+                    hasErrorType(throwable.javaClass.canonicalName)
                 }
         }
         verify(mockParentScope).handleEvent(
@@ -740,6 +742,7 @@ internal class RumResourceScopeTest {
                     hasActionId(fakeParentContext.actionId)
                     hasProviderDomain(URL(fakeUrl).host)
                     hasProviderType(ErrorEvent.ProviderType.FIRST_PARTY)
+                    hasErrorType(throwable.javaClass.canonicalName)
                 }
         }
         verify(mockParentScope).handleEvent(
@@ -786,6 +789,7 @@ internal class RumResourceScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
+                    hasErrorType(throwable.javaClass.canonicalName)
                     doesNotHaveAResourceProvider()
                 }
         }
@@ -841,6 +845,7 @@ internal class RumResourceScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
+                    hasErrorType(throwable.javaClass.canonicalName)
                     doesNotHaveAResourceProvider()
                 }
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
@@ -378,6 +378,7 @@ internal class DatadogNdkCrashHandlerTest {
                     )
                 }
             )
+            .hasErrorType(fakeNdkCrashLog.signalName)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/data/TraceWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/data/TraceWriterTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.tracing.internal.data
 
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
@@ -97,12 +98,13 @@ internal class TraceWriterTest {
 
         // THEN
         val errorMessagesCaptor = argumentCaptor<String>()
+        val attributesCaptor = argumentCaptor<Map<String, Any?>>()
         val stackTracesCaptor = argumentCaptor<String>()
         verify(mockAdvancedRumMonitor, times(2)).addErrorWithStacktrace(
             errorMessagesCaptor.capture(),
             eq(RumErrorSource.SOURCE),
             stackTracesCaptor.capture(),
-            eq(emptyMap())
+            attributesCaptor.capture()
         )
         errorMessagesCaptor.allValues.forEachIndexed { index, message ->
             assertThat(message).isEqualTo(
@@ -112,6 +114,12 @@ internal class TraceWriterTest {
                     spansList[index].tags[DDTags.ERROR_TYPE].toString(),
                     spansList[index].tags[DDTags.ERROR_MSG].toString()
                 )
+            )
+        }
+        attributesCaptor.allValues.forEachIndexed { index, map ->
+            assertThat(map).containsEntry(
+                RumAttributes.INTERNAL_ERROR_TYPE,
+                spansList[index].tags[DDTags.ERROR_TYPE].toString()
             )
         }
         stackTracesCaptor.allValues.forEachIndexed { index, stacktrace ->
@@ -189,12 +197,13 @@ internal class TraceWriterTest {
 
         // THEN
         val errorMessagesCaptor = argumentCaptor<String>()
+        val attributesCaptor = argumentCaptor<Map<String, Any?>>()
         val stackTracesCaptor = argumentCaptor<String>()
         verify(mockAdvancedRumMonitor, times(2)).addErrorWithStacktrace(
             errorMessagesCaptor.capture(),
             eq(RumErrorSource.SOURCE),
             stackTracesCaptor.capture(),
-            eq(emptyMap())
+            attributesCaptor.capture()
         )
         errorMessagesCaptor.allValues.forEachIndexed { index, message ->
             assertThat(message).isEqualTo(
@@ -208,6 +217,12 @@ internal class TraceWriterTest {
 
         stackTracesCaptor.allValues.forEachIndexed { index, stacktrace ->
             assertThat(stacktrace).isEqualTo(spansList[index].tags[DDTags.ERROR_STACK].toString())
+        }
+        attributesCaptor.allValues.forEachIndexed { index, map ->
+            assertThat(map).containsEntry(
+                RumAttributes.INTERNAL_ERROR_TYPE,
+                spansList[index].tags[DDTags.ERROR_TYPE].toString()
+            )
         }
         spansList.forEach {
             it.finish()


### PR DESCRIPTION
### What does this PR do?

Attaches the `error.type` attribute for the RUM ErrorEvent when available. The attribute value resolves from the `Throwable` by using the canonical name of the `Throwable` type.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

