### PR TITLE
RUMM-1342 Add action target name predicate API

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -80,7 +80,7 @@ class com.datadog.android.core.configuration.Configuration
     fun useCustomTracesEndpoint(String): Builder
     fun useCustomCrashReportsEndpoint(String): Builder
     fun useCustomRumEndpoint(String): Builder
-    fun trackInteractions(Array<com.datadog.android.rum.tracking.ViewAttributesProvider> = emptyArray()): Builder
+    fun trackInteractions(Array<com.datadog.android.rum.tracking.ViewAttributesProvider> = emptyArray(), com.datadog.android.rum.tracking.InteractionPredicate = NoOpInteractionPredicate()): Builder
     fun trackLongTasks(Long = DEFAULT_LONG_TASK_THRESHOLD_MS): Builder
     fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
     fun addPlugin(com.datadog.android.plugin.DatadogPlugin, com.datadog.android.plugin.Feature): Builder

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1059,6 +1059,8 @@ class com.datadog.android.rum.tracking.FragmentViewTrackingStrategy : ActivityLi
   override fun onActivityStopped(android.app.Activity)
   override fun equals(Any?): Boolean
   override fun hashCode(): Int
+interface com.datadog.android.rum.tracking.InteractionPredicate
+  fun getTargetName(Any): String?
 class com.datadog.android.rum.tracking.MixedViewTrackingStrategy : ActivityLifecycleTrackingStrategy, ViewTrackingStrategy
   constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities(), ComponentPredicate<androidx.fragment.app.Fragment> = AcceptAllSupportFragments(), ComponentPredicate<android.app.Fragment> = AcceptAllDefaultFragment())
   override fun onActivityCreated(android.app.Activity, android.os.Bundle?)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesUtils.kt
@@ -2,6 +2,20 @@ package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.content.res.Resources
 import com.datadog.android.core.internal.CoreFeature
