### PR TITLE
RUMM-1384: Add statement about minimum supported version to the official docs

### DIFF
--- a/docs/rum_getting_started.md
+++ b/docs/rum_getting_started.md
@@ -9,6 +9,8 @@ Datadog *Real User Monitoring (RUM)* enables you to visualize and analyze the re
 3. Initialize the library with application context.
 4. Initialize RUM Monitor, Interceptor and start sending data.
 
+**Minimum Android OS version**: Datadog SDK for Android supports Android OS starting from version 19.
+
 
 ### Declare SDK as dependency
 

--- a/docs/rum_getting_started.md
+++ b/docs/rum_getting_started.md
@@ -9,7 +9,7 @@ Datadog *Real User Monitoring (RUM)* enables you to visualize and analyze the re
 3. Initialize the library with application context.
 4. Initialize RUM Monitor, Interceptor and start sending data.
 
-**Minimum Android OS version**: Datadog SDK for Android supports Android OS starting from version 19.
+**Minimum Android OS version**: Datadog SDK for Android supports Android OS v19+.
 
 
 ### Declare SDK as dependency


### PR DESCRIPTION
### What does this PR do?

This changes adds the statement about minimum supported OS version. It is added at the similar place as for the Browser SDK https://docs.datadoghq.com/real_user_monitoring/browser/, right after initial Setup block.