### PR TITLE
RUMM-1425 Add nightly tests for RUM feature config options

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
@@ -1,0 +1,685 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.rum
+
+import android.os.Handler
+import android.os.Looper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.event.EventMapper
+import com.datadog.android.event.ViewEventMapper
+import com.datadog.android.nightly.TEST_METHOD_NAME_KEY
+import com.datadog.android.nightly.aResourceKey
+import com.datadog.android.nightly.aResourceMethod
+import com.datadog.android.nightly.aViewKey
+import com.datadog.android.nightly.aViewName
+import com.datadog.android.nightly.anActionName
+import com.datadog.android.nightly.anErrorMessage
+import com.datadog.android.nightly.rules.NightlyTestRule
+import com.datadog.android.nightly.utils.defaultTestAttributes
+import com.datadog.android.nightly.utils.executeInsideView
+import com.datadog.android.nightly.utils.initializeSdk
+import com.datadog.android.nightly.utils.measureSdkInitialize
+import com.datadog.android.nightly.utils.sendRandomActionOutcomeEvent
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.model.ActionEvent
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.LongTaskEvent
+import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.tools.unit.forge.aThrowable
+import com.datadog.tools.unit.invokeMethod
+import fr.xgouchet.elmyr.junit4.ForgeRule
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class RumConfigE2ETests {
+
+    @get:Rule
+    val forge = ForgeRule()
+
+    @get:Rule
+    val nightlyTestRule = NightlyTestRule()
+
+    // region Enable/Disable Feature
+
+    /**
+     * apiMethodSignature: Credentials#constructor(String, String, String, String?, String? = null)
+     */
+    @Test
+    fun rum_config_rum_feature_enabled() {
+        val testMethodName = "rum_config_rum_feature_enabled"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).build()
+            )
+        }
+        sendRandomRumEvent(forge, testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Credentials#constructor(String, String, String, String?, String? = null)
+     */
+    @Test
+    fun logs_config_logs_feature_disabled() {
+        val testMethodName = "rum_config_rum_feature_disabled"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = false,
+                    crashReportsEnabled = true
+                ).build()
+            )
+        }
+        sendRandomRumEvent(forge, testMethodName)
+    }
+
+    // endregion
+
+    // region ViewEventMapper
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumViewEventMapper(com.datadog.android.event.ViewEventMapper): Builder
+     */
+    @Test
+    fun rum_config_set_rum_view_event_mapper() {
+        val testMethodName = "rum_config_set_rum_view_event_mapper"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumViewEventMapper(
+                    eventMapper = object : ViewEventMapper {
+                        override fun map(event: ViewEvent): ViewEvent {
+                            event.view.name =
+                                forge.aStringMatching("$MAPPED_NAME_PREFIX[a-zA-z]{3,10}")
+                            return event
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        val key = forge.aViewKey()
+        val name = forge.aViewName()
+        GlobalRum.get().startView(
+            key,
+            name,
+            defaultTestAttributes(testMethodName)
+        )
+        GlobalRum.get().stopView(key, defaultTestAttributes(testMethodName))
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumViewEventMapper(com.datadog.android.event.ViewEventMapper): Builder
+     */
+    @Test
+    fun rum_config_set_rum_view_event_mapper_map_to_copy() {
+        val testMethodName = "rum_config_set_rum_view_event_mapper_map_to_copy"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumViewEventMapper(
+                    eventMapper = object : ViewEventMapper {
+                        override fun map(event: ViewEvent): ViewEvent {
+                            return event.copy()
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        val key = forge.aViewKey()
+        val name = forge.aViewName()
+        GlobalRum.get().startView(
+            key,
+            name,
+            defaultTestAttributes(testMethodName)
+        )
+        GlobalRum.get().stopView(key, defaultTestAttributes(testMethodName))
+    }
+
+    // endregion
+
+    // region ResourceEventMapper
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumResourceEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ResourceEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_resource_event_mapper_map_to_null() {
+        val testMethodName = "rum_config_set_rum_resource_event_mapper_map_to_null"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumResourceEventMapper(
+                    eventMapper = object : EventMapper<ResourceEvent> {
+                        override fun map(event: ResourceEvent): ResourceEvent? {
+                            return null
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        sendRandomResource(testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumResourceEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ResourceEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_resource_event_mapper_map_to_copy() {
+        val testMethodName = "rum_config_set_rum_resource_event_mapper_map_to_copy"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumResourceEventMapper(
+                    eventMapper = object : EventMapper<ResourceEvent> {
+                        override fun map(event: ResourceEvent): ResourceEvent {
+                            return event.copy()
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        sendRandomResource(testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumResourceEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ResourceEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_resource_event_mapper() {
+        val testMethodName = "rum_config_set_rum_resource_event_mapper"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumResourceEventMapper(
+                    eventMapper = object : EventMapper<ResourceEvent> {
+                        override fun map(event: ResourceEvent): ResourceEvent {
+                            event.resource.url = forge.aResourceKey(MAPPED_URL_PREFIX)
+                            return event
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        sendRandomResource(testMethodName)
+    }
+
+    // endregion
+
+    // region ActionEventMapper
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumActionEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ActionEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_action_event_mapper_map_to_null() {
+        val testMethodName = "rum_config_set_rum_action_event_mapper_map_to_null"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumActionEventMapper(
+                    eventMapper = object : EventMapper<ActionEvent> {
+                        override fun map(event: ActionEvent): ActionEvent? {
+                            return null
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        sendRandomActionEvent(testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumActionEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ActionEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_action_event_mapper_map_to_copy() {
+        val testMethodName = "rum_config_set_rum_action_event_mapper_map_to_copy"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumActionEventMapper(
+                    eventMapper = object : EventMapper<ActionEvent> {
+                        override fun map(event: ActionEvent): ActionEvent {
+                            return event.copy()
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        sendRandomActionEvent(testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumActionEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ActionEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_action_event_mapper() {
+        val testMethodName = "rum_config_set_rum_action_event_mapper"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumActionEventMapper(
+                    eventMapper = object : EventMapper<ActionEvent> {
+                        override fun map(event: ActionEvent): ActionEvent {
+                            event.view.url = forge.aViewKey(prefix = MAPPED_URL_PREFIX)
+                            return event
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        sendRandomActionEvent(testMethodName)
+    }
+
+    // endregion
+
+    // region ErrorEventMapper
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumErrorEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ErrorEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_error_event_mapper_map_to_null() {
+        val testMethodName = "rum_config_set_rum_error_event_mapper_map_to_null"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumErrorEventMapper(
+                    eventMapper = object : EventMapper<ErrorEvent> {
+                        override fun map(event: ErrorEvent): ErrorEvent? {
+                            return null
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        sendRandomErrorEvent(testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumErrorEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ErrorEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_error_event_mapper_map_to_copy() {
+        val testMethodName = "rum_config_set_rum_error_event_mapper_map_to_copy"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumErrorEventMapper(
+                    eventMapper = object : EventMapper<ErrorEvent> {
+                        override fun map(event: ErrorEvent): ErrorEvent {
+                            return event.copy()
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        sendRandomErrorEvent(testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun setRumErrorEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ErrorEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_error_event_mapper() {
+        val testMethodName = "rum_config_set_rum_error_event_mapper"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).setRumErrorEventMapper(
+                    eventMapper = object : EventMapper<ErrorEvent> {
+                        override fun map(event: ErrorEvent): ErrorEvent {
+                            event.view.url = forge.aViewKey(prefix = MAPPED_URL_PREFIX)
+                            return event
+                        }
+                    }
+                ).build()
+            )
+        }
+
+        sendRandomErrorEvent(testMethodName)
+    }
+
+    // endregion
+
+    // region LongTaskEventMapper
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun trackLongTasks(Long = DEFAULT_LONG_TASK_THRESHOLD_MS): Builder
+     * apiMethodSignature: Configuration#Builder#fun setRumLongTaskEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.LongTaskEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_longtask_event_mapper_map_to_null() {
+        val testMethodName = "rum_config_set_rum_longtask_event_mapper_map_to_null"
+        measureSdkInitialize {
+            val builder = Configuration.Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                rumEnabled = true,
+                crashReportsEnabled = true
+            )
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                builder
+                    .setRumLongTaskEventMapper(
+                        eventMapper = object : EventMapper<LongTaskEvent> {
+                            override fun map(event: LongTaskEvent): LongTaskEvent? {
+                                return null
+                            }
+                        }
+                    )
+                    .trackLongTasks()
+                    .build()
+            )
+        }
+
+        sendRandomLongTaskEvent(testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun trackLongTasks(Long = DEFAULT_LONG_TASK_THRESHOLD_MS): Builder
+     * apiMethodSignature: Configuration#Builder#fun setRumLongTaskEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.LongTaskEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_longtask_event_mapper_map_to_copy() {
+        val testMethodName = "rum_config_set_rum_longtask_event_mapper_map_to_copy"
+        measureSdkInitialize {
+            val builder = Configuration.Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                rumEnabled = true,
+                crashReportsEnabled = true
+            )
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                builder
+                    .setRumLongTaskEventMapper(
+                        eventMapper = object : EventMapper<LongTaskEvent> {
+                            override fun map(event: LongTaskEvent): LongTaskEvent {
+                                return event.copy()
+                            }
+                        }
+                    )
+                    .trackLongTasks()
+                    .build()
+            )
+        }
+
+        sendRandomLongTaskEvent(testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun trackLongTasks(Long = DEFAULT_LONG_TASK_THRESHOLD_MS): Builder
+     * apiMethodSignature: Configuration#Builder#fun setRumLongTaskEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.LongTaskEvent>): Builder
+     */
+    @Test
+    fun rum_config_set_rum_longtask_event_mapper() {
+        val testMethodName = "rum_config_set_rum_longtask_event_mapper"
+        measureSdkInitialize {
+            val builder = Configuration.Builder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                rumEnabled = true,
+                crashReportsEnabled = true
+            )
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                builder
+                    .setRumLongTaskEventMapper(
+                        eventMapper = object : EventMapper<LongTaskEvent> {
+                            override fun map(event: LongTaskEvent): LongTaskEvent {
+                                event.view.url = forge.aViewKey(prefix = MAPPED_URL_PREFIX)
+                                return event
+                            }
+                        }
+                    )
+                    .trackLongTasks()
+                    .build()
+            )
+        }
+
+        sendRandomLongTaskEvent(testMethodName)
+    }
+
+    // endregion
+
+    // region Session Sample
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun sampleRumSessions(Float): Builder
+     */
+    @Test
+    fun rum_config_sample_rum_sessions_all_in() {
+        val testMethodName = "rum_config_sample_rum_sessions_all_in"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).sampleRumSessions(100f).build()
+            )
+        }
+
+        sendRandomRumEvent(forge, testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun sampleRumSessions(Float): Builder
+     */
+    @Test
+    fun rum_config_sample_rum_sessions_all_out() {
+        val testMethodName = "rum_config_sample_rum_sessions_all_out"
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).sampleRumSessions(0f).build()
+            )
+        }
+
+        sendRandomRumEvent(forge, testMethodName)
+    }
+
+    /**
+     * apiMethodSignature: Configuration#Builder#fun sampleRumSessions(Float): Builder
+     */
+    @Test
+    fun rum_config_sample_rum_sessions_75_percent_in() {
+        val testMethodName = "rum_config_sample_rum_sessions_75_percent_in"
+        val eventsNumber = 10
+        measureSdkInitialize {
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                TrackingConsent.GRANTED,
+                Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    rumEnabled = true,
+                    crashReportsEnabled = true
+                ).sampleRumSessions(75f).build()
+            )
+        }
+
+        repeat(eventsNumber) {
+            sendRandomRumEvent(forge, testMethodName)
+            // expire the session here
+            GlobalRum.get().invokeMethod("resetSession")
+        }
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun sendRandomResource(testMethodName: String) {
+        executeInsideView(forge.aViewKey(), forge.aViewName(), testMethodName) {
+            val resourceKey = forge.aResourceKey()
+            GlobalRum.get().startResource(
+                resourceKey,
+                forge.aResourceMethod(),
+                resourceKey,
+                defaultTestAttributes(testMethodName)
+            )
+            GlobalRum.get().stopResource(
+                resourceKey,
+                forge.anInt(min = 200, max = 500),
+                forge.aLong(min = 1),
+                forge.aValueFrom(RumResourceKind::class.java),
+                defaultTestAttributes(testMethodName)
+            )
+        }
+    }
+
+    private fun sendRandomActionEvent(testMethodName: String) {
+        executeInsideView(forge.aViewKey(), forge.aViewName(), testMethodName) {
+            GlobalRum.get().addUserAction(
+                forge.aValueFrom(RumActionType::class.java),
+                forge.anActionName(),
+                defaultTestAttributes(testMethodName)
+            )
+            Thread.sleep(ACTION_INACTIVITY_THRESHOLD_MS)
+            sendRandomActionOutcomeEvent(forge)
+        }
+    }
+
+    private fun sendRandomErrorEvent(testMethodName: String) {
+        executeInsideView(forge.aViewKey(), forge.aViewName(), testMethodName) {
+            GlobalRum.get().addError(
+                forge.anErrorMessage(),
+                forge.aValueFrom(RumErrorSource::class.java),
+                forge.aNullable { forge.aThrowable() },
+                defaultTestAttributes(testMethodName)
+            )
+        }
+    }
+
+    private fun sendRandomLongTaskEvent(testMethodName: String) {
+        executeInsideView(forge.aViewKey(), forge.aViewName(), testMethodName) {
+            GlobalRum.addAttribute(TEST_METHOD_NAME_KEY, testMethodName)
+            Handler(Looper.getMainLooper()).post {
+                Thread.sleep(100)
+            }
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+        }
+    }
+
+    // endregion
+
+    companion object {
+        const val MAPPED_NAME_PREFIX = "mappedName"
+        const val MAPPED_URL_PREFIX = "mappedUrl"
+    }
+}

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConstants.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConstants.kt
@@ -12,3 +12,4 @@ const val RUM_VIEW_URL_PREFIX = "datadog/rum/"
 const val RUM_RESOURCE_URL_PREFIX = "datadog/resource/rum/"
 const val RUM_RESOURCE_ERROR_MESSAGE_PREFIX = "Rum Resource Error: "
 const val RUM_ERROR_MESSAGE_PREFIX = "Rum Error: "
+const val ACTION_INACTIVITY_THRESHOLD_MS = 100L

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
@@ -689,8 +689,4 @@ class RumMonitorE2ETests {
     }
 
     // endregion
-
-    companion object {
-        const val ACTION_INACTIVITY_THRESHOLD_MS = 100L
-    }
 }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -139,6 +139,10 @@ fun cleanStorageFiles() {
         .filesDir.deleteRecursively()
 }
 
+fun cleanGlobalAttributes() {
+    GlobalRum.removeAttribute(TEST_METHOD_NAME_KEY)
+}
+
 private fun createDatadogCredentials(): Credentials {
     return Credentials(
         clientToken = BuildConfig.NIGHTLY_TESTS_TOKEN,


### PR DESCRIPTION
### What does this PR do?

Adding the nightly test cases for the RUM Feature Configuration options :

- RUM feature enabled
- RUM feature disabled
- RUM feature with sampled RUM sessions
- LongTaskEvent mapper
- ViewEvent mapper
- ErrorEvent mapper
- ResourceEvent mapper
- ActionEvent mapper

### Additional Notes

Please note that for all the test cases added in this PR we are re-using the performance monitor dedicated for the SDK initialisation execution time. This is already computing the average duration / day so it will work as expected.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

