### PR TITLE
RUMM-1372 RumViewScope - decrement pendingAction when Action was dropped

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -210,6 +210,10 @@ internal class RumActionScope(
             )
             writer.write(rumEvent)
         } else {
+            parentScope.handleEvent(
+                RumRawEvent.ActionDropped(getRumContext().viewId.orEmpty()),
+                writer
+            )
             devLogger.i(
                 "RUM Action $actionId ($actualType on $name) was dropped " +
                     "(no side effect was registered during its scope)"

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -21,6 +21,7 @@ import com.datadog.android.utils.mockCoreFeature
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
@@ -929,7 +930,26 @@ internal class RumActionScopeTest {
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
-        verifyZeroInteractions(mockWriter, mockParentScope)
+        verifyZeroInteractions(mockWriter)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `𝕄 send ActionDropped event 𝕎 handleEvent(StopView) {no side effect}`() {
+        // Given
+        testedScope.resourceCount = 0
+        testedScope.viewTreeChangeCount = 0
+        testedScope.errorCount = 0
+        testedScope.crashCount = 0
+        fakeEvent = RumRawEvent.StopView(Object(), emptyMap())
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        val argumentCaptor = argumentCaptor<RumRawEvent.ActionDropped>()
+        verify(mockParentScope).handleEvent(argumentCaptor.capture(), eq(mockWriter))
+        assertThat(argumentCaptor.firstValue.viewId).isEqualTo(fakeParentContext.viewId ?: "")
         assertThat(result).isNull()
     }
 
@@ -947,7 +967,27 @@ internal class RumActionScopeTest {
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
-        verifyZeroInteractions(mockWriter, mockParentScope)
+        verifyZeroInteractions(mockWriter)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `𝕄 send ActionDropped after threshold 𝕎 handleEvent(any) {no side effect}`() {
+        // Given
+        testedScope.resourceCount = 0
+        testedScope.viewTreeChangeCount = 0
+        testedScope.errorCount = 0
+        testedScope.crashCount = 0
+        Thread.sleep(TEST_INACTIVITY_MS)
+        fakeEvent = mockEvent()
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        val argumentCaptor = argumentCaptor<RumRawEvent.ActionDropped>()
+        verify(mockParentScope).handleEvent(argumentCaptor.capture(), eq(mockWriter))
+        assertThat(argumentCaptor.firstValue.viewId).isEqualTo(fakeParentContext.viewId ?: "")
         assertThat(result).isNull()
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -24,6 +24,7 @@ import com.datadog.android.utils.mockCoreFeature
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
@@ -1001,7 +1002,28 @@ internal class RumContinuousActionScopeTest {
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
-        verifyZeroInteractions(mockWriter, mockParentScope)
+        verifyZeroInteractions(mockWriter)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `𝕄 send ActionDropped event 𝕎 handleEvent(StopView) {no side effect}`() {
+        assumeTrue(testedScope.type != RumActionType.CUSTOM)
+
+        // Given
+        testedScope.resourceCount = 0
+        testedScope.viewTreeChangeCount = 0
+        testedScope.errorCount = 0
+        testedScope.crashCount = 0
+        fakeEvent = RumRawEvent.StopView(Object(), emptyMap())
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        val argumentCaptor = argumentCaptor<RumRawEvent.ActionDropped>()
+        verify(mockParentScope).handleEvent(argumentCaptor.capture(), eq(mockWriter))
+        assertThat(argumentCaptor.firstValue.viewId).isEqualTo(fakeParentContext.viewId ?: "")
         assertThat(result).isNull()
     }
 


### PR DESCRIPTION
### What does this PR do?

When a `RumActionScope` was dropped without being sent we were not notifying the parent scope (`RumViewScope`) in order to decrement the `pendingActionCount`. This was creating a bad side effect by not allowing to stop a `View` in case there was any action started during the its lifetime that was dropped due to the `no - side - effects` rule. In this *PR* we are fixing this issue by notifying the `parentScope` through an `ActionDropped` event whenever this case arrives.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

