### PR TITLE
RUMM-1298 PokoGenerator#toJson do not override the reserved properties

### DIFF
--- a/buildSrc/src/test/kotlin/com/example/model/Comment.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Comment.kt
@@ -56,7 +56,9 @@ data class Comment(
             val json = JsonObject()
             json.addProperty("global", global)
             additionalProperties.forEach { (k, v) ->
-                json.addProperty(k, v)
+                if (k !in RESERVED_PROPERTIES) {
+                    json.addProperty(k, v)
+                }
             }
             return json
         }


### PR DESCRIPTION
### What does this PR do?

In this PR we align the code generation for the deserializer and serializer methods in the PokoGenerator in order to prevent overriding the reserved properties when `additionalProperties` provided. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

