### PR TITLE
Add newline after no-op classes generation messages

### DIFF
--- a/tools/noopfactory/src/main/kotlin/com/datadog/tools/noopfactory/NoOpFactoryAnnotationProcessor.kt
+++ b/tools/noopfactory/src/main/kotlin/com/datadog/tools/noopfactory/NoOpFactoryAnnotationProcessor.kt
@@ -105,7 +105,7 @@ class NoOpFactoryAnnotationProcessor : AbstractProcessor() {
         file.writeTo(writer)
         writer.close()
 
-        processingEnv.messager.printMessage(Diagnostic.Kind.NOTE, "Generated ${file.name}")
+        processingEnv.messager.printMessage(Diagnostic.Kind.NOTE, "Generated ${file.name}\r\n")
     }
 
     /**


### PR DESCRIPTION
Very tiny change which adds a line break to the messages, otherwise all of them are in a single line like that:

```
Note: Generated NoOpTracedRequestListenerNote: Generated NoOpNetworkInfoProviderNote: Generated NoOpDataUploaderNote: Generated NoOpConsentProviderNote: Generated NoOpTimeProviderNote: Generated NoOpSystemInfoProviderNote: Generated NoOpWriterNote: Generated NoOpReaderNote: Generated NoOpUploadSchedulerNote: Generated NoOpPersistenceStrategyNote: Generated NoOpDataProcessorNote: Generated NoOpBatchedDataMigratorNote: Generated NoOpAdvancedRumMonitorNote: Generated NoOpNdkCrashHandlerNote: Generated NoOpGesturesTrackerNote: Generated NoOpFragmentLifecycleCallbacksNote: Generated NoOpUserActionTrackingStrategyNote: Generated NoOpRumScopeNote: Generated NoOpRumMonitorNote: Generated NoOpTrackingStrategyNote: Generated NoOpViewTrackingStrategyNote: Generated NoOpLogHandlerNote: Generated NoOpMutableUserInfoProvider
```