### PR TITLE
PokoGenerator - support Any type for additionalProperties values 

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/JacocoConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/JacocoConfig.kt
@@ -15,20 +15,30 @@ import org.gradle.testing.jacoco.tasks.JacocoReport
 
 fun Project.jacocoConfig() {
 
-    val jacocoTestDebugUnitTestReport = tasks.create("jacocoTestDebugUnitTestReport", JacocoReport::class.java)
+    val jacocoTestDebugUnitTestReport = tasks.create(
+        "jacocoTestDebugUnitTestReport",
+        JacocoReport::class.java
+    )
     jacocoTestDebugUnitTestReport.reports {
         csv.isEnabled = false
         xml.isEnabled = true
         html.isEnabled = true
-        html.destination = file("${buildDir.path}/reports/jacoco/jacocoTestDebugUnitTestReport/html")
+        html.destination = file(
+            "${buildDir.path}/reports/jacoco/jacocoTestDebugUnitTestReport/html"
+        )
     }
 
-    val jacocoTestReleaseUnitTestReport = tasks.create("jacocoTestReleaseUnitTestReport", JacocoReport::class.java)
+    val jacocoTestReleaseUnitTestReport = tasks.create(
+        "jacocoTestReleaseUnitTestReport",
+        JacocoReport::class.java
+    )
     jacocoTestReleaseUnitTestReport.reports {
         csv.isEnabled = false
         xml.isEnabled = true
         html.isEnabled = true
-        html.destination = file("${buildDir.path}/reports/jacoco/jacocoTestReleaseUnitTestReport/html")
+        html.destination = file(
+            "${buildDir.path}/reports/jacoco/jacocoTestReleaseUnitTestReport/html"
+        )
     }
 
     val jacocoTestCoverageVerification =

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/PublishingConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/PublishingConfig.kt
@@ -100,20 +100,24 @@ fun Project.bintrayConfig() {
         override = true
         publish = true
 
-        pkg(delegateClosureOf<BintrayExtension.PackageConfig> {
-            repo = "datadog-maven"
-            name = projectName
-            userOrg = "datadog"
-            desc = "Datadog SDK fot Android"
-            websiteUrl = "https://www.datadoghq.com/"
-            setLicenses("Apache-2.0")
-            githubRepo = "DataDog/dd-sdk-android"
-            githubReleaseNotesFile = "README.md"
-            vcsUrl = "https://github.com/DataDog/dd-sdk-android.git"
+        pkg(
+            delegateClosureOf<BintrayExtension.PackageConfig> {
+                repo = "datadog-maven"
+                name = projectName
+                userOrg = "datadog"
+                desc = "Datadog SDK fot Android"
+                websiteUrl = "https://www.datadoghq.com/"
+                setLicenses("Apache-2.0")
+                githubRepo = "DataDog/dd-sdk-android"
+                githubReleaseNotesFile = "README.md"
+                vcsUrl = "https://github.com/DataDog/dd-sdk-android.git"
 
-            version(delegateClosureOf<BintrayExtension.VersionConfig> {
-                name = AndroidConfig.VERSION.name
-            })
-        })
+                version(
+                    delegateClosureOf<BintrayExtension.VersionConfig> {
+                        name = AndroidConfig.VERSION.name
+                    }
+                )
+            }
+        )
     }
 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/CheckApiSurfaceTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/CheckApiSurfaceTask.kt
@@ -27,7 +27,12 @@ open class CheckApiSurfaceTask : DefaultTask() {
     @TaskAction
     fun applyTask() {
         val lines = project.execShell(
-            "git", "diff", "--color=never", "HEAD", "--", surfaceFile.absolutePath
+            "git",
+            "diff",
+            "--color=never",
+            "HEAD",
+            "--",
+            surfaceFile.absolutePath
         )
 
         val additions = lines.filter { it.matches(Regex("^\\+[^+].*$")) }
@@ -35,7 +40,8 @@ open class CheckApiSurfaceTask : DefaultTask() {
 
         if (additions.isNotEmpty() || removals.isNotEmpty()) {
             throw IllegalStateException(
-                "Make sure you run the ${ApiSurfacePlugin.TASK_GEN_API_SURFACE} task before you push your PR.\n" +
+                "Make sure you run the ${ApiSurfacePlugin.TASK_GEN_API_SURFACE} task" +
+                    " before you push your PR.\n" +
                     additions.joinToString("\n") + removals.joinToString("\n")
             )
         }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateApiSurfaceTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateApiSurfaceTask.kt
@@ -41,9 +41,10 @@ open class GenerateApiSurfaceTask : DefaultTask() {
 
     private fun visitDirectoryRecursively(file: File) {
         when {
-            file.isDirectory -> file.listFiles().orEmpty()
-                .sortedBy { it.absolutePath }
-                .forEach { visitDirectoryRecursively(it) }
+            file.isDirectory ->
+                file.listFiles().orEmpty()
+                    .sortedBy { it.absolutePath }
+                    .forEach { visitDirectoryRecursively(it) }
             file.isFile -> visitFile(file)
             else -> System.err.println("${file.path} is neither file nor directory")
         }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/benchmark/BenchmarkJsonFileVisitor.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/benchmark/BenchmarkJsonFileVisitor.kt
@@ -43,7 +43,10 @@ class BenchmarkJsonFileVisitor {
 
     companion object {
         private val devicePrefixes = listOf(
-            "EMULATOR", "UNLOCKED", "DEBUGGABLE", "ENG-BUILD"
+            "EMULATOR",
+            "UNLOCKED",
+            "DEBUGGABLE",
+            "ENG-BUILD"
         )
     }
 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/benchmark/BenchmarkStrategy.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/benchmark/BenchmarkStrategy.kt
@@ -20,8 +20,8 @@ sealed class BenchmarkStrategy {
                 else -> {
                     System.err.println(
                         "Benchmark test \"$$compare\" reported a median time of " +
-                                "$toMeasure milliseconds, but threshold is set to " +
-                                "$threshold milliseconds"
+                            "$toMeasure milliseconds, but threshold is set to " +
+                            "$threshold milliseconds"
                     )
                     false
                 }
@@ -44,8 +44,8 @@ sealed class BenchmarkStrategy {
                 else -> {
                     System.err.println(
                         "We were expecting a relativeThreshold smaller or equal with $threshold " +
-                                "milliseconds between the benchmark : \"$compare\" and : " +
-                                "\"$compareTo\" instead it was of $toMeasure milliseconds"
+                            "milliseconds between the benchmark : \"$compare\" and : " +
+                            "\"$compareTo\" instead it was of $toMeasure milliseconds"
                     )
                     false
                 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/checklicenses/CheckThirdPartyLicensesTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/checklicenses/CheckThirdPartyLicensesTask.kt
@@ -78,7 +78,9 @@ open class CheckThirdPartyLicensesTask : DefaultTask() {
                 error = true
                 System.err.println("✗ $check dependency in ${extension.csvFile.name} : $dep")
             } else if (knownInOtherComponent != null) {
-                System.err.println("✗ $dep $check but exist in component ${knownInOtherComponent.component}")
+                System.err.println(
+                    "✗ $dep $check but exist in component ${knownInOtherComponent.component}"
+                )
             }
         }
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/checklicenses/SPDXLicenceConverter.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/checklicenses/SPDXLicenceConverter.kt
@@ -28,7 +28,8 @@ object SPDXLicenceConverter {
     private fun convertLicense(license: String): SPDXLicense? {
         if (license.isBlank()) return null
 
-        val nameMatch = FuzzySearch.extractOne(license.trim(),
+        val nameMatch = FuzzySearch.extractOne(
+            license.trim(),
             nameList
         )
         if (nameMatch.score > 90) {
@@ -36,7 +37,8 @@ object SPDXLicenceConverter {
             return nameMap[nameMatch.string]
         }
 
-        val identifierMatch = FuzzySearch.extractOne(license.trim(),
+        val identifierMatch = FuzzySearch.extractOne(
+            license.trim(),
             identifierList
         )
         if (identifierMatch.score > 90) {

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/checklicenses/ThirdPartyLicensesPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/checklicenses/ThirdPartyLicensesPlugin.kt
@@ -16,7 +16,8 @@ class ThirdPartyLicensesPlugin : Plugin<Project> {
     override fun apply(target: Project) {
         val extension = target.extensions
             .create(EXT_NAME, ThirdPartyLicensesExtension::class.java)
-        extension.csvFile = File(target.rootDir,
+        extension.csvFile = File(
+            target.rootDir,
             ThirdPartyLicensesExtension.DEFAULT_TP_LICENCE_FILENAME
         )
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/gitclone/GitCloneDependenciesTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/gitclone/GitCloneDependenciesTask.kt
@@ -60,9 +60,12 @@ open class GitCloneDependenciesTask : DefaultTask() {
     ) {
         println(" --- Cloning ${dependency.originRepository} into ${target.absolutePath}")
         project.execShell(
-            "git", "clone",
-            "--branch", dependency.originRef,
-            "--depth", "1",
+            "git",
+            "clone",
+            "--branch",
+            dependency.originRef,
+            "--depth",
+            "1",
             dependency.originRepository,
             target.absolutePath
         )

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/GenerateJsonSchemaTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/GenerateJsonSchemaTask.kt
@@ -23,7 +23,6 @@ import org.gradle.api.tasks.TaskAction
  */
 open class GenerateJsonSchemaTask : DefaultTask() {
 
-
     init {
         group = "datadog"
         description = "Review the Android benchmark results and ensure they fit the provided rules"
@@ -104,7 +103,7 @@ open class GenerateJsonSchemaTask : DefaultTask() {
     }
 
     private fun getInputDir(): File {
-        return File("${project.projectDir.path}${File.separator}${inputDirPath}")
+        return File("${project.projectDir.path}${File.separator}$inputDirPath")
     }
 
     private fun getOutputDir(): File {

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReader.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/JsonSchemaReader.kt
@@ -210,7 +210,9 @@ class JsonSchemaReader(
             transformEnum(typeName, definition.type, definition.enum, definition.description)
         } else if (definition.constant != null) {
             transformConstant(definition.type, definition.constant, definition.description)
-        } else if (!definition.properties.isNullOrEmpty() || definition.additionalProperties != null) {
+        } else if (!definition.properties.isNullOrEmpty() ||
+            definition.additionalProperties != null
+        ) {
             generateDataClass(typeName, definition)
         } else if (!definition.allOf.isNullOrEmpty()) {
             generateTypeAllOf(typeName, definition.allOf)
@@ -223,6 +225,8 @@ class JsonSchemaReader(
                     "Definition reference not found: ${definition.ref}."
                 )
             }
+        } else if (definition.type == JsonType.OBJECT) {
+            generateDataClass(typeName, definition)
         } else {
             throw UnsupportedOperationException("Unsupported schema definition\n$definition")
         }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoDeserializerGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoDeserializerGenerator.kt
@@ -84,19 +84,24 @@ class PokoDeserializerGenerator(
         appendDeserializerFunctionBlock(funBuilder, definition)
 
         funBuilder.nextControlFlow(
-            "catch (%L: %T)", EXEPTION_VAR_NAME, ILLEGAL_STATE_EXCEPTION
+            "catch (%L: %T)",
+            EXCEPTION_VAR_NAME,
+            ILLEGAL_STATE_EXCEPTION
         )
         funBuilder.addStatement(
             "throw %T(%L.message)",
-            JSON_PARSE_EXCEPTION, EXEPTION_VAR_NAME
+            JSON_PARSE_EXCEPTION,
+            EXCEPTION_VAR_NAME
         )
         funBuilder.nextControlFlow(
-            "catch (%L: %T)", EXEPTION_VAR_NAME,
+            "catch (%L: %T)",
+            EXCEPTION_VAR_NAME,
             NUMBER_FORMAT_EXCEPTION
         )
         funBuilder.addStatement(
             "throw %T(%L.message)",
-            JSON_PARSE_EXCEPTION, EXEPTION_VAR_NAME
+            JSON_PARSE_EXCEPTION,
+            EXCEPTION_VAR_NAME
         )
         funBuilder.endControlFlow()
         return funBuilder.build()
@@ -162,7 +167,7 @@ class PokoDeserializerGenerator(
             "val %L = mutableMapOf<%T, %T>()",
             PokoGenerator.ADDITIONAL_PROPERTIES_NAME,
             STRING,
-            additionalProperties.asKotlinTypeName(
+            additionalProperties.additionalPropertyType(
                 nestedEnums,
                 nestedClasses,
                 knownTypes,
@@ -176,13 +181,20 @@ class PokoDeserializerGenerator(
             funBuilder.beginControlFlow("if (entry.key !in %L)", RESERVED_PROPERTIES_NAME)
         }
 
-        assignDeserializedProperty(
-            propertyType = additionalProperties,
-            assignee = "${PokoGenerator.ADDITIONAL_PROPERTIES_NAME}[entry.key]",
-            getter = "entry.value",
-            nullable = false,
-            funBuilder = funBuilder
-        )
+        if (additionalProperties is TypeDefinition.Class) {
+            funBuilder.addStatement(
+                "%L[entry.key] = entry.value",
+                PokoGenerator.ADDITIONAL_PROPERTIES_NAME
+            )
+        } else {
+            assignDeserializedProperty(
+                propertyType = additionalProperties,
+                assignee = "${PokoGenerator.ADDITIONAL_PROPERTIES_NAME}[entry.key]",
+                getter = "entry.value",
+                nullable = false,
+                funBuilder = funBuilder
+            )
+        }
 
         if (hasKnownProperties) {
             funBuilder.endControlFlow()
@@ -478,7 +490,7 @@ class PokoDeserializerGenerator(
         private const val FROM_JSON = "fromJson"
         private const val FROM_JSON_PARAM_NAME = "serializedObject"
         private const val ROOT_JSON_OBJECT_PARAM_NAME = "jsonObject"
-        private const val EXEPTION_VAR_NAME = "e"
+        private const val EXCEPTION_VAR_NAME = "e"
         private const val ARRAY_COLLECTION_VAR_NAME = "collection"
         private const val JSON_ARRAY_VAR_NAME = "jsonArray"
         private val JSON_PARSE_EXCEPTION =

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoExtensions.kt
@@ -7,6 +7,7 @@
 package com.datadog.gradle.plugin.jsonschema
 
 import android.databinding.tool.ext.joinToCamelCaseAsVar
+import com.squareup.kotlinpoet.ANY
 import com.squareup.kotlinpoet.BOOLEAN
 import com.squareup.kotlinpoet.ClassName
 import com.squareup.kotlinpoet.DOUBLE
@@ -128,5 +129,25 @@ internal fun TypeDefinition.asKotlinTypeName(
             nestedEnums.add(def)
             ClassName(packageName, rootTypeName, def.name)
         }
+    }
+}
+
+internal fun TypeDefinition.additionalPropertyType(
+    nestedEnums: MutableSet<TypeDefinition.Enum>,
+    nestedClasses: MutableSet<TypeDefinition.Class>,
+    knownTypes: MutableList<String>,
+    packageName: String,
+    rootTypeName: String
+): TypeName {
+    return if (this is TypeDefinition.Primitive) {
+        this.asKotlinTypeName(
+            nestedEnums,
+            nestedClasses,
+            knownTypes,
+            packageName,
+            rootTypeName
+        )
+    } else {
+        ANY.copy(nullable = true)
     }
 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoSerializerGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoSerializerGenerator.kt
@@ -45,7 +45,10 @@ class PokoSerializerGenerator {
 
         when (additionalProperties) {
             is TypeDefinition.Primitive -> funBuilder.addStatement("json.addProperty(k, v)")
-            is TypeDefinition.Class,
+            is TypeDefinition.Class -> funBuilder.addStatement(
+                "json.add(k, v.%L())",
+                TO_JSON_ELEMENT
+            )
             is TypeDefinition.Enum -> funBuilder.addStatement("json.add(k, v.%L()) }", TO_JSON)
             is TypeDefinition.Null -> funBuilder.addStatement("json.add(k, null) }")
             is TypeDefinition.Array -> throw IllegalStateException(
@@ -126,7 +129,8 @@ class PokoSerializerGenerator {
             funBuilder.addStatement(
                 "json.add(%S, %L.%L())",
                 property.name,
-                varName, TO_JSON
+                varName,
+                TO_JSON
             )
         }
     }
@@ -145,8 +149,10 @@ class PokoSerializerGenerator {
         }
 
         funBuilder.addStatement(
-            "val %LArray = %T(%L.size)", varName,
-            JSON_ARRAY, arrayVar
+            "val %LArray = %T(%L.size)",
+            varName,
+            JSON_ARRAY,
+            arrayVar
         )
         when (type.items) {
             is TypeDefinition.Null,
@@ -224,6 +230,7 @@ class PokoSerializerGenerator {
     companion object {
 
         private const val TO_JSON = "toJson"
+        private const val TO_JSON_ELEMENT = "toJsonElement"
         private val JSON_ELEMENT = ClassName.bestGuess("com.google.gson.JsonElement")
         private val JSON_OBJECT = ClassName.bestGuess("com.google.gson.JsonObject")
         private val JSON_ARRAY = ClassName.bestGuess("com.google.gson.JsonArray")

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelValidationTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelValidationTest.kt
@@ -110,7 +110,7 @@ class ModelValidationTest(
                 arrayOf("all_of_merged", "UserMerged"),
                 arrayOf("constant_number", "Version"),
                 arrayOf("sets", "Video"),
-                arrayOf("defaults_with_optionals","Bike")
+                arrayOf("defaults_with_optionals", "Bike")
             )
         }
     }

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelWithAdditionalAttributesTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelWithAdditionalAttributesTest.kt
@@ -1,0 +1,112 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.jsonschema
+
+import com.datadog.android.core.internal.utils.toJsonArray
+import com.example.forgery.ForgeryConfiguration
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import fr.xgouchet.elmyr.junit4.ForgeRule
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import java.util.Date
+
+class ModelWithAdditionalAttributesTest {
+
+    @get:Rule
+    val forge = ForgeRule()
+
+    @Before
+    fun `set up`() {
+        ForgeryConfiguration().configure(forge)
+    }
+
+    @Test
+    fun `validate model for additionalProperties with Any? key value type`() {
+        val type = Class.forName("com.example.model.Company")
+        val toJson = type.getMethod("toJson")
+        val fromJson = type.getMethod("fromJson", String::class.java)
+        repeat(10) {
+            val expectedModel = forge.getForgery(type)
+            val json = toJson.invoke(expectedModel).toString()
+            val generatedModel = fromJson.invoke(null, json)
+            val mapClass = Map::class.java
+            assertThat(generatedModel)
+                .overridingErrorMessage(
+                    "Deserialized model was not the same " +
+                        "with the serialized for type: [$type] and test iteration: [$it]"
+                )
+                .usingComparatorForType(additionalPropertiesComparator, mapClass)
+                .isEqualToIgnoringGivenFields(expectedModel, "information")
+            // Assertj does not apply the custom comparator recursively :(
+            val expectedInformation: Any? = expectedModel.getFieldValue("information")
+            val generatedInformation: Any? = generatedModel.getFieldValue("information")
+            if (expectedInformation == null && generatedInformation == null) {
+                return
+            }
+            assertThat(generatedInformation)
+                .overridingErrorMessage(
+                    "Deserialized information model was not the same " +
+                        "with the serialized one at test iteration: [$it]"
+                )
+                .usingComparatorForType(additionalPropertiesComparator, mapClass)
+                .isEqualToComparingFieldByField(expectedInformation)
+
+        }
+    }
+
+    private val additionalPropertiesComparator = Comparator<Map<*, *>> { t1, t2 ->
+        if (t1.size == t2.size) {
+            t1.forEach {
+                val expectedValue = t2[it.key]
+                val currentValue = it.value
+                val isEqual = if (currentValue is JsonElement) {
+                    when (expectedValue) {
+                        null -> currentValue == JsonNull.INSTANCE
+                        is Boolean -> currentValue.asBoolean == expectedValue
+                        is Int -> currentValue.asInt == expectedValue
+                        is Long -> currentValue.asLong == expectedValue
+                        is Float -> currentValue.asFloat == expectedValue
+                        is Double -> currentValue.asDouble == expectedValue
+                        is String -> currentValue.asString == expectedValue
+                        is Date -> currentValue.asLong == expectedValue
+                        is JsonObject -> currentValue.asJsonObject.toString() ==
+                            expectedValue.toString()
+                        is JsonArray -> currentValue.asJsonArray == expectedValue
+                        is Iterable<*> -> currentValue.asJsonArray == expectedValue.toJsonArray()
+                        else -> currentValue.asString == expectedValue.toString()
+                    }
+                } else {
+                    expectedValue == currentValue
+                }
+                if (!isEqual) {
+                    return@Comparator 1
+                }
+            }
+            0
+        } else {
+            1
+        }
+    }
+
+    /**
+     * Gets the field value from the target instance.
+     * @param fieldName the name of the field
+     */
+    inline fun <reified T, R : Any> R.getFieldValue(
+        fieldName: String,
+        enclosingClass: Class<R> = this.javaClass
+    ): T {
+        val field = enclosingClass.getDeclaredField(fieldName)
+        field.isAccessible = true
+        return field.get(this) as T
+    }
+}

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
@@ -118,6 +118,49 @@ val Comment = TypeDefinition.Class(
     )
 )
 
+val Company = TypeDefinition.Class(
+    name = "Company",
+    properties = listOf(
+        TypeProperty("name", TypeDefinition.Primitive(JsonPrimitiveType.STRING), true),
+        TypeProperty(
+            "ratings",
+            TypeDefinition.Class(
+                name = "Ratings",
+                properties = listOf(
+                    TypeProperty(
+                        "global",
+                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
+                        false
+                    )
+                ),
+                additionalProperties = TypeDefinition.Primitive(JsonPrimitiveType.INTEGER)
+            ),
+            true
+        ),
+        TypeProperty(
+            "information",
+            TypeDefinition.Class(
+                name = "Information",
+                properties = listOf(
+                    TypeProperty(
+                        "date",
+                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
+                        true
+                    ),
+                    TypeProperty(
+                        "priority",
+                        TypeDefinition.Primitive(JsonPrimitiveType.INTEGER),
+                        true
+                    )
+                ),
+                additionalProperties = TypeDefinition.Class("?", emptyList())
+            ),
+            true
+        )
+    ),
+    additionalProperties = TypeDefinition.Class("?", emptyList())
+)
+
 val Conflict = TypeDefinition.Class(
     name = "Conflict",
     properties = listOf(

--- a/buildSrc/src/test/kotlin/com/example/forgery/CompanyForgeryFactory.kt
+++ b/buildSrc/src/test/kotlin/com/example/forgery/CompanyForgeryFactory.kt
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.example.forgery
+
+import com.example.model.Company
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class CompanyForgeryFactory : ForgeryFactory<Company> {
+    override fun getForgery(forge: Forge): Company {
+        return Company(
+            name = forge.aNullable { forge.anAlphabeticalString() },
+            ratings = forge.aNullable {
+                Company.Ratings(
+                    global = aLong(),
+                    additionalProperties = aMap { anAlphabeticalString() to aLong() }
+                )
+            },
+            information = forge.aNullable {
+                Company.Information(
+                    forge.aNullable { forge.aLong() },
+                    forge.aNullable { forge.aLong() },
+                    additionalProperties = aMap { anAlphabeticalString() to aNullable { anHexadecimalString() } }
+                )
+            },
+            additionalProperties = forge.aMap { anAlphabeticalString() to aNullable { anHexadecimalString() } }
+        )
+    }
+}

--- a/buildSrc/src/test/kotlin/com/example/forgery/ForgeryConfiguration.kt
+++ b/buildSrc/src/test/kotlin/com/example/forgery/ForgeryConfiguration.kt
@@ -33,5 +33,6 @@ internal class ForgeryConfiguration : ForgeConfigurator {
         forge.addFactory(VersionForgeryFactory())
         forge.addFactory(VideoForgeryFactory())
         forge.addFactory(BikeForgeryFactory())
+        forge.addFactory(CompanyForgeryFactory())
     }
 }

--- a/buildSrc/src/test/kotlin/com/example/model/Company.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Company.kt
@@ -1,0 +1,143 @@
+package com.example.model
+
+import com.datadog.android.core.internal.utils.toJsonElement
+import com.google.gson.JsonElement
+import com.google.gson.JsonObject
+import com.google.gson.JsonParseException
+import com.google.gson.JsonParser
+import java.lang.IllegalStateException
+import java.lang.NumberFormatException
+import kotlin.Any
+import kotlin.Array
+import kotlin.Long
+import kotlin.String
+import kotlin.collections.Map
+import kotlin.jvm.JvmStatic
+import kotlin.jvm.Throws
+
+data class Company(
+    val name: String? = null,
+    val ratings: Ratings? = null,
+    val information: Information? = null,
+    val additionalProperties: Map<String, Any?> = emptyMap()
+) {
+    fun toJson(): JsonElement {
+        val json = JsonObject()
+        name?.let { json.addProperty("name", it) }
+        ratings?.let { json.add("ratings", it.toJson()) }
+        information?.let { json.add("information", it.toJson()) }
+        additionalProperties.forEach { (k, v) ->
+            json.add(k,v.toJsonElement())
+        }
+        return json
+    }
+
+    companion object {
+        private val RESERVED_PROPERTIES: Array<String> = arrayOf("name", "ratings", "information")
+
+        @JvmStatic
+        @Throws(JsonParseException::class)
+        fun fromJson(serializedObject: String): Company {
+            try {
+                val jsonObject = JsonParser.parseString(serializedObject).asJsonObject
+                val name = jsonObject.get("name")?.asString
+                val ratings = jsonObject.get("ratings")?.toString()?.let {
+                    Ratings.fromJson(it)
+                }
+                val information = jsonObject.get("information")?.toString()?.let {
+                    Information.fromJson(it)
+                }
+                val additionalProperties = mutableMapOf<String, Any?>()
+                for (entry in jsonObject.entrySet()) {
+                    if (entry.key !in RESERVED_PROPERTIES) {
+                        additionalProperties[entry.key] = entry.value
+                    }
+                }
+                return Company(name, ratings, information, additionalProperties)
+            } catch (e: IllegalStateException) {
+                throw JsonParseException(e.message)
+            } catch (e: NumberFormatException) {
+                throw JsonParseException(e.message)
+            }
+        }
+    }
+
+    data class Ratings(
+        val global: Long,
+        val additionalProperties: Map<String, Long> = emptyMap()
+    ) {
+        fun toJson(): JsonElement {
+            val json = JsonObject()
+            json.addProperty("global", global)
+            additionalProperties.forEach { (k, v) ->
+                json.addProperty(k, v)
+            }
+            return json
+        }
+
+        companion object {
+            private val RESERVED_PROPERTIES: Array<String> = arrayOf("global")
+
+            @JvmStatic
+            @Throws(JsonParseException::class)
+            fun fromJson(serializedObject: String): Ratings {
+                try {
+                    val jsonObject = JsonParser.parseString(serializedObject).asJsonObject
+                    val global = jsonObject.get("global").asLong
+                    val additionalProperties = mutableMapOf<String, Long>()
+                    for (entry in jsonObject.entrySet()) {
+                        if (entry.key !in RESERVED_PROPERTIES) {
+                            additionalProperties[entry.key] = entry.value.asLong
+                        }
+                    }
+                    return Ratings(global, additionalProperties)
+                } catch (e: IllegalStateException) {
+                    throw JsonParseException(e.message)
+                } catch (e: NumberFormatException) {
+                    throw JsonParseException(e.message)
+                }
+            }
+        }
+    }
+
+    data class Information(
+        val date: Long? = null,
+        val priority: Long? = null,
+        val additionalProperties: Map<String, Any?> = emptyMap()
+    ) {
+        fun toJson(): JsonElement {
+            val json = JsonObject()
+            date?.let { json.addProperty("date", it) }
+            priority?.let { json.addProperty("priority", it) }
+            additionalProperties.forEach { (k, v) ->
+                json.add(k,v.toJsonElement())
+            }
+            return json
+        }
+
+        companion object {
+            private val RESERVED_PROPERTIES: Array<String> = arrayOf("date", "priority")
+
+            @JvmStatic
+            @Throws(JsonParseException::class)
+            fun fromJson(serializedObject: String): Information {
+                try {
+                    val jsonObject = JsonParser.parseString(serializedObject).asJsonObject
+                    val date = jsonObject.get("date")?.asLong
+                    val priority = jsonObject.get("priority")?.asLong
+                    val additionalProperties = mutableMapOf<String, Any?>()
+                    for (entry in jsonObject.entrySet()) {
+                        if (entry.key !in RESERVED_PROPERTIES) {
+                            additionalProperties[entry.key] = entry.value
+                        }
+                    }
+                    return Information(date, priority, additionalProperties)
+                } catch (e: IllegalStateException) {
+                    throw JsonParseException(e.message)
+                } catch (e: NumberFormatException) {
+                    throw JsonParseException(e.message)
+                }
+            }
+        }
+    }
+}

--- a/buildSrc/src/test/kotlin/com/example/model/MiscUtils.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/MiscUtils.kt
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.utils
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonElement
+import com.google.gson.JsonNull
+import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import java.util.Date
+
+// Placeholder functions needed for Deserializer code generator. These functions are needed for
+// unit tests and will be overridden in the main project.
+
+internal fun Any?.toJsonElement(): JsonElement {
+    return when (this) {
+        null -> JsonNull.INSTANCE
+        JsonNull.INSTANCE -> JsonNull.INSTANCE
+        is Boolean -> JsonPrimitive(this)
+        is Int -> JsonPrimitive(this)
+        is Long -> JsonPrimitive(this)
+        is Float -> JsonPrimitive(this)
+        is Double -> JsonPrimitive(this)
+        is String -> JsonPrimitive(this)
+        is Date -> JsonPrimitive(this.time)
+        is Iterable<*> -> this.toJsonArray()
+        is JsonObject -> this
+        is JsonArray -> this
+        is JsonPrimitive -> this
+        else -> JsonPrimitive(toString())
+    }
+}
+
+internal fun Iterable<*>.toJsonArray(): JsonElement {
+    val array = JsonArray()
+    forEach {
+        array.add(it.toJsonElement())
+    }
+    return array
+}

--- a/buildSrc/src/test/resources/input/additional_props_any.json
+++ b/buildSrc/src/test/resources/input/additional_props_any.json
@@ -1,0 +1,38 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Company",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "ratings": {
+      "type": "object",
+      "properties": {
+        "global": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": {
+        "type": "integer"
+      },
+      "required": [ "global"]
+    },
+    "information": {
+      "properties": {
+        "date":{
+          "type": "integer"
+        },
+        "priority": {
+          "type": "integer"
+        }
+      },
+      "additionalProperties": {
+        "type": "object"
+      }
+    }
+  },
+  "additionalProperties": {
+    "type": "object"
+  }
+}

--- a/dd-sdk-android/build.gradle.kts
+++ b/dd-sdk-android/build.gradle.kts
@@ -156,7 +156,8 @@ apply(from = "generate_pokos.gradle.kts")
 kotlinConfig()
 detektConfig(
     excludes = listOf(
-        "**/com/datadog/android/rum/model/**"
+        "**/com/datadog/android/rum/model/**",
+        "**/com/datadog/android/core/model/**"
     )
 )
 ktLintConfig()


### PR DESCRIPTION
### What does this PR do?

This PR adds a new capability to the PokoGenerator to be able to use `Map<String,Any?>` types when declaring the `additionalAttributes` into the json schemas. 

### Motivation

We needed this new capability to be able to generate internal model like the `UserInfo` from the `PokoGenerator` and to rely on the generated methods for deserializing/serializing the model instances.

### Additional Notes

Please note that because `Any` is not a valid json schema type we could not validate the `TypeDefinition` (`Company`) generated from the `additonal_props_any.json` schema but another test class was provided were we test the serialization/deserialization methods.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

