### PR TITLE
Fix flaky tests: test which checks a number of ticks on a view, and log event with reserved properties test

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGenerator.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/PokoGenerator.kt
@@ -437,7 +437,7 @@ class PokoGenerator(
         val propertyBuilder = PropertySpec.builder(
             RESERVED_PROPERTIES_NAME,
             ARRAY.parameterizedBy(STRING),
-            KModifier.PRIVATE
+            KModifier.INTERNAL
         ).initializer("arrayOf($propertyNames)")
         return propertyBuilder.build()
     }

--- a/buildSrc/src/test/kotlin/com/example/model/Comment.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Comment.kt
@@ -70,7 +70,7 @@ data class Comment(
         }
 
         companion object {
-            private val RESERVED_PROPERTIES: Array<String> = arrayOf("global")
+            internal val RESERVED_PROPERTIES: Array<String> = arrayOf("global")
 
             @JvmStatic
             @Throws(JsonParseException::class)

--- a/buildSrc/src/test/kotlin/com/example/model/Company.kt
+++ b/buildSrc/src/test/kotlin/com/example/model/Company.kt
@@ -32,7 +32,7 @@ data class Company(
     }
 
     companion object {
-        private val RESERVED_PROPERTIES: Array<String> = arrayOf("name", "ratings", "information")
+        internal val RESERVED_PROPERTIES: Array<String> = arrayOf("name", "ratings", "information")
 
         @JvmStatic
         @Throws(JsonParseException::class)
@@ -75,7 +75,7 @@ data class Company(
         }
 
         companion object {
-            private val RESERVED_PROPERTIES: Array<String> = arrayOf("global")
+            internal val RESERVED_PROPERTIES: Array<String> = arrayOf("global")
 
             @JvmStatic
             @Throws(JsonParseException::class)
@@ -115,7 +115,7 @@ data class Company(
         }
 
         companion object {
-            private val RESERVED_PROPERTIES: Array<String> = arrayOf("date", "priority")
+            internal val RESERVED_PROPERTIES: Array<String> = arrayOf("date", "priority")
 
             @JvmStatic
             @Throws(JsonParseException::class)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializer.kt
@@ -25,10 +25,9 @@ internal class LogEventSerializer(
         val sanitizedTags = dataConstraints
             .validateTags(log.ddtags.split(","))
             .joinToString(",")
-        // TODO: 13/04/2021 RUMM-1298 Handle the RESERVED_ATTRIBUTES in the `toJson` method
         val sanitizedAttributes = dataConstraints
             .validateAttributes(log.additionalProperties)
-            .filterKeys { it.isNotBlank() && it !in RESERVED_PROPERTIES }
+            .filterKeys { it.isNotBlank() }
         val usr = log.usr?.let {
             val sanitizedUserAttributes = dataConstraints.validateAttributes(
                 it.additionalProperties,
@@ -46,10 +45,5 @@ internal class LogEventSerializer(
 
     companion object {
         internal const val USER_EXTRA_GROUP_VERBOSE_NAME = "user extra information"
-
-        internal val RESERVED_PROPERTIES: List<String> = listOf(
-            "status", "service", "message",
-            "date", "logger", "usr", "network", "error", "ddtags"
-        )
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializerTest.kt
@@ -50,7 +50,7 @@ internal class LogEventSerializerTest {
         // Given
         val logWithoutAttributes = fakeLog.copy(additionalProperties = emptyMap())
         val attributes = forge.aMap {
-            anElementFrom(LogEventSerializer.RESERVED_PROPERTIES) to forge.anAsciiString()
+            anElementFrom(LogEvent.RESERVED_PROPERTIES.asList()) to forge.anAsciiString()
         }
         val logWithReservedAttributes = fakeLog.copy(additionalProperties = attributes)
 
@@ -225,7 +225,7 @@ internal class LogEventSerializerTest {
             doesNotHaveField(KEY_USR_EMAIL)
         }
         containsExtraAttributes(
-            userInfo.additionalProperties
+            userInfo.additionalProperties.minus(LogEvent.Usr.RESERVED_PROPERTIES)
         )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -3142,7 +3142,12 @@ internal class RumViewScopeTest {
         )
 
         // Then
-        val expectedTotal = cpuTicks.last() - cpuTicks.first()
+        val expectedTotal = if (cpuTicks.size > 1) {
+            cpuTicks.last() - cpuTicks.first()
+        } else {
+            // we need to have at least 2 ticks to submit "ticks on the view" metric
+            null
+        }
         argumentCaptor<RumEvent> {
             verify(mockWriter).write(capture())
             assertThat(lastValue)


### PR DESCRIPTION
### What does this PR do?

This PR fixes 2 flaky tests:

* The problem is that if we received tick only once, then it is not enough to calculate a metric `number of ticks on a view`, because we need at least 2 points per this code https://github.com/DataDog/dd-sdk-android/blob/0e9ac1420b70390b58b923902638e57ffc25af1c/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt#L85-L90

* There is a possibility to have `LogEvent.Usr.additionalProperties` with keys which are reserved and dropped during the serialization, but assertion was missing this drop part. Solved by making `RESERVED_PROPERTIES` as `internal` in generated models and by adding a link to it in the assertion.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

