### PR TITLE
RUMM-1556 When intercepting crashes wait for events to be persisted

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/thread/ThreadPoolExecutorExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/thread/ThreadPoolExecutorExt.kt
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.thread
+
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+internal const val MAX_SLEEP_DURATION_IN_MS = 10L
+
+internal fun ThreadPoolExecutor.waitToIdle(timeoutInMs: Long): Boolean {
+    val startTime = System.nanoTime()
+    val timeoutInNs = TimeUnit.MILLISECONDS.toNanos(timeoutInMs)
+    val sleepDurationInMs = timeoutInMs.coerceIn(0, MAX_SLEEP_DURATION_IN_MS)
+    do {
+        if (this.taskCount - this.completedTaskCount <= 0) {
+            return true
+        }
+        Thread.sleep(sleepDurationInMs)
+    } while ((System.nanoTime() - startTime) < timeoutInNs)
+
+    return false
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/thread/ThreadPoolExecutorExtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/thread/ThreadPoolExecutorExtTest.kt
@@ -1,0 +1,181 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.thread
+
+import com.datadog.android.utils.forge.Configurator
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.concurrent.ThreadPoolExecutor
+import kotlin.system.measureTimeMillis
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class ThreadPoolExecutorExtTest {
+
+    @Mock
+    lateinit var testedMockExecutor: ThreadPoolExecutor
+
+    @Test
+    fun `M return false W waitToIdle { timeout reached }`(
+        @LongForgery(min = 0, max = 500)
+        fakeTimeout: Long,
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeTaskCount = forge.aLong(min = 2, max = 10)
+        val fakeCompletedCount = forge.aLong(min = 0, max = fakeTaskCount - 1)
+        whenever(testedMockExecutor.taskCount).thenReturn(fakeTaskCount)
+        whenever(testedMockExecutor.completedTaskCount).thenReturn(fakeCompletedCount)
+
+        // WHEN
+        val isIdled = testedMockExecutor.waitToIdle(fakeTimeout)
+
+        // THEN
+        assertThat(isIdled).isFalse()
+    }
+
+    @Test
+    fun `M wait max timeout milliseconds W waitToIdle { executor not idled }`(
+        @LongForgery(min = 500, max = 1000)
+        fakeTimeout: Long,
+        forge: Forge
+    ) {
+        // GIVEN
+        val fakeTaskCount = forge.aLong(min = 2, max = 10)
+        val fakeCompletedCount = forge.aLong(min = 0, max = fakeTaskCount - 1)
+        whenever(testedMockExecutor.taskCount).thenReturn(fakeTaskCount)
+        whenever(testedMockExecutor.completedTaskCount).thenReturn(fakeCompletedCount)
+
+        // WHEN
+        val duration = measureTimeMillis {
+            testedMockExecutor.waitToIdle(fakeTimeout)
+        }
+
+        // THEN
+        assertThat(duration).isCloseTo(fakeTimeout, Offset.offset(100))
+    }
+
+    @Test
+    fun `M return true W waitToIdle { executor idled }`(
+        @LongForgery(min = 0, max = 500)
+        fakeTimeout: Long,
+        @LongForgery(min = 0, max = 10)
+        fakeTaskCount: Long
+
+    ) {
+        // GIVEN
+        whenever(testedMockExecutor.taskCount).thenReturn(fakeTaskCount)
+        whenever(testedMockExecutor.completedTaskCount)
+            .thenReturn(fakeTaskCount)
+
+        // WHEN
+        val isIdled = testedMockExecutor.waitToIdle(fakeTimeout)
+
+        // THEN
+        assertThat(isIdled).isTrue()
+    }
+
+    @Test
+    fun `M return true W waitToIdle { executor idled after multiple iterations }`(
+        @LongForgery(
+            min = MAX_SLEEP_DURATION_IN_MS * 3,
+            max = MAX_SLEEP_DURATION_IN_MS * 4
+        )
+        fakeTimeout: Long,
+        @LongForgery(min = 0, max = 10)
+        fakeTaskCount: Long
+
+    ) {
+        // GIVEN
+        whenever(testedMockExecutor.taskCount).thenReturn(fakeTaskCount)
+        whenever(testedMockExecutor.completedTaskCount)
+            .thenReturn(fakeTaskCount / 2).thenReturn(fakeTaskCount)
+
+        // WHEN
+        val isIdled = testedMockExecutor.waitToIdle(fakeTimeout)
+
+        // THEN
+        assertThat(isIdled).isTrue()
+    }
+
+    @Test
+    fun `M return false W waitToIdle { timeout is negative, executor not idled }`(
+        @LongForgery(min = Long.MIN_VALUE, max = 0)
+        fakeTimeout: Long,
+        forge: Forge
+    ) {
+        // WHEN
+        val fakeTaskCount = forge.aLong(min = 2, max = 10)
+        val fakeCompletedCount = forge.aLong(min = 0, max = fakeTaskCount - 1)
+        whenever(testedMockExecutor.taskCount).thenReturn(fakeTaskCount)
+        whenever(testedMockExecutor.completedTaskCount).thenReturn(fakeCompletedCount)
+        val isIdled = testedMockExecutor.waitToIdle(fakeTimeout)
+
+        // THEN
+        assertThat(isIdled).isFalse()
+    }
+
+    @Test
+    fun `M return true W waitToIdle { timeout is negative, executor idled }`(
+        @LongForgery(min = Long.MIN_VALUE, max = 0)
+        fakeTimeout: Long,
+        @LongForgery(min = 0, max = 10)
+        fakeTaskCount: Long
+    ) {
+        // GIVEN
+        whenever(testedMockExecutor.taskCount).thenReturn(fakeTaskCount)
+        whenever(testedMockExecutor.completedTaskCount)
+            .thenReturn(fakeTaskCount)
+
+        // WHEN
+        val isIdled = testedMockExecutor.waitToIdle(fakeTimeout)
+
+        // THEN
+        assertThat(isIdled).isTrue()
+    }
+
+    @Test
+    fun `M return true W waitToIdle { more tasks where added between sleep intervals }`(
+        @LongForgery(
+            min = MAX_SLEEP_DURATION_IN_MS * 3,
+            max = MAX_SLEEP_DURATION_IN_MS * 4
+        )
+        fakeTimeout: Long,
+        @LongForgery(min = 0, max = 10)
+        fakeTaskCount: Long
+    ) {
+        // GIVEN
+        whenever(testedMockExecutor.taskCount)
+            .thenReturn(fakeTaskCount)
+            .thenReturn(fakeTaskCount + 2)
+        whenever(testedMockExecutor.completedTaskCount)
+            .thenReturn(fakeTaskCount / 2)
+            .thenReturn(fakeTaskCount + 2)
+
+        // WHEN
+        val isIdled = testedMockExecutor.waitToIdle(fakeTimeout)
+
+        // THEN
+        assertThat(isIdled).isTrue()
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.error.internal
 
 import android.content.Context
+import android.util.Log
 import android.view.Choreographer
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
@@ -18,6 +19,7 @@ import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.upload.UploadWorker
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.thread.waitToIdle
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.TAG_DATADOG_UPLOAD
 import com.datadog.android.core.internal.utils.UPLOAD_WORKER_NAME
@@ -26,6 +28,7 @@ import com.datadog.android.core.model.UserInfo
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.assertj.LogEventAssert.Companion.assertThat
 import com.datadog.android.log.internal.domain.LogGenerator
+import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.log.internal.user.UserInfoProvider
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.privacy.TrackingConsent
@@ -36,6 +39,7 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -48,6 +52,7 @@ import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
@@ -62,6 +67,7 @@ import java.io.FileNotFoundException
 import java.io.IOException
 import java.lang.RuntimeException
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -121,8 +127,11 @@ internal class DatadogExceptionHandlerTest {
     @StringForgery(regex = "[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]")
     lateinit var fakeEnvName: String
 
+    lateinit var mockDevLogHandler: LogHandler
+
     @BeforeEach
     fun `set up`() {
+        mockDevLogHandler = mockDevLogHandler()
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
         whenever(mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
         // To avoid java.lang.NoClassDefFoundError: android/hardware/display/DisplayManagerGlobal.
@@ -207,6 +216,43 @@ internal class DatadogExceptionHandlerTest {
                 )
         }
         verifyZeroInteractions(mockPreviousHandler)
+    }
+
+    @Test
+    fun `M wait for the executor to idle W exception caught`() {
+        val mockScheduledThreadExecutor: ThreadPoolExecutor = mock()
+        CoreFeature.persistenceExecutorService = mockScheduledThreadExecutor
+        Thread.setDefaultUncaughtExceptionHandler(null)
+        testedHandler.register()
+        val currentThread = Thread.currentThread()
+
+        testedHandler.uncaughtException(currentThread, fakeThrowable)
+
+        verify(mockScheduledThreadExecutor)
+            .waitToIdle(DatadogExceptionHandler.MAX_WAIT_FOR_IDLE_TIME_IN_MS)
+        verify(mockDevLogHandler, never()).handleLog(
+            Log.WARN,
+            DatadogExceptionHandler.EXECUTOR_NOT_IDLED_WARNING_MESSAGE
+        )
+    }
+
+    @Test
+    fun `M log warning message W exception caught { executor could not be idled }`() {
+        val mockScheduledThreadExecutor: ThreadPoolExecutor = mock {
+            whenever(it.taskCount).thenReturn(2)
+            whenever(it.completedTaskCount).thenReturn(0)
+        }
+        CoreFeature.persistenceExecutorService = mockScheduledThreadExecutor
+        Thread.setDefaultUncaughtExceptionHandler(null)
+        testedHandler.register()
+        val currentThread = Thread.currentThread()
+
+        testedHandler.uncaughtException(currentThread, fakeThrowable)
+
+        verify(mockDevLogHandler).handleLog(
+            Log.WARN,
+            DatadogExceptionHandler.EXECUTOR_NOT_IDLED_WARNING_MESSAGE
+        )
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

The JVM intercepted crash is not always persisted as a log especially when `RUM` feature is disabled and the reason why is that in both cases : `RUM` and `Logs` we are using a `ScheduledWriter` to persist the event and the `Thread` does not have time to finish before the process is killed. In this *Pr* we are fixing this issue by having the `MainThread` waiting with a minimal timeout before delegating the caught `exception` to the original handler.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

