### PR TITLE
RUMM-1514 Nightly tests for NDK and JVM crash reporters

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -62,6 +62,7 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.lang.RuntimeException
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -62,7 +62,6 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.lang.RuntimeException
 import java.util.concurrent.CountDownLatch
-import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach

--- a/instrumented/nightly-tests/build.gradle.kts
+++ b/instrumented/nightly-tests/build.gradle.kts
@@ -43,6 +43,11 @@ android {
             nightlyTestsRumAppIdKey,
             "\"${project.findProperty(nightlyTestsRumAppIdKey)}\""
         )
+        externalNativeBuild {
+            cmake {
+                cppFlags.add("-std=c++14")
+            }
+        }
     }
 
     sourceSets.named("main") {
@@ -79,6 +84,14 @@ android {
             )
         }
     }
+
+    externalNativeBuild {
+        cmake {
+            path = File("$projectDir/src/main/cpp/CMakeLists.txt")
+            version = Dependencies.Versions.CMakeVersion
+        }
+    }
+    ndkVersion = Dependencies.Versions.NdkVersion
 }
 
 repositories {
@@ -89,6 +102,7 @@ repositories {
 
 dependencies {
     implementation(project(":dd-sdk-android"))
+    implementation(project(":dd-sdk-android-ndk"))
 
     implementation(Dependencies.Libraries.Gson)
     implementation(Dependencies.Libraries.Kotlin)

--- a/instrumented/nightly-tests/proguard-rules.pro
+++ b/instrumented/nightly-tests/proguard-rules.pro
@@ -30,3 +30,7 @@
 -keepnames class com.datadog.android.rum.internal.domain.RumContext {
     *;
 }
+
+# Required to be able to assert the intercepted exception types in the monitor
+-keepnames class com.datadog.android.nightly.exceptions.** {}
+-keepnames class com.datadog.android.nightly.services.** {}

--- a/instrumented/nightly-tests/proguard-rules.pro
+++ b/instrumented/nightly-tests/proguard-rules.pro
@@ -31,6 +31,6 @@
     *;
 }
 
-# Required to be able to assert the intercepted exception types in the monitor
+# Required to be able to assert the crash related error and log events in the Monitors
 -keepnames class com.datadog.android.nightly.exceptions.** {}
 -keepnames class com.datadog.android.nightly.services.** {}

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash/JvmCrashHandlerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash/JvmCrashHandlerE2ETests.kt
@@ -1,0 +1,110 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.crash
+
+import android.content.Intent
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
+import com.datadog.android.nightly.TEST_METHOD_NAME_KEY
+import com.datadog.android.nightly.rules.NightlyTestRule
+import com.datadog.android.nightly.services.CrashHandlerDisabledCrashService
+import com.datadog.android.nightly.services.JvmCrashService
+import com.datadog.android.nightly.services.RumDisabledCrashService
+import com.datadog.android.nightly.services.RumEnabledCrashService
+import com.datadog.android.nightly.utils.initializeSdk
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+@LargeTest
+class JvmCrashHandlerE2ETests {
+
+    @get:Rule
+    val nightlyTestRule = NightlyTestRule()
+
+    @Test
+    fun crash_reports_config_enabled() {
+        // We initialize the SDK in this process as both processes are sharing the same data
+        // storage space. Flushing the data in this process at the end of this test will also
+        // flush the data produced by the service process. Besides this our SDK has a safety
+        // measure to prevent sending an even twice from 2 different process. For this reason
+        // we are using a NoOpOkHttpUploader in case the process is not the app main process.
+        val testMethodName = "crash_reports_rum_enabled"
+        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        startService(
+            testMethodName,
+            JvmCrashService.RUM_ENABLED_SCENARIO,
+            RumEnabledCrashService::class.java
+        )
+        waitForProcessToIdle()
+        stopService(RumEnabledCrashService::class.java)
+    }
+
+    @Test
+    fun crash_reports_config_disabled() {
+        val testMethodName = "crash_reports_feature_disabled"
+        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        startService(
+            testMethodName,
+            JvmCrashService.CRASH_REPORTS_DISABLED_SCENARIO,
+            CrashHandlerDisabledCrashService::class.java
+        )
+        waitForProcessToIdle()
+        stopService(CrashHandlerDisabledCrashService::class.java)
+    }
+
+    @Test
+    fun crash_reports_rum_disabled() {
+        val testMethodName = "crash_reports_rum_disabled"
+        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        startService(
+            testMethodName,
+            JvmCrashService.RUM_DISABLED_SCENARIO,
+            RumDisabledCrashService::class.java
+        )
+        waitForProcessToIdle()
+        stopService(RumDisabledCrashService::class.java)
+    }
+
+    // region Internal
+
+    private fun <T : JvmCrashService> startService(
+        testMethodName: String,
+        testAction: String,
+        serviceClass: Class<T>
+    ) {
+        InstrumentationRegistry.getInstrumentation().targetContext.startService(
+            Intent(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                serviceClass
+            ).apply {
+                action = testAction
+                putExtra(TEST_METHOD_NAME_KEY, testMethodName)
+            }
+        )
+    }
+
+    private fun <T : JvmCrashService> stopService(serviceClass: Class<T>) {
+        InstrumentationRegistry.getInstrumentation().targetContext.stopService(
+            Intent(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                serviceClass
+            )
+        )
+    }
+
+    /**
+     * Give some time to the other process to handle the exception.
+     */
+    private fun waitForProcessToIdle() {
+        Thread.sleep(10000)
+    }
+
+    // endregion
+}

--- a/instrumented/nightly-tests/src/main/AndroidManifest.xml
+++ b/instrumented/nightly-tests/src/main/AndroidManifest.xml
@@ -17,6 +17,15 @@
         android:supportsRtl="true"
         android:theme="@style/Platform.MaterialComponents"
         tools:ignore="GoogleAppIndexingWarning,MissingApplicationIcon">
+        <service
+            android:name=".services.CrashHandlerDisabledCrashService"
+            android:process=":crashesdisabled" />
+        <service
+            android:name=".services.RumDisabledCrashService"
+            android:process=":rumdisabled" />
+        <service
+            android:name=".services.RumEnabledCrashService"
+            android:process=":rumenabled" />
     </application>
 
 </manifest>

--- a/instrumented/nightly-tests/src/main/AndroidManifest.xml
+++ b/instrumented/nightly-tests/src/main/AndroidManifest.xml
@@ -19,13 +19,19 @@
         tools:ignore="GoogleAppIndexingWarning,MissingApplicationIcon">
         <service
             android:name=".services.CrashHandlerDisabledCrashService"
-            android:process=":crashesdisabled" />
+            android:process=":crashhandler.disabled" />
         <service
             android:name=".services.RumDisabledCrashService"
-            android:process=":rumdisabled" />
+            android:process=":crahshandler.rumdisabled" />
         <service
             android:name=".services.RumEnabledCrashService"
-            android:process=":rumenabled" />
+            android:process=":crashhandler.rumenabled" />
+        <service
+            android:name=".services.NdkHandlerDisabledNdkCrashService"
+            android:process=":ndkcrashhandler.disabled" />
+        <service
+            android:name=".services.RumEnabledNdkCrashService"
+            android:process=":ndkcrashhandler.rumenabled" />
     </application>
 
 </manifest>

--- a/instrumented/nightly-tests/src/main/cpp/CMakeLists.txt
+++ b/instrumented/nightly-tests/src/main/cpp/CMakeLists.txt
@@ -1,0 +1,21 @@
+project("datadog-nightly-tests")
+cmake_minimum_required(VERSION 3.18.1)
+
+add_library( # Sets the name of the library.
+        datadog-nightly-lib
+        # Sets the library as a shared library.
+        SHARED
+        # Provides a relative path to your source file(s).
+        datadog-nightly-lib.cpp
+        )
+find_library(
+        # Sets the name of the path variable.
+        log-lib
+        # Specifies the name of the NDK library that
+        # you want CMake to locate.
+        log)
+target_link_libraries( # Specifies the target library.
+        datadog-nightly-lib
+        # Links the target library to the log library
+        # included in the NDK.
+        ${log-lib})

--- a/instrumented/nightly-tests/src/main/cpp/datadog-nightly-lib.cpp
+++ b/instrumented/nightly-tests/src/main/cpp/datadog-nightly-lib.cpp
@@ -1,0 +1,19 @@
+#include <jni.h>
+
+void crash_with_sigsegv_signal() {
+    int *pointer = nullptr;
+#pragma clang diagnostic push
+#pragma ide diagnostic ignored "NullDereferences"
+    int t = *pointer;
+#pragma clang diagnostic pop
+}
+
+
+extern "C" JNIEXPORT void JNICALL
+Java_com_datadog_android_nightly_services_NdkCrashService_simulateNdkCrash(
+        JNIEnv *env,
+        jobject thiz) {
+    crash_with_sigsegv_signal();
+}
+
+

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/exceptions/RumDisabledException.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/exceptions/RumDisabledException.kt
@@ -1,0 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.exceptions
+
+class RumDisabledException() : RuntimeException("Rum Disabled Runtime Exception")

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/exceptions/RumDisabledException.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/exceptions/RumDisabledException.kt
@@ -6,4 +6,4 @@
 
 package com.datadog.android.nightly.exceptions
 
-class RumDisabledException() : RuntimeException("Rum Disabled Runtime Exception")
+internal class RumDisabledException : RuntimeException("Rum Disabled Runtime Exception")

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/exceptions/RumEnabledException.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/exceptions/RumEnabledException.kt
@@ -6,4 +6,4 @@
 
 package com.datadog.android.nightly.exceptions
 
-class RumEnabledException() : RuntimeException("Rum Enabled Runtime Exception")
+internal class RumEnabledException : RuntimeException("Rum Enabled Runtime Exception")

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/exceptions/RumEnabledException.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/exceptions/RumEnabledException.kt
@@ -1,0 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.exceptions
+
+class RumEnabledException() : RuntimeException("Rum Enabled Runtime Exception")

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashHandlerDisabledCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashHandlerDisabledCrashService.kt
@@ -1,0 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.services
+
+class CrashHandlerDisabledCrashService : JvmCrashService()

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashHandlerDisabledCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashHandlerDisabledCrashService.kt
@@ -6,4 +6,14 @@
 
 package com.datadog.android.nightly.services
 
-class CrashHandlerDisabledCrashService : JvmCrashService()
+import android.content.Intent
+
+internal class CrashHandlerDisabledCrashService : JvmCrashService() {
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+        return super.onStartCommand(
+            intent.apply { action = CRASH_HANDLER_DISABLED_SCENARIO },
+            flags,
+            startId
+        )
+    }
+}

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashService.kt
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.services
+
+import android.app.Service
+import android.os.Bundle
+import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.nightly.BuildConfig
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumMonitor
+
+internal abstract class CrashService : Service() {
+
+    protected fun initRum(extras: Bundle?) {
+        GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
+        extras?.let { bundle ->
+            bundle.keySet().forEach {
+                GlobalRum.addAttribute(it, bundle[it])
+            }
+        }
+        GlobalRum.get().startView(this, this.javaClass.simpleName.toString())
+    }
+
+    protected fun getCredentials() = Credentials(
+        clientToken = BuildConfig.NIGHTLY_TESTS_TOKEN,
+        envName = "instrumentation",
+        variant = "",
+        rumApplicationId = BuildConfig.NIGHTLY_TESTS_RUM_APP_ID
+    )
+
+    companion object {
+        const val CRASH_HANDLER_DISABLED_SCENARIO = "crash_handler_disabled_scenario"
+        const val RUM_DISABLED_SCENARIO = "rum_disabled_scenario"
+        const val RUM_ENABLED_SCENARIO = "rum_enabled_scenario"
+    }
+}

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/JvmCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/JvmCrashService.kt
@@ -1,0 +1,101 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.services
+
+import android.app.Service
+import android.content.Intent
+import android.os.Bundle
+import android.os.Handler
+import android.os.IBinder
+import android.os.Looper
+import android.util.Log
+import com.datadog.android.Datadog
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.nightly.BuildConfig
+import com.datadog.android.nightly.exceptions.RumDisabledException
+import com.datadog.android.nightly.exceptions.RumEnabledException
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumMonitor
+
+open class JvmCrashService : Service() {
+
+    override fun onBind(intent: Intent?): IBinder? {
+        return null
+    }
+
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+        when (intent.action) {
+            CRASH_REPORTS_DISABLED_SCENARIO -> {
+                startSdk(crashReportsEnabled = false)
+                initRum(intent.extras)
+                sendException(RumEnabledException())
+            }
+            RUM_DISABLED_SCENARIO -> {
+                startSdk(rumEnabled = false)
+                sendException(RumDisabledException())
+            }
+            else -> {
+                startSdk()
+                initRum(intent.extras)
+                sendException(RumEnabledException())
+            }
+        }
+        return START_NOT_STICKY
+    }
+
+    private fun sendException(exception: Exception) {
+        // we will give time to the RUM view event to persist before crashing the process
+        Handler(Looper.getMainLooper()).postDelayed(
+            {
+                throw exception
+            },
+            1000
+        )
+    }
+
+    private fun startSdk(
+        crashReportsEnabled: Boolean = true,
+        rumEnabled: Boolean = true
+    ) {
+        Datadog.setVerbosity(Log.VERBOSE)
+        val configBuilder = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = crashReportsEnabled,
+            rumEnabled = rumEnabled
+        )
+        Datadog.initialize(
+            this,
+            Credentials(
+                clientToken = BuildConfig.NIGHTLY_TESTS_TOKEN,
+                envName = "instrumentation",
+                variant = "",
+                rumApplicationId = BuildConfig.NIGHTLY_TESTS_RUM_APP_ID
+            ),
+            configBuilder.build(),
+            TrackingConsent.GRANTED
+        )
+    }
+
+    private fun initRum(extras: Bundle?) {
+        GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
+        extras?.let { bundle ->
+            bundle.keySet().forEach {
+                GlobalRum.addAttribute(it, bundle[it])
+            }
+        }
+        GlobalRum.get().startView(this, this.javaClass.simpleName.toString())
+    }
+
+    companion object {
+        const val CRASH_REPORTS_DISABLED_SCENARIO = "crash_reports_disabled_scenario"
+        const val RUM_DISABLED_SCENARIO = "rum_disabled_scenario"
+        const val RUM_ENABLED_SCENARIO = "rum_enabled_scenario"
+    }
+}

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/NdkHandlerDisabledNdkCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/NdkHandlerDisabledNdkCrashService.kt
@@ -8,10 +8,10 @@ package com.datadog.android.nightly.services
 
 import android.content.Intent
 
