### PR TITLE
RUMM-1516 RumActionEvent - send empty string as default target name

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -127,7 +127,7 @@ internal class GesturesListener(
         val attributes = resolveAttributes(scrollTarget, targetId, onUpEvent)
         registeredRumMonitor.stopUserAction(
             type,
-            resolveTargetName(interactionPredicate, scrollTarget, targetId),
+            resolveTargetName(interactionPredicate, scrollTarget),
             attributes
         )
     }
@@ -171,7 +171,7 @@ internal class GesturesListener(
                 }
                 GlobalRum.get().addUserAction(
                     RumActionType.TAP,
-                    resolveTargetName(interactionPredicate, target, targetId),
+                    resolveTargetName(interactionPredicate, target),
                     attributes
                 )
             }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesUtils.kt
@@ -7,18 +7,13 @@ import com.datadog.android.rum.tracking.InteractionPredicate
 internal fun resolveTargetName(
     interactionPredicate: InteractionPredicate,
     target: Any,
-    targetId: String
 ): String {
     val customTargetName = interactionPredicate.getTargetName(target)
     return if (!customTargetName.isNullOrEmpty()) {
         customTargetName
     } else {
-        targetName(target, targetId)
+        ""
     }
-}
-
-internal fun targetName(target: Any, id: String): String {
-    return "${target.javaClass.simpleName}($id)"
 }
 
 internal fun resourceIdName(id: Int): String {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
@@ -49,7 +49,7 @@ internal class WindowCallbackWrapper(
         )
         GlobalRum.get().addUserAction(
             RumActionType.TAP,
-            resolveTargetName(interactionPredicate, item, resourceId),
+            resolveTargetName(interactionPredicate, item),
             attributes
         )
         return wrappedCallback.onMenuItemSelected(featureId, item)
@@ -60,6 +60,9 @@ internal class WindowCallbackWrapper(
             // TODO RUMM-495 add a BACK action to the json schema
             val customTargetName = interactionPredicate.getTargetName(event)
             val targetName = if (customTargetName.isNullOrEmpty()) {
+                // We will keep using the default target name as we are not
+                // sending the ACTION_TARGET_CLASSNAME attribute in this case and backend will not
+                // be able to resolve the targetName.
                 BACK_DEFAULT_TARGET_NAME
             } else {
                 customTargetName

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
@@ -106,7 +106,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             val argumentCaptor = argumentCaptor<Map<String, Any?>>()
             verify(rumMonitor.mockInstance).stopUserAction(
                 eq(RumActionType.SCROLL),
-                eq(targetName(scrollingTarget, expectedResourceName)),
+                eq(""),
                 argumentCaptor.capture()
             )
             assertThat(argumentCaptor.firstValue).isEqualTo(expectedAttributes)
@@ -172,7 +172,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             val argumentCaptor = argumentCaptor<Map<String, Any?>>()
             verify(rumMonitor.mockInstance).stopUserAction(
                 eq(RumActionType.SCROLL),
-                eq(targetName(scrollingTarget, expectedResourceName)),
+                eq(""),
                 argumentCaptor.capture()
             )
             assertThat(argumentCaptor.firstValue).isEqualTo(expectedAttributes)
@@ -255,7 +255,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             val argumentCaptor1 = argumentCaptor<Map<String, Any?>>()
             verify(rumMonitor.mockInstance).stopUserAction(
                 eq(RumActionType.SCROLL),
-                eq(targetName(scrollingTarget, expectedResourceName)),
+                eq(""),
                 argumentCaptor1.capture()
             )
             assertThat(argumentCaptor1.firstValue).isEqualTo(expectedAttributes1)
@@ -263,7 +263,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             val argumentCaptor2 = argumentCaptor<Map<String, Any?>>()
             verify(rumMonitor.mockInstance).stopUserAction(
                 eq(RumActionType.SCROLL),
-                eq(targetName(scrollingTarget, expectedResourceName)),
+                eq(""),
                 argumentCaptor2.capture()
             )
             assertThat(argumentCaptor2.firstValue).isEqualTo(expectedAttributes2)
@@ -373,7 +373,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             val argumentCaptor = argumentCaptor<Map<String, Any?>>()
             verify(rumMonitor.mockInstance).stopUserAction(
                 eq(RumActionType.SWIPE),
-                eq(targetName(scrollingTarget, expectedResourceName)),
+                eq(""),
                 argumentCaptor.capture()
             )
             assertThat(argumentCaptor.firstValue).isEqualTo(expectedAttributes)
@@ -448,7 +448,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             val argumentCaptor = argumentCaptor<Map<String, Any?>>()
             verify(rumMonitor.mockInstance).stopUserAction(
                 eq(RumActionType.SWIPE),
-                eq(targetName(scrollingTarget, expectedResourceName)),
+                eq(""),
                 argumentCaptor.capture()
             )
             assertThat(argumentCaptor.firstValue).isEqualTo(expectedAttributes)
@@ -514,7 +514,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
     }
 
     @Test
-    fun `M use the default target name W scrollDetected { custom target name is empty }`(
+    fun `M use an empty target name W scrollDetected { custom target name is empty }`(
         forge: Forge
     ) {
         val startDownEvent: MotionEvent = forge.getForgery()
@@ -562,7 +562,63 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             verify(rumMonitor.mockInstance).startUserAction(RumActionType.CUSTOM, "", emptyMap())
             verify(rumMonitor.mockInstance).stopUserAction(
                 eq(RumActionType.SCROLL),
-                eq(targetName(scrollingTarget, expectedResourceName)),
+                eq(""),
+                any()
+            )
+        }
+        verifyNoMoreInteractions(rumMonitor.mockInstance)
+    }
+
+    @Test
+    fun `M use an empty target name W scrollDetected { custom target name is null }`(
+        forge: Forge
+    ) {
+        val startDownEvent: MotionEvent = forge.getForgery()
+        val listSize = forge.anInt(1, 20)
+        val intermediaryEvents =
+            forge.aList(size = listSize) { forge.getForgery(MotionEvent::class.java) }
+        val distancesX = forge.aList(listSize) { forge.aFloat() }
+        val distancesY = forge.aList(listSize) { forge.aFloat() }
+        val targetId = forge.anInt()
+        val endUpEvent = intermediaryEvents[intermediaryEvents.size - 1]
+        val scrollingTarget: ScrollableListView = mockView(
+            id = targetId,
+            forEvent = startDownEvent,
+            hitTest = true,
+            forge = forge
+        )
+        val mockInteractionPredicate: InteractionPredicate = mock {
+            whenever(it.getTargetName(scrollingTarget)).thenReturn(null)
+        }
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = startDownEvent,
+            hitTest = true,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(scrollingTarget)
+        }
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(scrollingTarget, expectedResourceName)
+        testedListener = GesturesListener(
+            WeakReference(mockWindow),
+            interactionPredicate = mockInteractionPredicate
+        )
+
+        // When
+        testedListener.onDown(startDownEvent)
+        intermediaryEvents.forEachIndexed { index, event ->
+            testedListener.onScroll(startDownEvent, event, distancesX[index], distancesY[index])
+        }
+        testedListener.onUp(endUpEvent)
+
+        // Then
+        inOrder(rumMonitor.mockInstance) {
+            verify(rumMonitor.mockInstance).startUserAction(RumActionType.CUSTOM, "", emptyMap())
+            verify(rumMonitor.mockInstance).stopUserAction(
+                eq(RumActionType.SCROLL),
+                eq(""),
                 any()
             )
         }
@@ -648,7 +704,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             val argumentCaptor1 = argumentCaptor<Map<String, Any?>>()
             verify(rumMonitor.mockInstance).stopUserAction(
                 eq(RumActionType.SWIPE),
-                eq(targetName(scrollingTarget, expectedResourceName)),
+                eq(""),
                 argumentCaptor1.capture()
             )
             assertThat(argumentCaptor1.firstValue).isEqualTo(expectedAttributes1)
@@ -656,7 +712,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
             val argumentCaptor2 = argumentCaptor<Map<String, Any?>>()
             verify(rumMonitor.mockInstance).stopUserAction(
                 eq(RumActionType.SWIPE),
-                eq(targetName(scrollingTarget, expectedResourceName)),
+                eq(""),
                 argumentCaptor2.capture()
             )
             assertThat(argumentCaptor2.firstValue).isEqualTo(expectedAttributes2)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -121,7 +121,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         testedListener.onSingleTapUp(mockEvent)
 
         // Then
-        verifyMonitorCalledWithUserAction(target, expectedResourceName)
+        verifyMonitorCalledWithUserAction(target, "", expectedResourceName)
     }
 
     @Test
@@ -158,7 +158,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         testedListener.onSingleTapUp(mockEvent)
 
         // Then
-        verifyMonitorCalledWithUserAction(target, expectedResourceName)
+        verifyMonitorCalledWithUserAction(target, "", expectedResourceName)
     }
 
     @Test
