### PR TITLE
RUMM-1515: Support proper serialization for nested maps in custom user attributes

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
@@ -52,6 +52,7 @@ internal fun Any?.toJsonElement(): JsonElement {
         is String -> JsonPrimitive(this)
         is Date -> JsonPrimitive(this.time)
         is Iterable<*> -> this.toJsonArray()
+        is Map<*, *> -> this.toJsonObject()
         is JsonObject -> this
         is JsonArray -> this
         is JsonPrimitive -> this
@@ -84,6 +85,14 @@ internal fun Iterable<*>.toJsonArray(): JsonElement {
         array.add(it.toJsonElement())
     }
     return array
+}
+
+internal fun Map<*, *>.toJsonObject(): JsonElement {
+    val obj = JsonObject()
+    forEach {
+        obj.add(it.key.toString(), it.value.toJsonElement())
+    }
+    return obj
 }
 
 internal fun JsonObject.asMap(): Map<String, Any?> {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/JsonObjectAssertExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/JsonObjectAssertExt.kt
@@ -8,6 +8,7 @@ package com.datadog.android.log.assertj
 
 import com.datadog.android.core.internal.utils.NULL_MAP_VALUE
 import com.datadog.android.core.internal.utils.toJsonArray
+import com.datadog.android.core.internal.utils.toJsonObject
 import com.datadog.tools.unit.assertj.JsonObjectAssert
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
@@ -34,6 +35,7 @@ fun JsonObjectAssert.containsExtraAttributes(
                 is JsonObject -> hasField(key, value)
                 is JsonArray -> hasField(key, value)
                 is Iterable<*> -> hasField(key, value.toJsonArray())
+                is Map<*, *> -> hasField(key, value.toJsonObject())
                 else -> hasField(key, value.toString())
             }
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.rum.internal.domain.event
 
 import com.datadog.android.core.internal.constraints.DataConstraints
 import com.datadog.android.core.internal.utils.toJsonArray
+import com.datadog.android.core.internal.utils.toJsonObject
 import com.datadog.android.core.model.UserInfo
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.model.ActionEvent
@@ -505,6 +506,7 @@ internal class RumEventSerializerTest {
                     is JsonObject -> assertThat(jsonObject).hasField(keyName, value)
                     is JsonArray -> assertThat(jsonObject).hasField(keyName, value)
                     is Iterable<*> -> assertThat(jsonObject).hasField(keyName, value.toJsonArray())
+                    is Map<*, *> -> assertThat(jsonObject).hasField(keyName, value.toJsonObject())
                     else -> assertThat(jsonObject).hasField(keyName, value.toString())
                 }
             }
