### PR TITLE
RUMM-1376 Fix nightly test for `setBundleWithTraceEnabled()` API

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerBuilderE2ETests.kt
@@ -174,7 +174,7 @@ class LoggerBuilderE2ETests {
     fun logs_logger_builder_bundle_with_trace_enabled() {
         val testMethodName = "logs_logger_builder_bundle_with_trace_enabled"
         measureLoggerInitialize {
-            logger = Logger.Builder().setBundleWithRumEnabled(true).build()
+            logger = Logger.Builder().setBundleWithTraceEnabled(true).build()
         }
         val spanName = forge.anAlphabeticalString()
         val span = GlobalTracer.get().buildSpan(spanName).start()
@@ -197,6 +197,23 @@ class LoggerBuilderE2ETests {
         GlobalRum.get().startView(viewKey, forge.anAlphabeticalString())
         logger.sendRandomLog(testMethodName, forge)
         GlobalRum.get().stopView(viewKey)
+    }
+
+    /**
+     * apiMethodSignature: Logger#Builder#fun setBundleWithTraceEnabled(Boolean): Builder
+     */
+    @Test
+    fun logs_logger_builder_bundle_with_trace_disabled() {
+        val testMethodName = "logs_logger_builder_bundle_with_trace_disabled"
+        measureLoggerInitialize {
+            logger = Logger.Builder().setBundleWithTraceEnabled(false).build()
+        }
+        val spanName = forge.anAlphabeticalString()
+        val span = GlobalTracer.get().buildSpan(spanName).start()
+        val scope = GlobalTracer.get().scopeManager().activate(span)
+        logger.sendRandomLog(testMethodName, forge)
+        scope.close()
+        span.finish()
     }
 
     companion object {


### PR DESCRIPTION
### What does this PR do?

It fixes the API used in `logs_logger_builder_bundle_with_trace_enabled` to the correct one.

### Additional Notes

This wasn't reported by _"[RUM] [Android] Nightly - `logs_logger_builder_bundle_with_trace_enabled`: number of logs is below expected value"_ monitor because it's query is not strict enough:
```
logs("service:com.datadog.android.nightly @test_method_name:logs_logger_builder_bundle_with_trace_enabled").index("*").rollup("count").last("1d") < 1
```

As far as I see, we can't access `span_id` and `trace_id` in logs, so I don't know how this query can be fixed. Maybe we should query `spans()` not `logs()`?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

