### PR TITLE
RUMM-1079 EventMapper - prevent discarding View events

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -31,7 +31,7 @@ DEPRECATED class com.datadog.android.DatadogConfig
     fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
     fun addPlugin(com.datadog.android.plugin.DatadogPlugin, com.datadog.android.plugin.Feature): Builder
     fun sampleRumSessions(Float): Builder
-    fun setRumViewEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ViewEvent>): Builder
+    fun setRumViewEventMapper(com.datadog.android.event.ViewEventMapper): Builder
     fun setRumResourceEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ResourceEvent>): Builder
     fun setRumActionEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ActionEvent>): Builder
     fun setRumErrorEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ErrorEvent>): Builder
@@ -97,7 +97,7 @@ class com.datadog.android.core.configuration.Configuration
     fun setBatchSize(BatchSize): Builder
     fun setUploadFrequency(UploadFrequency): Builder
     fun sampleRumSessions(Float): Builder
-    fun setRumViewEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ViewEvent>): Builder
+    fun setRumViewEventMapper(com.datadog.android.event.ViewEventMapper): Builder
     fun setRumResourceEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ResourceEvent>): Builder
     fun setRumActionEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ActionEvent>): Builder
     fun setRumErrorEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ErrorEvent>): Builder
@@ -133,6 +133,8 @@ class com.datadog.android.core.model.NetworkInfo
       fun fromJson(kotlin.String): Connectivity
 interface com.datadog.android.event.EventMapper<T: Any>
   fun map(T): T?
+interface com.datadog.android.event.ViewEventMapper : EventMapper<com.datadog.android.rum.model.ViewEvent>
+  override fun map(com.datadog.android.rum.model.ViewEvent): com.datadog.android.rum.model.ViewEvent
 object com.datadog.android.log.LogAttributes
   const val APPLICATION_PACKAGE: String
   const val APPLICATION_VERSION: String

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.event.EventMapper
+import com.datadog.android.event.ViewEventMapper
 import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.plugin.Feature
 import com.datadog.android.rum.internal.domain.RumContext.Companion.NULL_UUID
@@ -460,12 +461,12 @@ private constructor(
         }
 
         /**
-         * Sets the [EventMapper] for the RUM [ViewEvent]. You can use this interface implementation
+         * Sets the [ViewEventMapper] for the RUM [ViewEvent]. You can use this interface implementation
          * to modify the [ViewEvent] attributes before serialisation.
          *
-         * @param eventMapper the [EventMapper] implementation.
+         * @param eventMapper the [ViewEventMapper] implementation.
          */
