### PR TITLE
RUMM-1508: Update OkHttp version to 3.12.13 to prevent crashes on the recent Android versions

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -12,7 +12,7 @@ object Dependencies {
         // Commons
         const val Kotlin = "1.4.20"
         const val Gson = "2.8.6"
-        const val OkHttp = "3.12.6"
+        const val OkHttp = "3.12.13"
         const val KronosNTP = "0.0.1-alpha10"
 
         // Android

--- a/dd-sdk-android-coil/transitiveDependencies
+++ b/dd-sdk-android-coil/transitiveDependencies
@@ -3,7 +3,7 @@ Dependencies List
 androidx.annotation:annotation:1.1.0                            :   27 Kb
 androidx.lifecycle:lifecycle-common-java8:2.2.0                 : 1015 b 
 androidx.lifecycle:lifecycle-common:2.2.0                       :   21 Kb
-com.squareup.okhttp3:okhttp:3.12.12                             :  417 Kb
+com.squareup.okhttp3:okhttp:3.12.13                             :  417 Kb
 com.squareup.okio:okio:2.9.0                                    :  247 Kb
 io.coil-kt:coil-base:1.0.0                                      :  395 Kb
 io.coil-kt:coil:1.0.0                                           :   15 Kb

--- a/dd-sdk-android-fresco/transitiveDependencies
+++ b/dd-sdk-android-fresco/transitiveDependencies
@@ -12,7 +12,7 @@ com.facebook.fresco:memory-type-java:2.3.0                      :    3 Kb
 com.facebook.fresco:memory-type-native:2.3.0                    :    4 Kb
 com.facebook.fresco:nativeimagefilters:2.3.0                    :   52 Kb
 com.facebook.fresco:nativeimagetranscoder:2.3.0                 :  764 Kb
-com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
+com.squareup.okhttp3:okhttp:3.12.13                             :  417 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb

--- a/dd-sdk-android-glide/transitiveDependencies
+++ b/dd-sdk-android-glide/transitiveDependencies
@@ -38,7 +38,7 @@ com.github.bumptech.glide:disklrucache:4.11.0                   :   19 Kb
 com.github.bumptech.glide:gifdecoder:4.11.0                     :   17 Kb
 com.github.bumptech.glide:glide:4.11.0                          :  614 Kb
 com.github.bumptech.glide:okhttp3-integration:4.11.0            :    8 Kb
-com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
+com.squareup.okhttp3:okhttp:3.12.13                             :  417 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb

--- a/dd-sdk-android-ktx/transitiveDependencies
+++ b/dd-sdk-android-ktx/transitiveDependencies
@@ -1,7 +1,7 @@
 Dependencies List
 
 androidx.annotation:annotation:1.1.0                            :   27 Kb
-com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
+com.squareup.okhttp3:okhttp:3.12.13                             :  417 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb

--- a/dd-sdk-android-ndk/transitiveDependencies
+++ b/dd-sdk-android-ndk/transitiveDependencies
@@ -1,7 +1,7 @@
 Dependencies List
 
 androidx.multidex:multidex:2.0.1                                :   26 Kb
-com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
+com.squareup.okhttp3:okhttp:3.12.13                             :  417 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.4.20                       : 1453 Kb

--- a/dd-sdk-android-rx/transitiveDependencies
+++ b/dd-sdk-android-rx/transitiveDependencies
@@ -1,6 +1,6 @@
 Dependencies List
 
-com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
+com.squareup.okhttp3:okhttp:3.12.13                             :  417 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 io.reactivex.rxjava3:rxjava:3.0.0                               :    2 Mb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.4.20                :  186 Kb

--- a/dd-sdk-android-sqldelight/transitiveDependencies
+++ b/dd-sdk-android-sqldelight/transitiveDependencies
@@ -2,7 +2,7 @@ Dependencies List
 
 androidx.annotation:annotation:1.1.0                            :   27 Kb
 androidx.sqlite:sqlite:2.1.0                                    :   10 Kb
-com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
+com.squareup.okhttp3:okhttp:3.12.13                             :  417 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 com.squareup.sqldelight:android-driver:1.4.3                    :   22 Kb
 com.squareup.sqldelight:runtime-jvm:1.4.3                       :   42 Kb

--- a/dd-sdk-android/transitiveDependencies
+++ b/dd-sdk-android/transitiveDependencies
@@ -33,7 +33,7 @@ com.google.code.gson:gson:2.8.6                                 :  234 Kb
 com.google.guava:listenablefuture:1.0                           :    3 Kb
 com.lyft.kronos:kronos-android:0.0.1-alpha10                    :    5 Kb
 com.lyft.kronos:kronos-java:0.0.1-alpha10                       :   29 Kb
-com.squareup.okhttp3:okhttp:3.12.6                              :  413 Kb
+com.squareup.okhttp3:okhttp:3.12.13                             :  417 Kb
 com.squareup.okio:okio:1.15.0                                   :   86 Kb
 io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 io.opentracing:opentracing-noop:0.32.0                          :   10 Kb


### PR DESCRIPTION
### What does this PR do?

This change fixes (or at least should fix, because I didn't manage to reproduce the crash in the sample app running Android API 30, but maybe it can depend on OEM) the issue reported at https://github.com/DataDog/dd-sdk-android/issues/658 by upgrading OkHttp version from `3.12.6` to the most recent `3.12.13`. Change is verified - I can see events in the Dashboard from sample app.

OkHttp 3.x changelog https://square.github.io/okhttp/changelog_3x/#version-31213
OkHttp `3.12.6` to `3.12.13` commits https://github.com/square/okhttp/compare/parent-3.12.6...parent-3.12.13 (there are only bugfixes there).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

