### PR TITLE
RUMM-1348 Add Datadog#flushStoredData method

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -256,6 +256,25 @@ object Datadog {
         }
     }
 
+    // Executes all the pending queues in the upload/persistence executors.
+    // Tries to send all the granted data for each feature and then clears the folders and shuts
+    // down the persistence and the upload executors.
+    // You should not use this method in production code. By calling this method you will basically
+    // stop the SDKs persistence - upload streams and will leave it in an inconsistent state. This
+    // method is mainly for test purposes.
+    @Suppress("unused")
+    private fun flushAndShutdownExecutors() {
+        if (initialized.get()) {
+            // We need to drain and shutdown the executors first to make sure we avoid duplicated
+            // data due to async operations.
+            CoreFeature.drainAndShutdownExecutors()
+            LogsFeature.flushStoredData()
+            TracesFeature.flushStoredData()
+            RumFeature.flushStoredData()
+            CrashReportsFeature.flushStoredData()
+        }
+    }
+
     /**
      * Sets the verbosity of the Datadog library.
      *

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -85,6 +85,10 @@ internal abstract class SdkFeature<T : Any, C : Configuration.Feature> {
         return featurePlugins
     }
 
+    fun flushStoredData() {
+        persistenceStrategy.getFlusher().flush(uploader)
+    }
+
     // endregion
 
     // region Abstract
@@ -95,7 +99,7 @@ internal abstract class SdkFeature<T : Any, C : Configuration.Feature> {
 
     open fun onStop() {}
 
-    open fun onPostStopped() { }
+    open fun onPostStopped() {}
 
     abstract fun createPersistenceStrategy(
         context: Context,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataFlusher.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataFlusher.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.data.upload
+
+import com.datadog.android.core.internal.net.DataUploader
+import com.datadog.android.core.internal.persistence.PayloadDecoration
+import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.FileOrchestrator
+
+internal class DataFlusher(
+    internal val fileOrchestrator: FileOrchestrator,
+    internal val decoration: PayloadDecoration,
+    internal val handler: FileHandler
+) : Flusher {
+
+    override fun flush(uploader: DataUploader) {
+        val toUploadFiles = fileOrchestrator.getFlushableFiles()
+        toUploadFiles.forEach {
+            val batch = handler.readData(it, decoration.prefixBytes, decoration.suffixBytes)
+            uploader.upload(batch)
+            handler.delete(it)
+        }
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/Flusher.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/Flusher.kt
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.data.upload
+
+import com.datadog.android.core.internal.net.DataUploader
+import com.datadog.tools.annotation.NoOpImplementation
+
+@NoOpImplementation
+internal interface Flusher {
+
+    fun flush(uploader: DataUploader)
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/PersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/PersistenceStrategy.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.core.internal.persistence
 
+import com.datadog.android.core.internal.data.upload.Flusher
 import com.datadog.tools.annotation.NoOpImplementation
 
 /**
@@ -18,4 +19,6 @@ internal interface PersistenceStrategy<T : Any> {
     fun getWriter(): DataWriter<T>
 
     fun getReader(): DataReader
+
+    fun getFlusher(): Flusher
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
@@ -33,6 +33,12 @@ internal interface FileOrchestrator {
     fun getReadableFile(excludeFiles: Set<File>): File?
 
     /**
+     * @return a List of all flushable files. A flushable file is any file (readable or writable)
+     * which contains valid data and is ready to be uploaded to the events endpoint.
+     */
+    fun getFlushableFiles(): List<File>
+
+    /**
      * @return a list of files in this orchestrator (both writable and readable)
      */
     fun getAllFiles(): List<File>

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
@@ -46,6 +46,10 @@ internal open class ConsentAwareFileOrchestrator(
         return null
     }
 
+    override fun getFlushableFiles(): List<File> {
+        return grantedOrchestrator.getFlushableFiles()
+    }
+
     // endregion
 
     // region TrackingConsentProviderCallback

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
@@ -79,6 +79,10 @@ internal class BatchFileOrchestrator(
         return listSortedBatchFiles()
     }
 
