### PR TITLE
RUMM-1346 Add nightly tests for Logger.Builder and Datadog.initialize

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerBuilderE2ETests.kt
@@ -1,0 +1,203 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.logs
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.log.Logger
+import com.datadog.android.nightly.rules.NightlyTestRule
+import com.datadog.android.nightly.utils.initializeSdk
+import com.datadog.android.nightly.utils.measureLoggerInitialize
+import com.datadog.android.rum.GlobalRum
+import fr.xgouchet.elmyr.junit4.ForgeRule
+import io.opentracing.util.GlobalTracer
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class LoggerBuilderE2ETests {
+
+    @get:Rule
+    val forge = ForgeRule()
+
+    @get:Rule
+    val nightlyTestRule = NightlyTestRule()
+
+    lateinit var logger: Logger
+
+    @Before
+    fun setUp() {
+        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setSampleRate(Float): Builder
+     */
+    @Test
+    fun logs_logger_builder_sample_all_in() {
+        val testMethodName = "logs_logger_builder_sample_all_in"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setSampleRate(1f).build()
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setSampleRate(Float): Builder
+     */
+    @Test
+    fun logs_logger_builder_sample_all_out() {
+        val testMethodName = "logs_logger_builder_sample_all_out"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setSampleRate(0f).build()
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setSampleRate(Float): Builder
+     */
+    @Test
+    fun logs_logger_builder_sample_in_75_percent() {
+        val testMethodName = "logs_logger_builder_sample_in_75_percent"
+        val logsNumber = 10
+        measureLoggerInitialize {
+            logger = Logger.Builder().setSampleRate(0.75f).build()
+        }
+        repeat(logsNumber) {
+            logger.sendRandomLog(testMethodName, forge)
+        }
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setDatadogLogsEnabled(Boolean): Builder
+     */
+    @Test
+    fun logs_logger_builder_datadog_logs_enabled() {
+        val testMethodName = "logs_logger_builder_datadog_logs_enabled"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setDatadogLogsEnabled(true).build()
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setDatadogLogsEnabled(Boolean): Builder
+     */
+    @Test
+    fun logs_logger_builder_datadog_logs_disabled() {
+        val testMethodName = "logs_logger_builder_datadog_logs_disabled"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setDatadogLogsEnabled(false).build()
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setNetworkInfoEnabled(Boolean): Builder
+     */
+    @Test
+    fun logs_logger_builder_network_info_enabled() {
+        val testMethodName = "logs_logger_builder_network_info_enabled"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setNetworkInfoEnabled(true).build()
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setNetworkInfoEnabled(Boolean): Builder
+     */
+    @Test
+    fun logs_logger_builder_network_info_disabled() {
+        val testMethodName = "logs_logger_builder_network_info_disabled"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setNetworkInfoEnabled(false).build()
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setServiceName(String): Builder
+     */
+    @Test
+    fun logs_logger_builder_set_service_name() {
+        val testMethodName = "logs_logger_builder_set_service_name"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setServiceName(CUSTOM_SERVICE_NAME).build()
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setLoggerName(String): Builder
+     */
+    @Test
+    fun logs_logger_builder_set_logger_name() {
+        val testMethodName = "logs_logger_builder_set_logger_name"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setLoggerName(CUSTOM_LOGGER_NAME).build()
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setBundleWithRumEnabled(Boolean): Builder
+     */
+    @Test
+    fun logs_logger_builder_bundle_with_rum_enabled() {
+        val testMethodName = "logs_logger_builder_bundle_with_rum_enabled"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setBundleWithRumEnabled(true).build()
+        }
+        val viewKey = forge.anAlphabeticalString()
+        GlobalRum.get().startView(viewKey, forge.anAlphabeticalString())
+        logger.sendRandomLog(testMethodName, forge)
+        GlobalRum.get().stopView(viewKey)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setBundleWithTraceEnabled(Boolean): Builder
+     */
+    @Test
+    fun logs_logger_builder_bundle_with_trace_enabled() {
+        val testMethodName = "logs_logger_builder_bundle_with_trace_enabled"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setBundleWithRumEnabled(true).build()
+        }
+        val spanName = forge.anAlphabeticalString()
+        val span = GlobalTracer.get().buildSpan(spanName).start()
+        val scope = GlobalTracer.get().scopeManager().activate(span)
+        logger.sendRandomLog(testMethodName, forge)
+        scope.close()
+        span.finish()
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setBundleWithRumEnabled(Boolean): Builder
+     */
+    @Test
+    fun logs_logger_builder_bundle_with_rum_disabled() {
+        val testMethodName = "logs_logger_builder_bundle_with_rum_disabled"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setBundleWithRumEnabled(false).build()
+        }
+        val viewKey = forge.anAlphabeticalString()
+        GlobalRum.get().startView(viewKey, forge.anAlphabeticalString())
+        logger.sendRandomLog(testMethodName, forge)
+        GlobalRum.get().stopView(viewKey)
+    }
+
+    companion object {
+        const val CUSTOM_SERVICE_NAME = "com.datadog.android.nightly.custom"
+        const val CUSTOM_LOGGER_NAME = "custom_logger_name"
+    }
+}

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
@@ -1,0 +1,152 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.logs
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.event.EventMapper
+import com.datadog.android.log.Logger
+import com.datadog.android.log.model.LogEvent
+import com.datadog.android.nightly.rules.NightlyTestRule
+import com.datadog.android.nightly.utils.initializeSdk
+import com.datadog.android.nightly.utils.measure
+import com.datadog.android.nightly.utils.measureLoggerInitialize
+import com.datadog.android.nightly.utils.measureSdkInitialize
+import com.datadog.android.privacy.TrackingConsent
+import fr.xgouchet.elmyr.junit4.ForgeRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class LogsConfigE2ETests {
+
+    @get:Rule
+    val forge = ForgeRule()
+
+    @get:Rule
+    val nightlyTestRule = NightlyTestRule()
+
+    lateinit var logger: Logger
+
+    /**
+     * apiMethodSignature: Credentials#constructor(String, String, String, String?, String? = null)
+     */
+    @Test
+    fun logs_config_feature_enabled() {
+        val testMethodName = "logs_config_feature_enabled"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).build()
+            )
+        }
+        measureLoggerInitialize {
+            logger = initializeLogger()
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: Credentials#constructor(String, String, String, String?, String? = null)
+     */
+    @Test
+    fun logs_config_logs_feature_disabled() {
+        val testMethodName = "logs_config_feature_disabled"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = false,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).build()
+            )
+        }
+        measureLoggerInitialize {
+            logger = initializeLogger()
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
+     */
+    @Test
+    fun logs_config_set_event_mapper() {
+        val testMethodName = "logs_config_set_event_mapper"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setLogEventMapper(
+                    object : EventMapper<LogEvent> {
+                        override fun map(event: LogEvent): LogEvent {
+                            event.status = LogEvent.Status.ERROR
+                            return event
+                        }
+                    }
+                ).build()
+            )
+        }
+        measureLoggerInitialize {
+            logger = initializeLogger()
+        }
+        measure(testMethodName) {
+            logger.sendRandomLog(testMethodName, forge)
+        }
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
+     */
+    @Test
+    fun logs_config_set_event_mapper_with_drop_event() {
+        val testMethodName = "logs_config_set_event_mapper_with_drop_event"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setLogEventMapper(
+                    object : EventMapper<LogEvent> {
+                        override fun map(event: LogEvent): LogEvent? {
+                            return null
+                        }
+                    }
+                )
+                    .build()
+            )
+        }
+        measureLoggerInitialize {
+            logger = initializeLogger()
+        }
+        measure(testMethodName) {
+            logger.sendRandomLog(testMethodName, forge)
+        }
+    }
+}

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -69,11 +69,15 @@ fun flushAndShutdownExecutors() {
     Datadog.invokeMethod("flushAndShutdownExecutors")
 }
 
-fun initializeSdk(targetContext: Context, consent: TrackingConsent = TrackingConsent.GRANTED) {
+fun initializeSdk(
+    targetContext: Context,
+    consent: TrackingConsent = TrackingConsent.GRANTED,
+    config: Configuration = createDatadogDefaultConfiguration()
+) {
     Datadog.initialize(
         targetContext,
         createDatadogCredentials(),
-        createDatadogConfiguration(),
+        config,
         consent
     )
     Datadog.setVerbosity(Log.VERBOSE)
@@ -97,7 +101,7 @@ private fun createDatadogCredentials(): Credentials {
     )
 }
 
-private fun createDatadogConfiguration(): Configuration {
+private fun createDatadogDefaultConfiguration(): Configuration {
     val configBuilder = Configuration.Builder(
         logsEnabled = true,
         tracesEnabled = true,


### PR DESCRIPTION
### What does this PR do?

In this PR we are adding the nightly test cases for the `Logger#Builder` options and also for the `Datadog#initialize` configuration settings related with the Logs feature.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

