### PR TITLE
RUMM-1313: Support external resource timings

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -316,6 +316,7 @@ object com.datadog.android.rum.RumAttributes
   const val INTERNAL_TIMESTAMP: String
   const val TRACE_ID: String
   const val SPAN_ID: String
+  const val RESOURCE_TIMINGS: String
   const val ERROR_RESOURCE_METHOD: String
   const val ERROR_RESOURCE_STATUS_CODE: String
   const val ERROR_RESOURCE_URL: String

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -85,6 +85,11 @@ object RumAttributes {
      */
     const val SPAN_ID: String = "_dd.span_id"
 
+    /**
+     * Timings coming from external sources, as object { startTime (number) + duration (number) }.
+     */
+    const val RESOURCE_TIMINGS: String = "_dd.resource_timings"
+
     // endregion
 
     // region Error

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimings.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimings.kt
@@ -1,0 +1,79 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.scope
+
+import com.datadog.android.rum.internal.domain.event.ResourceTiming
+
+private const val FIRST_BYTE_TIMING = "firstByte"
+private const val DOWNLOAD_TIMING = "download"
+private const val SSL_TIMING = "ssl"
+private const val CONNECT_TIMING = "connect"
+private const val DNS_TIMING = "dns"
+
+private val ALL_TIMINGS = listOf(
+    FIRST_BYTE_TIMING,
+    DOWNLOAD_TIMING,
+    SSL_TIMING,
+    CONNECT_TIMING,
+    DNS_TIMING
+)
+
+private const val START_TIME_KEY = "startTime"
+private const val DURATION_KEY = "duration"
+
+internal fun extractResourceTiming(timingsPayload: Map<String, Any?>?): ResourceTiming? {
+
+    if (timingsPayload == null) {
+        return null
+    }
+
+    val timings = ALL_TIMINGS.associateWith { value ->
+        extractTiming(value, timingsPayload)
+    }.filterValues { it != null }
+
+    return if (timings.isNotEmpty()) {
+        createResourceTiming(timings)
+    } else {
+        null
+    }
+}
+
+@Suppress("ComplexMethod")
+private fun createResourceTiming(timings: Map<String, Timing?>): ResourceTiming {
+    return ResourceTiming(
+        firstByteStart = timings[FIRST_BYTE_TIMING]?.startTime ?: 0L,
+        firstByteDuration = timings[FIRST_BYTE_TIMING]?.duration ?: 0L,
+        downloadStart = timings[DOWNLOAD_TIMING]?.startTime ?: 0L,
+        downloadDuration = timings[DOWNLOAD_TIMING]?.duration ?: 0L,
+        dnsStart = timings[DNS_TIMING]?.startTime ?: 0L,
+        dnsDuration = timings[DNS_TIMING]?.duration ?: 0L,
+        connectStart = timings[CONNECT_TIMING]?.startTime ?: 0L,
+        connectDuration = timings[CONNECT_TIMING]?.duration ?: 0L,
+        sslStart = timings[SSL_TIMING]?.startTime ?: 0L,
+        sslDuration = timings[SSL_TIMING]?.duration ?: 0L
+    )
+}
+
+private fun extractTiming(name: String, source: Map<String, Any?>): Timing? {
+
+    val timing = source[name]
+
+    return if (timing != null && timing is Map<*, *>) {
+        // number values coming from JavaScript will always be Double, for example
+        val startTime = (timing[START_TIME_KEY] as? Number)?.toLong()
+        val duration = (timing[DURATION_KEY] as? Number)?.toLong()
+        if (startTime != null && duration != null) {
+            Timing(startTime, duration)
+        } else {
+            null
+        }
+    } else {
+        null
+    }
+}
+
+private data class Timing(val startTime: Long, val duration: Long)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
@@ -83,7 +83,7 @@ internal fun ResourceTiming.ssl(): ResourceEvent.Ssl? {
 }
 
 internal fun ResourceTiming.firstByte(): ResourceEvent.FirstByte? {
-    return if (firstByteStart > 0) {
+    return if (firstByteStart >= 0 && firstByteDuration > 0) {
         ResourceEvent.FirstByte(duration = firstByteDuration, start = firstByteStart)
     } else null
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -133,7 +133,10 @@ internal class RumResourceScope(
         val context = getRumContext()
         val user = CoreFeature.userInfoProvider.getUserInfo()
 
-        val finalTiming = timing
+        @Suppress("UNCHECKED_CAST")
+        val finalTiming = timing ?: extractResourceTiming(
+            attributes.remove(RumAttributes.RESOURCE_TIMINGS) as? Map<String, Any?>
+        )
         val duration = eventTime.nanoTime - startedNanos
         val resourceEvent = ResourceEvent(
             date = eventTimestamp,
@@ -278,9 +281,8 @@ internal class RumResourceScope(
     // endregion
 
     companion object {
-        internal const val HTTP_ERROR_CODE_THRESHOLD = 400
-        internal const val ERROR_MSG_FORMAT = "Request error %s %s"
         internal const val ERROR_TYPE_BASED_ON_STATUS_CODE_FORMAT = "HTTP %d"
+
         fun fromEvent(
             parentScope: RumScope,
             event: RumRawEvent.StartResource,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimingsKtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimingsKtTest.kt
@@ -1,0 +1,245 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.scope
+
+import com.datadog.android.rum.internal.domain.event.ResourceTiming
+import com.datadog.android.utils.asTimingsPayload
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.KotlinAssertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@ForgeConfiguration(Configurator::class)
+internal class ExternalResourceTimingsKtTest {
+
+    @Test
+    fun `𝕄 create timings 𝕎 extractResourceTiming`(@Forgery reference: ResourceTiming) {
+
+        // Given
+        val timingsPayload = reference.asTimingsPayload()
+
+        // When
+        val timings = extractResourceTiming(timingsPayload)
+
+        // Then
+        assertThat(timings).isNotNull
+
+        timings!!.let {
+            assertThat(it.connectStart).isEqualTo(timingsPayload.startTimeOf("connect"))
+            assertThat(it.connectDuration).isEqualTo(timingsPayload.durationOf("connect"))
+            assertThat(it.downloadStart).isEqualTo(timingsPayload.startTimeOf("download"))
+            assertThat(it.downloadDuration).isEqualTo(timingsPayload.durationOf("download"))
+            assertThat(it.dnsStart).isEqualTo(timingsPayload.startTimeOf("dns"))
+            assertThat(it.dnsDuration).isEqualTo(timingsPayload.durationOf("dns"))
+            assertThat(it.sslStart).isEqualTo(timingsPayload.startTimeOf("ssl"))
+            assertThat(it.sslDuration).isEqualTo(timingsPayload.durationOf("ssl"))
+            assertThat(it.firstByteStart).isEqualTo(timingsPayload.startTimeOf("firstByte"))
+            assertThat(it.firstByteDuration).isEqualTo(timingsPayload.durationOf("firstByte"))
+        }
+    }
+
+    @Test
+    fun `𝕄 create timings 𝕎 extractResourceTiming { some timing is missing }`(
+        @Forgery timing: ResourceTiming,
+        forge: Forge
+    ) {
+
+        // Given
+        val timingsPayload = timing.asTimingsPayload()
+        timingsPayload.remove(forge.anElementFrom("ssl", "firstByte", "download", "connect", "dns"))
+
+        // When
+        val timings = extractResourceTiming(timingsPayload)
+
+        // Then
+        assertThat(timings).isNotNull
+
+        timings!!.let {
+            assertThat(it.connectStart).isEqualTo(timingsPayload.startTimeOf("connect"))
+            assertThat(it.connectDuration).isEqualTo(timingsPayload.durationOf("connect"))
+            assertThat(it.downloadStart).isEqualTo(timingsPayload.startTimeOf("download"))
+            assertThat(it.downloadDuration).isEqualTo(timingsPayload.durationOf("download"))
+            assertThat(it.dnsStart).isEqualTo(timingsPayload.startTimeOf("dns"))
+            assertThat(it.dnsDuration).isEqualTo(timingsPayload.durationOf("dns"))
+            assertThat(it.sslStart).isEqualTo(timingsPayload.startTimeOf("ssl"))
+            assertThat(it.sslDuration).isEqualTo(timingsPayload.durationOf("ssl"))
+            assertThat(it.firstByteStart).isEqualTo(timingsPayload.startTimeOf("firstByte"))
+            assertThat(it.firstByteDuration).isEqualTo(timingsPayload.durationOf("firstByte"))
+        }
+    }
+
+    @Test
+    fun `𝕄 create timings 𝕎 extractResourceTiming { timing info is incomplete }`(
+        @Forgery reference: ResourceTiming,
+        forge: Forge
+    ) {
+
+        // Given
+        val timingsPayload = reference.asTimingsPayload()
+
+        val badTiming = forge.anElementFrom("ssl", "firstByte", "download", "connect", "dns")
+
+        @Suppress("UNCHECKED_CAST")
+        val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
+
+        timing.remove(forge.anElementFrom("startTime", "duration"))
+
+        // When
+        val timings = extractResourceTiming(timingsPayload)
+
+        // Then
+        assertThat(timings).isNotNull
+
+        timings!!.let {
+            if (badTiming == "ssl") {
+                assertThat(it.sslStart).isEqualTo(0L)
+                assertThat(it.sslDuration).isEqualTo(0L)
+            } else {
+                assertThat(it.sslStart).isEqualTo(timingsPayload.startTimeOf("ssl"))
+                assertThat(it.sslDuration).isEqualTo(timingsPayload.durationOf("ssl"))
+            }
+
+            if (badTiming == "connect") {
+                assertThat(it.connectStart).isEqualTo(0L)
+                assertThat(it.connectDuration).isEqualTo(0L)
+            } else {
+                assertThat(it.connectStart).isEqualTo(timingsPayload.startTimeOf("connect"))
+                assertThat(it.connectDuration).isEqualTo(timingsPayload.durationOf("connect"))
+            }
+
+            if (badTiming == "download") {
+                assertThat(it.downloadStart).isEqualTo(0L)
+                assertThat(it.downloadDuration).isEqualTo(0L)
+            } else {
+                assertThat(it.downloadStart).isEqualTo(timingsPayload.startTimeOf("download"))
+                assertThat(it.downloadDuration).isEqualTo(timingsPayload.durationOf("download"))
+            }
+
+            if (badTiming == "dns") {
+                assertThat(it.dnsStart).isEqualTo(0L)
+                assertThat(it.dnsDuration).isEqualTo(0L)
+            } else {
+                assertThat(it.dnsStart).isEqualTo(timingsPayload.startTimeOf("dns"))
+                assertThat(it.dnsDuration).isEqualTo(timingsPayload.durationOf("dns"))
+            }
+
+            if (badTiming == "firstByte") {
+                assertThat(it.firstByteStart).isEqualTo(0L)
+                assertThat(it.firstByteDuration).isEqualTo(0L)
+            } else {
+                assertThat(it.firstByteStart).isEqualTo(timingsPayload.startTimeOf("firstByte"))
+                assertThat(it.firstByteDuration).isEqualTo(timingsPayload.durationOf("firstByte"))
+            }
+        }
+    }
+
+    @Test
+    fun `𝕄 create timings 𝕎 extractResourceTiming { timing info with wrong structure }`(
+        @Forgery reference: ResourceTiming,
+        forge: Forge
+    ) {
+
+        // Given
+        val timingsPayload = reference.asTimingsPayload()
+
+        val badTiming = forge.anElementFrom("ssl", "firstByte", "download", "connect", "dns")
+
+        @Suppress("UNCHECKED_CAST")
+        val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
+        timing[forge.anElementFrom("startTime", "duration")] = true
+
+        // When
+        val timings = extractResourceTiming(timingsPayload)
+
+        // Then
+        assertThat(timings).isNotNull
+
+        timings!!.let {
+            if (badTiming == "ssl") {
+                assertThat(it.sslStart).isEqualTo(0L)
+                assertThat(it.sslDuration).isEqualTo(0L)
+            } else {
+                assertThat(it.sslStart).isEqualTo(timingsPayload.startTimeOf("ssl"))
+                assertThat(it.sslDuration).isEqualTo(timingsPayload.durationOf("ssl"))
+            }
+
+            if (badTiming == "connect") {
+                assertThat(it.connectStart).isEqualTo(0L)
+                assertThat(it.connectDuration).isEqualTo(0L)
+            } else {
+                assertThat(it.connectStart).isEqualTo(timingsPayload.startTimeOf("connect"))
+                assertThat(it.connectDuration).isEqualTo(timingsPayload.durationOf("connect"))
+            }
+
+            if (badTiming == "download") {
+                assertThat(it.downloadStart).isEqualTo(0L)
+                assertThat(it.downloadDuration).isEqualTo(0L)
+            } else {
+                assertThat(it.downloadStart).isEqualTo(timingsPayload.startTimeOf("download"))
+                assertThat(it.downloadDuration).isEqualTo(timingsPayload.durationOf("download"))
+            }
+
+            if (badTiming == "dns") {
+                assertThat(it.dnsStart).isEqualTo(0L)
+                assertThat(it.dnsDuration).isEqualTo(0L)
+            } else {
+                assertThat(it.dnsStart).isEqualTo(timingsPayload.startTimeOf("dns"))
+                assertThat(it.dnsDuration).isEqualTo(timingsPayload.durationOf("dns"))
+            }
+
+            if (badTiming == "firstByte") {
+                assertThat(it.firstByteStart).isEqualTo(0L)
+                assertThat(it.firstByteDuration).isEqualTo(0L)
+            } else {
+                assertThat(it.firstByteStart).isEqualTo(timingsPayload.startTimeOf("firstByte"))
+                assertThat(it.firstByteDuration).isEqualTo(timingsPayload.durationOf("firstByte"))
+            }
+        }
+    }
+
+    @Test
+    fun `𝕄 not create timings 𝕎 extractResourceTiming { payload is null }`() {
+
+        // When
+        val timings = extractResourceTiming(null)
+
+        // Then
+        assertThat(timings).isNull()
+    }
+
+    // region Internal
+
+    private fun Map<*, *>.startTimeOf(timingName: String): Long {
+        @Suppress("UNCHECKED_CAST")
+        val timing = this[timingName] as? Map<String, Any?>
+        return if (timing != null) {
+            timing["startTime"] as? Long ?: 0L
+        } else {
+            0L
+        }
+    }
+
+    private fun Map<*, *>.durationOf(timingName: String): Long {
+        @Suppress("UNCHECKED_CAST")
+        val timing = this[timingName] as? Map<String, Any?>
+        return if (timing != null) {
+            timing["duration"] as? Long ?: 0L
+        } else {
+            0L
+        }
+    }
+
+    // endregion
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -23,6 +23,7 @@ import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.utils.asTimingsPayload
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
@@ -1158,6 +1159,67 @@ internal class RumResourceScopeTest {
         assertThat(resultWaitForTiming).isEqualTo(testedScope)
         assertThat(resultStop).isEqualTo(testedScope)
         assertThat(resultTiming).isEqualTo(null)
+    }
+
+    @Test
+    fun `𝕄 use explicit timings 𝕎 handleEvent { AddResourceTiming + StopResource }`(
+        @Forgery kind: RumResourceKind,
+        @LongForgery(200, 600) statusCode: Long,
+        @LongForgery(0, 1024) size: Long,
+        @Forgery timing: ResourceTiming,
+        forge: Forge
+    ) {
+
+        // Given
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys) +
+            mapOf(
+                "_dd.resource_timings"
+                    to forge.getForgery(ResourceTiming::class.java).asTimingsPayload()
+            )
+
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+
+        // When
+        testedScope
+            .handleEvent(RumRawEvent.AddResourceTiming(fakeKey, timing = timing), mockWriter)
+            ?.handleEvent(mockEvent, mockWriter)
+
+        // Then
+        argumentCaptor<RumEvent> {
+            verify(mockWriter).write(capture())
+            assertThat(firstValue)
+                .hasResourceData {
+                    hasTiming(timing)
+                }
+        }
+    }
+
+    @Test
+    fun `𝕄 use attributes timings 𝕎 handleEvent { StopResource without AddResourceTiming  }`(
+        @Forgery kind: RumResourceKind,
+        @LongForgery(200, 600) statusCode: Long,
+        @LongForgery(0, 1024) size: Long,
+        @Forgery timing: ResourceTiming,
+        forge: Forge
+    ) {
+
+        // Given
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys) +
+            mapOf("_dd.resource_timings" to timing.asTimingsPayload())
+
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+
+        // When
+        testedScope.handleEvent(mockEvent, mockWriter)
+
+        // Then
+        argumentCaptor<RumEvent> {
+            verify(mockWriter).write(capture())
+            assertThat(firstValue)
+                .hasResourceData {
+                    hasTiming(timing)
+                }
+        }
     }
 
     // region Internal

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/ResourceTimingExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/ResourceTimingExt.kt
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils
+
+import com.datadog.android.rum.internal.domain.event.ResourceTiming
+
+internal fun ResourceTiming.asTimingsPayload(): MutableMap<String, Any?> {
+    return mutableMapOf(
+        "download" to mutableMapOf(
+            "startTime" to downloadStart,
+            "duration" to downloadDuration
+        ),
+        "ssl" to mutableMapOf(
+            "startTime" to sslStart,
+            "duration" to sslDuration
+        ),
+        "firstByte" to mutableMapOf(
+            "startTime" to firstByteStart,
+            "duration" to firstByteDuration
+        ),
+        "connect" to mutableMapOf(
+            "startTime" to connectStart,
+            "duration" to connectDuration
+        ),
+        "dns" to mutableMapOf(
+            "startTime" to dnsStart,
+            "duration" to dnsDuration
+        )
+    )
+}


### PR DESCRIPTION
### What does this PR do?

This PR brings support of external resource timings which may come with `stopResource` call via free-form `attributes` map.

This is needed to support resource timings coming from any consumer of Android Bridge. Code may have a lot of `if`-checks, but this is because we need to read the free-form map, so we don't have advantage of the type system here.

This PR supports the following timings: `ssl`, `connect`, `dns`, `firstByte`, `download`, even though not all may come (like in case of React Native we can only provide `firstByte` and `download`, but this may not be the same for other users of the bridge).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

