### PR TITLE
RUMM-1375 Nightly tests coverage computation script

### DIFF
--- a/instrumentation-tools/nightly_tests_code_coverage.py
+++ b/instrumentation-tools/nightly_tests_code_coverage.py
@@ -1,0 +1,95 @@
+#  Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#  This product includes software developed at Datadog (https://www.datadoghq.com/).
+#  Copyright 2016-Present Datadog, Inc.
+
+import sys
+from argparse import ArgumentParser, Namespace, ArgumentTypeError
+from src.feature import Feature
+from src.api_surface import ApiSurface
+from src.constants import API_SURFACE_PATH
+from src.constants import NIGHTLY_TESTS_DIRECTORY_PATH
+from src.constants import NIGHTLY_TESTS_PACKAGE
+from src.constants import IGNORED_ENTITIES
+
+
+def restricted_float(x):
+    try:
+        x = float(x)
+    except ValueError:
+        raise ArgumentTypeError(f"{x} not a floating-point literal")
+
+    if x < 0.0 or x > 1.0:
+        raise ArgumentTypeError(f"{x} not in range [0.0, 1.0]")
+    return x
+
+
+def parse_arguments(args: list) -> Namespace:
+    parser = ArgumentParser()
+
+    parser.add_argument("-td", "--tests-directory-path",
+                        default=NIGHTLY_TESTS_DIRECTORY_PATH,
+                        help="The path to the nightly tests directory.")
+    parser.add_argument("-as", "--api-surface-paths",
+                        default=[API_SURFACE_PATH],
+                        nargs="+",
+                        help="The path to the api surface file.")
+    parser.add_argument("-t", "--test-coverage-threshold-to-assert",
+                        type=restricted_float,
+                        required=True,
+                        help="The test coverage threshold. It takes values from 0 to 1.")
+    parser.add_argument("-i", "--ignored-entities",
+                        nargs="+",
+                        default=IGNORED_ENTITIES,
+                        help="The entities to be ignored when traversing the apiSurface file.")
+
+    return parser.parse_args(args)
+
+
+def compute_test_coverage(
+        tests_directory_path: str,
+        api_surface_paths: [str],
+        threshold: int,
+        ignored_entities: [str]) -> int:
+    to_cover_test_cases = set()
+    api_surfaces = list(
+        map(lambda api_surface_path: ApiSurface(api_surface_path, ignored_entities), api_surface_paths))
+    for api_surface in api_surfaces:
+        to_cover_test_cases.update(api_surface.fetch_testable_methods())
+
+    covered_test_cases = set()
+    features = [
+        Feature(f'{tests_directory_path}/{NIGHTLY_TESTS_PACKAGE}/logs'),
+        Feature(f'{tests_directory_path}/{NIGHTLY_TESTS_PACKAGE}/rum'),
+        Feature(f'{tests_directory_path}/{NIGHTLY_TESTS_PACKAGE}/trace')
+    ]
+
+    for feature in features:
+        covered_test_cases.update(feature.fetch_test_cases())
+
+    total_amount = len(to_cover_test_cases)
+    intersection = to_cover_test_cases.intersection(covered_test_cases)
+    covered = len(intersection)
+    coverage = round(covered / total_amount, 2)
+
+    print(f'Total number of test cases: {total_amount}')
+    print(f'Total covered : {covered}')
+    print(f'Covered test cases:\n{chr(10).join(intersection)}')
+    print(f'Test coverage percentage is: {coverage}')
+
+    if coverage < threshold:
+        print(f'The test coverage percentage: [{coverage} is less than the required threshold: {threshold}]')
+        return 1
+
+    return 0
+
+
+def run_main() -> int:
+    cli_args = parse_arguments(sys.argv[1:])
+    return compute_test_coverage(cli_args.tests_directory_path,
+                                 cli_args.api_surface_paths,
+                                 cli_args.test_coverage_threshold_to_assert,
+                                 cli_args.ignored_entities)
+
+
+if __name__ == "__main__":
+    sys.exit(run_main())