@@ -200,7 +200,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         testedListener.onSingleTapUp(mockEvent)
 
         // Then
-        verifyMonitorCalledWithUserAction(validTarget, expectedResourceName)
+        verifyMonitorCalledWithUserAction(validTarget, "", expectedResourceName)
     }
 
     @Test
@@ -241,7 +241,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         testedListener.onSingleTapUp(mockEvent)
 
         // Then
-        verifyMonitorCalledWithUserAction(validTarget, expectedResourceName)
+        verifyMonitorCalledWithUserAction(validTarget, "", expectedResourceName)
     }
 
     @Test
@@ -297,7 +297,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         testedListener.onSingleTapUp(mockEvent)
 
         // Then
-        verifyMonitorCalledWithUserAction(mockDecorView, expectedResourceName)
+        verifyMonitorCalledWithUserAction(mockDecorView, "", expectedResourceName)
     }
 
     @Test
@@ -334,7 +334,11 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         testedListener.onSingleTapUp(mockEvent)
 
         // Then
-        verifyMonitorCalledWithUserAction(validTarget, "0x${targetId.toString(16)}")
+        verifyMonitorCalledWithUserAction(
+            validTarget,
+            "",
+            "0x${targetId.toString(16)}"
+        )
     }
 
     @Test
@@ -367,7 +371,11 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         testedListener.onSingleTapUp(mockEvent)
 
         // Then