+import com.datadog.android.rum.tracking.InteractionPredicate
+
+internal fun resolveTargetName(
+    interactionPredicate: InteractionPredicate,
+    target: Any,
+    targetId: String
+): String {
+    val customTargetName = interactionPredicate.getTargetName(target)
+    return if (!customTargetName.isNullOrEmpty()) {
+        customTargetName
+    } else {
+        targetName(target, targetId)
+    }
+}
 
 internal fun targetName(target: Any, id: String): String {
     return "${target.javaClass.simpleName}($id)"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ComponentPredicate.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ComponentPredicate.kt
@@ -26,7 +26,7 @@ interface ComponentPredicate<T> {
     fun accept(component: T): Boolean
 
     /**
-     * Sets a custome name for the tracked RUM View.
+     * Sets a custom name for the tracked RUM View.
      * @return the name to use for this view (if null or blank, the default will be used)
      */
     fun getViewName(component: T): String?

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/InteractionPredicate.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/InteractionPredicate.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.tracking
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+/**
+ * Provides custom attributes for the events produced by the user action tracking strategy.
+ */
+@NoOpImplementation
+interface InteractionPredicate {
+    /**
+     * Sets a custom name for the intercepted touch target.
+     * @return the name to use for this touch target (if null or blank, the default will be used)
+     */
+    fun getTargetName(target: Any): String?
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -30,6 +30,8 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
+import com.datadog.android.rum.tracking.InteractionPredicate
+import com.datadog.android.rum.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import com.datadog.android.utils.forge.Configurator
@@ -135,7 +137,8 @@ internal class ConfigurationBuilderTest {
                 samplingRate = Configuration.DEFAULT_SAMPLING_RATE,
                 userActionTrackingStrategy = UserActionTrackingStrategyLegacy(
                     DatadogGesturesTracker(
-                        arrayOf(JetpackViewAttributesProvider())
+                        arrayOf(JetpackViewAttributesProvider()),
+                        NoOpInteractionPredicate()
                     )
                 ),
                 viewTrackingStrategy = ActivityViewTrackingStrategy(false),
@@ -320,7 +323,7 @@ internal class ConfigurationBuilderTest {
     }
 
     @Test
-    fun `𝕄 build config with gestures enabled 𝕎 trackInteractions() and build()`(
+    fun `𝕄 bundle the custom attributes providers W trackInteractions()`(
         @IntForgery(0, 10) attributesCount: Int
     ) {
         // Given
@@ -342,6 +345,75 @@ internal class ConfigurationBuilderTest {
         assertThat(config.rumConfig!!)
             .hasUserActionTrackingStrategyLegacy()
             .hasActionTargetAttributeProviders(mockProviders)
+            .hasViewTrackingStrategy(Configuration.DEFAULT_RUM_CONFIG.viewTrackingStrategy!!)
+            .hasLongTaskTrackingEnabled(Configuration.DEFAULT_LONG_TASK_THRESHOLD_MS)
+        assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
+    }
+
+    @Test
+    fun `𝕄 bundle only the default providers W trackInteractions { providers not provided }`() {
+        // When
+        val config = testedBuilder
+            .trackInteractions()
+            .build()
+
+        // Then
+
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig!!)
+            .hasUserActionTrackingStrategyLegacy()
+            .hasDefaultActionTargetAttributeProviders()
+            .hasViewTrackingStrategy(Configuration.DEFAULT_RUM_CONFIG.viewTrackingStrategy!!)
+            .hasLongTaskTrackingEnabled(Configuration.DEFAULT_LONG_TASK_THRESHOLD_MS)
+        assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
+    }
+
+    @Test
+    fun `𝕄 use the custom predicate 𝕎 trackInteractions()`() {
+        // Given
+        val mockInteractionPredicate: InteractionPredicate = mock()
+
+        // When
+        val config = testedBuilder
+            .trackInteractions(interactionPredicate = mockInteractionPredicate)
+            .build()
+
+        // Then
+
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig!!)
+            .hasUserActionTrackingStrategyLegacy()
+            .hasInteractionPredicate(mockInteractionPredicate)
+            .hasViewTrackingStrategy(Configuration.DEFAULT_RUM_CONFIG.viewTrackingStrategy!!)
+            .hasLongTaskTrackingEnabled(Configuration.DEFAULT_LONG_TASK_THRESHOLD_MS)
+        assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
+    }
+
+    @Test
+    fun `𝕄 use the NoOpInteractionPredicate 𝕎 trackInteractions() { predicate not provided }`() {
+        // When
+        val config = testedBuilder
+            .trackInteractions()
+            .build()
+
+        // Then
+
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig!!)
+            .hasUserActionTrackingStrategyLegacy()
+            .hasInteractionPredicateOfType(NoOpInteractionPredicate::class.java)
             .hasViewTrackingStrategy(Configuration.DEFAULT_RUM_CONFIG.viewTrackingStrategy!!)
             .hasLongTaskTrackingEnabled(Configuration.DEFAULT_LONG_TASK_THRESHOLD_MS)
         assertThat(config.internalLogsConfig).isNull()
@@ -422,7 +494,8 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 userActionTrackingStrategy = UserActionTrackingStrategyLegacy(
                     DatadogGesturesTracker(
-                        arrayOf(JetpackViewAttributesProvider())
+                        arrayOf(JetpackViewAttributesProvider()),
+                        NoOpInteractionPredicate()
                     )
                 ),
                 viewTrackingStrategy = strategy
@@ -1098,7 +1171,8 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 userActionTrackingStrategy = UserActionTrackingStrategyLegacy(
                     DatadogGesturesTracker(
-                        arrayOf(JetpackViewAttributesProvider())
+                        arrayOf(JetpackViewAttributesProvider()),
+                        NoOpInteractionPredicate()
                     )
                 )
             )
@@ -1242,7 +1316,8 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 userActionTrackingStrategy = UserActionTrackingStrategyLegacy(
                     DatadogGesturesTracker(
-                        arrayOf(JetpackViewAttributesProvider())
+                        arrayOf(JetpackViewAttributesProvider()),
+                        NoOpInteractionPredicate()
                     )
                 )
             )
@@ -1276,7 +1351,8 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 userActionTrackingStrategy = UserActionTrackingStrategyLegacy(
                     DatadogGesturesTracker(
-                        arrayOf(JetpackViewAttributesProvider())
+                        arrayOf(JetpackViewAttributesProvider()),
+                        NoOpInteractionPredicate()
                     )
                 )
             )
@@ -1375,7 +1451,8 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 userActionTrackingStrategy = UserActionTrackingStrategyLegacy(
                     DatadogGesturesTracker(
-                        arrayOf(JetpackViewAttributesProvider())
+                        arrayOf(JetpackViewAttributesProvider()),
+                        NoOpInteractionPredicate()
                     )
                 )
             )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ConfigurationRumAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ConfigurationRumAssert.kt
