### PR TITLE
RUMM-1396 Fix flaky instrumented tests

### DIFF
--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/TracesTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/TracesTest.kt
@@ -91,6 +91,7 @@ internal abstract class TracesTest {
                     logObjects.add(it.asJsonObject)
                 }
             }
+        assertThat(expectedLogs.size).isEqualTo(logObjects.size)
         expectedLogs.forEach {
             val toMatch = logObjects.removeFirst()
             assertThat(toMatch)

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
@@ -37,7 +37,7 @@ fun createInstance(
  * @param fieldValue the value to set
  */
 @Suppress("SwallowedException")
-inline fun <reified T, R> Class<T>.setStaticValue(
+fun <T, R> Class<T>.setStaticValue(
     fieldName: String,
     fieldValue: R
 ) {
@@ -46,17 +46,7 @@ inline fun <reified T, R> Class<T>.setStaticValue(
     // make it accessible
     field.isAccessible = true
 
-    // Make it non final
-    try {
-        val modifiersField = Field::class.java.getDeclaredField("modifiers")
-        modifiersField.isAccessible = true
-        modifiersField.setInt(field, field.modifiers and Modifier.FINAL.inv())
-    } catch (e: NoSuchFieldException) {
-        // do nothing
-        @Suppress("PrintStackTrace")
-        e.printStackTrace()
-    }
-    field.set(null, fieldValue)
+    setFieldValue(null, field, fieldValue)
 }
 
 /**
@@ -96,7 +86,7 @@ inline fun <reified T, reified R> Class<T>.getStaticValue(fieldName: String): R 
  * @param fieldValue the value of the field
  */
 @Suppress("SwallowedException")
-inline fun <reified T> Any.setFieldValue(
+fun <T> Any.setFieldValue(
     fieldName: String,
     fieldValue: T
 ): Boolean {
@@ -119,20 +109,10 @@ inline fun <reified T> Any.setFieldValue(
             }
         }
     }
-
-    // make it accessible
-    if (field != null) {
-        field.isAccessible = true
-
-        // Make it non final
-        val modifiersField = Field::class.java.getDeclaredField("modifiers")
-        modifiersField.isAccessible = true
-        modifiersField.setInt(field, field.modifiers and Modifier.FINAL.inv())
-
-        field.set(this, fieldValue)
-        return true
+    return if (field != null) {
+        setFieldValue(this, field, fieldValue)
     } else {
-        return false
+        false
     }
 }
 
@@ -264,4 +244,33 @@ private fun <T : Any> T.getDeclaredMethodRecursively(
     }
 
     return method
+}
+
+@SuppressWarnings("PrintStackTrace")
+private fun <R> setFieldValue(instance: Any?, field: Field, fieldValue: R): Boolean {
+    field.isAccessible = true
+    // Make it non final
+    try {
+        val accessField = resolveAccessField()
+        accessField.isAccessible = true
+        accessField.setInt(field, field.modifiers and Modifier.FINAL.inv())
+    } catch (e: NoSuchFieldException) {
+        e.printStackTrace()
+        return false
+    }
+    field.set(instance, fieldValue)
+    return true
+}
+
+@SuppressWarnings("SwallowedException")
+private fun resolveAccessField(): Field {
+    // Android JVM does not use the JDK sources for reflection therefore the property access type
+    // field is named `accessFlags` instead of `modifiers` as in a default JVM
+    // Because these methods are being shared between JUnit and AndroidJUnit runtimes we will
+    // have to support both implementations.
+    return try {
+        Field::class.java.getDeclaredField("modifiers")
+    } catch (e: NoSuchFieldException) {
+        Field::class.java.getDeclaredField("accessFlags")
+    }
 }


### PR DESCRIPTION
### What does this PR do?

In this PR was trying to identify and fix potential flaky tests in our integration tests module. I tried for more consecutive times to run our integration tests locally and was able to identify a potential flaky test: `ConsentPendingGrantedTracesTest`. After being able to reproduce it ones I was not able to reproduce it anymore and ran the test suite at least 50 times on my end. I guess once it will fail in Bitrise I will have more information on this matter and will able to jump back to it.

I took the chance and fixed also the code in `ReflectUtils.kt` which was throwing a `NoSuchFieldException` if executed in `AndroidJUnit` runtime [See here](https://stackoverflow.com/questions/13755117/android-changing-private-static-final-field-using-java-reflection).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

