### PR TITLE
RUMM-1442 Fix the flaky 'rum_config_set_rum_action_event_mapper' nigh…

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
@@ -650,8 +650,8 @@ class RumConfigE2ETests {
                 forge.anActionName(),
                 defaultTestAttributes(testMethodName)
             )
-            Thread.sleep(ACTION_INACTIVITY_THRESHOLD_MS)
             sendRandomActionOutcomeEvent(forge)
+            Thread.sleep(ACTION_INACTIVITY_THRESHOLD_MS)
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

The output of this test was not consistent and I suspect it was because of the event forced timeout which was added before the resource was sent. I am not 100% sure that this was the root cause of the issue but I tried to reproduce it locally by running it 30 times in a loop and all the events were sent. I will keep an eye on this monitor for future eventual problems.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

