### PR TITLE
RUMM-1198 Evaluate warnings as errors in all the modules

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
@@ -12,11 +12,12 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
-fun Project.kotlinConfig() {
+fun Project.kotlinConfig(evaluateWarningsAsErrors: Boolean = true) {
 
     taskConfig<KotlinCompile> {
         kotlinOptions {
             jvmTarget = JavaVersion.VERSION_1_8.toString()
+            allWarningsAsErrors = evaluateWarningsAsErrors
         }
     }
 

--- a/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/DatadogCoilRequestListenerTest.kt
+++ b/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/DatadogCoilRequestListenerTest.kt
@@ -168,7 +168,7 @@ internal class DatadogCoilRequestListenerTest {
     }
 
     @Test
-    fun `M send RUM error event W Drawable Request fails`(forge: Forge) {
+    fun `M send RUM error event W Drawable Request fails`() {
         // GIVEN
         val mockDrawable: Drawable = mock()
         mockRequest = mockImageRequest(mockDrawable)
@@ -188,7 +188,7 @@ internal class DatadogCoilRequestListenerTest {
     }
 
     @Test
-    fun `M send RUM error event W Bitmap Request fails`(forge: Forge) {
+    fun `M send RUM error event W Bitmap Request fails`() {
         // GIVEN
         val mockDrawable: Bitmap = mock()
         mockRequest = mockImageRequest(mockDrawable)

--- a/dd-sdk-android-fresco/src/test/kotlin/com/datadog/android/fresco/DatadogFrescoCacheListenerTest.kt
+++ b/dd-sdk-android-fresco/src/test/kotlin/com/datadog/android/fresco/DatadogFrescoCacheListenerTest.kt
@@ -21,7 +21,7 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.RegexForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.IOException
@@ -57,7 +57,7 @@ internal class DatadogFrescoCacheListenerTest {
 
     lateinit var fakeEventKey: BitmapMemoryCacheKey
 
-    @RegexForgery(value = "http://[a-z]+\\.com")
+    @StringForgery(regex = "http://[a-z]+\\.com")
     lateinit var fakeCacheEventUri: String
 
     // region Unit Tests
@@ -111,7 +111,7 @@ internal class DatadogFrescoCacheListenerTest {
     }
 
     @Test
-    fun `M add RUM Error event W onReadException() with no throwable`(forge: Forge) {
+    fun `M add RUM Error event W onReadException() with no throwable`() {
         // GIVEN
         whenever(mockCacheEvent.exception).doReturn(null)
 
@@ -181,7 +181,7 @@ internal class DatadogFrescoCacheListenerTest {
     }
 
     @Test
-    fun `M add RUM Error W onWriteException() with no Throwable`(forge: Forge) {
+    fun `M add RUM Error W onWriteException() with no Throwable`() {
         // GIVEN
         whenever(mockCacheEvent.exception).doReturn(null)
 

--- a/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/DatadogGlideModuleTest.kt
+++ b/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/DatadogGlideModuleTest.kt
@@ -21,7 +21,7 @@ import com.datadog.tools.unit.getFieldValue
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.verify
-import fr.xgouchet.elmyr.annotation.RegexForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.InputStream
 import java.util.concurrent.ExecutorService
@@ -61,7 +61,7 @@ internal class DatadogGlideModuleTest {
     @Mock
     lateinit var mockRegistry: Registry
 
-    @RegexForgery("[a-z]+\\.[a-z]{3}")
+    @StringForgery(regex = "[a-z]+\\.[a-z]{3}")
     lateinit var fakeHost: String
 
     @BeforeEach

--- a/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/coroutine/FlowExtTest.kt
+++ b/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/coroutine/FlowExtTest.kt
@@ -83,8 +83,7 @@ class FlowExtTest {
 
     @Test
     fun `M doNothing W flow emits successfully`(
-        @StringForgery data: String,
-        @StringForgery message: String
+        @StringForgery data: String
     ) {
         // Given
         val flow = flow { emit(data) }

--- a/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/sqlite/SqliteDatabaseExtTest.kt
+++ b/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/sqlite/SqliteDatabaseExtTest.kt
@@ -24,6 +24,7 @@ import io.opentracing.Span
 import io.opentracing.Tracer
 import io.opentracing.util.GlobalTracer
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.catchThrowable
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -84,10 +85,9 @@ class SqliteDatabaseExtTest {
         // GIVEN
         whenever(mockTracer.activeSpan()) doReturn mockParentSpan
         whenever(mockSpanBuilder.asChildOf(mockParentSpan)) doReturn mockSpanBuilder
-        var transactionExecuted = false
 
         // WHEN
-        transactionExecuted = mockDatabase.transactionTraced(
+        val transactionExecuted: Boolean = mockDatabase.transactionTraced(
             fakeOperationName,
             true
         ) {
@@ -113,10 +113,9 @@ class SqliteDatabaseExtTest {
         // GIVEN
         whenever(mockTracer.activeSpan()) doReturn mockParentSpan
         whenever(mockSpanBuilder.asChildOf(mockParentSpan)) doReturn mockSpanBuilder
-        var transactionExecuted = false
 
         // WHEN
-        transactionExecuted = mockDatabase.transactionTraced(
+        val transactionExecuted: Boolean = mockDatabase.transactionTraced(
             fakeOperationName,
             false
         ) {
@@ -142,10 +141,9 @@ class SqliteDatabaseExtTest {
         // GIVEN
         whenever(mockTracer.activeSpan()) doReturn null
         whenever(mockSpanBuilder.asChildOf(null as Span?)) doReturn mockSpanBuilder
-        var transactionExecuted = false
 
         // WHEN
-        transactionExecuted = mockDatabase.transactionTraced(
+        val transactionExecuted = mockDatabase.transactionTraced(
             fakeOperationName,
             false
         ) {
@@ -169,21 +167,20 @@ class SqliteDatabaseExtTest {
     @Test
     fun `M close the Span around transaction W transactionTraced() throws exception`() {
         // GIVEN
-        var caughtException: Throwable? = null
         whenever(mockTracer.activeSpan()) doReturn null
         whenever(mockSpanBuilder.asChildOf(null as Span?)) doReturn mockSpanBuilder
 
         // WHEN
-        try {
-            mockDatabase.transactionTraced(fakeOperationName) {
-                throw fakeException
+
+        assertThat(
+            catchThrowable {
+                mockDatabase.transactionTraced(fakeOperationName) {
+                    throw fakeException
+                }
             }
-        } catch (e: Throwable) {
-            caughtException = fakeException
-        }
+        ).isEqualTo(fakeException)
 
         // THEN
-        assertThat(caughtException).isEqualTo(fakeException)
         verify(mockSpanBuilder).asChildOf(null as Span?)
         inOrder(mockSpan, mockScope) {
             verify(mockSpan).finish()
@@ -202,10 +199,9 @@ class SqliteDatabaseExtTest {
         val fakeTagValue = forge.anAlphabeticalString()
         whenever(mockTracer.activeSpan()) doReturn mockParentSpan
         whenever(mockSpanBuilder.asChildOf(mockParentSpan)) doReturn mockSpanBuilder
-        var transactionExecuted = false
 
         // WHEN
-        transactionExecuted = mockDatabase.transactionTraced(
+        val transactionExecuted = mockDatabase.transactionTraced(
             fakeOperationName,
             false
         ) {
@@ -225,10 +221,9 @@ class SqliteDatabaseExtTest {
         val contentValues = ContentValues()
         whenever(mockTracer.activeSpan()) doReturn mockParentSpan
         whenever(mockSpanBuilder.asChildOf(mockParentSpan)) doReturn mockSpanBuilder
-        var transactionExecuted = false
 
         // WHEN
-        transactionExecuted = mockDatabase.transactionTraced(
+        val transactionExecuted = mockDatabase.transactionTraced(
             fakeOperationName,
             false
         ) { mockDatabase ->

--- a/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/tracing/CloseableExtTest.kt
+++ b/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/tracing/CloseableExtTest.kt
@@ -15,7 +15,6 @@ import com.datadog.tools.unit.forge.BaseConfigurator
 import com.datadog.tools.unit.getStaticValue
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
-import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -67,9 +66,9 @@ class CloseableExtTest {
     }
 
     @Test
-    fun `M send an error event W exception in the block`(forge: Forge) {
+    fun `M send an error event W exception in the block`() {
         // GIVEN
-        var caughtException: Throwable? = null
+        val caughtException: Throwable?
 
         // WHEN
         try {
@@ -91,9 +90,9 @@ class CloseableExtTest {
     }
 
     @Test
-    fun `M close the closeable instance W exception in the block`(forge: Forge) {
+    fun `M close the closeable instance W exception in the block`() {
         // GIVEN
-        var caughtException: Throwable? = null
+        val caughtException: Throwable?
         // WHEN
         try {
             testMockCloseable.useMonitored {
@@ -110,7 +109,7 @@ class CloseableExtTest {
     }
 
     @Test
-    fun `M close the closeable instance W no exception in the block`(forge: Forge) {
+    fun `M close the closeable instance W no exception in the block`() {
         // WHEN
         val returnedValue = testMockCloseable.useMonitored {
             fakeString

--- a/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/tracing/OkHttpRequestExtTest.kt
+++ b/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/tracing/OkHttpRequestExtTest.kt
@@ -8,7 +8,7 @@ package com.datadog.android.ktx.tracing
 
 import com.datadog.tools.unit.forge.BaseConfigurator
 import com.nhaarman.mockitokotlin2.mock
-import fr.xgouchet.elmyr.annotation.RegexForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import io.opentracing.Span
@@ -31,7 +31,7 @@ class OkHttpRequestExtTest {
 
     @Test
     fun `set the parentSpan through the Request builder`(
-        @RegexForgery("http://[a-z0-9_]{8}\\.[a-z]{3}/") fakeUrl: String
+        @StringForgery(regex = "http://[a-z0-9_]{8}\\.[a-z]{3}/") fakeUrl: String
     ) {
         val parentSpan: Span = mock()
         val request = Request.Builder().url(fakeUrl).parentSpan(parentSpan).build()

--- a/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/tracing/SpanExtTest.kt
+++ b/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/tracing/SpanExtTest.kt
@@ -105,7 +105,6 @@ class SpanExtTest {
 
     @Test
     fun `M create span around lambda W withinSpan(name){}`(
-        @StringForgery operationName: String,
         @LongForgery result: Long
     ) {
         var lambdaCalled = false
@@ -127,7 +126,6 @@ class SpanExtTest {
 
     @Test
     fun `M create span and scope around lambda W withinSpan(name, parent){}`(
-        @StringForgery operationName: String,
         @LongForgery result: Long
     ) {
         var lambdaCalled = false
@@ -148,9 +146,7 @@ class SpanExtTest {
 
     @Test
     fun `M create span and scope around lambda W withinSpan(name, parent){} throwing error`(
-        @StringForgery operationName: String,
-        @Forgery throwable: Throwable,
-        @LongForgery result: Long
+        @Forgery throwable: Throwable
     ) {
         var lambdaCalled = false
 

--- a/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRumErrorConsumerTest.kt
+++ b/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRumErrorConsumerTest.kt
@@ -12,7 +12,6 @@ import com.datadog.android.rum.RumMonitor
 import com.datadog.tools.unit.forge.BaseConfigurator
 import com.datadog.tools.unit.getStaticValue
 import com.nhaarman.mockitokotlin2.verify
-import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -58,7 +57,7 @@ class DatadogRumErrorConsumerTest {
     }
 
     @Test
-    fun `M send an error event W intercepting an exception`(forge: Forge) {
+    fun `M send an error event W intercepting an exception`() {
         // WHEN
         testedConsumer.accept(fakeException)
 

--- a/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRxExtTest.kt
+++ b/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRxExtTest.kt
@@ -12,7 +12,6 @@ import com.datadog.android.rum.RumMonitor
 import com.datadog.tools.unit.forge.BaseConfigurator
 import com.datadog.tools.unit.getStaticValue
 import com.nhaarman.mockitokotlin2.verify
-import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -62,7 +61,7 @@ class DatadogRxExtTest {
     }
 
     @Test
-    fun `M send an error event W exception in the stream {Observable}`(forge: Forge) {
+    fun `M send an error event W exception in the stream {Observable}`() {
         // GIVEN
         val testObservable = Observable
             .just(0, 1, 2)
@@ -83,7 +82,7 @@ class DatadogRxExtTest {
     }
 
     @Test
-    fun `M send an error event W exception in the stream {Single}`(forge: Forge) {
+    fun `M send an error event W exception in the stream {Single}`() {
         // GIVEN
         val testSingle = SingleError.error<Int>(fakeException)
 
@@ -101,7 +100,7 @@ class DatadogRxExtTest {
     }
 
     @Test
-    fun `M send an error event W exception in the stream {Maybe}`(forge: Forge) {
+    fun `M send an error event W exception in the stream {Maybe}`() {
         // GIVEN
         val testMaybe = MaybeError.error<Int>(fakeException)
 
@@ -119,7 +118,7 @@ class DatadogRxExtTest {
     }
 
     @Test
-    fun `M send an error event W exception in the stream {Completable}`(forge: Forge) {
+    fun `M send an error event W exception in the stream {Completable}`() {
         // WHEN
         CompletableError.error(fakeException).sendErrorToDatadog().test()
 
@@ -133,7 +132,7 @@ class DatadogRxExtTest {
     }
 
     @Test
-    fun `M send an error event W exception in the stream {Flowable}`(forge: Forge) {
+    fun `M send an error event W exception in the stream {Flowable}`() {
         // GIVEN
         val testFlowable = Flowable
             .just(0, 1, 2)

--- a/dd-sdk-android-sqldelight/src/test/kotlin/com/datadog/android/sqldelight/DatadogSqliteCallbackTest.kt
+++ b/dd-sdk-android-sqldelight/src/test/kotlin/com/datadog/android/sqldelight/DatadogSqliteCallbackTest.kt
@@ -18,9 +18,8 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
-import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.IntForgery
-import fr.xgouchet.elmyr.annotation.RegexForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
@@ -52,7 +51,7 @@ class DatadogSqliteCallbackTest {
     @Mock
     lateinit var mockSqliteDatabase: SupportSQLiteDatabase
 
-    @RegexForgery("[a-z]/[a-z]")
+    @StringForgery(regex = "[a-z]/[a-z]")
     lateinit var fakeDbPath: String
 
     @IntForgery
@@ -73,7 +72,7 @@ class DatadogSqliteCallbackTest {
     }
 
     @Test
-    fun `M send an error event W intercepting a DB corruption`(forge: Forge) {
+    fun `M send an error event W intercepting a DB corruption`() {
         // WHEN
         testedSqliteCallback.onCorruption(mockSqliteDatabase)
 

--- a/dd-sdk-android-sqldelight/src/test/kotlin/com/datadog/android/sqldelight/SqlDelightExtTest.kt
+++ b/dd-sdk-android-sqldelight/src/test/kotlin/com/datadog/android/sqldelight/SqlDelightExtTest.kt
@@ -85,12 +85,12 @@ class SqlDelightExtTest {
         whenever(mockTracer.activateSpan(mockSpan)) doReturn mockScope
         whenever(mockSpanBuilder.start()) doReturn mockSpan
         doAnswer {
-            (it.arguments[1] as TransactionWithoutReturn.() -> Unit).invoke(
+            it.getArgument<TransactionWithoutReturn.() -> Unit>(1).invoke(
                 mockTransactionWithoutReturn
             )
         }.whenever(mockTransacter).transaction(any(), any())
         doAnswer {
-            (it.arguments[1] as TransactionWithReturn<Any>.() -> Boolean).invoke(
+            it.getArgument<TransactionWithReturn<Any>.() -> Boolean>(1).invoke(
                 mockTransactionWithReturn
             )
         }.whenever(mockTransacter)
@@ -282,13 +282,12 @@ class SqlDelightExtTest {
         // // GIVEN
         whenever(mockTracer.activeSpan()) doReturn mockParentSpan
         whenever(mockSpanBuilder.asChildOf(mockParentSpan)) doReturn mockSpanBuilder
-        var transactionExecuted = false
         val body: TransactionWithSpanAndWithReturn<Boolean>.() -> Boolean = {
             true
         }
 
         // WHEN
-        transactionExecuted =
+        val transactionExecuted =
             mockTransacter.transactionTracedWithResult(fakeOperationName, true, body)
 
         // THEN
@@ -310,13 +309,12 @@ class SqlDelightExtTest {
         // GIVEN
         whenever(mockTracer.activeSpan()) doReturn mockParentSpan
         whenever(mockSpanBuilder.asChildOf(mockParentSpan)) doReturn mockSpanBuilder
-        var transactionExecuted = false
         val body: TransactionWithSpanAndWithReturn<Boolean>.() -> Boolean = {
             true
         }
 
         // WHEN
-        transactionExecuted =
+        val transactionExecuted =
             mockTransacter.transactionTracedWithResult(fakeOperationName, false, body)
 
         // THEN
@@ -339,13 +337,12 @@ class SqlDelightExtTest {
         val fakeNoEnclosing = forge.aBool()
         whenever(mockTracer.activeSpan()) doReturn null
         whenever(mockSpanBuilder.asChildOf(null as Span?)) doReturn mockSpanBuilder
-        var transactionExecuted = false
         val body: TransactionWithSpanAndWithReturn<Boolean>.() -> Boolean = {
             true
         }
 
         // WHEN
-        transactionExecuted =
+        val transactionExecuted =
             mockTransacter.transactionTracedWithResult(fakeOperationName, fakeNoEnclosing, body)
 
         // THEN
@@ -432,7 +429,6 @@ class SqlDelightExtTest {
         val fakeNoEnclosing = forge.aBool()
         whenever(mockTracer.activeSpan()) doReturn null
         whenever(mockSpanBuilder.asChildOf(null as Span?)) doReturn mockSpanBuilder
-        var transactionExecuted = false
         val afterCommitLambda = {
         }
         val body: TransactionWithSpanAndWithReturn<Boolean>.() -> Boolean = {
@@ -441,7 +437,7 @@ class SqlDelightExtTest {
         }
 
         // WHEN
-        transactionExecuted =
+        val transactionExecuted =
             mockTransacter.transactionTracedWithResult(fakeOperationName, fakeNoEnclosing, body)
 
         // THEN
@@ -457,14 +453,13 @@ class SqlDelightExtTest {
         val fakeNoEnclosing = forge.aBool()
         whenever(mockTracer.activeSpan()) doReturn null
         whenever(mockSpanBuilder.asChildOf(null as Span?)) doReturn mockSpanBuilder
-        var transactionExecuted = false
         val body: TransactionWithSpanAndWithReturn<Boolean>.() -> Boolean = {
             setTag(fakeTagKey, fakeTagValue)
             true
         }
 
         // WHEN
-        transactionExecuted =
+        val transactionExecuted =
             mockTransacter.transactionTracedWithResult(fakeOperationName, fakeNoEnclosing, body)
 
         // THEN

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -105,7 +105,12 @@ internal class UploadWorkerTest {
         Datadog.initialize(
             mockContext,
             Credentials("CLIENT_TOKEN", "ENVIRONMENT", "", null),
-            Configuration.Builder(true, true, true, true).build(),
+            Configuration.Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            ).build(),
             TrackingConsent.GRANTED
         )
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/domain/FilePersistenceStrategyTest.kt
@@ -85,7 +85,12 @@ internal abstract class FilePersistenceStrategyTest<T : Any>(
         Datadog.initialize(
             mockContext,
             Credentials(forge.anHexadecimalString(), forge.anAlphabeticalString(), "", null),
-            Configuration.Builder(true, true, true, true).build(),
+            Configuration.Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            ).build(),
             TrackingConsent.GRANTED
         )
         val persistingStrategy = getStrategy()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -63,7 +63,12 @@ internal class WorkManagerUtilsTest {
         Datadog.initialize(
             mockAppContext,
             Credentials(forge.anHexadecimalString(), forge.anAlphabeticalString(), "", null),
-            Configuration.Builder(true, true, true, true).build(),
+            Configuration.Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            ).build(),
             TrackingConsent.GRANTED
         )
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -129,7 +129,12 @@ internal class DatadogExceptionHandlerTest {
         Datadog.initialize(
             mockContext,
             Credentials(fakeToken, fakeEnvName, "", null),
-            Configuration.Builder(true, true, true, true).build(),
+            Configuration.Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            ).build(),
             TrackingConsent.GRANTED
         )
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -445,7 +445,12 @@ internal class DatadogLogHandlerTest {
         Datadog.initialize(
             mockContext(),
             Credentials(forge.anAlphabeticalString(), forge.anAlphabeticalString(), "", null),
-            Configuration.Builder(true, true, true, true).build(),
+            Configuration.Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            ).build(),
             TrackingConsent.GRANTED
         )
         val tracer = AndroidTracer.Builder().build()
@@ -500,7 +505,12 @@ internal class DatadogLogHandlerTest {
         Datadog.initialize(
             mockContext(),
             Credentials(forge.anAlphabeticalString(), forge.anAlphabeticalString(), "", null),
-            Configuration.Builder(true, true, true, true).build(),
+            Configuration.Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            ).build(),
             TrackingConsent.GRANTED
         )
         val rumContext = forge.getForgery<RumContext>()

--- a/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/core/CoreInitBenchmark.kt
+++ b/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/core/CoreInitBenchmark.kt
@@ -11,7 +11,9 @@ import androidx.benchmark.junit4.measureRepeated
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.datadog.android.Datadog
-import com.datadog.android.DatadogConfig
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.tracking.MixedViewTrackingStrategy
 import com.datadog.tools.unit.invokeMethod
 import java.util.UUID
@@ -27,18 +29,28 @@ class CoreInitBenchmark {
     @Test
     fun benchmark_initialize() {
         val context = InstrumentationRegistry.getInstrumentation().context
-        val config = DatadogConfig
-            .Builder("NO_TOKEN", "benchmark", UUID.randomUUID().toString())
-            .setTracesEnabled(true)
-            .setLogsEnabled(true)
-            .setCrashReportsEnabled(true)
+        val config = Configuration
+            .Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            )
             .trackInteractions()
-            .useViewTrackingStrategy(MixedViewTrackingStrategy(true))
-            .setRumEnabled(true)
+            .useViewTrackingStrategy(MixedViewTrackingStrategy(trackExtras = true))
             .build()
-
         benchmark.measureRepeated {
-            Datadog.initialize(context, config)
+            Datadog.initialize(
+                context,
+                Credentials(
+                    "NO_TOKEN",
+                    "benchmark",
+                    "benchmark",
+                    UUID.randomUUID().toString()
+                ),
+                config,
+                TrackingConsent.GRANTED
+            )
 
             runWithTimingDisabled {
                 Datadog.invokeMethod("stop")

--- a/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/log/LogApiBenchmark.kt
+++ b/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/log/LogApiBenchmark.kt
@@ -11,12 +11,15 @@ import androidx.benchmark.junit4.measureRepeated
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.datadog.android.Datadog
-import com.datadog.android.DatadogConfig
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.log.Logger
+import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.benchmark.aThrowable
 import com.datadog.android.sdk.benchmark.mockResponse
 import com.datadog.tools.unit.invokeMethod
 import fr.xgouchet.elmyr.junit4.ForgeRule
+import java.util.UUID
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -31,6 +34,7 @@ import org.junit.runner.RunWith
 class LogApiBenchmark {
     @get:Rule
     val benchmark = BenchmarkRule()
+
     @get:Rule
     val forge = ForgeRule()
 
@@ -51,11 +55,26 @@ class LogApiBenchmark {
         val fakeEndpoint = mockWebServer.url("/").toString().removeSuffix("/")
 
         val context = InstrumentationRegistry.getInstrumentation().context
-        val config = DatadogConfig
-            .Builder("NO_TOKEN", "benchmark")
+        val config = Configuration
+            .Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            )
             .useCustomLogsEndpoint(fakeEndpoint)
             .build()
-        Datadog.initialize(context, config)
+        Datadog.initialize(
+            context,
+            Credentials(
+                "NO_TOKEN",
+                "benchmark",
+                "benchmark",
+                UUID.randomUUID().toString()
+            ),
+            config,
+            TrackingConsent.GRANTED
+        )
 
         testedLogger = Logger.Builder()
             .setDatadogLogsEnabled(true)

--- a/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/rum/RumGesturesTrackerBenchmark.kt
+++ b/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/rum/RumGesturesTrackerBenchmark.kt
@@ -4,6 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.datadog.android.sdk.benchmark.rum
 
 import androidx.benchmark.junit4.BenchmarkRule
@@ -16,7 +18,9 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import androidx.test.rule.ActivityTestRule
 import com.datadog.android.Datadog
-import com.datadog.android.DatadogConfig
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.tracking.ViewAttributesProvider
@@ -27,6 +31,7 @@ import com.datadog.tools.unit.getStaticValue
 import com.datadog.tools.unit.invokeGenericMethod
 import com.datadog.tools.unit.invokeMethod
 import com.datadog.tools.unit.setStaticValue
+import java.util.UUID
 import java.util.concurrent.atomic.AtomicBoolean
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
@@ -68,11 +73,27 @@ internal class RumGesturesTrackerBenchmark {
         val fakeEndpoint = mockWebServer.url("/").toString().removeSuffix("/")
 
         val context = InstrumentationRegistry.getInstrumentation().context
-        val config = DatadogConfig
-            .Builder("NO_TOKEN", "benchmark")
+        val config = Configuration
+            .Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            )
             .useCustomTracesEndpoint(fakeEndpoint)
             .build()
-        Datadog.initialize(context, config)
+        Datadog.initialize(
+            context,
+            Credentials(
+                "NO_TOKEN",
+                "benchmark",
+                "benchmark",
+                UUID.randomUUID().toString()
+            ),
+            config,
+            TrackingConsent.GRANTED
+        )
+
         val attrsProviderClassName =
             "com.datadog.android.rum.internal.tracking.JetpackViewAttributesProvider"
         val viewAttributesProvider: ViewAttributesProvider =

--- a/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/rum/RumManualApiBenchmark.kt
+++ b/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/rum/RumManualApiBenchmark.kt
@@ -11,7 +11,9 @@ import androidx.benchmark.junit4.measureRepeated
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.datadog.android.Datadog
-import com.datadog.android.DatadogConfig
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
@@ -55,12 +57,26 @@ class RumManualApiBenchmark {
         val fakeEndpoint = mockWebServer.url("/").toString().removeSuffix("/")
 
         val context = InstrumentationRegistry.getInstrumentation().context
-        val config = DatadogConfig
-            .Builder("NO_TOKEN", "benchmark", UUID.randomUUID().toString())
+        val config = Configuration
+            .Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            )
             .useCustomRumEndpoint(fakeEndpoint)
-            .setRumEnabled(true)
             .build()
-        Datadog.initialize(context, config)
+        Datadog.initialize(
+            context,
+            Credentials(
+                "NO_TOKEN",
+                "benchmark",
+                "benchmark",
+                UUID.randomUUID().toString()
+            ),
+            config,
+            TrackingConsent.GRANTED
+        )
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
     }
 

--- a/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/trace/TraceApiBenchmark.kt
+++ b/instrumented/benchmark/src/androidTest/kotlin/com/datadog/android/sdk/benchmark/trace/TraceApiBenchmark.kt
@@ -11,13 +11,16 @@ import androidx.benchmark.junit4.measureRepeated
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.datadog.android.Datadog
-import com.datadog.android.DatadogConfig
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.benchmark.aThrowable
 import com.datadog.android.sdk.benchmark.mockResponse
 import com.datadog.android.tracing.AndroidTracer
 import com.datadog.opentracing.DDSpan
 import com.datadog.tools.unit.invokeMethod
 import fr.xgouchet.elmyr.junit4.ForgeRule
+import java.util.UUID
 import okhttp3.mockwebserver.Dispatcher
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
@@ -56,11 +59,26 @@ class TraceApiBenchmark {
         val fakeEndpoint = mockWebServer.url("/").toString().removeSuffix("/")
 
         val context = InstrumentationRegistry.getInstrumentation().context
-        val config = DatadogConfig
-            .Builder("NO_TOKEN", "benchmark")
+        val config = Configuration
+            .Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            )
             .useCustomTracesEndpoint(fakeEndpoint)
             .build()
-        Datadog.initialize(context, config)
+        Datadog.initialize(
+            context,
+            Credentials(
+                "NO_TOKEN",
+                "benchmark",
+                "benchmark",
+                UUID.randomUUID().toString()
+            ),
+            config,
+            TrackingConsent.GRANTED
+        )
 
         testedTracer = AndroidTracer
             .Builder()

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/GesturesTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/GesturesTrackingTest.kt
@@ -6,8 +6,8 @@
 
 package com.datadog.android.sdk.integration.rum
 
+import android.view.View
 import androidx.cardview.widget.CardView
-import androidx.recyclerview.widget.RecyclerView
 import androidx.test.espresso.Espresso.onView
 import androidx.test.espresso.action.ViewActions.click
 import androidx.test.espresso.action.ViewActions.swipeDown
@@ -65,6 +65,10 @@ internal abstract class GesturesTrackingTest :
 
     // region Internal
 
+    private fun View.targetName(): String {
+        return this.javaClass.canonicalName ?: this.javaClass.simpleName
+    }
+
     private fun expectedEvents(
         viewUrl: String,
         activity: GesturesTrackingPlaygroundActivity
@@ -77,7 +81,7 @@ internal abstract class GesturesTrackingTest :
             ),
             ExpectedGestureEvent(
                 Gesture.TAP,
-                activity.button.javaClass.canonicalName,
+                activity.button.targetName(),
                 "button"
             ),
             ExpectedViewEvent(
@@ -86,7 +90,8 @@ internal abstract class GesturesTrackingTest :
             ),
             ExpectedGestureEvent(
                 Gesture.TAP,
-                CardView::class.java.canonicalName,
+                CardView::class.java.canonicalName
+                    ?: CardView::class.java.simpleName,
                 "recyclerViewRow",
                 extraAttributes = mapOf(
                     RumAttributes.ACTION_TARGET_PARENT_INDEX to 2,
@@ -102,7 +107,7 @@ internal abstract class GesturesTrackingTest :
             ),
             ExpectedGestureEvent(
                 Gesture.SWIPE,
-                RecyclerView::class.java.canonicalName,
+                activity.recyclerView.targetName(),
                 "recyclerView",
                 extraAttributes = mapOf(
                     RumAttributes.ACTION_GESTURE_DIRECTION to "down"

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/TracesTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/TracesTest.kt
@@ -4,6 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+@file:Suppress("PLATFORM_CLASS_MAPPED_TO_KOTLIN")
+
 package com.datadog.android.sdk.integration.trace
 
 import android.util.Log

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/AbstractProfilingRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/AbstractProfilingRule.kt
@@ -111,11 +111,7 @@ internal abstract class AbstractProfilingRule(
     }
 
     private fun List<Double>.max(): Double {
-        return maxWith(comparator)!!
-    }
-
-    private fun List<Double>.min(): Double {
-        return minWith(comparator)!!
+        return maxWithOrNull(comparator) ?: 0.0
     }
 
     private fun List<Double>.average(): Double {

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
@@ -4,6 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.datadog.android.sdk.rules
 
 import android.app.Activity

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -169,7 +169,7 @@ dependencies {
     api("com.facebook.stetho:stetho:1.5.1")
 }
 
-kotlinConfig()
+kotlinConfig(evaluateWarningsAsErrors = false)
 detektConfig()
 ktLintConfig()
 junitConfig()

--- a/sample/kotlin/src/main/cpp/datadog-native-sample-lib.cpp
+++ b/sample/kotlin/src/main/cpp/datadog-native-sample-lib.cpp
@@ -3,12 +3,18 @@
 
 void crash_with_sigsegv_signal() {
     int *pointer = nullptr;
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "NullDereferences"
     int t = *pointer;
+#pragma clang diagnostic pop
 }
 
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "hicpp-exception-baseclass"
 void crash_with_sigabrt_signal() {
     throw "Unhandled Exception";
 }
+#pragma clang diagnostic pop
 
 int crash_with_sigill_signal() {
     // do not return anything to simulate the SIGILL

--- a/tools/detekt/build.gradle.kts
+++ b/tools/detekt/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
 
 dependencies {
     implementation(Dependencies.Libraries.Kotlin)
+    implementation(Dependencies.Libraries.KotlinReflect)
     compileOnly(Dependencies.Libraries.DetektApi)
 
     testImplementation(Dependencies.Libraries.JUnit5)
@@ -34,6 +35,4 @@ kotlinConfig()
 detektConfig()
 ktLintConfig()
 junitConfig()
-// jacocoConfig()
 dependencyUpdateConfig()
-// publishingConfig("${rootDir.canonicalPath}/repo")

--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/UnsafeCallOnNullableTypeTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/UnsafeCallOnNullableTypeTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.tools.detekt.rules
 
-import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.lint
@@ -17,7 +16,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 internal class UnsafeCallOnNullableTypeTest {
 
     @Test
-    fun `detekt unsafe call on nullable type`(forge: Forge) {
+    fun `detekt unsafe call on nullable type`() {
         val code =
             """
                 fun test(str: String?) {
@@ -30,7 +29,7 @@ internal class UnsafeCallOnNullableTypeTest {
     }
 
     @Test
-    fun `does not detekt unsafe call on comments`(forge: Forge) {
+    fun `does not detekt unsafe call on comments`() {
         val code =
             """
                 fun test(str: String) {
@@ -44,7 +43,7 @@ internal class UnsafeCallOnNullableTypeTest {
     }
 
     @Test
-    fun `does not detekt safe call on nullable type`(forge: Forge) {
+    fun `does not detekt safe call on nullable type`() {
         val code =
             """
                 fun test(str: String?) {
@@ -57,7 +56,7 @@ internal class UnsafeCallOnNullableTypeTest {
     }
 
     @Test
-    fun `does not detekt safe call in combination with the elvis operator`(forge: Forge) {
+    fun `does not detekt safe call in combination with the elvis operator`() {
         val code =
             """
                 fun test(str: String?) {


### PR DESCRIPTION
### What does this PR do?

- Resolves all the warnings in all the other modules, except for the sample applications which will be cleaned later if needed.
- Enables the `warningAsErrors` flag in the kotlin compile task configuration for all the project modules except the sample applications.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

