### PR TITLE
RUMM-1389: Add tests for the APIs of configuration of the Trace feature

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanBuilderE2ETests.kt
@@ -32,7 +32,7 @@ class SpanBuilderE2ETests {
     }
 
     /**
-     * apiMethodSignature: SpanBuilder#start()
+     * apiMethodSignature: SpanBuilder#fun start()
      */
     @Test
     fun trace_span_builder_start() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
@@ -1,0 +1,259 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.trace
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.Datadog
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.event.SpanEventMapper
+import com.datadog.android.nightly.SPECIAL_STRING_TAG_NAME
+import com.datadog.android.nightly.rules.NightlyTestRule
+import com.datadog.android.nightly.utils.initializeSdk
+import com.datadog.android.nightly.utils.measure
+import com.datadog.android.nightly.utils.measureSdkInitialize
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.tracing.AndroidTracer
+import com.datadog.android.tracing.model.SpanEvent
+import fr.xgouchet.elmyr.junit4.ForgeRule
+import io.opentracing.util.GlobalTracer
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class SpanConfigE2ETests {
+
+    @get:Rule
+    val forge = ForgeRule()
+
+    @get:Rule
+    val nightlyTestRule = NightlyTestRule()
+
+    /**
+     * apiMethodSignature: Credentials#constructor(String, String, String, String?, String? = null)
+     */
+    @Test
+    fun trace_config_feature_enabled() {
+        val testMethodName = "trace_config_feature_enabled"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                config = Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).build()
+            )
+        }
+        GlobalTracer.get()
+            .buildSpan(testMethodName)
+            .start()
+            .finish()
+    }
+
+    /**
+     * apiMethodSignature: Credentials#constructor(String, String, String, String?, String? = null)
+     */
+    @Test
+    fun trace_config_feature_disabled() {
+        val testMethodName = "trace_config_feature_disabled"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                config = Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = false,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).build()
+            )
+        }
+        GlobalTracer.get()
+            .buildSpan(testMethodName)
+            .start()
+            .finish()
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setSpanEventMapper(com.datadog.android.event.SpanEventMapper): Builder
+     */
+    @Test
+    fun trace_config_set_span_event_mapper() {
+        val testMethodName = "trace_config_set_span_event_mapper"
+        val fakeResourceName = "truly-random"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                config = Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setSpanEventMapper(
+                    object : SpanEventMapper {
+                        override fun map(event: SpanEvent): SpanEvent {
+                            if (event.resource == fakeResourceName) {
+                                event.name = testMethodName
+                                event.resource = testMethodName
+                            }
+                            return event
+                        }
+                    }
+                ).build()
+            )
+        }
+        GlobalTracer.get()
+            .buildSpan(fakeResourceName)
+            .start()
+            .finish()
+    }
+
+    /**
+     * apiMethodSignature: AndroidTracer#Builder#fun setBundleWithRumEnabled(Boolean): Builder
+     */
+    @Test
+    fun trace_config_set_bundle_with_rum_enabled() {
+        // this one will have application_id tag
+        val testMethodName = "trace_config_set_bundle_with_rum_enabled"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                tracerProvider = { AndroidTracer.Builder().setBundleWithRumEnabled(true).build() }
+            )
+        }
+        val viewKey = "some-view-key"
+        val viewName = "some-view-name"
+        val rumMonitor = GlobalRum.get()
+        rumMonitor.startView(viewKey, viewName)
+
+        // we need to wait a bit until RUM Context is updated
+        Thread.sleep(2000)
+        GlobalTracer.get()
+            .buildSpan(testMethodName)
+            .start()
+            .finish()
+
+        rumMonitor.stopView(viewKey)
+    }
+
+    /**
+     * apiMethodSignature: AndroidTracer#Builder#fun setBundleWithRumEnabled(Boolean): Builder
+     */
+    @Test
+    fun trace_config_set_bundle_with_rum_disabled() {
+        // this one won't have application_id tag
+        val testMethodName = "trace_config_set_bundle_with_rum_disabled"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                tracerProvider = { AndroidTracer.Builder().setBundleWithRumEnabled(false).build() }
+            )
+        }
+
+        val viewKey = "some-view-key"
+        val viewName = "some-view-name"
+        val rumMonitor = GlobalRum.get()
+        rumMonitor.startView(viewKey, viewName)
+
+        // we need to wait a bit until RUM Context is updated
+        Thread.sleep(2000)
+        GlobalTracer.get()
+            .buildSpan(testMethodName)
+            .start()
+            .finish()
+
+        rumMonitor.stopView(viewKey)
+    }
+
+    /**
+     * apiMethodSignature: AndroidTracer#Builder#fun addGlobalTag(String, String): Builder
+     */
+    @Test
+    fun trace_config_add_global_tag() {
+        val testMethodName = "trace_config_add_global_tag"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                tracerProvider = {
+                    AndroidTracer.Builder()
+                        .addGlobalTag(
+                            SPECIAL_STRING_TAG_NAME,
+                            "str${forge.anAlphaNumericalString()}"
+                        )
+                        .build()
+                }
+            )
+        }
+        GlobalTracer.get()
+            .buildSpan(testMethodName)
+            .start()
+            .finish()
+    }
+
+    /**
+     * apiMethodSignature: AndroidTracer#Builder#fun setServiceName(String): Builder
+     */
+    @Test
+    fun trace_config_set_service_name() {
+        val testMethodName = "trace_config_set_service_name"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                tracerProvider = {
+                    AndroidTracer.Builder()
+                        .setServiceName("service-$testMethodName")
+                        .build()
+                }
+            )
+        }
+        GlobalTracer.get()
+            .buildSpan(testMethodName)
+            .start()
+            .finish()
+    }
+
+    /**
+     * apiMethodSignature: Datadog#fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
+     */
+    @Test
+    fun trace_config_set_user_info() {
+        val testMethodName = "trace_config_set_user_info"
+        measureSdkInitialize {
+            initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        }
+
+        val userId = "some-id-${forge.anAlphaNumericalString()}"
+        val userName = "some-name-${forge.anAlphaNumericalString()}"
+        val userEmail = "some-email@${forge.anAlphaNumericalString()}.com"
+        val userExtraInfo = mapOf(
+            "level1" to forge.anAlphaNumericalString(),
+            "another.level2" to forge.anAlphaNumericalString()
+        )
+
+        measure(PERF_PREFIX + testMethodName) {
+            Datadog.setUserInfo(
+                id = userId,
+                name = userName,
+                email = userEmail,
+                extraInfo = userExtraInfo
+            )
+        }
+        GlobalTracer.get()
+            .buildSpan(testMethodName)
+            .start()
+            .finish()
+    }
+
+    private companion object {
+        // this is needed because pure test method names are reserved for the spans under test
+        const val PERF_PREFIX = "perf_"
+    }
+}

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanE2ETests.kt
@@ -42,7 +42,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#setOperationName(String)
+     * apiMethodSignature: Span#fun setOperationName(String)
      */
     @Test
     fun trace_span_set_operation_name() {
@@ -58,7 +58,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#setTag(String, Boolean)
+     * apiMethodSignature: Span#fun setTag(String, Boolean)
      */
     @Test
     fun trace_span_set_tag_boolean() {
@@ -74,7 +74,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#setTag(String, String)
+     * apiMethodSignature: Span#fun setTag(String, String)
      */
     @Test
     fun trace_span_set_tag_string() {
@@ -90,7 +90,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#setTag(String, Number)
+     * apiMethodSignature: Span#fun setTag(String, Number)
      */
     @Test
     fun trace_span_set_tag_number() {
@@ -112,7 +112,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#<T>setTag(Tag<T>, T)
+     * apiMethodSignature: Span#fun <T>setTag(Tag<T>, T)
      */
     @Test
     fun trace_span_set_tag_generic() {
@@ -128,7 +128,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#setBaggageItem(String, String)
+     * apiMethodSignature: Span#fun setBaggageItem(String, String)
      */
     @Test
     fun trace_span_set_baggage_item() {
@@ -144,7 +144,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#log(Map)
+     * apiMethodSignature: Span#fun log(Map)
      */
     @Test
     fun trace_span_log_map() {
@@ -165,7 +165,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#log(String)
+     * apiMethodSignature: Span#fun log(String)
      */
     @Test
     fun trace_span_log_string() {
@@ -181,7 +181,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#log(long, Map)
+     * apiMethodSignature: Span#fun log(long, Map)
      */
     @Test
     fun trace_span_log_timestamp_map() {
@@ -203,7 +203,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#log(long, String)
+     * apiMethodSignature: Span#fun log(long, String)
      */
     @Test
     fun trace_span_log_timestamp_string() {
@@ -220,7 +220,7 @@ class SpanE2ETests {
     }
 
     /**
-     * apiMethodSignature: Span#finish()
+     * apiMethodSignature: Span#fun finish()
      */
     @Test
     fun trace_span_finish() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -25,6 +25,7 @@ import com.datadog.android.tracing.AndroidTracer
 import com.datadog.tools.unit.getStaticValue
 import com.datadog.tools.unit.invokeMethod
 import com.datadog.tools.unit.setStaticValue
+import io.opentracing.Tracer
 import io.opentracing.util.GlobalTracer
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.system.measureNanoTime
@@ -72,7 +73,8 @@ fun flushAndShutdownExecutors() {
 fun initializeSdk(
     targetContext: Context,
     consent: TrackingConsent = TrackingConsent.GRANTED,
-    config: Configuration = createDatadogDefaultConfiguration()
+    config: Configuration = createDatadogDefaultConfiguration(),
+    tracerProvider: () -> Tracer = { createDefaultAndroidTracer() }
 ) {
     Datadog.initialize(
         targetContext,
@@ -81,7 +83,7 @@ fun initializeSdk(
         consent
     )
     Datadog.setVerbosity(Log.VERBOSE)
-    GlobalTracer.registerIfAbsent(AndroidTracer.Builder().build())
+    GlobalTracer.registerIfAbsent(tracerProvider.invoke())
     GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
 }
 
@@ -110,3 +112,5 @@ private fun createDatadogDefaultConfiguration(): Configuration {
     )
     return configBuilder.build()
 }
+
+private fun createDefaultAndroidTracer(): Tracer = AndroidTracer.Builder().build()


### PR DESCRIPTION
### What does this PR do?

This change adds all the necessary tests for the observability of the Trace feature configuration APIs.