### PR TITLE
RUMM-1347: Support building with Java 11

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -50,7 +50,7 @@ dependencies {
     // Tests
     testImplementation("junit:junit:4.12")
     testImplementation("com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0")
-    testImplementation("net.wuerl.kotlin:assertj-core-kotlin:0.2.1")
+    testImplementation("org.assertj:assertj-core:3.18.1")
     testImplementation("com.github.xgouchet.Elmyr:core:1.0.0")
     testImplementation("com.github.xgouchet.Elmyr:inject:1.0.0")
     testImplementation("com.github.xgouchet.Elmyr:junit4:1.0.0")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -35,7 +35,7 @@ object Dependencies {
         const val JunitMockitoExt = "3.4.6"
 
         // Tests Tools
-        const val AssertJ = "0.2.1"
+        const val AssertJ = "3.18.1"
         const val Elmyr = "1.3.0"
         const val Jacoco = "0.8.4"
         const val MockitoKotlin = "2.2.0"
@@ -87,7 +87,7 @@ object Dependencies {
         const val KotlinReflect = "org.jetbrains.kotlin:kotlin-reflect:${Versions.Kotlin}"
 
         const val Gson = "com.google.code.gson:gson:${Versions.Gson}"
-        const val AssertJ = "net.wuerl.kotlin:assertj-core-kotlin:${Versions.AssertJ}"
+        const val AssertJ = "org.assertj:assertj-core:${Versions.AssertJ}"
 
         const val OkHttp = "com.squareup.okhttp3:okhttp:${Versions.OkHttp}"
         const val KronosNTP = "com.lyft.kronos:kronos-android:${Versions.KronosNTP}"

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitorTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitorTest.kt
@@ -8,7 +8,7 @@ package com.datadog.gradle.plugin.apisurface
 
 import java.io.File
 import java.lang.IllegalStateException
-import junit.framework.Assert.assertEquals
+import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelValidationTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelValidationTest.kt
@@ -73,13 +73,16 @@ class ModelValidationTest(
             val json = toJson.invoke(entity).toString()
             val generatedModel =
                 generatorFunction.invoke(null, json)
+
             assertThat(generatedModel)
                 .overridingErrorMessage(
                     "Deserialized model was not the same " +
                         "with the serialized for type: [$type] and test iteration: [$it]"
                 )
-                .usingComparatorForType(numberTypeComparator, Number::class.java)
-                .isEqualToComparingFieldByFieldRecursively(entity)
+                .usingRecursiveComparison()
+                .withComparatorForType(numberTypeComparator, Number::class.java)
+                .ignoringCollectionOrder()
+                .isEqualTo(entity)
         }
     }
 
@@ -88,6 +91,7 @@ class ModelValidationTest(
             is Long -> t2.compareTo(t1.toLong())
             is Double -> t2.compareTo(t1.toDouble())
             is Float -> t2.compareTo(t1.toFloat())
+            is Byte -> t2.compareTo(t1.toByte())
             else -> (t2 as Int).compareTo(t1.toInt())
         }
     }

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelWithAdditionalAttributesTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelWithAdditionalAttributesTest.kt
@@ -44,8 +44,10 @@ class ModelWithAdditionalAttributesTest {
                     "Deserialized model was not the same " +
                         "with the serialized for type: [$type] and test iteration: [$it]"
                 )
-                .usingComparatorForType(additionalPropertiesComparator, mapClass)
-                .isEqualToIgnoringGivenFields(expectedModel, "information")
+                .usingRecursiveComparison()
+                .withComparatorForType(additionalPropertiesComparator, mapClass)
+                .ignoringFields("information")
+                .isEqualTo(expectedModel)
             // Assertj does not apply the custom comparator recursively :(
             val expectedInformation: Any? = expectedModel.getFieldValue("information")
             val generatedInformation: Any? = generatedModel.getFieldValue("information")
@@ -57,8 +59,9 @@ class ModelWithAdditionalAttributesTest {
                     "Deserialized information model was not the same " +
                         "with the serialized one at test iteration: [$it]"
                 )
-                .usingComparatorForType(additionalPropertiesComparator, mapClass)
-                .isEqualToComparingFieldByField(expectedInformation)
+                .usingRecursiveComparison()
+                .withComparatorForType(additionalPropertiesComparator, mapClass)
+                .isEqualTo(expectedInformation)
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -109,13 +109,14 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.tracesConfig)
-            .isEqualToIgnoringGivenFields(
+            .usingRecursiveComparison()
+            .ignoringFields("spanEventMapper")
+            .isEqualTo(
                 Configuration.Feature.Tracing(
                     endpointUrl = DatadogEndpoint.TRACES_US,
                     plugins = emptyList(),
                     spanEventMapper = NoOpSpanEventMapper()
-                ),
-                "spanEventMapper"
+                )
             )
         assertThat(config.tracesConfig?.spanEventMapper)
             .isInstanceOf(NoOpSpanEventMapper::class.java)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/privacy/TrackingConsentProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/privacy/TrackingConsentProviderTest.kt
