### PR TITLE
Fix tracking consent label display, which wasn't updated after the change in the dialog

### DIFF
--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/NavActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/NavActivity.kt
@@ -15,12 +15,13 @@ import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.findNavController
+import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sample.service.LogsForegroundService
 import com.google.android.material.snackbar.Snackbar
 import java.security.SecureRandom
 import timber.log.Timber
 
-class NavActivity : AppCompatActivity() {
+class NavActivity : AppCompatActivity(), TrackingConsentChangeListener {
 
     lateinit var navController: NavController
     lateinit var rootView: View
@@ -36,7 +37,7 @@ class NavActivity : AppCompatActivity() {
 
         setContentView(R.layout.activity_nav)
         rootView = findViewById(R.id.frame_container)
-        appInfoView = findViewById<TextView>(R.id.app_info)
+        appInfoView = findViewById(R.id.app_info)
 
         navController = findNavController(R.id.nav_host_fragment)
     }
@@ -56,7 +57,7 @@ class NavActivity : AppCompatActivity() {
         Timber.d("onResume")
 
         val tracking = Preferences.defaultPreferences(this).getTrackingConsent()
-        appInfoView.text = "${BuildConfig.FLAVOR} / Tracking: $tracking"
+        updateTrackingConsentLabel(tracking)
     }
 
     override fun onPause() {
@@ -104,6 +105,13 @@ class NavActivity : AppCompatActivity() {
         return result
     }
 
+    override fun onTrackingConsentChanged(trackingConsent: TrackingConsent) =
+        updateTrackingConsentLabel(trackingConsent)
+
+    private fun updateTrackingConsentLabel(trackingConsent: TrackingConsent) {
+        appInfoView.text = "${BuildConfig.FLAVOR} / Tracking: $trackingConsent"
+    }
+
     private fun runLongTask() {
         val random = SecureRandom()
         val duration = random.nextInt(500) + 500
@@ -115,4 +123,8 @@ class NavActivity : AppCompatActivity() {
     companion object {
         const val LIPSUM = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, …"
     }
+}
+
+interface TrackingConsentChangeListener {
+    fun onTrackingConsentChanged(trackingConsent: TrackingConsent)
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/gdpr/GdprDialogFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/gdpr/GdprDialogFragment.kt
@@ -17,6 +17,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sample.Preferences
 import com.datadog.android.sample.R
+import com.datadog.android.sample.TrackingConsentChangeListener
 
 class GdprDialogFragment : DialogFragment() {
     lateinit var trackingConsentSelector: RadioGroup
@@ -40,6 +41,7 @@ class GdprDialogFragment : DialogFragment() {
             }
             Datadog.setTrackingConsent(trackingConsent)
             Preferences.defaultPreferences(requireContext()).setTrackingConsent(trackingConsent)
+            (activity as? TrackingConsentChangeListener)?.onTrackingConsentChanged(trackingConsent)
         }
         return rootView
     }


### PR DESCRIPTION
### What does this PR do?

This change fixes refresh of the tracking consent label: it wasn't updated, because it is a part of hosting activity layout, so `onResume` is not called after fragments switch, because same activity is active all the time. Probably it would be cleaner to register some listener in the object responsible for preferences, but it would be more code, because each time `Preferences#defaultPreferences` is called new object is created.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

