### PR TITLE
RUMM-1080 validate event count

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/data/file/RumFileWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/data/file/RumFileWriter.kt
@@ -45,11 +45,15 @@ internal class RumFileWriter(
                 is ViewEvent -> persistViewEvent(data)
                 is ActionEvent -> notifyEventSent(event.view.id, EventType.ACTION)
                 is ResourceEvent -> notifyEventSent(event.view.id, EventType.RESOURCE)
-                is ErrorEvent -> notifyEventSent(event.view.id, EventType.ERROR)
+                is ErrorEvent -> {
+                    if (event.error.isCrash == true) {
+                        notifyEventSent(event.view.id, EventType.CRASH)
+                    } else {
+                        notifyEventSent(event.view.id, EventType.ERROR)
+                    }
+                }
                 is LongTaskEvent -> notifyEventSent(event.view.id, EventType.LONG_TASK)
             }
-        } else {
-            System.err.println("writeDataFailed!")
         }
         return writeDataSuccess
     }
@@ -70,8 +74,6 @@ internal class RumFileWriter(
         val rumMonitor = GlobalRum.get()
         if (rumMonitor is AdvancedRumMonitor) {
             rumMonitor.eventSent(viewId, eventType)
-        } else {
-            System.err.println("Monitor is not an AdvancedRumMonitor: $rumMonitor")
         }
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -204,7 +204,6 @@ internal class RumActionScope(
                 userExtraAttributes = user.additionalProperties
             )
             writer.write(rumEvent)
-            parentScope.handleEvent(RumRawEvent.SentAction(), writer)
         } else {
             devLogger.i(
                 "RUM Action $actionId ($actualType on $name) was dropped " +

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -100,15 +100,44 @@ internal sealed class RumRawEvent {
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
-    internal data class SentResource(
+    internal data class ResourceSent(
+        val viewId: String,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
-    internal data class SentAction(
+    internal data class ActionSent(
+        val viewId: String,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
-    internal data class SentError(
+    internal data class ErrorSent(
+        val viewId: String,
+        val isCrash: Boolean,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
+    internal data class LongTaskSent(
+        val viewId: String,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
+    internal data class ResourceDropped(
+        val viewId: String,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
+    internal data class ActionDropped(
+        val viewId: String,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
+    internal data class ErrorDropped(
+        val viewId: String,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
+    internal data class LongTaskDropped(
+        val viewId: String,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -176,7 +176,6 @@ internal class RumResourceScope(
             userExtraAttributes = user.additionalProperties
         )
         writer.write(rumEvent)
-        parentScope.handleEvent(RumRawEvent.SentResource(), writer)
         sent = true
     }
 
@@ -241,7 +240,6 @@ internal class RumResourceScope(
             userExtraAttributes = user.additionalProperties
         )
         writer.write(rumEvent)
-        parentScope.handleEvent(RumRawEvent.SentError(), writer)
         sent = true
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -233,11 +233,6 @@ internal class RumViewScope(
             userExtraAttributes = user.additionalProperties
         )
         writer.write(rumEvent)
-        errorCount++
-        if (event.isFatal) {
-            crashCount++
-        }
-        sendViewUpdate(event, writer)
     }
 
     private fun onAddCustomTiming(event: RumRawEvent.AddCustomTiming, writer: Writer<RumEvent>) {
@@ -394,9 +389,6 @@ internal class RumViewScope(
             userExtraAttributes = user.additionalProperties
         )
         writer.write(rumEvent)
-
-        actionCount++
-        sendViewUpdate(event, writer)
     }
 
     private fun getStartupTime(event: RumRawEvent.ApplicationStarted): Long {
@@ -444,8 +436,6 @@ internal class RumViewScope(
             userExtraAttributes = user.additionalProperties
         )
         writer.write(rumEvent)
-        longTaskCount++
-        sendViewUpdate(event, writer)
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -33,4 +33,6 @@ internal interface AdvancedRumMonitor : RumMonitor {
         source: RumErrorSource,
         throwable: Throwable
     )
+
+    fun eventSent(viewId: String, type: EventType)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -35,4 +35,6 @@ internal interface AdvancedRumMonitor : RumMonitor {
     )
 
     fun eventSent(viewId: String, type: EventType)
+
+    fun eventDropped(viewId: String, type: EventType)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -234,6 +234,10 @@ internal class DatadogRumMonitor(
         )
     }
 
+    override fun eventSent(viewId: String, type: EventType) {
+        TODO("Not yet implemented")
+    }
+
     // endregion
 
     // region Internal

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -238,6 +238,10 @@ internal class DatadogRumMonitor(
         TODO("Not yet implemented")
     }
 
+    override fun eventDropped(viewId: String, type: EventType) {
+        TODO("Not yet implemented")
+    }
+
     // endregion
 
     // region Internal

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -235,11 +235,28 @@ internal class DatadogRumMonitor(
     }
 
     override fun eventSent(viewId: String, type: EventType) {
-        TODO("Not yet implemented")
+        when (type) {
+            EventType.ACTION -> handleEvent(RumRawEvent.ActionSent(viewId))
+            EventType.RESOURCE -> handleEvent(RumRawEvent.ResourceSent(viewId))
+            EventType.ERROR -> handleEvent(RumRawEvent.ErrorSent(viewId, false))
+            EventType.CRASH -> handleEvent(RumRawEvent.ErrorSent(viewId, true))
+            EventType.LONG_TASK -> handleEvent(RumRawEvent.LongTaskSent(viewId))
+            EventType.VIEW -> {
+                // Nothing to do
+            }
+        }
     }
 
     override fun eventDropped(viewId: String, type: EventType) {
-        TODO("Not yet implemented")
+        when (type) {
+            EventType.ACTION -> handleEvent(RumRawEvent.ActionDropped(viewId))
+            EventType.RESOURCE -> handleEvent(RumRawEvent.ResourceDropped(viewId))
+            EventType.ERROR, EventType.CRASH -> handleEvent(RumRawEvent.ErrorDropped(viewId))
+            EventType.LONG_TASK -> handleEvent(RumRawEvent.LongTaskDropped(viewId))
+            EventType.VIEW -> {
+                // Nothing to do
+            }
+        }
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/EventType.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/EventType.kt
@@ -11,5 +11,6 @@ internal enum class EventType {
     ACTION,
     RESOURCE,
     ERROR,
+    CRASH,
     LONG_TASK
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/EventType.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/EventType.kt
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.monitor
+
+internal enum class EventType {
+    VIEW,
+    ACTION,
+    RESOURCE,
+    ERROR,
+    LONG_TASK
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/data/file/RumFileWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/data/file/RumFileWriterTest.kt
@@ -456,12 +456,16 @@ internal class RumFileWriterTest {
     }
 
     @Test
-    fun `M notify the RumMonitor W write() { ErrorEvent }`(
+    fun `M notify the RumMonitor W write() { ErrorEvent isCrash=false }`(
         @Forgery fakeModel: RumEvent,
         @Forgery errorEvent: ErrorEvent
     ) {
         // GIVEN
-        val rumEvent = fakeModel.copy(event = errorEvent)
+        val rumEvent = fakeModel.copy(
+            event = errorEvent.copy(
+                error = errorEvent.error.copy(isCrash = false)
+            )
+        )
         whenever(mockRumSerializer.serialize(rumEvent)) doReturn fakeSerializedEvent
         whenever(mockOrchestrator.getWritableFile(any())).thenReturn(fakeOutputFile)
 
@@ -470,6 +474,27 @@ internal class RumFileWriterTest {
 
         // THEN
         verify(mockRumMonitor).eventSent(errorEvent.view.id, EventType.ERROR)
+    }
+
+    @Test
+    fun `M notify the RumMonitor W write() { ErrorEvent isCrash=true }`(
+        @Forgery fakeModel: RumEvent,
+        @Forgery errorEvent: ErrorEvent
+    ) {
+        // GIVEN
+        val rumEvent = fakeModel.copy(
+            event = errorEvent.copy(
+                error = errorEvent.error.copy(isCrash = true)
+            )
+        )
+        whenever(mockRumSerializer.serialize(rumEvent)) doReturn fakeSerializedEvent
+        whenever(mockOrchestrator.getWritableFile(any())).thenReturn(fakeOutputFile)
+
+        // WHEN
+        testedWriter.write(rumEvent)
+
+        // THEN
+        verify(mockRumMonitor).eventSent(errorEvent.view.id, EventType.CRASH)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
@@ -9,8 +9,13 @@ package com.datadog.android.rum.internal.domain.event
 import android.util.Log
 import com.datadog.android.event.EventMapper
 import com.datadog.android.log.internal.logger.LogHandler
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.NoOpRumMonitor
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
+import com.datadog.android.rum.internal.monitor.EventType
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.utils.forge.Configurator
@@ -18,14 +23,17 @@ import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.android.utils.mockSdkLogHandler
 import com.datadog.android.utils.restoreSdkLogHandler
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -56,17 +64,28 @@ internal class RumEventMapperTest {
     lateinit var mockViewEventMapper: EventMapper<ViewEvent>
 
     @Mock
+    lateinit var mockRumMonitor: AdvancedRumMonitor
+
+    @Mock
     lateinit var mockSdkLogHandler: LogHandler
 
     lateinit var mockDevLogHandler: LogHandler
 
     lateinit var originalLogHandler: LogHandler
 
+    @Forgery
+    lateinit var fakeRumEvent: RumEvent
+
     @BeforeEach
     fun `set up`() {
         originalLogHandler = mockSdkLogHandler(mockSdkLogHandler)
         mockDevLogHandler = mockDevLogHandler()
+
+        GlobalRum.monitor = mockRumMonitor
+        GlobalRum.isRegistered.set(true)
+
         whenever(mockViewEventMapper.map(any())).thenAnswer { it.arguments[0] }
+
         testedRumEventMapper = RumEventMapper(
             actionEventMapper = mockActionEventMapper,
             viewEventMapper = mockViewEventMapper,
@@ -78,14 +97,16 @@ internal class RumEventMapperTest {
     @AfterEach
     fun `tear down`() {
         restoreSdkLogHandler(originalLogHandler)
+
+        GlobalRum.monitor = NoOpRumMonitor()
+        GlobalRum.isRegistered.set(false)
     }
 
     @Test
     fun `M map the bundled event W map { ViewEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ViewEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockViewEventMapper.map(fakeBundledEvent)).thenReturn(fakeBundledEvent)
 
         // WHEN
@@ -100,8 +121,7 @@ internal class RumEventMapperTest {
     fun `M map the bundled event W map { ResourceEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ResourceEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockResourceEventMapper.map(fakeBundledEvent)).thenReturn(fakeBundledEvent)
 
         // WHEN
@@ -116,8 +136,7 @@ internal class RumEventMapperTest {
     fun `M map the bundled event W map { ErrorEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ErrorEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockErrorEventMapper.map(fakeBundledEvent)).thenReturn(fakeBundledEvent)
 
         // WHEN
@@ -132,8 +151,7 @@ internal class RumEventMapperTest {
     fun `M map the bundled event W map { ActionEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ActionEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockActionEventMapper.map(fakeBundledEvent)).thenReturn(fakeBundledEvent)
 
         // WHEN
@@ -148,7 +166,6 @@ internal class RumEventMapperTest {
     fun `M return the original event W map { no internal mapper used }`(forge: Forge) {
         // GIVEN
         testedRumEventMapper = RumEventMapper()
-        val fakeRumEvent: RumEvent = forge.getForgery()
         val bundledEvent = fakeRumEvent.event
 
         // WHEN
@@ -163,7 +180,6 @@ internal class RumEventMapperTest {
     fun `M return the original event W map { bundled event unknown }`(forge: Forge) {
         // GIVEN
         testedRumEventMapper = RumEventMapper()
-        val fakeRumEvent: RumEvent = forge.getForgery()
         val fakeRumEventCopy = fakeRumEvent.copy(event = Any())
 
         // WHEN
@@ -182,8 +198,7 @@ internal class RumEventMapperTest {
     fun `M use the original event W map returns null object { ViewEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ViewEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockViewEventMapper.map(fakeBundledEvent))
             .thenReturn(null)
 
@@ -202,8 +217,7 @@ internal class RumEventMapperTest {
     fun `M return null event W map returns null object { ResourceEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ResourceEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockResourceEventMapper.map(fakeBundledEvent))
             .thenReturn(null)
 
@@ -223,8 +237,7 @@ internal class RumEventMapperTest {
     fun `M return null event W map returns null object { ErrorEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ErrorEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockErrorEventMapper.map(fakeBundledEvent))
             .thenReturn(null)
 
@@ -244,8 +257,7 @@ internal class RumEventMapperTest {
     fun `M return null event W map returns null object { ActionEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ActionEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockActionEventMapper.map(fakeBundledEvent))
             .thenReturn(null)
 
@@ -265,8 +277,7 @@ internal class RumEventMapperTest {
     fun `M use the original event W map returns different object { ViewEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ViewEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockViewEventMapper.map(fakeBundledEvent))
             .thenReturn(forge.getForgery())
 
@@ -285,8 +296,7 @@ internal class RumEventMapperTest {
     fun `M return null event W map returns different object { ResourceEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ResourceEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockResourceEventMapper.map(fakeBundledEvent))
             .thenReturn(forge.getForgery())
 
@@ -306,8 +316,7 @@ internal class RumEventMapperTest {
     fun `M return null event W map returns different object { ErrorEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ErrorEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockErrorEventMapper.map(fakeBundledEvent))
             .thenReturn(forge.getForgery())
 
@@ -326,8 +335,7 @@ internal class RumEventMapperTest {
     fun `M return null event W map returns different object { ActionEvent }`(forge: Forge) {
         // GIVEN
         val fakeBundledEvent = forge.getForgery<ActionEvent>()
-        val fakeRumEvent: RumEvent =
-            forge.getForgery<RumEvent>().copy(event = fakeBundledEvent)
+        fakeRumEvent = fakeRumEvent.copy(event = fakeBundledEvent)
         whenever(mockActionEventMapper.map(fakeBundledEvent))
             .thenReturn(forge.getForgery())
 
@@ -341,5 +349,71 @@ internal class RumEventMapperTest {
             RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(fakeRumEvent)
 
         )
+    }
+
+    @Test
+    fun `𝕄 warn the RUM Monitor 𝕎 map() {action dropped}`(
+        @Forgery actionEvent: ActionEvent
+    ) {
+        // Given
+        fakeRumEvent = fakeRumEvent.copy(event = actionEvent)
+        whenever(mockActionEventMapper.map(actionEvent)) doReturn null
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        verify(mockRumMonitor).eventDropped(actionEvent.view.id, EventType.ACTION)
+    }
+
+    @Test
+    fun `𝕄 warn the RUM Monitor 𝕎 map() {resource dropped}`(
+        @Forgery resourceEvent: ResourceEvent
+    ) {
+        // Given
+        fakeRumEvent = fakeRumEvent.copy(event = resourceEvent)
+        whenever(mockResourceEventMapper.map(resourceEvent)) doReturn null
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        verify(mockRumMonitor).eventDropped(resourceEvent.view.id, EventType.RESOURCE)
+    }
+
+    @Test
+    fun `𝕄 warn the RUM Monitor 𝕎 map() {error dropped}`(
+        @Forgery errorEvent: ErrorEvent
+    ) {
+        // Given
+        fakeRumEvent = fakeRumEvent.copy(event = errorEvent)
+        whenever(mockErrorEventMapper.map(errorEvent)) doReturn null
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        verify(mockRumMonitor).eventDropped(errorEvent.view.id, EventType.ERROR)
+    }
+
+    // TODO RUMM-1146 enable data scrubbing for long tasks
+    @Disabled
+    @Test
+    fun `𝕄 warn the RUM Monitor 𝕎 map() {longTask dropped}`(
+        @Forgery longTaskEvent: LongTaskEvent
+    ) {
+        // Given
+        fakeRumEvent = fakeRumEvent.copy(event = longTaskEvent)
+        // whenever(mockLongTaskEventMapper.map(longTaskEvent)) doReturn null
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        verify(mockRumMonitor).eventDropped(longTaskEvent.view.id, EventType.LONG_TASK)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -17,11 +17,11 @@ import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.utils.mockCoreFeature
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.isA
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.same
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
@@ -153,10 +153,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -231,10 +228,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -307,10 +301,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -356,10 +347,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -397,10 +385,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -444,10 +429,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -485,10 +467,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -524,10 +503,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -564,10 +540,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -605,10 +578,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -648,10 +618,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -689,10 +656,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -736,10 +700,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -777,10 +738,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -818,10 +776,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -859,10 +814,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -901,10 +853,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -943,10 +892,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
         assertThat(result2).isNull()
@@ -1053,10 +999,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -1091,10 +1034,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1128,10 +1068,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1171,10 +1108,7 @@ internal class RumActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.rum.internal.domain.scope
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.Writer
 import com.datadog.android.core.internal.domain.Time
-import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.UserInfo
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
@@ -21,11 +20,11 @@ import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.utils.mockCoreFeature
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.isA
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.same
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
@@ -64,9 +63,6 @@ internal class RumContinuousActionScopeTest {
 
     @Mock
     lateinit var mockParentScope: RumScope
-
-    @Mock
-    lateinit var mockTimeProvider: TimeProvider
 
     @Mock
     lateinit var mockWriter: Writer<RumEvent>
@@ -212,10 +208,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -261,10 +254,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -308,10 +298,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -357,10 +344,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -409,10 +393,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -458,10 +439,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -510,10 +488,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -556,10 +531,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -609,10 +581,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -648,10 +617,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -686,10 +652,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -725,10 +688,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -766,10 +726,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -807,10 +764,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -855,10 +809,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -897,10 +848,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -939,10 +887,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -982,10 +927,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -1025,10 +967,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -1088,10 +1027,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isNull()
     }
@@ -1198,10 +1134,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
@@ -1242,10 +1175,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isSameAs(testedScope)
@@ -1287,10 +1217,7 @@ internal class RumContinuousActionScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentAction>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -31,10 +31,8 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.atMost
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.isA
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
-import com.nhaarman.mockitokotlin2.same
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
@@ -132,7 +130,7 @@ internal class RumResourceScopeTest {
     }
 
     @Test
-    fun `𝕄 send Resource 𝕎 handleEvent(StopResource)`(
+    fun `𝕄 send Resource event 𝕎 handleEvent(StopResource)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
         @LongForgery(0, 1024) size: Long,
@@ -174,10 +172,7 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -227,10 +222,7 @@ internal class RumResourceScopeTest {
                     hasProviderDomain(URL(fakeUrl).host)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -290,10 +282,7 @@ internal class RumResourceScopeTest {
                     hasProviderDomain(brokenUrl)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -345,10 +334,7 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -398,10 +384,7 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -441,10 +424,7 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -477,10 +457,7 @@ internal class RumResourceScopeTest {
                     hasActionId(fakeParentContext.actionId)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -501,10 +478,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(capture())
             assertThat(lastValue.event).isNotInstanceOf(ErrorEvent::class.java)
         }
-        verify(mockParentScope, never()).handleEvent(
-            isA<RumRawEvent.SentError>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -524,10 +498,7 @@ internal class RumResourceScopeTest {
             verify(mockWriter).write(capture())
             assertThat(lastValue.event).isNotInstanceOf(ErrorEvent::class.java)
         }
-        verify(mockParentScope, never()).handleEvent(
-            isA<RumRawEvent.SentError>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -576,10 +547,7 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -631,10 +599,7 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(resultTiming).isEqualTo(testedScope)
         assertThat(result).isEqualTo(null)
@@ -687,10 +652,7 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(resultTiming).isEqualTo(testedScope)
         assertThat(result).isEqualTo(null)
@@ -733,10 +695,7 @@ internal class RumResourceScopeTest {
                     hasErrorType(throwable.javaClass.canonicalName)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentError>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -791,10 +750,7 @@ internal class RumResourceScopeTest {
                     hasErrorType(throwable.javaClass.canonicalName)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentError>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -839,10 +795,7 @@ internal class RumResourceScopeTest {
                     hasErrorType(throwable.javaClass.canonicalName)
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentError>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -887,10 +840,7 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentError>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -943,10 +893,7 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentError>(),
-            same(mockWriter)
-        )
+        verify(mockParentScope, never()).handleEvent(any(), any())
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isEqualTo(null)
     }
@@ -1059,11 +1006,8 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
         verifyNoMoreInteractions(mockWriter)
+        verify(mockParentScope, never()).handleEvent(any(), any())
         assertThat(resultWaitForTiming).isSameAs(testedScope)
         assertThat(resultStop).isEqualTo(null)
     }
@@ -1110,11 +1054,8 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
         verifyNoMoreInteractions(mockWriter)
+        verify(mockParentScope, never()).handleEvent(any(), any())
         assertThat(resultWaitForTiming).isEqualTo(testedScope)
         assertThat(resultTiming).isEqualTo(testedScope)
         assertThat(resultStop).isEqualTo(null)
@@ -1163,11 +1104,8 @@ internal class RumResourceScopeTest {
                     doesNotHaveAResourceProvider()
                 }
         }
-        verify(mockParentScope).handleEvent(
-            isA<RumRawEvent.SentResource>(),
-            same(mockWriter)
-        )
         verifyNoMoreInteractions(mockWriter)
+        verify(mockParentScope, never()).handleEvent(any(), any())
         assertThat(resultWaitForTiming).isEqualTo(testedScope)
         assertThat(resultStop).isEqualTo(testedScope)
         assertThat(resultTiming).isEqualTo(null)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -868,7 +868,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
             assertThat(firstValue)
                 .hasAttributes(attributes)
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
@@ -883,26 +883,6 @@ internal class RumViewScopeTest {
                     hasCrashCount(0)
                     hasUserInfo(fakeUserInfo)
                     hasView(testedScope.viewId, testedScope.name, testedScope.url)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                }
-            assertThat(lastValue)
-                .hasAttributes(fakeAttributes + attributes)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasName(fakeName)
-                    hasUrl(fakeUrl)
-                    hasDurationGreaterThan(1)
-                    hasVersion(2)
-                    hasErrorCount(0)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(1)
-                    hasLongTaskCount(0)
-                    isActive(true)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                 }
@@ -1026,7 +1006,7 @@ internal class RumViewScopeTest {
     }
 
     @Test
-    fun `𝕄 send events 𝕎 handleEvent(ApplicationStarted) on stopped view`(
+    fun `𝕄 send event 𝕎 handleEvent(ApplicationStarted) on stopped view`(
         @StringForgery key: String,
         @StringForgery name: String,
         @LongForgery(0) duration: Long
@@ -1042,7 +1022,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
             assertThat(firstValue)
                 .hasActionData {
                     hasNonNullId()
@@ -1055,27 +1035,6 @@ internal class RumViewScopeTest {
                     hasCrashCount(0)
                     hasUserInfo(fakeUserInfo)
                     hasView(testedScope.viewId, testedScope.name, testedScope.url)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                }
-            assertThat(lastValue)
-                .hasAttributes(fakeAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasName(fakeName)
-                    hasUrl(fakeUrl)
-                    hasDurationGreaterThan(1)
-                    hasVersion(2)
-                    hasErrorCount(0)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(1)
-                    hasLongTaskCount(0)
-                    isActive(false)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                 }
@@ -1400,7 +1359,7 @@ internal class RumViewScopeTest {
     // region Error
 
     @Test
-    fun `𝕄 send events 𝕎 handleEvent(AddError) on active view`(
+    fun `𝕄 send event 𝕎 handleEvent(AddError) on active view`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
@@ -1422,7 +1381,7 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
 
             assertThat(firstValue)
                 .hasAttributes(attributes)
@@ -1440,33 +1399,13 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                 }
-
-            assertThat(lastValue)
-                .hasAttributes(fakeAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasErrorCount(1)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasLongTaskCount(0)
-                    isActive(true)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
-                    hasName(testedScope.name)
-                    hasUrl(testedScope.url)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                }
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
     }
 
     @Test
-    fun `𝕄 send Error and View event 𝕎 AddError {throwable=null}`(
+    fun `𝕄 send event 𝕎 AddError {throwable=null}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @StringForgery stacktrace: String,
@@ -1486,7 +1425,7 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
 
             assertThat(firstValue)
                 .hasAttributes(attributes)
@@ -1504,33 +1443,13 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                 }
-
-            assertThat(lastValue)
-                .hasAttributes(fakeAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasErrorCount(1)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasLongTaskCount(0)
-                    isActive(true)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
-                    hasName(testedScope.name)
-                    hasUrl(testedScope.url)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                }
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
     }
 
     @Test
-    fun `𝕄 send Error and View event 𝕎 AddError {stacktrace=null}`(
+    fun `𝕄 send event 𝕎 AddError {stacktrace=null}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
@@ -1552,7 +1471,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
 
             assertThat(firstValue)
                 .hasAttributes(attributes)
@@ -1571,33 +1490,13 @@ internal class RumViewScopeTest {
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
                 }
-
-            assertThat(lastValue)
-                .hasAttributes(fakeAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasErrorCount(1)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasLongTaskCount(0)
-                    isActive(true)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
-                    hasName(testedScope.name)
-                    hasUrl(testedScope.url)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                }
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
     }
 
     @Test
-    fun `𝕄 send events 𝕎 handleEvent(AddError) {throwable=null, stacktrace=null}`(
+    fun `𝕄 send event 𝕎 handleEvent(AddError) {throwable=null, stacktrace=null}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @BoolForgery fatal: Boolean,
@@ -1613,7 +1512,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
 
             assertThat(firstValue)
                 .hasAttributes(attributes)
@@ -1632,33 +1531,13 @@ internal class RumViewScopeTest {
                     hasActionId(fakeActionId)
                     hasErrorType(null)
                 }
-
-            assertThat(lastValue)
-                .hasAttributes(fakeAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasErrorCount(1)
-                    hasCrashCount(if (fatal) 1 else 0)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasLongTaskCount(0)
-                    isActive(true)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
-                    hasName(testedScope.name)
-                    hasUrl(testedScope.url)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                }
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
     }
 
     @Test
-    fun `𝕄 send events with global attributes 𝕎 handleEvent(AddError)`(
+    fun `𝕄 send event with global attributes 𝕎 handleEvent(AddError)`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
@@ -1681,11 +1560,8 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
-        val expectedViewAttributes = attributes.toMutableMap().apply {
-            putAll(fakeAttributes)
-        }
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
 
             assertThat(firstValue)
                 .hasAttributes(attributes)
@@ -1704,33 +1580,13 @@ internal class RumViewScopeTest {
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
                 }
-
-            assertThat(lastValue)
-                .hasAttributes(expectedViewAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasErrorCount(1)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasLongTaskCount(0)
-                    isActive(true)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
-                    hasName(testedScope.name)
-                    hasUrl(testedScope.url)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                }
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
     }
 
     @Test
-    fun `𝕄 send events 𝕎 handleEvent(AddError) {isFatal=true}`(
+    fun `𝕄 send event 𝕎 handleEvent(AddError) {isFatal=true}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
@@ -1753,7 +1609,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
 
             assertThat(firstValue)
                 .hasAttributes(attributes)
@@ -1772,32 +1628,13 @@ internal class RumViewScopeTest {
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
                 }
-
-            assertThat(lastValue)
-                .hasAttributes(fakeAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasErrorCount(1)
-                    hasCrashCount(1)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasLongTaskCount(0)
-                    isActive(true)
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
-                    hasName(testedScope.name)
-                    hasUrl(testedScope.url)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                }
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
     }
 
     @Test
-    fun `𝕄 send events 𝕎 handleEvent(AddError) {custom error type}`(
+    fun `𝕄 send event 𝕎 handleEvent(AddError) {custom error type}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
@@ -1822,7 +1659,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
 
             assertThat(firstValue)
                 .hasAttributes(attributes)
@@ -1841,33 +1678,13 @@ internal class RumViewScopeTest {
                     hasActionId(fakeActionId)
                     hasErrorType(errorType)
                 }
-
-            assertThat(lastValue)
-                .hasAttributes(fakeAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasErrorCount(1)
-                    hasCrashCount(1)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasLongTaskCount(0)
-                    isActive(true)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
-                    hasName(testedScope.name)
-                    hasUrl(testedScope.url)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                }
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
     }
 
     @Test
-    fun `𝕄 send events with global attributes 𝕎 handleEvent(AddError) {isFatal=true}`(
+    fun `𝕄 send event with global attributes 𝕎 handleEvent(AddError) {isFatal=true}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
@@ -1894,7 +1711,7 @@ internal class RumViewScopeTest {
             putAll(fakeAttributes)
         }
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
 
             assertThat(firstValue)
                 .hasAttributes(attributes)
@@ -1912,26 +1729,6 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
-                }
-
-            assertThat(lastValue)
-                .hasAttributes(expectedViewAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasErrorCount(1)
-                    hasCrashCount(1)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasLongTaskCount(0)
-                    isActive(true)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
-                    hasName(testedScope.name)
-                    hasUrl(testedScope.url)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
                 }
         }
         verifyNoMoreInteractions(mockWriter)
@@ -1987,7 +1784,7 @@ internal class RumViewScopeTest {
     // region Long Task
 
     @Test
-    fun `𝕄 send events 𝕎 handleEvent(AddLongTask) on active view`(
+    fun `𝕄 send event 𝕎 handleEvent(AddLongTask) on active view`(
         @LongForgery durationNs: Long,
         @StringForgery target: String
     ) {
@@ -1999,7 +1796,7 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
 
             assertThat(firstValue)
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
@@ -2012,31 +1809,13 @@ internal class RumViewScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                 }
-
-            assertThat(lastValue)
-                .hasAttributes(fakeAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasErrorCount(0)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasLongTaskCount(1)
-                    isActive(true)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
-                }
         }
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
     }
 
     @Test
-    fun `𝕄 send events with global attributes 𝕎 handleEvent(AddLongTask)`(
+    fun `𝕄 send event with global attributes 𝕎 handleEvent(AddLongTask)`(
         @LongForgery durationNs: Long,
         @StringForgery target: String,
         forge: Forge
@@ -2056,7 +1835,7 @@ internal class RumViewScopeTest {
             putAll(fakeAttributes)
         }
         argumentCaptor<RumEvent> {
-            verify(mockWriter, times(2)).write(capture())
+            verify(mockWriter).write(capture())
 
             assertThat(firstValue)
                 .hasAttributes(attributes)
@@ -2070,24 +1849,6 @@ internal class RumViewScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
-                }
-
-            assertThat(lastValue)
-                .hasAttributes(expectedViewAttributes)
-                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
-                .hasViewData {
-                    hasTimestamp(fakeEventTime.timestamp)
-                    hasErrorCount(0)
-                    hasCrashCount(0)
-                    hasResourceCount(0)
-                    hasActionCount(0)
-                    hasLongTaskCount(1)
-                    isActive(true)
-                    hasNoCustomTimings()
-                    hasUserInfo(fakeUserInfo)
-                    hasViewId(testedScope.viewId)
-                    hasApplicationId(fakeParentContext.applicationId)
-                    hasSessionId(fakeParentContext.sessionId)
                 }
         }
         verifyNoMoreInteractions(mockWriter)
@@ -2111,6 +1872,7 @@ internal class RumViewScopeTest {
         verifyZeroInteractions(mockWriter)
         assertThat(result).isNull()
     }
+
     // endregion
 
     // region Loading Time

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -127,7 +127,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery name: String
     ) {
         testedMonitor.startView(key, name, fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -145,7 +145,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery(type = StringForgeryType.ASCII) key: String
     ) {
         testedMonitor.stopView(key, fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -163,7 +163,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery name: String
     ) {
         testedMonitor.addUserAction(type, name, fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -183,7 +183,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery name: String
     ) {
         testedMonitor.startUserAction(type, name, fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -200,7 +200,7 @@ internal class DatadogRumMonitorTest {
     @Test
     fun `M delegate event to rootScope W stopUserAction()`() {
         testedMonitor.stopUserAction(fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -219,7 +219,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery name: String
     ) {
         testedMonitor.stopUserAction(type, name, fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -239,7 +239,7 @@ internal class DatadogRumMonitorTest {
         @RegexForgery("http(s?)://[a-z]+.com/[a-z]+") url: String
     ) {
         testedMonitor.startResource(key, method, url, fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -261,7 +261,7 @@ internal class DatadogRumMonitorTest {
         @Forgery kind: RumResourceKind
     ) {
         testedMonitor.stopResource(key, statusCode, size, kind, fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -282,7 +282,7 @@ internal class DatadogRumMonitorTest {
         @Forgery kind: RumResourceKind
     ) {
         testedMonitor.stopResource(key, null, null, kind, fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -306,7 +306,7 @@ internal class DatadogRumMonitorTest {
         @Forgery throwable: Throwable
     ) {
         testedMonitor.stopResourceWithError(key, statusCode, message, source, throwable)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -329,7 +329,7 @@ internal class DatadogRumMonitorTest {
         @Forgery throwable: Throwable
     ) {
         testedMonitor.stopResourceWithError(key, null, message, source, throwable)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -351,7 +351,7 @@ internal class DatadogRumMonitorTest {
         @Forgery throwable: Throwable
     ) {
         testedMonitor.addError(message, source, throwable, fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -374,7 +374,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery stacktrace: String
     ) {
         testedMonitor.addErrorWithStacktrace(message, source, stacktrace, fakeAttributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -394,7 +394,7 @@ internal class DatadogRumMonitorTest {
     fun `M delegate event to rootScope W viewTreeChanged()`() {
         val eventTime = Time()
         testedMonitor.viewTreeChanged(eventTime)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -410,7 +410,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery key: String
     ) {
         testedMonitor.waitForResourceTiming(key)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -428,7 +428,7 @@ internal class DatadogRumMonitorTest {
         @Forgery timing: ResourceTiming
     ) {
         testedMonitor.addResourceTiming(key, timing)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -446,7 +446,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery name: String
     ) {
         testedMonitor.addTiming(name)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -465,7 +465,7 @@ internal class DatadogRumMonitorTest {
         @Forgery throwable: Throwable
     ) {
         testedMonitor.addCrash(message, source, throwable)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -487,7 +487,7 @@ internal class DatadogRumMonitorTest {
         val loadingType = forge.aValueFrom(ViewEvent.LoadingType::class.java)
 
         testedMonitor.updateViewLoadingTime(key, loadingTime, loadingType)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -505,7 +505,7 @@ internal class DatadogRumMonitorTest {
     fun `M delegate event to rootScope W resetSession()`() {
 
         testedMonitor.resetSession()
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -524,7 +524,7 @@ internal class DatadogRumMonitorTest {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         testedMonitor.startView(key, name, attributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -545,7 +545,7 @@ internal class DatadogRumMonitorTest {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         testedMonitor.stopView(key, attributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -566,7 +566,7 @@ internal class DatadogRumMonitorTest {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         testedMonitor.addUserAction(type, name, attributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -589,7 +589,7 @@ internal class DatadogRumMonitorTest {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         testedMonitor.startUserAction(type, name, attributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -612,7 +612,7 @@ internal class DatadogRumMonitorTest {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         testedMonitor.stopUserAction(type, name, attributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -635,7 +635,7 @@ internal class DatadogRumMonitorTest {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         testedMonitor.startResource(key, method, url, attributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -660,7 +660,7 @@ internal class DatadogRumMonitorTest {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         testedMonitor.stopResource(key, statusCode, size, kind, attributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -685,7 +685,7 @@ internal class DatadogRumMonitorTest {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         testedMonitor.addError(message, source, throwable, attributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -711,7 +711,7 @@ internal class DatadogRumMonitorTest {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
         testedMonitor.addErrorWithStacktrace(message, source, stacktrace, attributes)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -738,7 +738,7 @@ internal class DatadogRumMonitorTest {
         val fakeAttributesWithErrorType =
             fakeAttributes + (RumAttributes.INTERNAL_ERROR_TYPE to errorType)
         testedMonitor.addError(message, source, throwable, fakeAttributesWithErrorType)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -770,7 +770,7 @@ internal class DatadogRumMonitorTest {
             stacktrace,
             fakeAttributesWithErrorType
         )
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
@@ -793,13 +793,141 @@ internal class DatadogRumMonitorTest {
         @StringForgery target: String
     ) {
         testedMonitor.addLongTask(duration, target)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
             verify(mockScope).handleEvent(capture(), same(mockWriter))
 
             val event = firstValue as RumRawEvent.AddLongTask
             assertThat(event.durationNs).isEqualTo(duration)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W eventSent {action}`(
+        @StringForgery viewId: String
+    ) {
+        testedMonitor.eventSent(viewId, EventType.ACTION)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.ActionSent
+            assertThat(event.viewId).isEqualTo(viewId)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W eventSent {resource}`(
+        @StringForgery viewId: String
+    ) {
+        testedMonitor.eventSent(viewId, EventType.RESOURCE)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.ResourceSent
+            assertThat(event.viewId).isEqualTo(viewId)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W eventSent {error}`(
+        @StringForgery viewId: String
+    ) {
+        testedMonitor.eventSent(viewId, EventType.ERROR)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.ErrorSent
+            assertThat(event.viewId).isEqualTo(viewId)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W eventSent {longTask}`(
+        @StringForgery viewId: String
+    ) {
+        testedMonitor.eventSent(viewId, EventType.LONG_TASK)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.LongTaskSent
+            assertThat(event.viewId).isEqualTo(viewId)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W eventDropped {action}`(
+        @StringForgery viewId: String
+    ) {
+        testedMonitor.eventDropped(viewId, EventType.ACTION)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.ActionDropped
+            assertThat(event.viewId).isEqualTo(viewId)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W eventDropped {resource}`(
+        @StringForgery viewId: String
+    ) {
+        testedMonitor.eventDropped(viewId, EventType.RESOURCE)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.ResourceDropped
+            assertThat(event.viewId).isEqualTo(viewId)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W eventDropped {error}`(
+        @StringForgery viewId: String
+    ) {
+        testedMonitor.eventDropped(viewId, EventType.ERROR)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.ErrorDropped
+            assertThat(event.viewId).isEqualTo(viewId)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W eventDropped {longTask}`(
+        @StringForgery viewId: String
+    ) {
+        testedMonitor.eventDropped(viewId, EventType.LONG_TASK)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.LongTaskDropped
+            assertThat(event.viewId).isEqualTo(viewId)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)
     }
@@ -812,7 +940,7 @@ internal class DatadogRumMonitorTest {
                 verifyZeroInteractions(mockScope)
                 val runnable = firstValue
                 runnable.run()
-                Thread.sleep(200)
+                Thread.sleep(PROCESSING_DELAY)
                 verify(mockHandler).removeCallbacks(same(runnable))
                 verify(mockScope).handleEvent(
                     argThat { this is RumRawEvent.KeepAlive },
@@ -830,7 +958,7 @@ internal class DatadogRumMonitorTest {
         val runnable = testedMonitor.keepAliveRunnable
 
         testedMonitor.handleEvent(mockEvent)
-        Thread.sleep(200)
+        Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<Runnable> {
             inOrder(mockScope, mockWriter, mockHandler) {
@@ -851,5 +979,9 @@ internal class DatadogRumMonitorTest {
 
         verify(mockHandler).removeCallbacks(same(testedMonitor.keepAliveRunnable))
         verifyNoMoreInteractions(mockHandler, mockWriter, mockScope)
+    }
+
+    companion object {
+        const val PROCESSING_DELAY = 100L
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -41,14 +41,15 @@ internal class Configurator :
 
         // RUM
         forge.addFactory(ActionEventForgeryFactory())
+        forge.addFactory(ErrorEventForgeryFactory())
+        forge.addFactory(LongTaskEventForgeryFactory())
+        forge.addFactory(MotionEventForgeryFactory())
         forge.addFactory(RumEventForgeryFactory())
+        forge.addFactory(RumEventMapperFactory())
         forge.addFactory(RumContextForgeryFactory())
         forge.addFactory(ResourceEventForgeryFactory())
         forge.addFactory(ResourceTimingForgeryFactory())
-        forge.addFactory(ErrorEventForgeryFactory())
         forge.addFactory(ViewEventForgeryFactory())
-        forge.addFactory(MotionEventForgeryFactory())
-        forge.addFactory(RumEventMapperFactory())
 
         // NDK Crash
         forge.addFactory(NdkCrashLogForgeryFactory())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/LongTaskEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/LongTaskEventForgeryFactory.kt
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.rum.internal.domain.event.ResourceTiming
+import com.datadog.android.rum.model.LongTaskEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import fr.xgouchet.elmyr.jvm.ext.aTimestamp
+import java.util.UUID
+
+internal class LongTaskEventForgeryFactory :
+    ForgeryFactory<LongTaskEvent> {
+    override fun getForgery(forge: Forge): LongTaskEvent {
+        val timing = forge.aNullable<ResourceTiming>()
+        return LongTaskEvent(
+            date = forge.aTimestamp(),
+            longTask = LongTaskEvent.LongTask(
+                duration = forge.aPositiveLong()
+            ),
+            view = LongTaskEvent.View(
+                id = forge.getForgery<UUID>().toString(),
+                url = forge.aStringMatching("https://[a-z]+.com/[a-z0-9_/]+"),
+                referrer = null
+            ),
+            usr = LongTaskEvent.Usr(
+                id = forge.anHexadecimalString(),
+                name = forge.aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+"),
+                email = forge.aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}")
+            ),
+            action = forge.aNullable { LongTaskEvent.Action(getForgery<UUID>().toString()) },
+            application = LongTaskEvent.Application(forge.getForgery<UUID>().toString()),
+            session = LongTaskEvent.Session(
+                id = forge.getForgery<UUID>().toString(),
+                type = LongTaskEvent.Type.USER
+            ),
+            dd = LongTaskEvent.Dd()
+        )
+    }
+}

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -69,6 +69,7 @@ android {
             com.datadog.gradle.config.configureFlavorForSampleApp(this, rootDir)
         }
         register("production") {
+            isDefault = true
             dimension = "version"
             com.datadog.gradle.config.configureFlavorForSampleApp(this, rootDir)
         }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/NavActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/NavActivity.kt
@@ -11,6 +11,7 @@ import android.os.Bundle
 import android.view.Menu
 import android.view.MenuItem
 import android.view.View
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
@@ -23,6 +24,7 @@ class NavActivity : AppCompatActivity() {
 
     lateinit var navController: NavController
     lateinit var rootView: View
+    lateinit var appInfoView: TextView
 
     // region Activity
 
@@ -34,6 +36,7 @@ class NavActivity : AppCompatActivity() {
 
         setContentView(R.layout.activity_nav)
         rootView = findViewById(R.id.frame_container)
+        appInfoView = findViewById<TextView>(R.id.app_info)
 
         navController = findNavController(R.id.nav_host_fragment)
     }
@@ -51,6 +54,9 @@ class NavActivity : AppCompatActivity() {
     override fun onResume() {
         super.onResume()
         Timber.d("onResume")
+
+        val tracking = Preferences.defaultPreferences(this).getTrackingConsent()
+        appInfoView.text = "${BuildConfig.FLAVOR} / Tracking: $tracking"
     }
 
     override fun onPause() {

--- a/sample/kotlin/src/main/res/layout/activity_nav.xml
+++ b/sample/kotlin/src/main/res/layout/activity_nav.xml
@@ -6,20 +6,32 @@
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              xmlns:app="http://schemas.android.com/apk/res-auto"
-              xmlns:tools="http://schemas.android.com/tools"
+             xmlns:app="http://schemas.android.com/apk/res-auto"
+             xmlns:tools="http://schemas.android.com/tools"
              android:id="@+id/frame_container"
-              android:layout_width="match_parent"
-              android:layout_height="match_parent"
-              tools:context=".NavActivity">
+             android:layout_width="match_parent"
+             android:layout_height="match_parent"
+             tools:context=".NavActivity">
+
+    <TextView
+        android:id="@+id/app_info"
+        android:layout_width="match_parent"
+        android:layout_height="32dp"
+        android:background="@color/datadog_violet"
+        android:textColor="@color/white"
+        android:singleLine="true"
+        android:gravity="center"
+        android:textSize="12sp"
+        tools:text="@tools:sample/lorem"
+        />
 
     <fragment
         android:id="@+id/nav_host_fragment"
         android:name="androidx.navigation.fragment.NavHostFragment"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-
+        android:layout_marginTop="32dp"
         app:defaultNavHost="true"
-        app:navGraph="@navigation/nav_graph" />
+        app:navGraph="@navigation/nav_graph"/>
 
 </FrameLayout>


### PR DESCRIPTION
### What does this PR do?

Ensure that the count of Resources, Actions, Errors and Long Tasks is valid when data scrubbing is used. 

### Motivation

When user discard events, the previous implementation could create views with invalid `view.<type>.count` values. This could lead to invalid dashboards, and filtering would bring a lot of false positives. 
