### PR TITLE
RUMM-1168 Make sure we specify the Locale for 'String.format'

### DIFF
--- a/dd-sdk-android-sqldelight/src/main/kotlin/com/datadog/android/sqldelight/DatadogSqliteCallback.kt
+++ b/dd-sdk-android-sqldelight/src/main/kotlin/com/datadog/android/sqldelight/DatadogSqliteCallback.kt
@@ -28,9 +28,9 @@ class DatadogSqliteCallback(schema: SqlDriver.Schema) : AndroidSqliteDriver.Call
         GlobalRum.get()
             .addError(
                 String.format(
+                    Locale.US,
                     DATABASE_CORRUPTION_ERROR_MESSAGE,
-                    db.path,
-                    Locale.US
+                    db.path
                 ),
                 RumErrorSource.SOURCE,
                 null,

--- a/dd-sdk-android-sqldelight/src/test/kotlin/com/datadog/android/sqldelight/DatadogSqliteCallbackTest.kt
+++ b/dd-sdk-android-sqldelight/src/test/kotlin/com/datadog/android/sqldelight/DatadogSqliteCallbackTest.kt
@@ -82,9 +82,9 @@ class DatadogSqliteCallbackTest {
         verify(mockRumMonitor).addError(
             eq(
                 String.format(
+                    Locale.US,
                     DatadogSqliteCallback.DATABASE_CORRUPTION_ERROR_MESSAGE,
-                    fakeDbPath,
-                    Locale.US
+                    fakeDbPath
                 )
             ),
             eq(RumErrorSource.SOURCE),

--- a/dd-sdk-android/src/main/java/com/datadog/trace/api/Config.java
+++ b/dd-sdk-android/src/main/java/com/datadog/trace/api/Config.java
@@ -758,7 +758,7 @@ public class Config {
 
     public String getFinalProfilingUrl() {
         if (profilingUrl == null) {
-            return String.format(PROFILING_URL_TEMPLATE, site);
+            return String.format(Locale.US, PROFILING_URL_TEMPLATE, site);
         } else {
             return profilingUrl;
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
@@ -26,6 +26,7 @@ import com.datadog.android.tracing.TracedRequestListener
 import com.datadog.android.tracing.TracingInterceptor
 import io.opentracing.Span
 import io.opentracing.Tracer
+import java.util.Locale
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -226,7 +227,7 @@ internal constructor(
         GlobalRum.get().stopResourceWithError(
             requestId,
             null,
-            ERROR_MSG_FORMAT.format(method, url),
+            ERROR_MSG_FORMAT.format(Locale.US, method, url),
             RumErrorSource.NETWORK,
             throwable,
             rumResourceAttributesProvider.onProvideAttributes(request, null, throwable)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -502,10 +502,16 @@ internal constructor(
                 if (it.matches(validUrlRegex)) {
                     try {
                         val parsedUrl = URL(it)
-                        devLogger.w(WARNING_USING_URL_FOR_HOST.format(it, parsedUrl.host))
+                        devLogger.w(
+                            WARNING_USING_URL_FOR_HOST.format(
+                                Locale.US,
+                                it,
+                                parsedUrl.host
+                            )
+                        )
                         parsedUrl.host
                     } catch (e: MalformedURLException) {
-                        devLogger.e(ERROR_MALFORMED_URL.format(it), e)
+                        devLogger.e(ERROR_MALFORMED_URL.format(Locale.US, it), e)
                         null
                     }
                 } else if (it.matches(validHostNameRegEx)) {
@@ -514,7 +520,7 @@ internal constructor(
                     // special rule exception to accept `localhost` as a valid domain name
                     it
                 } else {
-                    devLogger.e(ERROR_MALFORMED_HOST_IP_ADDRESS.format(it))
+                    devLogger.e(ERROR_MALFORMED_HOST_IP_ADDRESS.format(Locale.US, it))
                     null
                 }
             }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraints.kt
@@ -78,7 +78,11 @@ internal class DatadogDataConstraints : DataConstraints {
                             entry.key.replace(Regex("[^a-zA-Z0-9\\-_.@$]"), "_")
                         if (sanitizedKey != entry.key) {
                             devLogger.w(
-                                CUSTOM_TIMING_KEY_REPLACED_WARNING.format(entry.key, sanitizedKey)
+                                CUSTOM_TIMING_KEY_REPLACED_WARNING.format(
+                                    Locale.US,
+                                    entry.key,
+                                    sanitizedKey
+                                )
                             )
                         }
                         sanitizedKey

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/NetworkInfoDeserializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/NetworkInfoDeserializer.kt
@@ -10,6 +10,7 @@ import com.datadog.android.core.internal.domain.Deserializer
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.core.model.NetworkInfo
 import com.google.gson.JsonParseException
+import java.util.Locale
 
 internal class NetworkInfoDeserializer : Deserializer<NetworkInfo> {
 
@@ -17,10 +18,10 @@ internal class NetworkInfoDeserializer : Deserializer<NetworkInfo> {
         return try {
             NetworkInfo.fromJson(model)
         } catch (e: JsonParseException) {
-            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(model), e)
+            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(Locale.US, model), e)
             null
         } catch (e: IllegalStateException) {
-            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(model), e)
+            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(Locale.US, model), e)
             null
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/user/UserInfoDeserializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/user/UserInfoDeserializer.kt
@@ -10,6 +10,7 @@ import com.datadog.android.core.internal.domain.Deserializer
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.core.model.UserInfo
 import com.google.gson.JsonParseException
+import java.util.Locale
 
 internal class UserInfoDeserializer : Deserializer<UserInfo> {
 
@@ -17,10 +18,10 @@ internal class UserInfoDeserializer : Deserializer<UserInfo> {
         return try {
             UserInfo.fromJson(model)
         } catch (e: JsonParseException) {
-            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(model), e)
+            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(Locale.US, model), e)
             null
         } catch (e: IllegalStateException) {
-            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(model), e)
+            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(Locale.US, model), e)
             null
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializer.kt
@@ -15,6 +15,7 @@ import com.datadog.android.rum.model.ViewEvent
 import com.google.gson.JsonObject
 import com.google.gson.JsonParseException
 import com.google.gson.JsonParser
+import java.util.Locale
 
 internal class RumEventDeserializer : Deserializer<RumEvent> {
 
@@ -38,10 +39,10 @@ internal class RumEventDeserializer : Deserializer<RumEvent> {
                 userAttributes
             )
         } catch (e: JsonParseException) {
-            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(model), e)
+            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(Locale.US, model), e)
             null
         } catch (e: IllegalStateException) {
-            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(model), e)
+            sdkLogger.e(DESERIALIZE_ERROR_MESSAGE_FORMAT.format(Locale.US, model), e)
             null
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
@@ -18,6 +18,7 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
+import java.util.Locale
 
 internal data class RumEventMapper(
     val viewEventMapper: EventMapper<ViewEvent> = NoOpEventMapper(),
@@ -45,7 +46,7 @@ internal data class RumEventMapper(
             else -> {
                 sdkLogger.w(
                     NO_EVENT_MAPPER_ASSIGNED_WARNING_MESSAGE
-                        .format(bundledEvent.javaClass.simpleName)
+                        .format(Locale.US, bundledEvent.javaClass.simpleName)
                 )
                 bundledEvent
             }
@@ -66,17 +67,17 @@ internal data class RumEventMapper(
             (bundledMappedEvent == null || bundledMappedEvent != event.event)
         ) {
             devLogger.w(
-                VIEW_EVENT_NULL_WARNING_MESSAGE.format(event)
+                VIEW_EVENT_NULL_WARNING_MESSAGE.format(Locale.US, event)
             )
             event
         } else if (bundledMappedEvent == null) {
             devLogger.w(
-                EVENT_NULL_WARNING_MESSAGE.format(event)
+                EVENT_NULL_WARNING_MESSAGE.format(Locale.US, event)
             )
             null
         } else if (bundledMappedEvent !== event.event) {
             devLogger.w(
-                NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(event)
+                NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(Locale.US, event)
             )
             null
         } else {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -22,6 +22,7 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent
 import java.net.MalformedURLException
 import java.net.URL
+import java.util.Locale
 import java.util.UUID
 
 internal class RumResourceScope(
@@ -268,7 +269,7 @@ internal class RumResourceScope(
         return if (throwable != null) {
             throwable.javaClass.canonicalName
         } else if (statusCode != null) {
-            ERROR_TYPE_BASED_ON_STATUS_CODE_FORMAT.format(statusCode)
+            ERROR_TYPE_BASED_ON_STATUS_CODE_FORMAT.format(Locale.US, statusCode)
         } else {
             null
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
@@ -25,6 +25,7 @@ import com.datadog.android.rum.model.ViewEvent
 import com.google.gson.JsonParseException
 import java.io.File
 import java.lang.IllegalStateException
+import java.util.Locale
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 
@@ -137,7 +138,7 @@ internal class DatadogNdkCrashHandler(
         if (ndkCrashLog == null) {
             return
         }
-        val errorLogMessage = NDK_ERROR_LOG_MESSAGE.format(ndkCrashLog.signalName)
+        val errorLogMessage = NDK_ERROR_LOG_MESSAGE.format(Locale.US, ndkCrashLog.signalName)
         val bundledViewEvent = lastRumViewEvent?.event as? ViewEvent
         val logAttributes: Map<String, String>
         if (lastRumViewEvent != null && bundledViewEvent != null) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandler.kt
@@ -30,7 +30,7 @@ class DatadogDatabaseErrorHandler(
         defaultErrorHandler.onCorruption(dbObj)
         GlobalRum.get()
             .addError(
-                String.format(DATABASE_CORRUPTION_ERROR_MESSAGE, dbObj.path, Locale.US),
+                String.format(Locale.US, DATABASE_CORRUPTION_ERROR_MESSAGE, dbObj.path),
                 RumErrorSource.SOURCE,
                 null,
                 mapOf(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogConfigBuilderTest.kt
@@ -42,6 +42,7 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.net.MalformedURLException
 import java.net.URL
+import java.util.Locale
 import java.util.UUID
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -808,7 +809,7 @@ internal class DatadogConfigBuilderTest {
         hosts.forEach {
             verify(mockDevLogHandler).handleLog(
                 Log.ERROR,
-                Configuration.ERROR_MALFORMED_HOST_IP_ADDRESS.format(it)
+                Configuration.ERROR_MALFORMED_HOST_IP_ADDRESS.format(Locale.US, it)
             )
         }
     }
@@ -831,7 +832,7 @@ internal class DatadogConfigBuilderTest {
         hosts.forEach {
             verify(mockDevLogHandler).handleLog(
                 Log.ERROR,
-                Configuration.ERROR_MALFORMED_HOST_IP_ADDRESS.format(it)
+                Configuration.ERROR_MALFORMED_HOST_IP_ADDRESS.format(Locale.US, it)
             )
         }
     }
@@ -922,7 +923,7 @@ internal class DatadogConfigBuilderTest {
         hosts.forEach {
             verify(mockDevLogHandler).handleLog(
                 Log.WARN,
-                Configuration.WARNING_USING_URL_FOR_HOST.format(it, URL(it).host)
+                Configuration.WARNING_USING_URL_FOR_HOST.format(Locale.US, it, URL(it).host)
             )
         }
     }
@@ -943,7 +944,7 @@ internal class DatadogConfigBuilderTest {
         hosts.forEach {
             verify(mockDevLogHandler).handleLog(
                 eq(Log.ERROR),
-                eq(Configuration.ERROR_MALFORMED_URL.format(it)),
+                eq(Configuration.ERROR_MALFORMED_URL.format(Locale.US, it)),
                 any<MalformedURLException>(),
                 anyOrNull(),
                 anyOrNull(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -967,7 +967,7 @@ internal class ConfigurationBuilderTest {
         hosts.forEach {
             verify(mockDevLogHandler).handleLog(
                 Log.ERROR,
-                Configuration.ERROR_MALFORMED_HOST_IP_ADDRESS.format(it)
+                Configuration.ERROR_MALFORMED_HOST_IP_ADDRESS.format(Locale.US, it)
             )
         }
     }
@@ -990,7 +990,7 @@ internal class ConfigurationBuilderTest {
         hosts.forEach {
             verify(mockDevLogHandler).handleLog(
                 Log.ERROR,
-                Configuration.ERROR_MALFORMED_HOST_IP_ADDRESS.format(it)
+                Configuration.ERROR_MALFORMED_HOST_IP_ADDRESS.format(Locale.US, it)
             )
         }
     }
@@ -1094,7 +1094,7 @@ internal class ConfigurationBuilderTest {
         hosts.forEach {
             verify(mockDevLogHandler).handleLog(
                 Log.WARN,
-                Configuration.WARNING_USING_URL_FOR_HOST.format(it, URL(it).host)
+                Configuration.WARNING_USING_URL_FOR_HOST.format(Locale.US, it, URL(it).host)
             )
         }
     }
@@ -1115,7 +1115,7 @@ internal class ConfigurationBuilderTest {
         hosts.forEach {
             verify(mockDevLogHandler).handleLog(
                 eq(Log.ERROR),
-                eq(Configuration.ERROR_MALFORMED_URL.format(it)),
+                eq(Configuration.ERROR_MALFORMED_URL.format(Locale.US, it)),
                 any<MalformedURLException>(),
                 anyOrNull(),
                 anyOrNull(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
@@ -30,6 +30,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.Locale
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -189,7 +190,7 @@ internal class RumEventMapperTest {
         verify(mockSdkLogHandler).handleLog(
             Log.WARN,
             RumEventMapper.NO_EVENT_MAPPER_ASSIGNED_WARNING_MESSAGE
-                .format(fakeRumEventCopy.event.javaClass.simpleName)
+                .format(Locale.US, fakeRumEventCopy.event.javaClass.simpleName)
         )
         assertThat(mappedRumEvent).isEqualTo(fakeRumEventCopy)
     }
@@ -209,7 +210,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isEqualTo(fakeRumEvent)
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.VIEW_EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent)
+            RumEventMapper.VIEW_EVENT_NULL_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
         )
     }
 
@@ -228,7 +229,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent)
+            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
 
         )
     }
@@ -248,7 +249,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent)
+            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
 
         )
     }
@@ -268,7 +269,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent)
+            RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
 
         )
     }
@@ -288,7 +289,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isEqualTo(fakeRumEvent)
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.VIEW_EVENT_NULL_WARNING_MESSAGE.format(fakeRumEvent)
+            RumEventMapper.VIEW_EVENT_NULL_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
         )
     }
 
@@ -307,7 +308,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(fakeRumEvent)
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
 
         )
     }
@@ -327,7 +328,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(fakeRumEvent)
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
         )
     }
 
@@ -346,7 +347,7 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent).isNull()
         verify(mockDevLogHandler).handleLog(
             Log.WARN,
-            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(fakeRumEvent)
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
 
         )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
@@ -45,6 +45,7 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.File
 import java.io.FileOutputStream
+import java.util.Locale
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
 import org.assertj.core.api.Assertions.assertThat
@@ -159,7 +160,12 @@ internal class DatadogNdkCrashHandlerTest {
         whenever(
             mockedLockGenerator.generateLog(
                 eq(Log.CRASH),
-                eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+                eq(
+                    DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(
+                        Locale.US,
+                        fakeNdkCrashLog.signalName
+                    )
+                ),
                 anyOrNull(),
                 eq(
                     mapOf(
@@ -340,7 +346,12 @@ internal class DatadogNdkCrashHandlerTest {
         // THEN
         verify(mockedLockGenerator).generateLog(
             eq(Log.CRASH),
-            eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+            eq(
+                DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(
+                    Locale.US,
+                    fakeNdkCrashLog.signalName
+                )
+            ),
             anyOrNull(),
             eq(
                 mapOf(
@@ -373,7 +384,12 @@ internal class DatadogNdkCrashHandlerTest {
         // THEN
         verify(mockedLockGenerator).generateLog(
             eq(Log.CRASH),
-            eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+            eq(
+                DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(
+                    Locale.US,
+                    fakeNdkCrashLog.signalName
+                )
+            ),
             anyOrNull(),
             eq(
                 mapOf(
@@ -406,7 +422,12 @@ internal class DatadogNdkCrashHandlerTest {
         // THEN
         verify(mockedLockGenerator).generateLog(
             eq(Log.CRASH),
-            eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+            eq(
+                DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(
+                    Locale.US,
+                    fakeNdkCrashLog.signalName
+                )
+            ),
             anyOrNull(),
             any(),
             eq(emptySet()),
@@ -434,7 +455,12 @@ internal class DatadogNdkCrashHandlerTest {
         // THEN
         verify(mockedLockGenerator).generateLog(
             eq(Log.CRASH),
-            eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+            eq(
+                DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(
+                    Locale.US,
+                    fakeNdkCrashLog.signalName
+                )
+            ),
             anyOrNull(),
             any(),
             eq(emptySet()),
@@ -462,7 +488,12 @@ internal class DatadogNdkCrashHandlerTest {
         // THEN
         verify(mockedLockGenerator).generateLog(
             eq(Log.CRASH),
-            eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+            eq(
+                DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(
+                    Locale.US,
+                    fakeNdkCrashLog.signalName
+                )
+            ),
             anyOrNull(),
             any(),
             eq(emptySet()),
@@ -490,7 +521,12 @@ internal class DatadogNdkCrashHandlerTest {
         // THEN
         verify(mockedLockGenerator).generateLog(
             eq(Log.CRASH),
-            eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+            eq(
+                DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(
+                    Locale.US,
+                    fakeNdkCrashLog.signalName
+                )
+            ),
             anyOrNull(),
             any(),
             eq(emptySet()),
@@ -516,7 +552,12 @@ internal class DatadogNdkCrashHandlerTest {
         // THEN
         verify(mockedLockGenerator).generateLog(
             eq(Log.CRASH),
-            eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+            eq(
+                DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(
+                    Locale.US,
+                    fakeNdkCrashLog.signalName
+                )
+            ),
             anyOrNull(),
             eq(
                 mapOf(
@@ -591,7 +632,10 @@ internal class DatadogNdkCrashHandlerTest {
                 fakeBundledViewEvent.view.url
             )
             .hasMessage(
-                DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)
+                DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(
+                    Locale.US,
+                    fakeNdkCrashLog.signalName
+                )
             )
             .hasStackTrace(fakeNdkCrashLog.stacktrace)
             .isCrash(true)
@@ -678,7 +722,12 @@ internal class DatadogNdkCrashHandlerTest {
         whenever(
             mockedLockGenerator.generateLog(
                 eq(Log.CRASH),
-                eq(DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(fakeNdkCrashLog.signalName)),
+                eq(
+                    DatadogNdkCrashHandler.NDK_ERROR_LOG_MESSAGE.format(
+                        Locale.US,
+                        fakeNdkCrashLog.signalName
+                    )
+                ),
                 anyOrNull(),
                 eq(
                     mapOf(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandlerTest.kt
@@ -87,9 +87,9 @@ class DatadogDatabaseErrorHandlerTest {
         verify(mockRumMonitor).addError(
             eq(
                 String.format(
+                    Locale.US,
                     DatadogDatabaseErrorHandler.DATABASE_CORRUPTION_ERROR_MESSAGE,
-                    fakeDbPath,
-                    Locale.US
+                    fakeDbPath
                 )
             ),
             eq(RumErrorSource.SOURCE),


### PR DESCRIPTION
### What does this PR do?

The way we were using the `String.format(...` function was not consistent in our code (sometimes we specified the Locale and sometimes we didn't). 

Not specifying the `Locale` and using the default one is recommended when presenting information to the user but these messages need to be adapted for the specific country. Not specifying the `Locale` is not recommended for machine readable output (data sent to our endpoints) because it can produce weird interpretations and sometimes it can't even interpret an argument: floating-point numbers some locales will use ',' as the decimal point and '.' for digit grouping.

Because the only part were we are using the `String.format(...` function to send output to the UI/User is in our logs I do not see a reason why we should not apply this rule everywhere and use the `Locale.US` for any formatted String from now on.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

