### PR TITLE
RUMM-1507 Fix NDK NPE crash in signal_monitor

### DIFF
--- a/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.cpp
+++ b/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.cpp
@@ -107,7 +107,7 @@ Java_com_datadog_android_ndk_NdkCrashReportsPlugin_registerSignalHandler(
 
     update_main_context(env, storage_path);
     update_tracking_consent(consent);
-    install_signal_handlers();
+    start_monitoring();
 }
 
 
@@ -115,7 +115,7 @@ extern "C" JNIEXPORT void JNICALL
 Java_com_datadog_android_ndk_NdkCrashReportsPlugin_unregisterSignalHandler(
         JNIEnv *env,
         jobject /* this */) {
-    uninstall_signal_handlers();
+    stop_monitoring();
 }
 
 extern "C" JNIEXPORT void JNICALL

--- a/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.h
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.h
@@ -11,6 +11,7 @@
 #include <jni.h>
 #include <stdbool.h>
 
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -20,13 +21,13 @@ extern "C" {
  * serialize to disk and invoke the previously-installed handler
  * @return true if monitoring started successfully
  */
-bool install_signal_handlers();
+bool start_monitoring();
 
 /**
  * Stop monitoring for fatal exceptions and reinstall previously-installed
  * handlers
  */
-void uninstall_signal_handlers(void);
+void stop_monitoring(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### What does this PR do?

There was a NPE crash in the `signal-monitor#handle-signal` function. 
The main issue was :

-  in the `handle-signal` function after serializing and persisting the `NDK crash log` we were delegating the intercepted `signal` to the original handler and before
- because we wanted to avoid a continuous loop we will first deregister our handlers 
- in the `uninstall_handlers` function we were also deallocating the memory but because the memory therefore deallocating also the memory which was holding the original handlers. The main reason this crash was not reproduced every time is that the memory is not deallocated synchronously therefore in most of the time the original handlers were were still there when calling the next method.

Also have in mind that this crash is not very dangerous for our users, this only happens when the process already crashed. Before getting this NPE we are also already persisting the NDK crash log so the information will be there to be sent. The only bad outcome is that this will appear in the crash log instead of the original crash stacktrace.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

