### PR TITLE
RUMM-1081 (1/2) Generate GPG signing key in CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,6 +15,7 @@ variables:
 
 stages:
   - ci-image
+  - security
   - analysis
   - test
   - publish
@@ -31,6 +32,24 @@ ci-image:
   script:
     - docker build --tag $CI_IMAGE_DOCKER -f Dockerfile.gitlab .
     - docker push $CI_IMAGE_DOCKER
+
+# SECURITY
+
+create_key:
+  stage: security
+  when: manual
+  tags: [ "runner:docker", "size:large" ]
+  variables:
+    PROJECT_NAME: "dd-sdk-android"
+    EXPORT_TO_KEYSERVER: "true"
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/agent-key-management-tools/gpg:1
+  script:
+    - /create.sh
+  artifacts:
+    expire_in: 13 mos
+    paths:
+      - pubkeys
+
 
 # STATIC ANALYSIS
 


### PR DESCRIPTION
### What does this PR do?

Add a CI Task to generate and store GPG keys

### Motivation

To publish our artefacts on Sonatype OSSR (and Maven Central), we need to sign our aar/jar with a GPG key.
For security reasons, this GPG key should never be generated on an engineer's work computer. We use this CI script to generate the key and store it as a secret in AWS SSM.

In a future PR, we will be able to read the same GPG key and use it to sign and upload our artefacts to Sonatype OSSR
