### PR TITLE
RUMM-1422 Use XHR by default instead of Unknown for RUM Resources

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
@@ -198,7 +198,7 @@ internal constructor(
         val mimeType = response?.header(HEADER_CT)
         val kind = when {
             method in xhrMethods -> RumResourceKind.XHR
-            mimeType == null -> RumResourceKind.UNKNOWN
+            mimeType == null -> RumResourceKind.XHR
             else -> RumResourceKind.fromMimeType(mimeType)
         }
         val attributes = if (span == null) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumResourceKind.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumResourceKind.kt
@@ -41,7 +41,6 @@ enum class RumResourceKind(val value: String) {
                 baseType == "font" -> FONT
                 baseType == "text" && subtype == "css" -> CSS
                 baseType == "text" && subtype == "javascript" -> JS
-                mimeType.isBlank() -> UNKNOWN
                 else -> XHR
             }
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android
 
-import android.content.Context
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.net.identifyRequest
 import com.datadog.android.rum.RumAttributes
@@ -16,8 +15,6 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.tracing.TracingInterceptor
 import com.datadog.android.tracing.TracingInterceptorNotSendingSpanTest
-import com.datadog.android.utils.config.ApplicationContextTestConfiguration
-import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
@@ -113,7 +110,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val kind = when {
             fakeMethod in DatadogInterceptor.xhrMethods -> RumResourceKind.XHR
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
-            else -> RumResourceKind.UNKNOWN
+            else -> RumResourceKind.XHR
         }
 
         // When
@@ -153,7 +150,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val kind = when {
             fakeMethod in DatadogInterceptor.xhrMethods -> RumResourceKind.XHR
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
-            else -> RumResourceKind.UNKNOWN
+            else -> RumResourceKind.XHR
         }
 
         // When
@@ -212,8 +209,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     }
 
     companion object {
-        val appContext = ApplicationContextTestConfiguration(Context::class.java)
-        val coreFeature = CoreFeatureTestConfiguration(appContext)
         val rumMonitor = GlobalRumMonitorTestConfiguration()
 
         @TestConfigurationsProvider

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumResourceKindTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumResourceKindTest.kt
@@ -90,7 +90,7 @@ internal class RumResourceKindTest {
     }
 
     @Test
-    fun `detect unknown MimeType`(
+    fun `detect unknown MimeType as XHR`(
         forge: Forge
     ) {
         val mimeType = forge.aWhitespaceString()
@@ -98,6 +98,6 @@ internal class RumResourceKindTest {
         val kind = RumResourceKind.fromMimeType(mimeType)
 
         assertThat(kind)
-            .isEqualTo(RumResourceKind.UNKNOWN)
+            .isEqualTo(RumResourceKind.XHR)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
@@ -163,9 +163,13 @@ internal open class TracingInterceptorNotSendingSpanTest {
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
 
-        val mediaType = forge.anElementFrom("application", "image", "text", "model") +
-            "/" + forge.anAlphabeticalString()
-        fakeMediaType = MediaType.parse(mediaType)
+        fakeMediaType = if (forge.aBool()) {
+            val mediaType = forge.anElementFrom("application", "image", "text", "model") +
+                "/" + forge.anAlphabeticalString()
+            MediaType.parse(mediaType)
+        } else {
+            null
+        }
         fakeUrl = forgeUrl(forge)
         fakeRequest = forgeRequest(forge)
         TracesFeature.initialize(
@@ -697,8 +701,10 @@ internal open class TracingInterceptorNotSendingSpanTest {
             .protocol(Protocol.HTTP_2)
             .code(statusCode)
             .message("HTTP $statusCode")
-            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
             .body(ResponseBody.create(fakeMediaType, fakeResponseBody))
+        if (fakeMediaType != null) {
+            builder.header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
+        }
         return builder.build()
     }
 


### PR DESCRIPTION
### What does this PR do?

Use XHR by default instead of Unknown for RUM Resources

### Motivation

When we are unable to detect the resource type, we're going to use `XHR` by default instead of unknown to ensure the resource can have a backend trace attached to it.