@@ -21,7 +21,7 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
-import org.assertj.core.api.Java6Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileHandlerTest.kt
@@ -610,11 +610,14 @@ internal class BatchFileHandlerTest {
 
     @Test
     fun `𝕄 create dest, move all files and return true 𝕎 moveFiles() {dest dir does not exist)`(
-        @StringForgery fileNames: List<String>
+        @StringForgery fileNamesInput: List<String>
     ) {
         // Given
         fakeSrcDir.mkdirs()
         assumeFalse(fakeDstDir.exists())
+
+        // in case of file system is not case-sensitive, we need to drop all duplicates
+        val fileNames = fileNamesInput.distinctBy { it.toLowerCase(Locale.US) }
         fileNames.forEach { name ->
             File(fakeSrcDir, name).writeText(name.reversed())
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/user/UserInfoDeserializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/user/UserInfoDeserializerTest.kt
@@ -51,10 +51,10 @@ internal class UserInfoDeserializerTest {
         val deserializedUserInfo = testedDeserializer.deserialize(serializedUserInfo)
 
         // THEN
-        assertThat(deserializedUserInfo).isEqualToIgnoringGivenFields(
-            fakeUserInfo,
-            "additionalProperties"
-        )
+        assertThat(deserializedUserInfo)
+            .usingRecursiveComparison()
+            .ignoringFields("additionalProperties")
+            .isEqualTo(fakeUserInfo)
 
         DatadogMapAnyValueAssert.assertThat(deserializedUserInfo!!.additionalProperties)
             .isEqualTo(fakeUserInfo.additionalProperties)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/user/UserInfoSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/user/UserInfoSerializerTest.kt
@@ -35,10 +35,10 @@ internal class UserInfoSerializerTest {
         val deserializedUserInfo = UserInfo.fromJson(serializedObject)
 
         // THEN
-        assertThat(deserializedUserInfo).isEqualToIgnoringGivenFields(
-            fakeUserInfo,
-            "additionalProperties"
-        )
+        assertThat(deserializedUserInfo)
+            .usingRecursiveComparison()
+            .ignoringFields("additionalProperties")
+            .isEqualTo(fakeUserInfo)
 
         DatadogMapAnyValueAssert.assertThat(deserializedUserInfo.additionalProperties)
             .isEqualTo(fakeUserInfo.additionalProperties)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
@@ -129,10 +129,10 @@ internal class RumEventDeserializerTest {
         DatadogMapAnyValueAssert.assertThat(deserializedEvent.userExtraAttributes)
             .isEqualTo(fakeEvent.userExtraAttributes)
         val deserializedActionEvent = deserializedEvent.event as ActionEvent
-        assertThat(deserializedActionEvent).isEqualToIgnoringGivenFields(
-            fakeActionEvent,
-            "dd"
-        )
+        assertThat(deserializedActionEvent)
+            .usingRecursiveComparison()
+            .ignoringFields("dd")
+            .isEqualTo(fakeActionEvent)
     }
 
     @Test
@@ -155,10 +155,10 @@ internal class RumEventDeserializerTest {
         DatadogMapAnyValueAssert.assertThat(deserializedEvent.userExtraAttributes)
             .isEqualTo(fakeEvent.userExtraAttributes)
         val deserializedErrorEvent = deserializedEvent.event as ErrorEvent
-        assertThat(deserializedErrorEvent).isEqualToIgnoringGivenFields(
-            fakeErrorEvent,
-            "dd"
-        )
+        assertThat(deserializedErrorEvent)
+            .usingRecursiveComparison()
+            .ignoringFields("dd")
+            .isEqualTo(fakeErrorEvent)
     }
 
     @Test
@@ -181,10 +181,10 @@ internal class RumEventDeserializerTest {
         DatadogMapAnyValueAssert.assertThat(deserializedEvent.userExtraAttributes)
             .isEqualTo(fakeEvent.userExtraAttributes)
         val deserializedLongTaskEvent = deserializedEvent.event as LongTaskEvent
-        assertThat(deserializedLongTaskEvent).isEqualToIgnoringGivenFields(
-            fakeLongTaskEvent,
-            "dd"
-        )
+        assertThat(deserializedLongTaskEvent)
+            .usingRecursiveComparison()
+            .ignoringFields("dd")
+            .isEqualTo(fakeLongTaskEvent)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimingsKtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimingsKtTest.kt
@@ -13,7 +13,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import org.assertj.core.api.KotlinAssertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -229,7 +229,7 @@ internal class RumSessionScopeTest {
         var sessions = 0
         var sessionsKept = 0
 
-        repeat(512) {
+        repeat(1024) {
             testedScope.handleEvent(RumRawEvent.ResetSession(), mockWriter)
             val context = testedScope.getRumContext()
             if (testedScope.keepSession) {

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/LogsTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/LogsTest.kt
@@ -62,7 +62,7 @@ internal abstract class LogsTest {
                 }
 
             val tags = log.get(TAG_DDTAGS)?.asString.orEmpty().split(',')
-            assertThat(tags).containsOnlyElementsOf(globalTags)
+            assertThat(tags).isSubsetOf(globalTags)
 
             globalAttributes.forEach { (k, v) -> log.assertHasAttribute(k, v) }
             localAttributes.forEach { (k, v) -> log.assertHasAttribute(k, v) }

--- a/tools/unit/src/test/kotlin/com/datadog/tools/unit/ConditionWatcherTest.kt
+++ b/tools/unit/src/test/kotlin/com/datadog/tools/unit/ConditionWatcherTest.kt
@@ -9,7 +9,7 @@ package com.datadog.tools.unit
 import com.datadog.tools.unit.forge.aThrowable
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import org.assertj.core.api.KotlinAssertions.assertThat
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows


### PR DESCRIPTION
### What does this PR do?

Recent Android Studio 4.2 comes with Java 11 by default and it turns out our codebase wasn't able to be compiled under it. The issue comes with the old version of `AssertJ` (`3.7.0`, year 2017) which was used in the classpath. Switching to a newer issue helped.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

