### PR TITLE
RUMM-1215 Return key value when resolving view url for type String

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ViewUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ViewUtils.kt
@@ -12,6 +12,7 @@ internal fun Any.resolveViewUrl(): String {
         is FragmentNavigator.Destination -> className
         is DialogFragmentNavigator.Destination -> className
         is ActivityNavigator.Destination -> component?.resolveViewUrl() ?: UNKNOWN_DESTINATION_URL
+        is String -> this
         else -> javaClass.canonicalName ?: javaClass.simpleName
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/ViewUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/ViewUtilsTest.kt
@@ -130,4 +130,15 @@ internal class ViewUtilsTest {
         // Then
         assertThat(output).isEqualTo(UNKNOWN_DESTINATION_URL)
     }
+
+    @Test
+    fun `𝕄 return the key value 𝕎 resolveViewUrl() { destination of type String }`(
+        @StringForgery destination: String
+    ) {
+        // When
+        val output = destination.resolveViewUrl()
+
+        // Then
+        assertThat(output).isEqualTo(destination)
+    }
 }


### PR DESCRIPTION
### What does this PR do?

When called from RN `RumMonitor#startView` uses only `java.lang.String` key type and because of that the `view.url_path_group` attribute name was always `java/lang/String` for RN View events. 
In this PR we are addressing this by using the actual key value in this case.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

