### PR TITLE
RUMM-1180: Keep message for logs when it comes with error fields in OpenTracing format

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/handlers/AndroidSpanLogsHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/handlers/AndroidSpanLogsHandler.kt
@@ -85,7 +85,7 @@ internal class AndroidSpanLogsHandler(
 
         if (errorType != null) {
             val stackField = map.remove(Fields.STACK)
-            val msgField = map.remove(Fields.MESSAGE)
+            val msgField = map[Fields.MESSAGE]
             val stack = stackField?.toString() ?: throwable?.loggableStackTrace()
             val message = msgField?.toString() ?: throwable?.message
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/handlers/AndroidSpanLogsHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/handlers/AndroidSpanLogsHandlerTest.kt
@@ -12,7 +12,6 @@ import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.Logger
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.opentracing.DDSpan
-import com.datadog.opentracing.DDSpanContext
 import com.datadog.trace.api.DDTags
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.verify
@@ -51,9 +50,6 @@ internal class AndroidSpanLogsHandlerTest {
 
     @Mock
     lateinit var mockSpan: DDSpan
-
-    @Mock
-    lateinit var mockSpanContext: DDSpanContext
 
     @LongForgery
     var fakeTraceId: Long = 0L
@@ -220,7 +216,7 @@ internal class AndroidSpanLogsHandlerTest {
     }
 
     @Test
-    fun `log map with throwable and overriden error fields`(
+    fun `log map with throwable and overridden error fields`(
         forge: Forge,
         @Forgery throwable: Throwable,
         @StringForgery message: String,
@@ -249,7 +245,7 @@ internal class AndroidSpanLogsHandlerTest {
         verify(mockLogger)
             .internalLog(
                 Log.VERBOSE,
-                AndroidSpanLogsHandler.DEFAULT_EVENT_MESSAGE,
+                message,
                 null,
                 logAttributes
             )
@@ -319,7 +315,7 @@ internal class AndroidSpanLogsHandlerTest {
         verify(mockLogger)
             .internalLog(
                 Log.VERBOSE,
-                AndroidSpanLogsHandler.DEFAULT_EVENT_MESSAGE,
+                message,
                 null,
                 logAttributes
             )


### PR DESCRIPTION
### What does this PR do?

Fixes #522 . Before this change `MESSAGE` field was removed from the collection if it also contains error fields as part of `extractError` method, and then for the logs default message was used (since original was removed). But it actually makes sense to propagate it to the logs as well.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

