### PR TITLE
RUMM-1414: Use view name in the children events

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -190,6 +190,7 @@ internal class RumActionScope(
                 ),
                 view = ActionEvent.View(
                     id = context.viewId.orEmpty(),
+                    name = context.viewName,
                     url = context.viewUrl.orEmpty()
                 ),
                 application = ActionEvent.Application(context.applicationId),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -158,6 +158,7 @@ internal class RumResourceScope(
             action = context.actionId?.let { ResourceEvent.Action(it) },
             view = ResourceEvent.View(
                 id = context.viewId.orEmpty(),
+                name = context.viewName,
                 url = context.viewUrl.orEmpty()
             ),
             usr = ResourceEvent.Usr(
@@ -225,6 +226,7 @@ internal class RumResourceScope(
             action = context.actionId?.let { ErrorEvent.Action(it) },
             view = ErrorEvent.View(
                 id = context.viewId.orEmpty(),
+                name = context.viewName,
                 url = context.viewUrl.orEmpty()
             ),
             usr = ErrorEvent.Usr(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -541,6 +541,7 @@ internal open class RumViewScope(
             action = context.actionId?.let { LongTaskEvent.Action(it) },
             view = LongTaskEvent.View(
                 id = context.viewId.orEmpty(),
+                name = context.viewName,
                 url = context.viewUrl.orEmpty()
             ),
             usr = LongTaskEvent.Usr(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
@@ -257,9 +257,10 @@ internal class DatadogNdkCrashHandler(
                     ErrorEvent.SessionType.USER
                 ),
                 view = ErrorEvent.View(
-                    bundledViewEvent.view.id,
-                    bundledViewEvent.view.referrer,
-                    bundledViewEvent.view.url
+                    id = bundledViewEvent.view.id,
+                    name = bundledViewEvent.view.name,
+                    referrer = bundledViewEvent.view.referrer,
+                    url = bundledViewEvent.view.url
                 ),
                 usr = ErrorEvent.Usr(
                     bundledViewEvent.usr?.id,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -1831,8 +1831,7 @@ internal class RumViewScopeTest {
                     hasErrorCount(0)
                     hasCrashCount(0)
                     hasLongTaskCount(0)
-                    // ActionEvent doesn't record view.name currently
-                    hasView(testedScope.getRumContext().copy(viewName = null))
+                    hasView(testedScope.getRumContext())
                     hasUserInfo(fakeUserInfo)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumContextForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumContextForgeryFactory.kt
@@ -17,6 +17,7 @@ internal class RumContextForgeryFactory : ForgeryFactory<RumContext> {
             applicationId = forge.getForgery<UUID>().toString(),
             sessionId = forge.getForgery<UUID>().toString(),
             viewId = forge.aNullable { getForgery<UUID>().toString() },
+            viewName = forge.aNullable { forge.anAlphaNumericalString() },
             viewUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+"),
             actionId = forge.aNullable { getForgery<UUID>().toString() }
         )


### PR DESCRIPTION
### What does this PR do?

This change add support of `view.name` for the resource, action, error, long task events. Now name of the view will be displayed in the dashboard instead of its id.

Before:

![image](https://user-images.githubusercontent.com/4046447/121337833-3aa41b00-c91d-11eb-91ef-6760322af820.png)

After:

![image](https://user-images.githubusercontent.com/4046447/121337918-4db6eb00-c91d-11eb-8e92-22087eb9e291.png)


Minor UI thing spotted as well: when dashboard shows `view.id` popup still proposes to filter by `view.name`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