-        verifyMonitorCalledWithUserAction(validTarget, "0x${targetId.toString(16)}")
+        verifyMonitorCalledWithUserAction(
+            validTarget,
+            "",
+            "0x${targetId.toString(16)}"
+        )
     }
 
     @Test
@@ -431,13 +439,13 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         // Then
         verify(rumMonitor.mockInstance).addUserAction(
             RumActionType.TAP,
-            targetName(validTarget, expectedResourceName),
+            "",
             expectedAttributes
         )
     }
 
     @Test
-    fun `M use the class simple name as target name W tapIntercepted { cannonicalName is null }`(
+    fun `M use class simple name as target class name W tapIntercepted { cannonicalName is null }`(
         forge: Forge
     ) {
         val mockEvent: MotionEvent = forge.getForgery()
@@ -492,7 +500,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         // Then
         verify(rumMonitor.mockInstance).addUserAction(
             RumActionType.TAP,
-            targetName(validTarget, expectedResourceName),
+            "",
             expectedAttributes
         )
     }
@@ -547,7 +555,7 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
     }
 
     @Test
-    fun `M use the default target name W tapIntercepted { custom target name empty }`(
+    fun `M use empty string as target name W tapIntercepted { custom target name empty }`(
         forge: Forge
     ) {
         val mockEvent: MotionEvent = forge.getForgery()
@@ -589,17 +597,21 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
         // Then
         verify(rumMonitor.mockInstance).addUserAction(
             RumActionType.TAP,
-            targetName(validTarget, expectedResourceName),
+            "",
             expectedAttributes
         )
     }
 
     // region Internal
 
-    private fun verifyMonitorCalledWithUserAction(target: View, expectedResourceName: String) {
+    private fun verifyMonitorCalledWithUserAction(
+        target: View,
+        expectedTargetName: String,
+        expectedResourceName: String
+    ) {
         verify(rumMonitor.mockInstance).addUserAction(
             eq(RumActionType.TAP),
-            argThat { startsWith("${target.javaClass.simpleName}(") },
+            eq(expectedTargetName),
             argThat {
                 val targetClassName = target.javaClass.canonicalName
                 this[RumAttributes.ACTION_TARGET_CLASS_NAME] == targetClassName &&

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesUtilsTest.kt
@@ -72,24 +72,22 @@ class GesturesUtilsTest {
         whenever(mockInteractionPredicate.getTargetName(mockTarget)).thenReturn(fakeTargetName)
 
         // Then
-        assertThat(resolveTargetName(mockInteractionPredicate, mockTarget, fakeTargetId))
+        assertThat(resolveTargetName(mockInteractionPredicate, mockTarget))
             .isEqualTo(fakeTargetName)
     }
 
     @Test
-    fun `M return the default name W resolveTargetName { custom name empty }`() {
+    fun `M return empty string W resolveTargetName { custom name empty }`() {
         // Given
         whenever(mockInteractionPredicate.getTargetName(mockTarget)).thenReturn("")
 
         // Then
-        assertThat(resolveTargetName(mockInteractionPredicate, mockTarget, fakeTargetId))
-            .isEqualTo("${mockTarget.javaClass.simpleName}($fakeTargetId)")
+        assertThat(resolveTargetName(mockInteractionPredicate, mockTarget)).isEmpty()
     }
 
     @Test
-    fun `M return the default name W resolveTargetName { custom name null }`() {
-        assertThat(resolveTargetName(mockInteractionPredicate, mockTarget, fakeTargetId))
-            .isEqualTo("${mockTarget.javaClass.simpleName}($fakeTargetId)")
+    fun `M return  empty string  W resolveTargetName { custom name null }`() {
+        assertThat(resolveTargetName(mockInteractionPredicate, mockTarget)).isEmpty()
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapperTest.kt
@@ -139,7 +139,7 @@ internal class WindowCallbackWrapperTest {
         inOrder(mockCallback, rumMonitor.mockInstance) {
             verify(rumMonitor.mockInstance).addUserAction(
                 eq(RumActionType.TAP),
-                eq(targetName(menuItem, itemResourceName)),
+                eq(""),
                 argThat {
                     val targetClassName = menuItem.javaClass.canonicalName
                     this[RumAttributes.ACTION_TARGET_CLASS_NAME] == targetClassName &&
@@ -197,7 +197,7 @@ internal class WindowCallbackWrapperTest {
     }
 
     @Test
-    fun `M use the default target name W onMenuItemSelected { custom target empty }`(
+    fun `M use an empty target name W onMenuItemSelected { custom target empty }`(
         forge: Forge
     ) {
         // Given
@@ -228,7 +228,7 @@ internal class WindowCallbackWrapperTest {
         inOrder(mockCallback, rumMonitor.mockInstance) {
             verify(rumMonitor.mockInstance).addUserAction(
                 eq(RumActionType.TAP),
-                eq(targetName(menuItem, itemResourceName)),
+                eq(""),
                 argThat {
                     val targetClassName = menuItem.javaClass.canonicalName
                     this[RumAttributes.ACTION_TARGET_CLASS_NAME] == targetClassName &&


### PR DESCRIPTION
### What does this PR do?

Currently the `source-code-integration` team is overriding the `action.target.name` attribute in case the attribute `action.target.classname` is set. 
The reason behind this is that we are automatically resolving the `action.target.name` from the `action.target.classname` locally and in most of the cases the `classname` is obfuscated. On their end they are able to de - obfuscate first the `action.target.name` in case the `mapping.txt` was provided by the client and use this to override the `action.target.name`.

This worked fine until now when we added the possibility for the client to add its own custom `action.target.name` for each intercepted user - interaction. In order to make these 2 feature working together we will only send the custom `action.target.name` from our end and on the server side they will only override this attribute if it was not set or it is empty.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

