### PR TITLE
Fix the flakiness in the 'logs_logger_add_date_attribute' nightly test

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
@@ -30,6 +30,7 @@ import com.google.gson.JsonObject
 import fr.xgouchet.elmyr.junit4.ForgeRule
 import java.text.SimpleDateFormat
 import java.util.Date
+import java.util.TimeZone
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -501,6 +502,8 @@ class LoggerE2ETests {
         val CUSTOM_JSON_OBJECT_ATTRIBUTE: JsonObject = JsonObject().apply {
             addProperty(CUSTOM_JSON_OBJECT_PROPERTY, CUSTOM_INT_ATTRIBUTE)
         }
-        val CUSTOM_DATE_ATTRIBUTE: Date = SimpleDateFormat("yyyy-MM-dd").parse("2021-01-01")!!
+        val CUSTOM_DATE_ATTRIBUTE: Date = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
+            .apply { timeZone = TimeZone.getTimeZone("UTC") }
+            .parse("2021-01-01 00:00:00.000")!!
     }
 }


### PR DESCRIPTION
### What does this PR do?

For some reason using only the `yyyy-MM-dd` format in the `SimpleDateFormat` generates different timestamps from one process to another. In this PR we are trying to add a more granular format which will allow us to set the time to the number of milliseconds and see the monitor output in the following days.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

