### PR TITLE
RUMM-1293 Fix flaky tests

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
@@ -18,6 +18,7 @@ import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.error.internal.CrashReportsFeature
 import com.datadog.android.log.internal.LogsFeature
+import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.tracing.internal.TracesFeature
 
 internal class UploadWorker(
@@ -49,6 +50,12 @@ internal class UploadWorker(
         uploadAllBatches(
             TracesFeature.persistenceStrategy.getReader(),
             TracesFeature.uploader
+        )
+
+        // Upload RUM
+        uploadAllBatches(
+            RumFeature.persistenceStrategy.getReader(),
+            RumFeature.uploader
         )
 
         return Result.success()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraintsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraintsTest.kt
@@ -301,7 +301,6 @@ internal class DatadogDataConstraintsTest {
         @Forgery viewEvent: ViewEvent,
         forge: Forge
     ) {
-
         // Given
         val goodTimingPart = forge.anAlphabeticalString(case = Case.ANY)
         val badTimingPart = forge.anAsciiString()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -45,7 +45,6 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.util.concurrent.TimeUnit
 import kotlin.system.measureNanoTime
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -215,12 +214,11 @@ internal class RumContinuousActionScopeTest {
 
     @Test
     fun `𝕄 send Action with updated data 𝕎 handleEvent(StopAction+any) {viewTreeChangeCount!=0}`(
-        @Forgery type: RumActionType,
         @StringForgery name: String,
         forge: Forge
     ) {
         // Given
-        assumeTrue { type != fakeType }
+        val type = forge.aValueFrom(RumActionType::class.java, listOf(fakeType))
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
@@ -985,8 +983,10 @@ internal class RumContinuousActionScopeTest {
     }
 
     @Test
-    fun `𝕄 do nothing 𝕎 handleEvent(StopView) {no side effect}`() {
-        assumeTrue(testedScope.type != RumActionType.CUSTOM)
+    fun `𝕄 do nothing 𝕎 handleEvent(StopView) {no side effect}`(
+        forge: Forge
+    ) {
+        testedScope.type = forge.aValueFrom(RumActionType::class.java, listOf(RumActionType.CUSTOM))
 
         // Given
         testedScope.resourceCount = 0


### PR DESCRIPTION
### What does this PR do?

Fix tests reported as Flaky in CI App

### Motivation

Avoid noise in the CI App. Most of the tests are not flaky, but are just "not ran" because an assumption fails. By updating the way the fixtures are generated, we can avoid those assumptions. 

### Additional Notes

Fixed a bug in the Upload worker not sending RUM data.
