### PR TITLE
RUMM-1303 Add public api for logs data scrubbing

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -102,6 +102,7 @@ class com.datadog.android.core.configuration.Configuration
     fun setRumErrorEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ErrorEvent>): Builder
     fun setRumLongTaskEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.LongTaskEvent>): Builder
     fun setSpanEventMapper(com.datadog.android.event.SpanEventMapper): Builder
+    fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
     fun setInternalLogsEnabled(String, String): Builder
     fun setAdditionalConfiguration(Map<String, Any>): Builder
   companion object 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -214,9 +214,7 @@ object Datadog {
         }
     }
 
-    private fun applyAdditionalConfiguration(
-        @Suppress("UNUSED_PARAMETER") additionalConfiguration: Map<String, Any>
-    ) {
+    private fun applyAdditionalConfiguration(additionalConfiguration: Map<String, Any>) {
         additionalConfiguration[DD_SOURCE_TAG]?.let {
             if (it.toString().isNotBlank()) {
                 CoreFeature.sourceName = it.toString()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.internal.event.NoOpEventMapper
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.warnDeprecated
 import com.datadog.android.event.EventMapper
@@ -93,7 +94,8 @@ private constructor(
             logsConfig = logsConfig?.let {
                 Configuration.Feature.Logs(
                     endpointUrl = it.endpointUrl,
-                    plugins = it.plugins
+                    plugins = it.plugins,
+                    logsEventMapper = NoOpEventMapper()
                 )
             },
             crashReportConfig = crashReportConfig?.let {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -17,6 +17,7 @@ import com.datadog.android.event.EventMapper
 import com.datadog.android.event.NoOpSpanEventMapper
 import com.datadog.android.event.SpanEventMapper
 import com.datadog.android.event.ViewEventMapper
+import com.datadog.android.log.model.LogEvent
 import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.plugin.Feature as PluginFeature
 import com.datadog.android.rum.RumMonitor
@@ -70,7 +71,8 @@ internal constructor(
 
         internal data class Logs(
             override val endpointUrl: String,
-            override val plugins: List<DatadogPlugin>
+            override val plugins: List<DatadogPlugin>,
+            val logsEventMapper: EventMapper<LogEvent>
         ) : Feature()
 
         internal data class InternalLogs(
@@ -523,7 +525,8 @@ internal constructor(
         )
         internal val DEFAULT_LOGS_CONFIG = Feature.Logs(
             endpointUrl = DatadogEndpoint.LOGS_US,
-            plugins = emptyList()
+            plugins = emptyList(),
+            logsEventMapper = NoOpEventMapper()
         )
         internal val DEFAULT_CRASH_CONFIG = Feature.CrashReport(
             endpointUrl = DatadogEndpoint.LOGS_US,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -450,6 +450,20 @@ internal constructor(
         }
 
         /**
+         * Sets the [EventMapper] for the [LogEvent].
+         * You can use this interface implementation to modify the
+         * [LogEvent] attributes before serialisation.
+         *
+         * @param eventMapper the [EventMapper] implementation.
+         */
+        fun setLogEventMapper(eventMapper: EventMapper<LogEvent>): Builder {
+            applyIfFeatureEnabled(PluginFeature.LOG, "setLogEventMapper") {
+                logsConfig = logsConfig.copy(logsEventMapper = eventMapper)
+            }
+            return this
+        }
+
+        /**
          * Enables the internal logs to be sent to a dedicated Datadog Org.
          * @param clientToken the client token to use for internal logs
          * @param endpointUrl the endpoint url to sent the internal logs to

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportFilePersistenceStrategy.kt
@@ -13,7 +13,7 @@ import com.datadog.android.core.internal.persistence.file.batch.BatchFilePersist
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.Logger
-import com.datadog.android.log.internal.domain.LogEventSerializer
+import com.datadog.android.log.internal.domain.event.LogEventSerializer
 import com.datadog.android.log.model.LogEvent
 import java.util.concurrent.ExecutorService
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -29,7 +29,8 @@ internal object LogsFeature : SdkFeature<LogEvent, Configuration.Feature.Logs>()
             CoreFeature.trackingConsentProvider,
             context,
             CoreFeature.persistenceExecutorService,
-            sdkLogger
+            sdkLogger,
+            configuration.logsEventMapper
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFilePersistenceStrategy.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.internal.persistence.file.batch.BatchFilePersist
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.Logger
+import com.datadog.android.log.internal.domain.event.LogEventSerializer
 import com.datadog.android.log.model.LogEvent
 import java.util.concurrent.ExecutorService
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFilePersistenceStrategy.kt
@@ -12,7 +12,10 @@ import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOr
 import com.datadog.android.core.internal.persistence.file.batch.BatchFilePersistenceStrategy
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.core.internal.utils.sdkLogger
+import com.datadog.android.event.EventMapper
+import com.datadog.android.event.MapperSerializer
 import com.datadog.android.log.Logger
+import com.datadog.android.log.internal.domain.event.LogEventMapperWrapper
 import com.datadog.android.log.internal.domain.event.LogEventSerializer
 import com.datadog.android.log.model.LogEvent
 import java.util.concurrent.ExecutorService
@@ -21,7 +24,8 @@ internal class LogFilePersistenceStrategy(
     consentProvider: ConsentProvider,
     context: Context,
     executorService: ExecutorService,
-    internalLogger: Logger
+    internalLogger: Logger,
+    logEventMapper: EventMapper<LogEvent>
 ) :
     BatchFilePersistenceStrategy<LogEvent>(
         FeatureFileOrchestrator(
@@ -32,7 +36,7 @@ internal class LogFilePersistenceStrategy(
             internalLogger
         ),
         executorService,
-        LogEventSerializer(),
+        MapperSerializer(LogEventMapperWrapper(logEventMapper), LogEventSerializer()),
         PayloadDecoration.JSON_ARRAY_DECORATION,
         sdkLogger
     )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/event/LogEventMapperWrapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/event/LogEventMapperWrapper.kt
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.log.internal.domain.event
+
+import com.datadog.android.core.internal.utils.devLogger
+import com.datadog.android.event.EventMapper
+import com.datadog.android.log.model.LogEvent
+import java.util.Locale
+
+internal class LogEventMapperWrapper(private val wrappedEventMapper: EventMapper<LogEvent>) :
+    EventMapper<LogEvent> {
+    override fun map(event: LogEvent): LogEvent? {
+        val mappedEvent = wrappedEventMapper.map(event)
+        if (mappedEvent == null) {
+            devLogger.w(EVENT_NULL_WARNING_MESSAGE.format(Locale.US, event))
+            return null
+        }
+        if (mappedEvent !== event) {
+            devLogger.w(NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(Locale.US, event))
+            return null
+        }
+        return mappedEvent
+    }
+
+    companion object {
+
+        internal const val EVENT_NULL_WARNING_MESSAGE =
+            "LogEventMapper: the returned mapped object was null. " +
+                "This event will be dropped: %s"
+
+        internal const val NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE =
+            "LogEventMapper: the returned mapped object was not the " +
+                "same instance as the original object. This event will be dropped: %s"
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializer.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.domain
+package com.datadog.android.log.internal.domain.event
 
 import com.datadog.android.core.internal.constraints.DataConstraints
 import com.datadog.android.core.internal.constraints.DatadogDataConstraints

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/monitoring/internal/InternalLogFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/monitoring/internal/InternalLogFilePersistenceStrategy.kt
@@ -12,7 +12,7 @@ import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOr
 import com.datadog.android.core.internal.persistence.file.batch.BatchFilePersistenceStrategy
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.log.Logger
-import com.datadog.android.log.internal.domain.LogEventSerializer
+import com.datadog.android.log.internal.domain.event.LogEventSerializer
 import com.datadog.android.log.model.LogEvent
 import java.util.concurrent.ExecutorService
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracesFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracesFilePersistenceStrategy.kt
@@ -17,6 +17,7 @@ import com.datadog.android.event.SpanEventMapper
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.tracing.internal.domain.event.DdSpanToSpanEventMapper
+import com.datadog.android.tracing.internal.domain.event.SpanEventMapperWrapper
 import com.datadog.android.tracing.internal.domain.event.SpanEventSerializer
 import com.datadog.android.tracing.internal.domain.event.SpanMapperSerializer
 import com.datadog.opentracing.DDSpan
@@ -47,7 +48,7 @@ internal class TracesFilePersistenceStrategy(
             networkInfoProvider,
             userInfoProvider
         ),
-        spanEventMapper,
+        SpanEventMapperWrapper(spanEventMapper),
         SpanEventSerializer(envName)
     ),
     PayloadDecoration.NEW_LINE_DECORATION,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -103,7 +103,8 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(
             Configuration.Feature.Logs(
                 endpointUrl = DatadogEndpoint.LOGS_US,
-                plugins = emptyList()
+                plugins = emptyList(),
+                logsEventMapper = NoOpEventMapper()
             )
         )
         assertThat(config.tracesConfig)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.event.NoOpSpanEventMapper
 import com.datadog.android.event.SpanEventMapper
 import com.datadog.android.event.ViewEventMapper
 import com.datadog.android.log.internal.logger.LogHandler
+import com.datadog.android.log.model.LogEvent
 import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.plugin.Feature
 import com.datadog.android.rum.assertj.ConfigurationRumAssert.Companion.assertThat
@@ -1417,11 +1418,11 @@ internal class ConfigurationBuilderTest {
     @Test
     fun `𝕄 build config with Span eventMapper 𝕎 setSpanEventMapper() and build()`() {
         // Given
-        val eventMapper: SpanEventMapper = mock()
+        val mockEventMapper: SpanEventMapper = mock()
 
         // When
         val config = testedBuilder
-            .setSpanEventMapper(eventMapper)
+            .setSpanEventMapper(mockEventMapper)
             .build()
 
         // Then
@@ -1430,7 +1431,29 @@ internal class ConfigurationBuilderTest {
         assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(
             Configuration.DEFAULT_TRACING_CONFIG.copy(
-                spanEventMapper = eventMapper
+                spanEventMapper = mockEventMapper
+            )
+        )
+        assertThat(config.internalLogsConfig).isNull()
+    }
+
+    @Test
+    fun `𝕄 build config with Log eventMapper 𝕎 setLogEventMapper() and build()`() {
+        // Given
+        val mockEventMapper: EventMapper<LogEvent> = mock()
+
+        // When
+        val config = testedBuilder
+            .setLogEventMapper(mockEventMapper)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(
+            Configuration.DEFAULT_LOGS_CONFIG.copy(
+                logsEventMapper = mockEventMapper
             )
         )
         assertThat(config.internalLogsConfig).isNull()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraintsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraintsTest.kt
@@ -304,7 +304,8 @@ internal class DatadogDataConstraintsTest {
 
         // Given
         val goodTimingPart = forge.anAlphabeticalString(case = Case.ANY)
-        val badTimingPart = forge.aStringMatching("[^a-zA-Z0-9\\-_.@$]+")
+        val badTimingPart = forge.anAsciiString()
+            .replace(Regex("[a-zA-Z0-9:\\-_.@\$]"), "%|*|!|&|")
 
         val malformedKey = (goodTimingPart + badTimingPart)
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventMapperWrapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventMapperWrapperTest.kt
@@ -1,0 +1,129 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.log.internal.domain.event
+
+import android.util.Log
+import com.datadog.android.event.EventMapper
+import com.datadog.android.log.internal.logger.LogHandler
+import com.datadog.android.log.model.LogEvent
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.mockDevLogHandler
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.Locale
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.STRICT_STUBS)
+@ForgeConfiguration(Configurator::class)
+internal class LogEventMapperWrapperTest {
+
+    lateinit var testedEventMapper: LogEventMapperWrapper
+
+    @Mock
+    lateinit var mockWrappedEventMapper: EventMapper<LogEvent>
+
+    @Mock
+    lateinit var mockLogEvent: LogEvent
+
+    lateinit var mockDevLogHandler: LogHandler
+
+    @BeforeEach
+    fun `set up`() {
+        mockDevLogHandler = mockDevLogHandler()
+        testedEventMapper = LogEventMapperWrapper(mockWrappedEventMapper)
+    }
+
+    @Test
+    fun `M map and return the LogEvent W map`() {
+        // GIVEN
+        whenever(mockWrappedEventMapper.map(mockLogEvent)).thenReturn(mockLogEvent)
+
+        // WHEN
+        val mappedEvent = testedEventMapper.map(mockLogEvent)
+
+        // THEN
+        verify(mockWrappedEventMapper).map(mockLogEvent)
+        Assertions.assertThat(mappedEvent).isEqualTo(mockLogEvent)
+    }
+
+    @Test
+    fun `M return null if the mapped returned event is not the same instance W map`() {
+        // GIVEN
+        whenever(mockWrappedEventMapper.map(mockLogEvent)).thenReturn(mock())
+
+        // WHEN
+        val mappedEvent = testedEventMapper.map(mockLogEvent)
+
+        // THEN
+        verify(mockWrappedEventMapper).map(mockLogEvent)
+        Assertions.assertThat(mappedEvent).isNull()
+    }
+
+    @Test
+    fun `M log a warning if the mapped returned event is not the same instance W map`() {
+        // GIVEN
+        whenever(mockWrappedEventMapper.map(mockLogEvent)).thenReturn(mock())
+
+        // WHEN
+        testedEventMapper.map(mockLogEvent)
+
+        // THEN
+        verify(mockDevLogHandler).handleLog(
+            Log.WARN,
+            LogEventMapperWrapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(
+                Locale.US,
+                mockLogEvent.toString()
+            )
+        )
+    }
+
+    @Test
+    fun `M return null if the mapped returned event is null W map`() {
+        // GIVEN
+        whenever(mockWrappedEventMapper.map(mockLogEvent)).thenReturn(null)
+
+        // WHEN
+        val mappedEvent = testedEventMapper.map(mockLogEvent)
+
+        // THEN
+        verify(mockWrappedEventMapper).map(mockLogEvent)
+        Assertions.assertThat(mappedEvent).isNull()
+    }
+
+    @Test
+    fun `M log a warning if the mapped returned event is null W map`() {
+        // GIVEN
+        whenever(mockWrappedEventMapper.map(mockLogEvent)).thenReturn(null)
+
+        // WHEN
+        testedEventMapper.map(mockLogEvent)
+
+        // THEN
+        verify(mockDevLogHandler).handleLog(
+            Log.WARN,
+            LogEventMapperWrapper.EVENT_NULL_WARNING_MESSAGE.format(
+                Locale.US,
+                mockLogEvent.toString()
+            )
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializerTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.log.internal.domain
+package com.datadog.android.log.internal.domain.event
 
 import com.datadog.android.log.assertj.containsExtraAttributes
 import com.datadog.android.log.model.LogEvent

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracesFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracesFeatureTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.internal.persistence.file.advanced.ScheduledWrit
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileDataWriter
 import com.datadog.android.event.SpanEventMapper
 import com.datadog.android.tracing.internal.domain.TracesFilePersistenceStrategy
+import com.datadog.android.tracing.internal.domain.event.SpanEventMapperWrapper
 import com.datadog.android.tracing.internal.domain.event.SpanMapperSerializer
 import com.datadog.android.tracing.internal.net.TracesOkHttpUploader
 import com.datadog.android.utils.forge.Configurator
@@ -68,9 +69,13 @@ internal class TracesFeatureTest :
             (testedFeature.persistenceStrategy.getWriter() as? ScheduledWriter)
                 ?.delegateWriter as? BatchFileDataWriter
         val spanMapperSerializer = batchFileDataWriter?.serializer as? SpanMapperSerializer
-        val spanEventMapper =
-            spanMapperSerializer?.getFieldValue<SpanEventMapper, SpanMapperSerializer>(
+        val spanEventMapperWrapper =
+            spanMapperSerializer?.getFieldValue<SpanEventMapperWrapper, SpanMapperSerializer>(
                 "spanEventMapper"
+            )
+        val spanEventMapper =
+            spanEventMapperWrapper?.getFieldValue<SpanEventMapper, SpanEventMapperWrapper>(
+                "wrappedEventMapper"
             )
         assertThat(
             spanEventMapper

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationLogForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationLogForgeryFactory.kt
@@ -17,7 +17,8 @@ internal class ConfigurationLogForgeryFactory :
     override fun getForgery(forge: Forge): Configuration.Feature.Logs {
         return Configuration.Feature.Logs(
             endpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
-            plugins = forge.aList { mock<DatadogPlugin>() }
+            plugins = forge.aList { mock<DatadogPlugin>() },
+            logsEventMapper = mock()
         )
     }
 }

--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -131,6 +131,15 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
             }}
     );
     ```
+   
+6. If you need to modify some attributes in your Log events before batching you can do so by providing an implementation of `EventMapper<LogEvent>` when initializing the SDK:
+   ```kotlin
+      val config = DatadogConfig.Builder("<CLIENT_TOKEN>", "<ENVIRONMENT_NAME>", "<APPLICATION_ID>")
+                        // ...
+                        .setLogEventMapper(logEventMapper)
+                        .build()
+   ```
+   **Note**: If you return null or a different instance from the `EventMapper<LogEvent>` implementation the event will be dropped.
 
 ## Advanced logging
 

--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -221,13 +221,14 @@ Send [traces][1] to Datadog from your Android applications with [Datadog's `dd-s
     AndroidTracer.logErrorMessage(span, message)
     ```
 
-8. If you need to modify some attributes in your Span events before batching you can do so by providing an implementation of `SpanEventMapper<T>` when initialzing the SDK:
+8. If you need to modify some attributes in your Span events before batching you can do so by providing an implementation of `SpanEventMapper` when initializing the SDK:
    ```kotlin
       val config = DatadogConfig.Builder("<CLIENT_TOKEN>", "<ENVIRONMENT_NAME>", "<APPLICATION_ID>")
-                        ...
+                        // ...
                         .setSpanEventMapper(spanEventMapper)
                         .build()
    ```
+   
 ## Integrations
 
 In addition to manual tracing, the `dd-sdk-android` library provides the following integration.


### PR DESCRIPTION
### What does this PR do?

In this PR:
- we introduce the new `LogMapperSerializer`
- we add the public API method at the SDK configuration level to be able to set the log event mapper
- fixes a problem in the `TraceFilePersistenceStrategy` from previous PRs where the provided `SpanEventMapper` was not wrapped in our own `SpanEventMapperWrapper`
- fixes some flaky tests
- updates the docs related with the new public API method

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

