### PR TITLE
RUMM-1170 Continuous trace support when using RxJava and Retrofit

### DIFF
--- a/dd-sdk-android/src/main/java/com/datadog/opentracing/DDSpan.java
+++ b/dd-sdk-android/src/main/java/com/datadog/opentracing/DDSpan.java
@@ -125,6 +125,18 @@ public class DDSpan implements Span, MutableSpan {
   }
 
   /**
+   * By calling this method the span will be removed from the current active Trace without
+   * actually being persisted.
+   *
+   * Note: This method is meant for internal SDK usage. Be aware that if used this Span will
+   * be removed from the Trace and lost.
+   *
+  */
+  public final void drop() {
+    context.getTrace().dropSpan(this);
+  }
+
+    /**
    * Check if the span is the root parent. It means that the traceId is the same as the spanId. In
    * the context of distributed tracing this will return true if an only if this is the application
    * initializing the trace.

--- a/dd-sdk-android/src/main/java/com/datadog/opentracing/DDSpan.java
+++ b/dd-sdk-android/src/main/java/com/datadog/opentracing/DDSpan.java
@@ -131,7 +131,7 @@ public class DDSpan implements Span, MutableSpan {
    * Note: This method is meant for internal SDK usage. Be aware that if used this Span will
    * be removed from the Trace and lost.
    *
-  */
+   */
   public final void drop() {
     context.getTrace().dropSpan(this);
   }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
@@ -12,6 +12,7 @@ import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.tracing.internal.TracesFeature
+import com.datadog.opentracing.DDSpan
 import com.datadog.opentracing.DDTracer
 import com.datadog.trace.api.DDTags
 import com.datadog.trace.api.interceptor.MutableSpan
@@ -294,6 +295,8 @@ internal constructor(
         onRequestIntercepted(request, span, response, null)
         if (canSendSpan()) {
             span?.finish()
+        } else {
+            (span as? DDSpan)?.drop()
         }
     }
 
@@ -309,6 +312,8 @@ internal constructor(
         onRequestIntercepted(request, span, null, throwable)
         if (canSendSpan()) {
             span.finish()
+        } else {
+            (span as? DDSpan)?.drop()
         }
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/data/TraceWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/data/TraceWriter.kt
@@ -7,14 +7,8 @@
 package com.datadog.android.tracing.internal.data
 
 import com.datadog.android.core.internal.persistence.DataWriter
-import com.datadog.android.rum.GlobalRum
-import com.datadog.android.rum.RumAttributes
-import com.datadog.android.rum.RumErrorSource
-import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.opentracing.DDSpan
-import com.datadog.trace.api.DDTags
 import com.datadog.trace.common.writer.Writer
-import java.util.Locale
 
 internal class TraceWriter(
     val writer: DataWriter<DDSpan>
@@ -40,62 +34,4 @@ internal class TraceWriter(
     }
 
     // endregion
-
-    // region Internals
-
-    private fun sendRumErrorEvent(span: DDSpan) {
-        val errorType = span.tags[DDTags.ERROR_TYPE] as? String
-        val errorMessage = span.tags[DDTags.ERROR_MSG] as? String
-        val composedErrorMessage = spanErrorMessage(span.operationName, errorType, errorMessage)
-        val attributes = if (errorType != null) {
-            mapOf(RumAttributes.INTERNAL_ERROR_TYPE to errorType)
-        } else {
-            emptyMap()
-        }
-        (GlobalRum.get() as? AdvancedRumMonitor)?.addErrorWithStacktrace(
-            composedErrorMessage,
-            RumErrorSource.SOURCE,
-            span.tags[DDTags.ERROR_STACK]?.toString(),
-            attributes
-        )
-    }
-
-    private fun spanErrorMessage(
-        operationName: String,
-        errorType: String?,
-        errorMessage: String?
-    ): String {
-        return when {
-            errorMessage != null && errorType != null ->
-                SPAN_ERROR_WITH_TYPE_AND_MESSAGE_FORMAT.format(
-                    Locale.US,
-                    operationName,
-                    errorType,
-                    errorMessage
-                )
-            errorType != null ->
-                SPAN_ERROR_WITH_TYPE_FORMAT.format(
-                    Locale.US,
-                    operationName,
-                    errorType
-                )
-            errorMessage != null ->
-                SPAN_ERROR_WITH_MESSAGE_FORMAT.format(
-                    Locale.US,
-                    operationName,
-                    errorMessage
-                )
-            else -> SPAN_ERROR_FORMAT.format(Locale.US, operationName)
-        }
-    }
-
-    // endregion
-
-    companion object {
-        internal const val SPAN_ERROR_FORMAT: String = "Span error (%s)"
-        internal const val SPAN_ERROR_WITH_TYPE_AND_MESSAGE_FORMAT: String =
-            "Span error (%s): %s | %s "
-        internal const val SPAN_ERROR_WITH_TYPE_FORMAT: String = "Span error (%s): %s"
-        internal const val SPAN_ERROR_WITH_MESSAGE_FORMAT: String = "Span error (%s): %s"
-    }
 }

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -134,6 +134,9 @@ dependencies {
     implementation("androidx.legacy:legacy-support-v4:1.0.0")
     implementation("androidx.lifecycle:lifecycle-extensions:2.2.0")
     implementation("androidx.preference:preference-ktx:1.1.1")
+    implementation("io.opentracing.contrib:opentracing-rxjava-3:0.1.4"){
+        exclude(group = "io.opentracing")
+    }
 
     // Ktor (local web server)
     implementation("io.ktor:ktor:1.4.3")

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -36,6 +36,7 @@ import com.facebook.stetho.Stetho
 import com.google.gson.GsonBuilder
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
+import io.opentracing.rxjava3.TracingRxJava3Utils
 import io.opentracing.util.GlobalTracer
 import okhttp3.OkHttpClient
 import retrofit2.Retrofit
@@ -59,7 +60,7 @@ class SampleApplication : Application() {
     private val retrofitClient = Retrofit.Builder()
         .baseUrl("https://api.datadoghq.com/api/v2/")
         .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
-        .addCallAdapterFactory(RxJava3CallAdapterFactory.create())
+        .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
         .client(okHttpClient)
         .build()
 
@@ -103,6 +104,7 @@ class SampleApplication : Application() {
 
         GlobalTracer.registerIfAbsent(AndroidTracer.Builder().build())
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
+        TracingRxJava3Utils.enableTracing(GlobalTracer.get())
     }
 
     private fun createDatadogCredentials(): Credentials {

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/data/DataRepository.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/data/DataRepository.kt
@@ -36,7 +36,7 @@ class DataRepository(
                         .start()
                     GlobalTracer.get().scopeManager().activate(span)
                 }
-                .doOnTerminate {
+                .doFinally {
                     GlobalTracer.get().scopeManager().activeSpan()?.let {
                         it.finish()
                     }


### PR DESCRIPTION
### What does this PR do?

This PR contains some fixes and updated documentation to offer support for having a continuous Trace when using RxJava and Retrofit streams:

1. We make sure we are dropping the automatically generated requests spans in our `TracingInterceptor` when RUM feature is initialized. This will allow any active trace to be successfully closed and persisted as all of its children (spans) are finished.
2. Cleanup some code inside the `TraceWriter`
3. Provide documentations steps for tracing an RxJava + Retrofit stream

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

