### PR TITLE
RUMM-1493 Fix the RUM sampling nightly tests

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
@@ -599,7 +599,7 @@ class RumConfigE2ETests {
     @Test
     fun rum_config_sample_rum_sessions_75_percent_in() {
         val testMethodName = "rum_config_sample_rum_sessions_75_percent_in"
-        val eventsNumber = 10
+        val eventsNumber = 100
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
@@ -614,9 +614,12 @@ class RumConfigE2ETests {
         }
 
         repeat(eventsNumber) {
-            sendRandomRumEvent(forge, testMethodName)
+            // we do not want to add the test method name in the parent View name as
+            // this will add extra events to the monitor query value
+            sendRandomRumEvent(forge, testMethodName, parentViewEventName = "")
             // expire the session here
             GlobalRum.get().invokeMethod("resetSession")
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         }
     }
 

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBuilderE2ETests.kt
@@ -76,7 +76,7 @@ class RumMonitorBuilderE2ETests {
     @Test
     fun rum_rummonitor_builder_sample_in_75_percent() {
         val testMethodName = "rum_rummonitor_builder_sample_in_75_percent"
-        val eventsNumber = 10
+        val eventsNumber = 100
         initializeSdk(
             InstrumentationRegistry.getInstrumentation().targetContext,
             rumMonitorProvider = {
@@ -86,9 +86,12 @@ class RumMonitorBuilderE2ETests {
             }
         )
         repeat(eventsNumber) {
-            sendRandomRumEvent(forge, testMethodName)
+            // we do not want to add the test method name in the parent View name as
+            // this will add extra events to the monitor query value
+            sendRandomRumEvent(forge, testMethodName, parentViewEventName = "")
             // expire the session here
             GlobalRum.get().invokeMethod("resetSession")
+            InstrumentationRegistry.getInstrumentation().waitForIdleSync()
         }
     }
 }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumUtils.kt
@@ -29,7 +29,11 @@ fun measureRumMonitorInitialize(codeBlock: () -> RumMonitor): RumMonitor {
     return measure(INITIALIZE_RUMMONITOR_TEST_METHOD_NAME, codeBlock)
 }
 
-fun sendRandomRumEvent(forge: Forge, testMethodName: String) {
+fun sendRandomRumEvent(
+    forge: Forge,
+    testMethodName: String,
+    parentViewEventName: String = testMethodName
+) {
     when (forge.anInt(min = 0, max = 4)) {
         0 -> {
             val aViewKey = forge.aViewKey()
@@ -42,7 +46,7 @@ fun sendRandomRumEvent(forge: Forge, testMethodName: String) {
         }
         1 -> {
             val aResourceKey = forge.aResourceKey()
-            executeInsideView(forge.aViewKey(), forge.aViewName(), testMethodName) {
+            executeInsideView(forge.aViewKey(), forge.aViewName(), parentViewEventName) {
                 GlobalRum.get().startResource(
                     aResourceKey,
                     forge.aResourceMethod(),
@@ -59,7 +63,7 @@ fun sendRandomRumEvent(forge: Forge, testMethodName: String) {
             }
         }
         2 -> {
-            executeInsideView(forge.aViewKey(), forge.aViewName(), testMethodName) {
+            executeInsideView(forge.aViewKey(), forge.aViewName(), parentViewEventName) {
                 GlobalRum.get().addError(
                     forge.anErrorMessage(),
                     forge.aValueFrom(RumErrorSource::class.java),
@@ -69,7 +73,7 @@ fun sendRandomRumEvent(forge: Forge, testMethodName: String) {
             }
         }
         3 -> {
-            executeInsideView(forge.aViewKey(), forge.aViewName(), testMethodName) {
+            executeInsideView(forge.aViewKey(), forge.aViewName(), parentViewEventName) {
                 GlobalRum.get().addUserAction(
                     forge.aValueFrom(RumActionType::class.java),
                     forge.anActionName(),


### PR DESCRIPTION
### What does this PR do?

There were several issues with our nightly tests for the RUM session sampling API :
- the test instrumentation was broken as we were sending the `test_method_name` parameter also for the `View` events that should only have bundled the actual (assertable) action or resource event.
- we were not sending enough events to have a lower deviation rate when sampling the sessions and therefore we were always reaching the limit in the monitors

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

