### PR TITLE
RUMM-1212: Add additional free-form configuration to the Datadog configuration

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -101,6 +101,7 @@ class com.datadog.android.core.configuration.Configuration
     fun setRumActionEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ActionEvent>): Builder
     fun setRumErrorEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ErrorEvent>): Builder
     fun setInternalLogsEnabled(String, String): Builder
+    fun setAdditionalConfiguration(Map<String, Any>): Builder
   companion object 
 class com.datadog.android.core.configuration.Credentials
   constructor(String, String, String, String?, String? = null)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -148,6 +148,8 @@ object Datadog {
         initializeCrashReportFeature(configuration.crashReportConfig, appContext)
         initializeInternalLogsFeature(configuration.internalLogsConfig, appContext)
 
+        applyAdditionalConfiguration(configuration.additionalConfig)
+
         CoreFeature.ndkCrashHandler.handleNdkCrash(
             LogsFeature.persistenceStrategy.getWriter(),
             RumFeature.persistenceStrategy.getWriter()
@@ -211,6 +213,12 @@ object Datadog {
         if (configuration != null) {
             InternalLogsFeature.initialize(appContext, configuration)
         }
+    }
+
+    private fun applyAdditionalConfiguration(
+        @Suppress("UNUSED_PARAMETER") additionalConfiguration: Map<String, Any>
+    ) {
+        // no-op for now, will be filled later
     }
 
     /**

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -118,7 +118,8 @@ private constructor(
                     longTaskTrackingStrategy = null
                 )
             },
-            internalLogsConfig = null
+            internalLogsConfig = null,
+            additionalConfig = emptyMap()
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -50,7 +50,8 @@ internal constructor(
     internal val tracesConfig: Feature.Tracing?,
     internal val crashReportConfig: Feature.CrashReport?,
     internal val rumConfig: Feature.RUM?,
-    internal val internalLogsConfig: Feature.InternalLogs?
+    internal val internalLogsConfig: Feature.InternalLogs?,
+    internal val additionalConfig: Map<String, Any>
 ) {
 
     internal data class Core(
@@ -117,6 +118,7 @@ internal constructor(
         private var crashReportConfig: Feature.CrashReport = DEFAULT_CRASH_CONFIG
         private var rumConfig: Feature.RUM = DEFAULT_RUM_CONFIG
         private var internalLogsConfig: Feature.InternalLogs? = null
+        private var additionalConfig: Map<String, Any> = emptyMap()
 
         private var coreConfig = DEFAULT_CORE_CONFIG
 
@@ -130,7 +132,8 @@ internal constructor(
                 tracesConfig = if (tracesEnabled) tracesConfig else null,
                 crashReportConfig = if (crashReportsEnabled) crashReportConfig else null,
                 rumConfig = if (rumEnabled) rumConfig else null,
-                internalLogsConfig = internalLogsConfig
+                internalLogsConfig = internalLogsConfig,
+                additionalConfig = additionalConfig
             )
         }
 
@@ -427,6 +430,16 @@ internal constructor(
                 emptyList()
             )
             return this
+        }
+
+        /**
+         * Allows to provide additional configuration values which can be used by the SDK.
+         * @param additionalConfig Additional configuration values.
+         */
+        fun setAdditionalConfiguration(additionalConfig: Map<String, Any>): Builder {
+            return apply {
+                this.additionalConfig = additionalConfig
+            }
         }
 
         private fun checkCustomEndpoint(endpoint: String) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -131,6 +131,7 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -153,6 +154,7 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = DatadogEndpoint.RUM_US)
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -175,6 +177,7 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = DatadogEndpoint.RUM_EU)
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -197,6 +200,7 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = DatadogEndpoint.RUM_GOV)
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -233,6 +237,7 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = rumUrl)
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -269,6 +274,7 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = rumUrl)
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -297,6 +303,7 @@ internal class ConfigurationBuilderTest {
             .hasViewTrackingStrategy(Configuration.DEFAULT_RUM_CONFIG.viewTrackingStrategy!!)
             .hasLongTaskTrackingEnabled(Configuration.DEFAULT_LONG_TASK_THRESHOLD_MS)
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @TestTargetApi(Build.VERSION_CODES.Q)
@@ -326,6 +333,7 @@ internal class ConfigurationBuilderTest {
             .hasViewTrackingStrategy(Configuration.DEFAULT_RUM_CONFIG.viewTrackingStrategy!!)
             .hasLongTaskTrackingEnabled(Configuration.DEFAULT_LONG_TASK_THRESHOLD_MS)
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -350,6 +358,7 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -378,6 +387,7 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -400,6 +410,7 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -424,6 +435,7 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -465,6 +477,7 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -901,6 +914,7 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -924,6 +938,7 @@ internal class ConfigurationBuilderTest {
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
         assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -965,6 +980,7 @@ internal class ConfigurationBuilderTest {
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
         assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -1042,6 +1058,7 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -1075,6 +1092,7 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -1097,6 +1115,7 @@ internal class ConfigurationBuilderTest {
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
         assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -1172,6 +1191,7 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -1192,6 +1212,7 @@ internal class ConfigurationBuilderTest {
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
         assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -1212,6 +1233,7 @@ internal class ConfigurationBuilderTest {
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
         assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
         assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
     }
 
     @Test
@@ -1233,5 +1255,28 @@ internal class ConfigurationBuilderTest {
         assertThat(config.internalLogsConfig).isEqualTo(
             Configuration.Feature.InternalLogs(clientToken, url, emptyList())
         )
+        assertThat(config.additionalConfig).isEmpty()
+    }
+
+    @Test
+    fun `𝕄 build with additionalConfig 𝕎 setAdditionalConfiguration()`(forge: Forge) {
+        // Given
+        val additionalConfig = forge.aMap {
+            forge.anAsciiString() to forge.aString()
+        }
+
+        // When
+        val config = testedBuilder
+            .setAdditionalConfiguration(additionalConfig)
+            .build()
+
+        // Then
+        assertThat(config.additionalConfig).isEqualTo(additionalConfig)
+
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
     }
 }


### PR DESCRIPTION
### What does this PR do?

This change gives user a possibility to provide additional free-form configuration values which can be used at the SDK initialization step on top of the existing pre-defined configuration fields.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

