### PR TITLE
RUMM-1475 discard batches on invalid Client Token

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
@@ -102,7 +102,8 @@ internal class DataUploadRunnable(
             UploadStatus.SUCCESS,
             UploadStatus.HTTP_REDIRECTION,
             UploadStatus.HTTP_CLIENT_ERROR,
-            UploadStatus.UNKNOWN_ERROR
+            UploadStatus.UNKNOWN_ERROR,
+            UploadStatus.INVALID_TOKEN_ERROR
         )
 
         private val batteryFullOrChargingStatus = setOf(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -305,6 +305,23 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
+    fun `batch dropped on Invalid Token Error`(@Forgery batch: Batch) {
+        whenever(mockReader.lockAndReadNext()) doReturn batch
+        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.INVALID_TOKEN_ERROR
+
+        testedRunnable.run()
+
+        verify(mockReader).drop(batch)
+        verify(mockReader, never()).release(batch)
+        verify(mockDataUploader).upload(batch.data)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
     fun `batch kept on Server Error`(@Forgery batch: Batch) {
         whenever(mockReader.lockAndReadNext()) doReturn batch
         whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.HTTP_SERVER_ERROR

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
@@ -178,7 +178,7 @@ internal abstract class DataOkHttpUploaderTest<T : DataOkHttpUploader> {
     }
 
     @Test
-    fun `𝕄 return success 𝕎 upload() {403 status} `(
+    fun `𝕄 return invalid token error 𝕎 upload() {403 status} `(
         @StringForgery message: String
     ) {
         // Given


### PR DESCRIPTION
### What does this PR do?

When an application is configured with an invalid Client Token, discard the batch to avoid retrying endlessly with the same invalid token.
