### PR TITLE
Undeprecate the DatadogGlideModule constructor

### DIFF
--- a/dd-sdk-android-glide/README.md
+++ b/dd-sdk-android-glide/README.md
@@ -29,8 +29,14 @@ class SampleApplication : Application() {
     override fun onCreate() {
         super.onCreate()
 
-        val config = DatadogConfig.Builder("<CLIENT_TOKEN>", "<ENVIRONMENT_NAME>", "<APPLICATION_ID>").build()
-        Datadog.initialize(this, config)
+        val configuration = Configuration.Builder().build()
+        val credentials = Credentials(
+           <CLIENT_TOKEN>,
+           <ENV_NAME>,
+           <APP_VARIANT_NAME>,
+           <APPLICATION_ID>
+        )
+        Datadog.initialize(this, credentials, configuration, trackingConsent)
 
         val monitor = RumMonitor.Builder().build()
         GlobalRum.registerIfAbsent(monitor)


### PR DESCRIPTION
### What does this PR do?

Un-deprecate the DatadogGlideModule constructor (make it consistent with the un-deprecation of the Interceptor's constructors).

### Motivation

#528 
