### PR TITLE
RUMM-1277 Track refresh rate

### DIFF
--- a/dd-sdk-android/build.gradle.kts
+++ b/dd-sdk-android/build.gradle.kts
@@ -159,6 +159,9 @@ unMock {
     keep("android.content.ComponentName")
     keep("android.os.Looper")
     keep("android.os.MessageQueue")
+    keep("android.os.SystemProperties")
+    keep("android.view.Choreographer")
+    keep("android.view.DisplayEventReceiver")
 }
 
 apply(from = "clone_dd_trace.gradle.kts")

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -262,7 +262,8 @@ interface RumMonitor {
                     handler = Handler(Looper.getMainLooper()),
                     firstPartyHostDetector = CoreFeature.firstPartyHostDetector,
                     cpuVitalMonitor = RumFeature.cpuVitalMonitor,
-                    memoryVitalMonitor = RumFeature.memoryVitalMonitor
+                    memoryVitalMonitor = RumFeature.memoryVitalMonitor,
+                    frameRateVitalMonitor = RumFeature.frameRateVitalMonitor
                 )
             }
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -25,8 +25,8 @@ import com.datadog.android.rum.internal.tracking.NoOpUserActionTrackingStrategy
 import com.datadog.android.rum.internal.tracking.UserActionTrackingStrategy
 import com.datadog.android.rum.internal.tracking.ViewTreeChangeTrackingStrategy
 import com.datadog.android.rum.internal.vitals.CPUVitalReader
-import com.datadog.android.rum.internal.vitals.FrameRateVitalReader
 import com.datadog.android.rum.internal.vitals.MemoryVitalReader
+import com.datadog.android.rum.internal.vitals.VitalFrameCallback
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalObserver
 import com.datadog.android.rum.internal.vitals.VitalReader
