### PR TITLE
RUMM-1153: Possibility to attach custom attributes to automatically collected RUM Resource events

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -301,7 +301,7 @@ interface com.datadog.android.rum.RumMonitor
   fun stopUserAction(RumActionType, String, Map<String, Any?> = emptyMap())
   fun startResource(String, String, String, Map<String, Any?> = emptyMap())
   fun stopResource(String, Int?, Long?, RumResourceKind, Map<String, Any?>)
-  fun stopResourceWithError(String, Int?, String, RumErrorSource, Throwable)
+  fun stopResourceWithError(String, Int?, String, RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
   fun addError(String, RumErrorSource, Throwable?, Map<String, Any?>)
   fun addErrorWithStacktrace(String, RumErrorSource, String?, Map<String, Any?>)
   fun addTiming(String)

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -67,8 +67,8 @@ class com.datadog.android.DatadogEventListener : okhttp3.EventListener
   class Factory : okhttp3.EventListener.Factory
     override fun create(okhttp3.Call): okhttp3.EventListener
 open class com.datadog.android.DatadogInterceptor : com.datadog.android.tracing.TracingInterceptor
-  constructor(List<String>, com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener())
-  constructor(com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener())
+  constructor(List<String>, com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
+  constructor(com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
   override fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
   override fun canSendSpan(): Boolean
@@ -291,7 +291,7 @@ enum com.datadog.android.rum.RumErrorSource
   - AGENT
   - WEBVIEW
 class com.datadog.android.rum.RumInterceptor : com.datadog.android.DatadogInterceptor
-  constructor(List<String> = emptyList())
+  constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
 interface com.datadog.android.rum.RumMonitor
   fun startView(Any, String, Map<String, Any?> = emptyMap())
   fun stopView(Any, Map<String, Any?> = emptyMap())
@@ -309,6 +309,8 @@ interface com.datadog.android.rum.RumMonitor
     fun sampleRumSessions(Float): Builder
     fun build(): RumMonitor
     companion object 
+interface com.datadog.android.rum.RumResourceAttributesProvider
+  fun onProvideAttributes(okhttp3.Request, okhttp3.Response?, Throwable?): Map<String, Any?>
 enum com.datadog.android.rum.RumResourceKind
   constructor(String)
   - BEACON
@@ -1005,6 +1007,7 @@ open class com.datadog.android.rum.webview.RumWebViewClient : android.webkit.Web
   override fun onReceivedError(android.webkit.WebView?, android.webkit.WebResourceRequest?, android.webkit.WebResourceError?)
   override fun onReceivedHttpError(android.webkit.WebView?, android.webkit.WebResourceRequest?, android.webkit.WebResourceResponse?)
   override fun onReceivedSslError(android.webkit.WebView?, android.webkit.SslErrorHandler?, android.net.http.SslError?)
+  open fun onProvideRumResourceAttributes(android.webkit.WebView?, String?): Map<String, Any?>
   companion object 
 class com.datadog.android.sqlite.DatadogDatabaseErrorHandler : android.database.DatabaseErrorHandler
   constructor(android.database.DatabaseErrorHandler = DefaultDatabaseErrorHandler())

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumInterceptor.kt
@@ -38,7 +38,14 @@ import okhttp3.Request
  * - be wrapped in a Span and have trace id injected to get a full flame-graph in APM.
  * If no host provided the interceptor won't trace any OkHttp [Request], nor propagate tracing
  * information to the backend, but RUM Resource events will still be sent for each request.
+ * @param rumResourceAttributesProvider which listens on the intercepted [okhttp3.Request]
+ * and offers the possibility to add custom attributes to the RUM resource events.
  */
 class RumInterceptor(
-    firstPartyHosts: List<String> = emptyList()
-) : DatadogInterceptor(firstPartyHosts)
+    firstPartyHosts: List<String> = emptyList(),
+    rumResourceAttributesProvider: RumResourceAttributesProvider =
+        NoOpRumResourceAttributesProvider()
+) : DatadogInterceptor(
+    firstPartyHosts,
+    rumResourceAttributesProvider = rumResourceAttributesProvider
+)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -165,6 +165,8 @@ interface RumMonitor {
      * @param message a message explaining the error
      * @param source the source of the error
      * @param throwable the throwable
+     * @param attributes additional custom attributes to attach to the error. Attributes can be
+     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
      * @see [startResource]
      * @see [stopResource]
      */
@@ -173,7 +175,8 @@ interface RumMonitor {
         statusCode: Int?,
         message: String,
         source: RumErrorSource,
-        throwable: Throwable
+        throwable: Throwable,
+        attributes: Map<String, Any?> = emptyMap()
     )
 
     /**

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumResourceAttributesProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumResourceAttributesProvider.kt
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum
+
+import com.datadog.tools.annotation.NoOpImplementation
+import okhttp3.Request
+import okhttp3.Response
+
+/**
+ * Provider which listens for the OkHttp [Request] -> [Response] (or [Throwable]) chain and
+ * offers a possibility to add custom attributes to the RUM Resource event.
+ */
+@NoOpImplementation
+interface RumResourceAttributesProvider {
+
+    /**
+     * Offers a possibility to create custom attributes collection which later will be attached to
+     * the RUM resource event associated with the request.
+     * @param request the intercepted [Request]
+     * @param response the [Request] response in case of any
+     * @param throwable in case an error occurred during the [Request]
+     */
+    fun onProvideAttributes(
+        request: Request,
+        response: Response?,
+        throwable: Throwable?
+    ): Map<String, Any?>
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -79,6 +79,7 @@ internal sealed class RumRawEvent {
         val message: String,
         val source: RumErrorSource,
         val throwable: Throwable,
+        val attributes: Map<String, Any?>,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -106,6 +106,8 @@ internal class RumResourceScope(
     ) {
         if (key != event.key) return
 
+        attributes.putAll(event.attributes)
+
         sendError(
             event.message,
             event.source,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -127,10 +127,18 @@ internal class DatadogRumMonitor(
         statusCode: Int?,
         message: String,
         source: RumErrorSource,
-        throwable: Throwable
+        throwable: Throwable,
+        attributes: Map<String, Any?>
     ) {
         handleEvent(
-            RumRawEvent.StopResourceWithError(key, statusCode?.toLong(), message, source, throwable)
+            RumRawEvent.StopResourceWithError(
+                key,
+                statusCode?.toLong(),
+                message,
+                source,
+                throwable,
+                attributes
+            )
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/webview/RumWebViewClient.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/webview/RumWebViewClient.kt
@@ -53,7 +53,7 @@ open class RumWebViewClient : WebViewClient() {
                 200,
                 null,
                 RumResourceKind.DOCUMENT,
-                emptyMap()
+                onProvideRumResourceAttributes(view, url)
             )
         }
     }
@@ -123,8 +123,21 @@ open class RumWebViewClient : WebViewClient() {
 
     // endregion
 
+    // region Internal
+
+    /**
+     * Offers a possibility to create custom attributes collection which later will be attached to
+     * the RUM resource event associated with the request.
+     * @param view The WebView that is initiating the callback.
+     * @param url The url of the page.
+     */
+    open fun onProvideRumResourceAttributes(view: WebView?, url: String?): Map<String, Any?> {
+        return emptyMap()
+    }
+
+    // endregion
+
     companion object {
-        internal const val ORIGIN = "WebViewClient"
         internal const val METHOD_GET = "GET"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
@@ -286,10 +286,10 @@ internal constructor(
         val statusCode = response.code()
         span?.setTag(Tags.HTTP_STATUS.key, statusCode)
         if (statusCode in 400..499) {
-            (span as? MutableSpan)?.setError(true)
+            (span as? MutableSpan)?.isError = true
         }
         if (statusCode == 404) {
-            (span as? MutableSpan)?.setResourceName(RESOURCE_NAME_404)
+            (span as? MutableSpan)?.resourceName = RESOURCE_NAME_404
         }
         onRequestIntercepted(request, span, response, null)
         if (canSendSpan()) {
@@ -302,7 +302,7 @@ internal constructor(
         throwable: Throwable,
         span: Span
     ) {
-        (span as? MutableSpan)?.setError(true)
+        (span as? MutableSpan)?.isError = true
         span.setTag(DDTags.ERROR_MSG, throwable.message)
         span.setTag(DDTags.ERROR_TYPE, throwable.javaClass.name)
         span.setTag(DDTags.ERROR_STACK, throwable.loggableStackTrace())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutRumTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutRumTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android
 import android.util.Log
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumMonitor
+import com.datadog.android.rum.RumResourceAttributesProvider
 import com.datadog.android.tracing.TracingInterceptor
 import com.datadog.android.tracing.TracingInterceptorTest
 import com.datadog.android.utils.forge.Configurator
@@ -45,6 +46,9 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
     @Mock
     lateinit var mockRumMonitor: RumMonitor
 
+    @Mock
+    lateinit var mockRumAttributesProvider: RumResourceAttributesProvider
+
     @BeforeEach
     fun `set up RUM`() {
         GlobalRum.registerIfAbsent(mockRumMonitor)
@@ -59,7 +63,13 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
         tracedHosts: List<String>,
         factory: () -> Tracer
     ): TracingInterceptor {
-        return DatadogInterceptor(tracedHosts, mockRequestListener, mockDetector, factory)
+        return DatadogInterceptor(
+            tracedHosts,
+            mockRequestListener,
+            mockDetector,
+            mockRumAttributesProvider,
+            factory
+        )
     }
 
     override fun getExpectedOrigin(): String {
@@ -94,6 +104,7 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
 
         // Then
         verifyZeroInteractions(mockRumMonitor)
+        verifyZeroInteractions(mockRumAttributesProvider)
     }
 
     @Test
@@ -108,6 +119,7 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
 
         // Then
         verifyZeroInteractions(mockRumMonitor)
+        verifyZeroInteractions(mockRumAttributesProvider)
     }
 
     @Test
@@ -125,5 +137,6 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
 
         // Then
         verifyZeroInteractions(mockRumMonitor)
+        verifyZeroInteractions(mockRumAttributesProvider)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -201,7 +201,14 @@ internal class RumActionScopeTest {
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(500)
-        fakeEvent = RumRawEvent.StopResourceWithError(key, statusCode, message, source, throwable)
+        fakeEvent = RumRawEvent.StopResourceWithError(
+            key,
+            statusCode,
+            message,
+            source,
+            throwable,
+            emptyMap()
+        )
         val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(500)
         val result3 = testedScope.handleEvent(mockEvent(), mockWriter)
@@ -250,7 +257,14 @@ internal class RumActionScopeTest {
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(500)
-        fakeEvent = RumRawEvent.StopResourceWithError(key2, statusCode, message, source, throwable)
+        fakeEvent = RumRawEvent.StopResourceWithError(
+            key2,
+            statusCode,
+            message,
+            source,
+            throwable,
+            emptyMap()
+        )
         val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(500)
         val result3 = testedScope.handleEvent(mockEvent(), mockWriter)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -368,7 +368,14 @@ internal class RumContinuousActionScopeTest {
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap())
         val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(1000)
-        fakeEvent = RumRawEvent.StopResourceWithError(key, statusCode, message, source, throwable)
+        fakeEvent = RumRawEvent.StopResourceWithError(
+            key,
+            statusCode,
+            message,
+            source,
+            throwable,
+            emptyMap()
+        )
         val result3 = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(500)
         val result4 = testedScope.handleEvent(mockEvent(), mockWriter)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -66,7 +66,7 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(Configurator::class)
 internal class RumResourceScopeTest {
 
-    lateinit var testedScope: RumResourceScope
+    private lateinit var testedScope: RumResourceScope
 
     @Mock
     lateinit var mockParentScope: RumScope
@@ -95,7 +95,7 @@ internal class RumResourceScopeTest {
     @Forgery
     lateinit var fakeNetworkInfo: NetworkInfo
 
-    lateinit var fakeEventTime: Time
+    private lateinit var fakeEventTime: Time
 
     @BeforeEach
     fun `set up`(forge: Forge) {
@@ -666,9 +666,19 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
+        val attributes = forge.exhaustiveAttributes()
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
-        mockEvent = RumRawEvent.StopResourceWithError(fakeKey, null, message, source, throwable)
+        expectedAttributes.putAll(attributes)
+
+        mockEvent = RumRawEvent.StopResourceWithError(
+            fakeKey,
+            null,
+            message,
+            source,
+            throwable,
+            attributes
+        )
 
         // When
         Thread.sleep(500)
@@ -719,9 +729,19 @@ internal class RumResourceScopeTest {
             mockDetector
         )
         doAnswer { true }.whenever(mockDetector).isFirstPartyUrl(brokenUrl)
+        val attributes = forge.exhaustiveAttributes()
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
-        mockEvent = RumRawEvent.StopResourceWithError(fakeKey, null, message, source, throwable)
+        expectedAttributes.putAll(attributes)
+
+        mockEvent = RumRawEvent.StopResourceWithError(
+            fakeKey,
+            null,
+            message,
+            source,
+            throwable,
+            attributes
+        )
 
         // When
         Thread.sleep(500)
@@ -764,9 +784,20 @@ internal class RumResourceScopeTest {
     ) {
         // Given
         doAnswer { true }.whenever(mockDetector).isFirstPartyUrl(fakeUrl)
+
+        val attributes = forge.exhaustiveAttributes()
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
-        mockEvent = RumRawEvent.StopResourceWithError(fakeKey, null, message, source, throwable)
+        expectedAttributes.putAll(attributes)
+
+        mockEvent = RumRawEvent.StopResourceWithError(
+            fakeKey,
+            null,
+            message,
+            source,
+            throwable,
+            attributes
+        )
 
         // When
         Thread.sleep(500)
@@ -809,9 +840,19 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
+        val attributes = forge.exhaustiveAttributes()
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
-        mockEvent = RumRawEvent.StopResourceWithError(fakeKey, null, message, source, throwable)
+        expectedAttributes.putAll(attributes)
+
+        mockEvent = RumRawEvent.StopResourceWithError(
+            fakeKey,
+            null,
+            message,
+            source,
+            throwable,
+            attributes
+        )
         whenever(mockParentScope.getRumContext()) doReturn context
 
         // When
@@ -855,16 +896,20 @@ internal class RumResourceScopeTest {
     ) {
         // Given
         val attributes = forge.aMap { anHexadecimalString() to anAsciiString() }
+        val errorAttributes = forge.exhaustiveAttributes()
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
+        expectedAttributes.putAll(errorAttributes)
+
         GlobalRum.globalAttributes.putAll(attributes)
         mockEvent = RumRawEvent.StopResourceWithError(
             fakeKey,
             statusCode,
             message,
             source,
-            throwable
+            throwable,
+            errorAttributes
         )
 
         // When
@@ -932,7 +977,8 @@ internal class RumResourceScopeTest {
             statusCode,
             message,
             source,
-            throwable
+            throwable,
+            emptyMap()
         )
 
         Thread.sleep(500)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -305,7 +305,14 @@ internal class DatadogRumMonitorTest {
         @IntForgery(200, 600) statusCode: Int,
         @Forgery throwable: Throwable
     ) {
-        testedMonitor.stopResourceWithError(key, statusCode, message, source, throwable)
+        testedMonitor.stopResourceWithError(
+            key,
+            statusCode,
+            message,
+            source,
+            throwable,
+            fakeAttributes
+        )
         Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
@@ -317,6 +324,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.message).isEqualTo(message)
             assertThat(event.source).isEqualTo(source)
             assertThat(event.throwable).isEqualTo(throwable)
+            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)
     }
@@ -328,7 +336,7 @@ internal class DatadogRumMonitorTest {
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable
     ) {
-        testedMonitor.stopResourceWithError(key, null, message, source, throwable)
+        testedMonitor.stopResourceWithError(key, null, message, source, throwable, fakeAttributes)
         Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
@@ -340,6 +348,7 @@ internal class DatadogRumMonitorTest {
             assertThat(event.message).isEqualTo(message)
             assertThat(event.source).isEqualTo(source)
             assertThat(event.throwable).isEqualTo(throwable)
+            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
@@ -159,7 +159,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     // endregion
 
     @BeforeEach
-    fun `set up`(forge: Forge) {
+    open fun `set up`(forge: Forge) {
         mockDevLogHandler = mockDevLogHandler()
         mockAppContext = mockContext(fakePackageName, fakePackageVersion)
         Datadog.setVerbosity(Log.VERBOSE)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ExpectedEvents.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ExpectedEvents.kt
@@ -40,6 +40,21 @@ internal data class ExpectedViewEvent(
     override val rumContext: ExpectedRumContext = resolvedRumContext()
 ) : ExpectedEvent
 
+internal data class ExpectedResourceEvent(
+    val url: String,
+    val statusCode: Int,
+    val extraAttributes: Map<String, Any?>,
+    override val rumContext: ExpectedRumContext = resolvedRumContext()
+) : ExpectedEvent
+
+internal data class ExpectedErrorEvent(
+    val url: String,
+    val extraAttributes: Map<String, Any?>,
+    val isCrash: Boolean,
+    val source: ErrorSource,
+    override val rumContext: ExpectedRumContext = resolvedRumContext()
+) : ExpectedEvent
+
 internal interface ExpectedEvent {
     val rumContext: ExpectedRumContext
 }
@@ -47,6 +62,10 @@ internal interface ExpectedEvent {
 internal enum class Gesture(val gestureName: String) {
     TAP("tap"),
     SWIPE("swipe")
+}
+
+internal enum class ErrorSource(val sourceName: String) {
+    NETWORK("network")
 }
 
 private fun rumContextValues(): Triple<String, String, String> {

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ResourceTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ResourceTrackingTest.kt
@@ -1,0 +1,147 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.rum
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.rum.RumInterceptor
+import com.datadog.android.rum.RumResourceAttributesProvider
+import com.datadog.android.sdk.rules.HandledRequest
+import com.datadog.android.sdk.rules.MockServerActivityTestRule
+import com.datadog.android.sdk.rules.RumMockServerActivityTestRule
+import com.datadog.android.sdk.utils.isRumUrl
+import com.google.gson.JsonObject
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit4.ForgeRule
+import java.io.IOException
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+import org.junit.Assert.assertThrows
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+internal class ResourceTrackingTest {
+
+    @get:Rule
+    val mockServerRule = RumMockServerActivityTestRule(
+        ActivityTrackingPlaygroundActivity::class.java,
+        keepRequests = true,
+        trackingConsent = TrackingConsent.GRANTED
+    )
+
+    @get:Rule
+    val forge = ForgeRule()
+
+    private lateinit var okHttpClient: OkHttpClient
+    private lateinit var extraAttributes: Map<String, Any?>
+
+    @Before
+    fun setUp() {
+
+        extraAttributes = forge.exhaustiveAttributes()
+
+        okHttpClient = OkHttpClient.Builder()
+            .addInterceptor(
+                RumInterceptor(
+                    rumResourceAttributesProvider = object : RumResourceAttributesProvider {
+                        override fun onProvideAttributes(
+                            request: Request,
+                            response: Response?,
+                            throwable: Throwable?
+                        ): Map<String, Any?> = extraAttributes
+                    }
+                )
+            )
+            .build()
+    }
+
+    @Test
+    fun verifyAttributesAreSentWhenRequestIsSuccessful() {
+
+        val resourceUrl = "${mockServerRule.getConnectionUrl()}/nyan-cat.gif"
+
+        okHttpClient.newCall(
+            Request.Builder().url(resourceUrl).build()
+        ).execute()
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        Thread.sleep(RumTest.FINAL_WAIT_MS)
+
+        val resourceRequests =
+            mockServerRule.getRequests()
+                .rumEventsBy { it.has("resource") && it.get("type").asString == "resource" }
+
+        resourceRequests.verifyEventMatches(
+            listOf(
+                ExpectedResourceEvent(
+                    url = resourceUrl,
+                    statusCode = 200,
+                    extraAttributes = extraAttributes
+                )
+            )
+        )
+    }
+
+    @Test
+    fun verifyAttributesAreSentWhenRequestHasException() {
+
+        val resourceUrl = mockServerRule.getConnectionUrl() +
+            MockServerActivityTestRule.CONNECTION_ISSUE_PATH
+
+        assertThrows(IOException::class.java) {
+            okHttpClient.newCall(
+                Request.Builder().url(resourceUrl).build()
+            ).execute()
+        }
+
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        Thread.sleep(RumTest.FINAL_WAIT_MS)
+
+        val resourceRequests =
+            mockServerRule.getRequests()
+                .rumEventsBy { it.has("error") && it.get("type").asString == "error" }
+
+        resourceRequests.verifyEventMatches(
+            listOf(
+                ExpectedErrorEvent(
+                    url = resourceUrl,
+                    extraAttributes = extraAttributes,
+                    isCrash = false,
+                    source = ErrorSource.NETWORK
+                )
+            )
+        )
+    }
+
+    private fun List<HandledRequest>.rumEventsBy(
+        predicate: (rawEvent: JsonObject) -> Boolean
+    ): List<JsonObject> {
+        return filter { it.url?.isRumUrl() ?: false }
+            .flatMap { rumPayloadToJsonList(it.textBody!!) }
+            .filter { predicate.invoke(it) }
+    }
+
+    private fun Forge.exhaustiveAttributes(): Map<String, Any?> {
+        return listOf(
+            aBool(),
+            anInt(),
+            aLong(),
+            aFloat(),
+            aDouble(),
+            anAsciiString(),
+            aList { anAlphabeticalString() },
+            null
+        ).associateBy { anAlphabeticalString() }
+    }
+}

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ResourceTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ResourceTrackingTest.kt
@@ -15,9 +15,9 @@ import com.datadog.android.rum.RumResourceAttributesProvider
 import com.datadog.android.sdk.rules.HandledRequest
 import com.datadog.android.sdk.rules.MockServerActivityTestRule
 import com.datadog.android.sdk.rules.RumMockServerActivityTestRule
+import com.datadog.android.sdk.utils.exhaustiveAttributes
 import com.datadog.android.sdk.utils.isRumUrl
 import com.google.gson.JsonObject
-import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit4.ForgeRule
 import java.io.IOException
 import okhttp3.OkHttpClient
@@ -130,18 +130,5 @@ internal class ResourceTrackingTest {
         return filter { it.url?.isRumUrl() ?: false }
             .flatMap { rumPayloadToJsonList(it.textBody!!) }
             .filter { predicate.invoke(it) }
-    }
-
-    private fun Forge.exhaustiveAttributes(): Map<String, Any?> {
-        return listOf(
-            aBool(),
-            anInt(),
-            aLong(),
-            aFloat(),
-            aDouble(),
-            anAsciiString(),
-            aList { anAlphabeticalString() },
-            null
-        ).associateBy { anAlphabeticalString() }
     }
 }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/utils/ForgeExtensions.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/utils/ForgeExtensions.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.utils
+
+import fr.xgouchet.elmyr.Forge
+
+fun Forge.exhaustiveAttributes(): Map<String, Any?> {
+    return listOf(
+        aBool(),
+        anInt(),
+        aLong(),
+        aFloat(),
+        aDouble(),
+        anAsciiString(),
+        aList { anAlphabeticalString() },
+        null
+    ).associateBy { anAlphabeticalString() }
+}

--- a/tools/noopfactory/src/test/resources/gen/NoOpGenericInterface.kt
+++ b/tools/noopfactory/src/test/resources/gen/NoOpGenericInterface.kt
@@ -1,6 +1,12 @@
 package com.example
 
 import kotlin.CharSequence
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.collections.Set
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.emptySet
 
 internal class NoOpGenericInterface<T : CharSequence> : GenericInterface<T> {
 
@@ -14,4 +20,10 @@ internal class NoOpGenericInterface<T : CharSequence> : GenericInterface<T> {
     }
 
     override fun doSomethingWithNullableReturn(): T? = null
+
+    override fun doSomethingWithListReturn(): List<T> = emptyList()
+
+    override fun doSomethingWithMapReturn(): Map<T, T> = emptyMap()
+
+    override fun doSomethingWithSetReturn(): Set<T> = emptySet()
 }

--- a/tools/noopfactory/src/test/resources/gen/NoOpSimpleInterface.kt
+++ b/tools/noopfactory/src/test/resources/gen/NoOpSimpleInterface.kt
@@ -4,6 +4,12 @@ import java.util.Date
 import kotlin.ByteArray
 import kotlin.Int
 import kotlin.String
+import kotlin.collections.List
+import kotlin.collections.Map
+import kotlin.collections.Set
+import kotlin.collections.emptyList
+import kotlin.collections.emptyMap
+import kotlin.collections.emptySet
 
 internal class NoOpSimpleInterface : SimpleInterface {
 
@@ -31,4 +37,10 @@ internal class NoOpSimpleInterface : SimpleInterface {
     override fun doSomethingWithStringReturn(): String = ""
 
     override fun doSomethingWithNullableReturn(): Date? = null
+
+    override fun doSomethingWithListReturn(): List<String> = emptyList()
+
+    override fun doSomethingWithMapReturn(): Map<String, String> = emptyMap()
+
+    override fun doSomethingWithSetReturn(): Set<String> = emptySet()
 }

--- a/tools/noopfactory/src/test/resources/src/GenericInterface.kt
+++ b/tools/noopfactory/src/test/resources/src/GenericInterface.kt
@@ -12,4 +12,10 @@ interface GenericInterface<T : CharSequence> {
     fun doSomethingWithNullableParams(t: T?)
 
     fun doSomethingWithNullableReturn(): T?
+
+    fun doSomethingWithListReturn(): List<T>
+
+    fun doSomethingWithMapReturn(): Map<T, T>
+
+    fun doSomethingWithSetReturn(): Set<T>
 }

--- a/tools/noopfactory/src/test/resources/src/SimpleInterface.kt
+++ b/tools/noopfactory/src/test/resources/src/SimpleInterface.kt
@@ -27,4 +27,10 @@ interface SimpleInterface {
     fun doSomethingWithStringReturn(): String
 
     fun doSomethingWithNullableReturn(): Date?
+
+    fun doSomethingWithListReturn(): List<String>
+
+    fun doSomethingWithMapReturn(): Map<String, String>
+
+    fun doSomethingWithSetReturn(): Set<String>
 }


### PR DESCRIPTION
### What does this PR do?

This change gives user a possibility to attach custom attributes to automatically collected RUM Resource events: either in the `OkHttp` flow, or in the `WebView` flow.

Attributes are collected after the resource call is completed (with either `success` or `error` outcome)

### Additional Notes

Resources are also automatically collected [here](https://github.com/DataDog/dd-sdk-android/blob/master/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/resource/RumResourceInputStream.kt), but this part is not covered by this PR, because this class is low level and not sure if it is needed. Can be addressed in another PR if needed though.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)