### PR TITLE
RUMM-1519 Use Kronos time correction for Rum and Logs

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -123,6 +123,8 @@ internal object CoreFeature {
         setupOkHttpClient(configuration.needsClearTextHttp)
         firstPartyHostDetector.addKnownHosts(configuration.firstPartyHosts)
         setupExecutors()
+        // Time Provider
+        timeProvider = KronosTimeProvider(kronosClock)
         // BIG NOTE !!
         // Please do not move the block bellow.
         // The NDK crash handler `prepareData` function needs to be called exactly at this moment
@@ -192,6 +194,7 @@ internal object CoreFeature {
                     DatadogNdkCrashHandler.LOGGER_NAME,
                     networkInfoProvider,
                     userInfoProvider,
+                    timeProvider,
                     envName,
                     packageVersion
                 ),
@@ -247,9 +250,6 @@ internal object CoreFeature {
     ) {
         // Tracking Consent Provider
         trackingConsentProvider = TrackingConsentProvider(consent)
-
-        // Time Provider
-        timeProvider = KronosTimeProvider(kronosClock)
 
         // System Info Provider
         systemInfoProvider = BroadcastReceiverSystemInfoProvider()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -202,7 +202,8 @@ internal object CoreFeature {
                 RumEventDeserializer(),
                 NetworkInfoDeserializer(sdkLogger),
                 UserInfoDeserializer(sdkLogger),
-                sdkLogger
+                sdkLogger,
+                timeProvider
             )
             ndkCrashHandler.prepareData()
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/KronosTimeProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/KronosTimeProvider.kt
@@ -21,10 +21,14 @@ internal class KronosTimeProvider(
         return clock.getCurrentTimeMs()
     }
 
-    override fun getServerOffsetNanos(): Long {
+    override fun getServerOffsetMillis(): Long {
         val server = clock.getCurrentTimeMs()
         val device = System.currentTimeMillis()
         val delta = server - device
-        return TimeUnit.MILLISECONDS.toNanos(delta)
+        return delta
+    }
+
+    override fun getServerOffsetNanos(): Long {
+        return TimeUnit.MILLISECONDS.toNanos(getServerOffsetMillis())
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/TimeProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/TimeProvider.kt
@@ -16,4 +16,6 @@ internal interface TimeProvider {
     fun getServerTimestamp(): Long
 
     fun getServerOffsetNanos(): Long
+
+    fun getServerOffsetMillis(): Long
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -65,6 +65,7 @@ internal object CrashReportsFeature : SdkFeature<LogEvent, Configuration.Feature
                 DatadogExceptionHandler.LOGGER_NAME,
                 CoreFeature.networkInfoProvider,
                 CoreFeature.userInfoProvider,
+                CoreFeature.timeProvider,
                 CoreFeature.envName,
                 CoreFeature.packageVersion
             ),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -352,6 +352,7 @@ internal constructor(internal val handler: LogHandler) {
                 loggerName,
                 netInfoProvider,
                 CoreFeature.userInfoProvider,
+                CoreFeature.timeProvider,
                 CoreFeature.envName,
                 CoreFeature.packageVersion
             )
@@ -368,6 +369,7 @@ internal constructor(internal val handler: LogHandler) {
                 loggerName,
                 netInfoProvider,
                 NoOpUserInfoProvider(), // we don't want to track our customer's users
+                CoreFeature.timeProvider,
                 InternalLogsFeature.ENV_NAME,
                 CoreFeature.packageVersion
             )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogGenerator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogGenerator.kt
@@ -8,6 +8,7 @@ package com.datadog.android.log.internal.domain
 
 import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
+import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.core.model.UserInfo
 import com.datadog.android.log.LogAttributes
@@ -25,6 +26,7 @@ internal class LogGenerator(
     internal val loggerName: String,
     internal val networkInfoProvider: NetworkInfoProvider?,
     internal val userInfoProvider: UserInfoProvider,
+    internal val timeProvider: TimeProvider,
     envName: String,
     appVersion: String
 ) {
@@ -58,9 +60,10 @@ internal class LogGenerator(
         userInfo: UserInfo? = null,
         networkInfo: NetworkInfo? = null
     ): LogEvent {
+        val resolvedTimestamp = timestamp + timeProvider.getServerOffsetMillis()
         val combinedAttributes = resolveAttributes(attributes, bundleWithTraces, bundleWithRum)
         val formattedDate = synchronized(simpleDateFormat) {
-            simpleDateFormat.format(Date(timestamp))
+            simpleDateFormat.format(Date(resolvedTimestamp))
         }
         val combinedTags = resolveTags(tags)
         val error = throwable?.let {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
@@ -21,7 +21,6 @@ internal open class LogsOkHttpUploader(
 
     override fun buildQueryParams(): Map<String, Any> {
         return mutableMapOf(
-            QP_BATCH_TIME to System.currentTimeMillis(),
             QP_SOURCE to CoreFeature.sourceName
         )
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -264,7 +264,8 @@ interface RumMonitor {
                     cpuVitalMonitor = RumFeature.cpuVitalMonitor,
                     memoryVitalMonitor = RumFeature.memoryVitalMonitor,
                     frameRateVitalMonitor = RumFeature.frameRateVitalMonitor,
-                    backgroundTrackingEnabled = RumFeature.backgroundEventTracking
+                    backgroundTrackingEnabled = RumFeature.backgroundEventTracking,
+                    timeProvider = CoreFeature.timeProvider
                 )
             }
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -27,6 +27,7 @@ internal class RumActionScope(
     initialType: RumActionType,
     initialName: String,
     initialAttributes: Map<String, Any?>,
+    serverTimeOffsetInMs: Long,
     inactivityThresholdMs: Long = ACTION_INACTIVITY_MS,
     maxDurationMs: Long = ACTION_MAX_DURATION_MS
 ) : RumScope {
@@ -34,7 +35,7 @@ internal class RumActionScope(
     private val inactivityThresholdNs = TimeUnit.MILLISECONDS.toNanos(inactivityThresholdMs)
     private val maxDurationNs = TimeUnit.MILLISECONDS.toNanos(maxDurationMs)
 
-    private val eventTimestamp = eventTime.timestamp
+    internal val eventTimestamp = eventTime.timestamp + serverTimeOffsetInMs
     internal val actionId: String = UUID.randomUUID().toString()
     internal var type: RumActionType = initialType
     internal var name: String = initialName
@@ -237,7 +238,8 @@ internal class RumActionScope(
 
         fun fromEvent(
             parentScope: RumScope,
-            event: RumRawEvent.StartAction
+            event: RumRawEvent.StartAction,
+            timestampOffset: Long
         ): RumScope {
             return RumActionScope(
                 parentScope,
@@ -245,7 +247,8 @@ internal class RumActionScope(
                 event.eventTime,
                 event.type,
                 event.name,
-                event.attributes
+                event.attributes,
+                timestampOffset
             )
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -8,6 +8,7 @@ package com.datadog.android.rum.internal.domain.scope
 
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -19,7 +20,8 @@ internal class RumApplicationScope(
     firstPartyHostDetector: FirstPartyHostDetector,
     cpuVitalMonitor: VitalMonitor,
     memoryVitalMonitor: VitalMonitor,
-    frameRateVitalMonitor: VitalMonitor
+    frameRateVitalMonitor: VitalMonitor,
+    timeProvider: TimeProvider
 ) : RumScope {
 
     private val rumContext = RumContext(applicationId = applicationId)
@@ -30,7 +32,8 @@ internal class RumApplicationScope(
         firstPartyHostDetector,
         cpuVitalMonitor,
         memoryVitalMonitor,
-        frameRateVitalMonitor
+        frameRateVitalMonitor,
+        timeProvider
     )
 
     // region RumScope

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -32,6 +32,7 @@ internal class RumResourceScope(
     internal val key: String,
     eventTime: Time,
     initialAttributes: Map<String, Any?>,
+    serverTimeOffsetInMs: Long,
     internal val firstPartyHostDetector: FirstPartyHostDetector
 ) : RumScope {
 
@@ -40,7 +41,7 @@ internal class RumResourceScope(
     private var timing: ResourceTiming? = null
     private val initialContext = parentScope.getRumContext()
 
-    private val eventTimestamp = eventTime.timestamp
+    internal val eventTimestamp = eventTime.timestamp + serverTimeOffsetInMs
     private val startedNanos: Long = eventTime.nanoTime
     private val networkInfo = CoreFeature.networkInfoProvider.getLatestNetworkInfo()
 
@@ -288,7 +289,8 @@ internal class RumResourceScope(
         fun fromEvent(
             parentScope: RumScope,
             event: RumRawEvent.StartResource,
-            firstPartyHostDetector: FirstPartyHostDetector
+            firstPartyHostDetector: FirstPartyHostDetector,
+            timestampOffset: Long
         ): RumScope {
             return RumResourceScope(
                 parentScope,
@@ -297,6 +299,7 @@ internal class RumResourceScope(
                 event.key,
                 event.eventTime,
                 event.attributes,
+                timestampOffset,
                 firstPartyHostDetector
             )
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -13,6 +13,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.NoOpDataWriter
+import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.internal.domain.RumContext
@@ -32,6 +33,7 @@ internal class RumSessionScope(
     private val cpuVitalMonitor: VitalMonitor,
     private val memoryVitalMonitor: VitalMonitor,
     private val frameRateVitalMonitor: VitalMonitor,
+    private val timeProvider: TimeProvider,
     private val sessionInactivityNanos: Long = DEFAULT_SESSION_INACTIVITY_NS,
     private val sessionMaxDurationNanos: Long = DEFAULT_SESSION_MAX_DURATION_NS
 ) : RumScope {
@@ -84,7 +86,8 @@ internal class RumSessionScope(
                 firstPartyHostDetector,
                 cpuVitalMonitor,
                 memoryVitalMonitor,
-                frameRateVitalMonitor
+                frameRateVitalMonitor,
+                timeProvider
             )
             onApplicationDisplayed(event, viewScope, actualWriter)
             activeChildrenScopes.add(viewScope)
@@ -139,7 +142,8 @@ internal class RumSessionScope(
             firstPartyHostDetector,
             NoOpVitalMonitor(),
             NoOpVitalMonitor(),
-            NoOpVitalMonitor()
+            NoOpVitalMonitor(),
+            timeProvider
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.monitor
 import android.os.Handler
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -38,6 +39,7 @@ internal class DatadogRumMonitor(
     cpuVitalMonitor: VitalMonitor,
     memoryVitalMonitor: VitalMonitor,
     frameRateVitalMonitor: VitalMonitor,
+    timeProvider: TimeProvider,
     private val executorService: ExecutorService = Executors.newSingleThreadExecutor()
 ) : RumMonitor, AdvancedRumMonitor {
 
@@ -48,7 +50,8 @@ internal class DatadogRumMonitor(
         firstPartyHostDetector,
         cpuVitalMonitor,
         memoryVitalMonitor,
-        frameRateVitalMonitor
+        frameRateVitalMonitor,
+        timeProvider
     )
 
     internal val keepAliveRunnable = Runnable {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
@@ -26,7 +26,7 @@ import java.util.concurrent.TimeUnit
 internal class DatadogNdkCrashHandler(
     appContext: Context,
     private val dataPersistenceExecutorService: ExecutorService,
-    private val logGenerator: LogGenerator,
+    internal val logGenerator: LogGenerator,
     private val ndkCrashLogDeserializer: Deserializer<NdkCrashLog>,
     private val rumEventDeserializer: Deserializer<RumEvent>,
     private val networkInfoDeserializer: Deserializer<NetworkInfo>,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.ndk
 import android.content.Context
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.Deserializer
+import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.core.model.UserInfo
 import com.datadog.android.log.LogAttributes
@@ -31,7 +32,8 @@ internal class DatadogNdkCrashHandler(
     private val rumEventDeserializer: Deserializer<RumEvent>,
     private val networkInfoDeserializer: Deserializer<NetworkInfo>,
     private val userInfoDeserializer: Deserializer<UserInfo>,
-    private val internalLogger: Logger
+    private val internalLogger: Logger,
+    private val timeProvider: TimeProvider
 ) : NdkCrashHandler {
 
     private val ndkCrashDataDirectory: File = getNdkGrantedDir(appContext)
@@ -249,7 +251,7 @@ internal class DatadogNdkCrashHandler(
         }
         return RumEvent(
             ErrorEvent(
-                date = ndkCrashLog.timestamp,
+                date = ndkCrashLog.timestamp + timeProvider.getServerOffsetMillis(),
                 application = ErrorEvent.Application(bundledViewEvent.application.id),
                 service = bundledViewEvent.service,
                 session = ErrorEvent.Session(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploader.kt
@@ -38,7 +38,6 @@ internal open class RumOkHttpUploader(
 
     override fun buildQueryParams(): MutableMap<String, Any> {
         return mutableMapOf(
-            QP_BATCH_TIME to System.currentTimeMillis(),
             QP_SOURCE to CoreFeature.sourceName,
             QP_TAGS to tags
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -688,7 +688,11 @@ internal class CoreFeatureTest {
         )
 
         // Then
-        assertThat(CoreFeature.ndkCrashHandler).isInstanceOf(DatadogNdkCrashHandler::class.java)
+        assertThat(CoreFeature.ndkCrashHandler)
+            .isInstanceOfSatisfying(DatadogNdkCrashHandler::class.java) {
+                assertThat(it.logGenerator.timeProvider)
+                    .isInstanceOf(KronosTimeProvider::class.java)
+            }
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/time/KronosTimeProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/time/KronosTimeProviderTest.kt
@@ -56,7 +56,7 @@ internal class KronosTimeProviderTest {
     }
 
     @Test
-    fun `returns server time offset`() {
+    fun `returns server time offset in nanoseconds`() {
         val now = System.currentTimeMillis()
         val result = testedTimeProvider.getServerOffsetNanos()
 
@@ -64,6 +64,18 @@ internal class KronosTimeProviderTest {
         assertThat(result).isCloseTo(
             expectedOffset,
             Offset.offset(TimeUnit.MILLISECONDS.toNanos(1))
+        )
+    }
+
+    @Test
+    fun `returns server time offset in milliseconds`() {
+        val now = System.currentTimeMillis()
+        val result = testedTimeProvider.getServerOffsetMillis()
+
+        val expectedOffset = fakeDate.time - now
+        assertThat(result).isCloseTo(
+            expectedOffset,
+            Offset.offset(50L)
         )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/time/KronosTimeProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/time/KronosTimeProviderTest.kt
@@ -63,7 +63,7 @@ internal class KronosTimeProviderTest {
         val expectedOffset = TimeUnit.MILLISECONDS.toNanos(fakeDate.time - now)
         assertThat(result).isCloseTo(
             expectedOffset,
-            Offset.offset(TimeUnit.MILLISECONDS.toNanos(1))
+            Offset.offset(TimeUnit.MILLISECONDS.toNanos(TEST_OFFSET))
         )
     }
 
@@ -75,7 +75,7 @@ internal class KronosTimeProviderTest {
         val expectedOffset = fakeDate.time - now
         assertThat(result).isCloseTo(
             expectedOffset,
-            Offset.offset(50L)
+            Offset.offset(TEST_OFFSET)
         )
     }
 
@@ -84,6 +84,10 @@ internal class KronosTimeProviderTest {
         val now = System.currentTimeMillis()
         val result = testedTimeProvider.getDeviceTimestamp()
 
-        assertThat(result).isCloseTo(now, Offset.offset(50L))
+        assertThat(result).isCloseTo(now, Offset.offset(TEST_OFFSET))
+    }
+
+    companion object {
+        const val TEST_OFFSET = 10L
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import android.util.Log as AndroidLog
 import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.sampling.RateBasedSampler
@@ -234,6 +235,7 @@ internal class LoggerBuilderTest {
         assertThat(handler.logGenerator.serviceName).isEqualTo(InternalLogsFeature.SERVICE_NAME)
         assertThat(handler.logGenerator.userInfoProvider)
             .isInstanceOf(NoOpUserInfoProvider::class.java)
+        assertThat(handler.logGenerator.timeProvider).isEqualTo(CoreFeature.timeProvider)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.log.internal.logger
 
 import android.content.Context
 import android.util.Log as AndroidLog
+import android.view.Choreographer
 import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
@@ -15,6 +16,7 @@ import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.sampling.Sampler
+import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.core.model.UserInfo
 import com.datadog.android.log.LogAttributes
@@ -40,6 +42,7 @@ import com.datadog.tools.unit.setFieldValue
 import com.datadog.tools.unit.setStaticValue
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
@@ -99,6 +102,9 @@ internal class DatadogLogHandlerTest {
     lateinit var mockUserInfoProvider: UserInfoProvider
 
     @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
+    @Mock
     lateinit var mockSampler: Sampler
 
     lateinit var fakeAppVersion: String
@@ -107,6 +113,16 @@ internal class DatadogLogHandlerTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
+        // To avoid java.lang.NoClassDefFoundError: android/hardware/display/DisplayManagerGlobal.
+        // This class is only available in a real android JVM at runtime and not in a JUnit env.
+        Choreographer::class.java.setStaticValue(
+            "sThreadInstance",
+            object : ThreadLocal<Choreographer>() {
+                override fun initialValue(): Choreographer {
+                    return mock()
+                }
+            }
+        )
         fakeAppVersion = forge.aStringMatching("^[0-9]\\.[0-9]\\.[0-9]")
         fakeEnvName = forge.aStringMatching("[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]")
         fakeServiceName = forge.anAlphabeticalString()
@@ -126,6 +142,7 @@ internal class DatadogLogHandlerTest {
                 fakeLoggerName,
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
+                mockTimeProvider,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -382,6 +399,7 @@ internal class DatadogLogHandlerTest {
                 fakeLoggerName,
                 null,
                 mockUserInfoProvider,
+                mockTimeProvider,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -433,6 +451,7 @@ internal class DatadogLogHandlerTest {
                 fakeLoggerName,
                 null,
                 mockUserInfoProvider,
+                mockTimeProvider,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -587,6 +606,7 @@ internal class DatadogLogHandlerTest {
                 fakeLoggerName,
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
+                mockTimeProvider,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -622,6 +642,7 @@ internal class DatadogLogHandlerTest {
                 fakeLoggerName,
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
+                mockTimeProvider,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -654,6 +675,7 @@ internal class DatadogLogHandlerTest {
                 fakeLoggerName,
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
+                mockTimeProvider,
                 fakeEnvName,
                 fakeAppVersion
             ),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.rum.internal.domain.scope
 
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.utils.forge.Configurator
@@ -61,6 +62,9 @@ internal class RumApplicationScopeTest {
     @Mock
     lateinit var mockFrameRateVitalMonitor: VitalMonitor
 
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
 
@@ -79,7 +83,8 @@ internal class RumApplicationScopeTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor
+            mockFrameRateVitalMonitor,
+            mockTimeProvider
         )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -92,10 +92,15 @@ internal class RumContinuousActionScopeTest {
 
     lateinit var fakeEvent: RumRawEvent
 
+    var fakeServerOffset: Long = 0L
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeEventTime = Time()
-
+        val maxLimit = Long.MAX_VALUE - fakeEventTime.timestamp
+        val minLimit = -fakeEventTime.timestamp
+        fakeServerOffset =
+            forge.aLong(min = minLimit, max = maxLimit)
         fakeAttributes = forge.exhaustiveAttributes()
         fakeKey = forge.anAsciiString().toByteArray()
 
@@ -109,6 +114,7 @@ internal class RumContinuousActionScopeTest {
             fakeType,
             fakeName,
             fakeAttributes,
+            fakeServerOffset,
             TEST_INACTIVITY_MS,
             TEST_MAX_DURATION_MS
         )
@@ -196,7 +202,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(TEST_MAX_DURATION_NS)
@@ -241,7 +247,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(expectedAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasTargetName(name)
                     hasType(type)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(TEST_INACTIVITY_MS * 2))
@@ -285,7 +291,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(expectedAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasTargetName(fakeName)
                     hasType(fakeType)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(TEST_INACTIVITY_MS * 2))
@@ -331,7 +337,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(TEST_INACTIVITY_MS * 2))
@@ -387,7 +393,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(TEST_INACTIVITY_MS * 2))
@@ -434,7 +440,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationLowerThan(TimeUnit.MILLISECONDS.toNanos(TEST_INACTIVITY_MS * 2))
@@ -483,7 +489,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(TEST_INACTIVITY_MS * 2))
@@ -527,7 +533,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationLowerThan(TimeUnit.MILLISECONDS.toNanos(100))
@@ -577,7 +583,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationLowerThan(TimeUnit.MILLISECONDS.toNanos(100))
@@ -613,7 +619,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -648,7 +654,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -683,7 +689,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -721,7 +727,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -759,7 +765,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -806,7 +812,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(expectedAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -845,7 +851,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -884,7 +890,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -925,7 +931,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -964,7 +970,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -1048,7 +1054,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(RumActionType.CUSTOM)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -1154,7 +1160,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(TEST_MAX_DURATION_NS)
@@ -1195,7 +1201,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(TEST_MAX_DURATION_NS)
@@ -1237,7 +1243,7 @@ internal class RumContinuousActionScopeTest {
                 .hasAttributes(fakeAttributes)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(fakeType)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(duration)
@@ -1271,7 +1277,7 @@ internal class RumContinuousActionScopeTest {
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasActionData {
                     hasId(testedScope.actionId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasType(ActionEvent.ActionType.CUSTOM)
                     hasTargetName(fakeName)
                     hasDurationGreaterThan(1)
@@ -1291,6 +1297,10 @@ internal class RumContinuousActionScopeTest {
     }
 
     // region Internal
+
+    private fun resolveExpectedTimestamp(): Long {
+        return fakeEventTime.timestamp + fakeServerOffset
+    }
 
     private fun mockEvent(): RumRawEvent {
         val event: RumRawEvent = mock()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -100,11 +100,17 @@ internal class RumResourceScopeTest {
     @Forgery
     lateinit var fakeNetworkInfo: NetworkInfo
 
+    var fakeServerOffset: Long = 0L
+
     private lateinit var fakeEventTime: Time
 
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeEventTime = Time()
+        val maxLimit = Long.MAX_VALUE - fakeEventTime.timestamp
+        val minLimit = -fakeEventTime.timestamp
+        fakeServerOffset =
+            forge.aLong(min = minLimit, max = maxLimit)
         fakeAttributes = forge.exhaustiveAttributes()
         fakeKey = forge.anAsciiString()
         fakeMethod = forge.anElementFrom("PUT", "POST", "GET", "DELETE")
@@ -123,6 +129,7 @@ internal class RumResourceScopeTest {
             fakeKey,
             fakeEventTime,
             fakeAttributes,
+            fakeServerOffset,
             mockDetector
         )
     }
@@ -153,7 +160,7 @@ internal class RumResourceScopeTest {
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
                     hasId(testedScope.resourceId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -202,7 +209,7 @@ internal class RumResourceScopeTest {
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
                     hasId(testedScope.resourceId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -241,6 +248,7 @@ internal class RumResourceScopeTest {
             fakeKey,
             fakeEventTime,
             fakeAttributes,
+            fakeServerOffset,
             mockDetector
         )
         doAnswer { true }.whenever(mockDetector).isFirstPartyUrl(brokenUrl)
@@ -262,7 +270,7 @@ internal class RumResourceScopeTest {
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
                     hasId(testedScope.resourceId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(brokenUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -316,7 +324,7 @@ internal class RumResourceScopeTest {
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
                     hasId(testedScope.resourceId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -366,7 +374,7 @@ internal class RumResourceScopeTest {
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
                     hasId(testedScope.resourceId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -406,7 +414,7 @@ internal class RumResourceScopeTest {
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
                     hasId(testedScope.resourceId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -531,7 +539,7 @@ internal class RumResourceScopeTest {
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
                     hasId(testedScope.resourceId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -582,7 +590,7 @@ internal class RumResourceScopeTest {
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
                     hasId(testedScope.resourceId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -635,7 +643,7 @@ internal class RumResourceScopeTest {
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
                     hasId(testedScope.resourceId)
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -727,6 +735,7 @@ internal class RumResourceScopeTest {
             fakeKey,
             fakeEventTime,
             fakeAttributes,
+            fakeServerOffset,
             mockDetector
         )
         doAnswer { true }.whenever(mockDetector).isFirstPartyUrl(brokenUrl)
@@ -1041,7 +1050,7 @@ internal class RumResourceScopeTest {
                 .hasAttributes(expectedAttributes)
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -1089,7 +1098,7 @@ internal class RumResourceScopeTest {
                 .hasAttributes(expectedAttributes)
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -1138,7 +1147,7 @@ internal class RumResourceScopeTest {
                 .hasAttributes(expectedAttributes)
                 .hasUserExtraAttributes(fakeUserInfo.additionalProperties)
                 .hasResourceData {
-                    hasTimestamp(fakeEventTime.timestamp)
+                    hasTimestamp(resolveExpectedTimestamp())
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasKind(kind)
@@ -1228,6 +1237,10 @@ internal class RumResourceScopeTest {
         val event: RumRawEvent = mock()
         whenever(event.eventTime) doReturn Time()
         return event
+    }
+
+    private fun resolveExpectedTimestamp(): Long {
+        return fakeEventTime.timestamp + fakeServerOffset
     }
 
     // endregion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.Datadog
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.NoOpDataWriter
+import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.core.model.UserInfo
 import com.datadog.android.log.internal.logger.LogHandler
@@ -102,6 +103,9 @@ internal class RumSessionScopeTest {
     @Mock
     lateinit var mockFrameRateVitalMonitor: VitalMonitor
 
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
     lateinit var mockDevLogHandler: LogHandler
 
     @Forgery
@@ -136,6 +140,7 @@ internal class RumSessionScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -164,6 +169,7 @@ internal class RumSessionScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -261,6 +267,7 @@ internal class RumSessionScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -322,6 +329,7 @@ internal class RumSessionScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -505,6 +513,7 @@ internal class RumSessionScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -530,6 +539,7 @@ internal class RumSessionScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -564,6 +574,7 @@ internal class RumSessionScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -589,6 +600,7 @@ internal class RumSessionScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -614,6 +626,7 @@ internal class RumSessionScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -643,6 +656,7 @@ internal class RumSessionScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.monitor
 import android.os.Handler
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -52,7 +53,6 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -94,6 +94,9 @@ internal class DatadogRumMonitorTest {
     @Mock
     lateinit var mockFrameRateVitalMonitor: VitalMonitor
 
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
 
@@ -102,7 +105,7 @@ internal class DatadogRumMonitorTest {
     @FloatForgery(min = 0f, max = 100f)
     var fakeSamplingRate: Float = 0f
 
-    @LongForgery(1000000000000, 2000000000000)
+    @LongForgery(TIMESTAMP_MIN, TIMESTAMP_MAX)
     var fakeTimestamp: Long = 0L
 
     @BoolForgery
@@ -120,13 +123,10 @@ internal class DatadogRumMonitorTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor
+            mockFrameRateVitalMonitor,
+            mockTimeProvider
         )
         testedMonitor.setFieldValue("rootScope", mockScope)
-    }
-
-    @AfterEach
-    fun `tear down`() {
     }
 
     @Test
@@ -140,7 +140,8 @@ internal class DatadogRumMonitorTest {
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor
+            mockFrameRateVitalMonitor,
+            mockTimeProvider
         )
 
         val rootScope = testedMonitor.rootScope
@@ -1041,6 +1042,7 @@ internal class DatadogRumMonitorTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             mockExecutor
         )
 
@@ -1067,6 +1069,7 @@ internal class DatadogRumMonitorTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockTimeProvider,
             mockExecutorService
         )
 
@@ -1094,7 +1097,8 @@ internal class DatadogRumMonitorTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockExecutorService
+            mockTimeProvider,
+            mockExecutorService,
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)
 
@@ -1106,6 +1110,8 @@ internal class DatadogRumMonitorTest {
     }
 
     companion object {
+        const val TIMESTAMP_MIN = 1000000000000
+        const val TIMESTAMP_MAX = 2000000000000
         const val PROCESSING_DELAY = 100L
     }
 }


### PR DESCRIPTION
### What does this PR do?

To correct potentially corrupted system UTC time value we were using 2 different approaches for our features: for RUM and Logs we were using a server side time correction (when sending the batch we were sending also the `System.currentTimeInMillis` as a query parameter and the correction was done server side) and for Traces we were using the local `KronosTimeProvider` which is computing the time offset by using an NTP server.
To align on all features we are switching the time correction for RUM and Logs to Kronos and we are dropping the server side time correction.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

