### PR TITLE
RUMM-1039: Add a possibility to specify custom Source tag for Spans, Logs and RUM events

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -218,7 +218,11 @@ object Datadog {
     private fun applyAdditionalConfiguration(
         @Suppress("UNUSED_PARAMETER") additionalConfiguration: Map<String, Any>
     ) {
-        // no-op for now, will be filled later
+        additionalConfiguration[DD_SOURCE_TAG]?.let {
+            if (it.toString().isNotBlank()) {
+                CoreFeature.sourceName = it.toString()
+            }
+        }
     }
 
     /**
@@ -361,6 +365,8 @@ object Datadog {
         "The environment name should contain maximum 196 of the following allowed characters " +
             "[a-zA-Z0-9_:./-] and should never finish with a semicolon." +
             "In this case the Datadog SDK will not be initialised."
+
+    internal const val DD_SOURCE_TAG = "_dd.source"
 
     // endregion
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -282,7 +282,7 @@ private constructor(
 
         /**
          * Sets the service name that will appear in your logs, traces and crash reports.
-         * @param serviceName the service name (default = "android")
+         * @param serviceName the service name (default = application package name)
          */
         fun setServiceName(serviceName: String): Builder {
             coreConfig = coreConfig.copy(serviceName = serviceName)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -69,6 +69,10 @@ internal object CoreFeature {
     internal val NETWORK_TIMEOUT_MS = TimeUnit.SECONDS.toMillis(45)
     private val THREAD_POOL_MAX_KEEP_ALIVE_MS = TimeUnit.SECONDS.toMillis(5)
     private const val CORE_DEFAULT_POOL_SIZE = 1 // Only one thread will be kept alive
+    // this is a default source to be used when uploading RUM/Logs/Span data, however there is a
+    // possibility to override it which is useful when SDK is used via bridge, say
+    // from React Native integration
+    internal const val DEFAULT_SOURCE_NAME = "android"
 
     // endregion
 
@@ -89,6 +93,7 @@ internal object CoreFeature {
     internal var packageName: String = ""
     internal var packageVersion: String = ""
     internal var serviceName: String = ""
+    internal var sourceName: String = DEFAULT_SOURCE_NAME
     internal var rumApplicationId: String? = null
     internal var isMainProcess: Boolean = true
     internal var envName: String = ""
@@ -324,6 +329,7 @@ internal object CoreFeature {
         packageName = ""
         packageVersion = ""
         serviceName = ""
+        sourceName = DEFAULT_SOURCE_NAME
         rumApplicationId = null
         isMainProcess = true
         envName = ""

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -117,7 +117,6 @@ internal abstract class DataOkHttpUploader(
     // endregion
 
     companion object {
-        internal const val DD_SOURCE_ANDROID = "android"
 
         internal const val CONTENT_TYPE_JSON = "application/json"
         internal const val CONTENT_TYPE_TEXT_UTF8 = "text/plain;charset=UTF-8"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -210,7 +210,7 @@ internal constructor(internal val handler: LogHandler) {
 
         /**
          * Sets the service name that will appear in your logs.
-         * @param serviceName the service name (default = "android")
+         * @param serviceName the service name (default = application package name)
          */
         fun setServiceName(serviceName: String): Builder {
             this.serviceName = serviceName

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.log.internal.net
 
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.DataOkHttpUploader
 import java.util.Locale
 import okhttp3.OkHttpClient
@@ -21,7 +22,7 @@ internal open class LogsOkHttpUploader(
     override fun buildQueryParams(): Map<String, Any> {
         return mutableMapOf(
             QP_BATCH_TIME to System.currentTimeMillis(),
-            QP_SOURCE to DD_SOURCE_ANDROID
+            QP_SOURCE to CoreFeature.sourceName
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
@@ -34,7 +34,7 @@ internal open class RumOkHttpUploader(
     override fun buildQueryParams(): MutableMap<String, Any> {
         return mutableMapOf(
             QP_BATCH_TIME to System.currentTimeMillis(),
-            QP_SOURCE to DD_SOURCE_ANDROID,
+            QP_SOURCE to CoreFeature.sourceName,
             QP_TAGS to tags
         )
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt
@@ -93,7 +93,7 @@ class AndroidTracer internal constructor(
 
         /**
          * Sets the service name that will appear in your traces.
-         * @param serviceName the service name (default = "android")
+         * @param serviceName the service name (default = application package name)
          */
         fun setServiceName(serviceName: String): Builder {
             this.serviceName = serviceName

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializer.kt
@@ -76,7 +76,7 @@ internal class SpanSerializer(
             metaObject.addProperty(it.key, it.value)
         }
 
-        metaObject.addProperty(TAG_DD_SOURCE, DD_SOURCE_ANDROID)
+        metaObject.addProperty(TAG_DD_SOURCE, CoreFeature.sourceName)
         metaObject.addProperty(TAG_SPAN_KIND, KIND_CLIENT)
         metaObject.addProperty(TAG_TRACER_VERSION, BuildConfig.SDK_VERSION_NAME)
         metaObject.addProperty(TAG_APPLICATION_VERSION, CoreFeature.packageVersion)
@@ -179,7 +179,6 @@ internal class SpanSerializer(
     companion object {
 
         internal const val TYPE_CUSTOM = "custom"
-        internal const val DD_SOURCE_ANDROID = "android"
         internal const val KIND_CLIENT = "client"
 
         // PAYLOAD TAGS

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -503,6 +503,73 @@ internal class DatadogTest {
         )
     }
 
+    @Test
+    fun `𝕄 apply source name 𝕎 applyAdditionalConfig(config) { with source name }`() {
+
+        val source = "react-native"
+
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to source))
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(mockAppContext, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sourceName).isEqualTo(source)
+    }
+
+    @Test
+    fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { with empty source name }`(
+        forge: Forge
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to forge.aWhitespaceString()))
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(mockAppContext, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
+    }
+
+    @Test
+    fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { without source name }`(
+        forge: Forge
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(forge.aMap { anAsciiString() to aString() })
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(mockAppContext, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
+    }
+
     // endregion
 
     // region Internal

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/net/LogsOkHttpUploaderTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.log.net
 
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.DataOkHttpUploader
 import com.datadog.android.core.internal.net.DataOkHttpUploaderTest
 import com.datadog.android.log.internal.net.LogsOkHttpUploader
@@ -47,7 +48,7 @@ internal class LogsOkHttpUploaderTest : DataOkHttpUploaderTest<LogsOkHttpUploade
     override fun expectedPathRegex(): String {
         return "^\\/v1\\/input/$fakeToken" +
             "\\?${DataOkHttpUploader.QP_BATCH_TIME}=\\d+" +
-            "&${DataOkHttpUploader.QP_SOURCE}=${DataOkHttpUploader.DD_SOURCE_ANDROID}" +
+            "&${DataOkHttpUploader.QP_SOURCE}=${CoreFeature.sourceName}" +
             "$"
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderTest.kt
@@ -83,7 +83,7 @@ internal class RumOkHttpUploaderTest : DataOkHttpUploaderTest<RumOkHttpUploader>
     override fun expectedPathRegex(): String {
         return "^\\/v1\\/input/$fakeToken" +
             "\\?${DataOkHttpUploader.QP_BATCH_TIME}=\\d+" +
-            "&${DataOkHttpUploader.QP_SOURCE}=${DataOkHttpUploader.DD_SOURCE_ANDROID}" +
+            "&${DataOkHttpUploader.QP_SOURCE}=${CoreFeature.sourceName}" +
             "&${RumOkHttpUploader.QP_TAGS}=" +
             "${RumAttributes.SERVICE_NAME}:$fakePackageName," +
             "${RumAttributes.APPLICATION_VERSION}:$fakePackageVersion," +

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/SpanSerializerTest.kt
@@ -265,7 +265,7 @@ internal class SpanSerializerTest {
             .hasField(SpanSerializer.TAG_TYPE, SpanSerializer.TYPE_CUSTOM)
             .hasField(SpanSerializer.TAG_META, span.meta)
             .hasField(SpanSerializer.TAG_META) {
-                hasField(SpanSerializer.TAG_DD_SOURCE, SpanSerializer.DD_SOURCE_ANDROID)
+                hasField(SpanSerializer.TAG_DD_SOURCE, CoreFeature.sourceName)
                 hasField(SpanSerializer.TAG_SPAN_KIND, SpanSerializer.KIND_CLIENT)
                 hasField(SpanSerializer.TAG_TRACER_VERSION, BuildConfig.SDK_VERSION_NAME)
                 hasField(SpanSerializer.TAG_APPLICATION_VERSION, CoreFeature.packageVersion)


### PR DESCRIPTION
### What does this PR do?

This change introduces a possibility to specify custom `Source` tag for Logs, Spans and RUM events instead of default `android`, this is done with a help of `additionalConfig` collection which was added earlier in #549. This is useful if we want to distinguish whenever SDK is used directly in the native app, or integrated via bridge (say in React Native).

### Additional Notes

This approach doesn't work well when user has mixed app (native + React Native), because `initialize` call from React Native will be ignored (since SDK would already be initialized). But even if it is not be ignored, it wouldn't work reliably, because it would override default `android` property, which is still valid for events coming from the native layer. But to fix that architecture re-work should be done then, because then `source` should be attached to individual event instead of being attached to the SDK configuration.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

