### PR TITLE
RUMM-1338: Keep instant custom actions even if there is active action ongoing

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -351,7 +351,7 @@ interface com.datadog.android.rum.RumMonitor
   fun stopView(Any, Map<String, Any?> = emptyMap())
   fun addUserAction(RumActionType, String, Map<String, Any?>)
   fun startUserAction(RumActionType, String, Map<String, Any?>)
-  fun stopUserAction(Map<String, Any?> = emptyMap())
+  DEPRECATED fun stopUserAction(Map<String, Any?> = emptyMap())
   fun stopUserAction(RumActionType, String, Map<String, Any?> = emptyMap())
   fun startResource(String, String, String, Map<String, Any?> = emptyMap())
   fun stopResource(String, Int?, Long?, RumResourceKind, Map<String, Any?>)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -97,7 +97,12 @@ interface RumMonitor {
      * @param attributes additional custom attributes to attach to the action
      * @see [addUserAction]
      * @see [startUserAction]
+     * @deprecated Use [stopUserAction] with name parameter instead.
      */
+    @Deprecated(
+        "This method is deprecated. Please" +
+            " use RumMonitor#stopUserAction(type, name, attributes) instead"
+    )
     fun stopUserAction(
         attributes: Map<String, Any?> = emptyMap()
     )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -169,4 +169,8 @@ internal sealed class RumRawEvent {
         val target: String,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
+
+    internal data class SendCustomActionNow(
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.rum.assertj.RumEventAssert.Companion.assertThat
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.RumEvent
+import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
@@ -163,13 +164,13 @@ internal class RumContinuousActionScopeTest {
 
     @Test
     fun `𝕄 do nothing 𝕎 handleEvent(any) {crashCount != 0}`(
-        @LongForgery(1) nonFatalcount: Long,
-        @LongForgery(1) fatalcount: Long
+        @LongForgery(1) nonFatalCount: Long,
+        @LongForgery(1) fatalCount: Long
     ) {
         // Given
         Thread.sleep(RumActionScope.ACTION_INACTIVITY_MS)
-        testedScope.errorCount = nonFatalcount + fatalcount
-        testedScope.crashCount = fatalcount
+        testedScope.errorCount = nonFatalCount + fatalCount
+        testedScope.crashCount = fatalCount
 
         // When
         val result = testedScope.handleEvent(mockEvent(), mockWriter)
@@ -904,12 +905,12 @@ internal class RumContinuousActionScopeTest {
 
     @Test
     fun `𝕄 send Action after threshold 𝕎 handleEvent(StopAction+any) {crashCount != 0}`(
-        @LongForgery(1, 1024) nonFatalcount: Long,
-        @LongForgery(1, 1024) fatalcount: Long
+        @LongForgery(1, 1024) nonFatalCount: Long,
+        @LongForgery(1, 1024) fatalCount: Long
     ) {
         // Given
-        testedScope.errorCount = nonFatalcount + fatalcount
-        testedScope.crashCount = fatalcount
+        testedScope.errorCount = nonFatalCount + fatalCount
+        testedScope.crashCount = fatalCount
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap())
 
         // When
@@ -928,8 +929,8 @@ internal class RumContinuousActionScopeTest {
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
-                    hasErrorCount(nonFatalcount + fatalcount)
-                    hasCrashCount(fatalcount)
+                    hasErrorCount(nonFatalCount + fatalCount)
+                    hasCrashCount(fatalCount)
                     hasView(fakeParentContext)
                     hasUserInfo(fakeUserInfo)
                     hasApplicationId(fakeParentContext.applicationId)
@@ -1253,6 +1254,40 @@ internal class RumContinuousActionScopeTest {
         verifyNoMoreInteractions(mockWriter)
         assertThat(result).isSameAs(testedScope)
         assertThat(result2).isNull()
+    }
+
+    @Test
+    fun `𝕄 send Action 𝕎 handleEvent(SendCustomActionNow)`() {
+        // When
+        testedScope.type = RumActionType.CUSTOM
+        val event = RumRawEvent.SendCustomActionNow()
+        val result = testedScope.handleEvent(event, mockWriter)
+
+        // Then
+        argumentCaptor<RumEvent> {
+            verify(mockWriter).write(capture())
+            assertThat(lastValue)
+                .hasAttributes(fakeAttributes)
+                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
+                .hasActionData {
+                    hasId(testedScope.actionId)
+                    hasTimestamp(fakeEventTime.timestamp)
+                    hasType(ActionEvent.ActionType.CUSTOM)
+                    hasTargetName(fakeName)
+                    hasDurationGreaterThan(1)
+                    hasResourceCount(0)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasLongTaskCount(0)
+                    hasView(fakeParentContext)
+                    hasUserInfo(fakeUserInfo)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                }
+        }
+        verify(mockParentScope, never()).handleEvent(any(), any())
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isNull()
     }
 
     // region Internal

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -198,6 +198,7 @@ internal class DatadogRumMonitorTest {
 
     @Test
     fun `M delegate event to rootScope W stopUserAction()`() {
+        @Suppress("DEPRECATION")
         testedMonitor.stopUserAction(fakeAttributes)
         Thread.sleep(PROCESSING_DELAY)
 


### PR DESCRIPTION
### What does this PR do?

This change adds support of keeping instant (ones recorded using `.addUserAction`) custom actions even if there is another action ongoing. Before such actions would be dropped.

Here they would be instantly sent, because they don't have any dependencies, so they are not lost.

This change also deprecates variant of `stopUserAction` method which doesn't have `name` parameter in order to:

* be consistent with other methods of the interface
* prevent users from calling it to allow better internal API changes in future

This change doesn't solve however the problem of custom action which may be recorded using `startUserAction/stopUserAction` API, since in this case it cannot be instant, so can have dependencies.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

