### PR TITLE
RUMM-1174 Fix the integration tests

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -434,6 +434,7 @@ internal class RumViewScope(
         event: RumRawEvent.ApplicationStarted,
         writer: Writer<RumEvent>
     ) {
+        pendingActionCount++
         val context = getRumContext()
         val user = CoreFeature.userInfoProvider.getUserInfo()
 
@@ -522,7 +523,9 @@ internal class RumViewScope(
             pendingResourceCount +
             pendingErrorCount +
             pendingLongTaskCount
-        return stopped && activeResourceScopes.isEmpty() && pending == 0L
+        // we use <= 0 for pending counter as a safety measure to make sure this ViewScope will
+        // be closed.
+        return stopped && activeResourceScopes.isEmpty() && (pending <= 0L)
     }
 
     // endregion

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -61,7 +61,6 @@ android {
     buildTypes {
         getByName("release") {
             isMinifyEnabled = true
-            isUseProguard = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"
@@ -69,7 +68,6 @@ android {
         }
         getByName("debug") {
             isMinifyEnabled = true
-            isUseProguard = true
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro"

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/CPUProfileForLogs.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/CPUProfileForLogs.kt
@@ -8,7 +8,7 @@ package com.datadog.android.sdk.integration.log
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import com.datadog.android.sdk.integrationtests.ActivityProfiling
+import com.datadog.android.sdk.ActivityProfiling
 import com.datadog.android.sdk.rules.AbstractProfilingRule
 import com.datadog.android.sdk.rules.CPUProfilingRule
 import com.datadog.android.sdk.rules.MockServerActivityTestRule

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/MemoryProfileForLogs.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/MemoryProfileForLogs.kt
@@ -8,7 +8,7 @@ package com.datadog.android.sdk.integration.log
 
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
-import com.datadog.android.sdk.integrationtests.ActivityProfiling
+import com.datadog.android.sdk.ActivityProfiling
 import com.datadog.android.sdk.rules.AbstractProfilingRule
 import com.datadog.android.sdk.rules.MemoryProfilingRule
 import com.datadog.android.sdk.rules.MockServerActivityTestRule

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingTest.kt
@@ -21,7 +21,6 @@ internal abstract class ActivityTrackingTest :
     ): MutableList<ExpectedEvent> {
 
         val expectedEvents = mutableListOf<ExpectedEvent>()
-        expectedEvents.add(ExpectedApplicationStart())
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val activity = mockServerRule.activity
         val viewUrl = activity.javaClass.canonicalName!!.replace(
@@ -30,6 +29,11 @@ internal abstract class ActivityTrackingTest :
         )
 
         instrumentation.waitForIdleSync()
+
+        // one for the Application start action
+        expectedEvents.add(
+            ExpectedApplicationStart()
+        )
 
         // one for application start update
         expectedEvents.add(
@@ -73,6 +77,7 @@ internal abstract class ActivityTrackingTest :
 
         instrumentation.waitForIdleSync()
 
+        Thread.sleep(500)
         // activity start - resume
 
         instrumentation.runOnMainSync {

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/AbstractProfilingRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/AbstractProfilingRule.kt
@@ -9,7 +9,6 @@ package com.datadog.android.sdk.rules
 import androidx.test.platform.app.InstrumentationRegistry
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import kotlin.math.abs
 import kotlin.math.max
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.rules.TestRule
@@ -122,16 +121,6 @@ internal abstract class AbstractProfilingRule(
     private fun List<Double>.average(): Double {
         val sum = sumByDouble { it }
         return sum / size.toDouble()
-    }
-
-    private fun List<Double>.statistics(): Pair<Double, Double> {
-        val sum = sumByDouble { it }
-        val average = sum / size.toDouble()
-
-        val sumDeviation = sumByDouble { abs(it - average) }
-        val stDeviation = sumDeviation / size.toDouble()
-
-        return average to stDeviation
     }
 
     // endregion

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/utils/ExtraIntentExtensions.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/utils/ExtraIntentExtensions.kt
@@ -21,7 +21,7 @@ fun Intent.addExtras(map: Map<String, Any?>) {
     }
 }
 
-internal fun Intent.addTrackingConsent(consent: TrackingConsent) {
+fun Intent.addTrackingConsent(consent: TrackingConsent) {
     val consentToInt = when (consent) {
         TrackingConsent.PENDING -> PENDING
         TrackingConsent.GRANTED -> GRANTED

--- a/instrumented/integration/src/main/AndroidManifest.xml
+++ b/instrumented/integration/src/main/AndroidManifest.xml
@@ -39,7 +39,7 @@
             android:label="@string/rum_activity_view_tracking_end_to_end"
             android:windowSoftInputMode="adjustResize"/>
         <activity
-            android:name="com.datadog.android.sdk.integrationtests.ActivityProfiling"
+            android:name="com.datadog.android.sdk.ActivityProfiling"
             android:label="@string/activity_logs_profiling"
             android:windowSoftInputMode="adjustResize">
             <intent-filter>

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/ActivityProfiling.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/ActivityProfiling.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.sdk.integrationtests
+package com.datadog.android.sdk
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
@@ -28,6 +28,8 @@ internal object RuntimeConfig {
     var tracesEndpointUrl: String = LOCALHOST
     var rumEndpointUrl: String = LOCALHOST
 
+    val LONG_TASK_LARGE_THRESHOLD = Long.MAX_VALUE
+
     fun logger(): Logger {
         // Initialise Logger
         val logger = Logger.Builder()

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingPlaygroundActivity.kt
@@ -23,8 +23,11 @@ internal class ActivityTrackingPlaygroundActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
 
         val credentials = RuntimeConfig.credentials()
+        // we will use a large long task threshold to make sure we will not have LongTask events
+        // noise in our integration tests.
         val config = RuntimeConfig.configBuilder()
             .trackInteractions()
+            .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
             .useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
             .build()
         val trackingConsent = intent.getTrackingConsent()

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingPlaygroundActivity.kt
@@ -29,6 +29,7 @@ internal class FragmentTrackingPlaygroundActivity : AppCompatActivity() {
         val credentials = RuntimeConfig.credentials()
         val config = RuntimeConfig.configBuilder()
             .trackInteractions()
+            .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
             .useViewTrackingStrategy(FragmentViewTrackingStrategy(true))
             .build()
         val trackingConsent = intent.getTrackingConsent()

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/GesturesTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/GesturesTrackingPlaygroundActivity.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.sdk.integration.rum
 
 import android.os.Bundle
-import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -17,13 +16,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
-import com.datadog.android.Datadog
-import com.datadog.android.rum.GlobalRum
-import com.datadog.android.rum.RumMonitor
-import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.sdk.integration.R
-import com.datadog.android.sdk.integration.RuntimeConfig
-import com.datadog.android.sdk.utils.getTrackingConsent
 
 internal class GesturesTrackingPlaygroundActivity : AppCompatActivity() {
 
@@ -37,19 +30,6 @@ internal class GesturesTrackingPlaygroundActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        val credentials = RuntimeConfig.credentials()
-        val config = RuntimeConfig.configBuilder()
-            .trackInteractions()
-            .useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
-            .build()
-        val trackingConsent = intent.getTrackingConsent()
-
-        Datadog.initialize(this, credentials, config, trackingConsent)
-        Datadog.setVerbosity(Log.VERBOSE)
-
-        GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
-
         setContentView(R.layout.gestures_tracking_layout)
 
         showHide = findViewById(R.id.show_hide)

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/ObjectTest.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/ObjectTest.kt
@@ -28,7 +28,7 @@ abstract class ObjectTest<T : Any> {
      * x.equals(x) is always true
      */
     @Test
-    fun `equals is reflexive`(forge: Forge) {
+    fun equalsIsReflexive(forge: Forge) {
         // Given
         val x = createInstance(forge)
 
@@ -44,7 +44,7 @@ abstract class ObjectTest<T : Any> {
      * x.equals(y) == y.equals(x)
      */
     @Test
-    fun `equals is symmetric`(forge: Forge) {
+    fun equalsIsSymmetric(forge: Forge) {
         // Given
         val x = createInstance(forge)
         val y = createInstance(forge)
@@ -63,7 +63,7 @@ abstract class ObjectTest<T : Any> {
      * if (x.equals(y) && y.equals(z)) then x.equals(z)
      */
     @Test
-    fun `equals is transitive`(forge: Forge) {
+    fun equalsIsTransitive(forge: Forge) {
         // Given
         val x = createInstance(forge)
         val y = createEqualInstance(x, forge)
@@ -86,7 +86,7 @@ abstract class ObjectTest<T : Any> {
      * if a (relevant) field is changed, equals should detect it
      */
     @Test
-    fun `equals is consistent`(forge: Forge) {
+    fun equalsIsConsistent(forge: Forge) {
         // Given
         val x = createInstance(forge)
         val y = createUnequalInstance(x, forge) ?: return
@@ -104,7 +104,7 @@ abstract class ObjectTest<T : Any> {
      * if the two compared instances are of different types, equals is false
      */
     @Test
-    fun `equals is type sensitive`(forge: Forge) {
+    fun equalsIsTypeSensitive(forge: Forge) {
         // Given
         val x = createInstance(forge)
         val y = Object()
@@ -130,7 +130,7 @@ abstract class ObjectTest<T : Any> {
      */
     @Test
     @Suppress("FunctionMaxLength")
-    fun `hashCode is internally consistent`(forge: Forge) {
+    fun hashCodeIsInternallyConsistent(forge: Forge) {
         // Given
         val x = createInstance(forge)
 
@@ -162,7 +162,7 @@ abstract class ObjectTest<T : Any> {
      */
     @Test
     @Suppress("FunctionMaxLength")
-    fun `hashCode is consistent with equal`(forge: Forge) {
+    fun hashCodeIsConsistentWithEqual(forge: Forge) {
         // Given
         val x = createInstance(forge)
         val y = createEqualInstance(x, forge)


### PR DESCRIPTION
### What does this PR do?

This PR addresses following things:

1. We had a bug in the `RumViewScope` that could not close the View when the `ApplicationStart` event was sent during the View lifetime.
2. Due to the new configuration defaults we were sending lots of `LongTask` events during our integration test cases and those were all failing. I had to add a very long threshold for the `LongTaskStrategy` to avoid that and I will open a new Jira task where we specifically add an Espresso test for it.
3. The `integration tests` project was using the `Proguard` based deprecated compiler and not R8.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

