### PR TITLE
RUMM-1048: Fix wrong logcat tag for Timber integration

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
@@ -70,11 +70,19 @@ internal class LogcatLogHandler(
     internal fun getCallerStackElement(): StackTraceElement? {
         return if (Datadog.isDebug && useClassnameAsTag) {
             val stackTrace = Throwable().stackTrace
-            stackTrace.firstOrNull {
-                it.className !in ignoredClassNames
-            }
+            return findValidCallStackElement(stackTrace)
         } else {
             null
+        }
+    }
+
+    internal fun findValidCallStackElement(
+        stackTrace: Array<StackTraceElement>
+    ): StackTraceElement? {
+        return stackTrace.firstOrNull {
+            it.className !in ignoredClassNames &&
+                !it.className.startsWith("com.datadog.android.timber") &&
+                !it.className.startsWith("timber.log")
         }
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
@@ -79,10 +79,9 @@ internal class LogcatLogHandler(
     internal fun findValidCallStackElement(
         stackTrace: Array<StackTraceElement>
     ): StackTraceElement? {
-        return stackTrace.firstOrNull {
-            it.className !in ignoredClassNames &&
-                !it.className.startsWith("com.datadog.android.timber") &&
-                !it.className.startsWith("timber.log")
+        return stackTrace.firstOrNull { element ->
+            element.className !in IGNORED_CLASS_NAMES &&
+                IGNORED_PACKAGE_PREFIXES.none { element.className.startsWith(it) }
         }
     }
 
@@ -93,7 +92,8 @@ internal class LogcatLogHandler(
         private const val MAX_TAG_LENGTH = 23
 
         private val ANONYMOUS_CLASS = Regex("(\\$\\d+)+$")
-        private val ignoredClassNames = arrayOf(
+        // internal for testing
+        internal val IGNORED_CLASS_NAMES = arrayOf(
             Logger::class.java.canonicalName,
             LogHandler::class.java.canonicalName,
             LogHandler::class.java.canonicalName + "\$DefaultImpls",
@@ -101,6 +101,12 @@ internal class LogcatLogHandler(
             ConditionalLogHandler::class.java.canonicalName,
             CombinedLogHandler::class.java.canonicalName,
             DatadogLogHandler::class.java.canonicalName
+        )
+
+        // internal for testing
+        internal val IGNORED_PACKAGE_PREFIXES = arrayOf(
+            "com.datadog.android.timber",
+            "timber.log"
         )
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
@@ -88,9 +88,10 @@ internal class LogcatLogHandlerTest {
     @Test
     fun `resolves valid stack trace element when wrapped in timber`() {
 
+        /* ktlint-disable max-line-length */
         // Given
         val rawStackTrace =
-                "com.datadog.android.log.internal.logger.LogcatLogHandler.handleLog(LogcatLogHandler.kt:31)\n" +
+            "com.datadog.android.log.internal.logger.LogcatLogHandler.handleLog(LogcatLogHandler.kt:31)\n" +
                 "com.datadog.android.log.internal.logger.CombinedLogHandler.handleLog(CombinedLogHandler.kt:23)\n" +
                 "com.datadog.android.log.Logger.internalLog\$dd_sdk_android_debug(Logger.kt:517)\n" +
                 "com.datadog.android.log.Logger.internalLog\$dd_sdk_android_debug\$default(Logger.kt:512)\n" +
@@ -105,6 +106,7 @@ internal class LogcatLogHandlerTest {
                 "android.view.View.performClick(View.java:7448)\n" +
                 "android.view.View.performClickInternal(View.java:7425)\n" +
                 "android.view.View.access\$3600(View.java:810)"
+        /* ktlint-enable max-line-length */
 
         val matchingRegex = Regex("(\\S+)\\((\\S+)\\)")
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
@@ -84,4 +84,52 @@ internal class LogcatLogHandlerTest {
                     "\$runnable\$1"
             )
     }
+
+    @Test
+    fun `resolves valid stack trace element when wrapped in timber`() {
+
+        // Given
+        val rawStackTrace =
+                "com.datadog.android.log.internal.logger.LogcatLogHandler.handleLog(LogcatLogHandler.kt:31)\n" +
+                "com.datadog.android.log.internal.logger.CombinedLogHandler.handleLog(CombinedLogHandler.kt:23)\n" +
+                "com.datadog.android.log.Logger.internalLog\$dd_sdk_android_debug(Logger.kt:517)\n" +
+                "com.datadog.android.log.Logger.internalLog\$dd_sdk_android_debug\$default(Logger.kt:512)\n" +
+                "com.datadog.android.log.Logger.log(Logger.kt:165)\n" +
+                "com.datadog.android.log.Logger.log\$default(Logger.kt:163)\n" +
+                "com.datadog.android.timber.DatadogTree.log(DatadogTree.kt:32)\n" +
+                "timber.log.Timber\$Tree.prepareLog(Timber.java:532)\n" +
+                "timber.log.Timber\$Tree.d(Timber.java:405)\n" +
+                "timber.log.Timber\$1.d(Timber.java:243)\n" +
+                "timber.log.Timber.d(Timber.java:38)\n" +
+                "com.datadog.android.sample.home.HomeFragment.onClick(HomeFragment.kt:65)\n" +
+                "android.view.View.performClick(View.java:7448)\n" +
+                "android.view.View.performClickInternal(View.java:7425)\n" +
+                "android.view.View.access\$3600(View.java:810)"
+
+        val matchingRegex = Regex("(\\S+)\\((\\S+)\\)")
+
+        val stackTrace = rawStackTrace.lines().map { line ->
+            // let it crash here if something is wrong with matching
+            val groups = matchingRegex.matchEntire(line)!!.groupValues
+
+            // group 1 is like com.datadog.android.log.internal.logger.LogcatLogHandler.handleLog
+            val declaringClass = groups[1].split('.')
+                .dropLast(1)
+                .joinToString(separator = ".")
+            val methodName = groups[1].split('.').last()
+
+            // group 2 is like LogcatLogHandler.kt:31
+            val (fileName, lineNumber) = groups[2].split(':')
+
+            StackTraceElement(declaringClass, methodName, fileName, lineNumber.toInt())
+        }.toTypedArray()
+
+        // When
+        val element = testedHandler.findValidCallStackElement(stackTrace)
+
+        // Then
+        checkNotNull(element)
+        assertThat(element.className)
+            .isEqualTo("com.datadog.android.sample.home.HomeFragment")
+    }
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes wrong tag in the logcat output for Timber integration, when wrong call stack element was picked (closes #483)

### Motivation

Existing issue #483

### Additional Notes

This is not a universal solution and will fix only Timber integration case. Need to come up with better call site matching later.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

