### PR TITLE
RUMM-1176 Constant TypeDefinition - refactor 'fromJson' method

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoExtensions.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoExtensions.kt
@@ -151,3 +151,13 @@ internal fun TypeDefinition.additionalPropertyType(
         ANY.copy(nullable = true)
     }
 }
+
+internal fun TypeDefinition.Class.isConstantClass(): Boolean {
+    // all the properties are of type Constant and the additionalProperties is null
+    this.properties.forEach {
+        if (it.type !is TypeDefinition.Constant) {
+            return false
+        }
+    }
+    return this.additionalProperties == null
+}

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGenerator.kt
@@ -99,11 +99,17 @@ class PokoGenerator(
             constructorBuilder,
             docBuilder
         )
-        val companion = deserializerGenerator.generateCompanionForClass(definition, rootTypeName)
-
         typeBuilder.primaryConstructor(constructorBuilder.build())
             .addKdoc(docBuilder.build())
-            .addType(companion)
+
+        // if the class contains only constant primitives we do not need this
+        if (!definition.isConstantClass()) {
+            val companion =
+                deserializerGenerator.generateCompanionForClass(definition, rootTypeName)
+            typeBuilder.addType(companion)
+        }
+
+
 
         return typeBuilder
     }

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/TestDefinitions.kt
@@ -566,7 +566,38 @@ val Version = TypeDefinition.Class(
     name = "Version",
     properties = listOf(
         TypeProperty("version", TypeDefinition.Constant(JsonType.INTEGER, 42.0), false),
-        TypeProperty("delta", TypeDefinition.Constant(JsonType.NUMBER, 3.1415), true)
+        TypeProperty("delta", TypeDefinition.Constant(JsonType.NUMBER, 3.1415), true),
+        TypeProperty(
+            "id", TypeDefinition.Class(
+                name = "Id",
+                properties = listOf(
+                    TypeProperty(
+                        "serialNumber",
+                        TypeDefinition.Constant(JsonType.NUMBER, 12112.0),
+                        true
+                    )
+                )
+            ),
+            false
+        ),
+        TypeProperty(
+            "date", TypeDefinition.Class(
+                name = "Date",
+                properties = listOf(
+                    TypeProperty(
+                        "year",
+                        TypeDefinition.Constant(JsonType.INTEGER, 2021.0),
+                        true
+                    ),
+                    TypeProperty(
+                        "month",
+                        TypeDefinition.Constant(JsonType.INTEGER, 3.0),
+                        true
+                    )
+                )
+            ),
+            true
+        )
     )
 )
 

--- a/buildSrc/src/test/kotlin/com/example/forgery/VersionForgeryFactory.kt
+++ b/buildSrc/src/test/kotlin/com/example/forgery/VersionForgeryFactory.kt
@@ -12,6 +12,9 @@ import fr.xgouchet.elmyr.ForgeryFactory
 
 internal class VersionForgeryFactory : ForgeryFactory<Version> {
     override fun getForgery(forge: Forge): Version {
-        return Version()
+        return Version(
+            Version.Id(),
+            forge.aNullable { Version.Date() }
+        )
     }
 }

--- a/buildSrc/src/test/kotlin/com/example/model/Location.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Location.kt
@@ -2,13 +2,7 @@ package com.example.model
 
 import com.google.gson.JsonElement
 import com.google.gson.JsonObject
-import com.google.gson.JsonParseException
-import com.google.gson.JsonParser
-import java.lang.IllegalStateException
-import java.lang.NumberFormatException
 import kotlin.String
-import kotlin.jvm.JvmStatic
-import kotlin.jvm.Throws
 
 class Location {
     val planet: String = "earth"
@@ -17,20 +11,5 @@ class Location {
         val json = JsonObject()
         json.addProperty("planet", planet)
         return json
-    }
-
-    companion object {
-        @JvmStatic
-        @Throws(JsonParseException::class)
-        fun fromJson(serializedObject: String): Location {
-            try {
-                val jsonObject = JsonParser.parseString(serializedObject).asJsonObject
-                return Location()
-            } catch (e: IllegalStateException) {
-                throw JsonParseException(e.message)
-            } catch (e: NumberFormatException) {
-                throw JsonParseException(e.message)
-            }
-        }
     }
 }

--- a/buildSrc/src/test/kotlin/com/example/model/Version.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Version.kt
@@ -12,7 +12,10 @@ import kotlin.String
 import kotlin.jvm.JvmStatic
 import kotlin.jvm.Throws
 
