### PR TITLE
RUM Resource - fix network timings reports feature

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogEventListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogEventListener.kt
@@ -63,13 +63,14 @@ internal constructor(val key: String) : EventListener() {
     /** @inheritdoc */
     override fun callStart(call: Call) {
         super.callStart(call)
-        (GlobalRum.get() as? AdvancedRumMonitor)?.waitForResourceTiming(key)
+        sendWaitForResourceTimingEvent()
         callStart = System.nanoTime()
     }
 
     /** @inheritdoc */
     override fun dnsStart(call: Call, domainName: String) {
         super.dnsStart(call, domainName)
+        sendWaitForResourceTimingEvent()
         dnsStart = System.nanoTime()
     }
 
@@ -82,6 +83,7 @@ internal constructor(val key: String) : EventListener() {
     /** @inheritdoc */
     override fun connectStart(call: Call, inetSocketAddress: InetSocketAddress, proxy: Proxy) {
         super.connectStart(call, inetSocketAddress, proxy)
+        sendWaitForResourceTimingEvent()
         connStart = System.nanoTime()
     }
 
@@ -99,6 +101,7 @@ internal constructor(val key: String) : EventListener() {
     /** @inheritdoc */
     override fun secureConnectStart(call: Call) {
         super.secureConnectStart(call)
+        sendWaitForResourceTimingEvent()
         sslStart = System.nanoTime()
     }
 
@@ -111,6 +114,7 @@ internal constructor(val key: String) : EventListener() {
     /** @inheritdoc */
     override fun responseHeadersStart(call: Call) {
         super.responseHeadersStart(call)
+        sendWaitForResourceTimingEvent()
         headersStart = System.nanoTime()
     }
 
@@ -126,6 +130,7 @@ internal constructor(val key: String) : EventListener() {
     /** @inheritdoc */
     override fun responseBodyStart(call: Call) {
         super.responseBodyStart(call)
+        sendWaitForResourceTimingEvent()
         bodyStart = System.nanoTime()
     }
 
@@ -150,6 +155,10 @@ internal constructor(val key: String) : EventListener() {
     // endregion
 
     // region Internal
+
+    private fun sendWaitForResourceTimingEvent() {
+        (GlobalRum.get() as? AdvancedRumMonitor)?.waitForResourceTiming(key)
+    }
 
     private fun sendTiming() {
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogEventListenerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogEventListenerTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.utils.forge.Configurator
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
@@ -137,7 +138,7 @@ internal class DatadogEventListenerTest {
         // Then
         argumentCaptor<ResourceTiming> {
             inOrder(mockMonitor, mockCall) {
-                verify(mockMonitor).waitForResourceTiming(fakeKey)
+                verify(mockMonitor, times(5)).waitForResourceTiming(fakeKey)
                 verify(mockMonitor).addResourceTiming(eq(fakeKey), capture())
                 verifyNoMoreInteractions()
             }
@@ -193,7 +194,7 @@ internal class DatadogEventListenerTest {
         // Then
         argumentCaptor<ResourceTiming> {
             inOrder(mockMonitor, mockCall) {
-                verify(mockMonitor).waitForResourceTiming(fakeKey)
+                verify(mockMonitor, times(6)).waitForResourceTiming(fakeKey)
                 verify(mockMonitor).addResourceTiming(eq(fakeKey), capture())
                 verifyNoMoreInteractions()
             }
@@ -235,7 +236,7 @@ internal class DatadogEventListenerTest {
         // Then
         argumentCaptor<ResourceTiming> {
             inOrder(mockMonitor, mockCall) {
-                verify(mockMonitor).waitForResourceTiming(fakeKey)
+                verify(mockMonitor, times(2)).waitForResourceTiming(fakeKey)
                 verify(mockMonitor).addResourceTiming(eq(fakeKey), capture())
                 verifyNoMoreInteractions()
             }
@@ -286,7 +287,7 @@ internal class DatadogEventListenerTest {
         // Then
         argumentCaptor<ResourceTiming> {
             inOrder(mockMonitor, mockCall) {
-                verify(mockMonitor).waitForResourceTiming(fakeKey)
+                verify(mockMonitor, times(6)).waitForResourceTiming(fakeKey)
                 verify(mockMonitor).addResourceTiming(eq(fakeKey), capture())
                 verifyNoMoreInteractions()
             }
@@ -341,6 +342,60 @@ internal class DatadogEventListenerTest {
 
         // Then
         verifyZeroInteractions(mockMonitor)
+    }
+
+    @Test
+    fun `M send WaitForResourceTiming event W callStart`() {
+        // When
+        testedListener.callStart(mockCall)
+
+        // Then
+        verify(mockMonitor).waitForResourceTiming(fakeKey)
+    }
+
+    @Test
+    fun `M send WaitForResourceTiming event W dnsStart`() {
+        // When
+        testedListener.dnsStart(mockCall, fakeDomain)
+
+        // Then
+        verify(mockMonitor).waitForResourceTiming(fakeKey)
+    }
+
+    @Test
+    fun `M send WaitForResourceTiming event W connectStart`() {
+        // When
+        testedListener.connectStart(mockCall, InetSocketAddress(0), Proxy.NO_PROXY)
+
+        // Then
+        verify(mockMonitor).waitForResourceTiming(fakeKey)
+    }
+
+    @Test
+    fun `M send WaitForResourceTiming W secureConnectionStart`() {
+        // When
+        testedListener.secureConnectStart(mockCall)
+
+        // Then
+        verify(mockMonitor).waitForResourceTiming(fakeKey)
+    }
+
+    @Test
+    fun `M send WaitForResourceTiming event W responseHeadersStart`() {
+        // When
+        testedListener.responseHeadersStart(mockCall)
+
+        // Then
+        verify(mockMonitor).waitForResourceTiming(fakeKey)
+    }
+
+    @Test
+    fun `M send WaitForResourceTiming event W responseBodyStart`() {
+        // When
+        testedListener.responseBodyStart(mockCall)
+
+        // Then
+        verify(mockMonitor).waitForResourceTiming(fakeKey)
     }
 
     companion object {


### PR DESCRIPTION
### What does this PR do?

The instrumented RUM Resource event is started in the `intercept` method in the `DatadogInterceptor`. In case we want to report also the request metrics for this resource we will use a `NetworkInterceptor` -> `DatadogEventListener` which previously was asking the active resource to `WaitForResourceEvent` before sending it. The problem is that the `WaitForResourceTimingEvent` was sent during the `callStart` callback method which for some reason is being called before the `DatadogInterceptor#intercept` in the new version of OkHttp and as it is not active resource event at this time this event will be dropped. 
To fix this issue and to make the active resource to wait for the resource timing event before sending it we will send the `WaitForResourceTimingEvent` on each `start*` callback method in the `DatadogEventListener`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