-internal class RumDisabledCrashService : JvmCrashService() {
+internal class NdkHandlerDisabledNdkCrashService : NdkCrashService() {
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         return super.onStartCommand(
-            intent.apply { action = RUM_DISABLED_SCENARIO },
+            intent.apply { action = CRASH_HANDLER_DISABLED_SCENARIO },
             flags,
             startId
         )

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/RumDisabledCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/RumDisabledCrashService.kt
@@ -1,0 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.services
+
+class RumDisabledCrashService : JvmCrashService()

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/RumEnabledCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/RumEnabledCrashService.kt
@@ -1,0 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.services
+
+class RumEnabledCrashService : JvmCrashService()

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/RumEnabledCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/RumEnabledCrashService.kt
@@ -6,4 +6,14 @@
 
 package com.datadog.android.nightly.services
 
-class RumEnabledCrashService : JvmCrashService()
+import android.content.Intent
+
+internal class RumEnabledCrashService : JvmCrashService() {
+    override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
+        return super.onStartCommand(
+            intent.apply { action = RUM_ENABLED_SCENARIO },
+            flags,
+            startId
+        )
+    }
+}

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/RumEnabledNdkCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/RumEnabledNdkCrashService.kt
@@ -8,10 +8,10 @@ package com.datadog.android.nightly.services
 
 import android.content.Intent
 
-internal class RumDisabledCrashService : JvmCrashService() {
+internal class RumEnabledNdkCrashService : NdkCrashService() {
     override fun onStartCommand(intent: Intent, flags: Int, startId: Int): Int {
         return super.onStartCommand(
-            intent.apply { action = RUM_DISABLED_SCENARIO },
+            intent.apply { action = RUM_ENABLED_SCENARIO },
             flags,
             startId
         )


### PR DESCRIPTION
### What does this PR do?

In this PR we are adding the required nightly tests for the `JVM` and `NDK` crash reporters. We were able to cover all the scenarios for the `JVM` crash reporter but for the `NDK` one we are missing one scenario (when RUM is not enabled) which could not be yet solved. A separated [task](https://datadoghq.atlassian.net/browse/RUMM-1554) was opened in our JIRA board to try to tackle this later.

A bug was detected at the JVM crash reporter level. When `RUM` feature is not enabled the `onHandleException` method is not delayed enough to give time to the `Logs` `ScheduledWriter` to write the log event so in my tests this was always missing. This is the same for the `RUM` writer but for some reason this has the time to finish in time, I guess it was pure luck. I opened a [task](https://datadoghq.atlassian.net/browse/RUMM-1556) to properly investigate/fix this.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

