### PR TITLE
Use Kotlin coroutines 1.4.2, because version 1.4.1 has StackOverflowError bug

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -69,7 +69,7 @@ object Dependencies {
         const val RxJava = "3.0.0"
         const val SQLDelight = "1.4.3"
         const val Timber = "4.7.1"
-        const val Coroutines = "1.4.1"
+        const val Coroutines = "1.4.2"
 
         // NDK
         const val NdkVersion = "21.3.6528147"

--- a/dd-sdk-android-ktx/transitiveDependencies
+++ b/dd-sdk-android-ktx/transitiveDependencies
@@ -5,8 +5,8 @@ com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1          :   19 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.1         : 1633 Kb
+org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2          :   19 Kb
+org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.4.2         : 1635 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
 Total transitive dependencies size                              :    3 Mb


### PR DESCRIPTION
### What does this PR do?

Kotlin coroutines version 1.4.1 has a bug causing stack overflow which was fixed here https://github.com/Kotlin/kotlinx.coroutines/issues/2371 as part of 1.4.2 release.

This bug causes a crash in the sample app.

Changelog: https://github.com/Kotlin/kotlinx.coroutines/blob/master/CHANGES.md
