### PR TITLE
InternalLogger: use application.version as package name key

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/monitoring/internal/InternalLogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/monitoring/internal/InternalLogsFeature.kt
@@ -23,6 +23,7 @@ internal object InternalLogsFeature : SdkFeature<Log, Configuration.Feature.Inte
 
     internal const val SERVICE_NAME = "dd-sdk-android"
     internal const val ENV_NAME = "prod"
+    private const val APPLICATION_PACKAGE_KEY = "application.name"
 
     // region SdkFeature
 
@@ -30,7 +31,7 @@ internal object InternalLogsFeature : SdkFeature<Log, Configuration.Feature.Inte
         // The sdk logger might have already been initialized
         // while the feature was not yet initialized
         rebuildSdkLogger()
-        sdkLogger.addAttribute("application", CoreFeature.packageName)
+        sdkLogger.addAttribute(APPLICATION_PACKAGE_KEY, CoreFeature.packageName)
     }
 
     override fun onPostStopped() {


### PR DESCRIPTION
### What does this PR do?

The current key: application that we are using to send the application package name as an internal log attribute is clashing with the already existing facet application.version. We will not be able to create a facet from it and make it queryable so we decided to use a new key instead: application.name

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

