### PR TITLE
RUMM-1068: Keep line and filename information in the user builds to make Error Tracking feature work reliably

### DIFF
--- a/dd-sdk-android/build.gradle.kts
+++ b/dd-sdk-android/build.gradle.kts
@@ -53,6 +53,8 @@ android {
 
         buildConfigField("int", "SDK_VERSION_CODE", "${AndroidConfig.VERSION.code}")
         buildConfigField("String", "SDK_VERSION_NAME", "\"${AndroidConfig.VERSION.name}\"")
+
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     sourceSets.named("main") {

--- a/dd-sdk-android/consumer-rules.pro
+++ b/dd-sdk-android/consumer-rules.pro
@@ -1,0 +1,2 @@
+# This is needed for the Datadog Error Tracking feature to work reliably
+-keepattributes SourceFile,LineNumberTable


### PR DESCRIPTION
### What does this PR do?

This change add proguard rule to keep code attributes needed for the Error Tracking feature, namely line number and source file name. This is achieved by adding special file with consumer configuration which will be used nor for the SDK build, but will be shipped with AAR and used in the application build (merged proguard configs).

### Additional Notes

Proguard docs on the possible attributes can be found here: https://www.guardsquare.com/en/products/proguard/manual/usage/attributes

Android docs on the consumer proguard rules: https://developer.android.com/studio/projects/android-library#Considerations

The feature itself is available at least since `AGP 3.0` (mentioned here https://google.github.io/android-gradle-dsl/3.0/com.android.build.gradle.internal.dsl.DefaultConfig.html#com.android.build.gradle.internal.dsl.DefaultConfig:consumerProguardFiles), so should cover majority of the builds.

### Review checklist (to be filled by reviewers)

- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

