### PR TITLE
RUMM-1223: Fix some flaky tests related to the map merging order when maps have common keys

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.forge.aFilteredMap
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.utils.mockCoreFeature
 import com.nhaarman.mockitokotlin2.any
@@ -601,12 +602,12 @@ internal class RumActionScopeTest {
 
     @Test
     fun `𝕄 send Action immediately 𝕎 handleEvent(StopView) {crashCount != 0}`(
-        @LongForgery(1, 1024) nonFatalcount: Long,
-        @LongForgery(1, 1024) fatalcount: Long
+        @LongForgery(1, 1024) nonFatalCount: Long,
+        @LongForgery(1, 1024) fatalCount: Long
     ) {
         // Given
-        testedScope.errorCount = nonFatalcount + fatalcount
-        testedScope.crashCount = fatalcount
+        testedScope.errorCount = nonFatalCount + fatalCount
+        testedScope.crashCount = fatalCount
 
         // When
         fakeEvent = RumRawEvent.StopView(Object(), emptyMap())
@@ -625,8 +626,8 @@ internal class RumActionScopeTest {
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
                     hasResourceCount(0)
-                    hasErrorCount(nonFatalcount + fatalcount)
-                    hasCrashCount(fatalcount)
+                    hasErrorCount(nonFatalCount + fatalCount)
+                    hasCrashCount(fatalCount)
                     hasLongTaskCount(0)
                     hasView(fakeParentContext)
                     hasUserInfo(fakeUserInfo)
@@ -683,7 +684,9 @@ internal class RumActionScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.aMap { anHexadecimalString() to anAsciiString() }
+        val attributes = forge.aFilteredMap(excludedKeys = fakeAttributes.keys) {
+            anHexadecimalString() to anAsciiString()
+        }
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -18,6 +18,7 @@ import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.forge.aFilteredMap
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.utils.mockCoreFeature
 import com.nhaarman.mockitokotlin2.any
@@ -222,7 +223,7 @@ internal class RumContinuousActionScopeTest {
     ) {
         // Given
         assumeTrue { type != fakeType }
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -266,7 +267,7 @@ internal class RumContinuousActionScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -704,12 +705,12 @@ internal class RumContinuousActionScopeTest {
 
     @Test
     fun `𝕄 send Action immediately 𝕎 handleEvent(StopView) {crashCount != 0}`(
-        @LongForgery(1, 1024) nonFatalcount: Long,
-        @LongForgery(1, 1024) fatalcount: Long
+        @LongForgery(1, 1024) nonFatalCount: Long,
+        @LongForgery(1, 1024) fatalCount: Long
     ) {
         // Given
-        testedScope.errorCount = nonFatalcount + fatalcount
-        testedScope.crashCount = fatalcount
+        testedScope.errorCount = nonFatalCount + fatalCount
+        testedScope.crashCount = fatalCount
 
         // When
         fakeEvent = RumRawEvent.StopView(Object(), emptyMap())
@@ -727,8 +728,8 @@ internal class RumContinuousActionScopeTest {
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
                     hasResourceCount(0)
-                    hasErrorCount(nonFatalcount + fatalcount)
-                    hasCrashCount(fatalcount)
+                    hasErrorCount(nonFatalCount + fatalCount)
+                    hasCrashCount(fatalCount)
                     hasView(fakeParentContext)
                     hasUserInfo(fakeUserInfo)
                     hasApplicationId(fakeParentContext.applicationId)
@@ -785,7 +786,9 @@ internal class RumContinuousActionScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.aMap { anHexadecimalString() to anAsciiString() }
+        val attributes = forge.aFilteredMap(excludedKeys = fakeAttributes.keys) {
+            anHexadecimalString() to anAsciiString()
+        }
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -24,6 +24,7 @@ import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.forge.aFilteredMap
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.utils.mockCoreFeature
 import com.nhaarman.mockitokotlin2.any
@@ -135,7 +136,7 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -184,7 +185,7 @@ internal class RumResourceScopeTest {
     ) {
         // Given
         doAnswer { true }.whenever(mockDetector).isFirstPartyUrl(fakeUrl)
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -244,7 +245,7 @@ internal class RumResourceScopeTest {
             mockDetector
         )
         doAnswer { true }.whenever(mockDetector).isFirstPartyUrl(brokenUrl)
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -295,7 +296,8 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes().toMutableMap()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+            .toMutableMap()
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -346,7 +348,7 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -509,7 +511,9 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.aMap { anHexadecimalString() to anAsciiString() }
+        val attributes = forge.aFilteredMap(excludedKeys = fakeAttributes.keys) {
+            anHexadecimalString() to anAsciiString()
+        }
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -559,7 +563,7 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -612,7 +616,7 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -664,7 +668,7 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -727,7 +731,7 @@ internal class RumResourceScopeTest {
             mockDetector
         )
         doAnswer { true }.whenever(mockDetector).isFirstPartyUrl(brokenUrl)
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -783,7 +787,7 @@ internal class RumResourceScopeTest {
         // Given
         doAnswer { true }.whenever(mockDetector).isFirstPartyUrl(fakeUrl)
 
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -838,7 +842,7 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -893,8 +897,12 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.aMap { anHexadecimalString() to anAsciiString() }
-        val errorAttributes = forge.exhaustiveAttributes()
+        val attributes = forge.aFilteredMap(excludedKeys = fakeAttributes.keys) {
+            anHexadecimalString() to anAsciiString()
+        }
+        val errorAttributes = forge.exhaustiveAttributes(
+            excludedKeys = fakeAttributes.keys + attributes.keys
+        )
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -948,7 +956,7 @@ internal class RumResourceScopeTest {
         @LongForgery(0, 1024) size: Long,
         forge: Forge
     ) {
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -993,7 +1001,7 @@ internal class RumResourceScopeTest {
         @LongForgery(0, 1024) size: Long,
         forge: Forge
     ) {
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -1017,7 +1025,7 @@ internal class RumResourceScopeTest {
         @LongForgery(0, 1024) size: Long,
         forge: Forge
     ) {
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -1063,7 +1071,7 @@ internal class RumResourceScopeTest {
         @Forgery timing: ResourceTiming,
         forge: Forge
     ) {
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -1112,7 +1120,7 @@ internal class RumResourceScopeTest {
         @Forgery timing: ResourceTiming,
         forge: Forge
     ) {
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -24,6 +24,7 @@ import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.forge.aFilteredMap
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.utils.mockCoreFeature
 import com.datadog.android.utils.mockDevLogHandler
@@ -319,7 +320,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -370,7 +371,7 @@ internal class RumViewScopeTest {
 
         // we limit it to 100 to avoid overflow and when we add those and end up with a positive
         // number
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -450,7 +451,9 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.aMap { anHexadecimalString() to anAsciiString() }
+        val attributes = forge.aFilteredMap(excludedKeys = fakeAttributes.keys) {
+            anHexadecimalString() to anAsciiString()
+        }
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -612,7 +615,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -664,7 +667,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeResourceScopes.put(key, mockChildScope)
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -750,7 +753,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -771,7 +774,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
@@ -1622,7 +1625,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
 
         // When
         val result = testedScope.handleEvent(
@@ -1650,7 +1653,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         val mockDevLogHandler = mockDevLogHandler()
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         testedScope.activeActionScope = mockChildScope
         fakeEvent = RumRawEvent.StartAction(type, name, waitForStop, attributes)
         whenever(mockChildScope.handleEvent(fakeEvent, mockWriter)) doReturn mockChildScope
@@ -1684,7 +1687,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         testedScope.stopped = true
         fakeEvent = RumRawEvent.StartAction(type, name, waitForStop, attributes)
 
@@ -1850,7 +1853,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         // Given
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
 
         // When
         val result = testedScope.handleEvent(
@@ -1883,7 +1886,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.StartResource(key, url, method, attributes)
 
         // When
@@ -2050,7 +2053,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(
             message,
             source,
@@ -2094,7 +2097,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         testedScope.activeActionScope = mockActionScope
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(
             message,
             source,
@@ -2138,7 +2141,7 @@ internal class RumViewScopeTest {
         forge: Forge
     ) {
         testedScope.activeActionScope = mockActionScope
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(
             message,
             source,
@@ -2186,7 +2189,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(message, source, null, null, fatal, attributes)
 
         // When
@@ -2276,7 +2279,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(
             message,
             source,
@@ -2325,7 +2328,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(
             message,
             source,
@@ -2424,7 +2427,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(message, source, throwable, null, fatal, attributes)
         testedScope.stopped = true
 
@@ -2446,7 +2449,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
-        val attributes = forge.exhaustiveAttributes()
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(message, source, null, stacktrace, fatal, attributes)
         testedScope.stopped = true
 
@@ -2946,8 +2949,9 @@ internal class RumViewScopeTest {
         existingAttributes: Map<String, Any?>
     ): Map<String, Any?> {
         val existingKeys = existingAttributes.keys
-        return forge.aMap<String, Any?> { anHexadecimalString() to anAsciiString() }
-            .filter { it.key !in existingKeys }
+        return forge.aFilteredMap(excludedKeys = existingKeys) {
+            anHexadecimalString() to anAsciiString()
+        }
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

This change fixes one issue causing flaky tests (although it happens pretty rare): Say there is `mapA` and `mapB` and there are some common keys in both, with different values. Obviously, `mapA`+`mapB` != `mapB`+`mapA` then, because things will be overwritten differently. Underlying code is doing `mapB+mapA`, but test code does `mapA+mapB` to make an assertion, so test fails.

So this changes introduces the necessary method which will make sure that generated map has unique keys.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