--- a/instrumentation-tools/src/api_surface.py
+++ b/instrumentation-tools/src/api_surface.py
@@ -1,0 +1,79 @@
+#  Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#  This product includes software developed at Datadog (https://www.datadoghq.com/).
+#  Copyright 2016-Present Datadog, Inc.
+
+import re
+from math import floor
+
+DIVIDER = "#"
+TESTABLE_API_REGEX = re.compile("^(.+)(constructor|fun)(.+)")
+TYPE_REGEX = re.compile("^(?<!companion)(\\s*)[a-zA-z]*(class|interface|enum|object)(.*)(\\.|\\s)(.+)$")
+INDENT_SIZE = 2
+
+"""
+In this function we will sanitize the current API prefix as following.
+Say we have the following apiSurface file:
+
+class Foo
+  fun a
+  class Bar
+    fun b
+class AnotherFoo
+  fun c
+
+When we reach line `class AnotherFoo` the prefix will be `Foo#Bar` but the API key 
+for `fun c` should be: `AnotherFoo#fun c` therefore based on the indentation difference (2) 
+in this case we will substract 2 entities from the prefix (Foo and Bar) which will result in an empty prefix at
+this point. Going further we will attach the current entity `AnotherFoo#`
+
+"""
+
+
+def sanitize_prefix(previous_indent: int,
+                    current_indent: int,
+                    prefix: str) -> str:
+    # we divide the difference to 2 as the indentation step in apiSurface tool is 2
+    difference = floor((current_indent - previous_indent) / INDENT_SIZE)
+    if difference <= 0:
+        split = prefix.split(DIVIDER)
+        # in case the levels of indentation are equal we drop one group
+        # from prefix therefore we need to add 1 to difference
+        drop_number_of_groups = abs(difference) + 1
+        remaining_groups = len(split) - 1 - drop_number_of_groups
+        new_prefix = DIVIDER.join(split[:remaining_groups])
+        if len(new_prefix) > 0:
+            new_prefix += DIVIDER
+        return new_prefix
+    else:
+        return prefix
+
+
+class ApiSurface:
+    file_path: str
+    ignored_groups_reg_ex: re
+
+    def __init__(self, file_path: str, ignored_entities: [str] = None):
+        self.file_path = file_path
+        if ignored_entities:
+            self.ignored_groups_reg_ex = re.compile(f"^{'|'.join(ignored_entities)}", re.IGNORECASE)
+        else:
+            self.ignored_groups_reg_ex = None
+
+    def fetch_testable_methods(self) -> set:
+        to_return = set()
+        with open(self.file_path, 'r') as file:
+            rows = file.readlines()
+        prefix = ""
+        current_indent = 0
+        for row in rows:
+            is_group_root_matcher = TYPE_REGEX.match(row)
+            if is_group_root_matcher:
+                indent = len(is_group_root_matcher.group(1))
+                prefix = sanitize_prefix(current_indent, indent, prefix)
+                current_indent = indent
+                group_name = is_group_root_matcher.group(5)
+                prefix += group_name + DIVIDER
+            elif TESTABLE_API_REGEX.match(row) and (
+                    self.ignored_groups_reg_ex is None or not self.ignored_groups_reg_ex.match(prefix)):
+                to_return.add(prefix + row.strip())
+        return to_return

--- a/instrumentation-tools/src/constants.py
+++ b/instrumentation-tools/src/constants.py
@@ -1,0 +1,45 @@
+#  Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#  This product includes software developed at Datadog (https://www.datadoghq.com/).
+#  Copyright 2016-Present Datadog, Inc.
+
+API_SURFACE_PATH = "dd-sdk-android/apiSurface"
+NIGHTLY_TESTS_DIRECTORY_PATH = "instrumented/nightly-tests/src/androidTest/kotlin"
+NIGHTLY_TESTS_PACKAGE = "com/datadog/android/nightly"
+IGNORED_ENTITIES = ["errorevent",
+                    "viewevent",
+                    "resourceevent",
+                    "actionevent",
+                    "longtaskevent",
+                    "logevent",
+                    "spanevent",
+                    "rumresourcekind",
+                    "userinfo",
+                    "networkinfo",
+                    "eventmapper",
+                    "spaneventmapper",
+                    "vieweventmapper",
+                    "datadogcontext",
+                    "datadogrumcontext",
+                    "rumresourceinputstream",
+                    "acceptallactivities",
+                    "acceptalldefaultfragment",
+                    "acceptallnavdestinations",
+                    "acceptallsupportfragments",
+                    "activitylifecycletrackingstrategy"
+                    "activityviewtrackingstrategy",
+                    "fragmentviewtrackingstrategy",
+                    "componentpredicate",
+                    "mixedviewtrackingstrategy",
+                    "navigationviewtrackingstrategy",
+                    "trackingstrategy",
+                    "rumwebviewclient",
+                    "datadogdatabaseerrorhandler",
+                    "tracedrequestlistener",
+                    "tracinginterceptor",
+                    "datadogconfig",
+                    "datadogeventlistener",
+                    "eventlistener",
+                    "inputstream",
+                    "viewtrackingstrategy",
+                    "ondestinationchangedlistener",
+                    "databaseerrorhandler"]

--- a/instrumentation-tools/src/feature.py
+++ b/instrumentation-tools/src/feature.py
@@ -1,0 +1,31 @@
+#  Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+#  This product includes software developed at Datadog (https://www.datadoghq.com/).
+#  Copyright 2016-Present Datadog, Inc.
+
+import os
+import re
+
+TEST_CASE_ID_REG_EX = re.compile("(.+)apiMethodSignature: (.+)$")
+
+
+class Feature:
+    directory_path: str
+
+    def __init__(self, directory_path: str):
+        self.directory_path = directory_path
+
+    def fetch_test_cases(self) -> set:
+        print(f'Walking through {self.directory_path}')
+        test_cases = set()
+        for root, subdirs, files in os.walk(self.directory_path):
+            for file in files:
+                print(f'fetching the test cases in {file}')
+                self.fetch_test_cases_from_file(f'{root}/{file}', test_cases)
+        return test_cases
+
+    def fetch_test_cases_from_file(self, file_path: str, test_cases: set):
+        with open(file_path, 'r') as file:
+            for line in file.readlines():
+                match = TEST_CASE_ID_REG_EX.match(line)
+                if match:
+                    test_cases.add(match.group(2))


### PR DESCRIPTION
### What does this PR do?

A first version of the python script tool that will compute the coverage of our nightly tests based on the generated `apiSurface` file. This script will be running as a CI step in our project.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Please note that for now the default threshold is set to a very small value as a consequence of the current amount of tests we have in our `nightly-tests` module. This parameter will be adjusted along the time.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