@@ -525,6 +527,7 @@ internal class RumEventSerializerTest {
                     is JsonObject -> assertThat(jsonObject).hasField(keyName, value)
                     is JsonArray -> assertThat(jsonObject).hasField(keyName, value)
                     is Iterable<*> -> assertThat(jsonObject).hasField(keyName, value.toJsonArray())
+                    is Map<*, *> -> assertThat(jsonObject).hasField(keyName, value.toJsonObject())
                     else -> assertThat(jsonObject).hasField(keyName, value.toString())
                 }
             }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -119,7 +119,7 @@ internal class RumActionScopeTest {
     fun `𝕄 send Action after threshold 𝕎 handleEvent(StartResource+StopResource+any)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         @LongForgery(200, 600) statusCode: Long,
         @LongForgery(0, 1024) size: Long,
         @Forgery kind: RumResourceKind
@@ -167,7 +167,7 @@ internal class RumActionScopeTest {
         @StringForgery key: String,
         @StringForgery key2: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         @LongForgery(200, 600) statusCode: Long,
         @LongForgery(0, 1024) size: Long,
         @Forgery kind: RumResourceKind
@@ -193,7 +193,7 @@ internal class RumActionScopeTest {
     fun `𝕄 send Action after threshold 𝕎 handleEvent(StartResource+StopResourceWithError+any)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         @LongForgery(200, 600) statusCode: Long,
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
@@ -249,7 +249,7 @@ internal class RumActionScopeTest {
         @StringForgery key: String,
         @StringForgery key2: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         @LongForgery(200, 600) statusCode: Long,
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
@@ -282,7 +282,7 @@ internal class RumActionScopeTest {
     @Test
     fun `𝕄 send Action after threshold 𝕎 handleEvent(StartResource+any) missing resource key`(
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // Given
         var key: Any? = Object()
@@ -1008,7 +1008,7 @@ internal class RumActionScopeTest {
     fun `𝕄 doNothing 𝕎 handleEvent(StartResource+any)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
@@ -1026,7 +1026,7 @@ internal class RumActionScopeTest {
     fun `𝕄 send Action after timeout 𝕎 handleEvent(StartResource+any)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -308,7 +308,7 @@ internal class RumContinuousActionScopeTest {
     fun `𝕄 send Action after threshold 𝕎 handleEvent(StartResource+StopAction+StopResource+any)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         @LongForgery(200, 600) statusCode: Long,
         @LongForgery(0, 1024) size: Long,
         @Forgery kind: RumResourceKind
@@ -356,7 +356,7 @@ internal class RumContinuousActionScopeTest {
     fun `𝕄 send Action 𝕎 handleEvent(StartResource+StopAction+StopResourceWithError+any)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         @LongForgery(200, 600) statusCode: Long,
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
@@ -411,7 +411,7 @@ internal class RumContinuousActionScopeTest {
     @Test
     fun `𝕄 send Action 𝕎 handleEvent(StartResource+StopAction+any) missing resource key`(
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // Given
         var key: Any? = Object()
@@ -1099,7 +1099,7 @@ internal class RumContinuousActionScopeTest {
     fun `𝕄 do nothing 𝕎 handleEvent(StartResource+any)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
@@ -1117,7 +1117,7 @@ internal class RumContinuousActionScopeTest {
     fun `𝕄 do nothing 𝕎 handleEvent(StartResource+StopAction+any)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
@@ -1139,7 +1139,7 @@ internal class RumContinuousActionScopeTest {
     fun `𝕄 send Action after timeout 𝕎 handleEvent(StartResource+any)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
@@ -1177,7 +1177,7 @@ internal class RumContinuousActionScopeTest {
     fun `𝕄 send Action after timeout 𝕎 handleEvent(StartResource+StopAction+any)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -85,7 +85,7 @@ internal class RumResourceScopeTest {
     @Mock
     lateinit var mockDetector: FirstPartyHostDetector
 
-    @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+")
+    @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+")
     lateinit var fakeUrl: String
     lateinit var fakeKey: String
     lateinit var fakeMethod: String

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -1945,7 +1945,7 @@ internal class RumViewScopeTest {
     fun `𝕄 create ResourceScope 𝕎 handleEvent(StartResource)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         forge: Forge
     ) {
         // Given
@@ -1977,7 +1977,7 @@ internal class RumViewScopeTest {
     fun `𝕄 create ResourceScope with active actionId 𝕎 handleEvent(StartResource)`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         forge: Forge
     ) {
         // Given
@@ -2061,7 +2061,7 @@ internal class RumViewScopeTest {
     fun `𝕄 wait for pending Resource 𝕎 handleEvent(StartResource) on active view`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         // Given
         testedScope.pendingResourceCount = 0

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -265,7 +265,7 @@ internal class DatadogRumMonitorTest {
     fun `M delegate event to rootScope W startResource()`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         testedMonitor.startResource(key, method, url, fakeAttributes)
         Thread.sleep(PROCESSING_DELAY)
@@ -673,7 +673,7 @@ internal class DatadogRumMonitorTest {
     fun `M delegate event to rootScope with timestamp W startResource()`(
         @StringForgery key: String,
         @StringForgery method: String,
-        @StringForgery(regex = "http(s?)://[a-z]+.com/[a-z]+") url: String
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
     ) {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/assertj/JsonElementAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/assertj/JsonElementAssert.kt
@@ -33,7 +33,7 @@ internal class JsonElementAssert(actual: JsonElement) :
             is String -> Assertions.assertThat(actual.asString).isEqualTo(expected)
             is Date -> Assertions.assertThat(actual.asLong).isEqualTo(expected.time)
             is JsonNull -> Assertions.assertThat(actual).isEqualTo(JsonNull.INSTANCE)
-            is JsonObject -> Assertions.assertThat(actual.toString()).isEqualTo(expected.toString())
+            is JsonObject -> Assertions.assertThat(actual.asJsonObject).isEqualTo(expected)
             is JsonArray -> Assertions.assertThat(actual.asJsonArray).isEqualTo(expected)
             is Iterable<*> -> Assertions.assertThat(actual.asJsonArray).isEqualTo(
                 expected.toJsonArray()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/assertj/JsonElementAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/assertj/JsonElementAssert.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.utils.assertj
 
 import com.datadog.android.core.internal.utils.toJsonArray
+import com.datadog.android.core.internal.utils.toJsonObject
 import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonNull
@@ -36,6 +37,9 @@ internal class JsonElementAssert(actual: JsonElement) :
             is JsonArray -> Assertions.assertThat(actual.asJsonArray).isEqualTo(expected)
             is Iterable<*> -> Assertions.assertThat(actual.asJsonArray).isEqualTo(
                 expected.toJsonArray()
+            )
+            is Map<*, *> -> Assertions.assertThat(actual.asJsonObject).isEqualTo(
+                expected.toJsonObject()
             )
             else -> Assertions.assertThat(actual.asString).isEqualTo(expected.toString())
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ForgeExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ForgeExt.kt
@@ -44,6 +44,9 @@ internal fun Forge.exhaustiveAttributes(
         .toMap().toMutableMap()
     map[""] = anHexadecimalString()
     map[aWhitespaceString()] = anHexadecimalString()
+    map[anAlphabeticalString()] = aMap {
+        anAlphaNumericalString() to anAlphaNumericalString()
+    }
 
     val filtered = map.filterKeys { it !in excludedKeys }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ForgeExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ForgeExt.kt
@@ -25,27 +25,12 @@ internal fun Forge.exhaustiveAttributes(
     excludedKeys: Set<String> = emptySet(),
     filterThreshold: Float = 0.5f
 ): Map<String, Any?> {
-    val map = listOf(
-        aBool(),
-        anInt(),
-        aLong(),
-        aFloat(),
-        aDouble(),
-        anAsciiString(),
-        getForgery<Date>(),
-        getForgery<Locale>(),
-        getForgery<TimeZone>(),
-        getForgery<File>(),
-        getForgery<JsonObject>(),
-        getForgery<JsonArray>(),
-        aList { anAlphabeticalString() },
-        null
-    ).map { anAlphabeticalString() to it }
-        .toMap().toMutableMap()
+    val map = generateMapWithExhaustiveValues(this).toMutableMap()
+
     map[""] = anHexadecimalString()
     map[aWhitespaceString()] = anHexadecimalString()
-    map[anAlphabeticalString()] = aMap {
-        anAlphaNumericalString() to anAlphaNumericalString()
+    map[anAlphabeticalString()] = generateMapWithExhaustiveValues(this).toMutableMap().apply {
+        this[anAlphabeticalString()] = generateMapWithExhaustiveValues(this@exhaustiveAttributes)
     }
 
     val filtered = map.filterKeys { it !in excludedKeys }
@@ -97,4 +82,29 @@ private fun assumeDifferenceIsNoMore(result: Int, base: Int, maxDifference: Floa
         diff <= maxDifference,
         "Too many elements removed, condition cannot be satisfied."
     )
+}
+
+private fun generateMapWithExhaustiveValues(forge: Forge): Map<String, Any?> {
+    return forge.run {
+        listOf(
+            aBool(),
+            anInt(),
+            aLong(),
+            // TODO RUMM-1531 put it back once proper JSON assertions are ready
+            // aFloat(),
+            aDouble(),
+            anAsciiString(),
+            getForgery<Date>(),
+            getForgery<Locale>(),
+            getForgery<TimeZone>(),
+            getForgery<File>(),
+            getForgery<JsonObject>(),
+            getForgery<JsonArray>(),
+            aList { anAlphabeticalString() },
+            aList { aDouble() },
+            null
+        )
+            .map { anAlphaNumericalString() to it }
+            .toMap()
+    }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/JsonArrayForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/JsonArrayForgeryFactory.kt
@@ -17,7 +17,7 @@ class JsonArrayForgeryFactory : ForgeryFactory<JsonArray> {
             JsonArray(),
             forge.aStringArray(),
             forge.anIntArray(),
-            forge.aFloatArray()
+            forge.aDoubleArray()
         )
     }
 
@@ -37,9 +37,9 @@ class JsonArrayForgeryFactory : ForgeryFactory<JsonArray> {
         }
     }
 
-    private fun Forge.aFloatArray(): JsonArray {
+    private fun Forge.aDoubleArray(): JsonArray {
         return JsonArray().apply {
-            aList { anInt() }
+            aList { aDouble() }
                 .forEach { add(it) }
         }
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/JsonPrimitiveForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/JsonPrimitiveForgeryFactory.kt
@@ -16,7 +16,8 @@ class JsonPrimitiveForgeryFactory : ForgeryFactory<JsonPrimitive> {
         return forge.anElementFrom(
             JsonPrimitive(forge.aBool()),
             JsonPrimitive(forge.anInt()),
-            JsonPrimitive(forge.aFloat()),
+            // TODO RUMM-1531 put it back once proper JSON assertions are ready
+            // JsonPrimitive(forge.aFloat()),
             JsonPrimitive(forge.aLong()),
             JsonPrimitive(forge.aDouble()),
             JsonPrimitive(forge.anAlphabeticalString()),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumContextForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumContextForgeryFactory.kt
@@ -18,7 +18,7 @@ internal class RumContextForgeryFactory : ForgeryFactory<RumContext> {
             sessionId = forge.getForgery<UUID>().toString(),
             viewId = forge.aNullable { getForgery<UUID>().toString() },
             viewName = forge.aNullable { forge.anAlphaNumericalString() },
-            viewUrl = forge.aStringMatching("http(s?)://[a-z]+.com/[a-z]+"),
+            viewUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/[a-z]+"),
             actionId = forge.aNullable { getForgery<UUID>().toString() }
         )
     }


### PR DESCRIPTION
### What does this PR do?

This change fixes the the serialization issue for nested maps in custom attributes. Say we have a following map `"foo" to ("bar" to "foobar")`. Before this change final JSON would look like that:

```
{
  "foo": "{bar = foobar}"
}
```
after the change:
```
{
  "foo": {
    "bar": "foobar"
  }
}
```

This was happening because we were missing `Map` case when doing conversion to `JsonElement`, so default `else` branch was used, which just converted nested map to `String`.

Why it wasn't caught by the test: test also had mistake, so that it was always asserting `Map.Entry` object instead of the actual map value, which was handled by the `else` branch.

Second commit fixes flaky tests: character `.` was used in the regex without escaping, so it had a meaning of any character instead of the original intention to have a dot.

Why it was working: because URL of format `https://foobarKcom` is still a valid URL. But very-very rare `.` resulted in a char which is not allowed by URL spec, so tests were failing with `MalformedURLException`. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

