### PR TITLE
RUMM-953 Un-deprecate local known hosts

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -67,7 +67,7 @@ class com.datadog.android.DatadogEventListener : okhttp3.EventListener
   class Factory : okhttp3.EventListener.Factory
     override fun create(okhttp3.Call): okhttp3.EventListener
 open class com.datadog.android.DatadogInterceptor : com.datadog.android.tracing.TracingInterceptor
-  DEPRECATED constructor(List<String>, com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener())
+  constructor(List<String>, com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener())
   constructor(com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener())
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
   override fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
@@ -260,6 +260,7 @@ enum com.datadog.android.rum.RumErrorSource
   - AGENT
   - WEBVIEW
 class com.datadog.android.rum.RumInterceptor : com.datadog.android.DatadogInterceptor
+  constructor(List<String> = emptyList())
 interface com.datadog.android.rum.RumMonitor
   fun startView(Any, String, Map<String, Any?> = emptyMap())
   fun stopView(Any, Map<String, Any?> = emptyMap())
@@ -905,7 +906,7 @@ class com.datadog.android.tracing.AndroidTracer : com.datadog.opentracing.DDTrac
 interface com.datadog.android.tracing.TracedRequestListener
   fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span, okhttp3.Response?, Throwable?)
 open class com.datadog.android.tracing.TracingInterceptor : okhttp3.Interceptor
-  DEPRECATED constructor(List<String>, TracedRequestListener = NoOpTracedRequestListener())
+  constructor(List<String>, TracedRequestListener = NoOpTracedRequestListener())
   constructor(TracedRequestListener = NoOpTracedRequestListener())
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
   protected open fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
