### PR TITLE
Skip artifact signing for local publishing

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -107,7 +107,7 @@ fun Project.publishingConfig(projectDescription: String) {
         signingExtension.apply {
             val privateKey = System.getenv("GPG_PRIVATE_KEY")
             val password = System.getenv("GPG_PASSWORD")
-            isRequired = true
+            isRequired = !hasProperty("dd-skip-signing")
             useInMemoryPgpKeys(privateKey, password)
             sign(publishingExtension.publications.getByName(MavenConfig.PUBLICATION))
         }


### PR DESCRIPTION
### What does this PR do?

This change solves quite a specific issue: it removes the need of having GPG keys for signing local artifacts (they are useful when development of the bridge is done). Thus condition is quite specific: requirement is lifted only when `publishToMavenLocal` is executed (which is enough to reach the goal). Official documentation proposes to use [taskGraph](https://docs.gradle.org/current/userguide/signing_plugin.html#sec:conditional_signing), but I feel that without project flag (which is too much to introduce) it may become error-prone in case if `taskGraph` also has remote publishing tasks in addition to local publishing.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

