### PR TITLE
RUMM-1370: Don't send empty variant tag

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -105,6 +105,8 @@ class com.datadog.android.core.configuration.Configuration
   companion object 
 class com.datadog.android.core.configuration.Credentials
   constructor(String, String, String, String?, String? = null)
+  companion object 
+    const val NO_VARIANT: String
 enum com.datadog.android.core.configuration.UploadFrequency
   constructor(Long)
   - FREQUENT

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogConfig.kt
@@ -137,7 +137,7 @@ private constructor(
             envName = coreConfig.envName,
             serviceName = coreConfig.serviceName,
             rumApplicationId = rumConfig?.applicationId?.toString(),
-            variant = ""
+            variant = Credentials.NO_VARIANT
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Credentials.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Credentials.kt
@@ -12,7 +12,7 @@ package com.datadog.android.core.configuration
  * @param envName the environment name that will be sent with each event. This can be used to
  * filter your events on different environments (e.g.: "staging" vs. "production").
  * @param variant the variant of your application, which should be the value from your
- * `BuildConfig.FLAVOR` constant
+ * `BuildConfig.FLAVOR` constant if you have different flavors, [NO_VARIANT] otherwise.
  * @param rumApplicationId your applicationId for RUM events
  * @param serviceName the service name (if set to null, it'll be set to your application's
  * package name, e.g.: com.example.android)
@@ -23,4 +23,11 @@ data class Credentials(
     val variant: String,
     val rumApplicationId: String?,
     val serviceName: String? = null
-)
+) {
+    companion object {
+        /**
+         * Value to use if application doesn't have flavors.
+         */
+        const val NO_VARIANT: String = ""
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
@@ -20,13 +20,18 @@ internal open class RumOkHttpUploader(
 ) : DataOkHttpUploader(buildUrl(endpoint, token), callFactory, CONTENT_TYPE_TEXT_UTF8) {
 
     private val tags: String by lazy {
-        arrayOf(
+        val elements = mutableListOf(
             "${RumAttributes.SERVICE_NAME}:${CoreFeature.serviceName}",
             "${RumAttributes.APPLICATION_VERSION}:${CoreFeature.packageVersion}",
             "${RumAttributes.SDK_VERSION}:${BuildConfig.SDK_VERSION_NAME}",
-            "${RumAttributes.ENV}:${CoreFeature.envName}",
-            "${RumAttributes.VARIANT}:${CoreFeature.variant}"
-        ).joinToString(",")
+            "${RumAttributes.ENV}:${CoreFeature.envName}"
+        )
+
+        if (CoreFeature.variant.isNotEmpty()) {
+            elements.add("${RumAttributes.VARIANT}:${CoreFeature.variant}")
+        }
+
+        elements.joinToString(",")
     }
 
     // region DataOkHttpUploader

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -115,7 +115,7 @@ internal class UploadWorkerTest {
         prepareMainLooper()
         Datadog.initialize(
             mockContext,
-            Credentials("CLIENT_TOKEN", "ENVIRONMENT", "", null),
+            Credentials("CLIENT_TOKEN", "ENVIRONMENT", Credentials.NO_VARIANT, null),
             Configuration.Builder(
                 logsEnabled = true,
                 tracesEnabled = true,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -62,7 +62,12 @@ internal class WorkManagerUtilsTest {
         prepareMainLooper()
         Datadog.initialize(
             mockAppContext,
-            Credentials(forge.anHexadecimalString(), forge.anAlphabeticalString(), "", null),
+            Credentials(
+                forge.anHexadecimalString(),
+                forge.anAlphabeticalString(),
+                Credentials.NO_VARIANT,
+                null
+            ),
             Configuration.Builder(
                 logsEnabled = true,
                 tracesEnabled = true,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -129,7 +129,7 @@ internal class DatadogExceptionHandlerTest {
         prepareMainLooper()
         Datadog.initialize(
             mockContext,
-            Credentials(fakeToken, fakeEnvName, "", null),
+            Credentials(fakeToken, fakeEnvName, Credentials.NO_VARIANT, null),
             Configuration.Builder(
                 logsEnabled = true,
                 tracesEnabled = true,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -444,7 +444,12 @@ internal class DatadogLogHandlerTest {
         // Given
         Datadog.initialize(
             mockContext(),
-            Credentials(forge.anAlphabeticalString(), forge.anAlphabeticalString(), "", null),
+            Credentials(
+                forge.anAlphabeticalString(),
+                forge.anAlphabeticalString(),
+                Credentials.NO_VARIANT,
+                null
+            ),
             Configuration.Builder(
                 logsEnabled = true,
                 tracesEnabled = true,
@@ -504,7 +509,12 @@ internal class DatadogLogHandlerTest {
         // Given
         Datadog.initialize(
             mockContext(),
-            Credentials(forge.anAlphabeticalString(), forge.anAlphabeticalString(), "", null),
+            Credentials(
+                forge.anAlphabeticalString(),
+                forge.anAlphabeticalString(),
+                Credentials.NO_VARIANT,
+                null
+            ),
             Configuration.Builder(
                 logsEnabled = true,
                 tracesEnabled = true,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderTest.kt
@@ -45,7 +45,6 @@ internal class RumOkHttpUploaderTest : DataOkHttpUploaderTest<RumOkHttpUploader>
     @StringForgery
     lateinit var fakeEnvName: String
 
-    @StringForgery
     lateinit var fakeVariant: String
 
     lateinit var mockAppContext: Application
@@ -53,6 +52,7 @@ internal class RumOkHttpUploaderTest : DataOkHttpUploaderTest<RumOkHttpUploader>
     @BeforeEach
     override fun `set up`(forge: Forge) {
         super.`set up`(forge)
+        fakeVariant = forge.anElementFrom(forge.anAlphaNumericalString(), "")
         mockAppContext = mockContext(fakePackageName, fakePackageVersion)
         mockCoreFeature(fakePackageName, fakePackageVersion, fakeEnvName, fakeVariant)
     }
@@ -76,11 +76,15 @@ internal class RumOkHttpUploaderTest : DataOkHttpUploaderTest<RumOkHttpUploader>
     }
 
     override fun expectedQueryParams(): Map<String, String> {
-        val tags = "${RumAttributes.SERVICE_NAME}:$fakePackageName," +
+        var tags = "${RumAttributes.SERVICE_NAME}:$fakePackageName," +
             "${RumAttributes.APPLICATION_VERSION}:$fakePackageVersion," +
             "${RumAttributes.SDK_VERSION}:${BuildConfig.SDK_VERSION_NAME}," +
-            "${RumAttributes.ENV}:$fakeEnvName," +
-            "${RumAttributes.VARIANT}:$fakeVariant"
+            "${RumAttributes.ENV}:$fakeEnvName"
+
+        if (fakeVariant.isNotEmpty()) {
+            tags += ",${RumAttributes.VARIANT}:$fakeVariant"
+        }
+
         return mapOf(
             DataOkHttpUploader.QP_SOURCE to CoreFeature.sourceName,
             RumOkHttpUploader.QP_TAGS to tags

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/CredentialsForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/CredentialsForgeryFactory.kt
@@ -17,7 +17,7 @@ internal class CredentialsForgeryFactory :
         return Credentials(
             clientToken = forge.anHexadecimalString(),
             envName = forge.anAlphabeticalString(),
-            variant = forge.anAlphabeticalString(),
+            variant = forge.anElementFrom(forge.anAlphabeticalString(), ""),
             serviceName = forge.aStringMatching("[a-z]+(\\.[a-z]+)+"),
             rumApplicationId = forge.getForgery<UUID>().toString()
         )

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
@@ -55,7 +55,7 @@ internal object RuntimeConfig {
         return Credentials(
             DD_TOKEN,
             INTEGRATION_TESTS_ENVIRONMENT,
-            "",
+            Credentials.NO_VARIANT,
             APP_ID
         )
     }


### PR DESCRIPTION
### What does this PR do?

This change prevents sending empty `variant` tag (which is the case when app doesn't declare flavors), because having it leads to the weird display in UI.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

