### PR TITLE
RUMM-1060: Sanitize `custom_timings` attribute keys

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DataConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DataConstraints.kt
@@ -18,4 +18,6 @@ internal interface DataConstraints {
     ): Map<String, Any?>
 
     fun validateTags(tags: List<String>): List<String>
+
+    fun validateEvent(rumEvent: Any): Any
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
@@ -26,7 +26,8 @@ internal class RumEventSerializer(
     // region Serializer
 
     override fun serialize(model: RumEvent): String {
-        val json = model.event.toJson().asJsonObject
+
+        val json = dataConstraints.validateEvent(model.event).toJson().asJsonObject
 
         addCustomAttributes(
             dataConstraints.validateAttributes(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
@@ -48,6 +48,9 @@ internal class RumEventDeserializerTest {
             whenever(it.validateTags(any())).thenAnswer {
                 it.getArgument(0)
             }
+            whenever(it.validateEvent(any())).thenAnswer {
+                it.getArgument(0)
+            }
         }
     )
 


### PR DESCRIPTION
### What does this PR do?

Follow up on changes described [here](https://github.com/DataDog/rum-events-format/pull/28/files): `ViewEvent.CustomTimings` attributes allows limited set of characters. This change does the necessary sanitization (unsupported characters are replaced with `_`) and logs the warning when key is changed.

### Motivation

Changed introduced in https://github.com/DataDog/rum-events-format/pull/28/files

### Additional Notes

N/A

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

