### PR TITLE
RUMM-1321 Let all user info be in the usr root

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
@@ -93,7 +93,7 @@ internal class RumEventSerializer(
         )
 
         internal const val GLOBAL_ATTRIBUTE_PREFIX: String = "context"
-        internal const val USER_ATTRIBUTE_PREFIX: String = "$GLOBAL_ATTRIBUTE_PREFIX.usr"
+        internal const val USER_ATTRIBUTE_PREFIX: String = "usr"
         internal const val USER_EXTRA_GROUP_VERBOSE_NAME = "user extra information"
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -377,10 +377,9 @@ internal class RumEventSerializerTest {
     }
 
     @Test
-    fun `M sanitise the user extra info keys W level deeper than 8`(forge: Forge) {
+    fun `M sanitise the user extra info keys W total level deeper than 10`(forge: Forge) {
         // GIVEN
-        val fakeBadKey =
-            forge.aList(size = 9) { forge.anAlphabeticalString() }.joinToString(".")
+        val fakeBadKey = forge.aList(size = 10) { forge.anAlphabeticalString() }.joinToString(".")
         val lastIndexOf = fakeBadKey.lastIndexOf('.')
         val expectedSanitisedKey =
             fakeBadKey.replaceRange(lastIndexOf..lastIndexOf, "_")


### PR DESCRIPTION
### What does this PR do?

To align the data with the browser SDK, and make the infos more consistent, we keep all the usr custom attributes in the root `usr` object.