+    override fun getFlushableFiles(): List<File> {
+        return getAllFiles()
+    }
+
     override fun getRootDir(): File? {
         if (!isRootDirValid()) {
             return null

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategy.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.core.internal.persistence.file.batch
 
+import com.datadog.android.core.internal.data.upload.DataFlusher
+import com.datadog.android.core.internal.data.upload.Flusher
 import com.datadog.android.core.internal.persistence.DataReader
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.PayloadDecoration
@@ -20,7 +22,7 @@ internal open class BatchFilePersistenceStrategy<T : Any>(
     private val fileOrchestrator: FileOrchestrator,
     private val executorService: ExecutorService,
     serializer: Serializer<T>,
-    payloadDecoration: PayloadDecoration,
+    private val payloadDecoration: PayloadDecoration,
     internalLogger: Logger
 ) : PersistenceStrategy<T> {
 
@@ -51,6 +53,10 @@ internal open class BatchFilePersistenceStrategy<T : Any>(
 
     override fun getReader(): DataReader {
         return fileReader
+    }
+
+    override fun getFlusher(): Flusher {
+        return DataFlusher(fileOrchestrator, payloadDecoration, fileHandler)
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
@@ -39,5 +39,9 @@ internal class SingleFileOrchestrator(
         return null
     }
 
+    override fun getFlushableFiles(): List<File> {
+        return getAllFiles()
+    }
+
     // endregion
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal
 
 import android.app.Application
 import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.internal.data.upload.DataFlusher
 import com.datadog.android.core.internal.data.upload.DataUploadScheduler
 import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
 import com.datadog.android.core.internal.data.upload.UploadScheduler
@@ -256,6 +257,20 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
 
         // Then
         verify(mockReader).dropAll()
+    }
+
+    @Test
+    fun `M call the DataFlusher W flushData`() {
+        // Given
+        val mockDataFlusher: DataFlusher = mock()
+        whenever(mockPersistenceStrategy.getFlusher()).thenReturn(mockDataFlusher)
+        testedFeature.persistenceStrategy = mockPersistenceStrategy
+
+        // When
+        testedFeature.flushStoredData()
+
+        // Then
+        verify(mockDataFlusher).flush(testedFeature.uploader)
     }
 
     companion object {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataFlusherTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataFlusherTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.data.upload
+
+import com.datadog.android.core.internal.net.DataUploader
+import com.datadog.android.core.internal.persistence.PayloadDecoration
+import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.FileOrchestrator
+import com.datadog.android.utils.forge.Configurator
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.io.File
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DataFlusherTest {
+    lateinit var testedFlusher: DataFlusher
+
+    @Mock
+    lateinit var mockDataUploader: DataUploader
+
+    @Mock
+    lateinit var mockFileOrchestrator: FileOrchestrator
+
+    lateinit var payloadDecoration: PayloadDecoration
+
+    @Mock
+    lateinit var mockFileHandler: FileHandler
+
+    @StringForgery
+    lateinit var fakePrefix: String
+
+    @StringForgery
+    lateinit var fakeSuffix: String
+
+    @StringForgery
+    lateinit var fakeSeparator: String
+
+    @BeforeEach
+    fun `set up`() {
+        payloadDecoration = PayloadDecoration(fakePrefix, fakeSuffix, fakeSeparator)
+        testedFlusher = DataFlusher(
+            mockFileOrchestrator,
+            payloadDecoration,
+            mockFileHandler
+        )
+    }
+
+    @Test
+    fun `M upload all the batches W flush`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeFiles = forge.aList { mock<File>() }
+        val fakeBatchesAsByteArray = forge
+            .aList(fakeFiles.size) {
+                forge.aString()
+            }
+            .map { it.toByteArray(Charsets.UTF_8) }
+        whenever(mockFileOrchestrator.getFlushableFiles()).thenReturn(fakeFiles)
+        fakeFiles.forEachIndexed { index, file ->
+            whenever(
+                mockFileHandler.readData(
+                    file,
+                    payloadDecoration.prefixBytes,
+                    payloadDecoration.suffixBytes
+                )
+            ).thenReturn(fakeBatchesAsByteArray[index])
+        }
+
+        // When
+        testedFlusher.flush(mockDataUploader)
+
+        // Then
+        fakeBatchesAsByteArray.forEach {
+            verify(mockDataUploader).upload(it)
+        }
+    }
+
+    @Test
+    fun `M delete all the batches W flush`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeFiles = forge.aList { mock<File>() }
+        val fakeBatchesAsByteArray = forge
+            .aList(fakeFiles.size) {
+                forge.aString()
+            }
+            .map { it.toByteArray(Charsets.UTF_8) }
+        whenever(mockFileOrchestrator.getFlushableFiles()).thenReturn(fakeFiles)
+        fakeFiles.forEachIndexed { index, file ->
+            whenever(
+                mockFileHandler.readData(
+                    file,
+                    payloadDecoration.prefixBytes,
+                    payloadDecoration.suffixBytes
+                )
+            ).thenReturn(fakeBatchesAsByteArray[index])
+        }
+
+        // When
+        testedFlusher.flush(mockDataUploader)
+
+        // Then
+        fakeFiles.forEach {
+            verify(mockFileHandler).delete(it)
+        }
+    }
+
+    @Test
+    fun `M do nothing W flush { no data available }`() {
+        // Given
+        whenever(mockFileOrchestrator.getFlushableFiles()).thenReturn(emptyList())
+
+        // When
+        testedFlusher.flush(mockDataUploader)
+
+        // Then
+        verifyZeroInteractions(mockFileHandler)
+        verifyZeroInteractions(mockDataUploader)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
@@ -276,7 +276,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
     // region getReadableFile
 
-    @RepeatedTest(8)
+    @Test
     fun `𝕄 return granted file 𝕎 getReadableFile() {initial consent}`(
         @Forgery consent: TrackingConsent,
         @Forgery file: File
@@ -293,7 +293,7 @@ internal class ConsentAwareFileOrchestratorTest {
         verifyZeroInteractions(mockPendingOrchestrator)
     }
 
-    @RepeatedTest(16)
+    @Test
     fun `𝕄 return granted file 𝕎 getReadableFile() {updated consent}`(
         @Forgery initialConsent: TrackingConsent,
         @Forgery updatedConsent: TrackingConsent,
@@ -316,7 +316,7 @@ internal class ConsentAwareFileOrchestratorTest {
 
     // region getAllFiles
 
-    @RepeatedTest(8)
+    @Test
     fun `𝕄 return all files 𝕎 getAllFiles() {initial consent}`(
         @Forgery consent: TrackingConsent,
         forge: Forge
@@ -337,7 +337,7 @@ internal class ConsentAwareFileOrchestratorTest {
             .containsAll(grantedFiles)
     }
 
-    @RepeatedTest(16)
+    @Test
     fun `𝕄 return all files 𝕎 getAllFiles() {updated consent}`(
         @Forgery initialConsent: TrackingConsent,
         @Forgery updatedConsent: TrackingConsent,
@@ -358,6 +358,30 @@ internal class ConsentAwareFileOrchestratorTest {
         assertThat(result)
             .containsAll(pendingFiles)
             .containsAll(grantedFiles)
+    }
+
+    // endregion
+
+    // region getGrantedFiles
+
+    @Test
+    fun `𝕄 return granted files 𝕎 getFlushableFiles()`(
+        @Forgery consent: TrackingConsent,
+        forge: Forge
+    ) {
+        // Given
+        instantiateTestedOrchestrator(consent)
+        val pendingFiles = forge.aList { getForgery<File>() }
+        val grantedFiles = forge.aList { getForgery<File>() }
+        whenever(mockPendingOrchestrator.getFlushableFiles()) doReturn pendingFiles
+        whenever(mockGrantedOrchestrator.getFlushableFiles()) doReturn grantedFiles
+
+        // When
+        val result = testedOrchestrator.getFlushableFiles()
+
+        // Then
+        assertThat(result)
+            .containsExactlyElementsOf(grantedFiles)
     }
 
     // endregion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/SingleFileOrchestratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/SingleFileOrchestratorTest.kt
@@ -129,6 +129,17 @@ internal class SingleFileOrchestratorTest {
             .hasSize(1)
     }
 
+    @Test
+    fun `𝕄 return file 𝕎 getAllFlushableFiles()`() {
+        // When
+        val result = testedOrchestrator.getFlushableFiles()
+
+        // Then
+        assertThat(result)
+            .contains(fakeFile)
+            .hasSize(1)
+    }
+
     // endregion
 
     // region getRootDir

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
@@ -748,6 +748,48 @@ internal class BatchFileOrchestratorTest {
 
     // endregion
 
+    // region getAllFlushableFiles
+
+    @Test
+    fun `𝕄 return all files 𝕎 getAllFlushableFiles() {dir is not empty}`(
+        @IntForgery(1, 32) count: Int
+    ) {
+        // Given
+        assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
+        val old = System.currentTimeMillis() - (RECENT_DELAY_MS * 2)
+        val new = System.currentTimeMillis() - (RECENT_DELAY_MS / 2)
+        val expectedFiles = mutableListOf<File>()
+        for (i in 1..count) {
+            // create both non readable and non writable files
+            expectedFiles.add(
+                File(fakeRootDir, (new + i).toString()).also { it.createNewFile() }
+            )
+            expectedFiles.add(
+                File(fakeRootDir, (old - i).toString()).also { it.createNewFile() }
+            )
+        }
+
+        // When
+        val result = testedOrchestrator.getFlushableFiles()
+
+        // Then
+        assertThat(result).containsAll(expectedFiles)
+    }
+
+    @Test
+    fun `𝕄 return empty list 𝕎 getAllFlushableFiles() {dir is empty}`() {
+        // Given
+        assumeTrue(fakeRootDir.listFiles().isNullOrEmpty())
+
+        // When
+        val result = testedOrchestrator.getFlushableFiles()
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+
+    // endregion
+
     // region getRootDir
 
     @Test


### PR DESCRIPTION
### What does this PR do?

In our instrumentation tests we often need to stop the SDK from one tests case to another for using different configurations. For making sure that all the data was sent we were using a `Thread.sleep()` mechanism which was not very efficient and was introducing a lot of dead time in our CI tasks. To mitigate this  issue we are introducing the `Datadog#flushStoredData` which is making sure that all the executors queues are drained and that the stored granted data for each feature is being sent before stopping the SDK.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