-        fun setRumViewEventMapper(eventMapper: EventMapper<ViewEvent>): Builder {
+        fun setRumViewEventMapper(eventMapper: ViewEventMapper): Builder {
             rumConfig = rumConfig.copy(
                 rumEventMapper = rumConfig.rumEventMapper.copy(viewEventMapper = eventMapper)
             )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -13,6 +13,7 @@ import com.datadog.android.DatadogInterceptor
 import com.datadog.android.core.internal.event.NoOpEventMapper
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.event.EventMapper
+import com.datadog.android.event.ViewEventMapper
 import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.plugin.Feature as PluginFeature
 import com.datadog.android.rum.internal.domain.event.RumEvent
@@ -346,12 +347,12 @@ internal constructor(
         }
 
         /**
-         * Sets the [EventMapper] for the RUM [ViewEvent]. You can use this interface implementation
+         * Sets the [ViewEventMapper] for the RUM [ViewEvent]. You can use this interface implementation
          * to modify the [ViewEvent] attributes before serialisation.
          *
-         * @param eventMapper the [EventMapper] implementation.
+         * @param eventMapper the [ViewEventMapper] implementation.
          */
-        fun setRumViewEventMapper(eventMapper: EventMapper<ViewEvent>): Builder {
+        fun setRumViewEventMapper(eventMapper: ViewEventMapper): Builder {
             applyIfFeatureEnabled(PluginFeature.RUM, "setRumViewEventMapper") {
                 rumConfig = rumConfig.copy(
                     rumEventMapper = getRumEventMapper().copy(viewEventMapper = eventMapper)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/event/ViewEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/event/ViewEventMapper.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.event
+
+import com.datadog.android.rum.model.ViewEvent
+
+/**
+ * An interface which can be implemented to modify the writable attributes inside ViewEvent.
+ */
+interface ViewEventMapper : EventMapper<ViewEvent> {
+    /**
+     * By implementing this method you can intercept and modify the writable
+     * attributes inside any event [ViewEvent] before it gets serialised.
+     *
+     * @param event the event to be serialised
+     * @return the modified event [ViewEvent]
+     *
+     */
+    override fun map(event: ViewEvent): ViewEvent
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
@@ -53,17 +53,17 @@ internal data class RumEventMapper(
             (bundledMappedEvent == null || bundledMappedEvent != event.event)
         ) {
             devLogger.w(
-                VIEW_EVENT_NULL_WARNING_MESSAGE.format(event.toString())
+                VIEW_EVENT_NULL_WARNING_MESSAGE.format(event)
             )
             event
         } else if (bundledMappedEvent == null) {
             devLogger.w(
-                EVENT_NULL_WARNING_MESSAGE.format(event.toString())
+                EVENT_NULL_WARNING_MESSAGE.format(event)
             )
             null
         } else if (bundledMappedEvent !== event.event) {
             devLogger.w(
-                NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(event.toString())
+                NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(event)
             )
             null
         } else {
@@ -73,13 +73,13 @@ internal data class RumEventMapper(
 
     companion object {
         internal const val VIEW_EVENT_NULL_WARNING_MESSAGE =
-            "RumEventMapper: the returned mapped ViewEvent was null." +
+            "RumEventMapper: the returned mapped ViewEvent was null. " +
                 "The original event object will be used instead: %s"
         internal const val EVENT_NULL_WARNING_MESSAGE =
-            "RumEventMapper: the returned mapped object was null." +
+            "RumEventMapper: the returned mapped object was null. " +
                 "This event will be dropped: %s"
         internal const val NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE =
-            "RumEventMapper: the returned mapped object was not the" +
+            "RumEventMapper: the returned mapped object was not the " +
                 "same instance as the original object. This event will be dropped: %s"
         internal const val NO_EVENT_MAPPER_ASSIGNED_WARNING_MESSAGE =
             "RumEventMapper: there was no EventMapper assigned for" +

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
@@ -10,6 +10,7 @@ import android.os.Build
 import android.util.Log
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.event.EventMapper
+import com.datadog.android.event.ViewEventMapper
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.plugin.Feature
@@ -17,7 +18,6 @@ import com.datadog.android.rum.assertj.RumConfigAssert.Companion.assertThat
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent
-import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import com.datadog.android.utils.forge.Configurator
@@ -1164,7 +1164,7 @@ internal class DatadogConfigBuilderTest {
     fun `M provide the update mapper into RUM config W all event mappers are set`() {
         // GIVEN
         val mockActionEventMapper: EventMapper<ActionEvent> = mock()
-        val mockViewEventMapper: EventMapper<ViewEvent> = mock()
+        val mockViewEventMapper: ViewEventMapper = mock()
         val mockResourceEventMapper: EventMapper<ResourceEvent> = mock()
         val mockErrorEventMapper: EventMapper<ErrorEvent> = mock()
 
@@ -1198,8 +1198,7 @@ internal class DatadogConfigBuilderTest {
     @Test
     fun `M add the event mapper into the RUM config W { setRumViewEventMapper }`() {
         // GIVEN
-        val mockMapper: EventMapper<ViewEvent> = mock()
-
+        val mockMapper: ViewEventMapper = mock()
         // WHEN
         val config =
             DatadogConfig.Builder(fakeClientToken, fakeEnvName, fakeApplicationId)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import com.datadog.android.DatadogEndpoint
 import com.datadog.android.core.internal.event.NoOpEventMapper
 import com.datadog.android.event.EventMapper
+import com.datadog.android.event.ViewEventMapper
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.plugin.Feature
@@ -19,7 +20,6 @@ import com.datadog.android.rum.internal.domain.event.RumEventMapper
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent
-import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import com.datadog.android.utils.forge.Configurator
@@ -401,7 +401,7 @@ internal class ConfigurationBuilderTest {
     @Test
     fun `𝕄 build config with RUM View eventMapper 𝕎 setRumViewEventMapper() and build()`() {
         // Given
-        val eventMapper: EventMapper<ViewEvent> = mock()
+        val eventMapper: ViewEventMapper = mock()
 
         // When
         val config = testedBuilder
@@ -571,7 +571,7 @@ internal class ConfigurationBuilderTest {
             crashReportsEnabled = true,
             rumEnabled = false
         )
-        val eventMapper: EventMapper<ViewEvent> = mock()
+        val eventMapper: ViewEventMapper = mock()
 
         // When
         testedBuilder.setRumViewEventMapper(eventMapper)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
@@ -194,7 +194,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isEqualTo(fakeRumEvent)
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.VIEW_EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent.toString())
+            RumEventMapper.VIEW_EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent)
         )
     }
 
@@ -214,7 +214,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent.toString())
+            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent)
 
         )
     }
@@ -235,7 +235,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent.toString())
+            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent)
 
         )
     }
@@ -256,7 +256,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent.toString())
+            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent)
 
         )
     }
@@ -277,7 +277,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isEqualTo(fakeRumEvent)
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.VIEW_EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent.toString())
+            RumEventMapper.VIEW_EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent)
         )
     }
 
@@ -297,7 +297,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(fakeRumEvent.toString())
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(fakeRumEvent)
 
         )
     }
@@ -318,7 +318,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(fakeRumEvent.toString())
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(fakeRumEvent)
         )
     }
 
@@ -338,7 +338,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(fakeRumEvent.toString())
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(fakeRumEvent)
 
         )
     }


### PR DESCRIPTION
### What does this PR do?

In this PR we introduce the `ViewEventMapper` interface and will enforce the argument of the Public API method which provides the mapper for the View events to extend from this new interface. By doing this we will prevent the View events from being discarded from the mapper.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

