### PR TITLE
RUMM-1345: Wait for the executors termination to remove flakiness from the tests

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -322,6 +322,9 @@ internal object CoreFeature {
     private fun shutDownExecutors() {
         uploadExecutorService.shutdownNow()
         persistenceExecutorService.shutdownNow()
+
+        uploadExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+        persistenceExecutorService.awaitTermination(1, TimeUnit.SECONDS)
     }
 
     private fun cleanupApplicationInfo() {


### PR DESCRIPTION
### What does this PR do?

This change makes code to wait for the executors termination, otherwise there is a flakiness in the tests: like test code fails, because expected state is not yet there.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

