### PR TITLE
RUMM-1327 fix tracing when adding network interceptor

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
@@ -272,6 +272,7 @@ internal constructor(
             span.context(),
             Format.Builtin.TEXT_MAP_INJECT,
             TextMapInject { key, value ->
+                tracedRequestBuilder.removeHeader(key)
                 tracedRequestBuilder.addHeader(key, value)
             }
         )


### PR DESCRIPTION
### What does this PR do?

Fix the request headers when tracing is added. 

### Motivation

When a customer uses two interceptor (to track the global resource as well as individual redirections/retries), the tracing headers are added twice which can cause some mixups with the backend traces. 
 
```
        .addInterceptor(DatadogInterceptor())
        .addNetworkInterceptor(TracingInterceptor())
```
