### PR TITLE
RUMM-1361 Add nexus stagingRepositoryId 

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -148,7 +148,7 @@ publish:release:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - git fetch --depth=1 origin master
-    - ./gradlew :dd-sdk-android:publishReleasePublicationToMavenRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android:publishToSonatype --stacktrace --no-daemon
 
 publish:release-coil:
   tags: [ "runner:main", "size:large" ]
@@ -164,7 +164,7 @@ publish:release-coil:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - git fetch --depth=1 origin master
-    - ./gradlew :dd-sdk-android-coil:publishReleasePublicationToMavenRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android-coil:publishToSonatype --stacktrace --no-daemon
 
 publish:release-fresco:
   tags: [ "runner:main", "size:large" ]
@@ -180,7 +180,7 @@ publish:release-fresco:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - git fetch --depth=1 origin master
-    - ./gradlew :dd-sdk-android-fresco:publishReleasePublicationToMavenRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android-fresco:publishToSonatype --stacktrace --no-daemon
 
 publish:release-glide:
   tags: [ "runner:main", "size:large" ]
@@ -196,7 +196,7 @@ publish:release-glide:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - git fetch --depth=1 origin master
-    - ./gradlew :dd-sdk-android-glide:publishReleasePublicationToMavenRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android-glide:publishToSonatype --stacktrace --no-daemon
 
 publish:release-ktx:
   tags: [ "runner:main", "size:large" ]
@@ -212,7 +212,7 @@ publish:release-ktx:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - git fetch --depth=1 origin master
-    - ./gradlew :dd-sdk-android-ktx:publishReleasePublicationToMavenRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android-ktx:publishToSonatype --stacktrace --no-daemon
 
 publish:release-ndk:
   tags: [ "runner:main", "size:large" ]
@@ -228,7 +228,7 @@ publish:release-ndk:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - git fetch --depth=1 origin master
-    - ./gradlew :dd-sdk-android-ndk:publishReleasePublicationToMavenRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android-ndk:publishToSonatype --stacktrace --no-daemon
 
 publish:release-rx:
   tags: [ "runner:main", "size:large" ]
@@ -244,7 +244,7 @@ publish:release-rx:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - git fetch --depth=1 origin master
-    - ./gradlew :dd-sdk-android-rx:publishReleasePublicationToMavenRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android-rx:publishToSonatype --stacktrace --no-daemon
 
 publish:release-sqldelight:
   tags: [ "runner:main", "size:large" ]
@@ -260,7 +260,7 @@ publish:release-sqldelight:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - git fetch --depth=1 origin master
-    - ./gradlew :dd-sdk-android-sqldelight:publishReleasePublicationToMavenRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android-sqldelight:publishToSonatype --stacktrace --no-daemon
 
 publish:release-timber:
   tags: [ "runner:main", "size:large" ]
@@ -276,7 +276,7 @@ publish:release-timber:
     - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - git fetch --depth=1 origin master
-    - ./gradlew :dd-sdk-android-timber:publishReleasePublicationToMavenRepository --stacktrace --no-daemon
+    - ./gradlew :dd-sdk-android-timber:publishToSonatype --stacktrace --no-daemon
 
 # SLACK NOTIFICATIONS
 
@@ -287,7 +287,7 @@ notify:release:
   only:
     - tags
   script:
-    - MAVEN_URL="https://search.maven.org/artifact/com.datadoghq/dd-sdk-android/$CI_COMMI_TAG/aar"
+    - MAVEN_URL="https://search.maven.org/artifact/com.datadoghq/dd-sdk-android/$CI_COMMIT_TAG/aar"
     - 'MESSAGE_TEXT=":package: $CI_PROJECT_NAME $CI_COMMIT_TAG published on :maven: $MAVEN_URL"'
     - postmessage "#mobile-rum" "$MESSAGE_TEXT"
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -4,6 +4,11 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+plugins {
+    `maven-publish`
+    id("io.github.gradle-nexus.publish-plugin")
+}
+
 buildscript {
     repositories {
         google()
@@ -31,6 +36,18 @@ allprojects {
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Jitpack) }
         jcenter()
         flatDir { dirs("libs") }
+    }
+}
+
+nexusPublishing {
+    repositories {
+        sonatype {
+            val sonatypeUsername = System.getenv("OSSRH_USERNAME")
+            val sonatypePassword = System.getenv("OSSRH_PASSWORD")
+            stagingProfileId.set("378eecbbe2cf9")
+            if (sonatypeUsername != null) username.set(sonatypeUsername)
+            if (sonatypePassword != null) password.set(sonatypePassword)
+        }
     }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation("me.xdrop:fuzzywuzzy:1.2.0")
     implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.10")
     implementation("org.apache.maven:maven-model:3.6.3")
+    implementation("io.github.gradle-nexus:publish-plugin:1.1.0")
 
     // check api surface
     implementation("com.github.kotlinx.ast:grammar-kotlin-parser-antlr-kotlin-jvm:c35b50fa44")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/MavenConfig.kt
@@ -6,9 +6,7 @@
 
 package com.datadog.gradle.config
 
-import java.net.URI
 import org.gradle.api.Project
-import org.gradle.api.artifacts.repositories.PasswordCredentials
 import org.gradle.api.publish.PublishingExtension
 import org.gradle.api.publish.maven.MavenPublication
 import org.gradle.jvm.tasks.Jar
@@ -48,19 +46,6 @@ fun Project.publishingConfig(projectDescription: String) {
         }
 
         publishingExtension.apply {
-            repositories.maven {
-                url = URI("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
-                val username = System.getenv("OSSRH_USERNAME")
-                val password = System.getenv("OSSRH_PASSWORD")
-                if ((!username.isNullOrEmpty()) && (!password.isNullOrEmpty())) {
-                    credentials(PasswordCredentials::class.java) {
-                        setUsername(username)
-                        setPassword(password)
-                    }
-                } else {
-                    System.err.println("Missing publishing credentials for $projectName")
-                }
-            }
 
             publications.create(MavenConfig.PUBLICATION, MavenPublication::class.java) {
                 from(components.getByName("release"))

--- a/instrumented/benchmark/build.gradle.kts
+++ b/instrumented/benchmark/build.gradle.kts
@@ -10,7 +10,6 @@ plugins {
     id("com.android.library")
     id("androidx.benchmark")
     kotlin("android")
-    `maven-publish`
     id("com.github.ben-manes.versions")
     id("io.gitlab.arturbosch.detekt")
     id("org.jlleitschuh.gradle.ktlint")

--- a/tools/detekt/build.gradle.kts
+++ b/tools/detekt/build.gradle.kts
@@ -14,7 +14,6 @@ import com.datadog.gradle.testImplementation
 
 plugins {
     id("org.jetbrains.kotlin.jvm")
-    `maven-publish`
     id("com.github.ben-manes.versions")
     id("io.gitlab.arturbosch.detekt")
     id("org.jlleitschuh.gradle.ktlint")


### PR DESCRIPTION
### What does this PR do?

Use a plugin to enforce a `stagingRepositoryId` when uploading the artifacts to Sonatype

### Motivation

The outbound requests from gitlab use a Load Balancer, which means that different files for the same artifact publication can end up in different automatic StagingRepository (cf: https://issues.sonatype.org/browse/OSSRH-19485).