@@ -127,10 +127,9 @@ internal object RumFeature : SdkFeature<RumEvent, Configuration.Feature.RUM>() {
         initializeVitalMonitor(CPUVitalReader(), cpuVitalMonitor)
         initializeVitalMonitor(MemoryVitalReader(), memoryVitalMonitor)
 
-        val frameRateReader = FrameRateVitalReader { isInitialized() }
-        initializeVitalMonitor(frameRateReader, frameRateVitalMonitor)
+        val vitalFrameCallback = VitalFrameCallback(frameRateVitalMonitor) { isInitialized() }
         try {
-            Choreographer.getInstance().postFrameCallback(frameRateReader)
+            Choreographer.getInstance().postFrameCallback(vitalFrameCallback)
         } catch (e: IllegalStateException) {
             // This can happen if the SDK is initialized on a Thread with no looper
             sdkLogger.e("Unable to initialize the Choreographer FrameCallback", e)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -24,8 +24,10 @@ import com.datadog.android.rum.internal.net.RumOkHttpUploader
 import com.datadog.android.rum.internal.tracking.NoOpUserActionTrackingStrategy
 import com.datadog.android.rum.internal.tracking.UserActionTrackingStrategy
 import com.datadog.android.rum.internal.tracking.ViewTreeChangeTrackingStrategy
+import com.datadog.android.rum.internal.vitals.AggregatingVitalMonitor
 import com.datadog.android.rum.internal.vitals.CPUVitalReader
 import com.datadog.android.rum.internal.vitals.MemoryVitalReader
+import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalFrameCallback
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalObserver
@@ -49,9 +51,9 @@ internal object RumFeature : SdkFeature<RumEvent, Configuration.Feature.RUM>() {
     internal var rumEventMapper: EventMapper<RumEvent> = NoOpEventMapper()
     internal var longTaskTrackingStrategy: TrackingStrategy = NoOpTrackingStrategy()
 
-    internal val cpuVitalMonitor: VitalMonitor = VitalMonitor()
-    internal val memoryVitalMonitor: VitalMonitor = VitalMonitor()
-    internal val frameRateVitalMonitor: VitalMonitor = VitalMonitor()
+    internal var cpuVitalMonitor: VitalMonitor = NoOpVitalMonitor()
+    internal var memoryVitalMonitor: VitalMonitor = NoOpVitalMonitor()
+    internal var frameRateVitalMonitor: VitalMonitor = NoOpVitalMonitor()
 
     internal lateinit var vitalExecutorService: ScheduledThreadPoolExecutor
 
@@ -77,6 +79,10 @@ internal object RumFeature : SdkFeature<RumEvent, Configuration.Feature.RUM>() {
         actionTrackingStrategy = NoOpUserActionTrackingStrategy()
         longTaskTrackingStrategy = NoOpTrackingStrategy()
         rumEventMapper = NoOpEventMapper()
+
+        cpuVitalMonitor = NoOpVitalMonitor()
+        memoryVitalMonitor = NoOpVitalMonitor()
+        frameRateVitalMonitor = NoOpVitalMonitor()
 
         vitalExecutorService.shutdownNow()
     }
@@ -122,6 +128,10 @@ internal object RumFeature : SdkFeature<RumEvent, Configuration.Feature.RUM>() {
     }
 
     private fun initializeVitalMonitors() {
+        cpuVitalMonitor = AggregatingVitalMonitor()
+        memoryVitalMonitor = AggregatingVitalMonitor()
+        frameRateVitalMonitor = AggregatingVitalMonitor()
+
         vitalExecutorService = ScheduledThreadPoolExecutor(1)
 
         initializeVitalMonitor(CPUVitalReader(), cpuVitalMonitor)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -127,7 +127,7 @@ internal object RumFeature : SdkFeature<RumEvent, Configuration.Feature.RUM>() {
         initializeVitalMonitor(CPUVitalReader(), cpuVitalMonitor)
         initializeVitalMonitor(MemoryVitalReader(), memoryVitalMonitor)
 
-        val frameRateReader = FrameRateVitalReader()
+        val frameRateReader = FrameRateVitalReader { isInitialized() }
         initializeVitalMonitor(frameRateReader, frameRateVitalMonitor)
         try {
             Choreographer.getInstance().postFrameCallback(frameRateReader)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -15,18 +15,20 @@ import com.datadog.android.rum.internal.vitals.VitalMonitor
 internal class RumApplicationScope(
     applicationId: String,
     internal val samplingRate: Float,
-    private val firstPartyHostDetector: FirstPartyHostDetector,
-    private val cpuVitalMonitor: VitalMonitor,
-    private val memoryVitalMonitor: VitalMonitor
+    firstPartyHostDetector: FirstPartyHostDetector,
+    cpuVitalMonitor: VitalMonitor,
+    memoryVitalMonitor: VitalMonitor,
+    frameRateVitalMonitor: VitalMonitor
 ) : RumScope {
 
-    private val rumContext = RumContext(applicationId = applicationId.toString())
+    private val rumContext = RumContext(applicationId = applicationId)
     internal val childScope: RumScope = RumSessionScope(
         this,
         samplingRate,
         firstPartyHostDetector,
         cpuVitalMonitor,
-        memoryVitalMonitor
+        memoryVitalMonitor,
+        frameRateVitalMonitor
     )
 
     // region RumScope

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -29,6 +29,7 @@ internal class RumSessionScope(
     internal val firstPartyHostDetector: FirstPartyHostDetector,
     private val cpuVitalMonitor: VitalMonitor,
     private val memoryVitalMonitor: VitalMonitor,
+    private val frameRateVitalMonitor: VitalMonitor,
     private val sessionInactivityNanos: Long = DEFAULT_SESSION_INACTIVITY_NS,
     private val sessionMaxDurationNanos: Long = DEFAULT_SESSION_MAX_DURATION_NS
 ) : RumScope {
@@ -80,7 +81,8 @@ internal class RumSessionScope(
                 event,
                 firstPartyHostDetector,
                 cpuVitalMonitor,
-                memoryVitalMonitor
+                memoryVitalMonitor,
+                frameRateVitalMonitor
             )
             onApplicationDisplayed(event, viewScope, actualWriter)
             activeChildrenScopes.add(viewScope)
@@ -133,7 +135,8 @@ internal class RumSessionScope(
             emptyMap(),
             firstPartyHostDetector,
             cpuVitalMonitor,
-            memoryVitalMonitor
+            memoryVitalMonitor,
+            frameRateVitalMonitor
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -17,6 +17,7 @@ import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.RumEvent
+import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import java.security.SecureRandom
 import java.util.UUID
@@ -134,9 +135,9 @@ internal class RumSessionScope(
             event.eventTime,
             emptyMap(),
             firstPartyHostDetector,
-            cpuVitalMonitor,
-            memoryVitalMonitor,
-            frameRateVitalMonitor
+            NoOpVitalMonitor(),
+            NoOpVitalMonitor(),
+            NoOpVitalMonitor()
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -435,6 +435,8 @@ internal open class RumViewScope(
             null
         }
 
+        val memoryInfo = lastMemoryInfo
+        val refreshRateInfo = lastFrameRateInfo
         val viewEvent = ViewEvent(
             date = eventTimestamp,
             view = ViewEvent.View(
@@ -453,10 +455,10 @@ internal open class RumViewScope(
                 isActive = !stopped,
                 cpuTicksCount = cpuTicks,
                 cpuTicksPerSecond = cpuTicks?.let { (it * ONE_SECOND_NS) / updatedDurationNs },
-                memoryAverage = lastMemoryInfo?.meanValue,
-                memoryMax = lastMemoryInfo?.maxValue,
-                refreshRateAverage = lastFrameRateInfo?.meanValue?.let { it * refreshRateScale },
-                refreshRateMin = lastFrameRateInfo?.minValue?.let { it * refreshRateScale }
+                memoryAverage = memoryInfo?.meanValue,
+                memoryMax = memoryInfo?.maxValue,
+                refreshRateAverage = refreshRateInfo?.meanValue?.let { it * refreshRateScale },
+                refreshRateMin = refreshRateInfo?.minValue?.let { it * refreshRateScale }
             ),
             usr = ViewEvent.Usr(
                 id = user.id,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -34,8 +34,9 @@ internal class DatadogRumMonitor(
     private val writer: DataWriter<RumEvent>,
     internal val handler: Handler,
     firstPartyHostDetector: FirstPartyHostDetector,
-    private val cpuVitalMonitor: VitalMonitor,
-    private val memoryVitalMonitor: VitalMonitor,
+    cpuVitalMonitor: VitalMonitor,
+    memoryVitalMonitor: VitalMonitor,
+    frameRateVitalMonitor: VitalMonitor,
     private val executorService: ExecutorService = Executors.newSingleThreadExecutor()
 ) : RumMonitor, AdvancedRumMonitor {
 
@@ -44,7 +45,8 @@ internal class DatadogRumMonitor(
         samplingRate,
         firstPartyHostDetector,
         cpuVitalMonitor,
-        memoryVitalMonitor
+        memoryVitalMonitor,
+        frameRateVitalMonitor
     )
 
     internal val keepAliveRunnable = Runnable {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/vitals/AggregatingVitalMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/vitals/AggregatingVitalMonitor.kt
@@ -1,0 +1,86 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.vitals
+
+import kotlin.math.max
+import kotlin.math.min
+
+internal class AggregatingVitalMonitor : VitalMonitor {
+
+    private var lastKnownSample: Double = Double.NaN
+
+    private val listeners: MutableMap<VitalListener, VitalInfo> = mutableMapOf()
+
+    // region VitalObserver
+
+    override fun onNewSample(value: Double) {
+        lastKnownSample = value
+        notifyListeners(value)
+    }
+
+    // endregion
+
+    // region VitalMonitor
+
+    override fun getLastSample(): Double {
+        return lastKnownSample
+    }
+
+    override fun register(listener: VitalListener) {
+        val value = lastKnownSample
+        synchronized(listeners) {
+            listeners[listener] = VitalInfo.EMPTY
+        }
+        if (!value.isNaN()) {
+            notifyListener(listener, value)
+        }
+    }
+
+    override fun unregister(listener: VitalListener) {
+        synchronized(listeners) {
+            listeners.remove(listener)
+        }
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun notifyListeners(value: Double) {
+        synchronized(listeners) {
+            for (listener in listeners.keys) {
+                notifyListener(listener, value)
+            }
+        }
+    }
+
+    private fun notifyListener(listener: VitalListener, value: Double) {
+        val vitalInfo = listeners[listener] ?: VitalInfo.EMPTY
+        val newSampleCount = vitalInfo.sampleCount + 1
+
+        // Assuming M(n) is the mean value of the first n samples
+        // M(n) = ∑ sample(n) / n
+        // n⨉M(n) = ∑ sample(n)
+        // M(n+1) = ∑ sample(n+1) / (n+1)
+        //        = [ sample(n+1) + ∑ sample(n) ] / (n+1)
+        //        = (sample(n+1) + n⨉M(n)) / (n+1)
+        val meanValue = (value + (vitalInfo.sampleCount * vitalInfo.meanValue)) / newSampleCount
+
+        val updatedInfo = VitalInfo(
+            newSampleCount,
+            min(value, vitalInfo.minValue),
+            max(value, vitalInfo.maxValue),
+            meanValue
+        )
+        listener.onVitalUpdate(updatedInfo)
+        synchronized(listeners) {
+            listeners[listener] = updatedInfo
+        }
+    }
+
+    // endregion
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/vitals/FrameRateVitalReader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/vitals/FrameRateVitalReader.kt
@@ -12,7 +12,9 @@ import java.util.concurrent.TimeUnit
 /**
  * Reads the UI framerate based on the [Choreographer.FrameCallback].
  */
-internal class FrameRateVitalReader : VitalReader, Choreographer.FrameCallback {
+internal class FrameRateVitalReader(
+    val keepRunning: () -> Boolean
+) : VitalReader, Choreographer.FrameCallback {
 
     private var lastFrameTimestampNs: Long = 0L
     private var lastFrameRate: Double = Double.NaN
@@ -35,7 +37,10 @@ internal class FrameRateVitalReader : VitalReader, Choreographer.FrameCallback {
             }
         }
         lastFrameTimestampNs = frameTimeNanos
-        Choreographer.getInstance().postFrameCallback(this)
+
+        if (keepRunning()) {
+            Choreographer.getInstance().postFrameCallback(this)
+        }
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/vitals/FrameRateVitalReader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/vitals/FrameRateVitalReader.kt
@@ -1,0 +1,46 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.vitals
+
+import android.view.Choreographer
+import java.util.concurrent.TimeUnit
+
+/**
+ * Reads the UI framerate based on the [Choreographer.FrameCallback].
+ */
+internal class FrameRateVitalReader : VitalReader, Choreographer.FrameCallback {
+
+    private var lastFrameTimestampNs: Long = 0L
+    private var lastFrameRate: Double = Double.NaN
+
+    // region VitalReader
+
+    override fun readVitalData(): Double? {
+        return if (lastFrameRate.isNaN()) null else lastFrameRate
+    }
+
+    // endregion
+
+    // region Choreographer.FrameCallback
+
+    override fun doFrame(frameTimeNanos: Long) {
+        if (lastFrameTimestampNs != 0L) {
+            val durationNs = (frameTimeNanos - lastFrameTimestampNs).toDouble()
+            if (durationNs > 0.0) {
+                lastFrameRate = ONE_SECOND_NS / durationNs
+            }
+        }
+        lastFrameTimestampNs = frameTimeNanos
+        Choreographer.getInstance().postFrameCallback(this)
+    }
+
+    // endregion
+
+    companion object {
+        val ONE_SECOND_NS = TimeUnit.SECONDS.toNanos(1).toDouble()
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android
 
-import android.content.Context
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.net.identifyRequest
 import com.datadog.android.rum.RumAttributes
@@ -16,8 +15,6 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.tracing.TracingInterceptor
 import com.datadog.android.tracing.TracingInterceptorNotSendingSpanTest
-import com.datadog.android.utils.config.ApplicationContextTestConfiguration
-import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
@@ -212,8 +209,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     }
 
     companion object {
-        val appContext = ApplicationContextTestConfiguration(Context::class.java)
-        val coreFeature = CoreFeatureTestConfiguration(appContext)
         val rumMonitor = GlobalRumMonitorTestConfiguration()
 
         @TestConfigurationsProvider

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.net.ConnectivityManager
 import android.util.Log as AndroidLog
+import android.view.Choreographer
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.internal.CoreFeature
@@ -33,6 +34,7 @@ import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.invokeMethod
+import com.datadog.tools.unit.setStaticValue
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
@@ -99,6 +101,16 @@ internal class DatadogTest {
         whenever(appContext.mockInstance.filesDir).thenReturn(tempRootDir)
         whenever(appContext.mockInstance.getSystemService(Context.CONNECTIVITY_SERVICE))
             .doReturn(mockConnectivityMgr)
+
+        // Prevent crash when initializing RumFeature
+        Choreographer::class.java.setStaticValue(
+            "sThreadInstance",
+            object : ThreadLocal<Choreographer>() {
+                override fun initialValue(): Choreographer {
+                    return mock()
+                }
+            }
+        )
     }
 
     @AfterEach

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal.data.upload
 
 import android.content.Context
+import android.view.Choreographer
 import androidx.work.ListenableWorker
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -33,8 +34,10 @@ import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.invokeMethod
+import com.datadog.tools.unit.setStaticValue
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -109,6 +112,16 @@ internal class UploadWorkerTest {
         whenever(mockTracesStrategy.getReader()) doReturn mockTracesReader
         whenever(mockCrashReportsStrategy.getReader()) doReturn mockCrashReader
         whenever(mockRumStrategy.getReader()) doReturn mockRumReader
+
+        // Prevent crash when initializing RumFeature
+        Choreographer::class.java.setStaticValue(
+            "sThreadInstance",
+            object : ThreadLocal<Choreographer>() {
+                override fun initialValue(): Choreographer {
+                    return mock()
+                }
+            }
+        )
 
         Datadog.initialize(
             appContext.mockInstance,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -12,6 +12,7 @@ import java.util.concurrent.TimeUnit
 import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
+import org.assertj.core.data.Percentage
 
 internal class ViewEventAssert(actual: ViewEvent) :
     AbstractObjectAssert<ViewEventAssert, ViewEvent>(
@@ -306,18 +307,36 @@ internal class ViewEventAssert(actual: ViewEvent) :
     }
 
     fun hasRefreshRateMetric(average: Double?, min: Double?): ViewEventAssert {
-        assertThat(actual.view.refreshRateAverage)
-            .overridingErrorMessage(
-                "Expected RUM event to have view.refresh_rate_average $average " +
-                    "but was ${actual.view.refreshRateAverage}"
-            )
-            .isEqualTo(average)
-        assertThat(actual.view.refreshRateMin)
-            .overridingErrorMessage(
-                "Expected RUM event to have view.refresh_rate_min $min " +
-                    "but was ${actual.view.refreshRateMin}"
-            )
-            .isEqualTo(min)
+        if (average == null) {
+            assertThat(actual.view.refreshRateAverage as? Double)
+                .overridingErrorMessage(
+                    "Expected RUM event to have view.refresh_rate_average $average " +
+                        "but was ${actual.view.refreshRateAverage}"
+                )
+                .isNull()
+        } else {
+            assertThat(actual.view.refreshRateAverage as? Double)
+                .overridingErrorMessage(
+                    "Expected RUM event to have view.refresh_rate_average $average " +
+                        "but was ${actual.view.refreshRateAverage}"
+                )
+                .isCloseTo(average, Percentage.withPercentage(1.0))
+        }
+        if (min == null) {
+            assertThat(actual.view.refreshRateMin as? Double)
+                .overridingErrorMessage(
+                    "Expected RUM event to have view.refresh_rate_min $min " +
+                        "but was ${actual.view.refreshRateMin}"
+                )
+                .isNull()
+        } else {
+            assertThat(actual.view.refreshRateMin as? Double)
+                .overridingErrorMessage(
+                    "Expected RUM event to have view.refresh_rate_min $min " +
+                        "but was ${actual.view.refreshRateMin}"
+                )
+                .isCloseTo(min, Percentage.withPercentage(1.0))
+        }
         return this
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -15,6 +15,8 @@ import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.internal.net.RumOkHttpUploader
 import com.datadog.android.rum.internal.tracking.NoOpUserActionTrackingStrategy
 import com.datadog.android.rum.internal.tracking.UserActionTrackingStrategy
+import com.datadog.android.rum.internal.vitals.AggregatingVitalMonitor
+import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.tracking.NoOpTrackingStrategy
 import com.datadog.android.rum.tracking.NoOpViewTrackingStrategy
 import com.datadog.android.rum.tracking.TrackingStrategy
@@ -182,6 +184,20 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     }
 
     @Test
+    fun `𝕄 setup vital monitors 𝕎 initialize()`() {
+        // When
+        testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
+
+        // Then
+        assertThat(testedFeature.cpuVitalMonitor)
+            .isInstanceOf(AggregatingVitalMonitor::class.java)
+        assertThat(testedFeature.memoryVitalMonitor)
+            .isInstanceOf(AggregatingVitalMonitor::class.java)
+        assertThat(testedFeature.frameRateVitalMonitor)
+            .isInstanceOf(AggregatingVitalMonitor::class.java)
+    }
+
+    @Test
     fun `𝕄 use noop viewTrackingStrategy 𝕎 stop()`() {
         // Given
         testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
@@ -265,5 +281,19 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
 
         // Then
         verify(mockVitalExecutorService).shutdownNow()
+    }
+
+    @Test
+    fun `𝕄 reset vital monitors 𝕎 stop()`() {
+        // Given
+        testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
+
+        // When
+        testedFeature.stop()
+
+        // Then
+        assertThat(testedFeature.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+        assertThat(testedFeature.memoryVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+        assertThat(testedFeature.frameRateVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -57,6 +57,9 @@ internal class RumApplicationScopeTest {
     @Mock
     lateinit var mockMemoryVitalMonitor: VitalMonitor
 
+    @Mock
+    lateinit var mockFrameRateVitalMonitor: VitalMonitor
+
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
 
@@ -70,7 +73,8 @@ internal class RumApplicationScopeTest {
             fakeSamplingRate,
             mockDetector,
             mockCpuVitalMonitor,
-            mockMemoryVitalMonitor
+            mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor
         )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -23,6 +23,7 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.RumEvent
+import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
@@ -524,6 +525,9 @@ internal class RumSessionScopeTest {
                 assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
                 assertThat(it.keyRef.get()).isEqualTo(RumViewScope.RUM_BACKGROUND_VIEW_URL)
                 assertThat(it.name).isEqualTo(RumViewScope.RUM_BACKGROUND_VIEW_NAME)
+                assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.memoryVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.frameRateVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
             }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -97,6 +97,9 @@ internal class RumSessionScopeTest {
     @Mock
     lateinit var mockMemoryVitalMonitor: VitalMonitor
 
+    @Mock
+    lateinit var mockFrameRateVitalMonitor: VitalMonitor
+
     lateinit var mockDevLogHandler: LogHandler
 
     @Forgery
@@ -126,6 +129,7 @@ internal class RumSessionScopeTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -152,6 +156,7 @@ internal class RumSessionScopeTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -247,6 +252,7 @@ internal class RumSessionScopeTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -306,6 +312,7 @@ internal class RumSessionScopeTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -487,6 +494,7 @@ internal class RumSessionScopeTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -6,8 +6,13 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
+import android.app.Activity
 import android.content.Context
+import android.os.Build
 import android.util.Log
+import android.view.Display
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.utils.loggableStackTrace
@@ -34,12 +39,15 @@ import com.datadog.android.utils.forge.aFilteredMap
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.annotations.TestTargetApi
+import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.reset
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
@@ -47,6 +55,8 @@ import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.DoubleForgery
+import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -71,7 +81,8 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(TestConfigurationExtension::class)
+    ExtendWith(TestConfigurationExtension::class),
+    ExtendWith(ApiLevelExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
@@ -3252,7 +3263,7 @@ internal class RumViewScopeTest {
         var min = 60.0
         var max = 0.0
         var count = 0
-        frameRates.forEachIndexed { _, value ->
+        frameRates.forEach { value ->
             count++
             sum += value
             min = min(min, value)
@@ -3284,6 +3295,209 @@ internal class RumViewScopeTest {
                     hasCpuMetric(null)
                     hasMemoryMetric(null, null)
                     hasRefreshRateMetric(sum / frameRates.size, min)
+                    isActive(true)
+                    hasNoCustomTimings()
+                    hasUserInfo(fakeUserInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @TestTargetApi(Build.VERSION_CODES.R)
+    @Test
+    fun `𝕄 detect device refresh rate 𝕎 init()+onVitalUpdate()+handleEvent(KeepAlive) {Activity}`(
+        @FloatForgery(120.0f, 240.0f) deviceRefreshRate: Float,
+        @DoubleForgery(30.0, 60.0) meanRefreshRate: Double,
+        @DoubleForgery(0.0, 30.0) minRefreshRate: Double
+    ) {
+        // Given
+        val mockActivity = mock<Activity>()
+        val mockDisplay = mock<Display>()
+        whenever(mockActivity.display) doReturn mockDisplay
+        whenever(mockDisplay.refreshRate) doReturn deviceRefreshRate
+        reset(mockFrameRateVitalMonitor)
+        val testedScope = RumViewScope(
+            mockParentScope,
+            mockActivity,
+            fakeName,
+            fakeEventTime,
+            fakeAttributes,
+            mockDetector,
+            mockCpuVitalMonitor,
+            mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor
+        )
+        val listenerCaptor = argumentCaptor<VitalListener> {
+            verify(mockFrameRateVitalMonitor).register(capture())
+        }
+        val listener = listenerCaptor.firstValue
+
+        // When
+        listener.onVitalUpdate(VitalInfo(1, minRefreshRate, meanRefreshRate * 2, meanRefreshRate))
+        val result = testedScope.handleEvent(RumRawEvent.KeepAlive(), mockWriter)
+
+        // Then
+        val expectedAverage = (meanRefreshRate * 60.0) / deviceRefreshRate
+        val expectedMinimum = (minRefreshRate * 60.0) / deviceRefreshRate
+        argumentCaptor<RumEvent> {
+            verify(mockWriter).write(capture())
+            assertThat(lastValue)
+                .hasAttributes(fakeAttributes)
+                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
+                .hasViewData {
+                    hasTimestamp(fakeEventTime.timestamp)
+                    hasName(fakeName)
+                    hasDurationGreaterThan(1)
+                    hasVersion(2)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasResourceCount(0)
+                    hasActionCount(0)
+                    hasLongTaskCount(0)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(expectedAverage, expectedMinimum)
+                    isActive(true)
+                    hasNoCustomTimings()
+                    hasUserInfo(fakeUserInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @TestTargetApi(Build.VERSION_CODES.R)
+    @Test
+    fun `𝕄 detect device refresh rate 𝕎 init()+onVitalUpdate()+handleEvent(KeepAlive) {Frag X}`(
+        @FloatForgery(120.0f, 240.0f) deviceRefreshRate: Float,
+        @DoubleForgery(30.0, 60.0) meanRefreshRate: Double,
+        @DoubleForgery(0.0, 30.0) minRefreshRate: Double
+    ) {
+        // Given
+        val mockFragment = mock<Fragment>()
+        val mockActivity = mock<FragmentActivity>()
+        val mockDisplay = mock<Display>()
+        whenever(mockFragment.activity) doReturn mockActivity
+        whenever(mockActivity.display) doReturn mockDisplay
+        whenever(mockDisplay.refreshRate) doReturn deviceRefreshRate
+        reset(mockFrameRateVitalMonitor)
+        val testedScope = RumViewScope(
+            mockParentScope,
+            mockFragment,
+            fakeName,
+            fakeEventTime,
+            fakeAttributes,
+            mockDetector,
+            mockCpuVitalMonitor,
+            mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor
+        )
+        val listenerCaptor = argumentCaptor<VitalListener> {
+            verify(mockFrameRateVitalMonitor).register(capture())
+        }
+        val listener = listenerCaptor.firstValue
+
+        // When
+        listener.onVitalUpdate(VitalInfo(1, minRefreshRate, meanRefreshRate * 2, meanRefreshRate))
+        val result = testedScope.handleEvent(RumRawEvent.KeepAlive(), mockWriter)
+
+        // Then
+        val expectedAverage = (meanRefreshRate * 60.0) / deviceRefreshRate
+        val expectedMinimum = (minRefreshRate * 60.0) / deviceRefreshRate
+        argumentCaptor<RumEvent> {
+            verify(mockWriter).write(capture())
+            assertThat(lastValue)
+                .hasAttributes(fakeAttributes)
+                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
+                .hasViewData {
+                    hasTimestamp(fakeEventTime.timestamp)
+                    hasName(fakeName)
+                    hasDurationGreaterThan(1)
+                    hasVersion(2)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasResourceCount(0)
+                    hasActionCount(0)
+                    hasLongTaskCount(0)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(expectedAverage, expectedMinimum)
+                    isActive(true)
+                    hasNoCustomTimings()
+                    hasUserInfo(fakeUserInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Suppress("DEPRECATION")
+    @TestTargetApi(Build.VERSION_CODES.R)
+    @Test
+    fun `𝕄 detect device refresh rate 𝕎 init()+onVitalUpdate()+handleEvent(KeepAlive) {Fragment}`(
+        @FloatForgery(120.0f, 240.0f) deviceRefreshRate: Float,
+        @DoubleForgery(30.0, 60.0) meanRefreshRate: Double,
+        @DoubleForgery(0.0, 30.0) minRefreshRate: Double
+    ) {
+        // Given
+        val mockFragment = mock<android.app.Fragment>()
+        val mockActivity = mock<Activity>()
+        val mockDisplay = mock<Display>()
+        whenever(mockFragment.activity) doReturn mockActivity
+        whenever(mockActivity.display) doReturn mockDisplay
+        whenever(mockDisplay.refreshRate) doReturn deviceRefreshRate
+        reset(mockFrameRateVitalMonitor)
+        val testedScope = RumViewScope(
+            mockParentScope,
+            mockFragment,
+            fakeName,
+            fakeEventTime,
+            fakeAttributes,
+            mockDetector,
+            mockCpuVitalMonitor,
+            mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor
+        )
+        val listenerCaptor = argumentCaptor<VitalListener> {
+            verify(mockFrameRateVitalMonitor).register(capture())
+        }
+        val listener = listenerCaptor.firstValue
+
+        // When
+        listener.onVitalUpdate(VitalInfo(1, minRefreshRate, meanRefreshRate * 2, meanRefreshRate))
+        val result = testedScope.handleEvent(RumRawEvent.KeepAlive(), mockWriter)
+
+        // Then
+        val expectedAverage = (meanRefreshRate * 60.0) / deviceRefreshRate
+        val expectedMinimum = (minRefreshRate * 60.0) / deviceRefreshRate
+        argumentCaptor<RumEvent> {
+            verify(mockWriter).write(capture())
+            assertThat(lastValue)
+                .hasAttributes(fakeAttributes)
+                .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
+                .hasViewData {
+                    hasTimestamp(fakeEventTime.timestamp)
+                    hasName(fakeName)
+                    hasDurationGreaterThan(1)
+                    hasVersion(2)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasResourceCount(0)
+                    hasActionCount(0)
+                    hasLongTaskCount(0)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(expectedAverage, expectedMinimum)
                     isActive(true)
                     hasNoCustomTimings()
                     hasUserInfo(fakeUserInfo)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -90,6 +90,9 @@ internal class DatadogRumMonitorTest {
     @Mock
     lateinit var mockMemoryVitalMonitor: VitalMonitor
 
+    @Mock
+    lateinit var mockFrameRateVitalMonitor: VitalMonitor
+
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
 
@@ -111,7 +114,8 @@ internal class DatadogRumMonitorTest {
             mockHandler,
             mockDetector,
             mockCpuVitalMonitor,
-            mockMemoryVitalMonitor
+            mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor
         )
         testedMonitor.setFieldValue("rootScope", mockScope)
     }
@@ -129,7 +133,8 @@ internal class DatadogRumMonitorTest {
             mockHandler,
             mockDetector,
             mockCpuVitalMonitor,
-            mockMemoryVitalMonitor
+            mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor
         )
 
         val rootScope = testedMonitor.rootScope
@@ -1022,6 +1027,7 @@ internal class DatadogRumMonitorTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
             mockExecutor
         )
 
@@ -1046,6 +1052,7 @@ internal class DatadogRumMonitorTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
             mockExecutorService
         )
 
@@ -1071,6 +1078,7 @@ internal class DatadogRumMonitorTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
             mockExecutorService
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/AggregatingVitalMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/AggregatingVitalMonitorTest.kt
@@ -35,16 +35,16 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class VitalMonitorTest {
+internal class AggregatingVitalMonitorTest {
 
-    lateinit var testedMonitor: VitalMonitor
+    lateinit var testedMonitor: AggregatingVitalMonitor
 
     @Mock
     lateinit var mockListener: VitalListener
 
     @BeforeEach
     fun `set up`() {
-        testedMonitor = VitalMonitor()
+        testedMonitor = AggregatingVitalMonitor()
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/FrameRateVitalReaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/FrameRateVitalReaderTest.kt
@@ -1,0 +1,145 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.vitals
+
+import android.view.Choreographer
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.setStaticValue
+import com.nhaarman.mockitokotlin2.verify
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class FrameRateVitalReaderTest {
+
+    lateinit var testedReader: FrameRateVitalReader
+
+    @Mock
+    lateinit var mockChoreographer: Choreographer
+
+    @BeforeEach
+    fun `set up`() {
+        testedReader = FrameRateVitalReader()
+
+        Choreographer::class.java.setStaticValue(
+            "sThreadInstance",
+            object : ThreadLocal<Choreographer>() {
+                override fun initialValue(): Choreographer {
+                    return mockChoreographer
+                }
+            }
+        )
+    }
+
+    @Test
+    fun `𝕄 return null 𝕎 readVitalData() {no data}`() {
+        // When
+        val result = testedReader.readVitalData()
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `𝕄 return null 𝕎 readVitalData() {only one frame timestamp}`(
+        @LongForgery timestampNs: Long
+    ) {
+        // Given
+        testedReader.doFrame(timestampNs)
+
+        // When
+        val result = testedReader.readVitalData()
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `𝕄 return null 𝕎 readVitalData() {duration is null}`(
+        @LongForgery timestampNs: Long
+    ) {
+        // Given
+        testedReader.doFrame(timestampNs)
+        testedReader.doFrame(timestampNs)
+
+        // When
+        val result = testedReader.readVitalData()
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `𝕄 return last frameRate 𝕎 readVitalData() {two frame timestamp}`(
+        @LongForgery timestampNs: Long,
+        @LongForgery(1, ONE_SECOND_NS) frameDurationNs: Long
+    ) {
+        // Given
+        testedReader.doFrame(timestampNs)
+        testedReader.doFrame(timestampNs + frameDurationNs)
+        val expectedFrameRate = ONE_SECOND_NS.toDouble() / frameDurationNs.toDouble()
+
+        // When
+        val result = testedReader.readVitalData()
+
+        // Then
+        assertThat(result).isEqualTo(expectedFrameRate)
+    }
+
+    @Test
+    fun `𝕄 return last frameRate 𝕎 readVitalData() {many frame timestamp}`(
+        @LongForgery initialTimestampNs: Long,
+        @LongForgery(1, ONE_SECOND_NS) frameDurationsNs: List<Long>
+    ) {
+        // Given
+        var timestampNs = initialTimestampNs
+        testedReader.doFrame(timestampNs)
+        frameDurationsNs.forEach {
+            timestampNs += it
+            testedReader.doFrame(timestampNs)
+        }
+        val expectedFrameRate = ONE_SECOND_NS.toDouble() / frameDurationsNs.last().toDouble()
+
+        // When
+        val result = testedReader.readVitalData()
+
+        // Then
+        assertThat(result).isEqualTo(expectedFrameRate)
+    }
+
+    @Test
+    fun `𝕄 schedule callback 𝕎 doFrame() {only one frame timestamp`(
+        @LongForgery timestampNs: Long
+    ) {
+        // Given
+
+        // When
+        testedReader.doFrame(timestampNs)
+
+        // Then
+        verify(mockChoreographer).postFrameCallback(testedReader)
+    }
+
+    companion object {
+        const val ONE_SECOND_NS: Long = 1000L * 1000L * 1000L
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/FrameRateVitalReaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/FrameRateVitalReaderTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.vitals
 import android.view.Choreographer
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.setStaticValue
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -38,7 +39,7 @@ internal class FrameRateVitalReaderTest {
 
     @BeforeEach
     fun `set up`() {
-        testedReader = FrameRateVitalReader()
+        testedReader = FrameRateVitalReader { true }
 
         Choreographer::class.java.setStaticValue(
             "sThreadInstance",
@@ -127,7 +128,7 @@ internal class FrameRateVitalReaderTest {
     }
 
     @Test
-    fun `𝕄 schedule callback 𝕎 doFrame() {only one frame timestamp`(
+    fun `𝕄 schedule callback 𝕎 doFrame()`(
         @LongForgery timestampNs: Long
     ) {
         // Given
@@ -137,6 +138,20 @@ internal class FrameRateVitalReaderTest {
 
         // Then
         verify(mockChoreographer).postFrameCallback(testedReader)
+    }
+
+    @Test
+    fun `𝕄 not schedule callback 𝕎 doFrame() {keepRunning returns false}`(
+        @LongForgery timestampNs: Long
+    ) {
+        // Given
+        testedReader = FrameRateVitalReader { false }
+
+        // When
+        testedReader.doFrame(timestampNs)
+
+        // Then
+        verify(mockChoreographer, never()).postFrameCallback(testedReader)
     }
 
     companion object {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/VitalFrameCallbackTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/VitalFrameCallbackTest.kt
@@ -9,12 +9,12 @@ package com.datadog.android.rum.internal.vitals
 import android.view.Choreographer
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.setStaticValue
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -30,16 +30,19 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class FrameRateVitalReaderTest {
+internal class VitalFrameCallbackTest {
 
-    lateinit var testedReader: FrameRateVitalReader
+    lateinit var testedFrameCallback: Choreographer.FrameCallback
+
+    @Mock
+    lateinit var mockObserver: VitalObserver
 
     @Mock
     lateinit var mockChoreographer: Choreographer
 
     @BeforeEach
     fun `set up`() {
-        testedReader = FrameRateVitalReader { true }
+        testedFrameCallback = VitalFrameCallback(mockObserver) { true }
 
         Choreographer::class.java.setStaticValue(
             "sThreadInstance",
@@ -52,79 +55,32 @@ internal class FrameRateVitalReaderTest {
     }
 
     @Test
-    fun `𝕄 return null 𝕎 readVitalData() {no data}`() {
-        // When
-        val result = testedReader.readVitalData()
-
-        // Then
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `𝕄 return null 𝕎 readVitalData() {only one frame timestamp}`(
+    fun `𝕄 do nothing 𝕎 doFrame() {single frame timestamp}`(
         @LongForgery timestampNs: Long
     ) {
         // Given
-        testedReader.doFrame(timestampNs)
 
         // When
-        val result = testedReader.readVitalData()
+        testedFrameCallback.doFrame(timestampNs)
 
         // Then
-        assertThat(result).isNull()
+        verify(mockObserver, never()).onNewSample(any())
     }
 
     @Test
-    fun `𝕄 return null 𝕎 readVitalData() {duration is null}`(
-        @LongForgery timestampNs: Long
-    ) {
-        // Given
-        testedReader.doFrame(timestampNs)
-        testedReader.doFrame(timestampNs)
-
-        // When
-        val result = testedReader.readVitalData()
-
-        // Then
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `𝕄 return last frameRate 𝕎 readVitalData() {two frame timestamp}`(
+    fun `𝕄 forward frame rate to observer 𝕎 doFrame() {two frame timestamp}`(
         @LongForgery timestampNs: Long,
         @LongForgery(1, ONE_SECOND_NS) frameDurationNs: Long
     ) {
         // Given
-        testedReader.doFrame(timestampNs)
-        testedReader.doFrame(timestampNs + frameDurationNs)
         val expectedFrameRate = ONE_SECOND_NS.toDouble() / frameDurationNs.toDouble()
 
         // When
-        val result = testedReader.readVitalData()
+        testedFrameCallback.doFrame(timestampNs)
+        testedFrameCallback.doFrame(timestampNs + frameDurationNs)
 
         // Then
-        assertThat(result).isEqualTo(expectedFrameRate)
-    }
-
-    @Test
-    fun `𝕄 return last frameRate 𝕎 readVitalData() {many frame timestamp}`(
-        @LongForgery initialTimestampNs: Long,
-        @LongForgery(1, ONE_SECOND_NS) frameDurationsNs: List<Long>
-    ) {
-        // Given
-        var timestampNs = initialTimestampNs
-        testedReader.doFrame(timestampNs)
-        frameDurationsNs.forEach {
-            timestampNs += it
-            testedReader.doFrame(timestampNs)
-        }
-        val expectedFrameRate = ONE_SECOND_NS.toDouble() / frameDurationsNs.last().toDouble()
-
-        // When
-        val result = testedReader.readVitalData()
-
-        // Then
-        assertThat(result).isEqualTo(expectedFrameRate)
+        verify(mockObserver).onNewSample(expectedFrameRate)
     }
 
     @Test
@@ -134,10 +90,10 @@ internal class FrameRateVitalReaderTest {
         // Given
 
         // When
-        testedReader.doFrame(timestampNs)
+        testedFrameCallback.doFrame(timestampNs)
 
         // Then
-        verify(mockChoreographer).postFrameCallback(testedReader)
+        verify(mockChoreographer).postFrameCallback(testedFrameCallback)
     }
 
     @Test
@@ -145,13 +101,13 @@ internal class FrameRateVitalReaderTest {
         @LongForgery timestampNs: Long
     ) {
         // Given
-        testedReader = FrameRateVitalReader { false }
+        testedFrameCallback = VitalFrameCallback(mockObserver) { false }
 
         // When
-        testedReader.doFrame(timestampNs)
+        testedFrameCallback.doFrame(timestampNs)
 
         // Then
-        verify(mockChoreographer, never()).postFrameCallback(testedReader)
+        verify(mockChoreographer, never()).postFrameCallback(any())
     }
 
     companion object {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/VitalFrameCallbackTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/VitalFrameCallbackTest.kt
@@ -68,9 +68,39 @@ internal class VitalFrameCallbackTest {
     }
 
     @Test
+    fun `𝕄 do nothing 𝕎 doFrame() {too small duration}`(
+        @LongForgery timestampNs: Long,
+        @LongForgery(1, ONE_MILLISSECOND_NS) frameDurationNs: Long
+    ) {
+        // Given
+
+        // When
+        testedFrameCallback.doFrame(timestampNs)
+        testedFrameCallback.doFrame(timestampNs + frameDurationNs)
+
+        // Then
+        verify(mockObserver, never()).onNewSample(any())
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 doFrame() {too large duration}`(
+        @LongForgery timestampNs: Long,
+        @LongForgery(TEN_SECOND_NS, ONE_MINUTE_NS) frameDurationNs: Long
+    ) {
+        // Given
+
+        // When
+        testedFrameCallback.doFrame(timestampNs)
+        testedFrameCallback.doFrame(timestampNs + frameDurationNs)
+
+        // Then
+        verify(mockObserver, never()).onNewSample(any())
+    }
+
+    @Test
     fun `𝕄 forward frame rate to observer 𝕎 doFrame() {two frame timestamp}`(
         @LongForgery timestampNs: Long,
-        @LongForgery(1, ONE_SECOND_NS) frameDurationNs: Long
+        @LongForgery(ONE_MILLISSECOND_NS, ONE_SECOND_NS) frameDurationNs: Long
     ) {
         // Given
         val expectedFrameRate = ONE_SECOND_NS.toDouble() / frameDurationNs.toDouble()
@@ -111,6 +141,9 @@ internal class VitalFrameCallbackTest {
     }
 
     companion object {
+        const val ONE_MILLISSECOND_NS: Long = 1000L * 1000L
         const val ONE_SECOND_NS: Long = 1000L * 1000L * 1000L
+        const val TEN_SECOND_NS: Long = 10L * ONE_SECOND_NS
+        const val ONE_MINUTE_NS: Long = 60L * ONE_SECOND_NS
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.tracing.internal
 
 import android.content.Context
 import android.util.Log
+import android.view.Choreographer
 import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.log.LogAttributes
@@ -28,6 +29,7 @@ import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.getStaticValue
 import com.datadog.tools.unit.invokeMethod
 import com.datadog.tools.unit.setFieldValue
+import com.datadog.tools.unit.setStaticValue
 import com.datadog.trace.api.Config
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.inOrder
@@ -80,6 +82,16 @@ internal class AndroidTracerTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
+        // Prevent crash when initializing RumFeature
+        Choreographer::class.java.setStaticValue(
+            "sThreadInstance",
+            object : ThreadLocal<Choreographer>() {
+                override fun initialValue(): Choreographer {
+                    return mock()
+                }
+            }
+        )
+
         mockDevLogsHandler = mockDevLogHandler()
         fakeServiceName = forge.anAlphabeticalString()
         fakeEnvName = forge.anAlphabeticalString()


### PR DESCRIPTION
### What does this PR do?

Track the device's refresh rate and report it in RUM Views. The refresh rate uses the Choreographer's callback to know when each frame started and compute an accurate approximation of the device's frame rate.
