### PR TITLE
RUMM-1325 cleanup crash message

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -15,7 +15,6 @@ import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import java.lang.ref.WeakReference
-import java.util.Locale
 
 internal class DatadogExceptionHandler(
     private val logGenerator: LogGenerator,
@@ -75,10 +74,12 @@ internal class DatadogExceptionHandler(
     }
 
     private fun createCrashMessage(throwable: Throwable): String {
-        return if (throwable.message.isNullOrBlank()) {
-            MESSAGE
+        val rawMessage = throwable.message
+        return if (rawMessage.isNullOrBlank()) {
+            val className = throwable.javaClass.canonicalName ?: throwable.javaClass.simpleName
+            "$MESSAGE: $className"
         } else {
-            MESSAGE + ": %s".format(Locale.US, throwable.message)
+            rawMessage
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Cleanup the  crash error message.

### Motivation

The Error Tracking is working on making visible which errors come from  a crash (uncaught errors) and which are just logged errors (caught errors). We need to use the raw message if possible, with the prefix. 
