### PR TITLE
RUMM-1181: Use Kotlin 1.4.20, get rid of language level warnings in the classpath

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -13,9 +13,6 @@ plugins {
 }
 
 buildscript {
-    dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
-    }
     repositories {
         mavenCentral()
     }
@@ -34,8 +31,7 @@ repositories {
 dependencies {
 
     // Dependencies used to configure the gradle plugins
-    implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.3.72")
-    implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.72")
+    implementation(embeddedKotlin("gradle-plugin"))
     implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.1.1")
     implementation("org.jlleitschuh.gradle:ktlint-gradle:9.4.0")
     implementation("com.android.tools.build:gradle:4.1.2")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -10,7 +10,7 @@ object Dependencies {
 
     object Versions {
         // Commons
-        const val Kotlin = "1.4.0"
+        const val Kotlin = "1.4.20"
         const val Gson = "2.8.6"
         const val OkHttp = "3.12.6"
         const val KronosNTP = "0.0.1-alpha10"

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -69,7 +69,7 @@ object Dependencies {
         const val RxJava = "3.0.0"
         const val SQLDelight = "1.4.3"
         const val Timber = "4.7.1"
-        const val Coroutines = "1.3.9"
+        const val Coroutines = "1.4.1"
 
         // NDK
         const val NdkVersion = "21.3.6528147"

--- a/dd-sdk-android-coil/build.gradle.kts
+++ b/dd-sdk-android-coil/build.gradle.kts
@@ -22,7 +22,6 @@ plugins {
     id("com.android.library")
     id("androidx.benchmark")
     kotlin("android")
-    kotlin("android.extensions")
     kotlin("kapt")
     `maven-publish`
     id("com.github.ben-manes.versions")

--- a/dd-sdk-android-coil/transitiveDependencies
+++ b/dd-sdk-android-coil/transitiveDependencies
@@ -7,9 +7,8 @@ com.squareup.okhttp3:okhttp:3.12.12                             :  417 Kb
 com.squareup.okio:okio:2.9.0                                    :  247 Kb
 io.coil-kt:coil-base:1.0.0                                      :  395 Kb
 io.coil-kt:coil:1.0.0                                           :   15 Kb
-org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.4.10   :    8 Kb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10                :  186 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.4.10                       : 1452 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.3.9         : 1629 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/dd-sdk-android-fresco/build.gradle.kts
+++ b/dd-sdk-android-fresco/build.gradle.kts
@@ -22,7 +22,6 @@ plugins {
     id("com.android.library")
     id("androidx.benchmark")
     kotlin("android")
-    kotlin("android.extensions")
     kotlin("kapt")
     `maven-publish`
     id("com.github.ben-manes.versions")

--- a/dd-sdk-android-fresco/transitiveDependencies
+++ b/dd-sdk-android-fresco/transitiveDependencies
@@ -14,9 +14,8 @@ com.facebook.fresco:nativeimagefilters:2.3.0                    :   52 Kb
 com.facebook.fresco:nativeimagetranscoder:2.3.0                 :  764 Kb
 com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
-org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72   :    8 Kb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10                :  186 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.4.10                       : 1452 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    3 Mb

--- a/dd-sdk-android-glide/build.gradle.kts
+++ b/dd-sdk-android-glide/build.gradle.kts
@@ -22,7 +22,6 @@ plugins {
     id("com.android.library")
     id("androidx.benchmark")
     kotlin("android")
-    kotlin("android.extensions")
     kotlin("kapt")
     `maven-publish`
     id("com.github.ben-manes.versions")

--- a/dd-sdk-android-glide/transitiveDependencies
+++ b/dd-sdk-android-glide/transitiveDependencies
@@ -40,9 +40,8 @@ com.github.bumptech.glide:glide:4.11.0                          :  614 Kb
 com.github.bumptech.glide:okhttp3-integration:4.11.0            :    8 Kb
 com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
-org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72   :    8 Kb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10                :  186 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.4.10                       : 1452 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    4 Mb

--- a/dd-sdk-android-ktx/build.gradle.kts
+++ b/dd-sdk-android-ktx/build.gradle.kts
@@ -22,7 +22,6 @@ plugins {
     id("com.android.library")
     id("androidx.benchmark")
     kotlin("android")
-    kotlin("android.extensions")
     `maven-publish`
     id("com.github.ben-manes.versions")
     id("io.gitlab.arturbosch.detekt")

--- a/dd-sdk-android-ktx/transitiveDependencies
+++ b/dd-sdk-android-ktx/transitiveDependencies
@@ -3,9 +3,8 @@ Dependencies List
 androidx.annotation:annotation:1.1.0                            :   27 Kb
 com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
-org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72   :    8 Kb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10                :  186 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.4.10                       : 1452 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.3.9         : 1629 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/dd-sdk-android-ktx/transitiveDependencies
+++ b/dd-sdk-android-ktx/transitiveDependencies
@@ -5,8 +5,8 @@ com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9          :   19 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.3.9         : 1629 Kb
+org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1          :   19 Kb
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.1         : 1633 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    3 Mb

--- a/dd-sdk-android-ndk/build.gradle.kts
+++ b/dd-sdk-android-ndk/build.gradle.kts
@@ -21,7 +21,6 @@ import com.datadog.gradle.testImplementation
 plugins {
     id("com.android.library")
     kotlin("android")
-    kotlin("android.extensions")
     `maven-publish`
     id("com.github.ben-manes.versions")
     id("io.gitlab.arturbosch.detekt")

--- a/dd-sdk-android-ndk/transitiveDependencies
+++ b/dd-sdk-android-ndk/transitiveDependencies
@@ -3,9 +3,8 @@ Dependencies List
 androidx.multidex:multidex:2.0.1                                :   26 Kb
 com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
-org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72   :    8 Kb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10                :  186 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.4.10                       : 1452 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    2 Mb

--- a/dd-sdk-android-rx/build.gradle.kts
+++ b/dd-sdk-android-rx/build.gradle.kts
@@ -22,7 +22,6 @@ plugins {
     id("com.android.library")
     id("androidx.benchmark")
     kotlin("android")
-    kotlin("android.extensions")
     kotlin("kapt")
     `maven-publish`
     id("com.github.ben-manes.versions")

--- a/dd-sdk-android-rx/transitiveDependencies
+++ b/dd-sdk-android-rx/transitiveDependencies
@@ -3,9 +3,8 @@ Dependencies List
 com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 io.reactivex.rxjava3:rxjava:3.0.0                               :    2 Mb
-org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72   :    8 Kb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10                :  186 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.4.10                       : 1452 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 org.reactivestreams:reactive-streams:1.0.3                      :   11 Kb
 

--- a/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/dd-sdk-android-sqldelight/build.gradle.kts
@@ -22,7 +22,6 @@ plugins {
     id("com.android.library")
     id("androidx.benchmark")
     kotlin("android")
-    kotlin("android.extensions")
     kotlin("kapt")
     `maven-publish`
     id("com.github.ben-manes.versions")

--- a/dd-sdk-android-sqldelight/transitiveDependencies
+++ b/dd-sdk-android-sqldelight/transitiveDependencies
@@ -6,11 +6,10 @@ com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 com.squareup.sqldelight:android-driver:1.4.3                    :   22 Kb
 com.squareup.sqldelight:runtime-jvm:1.4.3                       :   42 Kb
-org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72   :    8 Kb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10                :  186 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.4.0                   :    3 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.4.0                   :   15 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.4.10                       : 1452 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    2 Mb

--- a/dd-sdk-android-timber/build.gradle.kts
+++ b/dd-sdk-android-timber/build.gradle.kts
@@ -20,7 +20,6 @@ import com.datadog.gradle.testImplementation
 plugins {
     id("com.android.library")
     kotlin("android")
-    kotlin("android.extensions")
     `maven-publish`
     id("com.github.ben-manes.versions")
     id("io.gitlab.arturbosch.detekt")

--- a/dd-sdk-android-timber/transitiveDependencies
+++ b/dd-sdk-android-timber/transitiveDependencies
@@ -1,10 +1,9 @@
 Dependencies List
 
 com.jakewharton.timber:timber:4.7.1                             :   21 Kb
-org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72   :    8 Kb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10                :  186 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.4.10                       : 1452 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains:annotations:16.0.1                                :   18 Kb
 
-Total transitive dependencies size                              : 1686 Kb
+Total transitive dependencies size                              : 1679 Kb
 

--- a/dd-sdk-android/build.gradle.kts
+++ b/dd-sdk-android/build.gradle.kts
@@ -24,7 +24,6 @@ import com.datadog.gradle.testImplementation
 plugins {
     id("com.android.library")
     kotlin("android")
-    kotlin("android.extensions")
     kotlin("kapt")
     `maven-publish`
     id("com.github.ben-manes.versions")

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
@@ -18,8 +18,11 @@ import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.utils.mockContext
 import com.datadog.tools.unit.setFieldValue
 import com.datadog.tools.unit.setStaticValue
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
@@ -29,6 +32,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -71,6 +75,14 @@ internal class ProcessLifecycleCallbackTest {
                     NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
                 )
             )
+
+        whenever(
+            mockWorkManager.enqueueUniqueWork(
+                ArgumentMatchers.anyString(),
+                any(),
+                any<OneTimeWorkRequest>()
+            )
+        ) doReturn mock()
 
         // When
         testedCallback.onStopped()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -17,10 +17,14 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockContext
 import com.datadog.tools.unit.invokeMethod
 import com.datadog.tools.unit.setStaticValue
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argThat
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -29,6 +33,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.ArgumentMatchers.anyString
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -57,6 +62,15 @@ internal class WorkManagerUtilsTest {
                 forge.anHexadecimalString()
             ).build()
         )
+
+        whenever(mockWorkManager.cancelAllWorkByTag(anyString())) doReturn mock()
+        whenever(
+            mockWorkManager.enqueueUniqueWork(
+                anyString(),
+                any(),
+                any<OneTimeWorkRequest>()
+            )
+        ) doReturn mock()
     }
 
     @AfterEach

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -38,10 +38,12 @@ import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.invokeMethod
 import com.datadog.tools.unit.setFieldValue
 import com.datadog.tools.unit.setStaticValue
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
@@ -63,6 +65,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.ArgumentMatchers
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -182,6 +185,15 @@ internal class DatadogExceptionHandlerTest {
 
     @Test
     fun `M schedule the worker W logging an exception`(forge: Forge) {
+
+        whenever(
+            mockWorkManager.enqueueUniqueWork(
+                ArgumentMatchers.anyString(),
+                any(),
+                any<OneTimeWorkRequest>()
+            )
+        ) doReturn mock()
+
         WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
         Thread.setDefaultUncaughtExceptionHandler(null)
         testedHandler.register()

--- a/dd-sdk-android/transitiveDependencies
+++ b/dd-sdk-android/transitiveDependencies
@@ -38,9 +38,8 @@ com.squareup.okio:okio:1.15.0                                   :   86 Kb
 io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb
-org.jetbrains.kotlin:kotlin-android-extensions-runtime:1.3.72   :    8 Kb
-org.jetbrains.kotlin:kotlin-stdlib-common:1.4.10                :  186 Kb
-org.jetbrains.kotlin:kotlin-stdlib:1.4.10                       : 1452 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0          :   20 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0             : 1487 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb

--- a/instrumented/benchmark/build.gradle.kts
+++ b/instrumented/benchmark/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     id("com.android.library")
     id("androidx.benchmark")
     kotlin("android")
-    kotlin("android.extensions")
     `maven-publish`
     id("com.github.ben-manes.versions")
     id("io.gitlab.arturbosch.detekt")

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -10,7 +10,6 @@ import org.gradle.api.JavaVersion
 plugins {
     id("com.android.application")
     kotlin("android")
-    kotlin("android.extensions")
     id("io.gitlab.arturbosch.detekt")
     id("org.jlleitschuh.gradle.ktlint")
     jacoco

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -17,7 +17,6 @@ import com.datadog.gradle.implementation
 plugins {
     id("com.android.application")
     kotlin("android")
-    kotlin("android.extensions")
     kotlin("kapt")
     `maven-publish`
     id("com.github.ben-manes.versions")
@@ -137,9 +136,9 @@ dependencies {
     implementation("androidx.preference:preference-ktx:1.1.1")
 
     // Ktor (local web server)
-    implementation("io.ktor:ktor:1.2.5")
-    implementation("io.ktor:ktor-server-netty:1.2.5")
-    implementation("io.ktor:ktor-gson:1.2.5")
+    implementation("io.ktor:ktor:1.4.3")
+    implementation("io.ktor:ktor-server-netty:1.4.3")
+    implementation("io.ktor:ktor-gson:1.4.3")
 
     // Image Loading Library
     implementation(Dependencies.Libraries.Coil)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/server/LocalServer.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/server/LocalServer.kt
@@ -38,7 +38,7 @@ class LocalServer {
 
     fun stop() {
         Thread {
-            engine?.stop(SHUTDOWN_MS, STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS)
+            engine?.stop(SHUTDOWN_MS, STOP_TIMEOUT_MS)
         }.start()
     }
 

--- a/tools/noopfactory/build.gradle.kts
+++ b/tools/noopfactory/build.gradle.kts
@@ -24,7 +24,7 @@ plugins {
 dependencies {
     implementation(Dependencies.Libraries.Kotlin)
     implementation(Dependencies.Libraries.KotlinReflect)
-    implementation("com.squareup:kotlinpoet:1.5.0")
+    implementation("com.squareup:kotlinpoet:1.7.2")
 
     testImplementation(Dependencies.Libraries.JUnit5)
     testImplementation(Dependencies.Libraries.TestTools)

--- a/tools/unit/build.gradle.kts
+++ b/tools/unit/build.gradle.kts
@@ -18,7 +18,6 @@ import com.datadog.gradle.testImplementation
 plugins {
     id("com.android.library")
     kotlin("android")
-    kotlin("android.extensions")
     id("com.github.ben-manes.versions")
     id("io.gitlab.arturbosch.detekt")
     id("org.jlleitschuh.gradle.ktlint")


### PR DESCRIPTION
### What does this PR do?

Similar to https://github.com/DataDog/dd-sdk-android-gradle-plugin/pull/20, takes advantage of embedded Kotlin version. This change also bumps language level for all the modules from 1.3 to 1.4 in the IDE, so warnings analysis may be re-done.

Warning about different language levels in the compile classpath remains for the `:tools:detekt` module, but to resolve it update of `detekt` is needed, which is better to do in another PR later (since probably rules config will be changed as well). Anyway, since it is a part of the build tooling and not a part of the final artifact, I think it is fine to keep it like that for now.