### PR TITLE
RUMM-1268 let user enable/disable background RUM events

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -87,6 +87,7 @@ class com.datadog.android.core.configuration.Configuration
     fun setBatchSize(BatchSize): Builder
     fun setUploadFrequency(UploadFrequency): Builder
     fun sampleRumSessions(Float): Builder
+    fun trackBackgroundRumEvents(Boolean): Builder
     fun setRumViewEventMapper(com.datadog.android.event.ViewEventMapper): Builder
     fun setRumResourceEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ResourceEvent>): Builder
     fun setRumActionEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ActionEvent>): Builder

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -101,7 +101,8 @@ internal constructor(
             val userActionTrackingStrategy: UserActionTrackingStrategy?,
             val viewTrackingStrategy: ViewTrackingStrategy?,
             val longTaskTrackingStrategy: TrackingStrategy?,
-            val rumEventMapper: EventMapper<RumEvent>
+            val rumEventMapper: EventMapper<RumEvent>,
+            val backgroundEventTracking: Boolean
         ) : Feature()
     }
 
@@ -410,11 +411,25 @@ internal constructor(
          *
          * @param samplingRate the sampling rate must be a value between 0 and 100. A value of 0
          * means no RUM event will be sent, 100 means all sessions will be kept.
-         *
          */
         fun sampleRumSessions(samplingRate: Float): Builder {
             applyIfFeatureEnabled(PluginFeature.RUM, "sampleRumSessions") {
                 rumConfig = rumConfig.copy(samplingRate = samplingRate)
+            }
+            return this
+        }
+
+        /**
+         * Enables/Disables tracking RUM event when no Activity is in foreground.
+         *
+         * By default, background events are not tracked. Enabling this feature might increase the
+         * number of sessions tracked and impact your billing.
+         *
+         * @param enabled whether background events should be tracked in RUM.
+         */
+        fun trackBackgroundRumEvents(enabled: Boolean): Builder {
+            applyIfFeatureEnabled(PluginFeature.RUM, "trackBackgroundRumEvents") {
+                rumConfig = rumConfig.copy(backgroundEventTracking = enabled)
             }
             return this
         }
@@ -617,7 +632,8 @@ internal constructor(
             userActionTrackingStrategy = provideUserTrackingStrategy(emptyArray()),
             viewTrackingStrategy = ActivityViewTrackingStrategy(false),
             longTaskTrackingStrategy = MainLooperLongTaskStrategy(DEFAULT_LONG_TASK_THRESHOLD_MS),
-            rumEventMapper = NoOpEventMapper()
+            rumEventMapper = NoOpEventMapper(),
+            backgroundEventTracking = false
         )
 
         internal val ERROR_FEATURE_DISABLED = "The %s feature has been disabled in your " +

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -263,7 +263,8 @@ interface RumMonitor {
                     firstPartyHostDetector = CoreFeature.firstPartyHostDetector,
                     cpuVitalMonitor = RumFeature.cpuVitalMonitor,
                     memoryVitalMonitor = RumFeature.memoryVitalMonitor,
-                    frameRateVitalMonitor = RumFeature.frameRateVitalMonitor
+                    frameRateVitalMonitor = RumFeature.frameRateVitalMonitor,
+                    backgroundTrackingEnabled = RumFeature.backgroundEventTracking
                 )
             }
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -43,6 +43,7 @@ import java.util.concurrent.TimeUnit
 internal object RumFeature : SdkFeature<RumEvent, Configuration.Feature.RUM>() {
 
     internal var samplingRate: Float = 0f
+    internal var backgroundEventTracking: Boolean = false
 
     internal var viewTrackingStrategy: ViewTrackingStrategy = NoOpViewTrackingStrategy()
     internal var actionTrackingStrategy: UserActionTrackingStrategy =
@@ -61,6 +62,7 @@ internal object RumFeature : SdkFeature<RumEvent, Configuration.Feature.RUM>() {
 
     override fun onInitialize(context: Context, configuration: Configuration.Feature.RUM) {
         samplingRate = configuration.samplingRate
+        backgroundEventTracking = configuration.backgroundEventTracking
         rumEventMapper = configuration.rumEventMapper
 
         configuration.viewTrackingStrategy?.let { viewTrackingStrategy = it }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -15,6 +15,7 @@ import com.datadog.android.rum.internal.vitals.VitalMonitor
 internal class RumApplicationScope(
     applicationId: String,
     internal val samplingRate: Float,
+    internal val backgroundTrackingEnabled: Boolean,
     firstPartyHostDetector: FirstPartyHostDetector,
     cpuVitalMonitor: VitalMonitor,
     memoryVitalMonitor: VitalMonitor,
@@ -25,6 +26,7 @@ internal class RumApplicationScope(
     internal val childScope: RumScope = RumSessionScope(
         this,
         samplingRate,
+        backgroundTrackingEnabled,
         firstPartyHostDetector,
         cpuVitalMonitor,
         memoryVitalMonitor,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -27,6 +27,7 @@ import java.util.concurrent.atomic.AtomicLong
 internal class RumSessionScope(
     private val parentScope: RumScope,
     internal val samplingRate: Float,
+    internal val backgroundTrackingEnabled: Boolean,
     internal val firstPartyHostDetector: FirstPartyHostDetector,
     private val cpuVitalMonitor: VitalMonitor,
     private val memoryVitalMonitor: VitalMonitor,
@@ -111,11 +112,12 @@ internal class RumSessionScope(
         event: RumRawEvent,
         actualWriter: DataWriter<RumEvent>
     ) {
-        if (event is RumRawEvent.AddError ||
+        val isValidBackgroundEvent = event is RumRawEvent.AddError ||
             event is RumRawEvent.AddLongTask ||
             event is RumRawEvent.StartAction ||
             event is RumRawEvent.StartResource
-        ) {
+
+        if (isValidBackgroundEvent && backgroundTrackingEnabled) {
             // there is no active ViewScope to handle this event. We will assume the application
             // is in background and we will create a special ViewScope (background)
             // to handle all the events.

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -31,6 +31,7 @@ import java.util.concurrent.TimeUnit
 internal class DatadogRumMonitor(
     applicationId: String,
     internal val samplingRate: Float,
+    internal val backgroundTrackingEnabled: Boolean,
     private val writer: DataWriter<RumEvent>,
     internal val handler: Handler,
     firstPartyHostDetector: FirstPartyHostDetector,
@@ -43,6 +44,7 @@ internal class DatadogRumMonitor(
     internal val rootScope: RumScope = RumApplicationScope(
         applicationId,
         samplingRate,
+        backgroundTrackingEnabled,
         firstPartyHostDetector,
         cpuVitalMonitor,
         memoryVitalMonitor,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -42,6 +42,7 @@ import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -139,7 +140,8 @@ internal class ConfigurationBuilderTest {
                 ),
                 viewTrackingStrategy = ActivityViewTrackingStrategy(false),
                 rumEventMapper = NoOpEventMapper(),
-                longTaskTrackingStrategy = MainLooperLongTaskStrategy(100L)
+                longTaskTrackingStrategy = MainLooperLongTaskStrategy(100L),
+                backgroundEventTracking = false
             )
         )
         assertThat(config.internalLogsConfig).isNull()
@@ -447,6 +449,29 @@ internal class ConfigurationBuilderTest {
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 samplingRate = sampling
+            )
+        )
+        assertThat(config.internalLogsConfig).isNull()
+        assertThat(config.additionalConfig).isEmpty()
+    }
+
+    @Test
+    fun `𝕄 build config with background event 𝕎 trackBackgroundEvents() and build()`(
+        @BoolForgery backgroundEventEnabled: Boolean
+    ) {
+        // When
+        val config = testedBuilder
+            .trackBackgroundRumEvents(backgroundEventEnabled)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(
+                backgroundEventTracking = backgroundEventEnabled
             )
         )
         assertThat(config.internalLogsConfig).isNull()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
@@ -84,6 +84,7 @@ internal class RumMonitorBuilderTest {
             }
         assertThat(monitor.handler.looper).isSameAs(Looper.getMainLooper())
         assertThat(monitor.samplingRate).isEqualTo(fakeConfig.samplingRate)
+        assertThat(monitor.backgroundTrackingEnabled).isEqualTo(fakeConfig.backgroundEventTracking)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -90,6 +90,16 @@ internal class RumFeatureTest : SdkFeatureTest<RumEvent, Configuration.Feature.R
     }
 
     @Test
+    fun `𝕄 store background tracking 𝕎 initialize()`() {
+        // When
+        testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
+
+        // Then
+        assertThat(testedFeature.backgroundEventTracking)
+            .isEqualTo(fakeConfigurationFeature.backgroundEventTracking)
+    }
+
+    @Test
     fun `𝕄 store and register viewTrackingStrategy 𝕎 initialize()`() {
         // When
         testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.setFieldValue
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -66,11 +67,15 @@ internal class RumApplicationScopeTest {
     @FloatForgery(min = 0f, max = 100f)
     var fakeSamplingRate: Float = 0f
 
+    @BoolForgery
+    var fakeBackgroundTrackingEnabled: Boolean = false
+
     @BeforeEach
     fun `set up`() {
         testedScope = RumApplicationScope(
             fakeApplicationId,
             fakeSamplingRate,
+            fakeBackgroundTrackingEnabled,
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -88,6 +93,7 @@ internal class RumApplicationScopeTest {
 
         check(childScope is RumSessionScope)
         assertThat(childScope.samplingRate).isEqualTo(fakeSamplingRate)
+        assertThat(childScope.backgroundTrackingEnabled).isEqualTo(fakeBackgroundTrackingEnabled)
         assertThat(childScope.firstPartyHostDetector).isSameAs(mockDetector)
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -38,6 +38,7 @@ import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -104,12 +105,16 @@ internal class DatadogRumMonitorTest {
     @LongForgery(1000000000000, 2000000000000)
     var fakeTimestamp: Long = 0L
 
+    @BoolForgery
+    var fakeBackgroundTrackingEnabled: Boolean = false
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeAttributes = forge.exhaustiveAttributes()
         testedMonitor = DatadogRumMonitor(
             fakeApplicationId,
             fakeSamplingRate,
+            fakeBackgroundTrackingEnabled,
             mockWriter,
             mockHandler,
             mockDetector,
@@ -129,6 +134,7 @@ internal class DatadogRumMonitorTest {
         testedMonitor = DatadogRumMonitor(
             fakeApplicationId,
             fakeSamplingRate,
+            fakeBackgroundTrackingEnabled,
             mockWriter,
             mockHandler,
             mockDetector,
@@ -140,6 +146,7 @@ internal class DatadogRumMonitorTest {
         val rootScope = testedMonitor.rootScope
         check(rootScope is RumApplicationScope)
         assertThat(rootScope.samplingRate).isEqualTo(fakeSamplingRate)
+        assertThat(rootScope.backgroundTrackingEnabled).isEqualTo(fakeBackgroundTrackingEnabled)
     }
 
     @Test
@@ -1022,6 +1029,7 @@ internal class DatadogRumMonitorTest {
         testedMonitor = DatadogRumMonitor(
             fakeApplicationId,
             fakeSamplingRate,
+            fakeBackgroundTrackingEnabled,
             mockWriter,
             mockHandler,
             mockDetector,
@@ -1047,6 +1055,7 @@ internal class DatadogRumMonitorTest {
         testedMonitor = DatadogRumMonitor(
             fakeApplicationId,
             fakeSamplingRate,
+            fakeBackgroundTrackingEnabled,
             mockWriter,
             mockHandler,
             mockDetector,
@@ -1073,6 +1082,7 @@ internal class DatadogRumMonitorTest {
         testedMonitor = DatadogRumMonitor(
             fakeApplicationId,
             fakeSamplingRate,
+            fakeBackgroundTrackingEnabled,
             mockWriter,
             mockHandler,
             mockDetector,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -22,7 +22,8 @@ internal class ConfigurationRumForgeryFactory :
             userActionTrackingStrategy = mock(),
             viewTrackingStrategy = mock(),
             rumEventMapper = mock(),
-            longTaskTrackingStrategy = mock()
+            longTaskTrackingStrategy = mock(),
+            backgroundEventTracking = forge.aBool()
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

Let customers enable/disable tracking of background (view-less) events. This feature is turned off by default to avoid generating too many sessions and impact their billing.