@@ -12,6 +12,7 @@ import com.datadog.android.rum.internal.instrumentation.UserActionTrackingStrate
 import com.datadog.android.rum.internal.instrumentation.UserActionTrackingStrategyLegacy
 import com.datadog.android.rum.internal.instrumentation.gestures.DatadogGesturesTracker
 import com.datadog.android.rum.internal.tracking.UserActionTrackingStrategy
+import com.datadog.android.rum.tracking.InteractionPredicate
 import com.datadog.android.rum.tracking.TrackingStrategy
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import org.assertj.core.api.AbstractObjectAssert
@@ -62,6 +63,34 @@ internal class ConfigurationRumAssert(actual: Configuration.Feature.RUM) :
         RumGestureTrackerAssert.assertThat(gesturesTracker as DatadogGesturesTracker)
             .hasCustomTargetAttributesProviders(providers)
             .hasDefaultTargetAttributesProviders()
+        return this
+    }
+
+    fun hasDefaultActionTargetAttributeProviders(): ConfigurationRumAssert {
+        val gesturesTracker = actual.userActionTrackingStrategy?.getGesturesTracker()
+        assertThat(gesturesTracker).isInstanceOf(DatadogGesturesTracker::class.java)
+        RumGestureTrackerAssert.assertThat(gesturesTracker as DatadogGesturesTracker)
+            .hasDefaultTargetAttributesProviders()
+        return this
+    }
+
+    fun hasInteractionPredicate(
+        interactionPredicate: InteractionPredicate
+    ): ConfigurationRumAssert {
+        val gesturesTracker = actual.userActionTrackingStrategy?.getGesturesTracker()
+        assertThat(gesturesTracker).isInstanceOf(DatadogGesturesTracker::class.java)
+        RumGestureTrackerAssert.assertThat(gesturesTracker as DatadogGesturesTracker)
+            .hasInteractionPredicate(interactionPredicate)
+        return this
+    }
+
+    fun hasInteractionPredicateOfType(
+        type: Class<*>
+    ): ConfigurationRumAssert {
+        val gesturesTracker = actual.userActionTrackingStrategy?.getGesturesTracker()
+        assertThat(gesturesTracker).isInstanceOf(DatadogGesturesTracker::class.java)
+        RumGestureTrackerAssert.assertThat(gesturesTracker as DatadogGesturesTracker)
+            .hasInteractionPredicateOfType(type)
         return this
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/RumGestureTrackerAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/RumGestureTrackerAssert.kt
@@ -8,6 +8,7 @@ package com.datadog.android.rum.assertj
 
 import com.datadog.android.rum.internal.instrumentation.gestures.DatadogGesturesTracker
 import com.datadog.android.rum.internal.tracking.JetpackViewAttributesProvider
+import com.datadog.android.rum.tracking.InteractionPredicate
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat
@@ -38,6 +39,18 @@ internal class RumGestureTrackerAssert(actual: DatadogGesturesTracker) :
         RumGestureTrackerAssert {
             assertThat(actual.targetAttributesProviders)
                 .containsAll(customProviders.toMutableList())
+            return this
+        }
+
+    fun hasInteractionPredicate(interactionPredicate: InteractionPredicate):
+        RumGestureTrackerAssert {
+            assertThat(actual.interactionPredicate).isEqualTo(interactionPredicate)
+            return this
+        }
+
+    fun hasInteractionPredicateOfType(type: Class<*>):
+        RumGestureTrackerAssert {
+            assertThat(actual.interactionPredicate).isInstanceOf(type)
             return this
         }
 

--- a/instrumentation-tools/src/constants.py
+++ b/instrumentation-tools/src/constants.py
@@ -46,4 +46,5 @@ IGNORED_TYPES = ["errorevent",
                  "batchsize",
                  "trackingconsentprovidercallback",
                  "uploadfrequency",
-                 "feature"]
+                 "feature",
+                 "interactionpredicate"]


### PR DESCRIPTION
### What does this PR do?

In this PR we provide a new optional argument for the Public API method: `Configuration#Builder#trackInteractions` -> `InteractionPredicate`
The `InteractionPredicate` interface can be implemented to provide a custom name for the intercepted user interaction target. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Please note that for the moment this feature will not produce any visible output on the Datadog dashboard because the `action.target.name` attribute is overridden by backend team at the intake level [See here](https://github.com/DataDog/logs-backend/blob/7a5da689f6c4f1ae62ef102033d67b1bf4da81fb/processing/src/main/java/com/dd/logs/processing/processors/AndroidRetraceProcessor.java#L174).
As a follow up, based on the resolution decided together with the Error Tracking team we will provide a new PR which will fix this problem.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

