### PR TITLE
Remove ambiguous statement about deobfuscation in docs.

### DIFF
--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -62,7 +62,7 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
    * `TrackingConsent.GRANTED`: The SDK sends all current batched data and future data directly to the data collection endpoint.
    * `TrackingConsent.NOT_GRANTED`: The SDK wipes all batched data and does not collect any future data.
 
-   Note that in the credentials required for initialization, your application variant name is also required. This is important because it enables  the right proguard `mapping.txt` file to be automatically uploaded at build time. This allows a Datadog dashboard to de-obfuscate the stack traces.
+   Note that in the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM Error stack traces. For more information see the [guide to uploading Android source mapping files][8].
 
    Use the utility method `isInitialized` to check if the SDK is properly initialized:
 

--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -62,7 +62,7 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
    * `TrackingConsent.GRANTED`: The SDK sends all current batched data and future data directly to the data collection endpoint.
    * `TrackingConsent.NOT_GRANTED`: The SDK wipes all batched data and does not collect any future data.
 
-   Note that in the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM Error stack traces. For more information see the [guide to uploading Android source mapping files][8].
+**Note**: In the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM error stack traces. For more information see the [guide to uploading Android source mapping files][8].
 
    Use the utility method `isInitialized` to check if the SDK is properly initialized:
 

--- a/docs/rum_getting_started.md
+++ b/docs/rum_getting_started.md
@@ -90,7 +90,7 @@ class SampleApplication : Application() {
 
 Learn more about [`ViewTrackingStrategy`][5] to enable automatic tracking of all your views (activities, fragments, etc.), [`trackingConsent`][6] to add GDPR compliance for your EU users, and [other configuration options][7] to initialize the library.
 
-Note that in the credentials required for initialization, your application variant name is also required. This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated stack traces. For more information see the [guide to uploading Android source mapping files][8].
+Note that in the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM Error stack traces. For more information see the [guide to uploading Android source mapping files][8].
 
 ### Initialize RUM Monitor and Interceptor
 

--- a/docs/rum_getting_started.md
+++ b/docs/rum_getting_started.md
@@ -90,7 +90,7 @@ class SampleApplication : Application() {
 
 Learn more about [`ViewTrackingStrategy`][5] to enable automatic tracking of all your views (activities, fragments, etc.), [`trackingConsent`][6] to add GDPR compliance for your EU users, and [other configuration options][7] to initialize the library.
 
-Note that in the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM Error stack traces. For more information see the [guide to uploading Android source mapping files][8].
+**Note**: In the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM error stack traces. For more information see the [guide to uploading Android source mapping files][8].
 
 ### Initialize RUM Monitor and Interceptor
 

--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -60,7 +60,7 @@ Send [traces][1] to Datadog from your Android applications with [Datadog's `dd-s
    * `TrackingConsent.GRANTED`: The SDK sends all current batched data and future data directly to the data collection endpoint.
    * `TrackingConsent.NOT_GRANTED`: The SDK wipes all batched data and does not collect any future data.
 
-   Note that in the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM Error stack traces. For more information see the [guide to uploading Android source mapping files][8].
+**Note**: In  the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM error stack traces. For more information see the [guide to uploading Android source mapping files][8].
 
    Use the utility method `isInitialized` to check if the SDK is properly initialized:
 

--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -60,7 +60,7 @@ Send [traces][1] to Datadog from your Android applications with [Datadog's `dd-s
    * `TrackingConsent.GRANTED`: The SDK sends all current batched data and future data directly to the data collection endpoint.
    * `TrackingConsent.NOT_GRANTED`: The SDK wipes all batched data and does not collect any future data.
 
-   Note that in the credentials required for initialization, your application variant name is also required. This is important because it enables  the right proguard `mapping.txt` file to be automatically uploaded at build time. This allows a Datadog dashboard to de-obfuscate the stack traces.
+   Note that in the credentials required for initialization, your application variant name is also required, and should use your `BuildConfig.FLAVOR` value (or an empty string if you don't have variants). This is important because it enables the right ProGuard `mapping.txt` file to be automatically uploaded at build time to be able to view de-obfuscated RUM Error stack traces. For more information see the [guide to uploading Android source mapping files][8].
 
    Use the utility method `isInitialized` to check if the SDK is properly initialized:
 


### PR DESCRIPTION
Fixes #627

Deobfuscation is only applied on RUM Errors stack trace, but the note in the Logs/Traces documentation
led some customers to believe deobfuscation would also be applied to Logs / Spans.

### Motivation

Also add a recommendation to use the `BuildConfig.FLAVOR` value to initialize the SDK.
