### PR TITLE
Standardizing Italics in RUM Docs

### DIFF
--- a/docs/rum_getting_started.md
+++ b/docs/rum_getting_started.md
@@ -1,6 +1,6 @@
 # Getting Started with Android RUM Collection
 
-Datadog *Real User Monitoring (RUM)* enables you to visualize and analyze the real-time performance and user journeys of your application's individual users.
+Datadog Real User Monitoring (RUM) enables you to visualize and analyze the real-time performance and user journeys of your application's individual users.
 
 ## Setup
 
@@ -14,7 +14,7 @@ Datadog *Real User Monitoring (RUM)* enables you to visualize and analyze the re
 
 ### Declare SDK as dependency
 
-Declare [dd-sdk-android][1] and [gradle plugin][13] as a dependency in your `build.gradle` file:
+Declare [dd-sdk-android][1] and the [gradle plugin][13] as a dependency in your `build.gradle` file:
 
 ```
 plugins {


### PR DESCRIPTION
### What does this PR do?

Standardize the use of italics documented in Writing Style (Docs4Docs).

### Motivation

Italics are used to introduce product names and features in product landing pages (the parent page in the TOC). Child pages underneath the parent page do not use italics to discuss product names and features.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