@@ -86,27 +86,21 @@ internal constructor(
      * Creates a [TracingInterceptor] to automatically create a trace around OkHttp [Request]s, and
      * track RUM Resources.
      *
-     * @param tracedHosts a list of all the hosts that you want to be automatically tracked
-     * by our APM [TracingInterceptor]. If no host provided the interceptor won't trace
-     * any OkHttp [Request], nor propagate tracing information to the backend.
-     * Please note that the host constraint will only be applied on the [TracingInterceptor] and we
-     * will continue to dispatch RUM Resource events for each request without applying any host
-     * filtering.
+     * @param firstPartyHosts the list of first party hosts.
+     * Requests made to a URL with any one of these hosts (or any subdomain) will:
+     * - be considered a first party RUM Resource and categorised as such in your RUM dashboard;
+     * - be wrapped in a Span and have trace id injected to get a full flame-graph in APM.
+     * If no host provided the interceptor won't trace any OkHttp [Request], nor propagate tracing
+     * information to the backend, but RUM Resource events will still be sent for each request.
      * @param tracedRequestListener which listens on the intercepted [okhttp3.Request] and offers
      * the possibility to modify the created [io.opentracing.Span].
      */
     @JvmOverloads
-    @Deprecated(
-        "Hosts should be defined in the DatadogConfig.setFirstPartyHosts()",
-        ReplaceWith(
-            expression = "DatadogInterceptor(tracedRequestListener)"
-        )
-    )
     constructor(
-        tracedHosts: List<String>,
+        firstPartyHosts: List<String>,
         tracedRequestListener: TracedRequestListener = NoOpTracedRequestListener()
     ) : this(
-        tracedHosts,
+        firstPartyHosts,
         tracedRequestListener,
         CoreFeature.firstPartyHostDetector,
         { AndroidTracer.Builder().build() }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.configuration
 
 import android.os.Build
 import com.datadog.android.DatadogEndpoint
+import com.datadog.android.DatadogInterceptor
 import com.datadog.android.core.internal.event.NoOpEventMapper
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.event.EventMapper

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumInterceptor.kt
@@ -11,6 +11,7 @@ import com.datadog.android.DatadogInterceptor
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
+import okhttp3.Request
 
 /**
  * Provides automatic RUM integration for [OkHttpClient] by way of the [Interceptor] system.
@@ -31,5 +32,13 @@ import okhttp3.OkHttpClient
  *       .addInterceptor(new RumInterceptor())
  *       .build();
  * ```
+ * @param firstPartyHosts the list of first party hosts.
+ * Requests made to a URL with any one of these hosts (or any subdomain) will:
+ * - be considered a first party RUM Resource and categorised as such in your RUM dashboard;
+ * - be wrapped in a Span and have trace id injected to get a full flame-graph in APM.
+ * If no host provided the interceptor won't trace any OkHttp [Request], nor propagate tracing
+ * information to the backend, but RUM Resource events will still be sent for each request.
  */
-class RumInterceptor : DatadogInterceptor(listOf(""))
+class RumInterceptor(
+    firstPartyHosts: List<String> = emptyList()
+) : DatadogInterceptor(firstPartyHosts)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
@@ -62,8 +62,7 @@ import okhttp3.Response
  */
 @Suppress("StringLiteralDuplication")
 open class TracingInterceptor
-@JvmOverloads internal constructor(
-    @Deprecated("hosts should be defined in the DatadogConfig.setFirstPartyHosts()")
+internal constructor(
     internal val tracedHosts: List<String>,
     internal val tracedRequestListener: TracedRequestListener,
     internal val firstPartyHostDetector: FirstPartyHostDetector,
@@ -73,11 +72,12 @@ open class TracingInterceptor
 
     private val localTracerReference: AtomicReference<Tracer> = AtomicReference()
 
+    private val localFirstPartyHostDetector = FirstPartyHostDetector(tracedHosts)
+
     init {
-        if (tracedHosts.isEmpty() && firstPartyHostDetector.isEmpty()) {
+        if (localFirstPartyHostDetector.isEmpty() && firstPartyHostDetector.isEmpty()) {
             devLogger.w(WARNING_TRACING_NO_HOSTS)
         }
-        firstPartyHostDetector.addKnownHosts(tracedHosts)
     }
 
     /**
@@ -89,12 +89,6 @@ open class TracingInterceptor
      * @param tracedRequestListener a listener for automatically created [Span]s
      */
     @JvmOverloads
-    @Deprecated(
-        "Hosts should be defined in the DatadogConfig.setFirstPartyHosts().",
-        ReplaceWith(
-            expression = "TracingInterceptor(tracedRequestListener)"
-        )
-    )
     constructor(
         tracedHosts: List<String>,
         tracedRequestListener: TracedRequestListener = NoOpTracedRequestListener()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
@@ -580,6 +580,19 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
+    fun `M do not update the hostDetector W host list provided`(forge: Forge) {
+        // GIVEN
+        val localHosts =
+            forge.aList { forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN) }
+
+        // WHEN
+        testedInterceptor = instantiateTestedInterceptor(localHosts) { mockLocalTracer }
+
+        // THEN
+        verify(mockDetector, never()).addKnownHosts(localHosts)
+    }
+
+    @Test
     fun `𝕄 do nothing 𝕎 intercept() for request with unknown host`(
         @IntForgery(min = 200, max = 300) statusCode: Int,
         forge: Forge

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
@@ -570,15 +570,15 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M update the hostDetector W legacy host list provided`(forge: Forge) {
+    fun `M do not update the hostDetector W host list provided`(forge: Forge) {
         // GIVEN
-        val legacyHostList = forge.aList { forge.aStringMatching(HOSTNAME_PATTERN) }
+        val localHosts = forge.aList { forge.aStringMatching(HOSTNAME_PATTERN) }
 
         // WHEN
-        testedInterceptor = instantiateTestedInterceptor(legacyHostList) { mockLocalTracer }
+        testedInterceptor = instantiateTestedInterceptor(localHosts) { mockLocalTracer }
 
         // THEN
-        verify(mockDetector).addKnownHosts(legacyHostList)
+        verify(mockDetector, never()).addKnownHosts(localHosts)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

We want to allow customer to set known first party locally per interceptor