-class Version {
+data class Version(
+    val id: Id,
+    val date: Date? = null
+) {
     val version: Long = 42L
 
     val delta: Double = 3.1415
@@ -21,6 +24,8 @@ class Version {
         val json = JsonObject()
         json.addProperty("version", version)
         json.addProperty("delta", delta)
+        json.add("id", id.toJson())
+        date?.let { json.add("date", it.toJson()) }
         return json
     }
 
@@ -30,12 +35,39 @@ class Version {
         fun fromJson(serializedObject: String): Version {
             try {
                 val jsonObject = JsonParser.parseString(serializedObject).asJsonObject
-                return Version()
+                val id=Id()
+                val date = jsonObject.get("date")?.toString()?.let {
+                    Date()
+                }
+                return Version(id, date)
             } catch (e: IllegalStateException) {
                 throw JsonParseException(e.message)
             } catch (e: NumberFormatException) {
                 throw JsonParseException(e.message)
             }
+        }
+    }
+
+    class Id {
+        val serialNumber: Double = 12112.0
+
+        fun toJson(): JsonElement {
+            val json = JsonObject()
+            json.addProperty("serialNumber", serialNumber)
+            return json
+        }
+    }
+
+    class Date {
+        val year: Long = 2021L
+
+        val month: Long = 3L
+
+        fun toJson(): JsonElement {
+            val json = JsonObject()
+            json.addProperty("year", year)
+            json.addProperty("month", month)
+            return json
         }
     }
 }

--- a/buildSrc/src/test/resources/input/constant_number.json
+++ b/buildSrc/src/test/resources/input/constant_number.json
@@ -4,13 +4,38 @@
   "type": "object",
   "properties": {
     "version": {
-      "type" : "integer",
+      "type": "integer",
       "const": 42
     },
     "delta": {
-      "type" : "number",
+      "type": "number",
       "const": 3.1415
+    },
+    "id": {
+      "type": "object",
+      "properties": {
+        "serialNumber": {
+          "type": "number",
+          "const": 12112.0
+        }
+      }
+    },
+    "date": {
+      "type": "object",
+      "properties": {
+        "year": {
+          "type": "integer",
+          "const": 2021
+        },
+        "month": {
+          "type": "integer",
+          "const": 3
+        }
+      }
     }
   },
-  "required": [ "version"]
+  "required": [
+    "version",
+    "id"
+  ]
 }

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -358,8 +358,6 @@ class com.datadog.android.rum.model.ActionEvent
   class Dd
     val formatVersion: kotlin.Long
     fun toJson(): com.google.gson.JsonElement
-    companion object 
-      fun fromJson(kotlin.String): Dd
   class Action
     constructor(ActionType, kotlin.String? = null, kotlin.Long? = null, Target? = null, Error? = null, Crash? = null, LongTask? = null, Resource? = null)
     fun toJson(): com.google.gson.JsonElement
@@ -470,8 +468,6 @@ class com.datadog.android.rum.model.ErrorEvent
   class Dd
     val formatVersion: kotlin.Long
     fun toJson(): com.google.gson.JsonElement
-    companion object 
-      fun fromJson(kotlin.String): Dd
   class Error
     constructor(kotlin.String, Source, kotlin.String? = null, kotlin.Boolean? = null, kotlin.String? = null, Resource? = null)
     fun toJson(): com.google.gson.JsonElement
@@ -602,8 +598,6 @@ class com.datadog.android.rum.model.LongTaskEvent
   class Dd
     val formatVersion: kotlin.Long
     fun toJson(): com.google.gson.JsonElement
-    companion object 
-      fun fromJson(kotlin.String): Dd
   class LongTask
     constructor(kotlin.Long)
     fun toJson(): com.google.gson.JsonElement

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/server/LocalServer.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/server/LocalServer.kt
@@ -16,7 +16,6 @@ import io.ktor.routing.routing
 import io.ktor.server.engine.ApplicationEngine
 import io.ktor.server.engine.embeddedServer
 import io.ktor.server.netty.Netty
-import java.util.concurrent.TimeUnit
 
 class LocalServer {
 


### PR DESCRIPTION
### What does this PR do?

We removed the unnecessary code from the `toJson` method  generated for the `TypeDefinition.Constant` property.
We suppress the lint warning for the unused argument in the method signature. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

