### PR TITLE
RUMM-1151 Use the Local first-party host detector

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
@@ -10,7 +10,6 @@ import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.net.identifyRequest
 import com.datadog.android.core.internal.utils.devLogger
-import com.datadog.android.core.internal.utils.warnDeprecated
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -104,14 +103,7 @@ internal constructor(
         tracedRequestListener,
         CoreFeature.firstPartyHostDetector,
         { AndroidTracer.Builder().build() }
-    ) {
-        warnDeprecated(
-            "Constructor DatadogInterceptor(List<String>, TracedRequestListener)",
-            "1.6.0",
-            "1.8.0",
-            "DatadogInterceptor(TracedRequestListener)"
-        )
-    }
+    )
 
     /**
      * Creates a [TracingInterceptor] to automatically create a trace around OkHttp [Request]s, and

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -102,7 +102,7 @@ internal object CoreFeature {
         initializeClockSync(appContext)
         setupInfoProviders(appContext, consent)
         setupOkHttpClient(configuration.needsClearTextHttp)
-        firstPartyHostDetector = FirstPartyHostDetector(configuration.firstPartyHosts)
+        firstPartyHostDetector.addKnownHosts(configuration.firstPartyHosts)
         setupExecutors()
 
         initialized.set(true)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/FirstPartyHostDetector.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/FirstPartyHostDetector.kt
@@ -33,6 +33,6 @@ internal class FirstPartyHostDetector(
     }
 
     fun addKnownHosts(hosts: List<String>) {
-        knownHosts = knownHosts + hosts
+        knownHosts = knownHosts + hosts.map { it.toLowerCase(Locale.US) }
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
@@ -11,7 +11,6 @@ import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.loggableStackTrace
-import com.datadog.android.core.internal.utils.warnDeprecated
 import com.datadog.android.tracing.internal.TracesFeature
 import com.datadog.opentracing.DDTracer
 import com.datadog.trace.api.DDTags
@@ -98,14 +97,7 @@ internal constructor(
         CoreFeature.firstPartyHostDetector,
         null,
         { AndroidTracer.Builder().build() }
-    ) {
-        warnDeprecated(
-            "Constructor TracingInterceptor(List<String>, TracedRequestListener)",
-            "1.6.0",
-            "1.8.0",
-            "TracingInterceptor(TracedRequestListener)"
-        )
-    }
+    )
 
     /**
      * Creates a [TracingInterceptor] to automatically create a trace around OkHttp [Request]s.
@@ -174,7 +166,8 @@ internal constructor(
 
     private fun isRequestTraceable(request: Request): Boolean {
         val url = request.url()
-        return firstPartyHostDetector.isFirstPartyUrl(url)
+        return firstPartyHostDetector.isFirstPartyUrl(url) ||
+            localFirstPartyHostDetector.isFirstPartyUrl(url)
     }
 
     @Suppress("TooGenericExceptionCaught", "ThrowingInternalException")


### PR DESCRIPTION
### What does this PR do?

Ensure the local first party hosts provided in the OkHttp Interceptors are actually used. 

Fixes  #513

### Additional Notes

We also removed the `warnDeprecated` calls that existed and weren't not removed in the un-deprecation of the related constructors