### PR TITLE
RUMM-1538 Sanitize NDK stacktrace

### DIFF
--- a/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
@@ -56,10 +56,12 @@ namespace {
         return std::string(address_as_hexa);
     }
 
-    void get_info_from_address(size_t index, const uintptr_t address, std::string *backtrace) {
-        backtrace->append(std::to_string(index));
+    void get_info_from_address(size_t index,
+                               const uintptr_t address,
+                               std::string *backtrace) {
         Dl_info info;
         int fetch_info_success = dladdr(reinterpret_cast<void *>(address), &info);
+        backtrace->append(std::to_string(index));
         if (fetch_info_success) {
 
             if (info.dli_fname) {
@@ -98,17 +100,17 @@ bool copyString(const std::string &str, char *ptr, size_t max_size) {
     return copy_size == str_size;
 }
 
-bool generate_backtrace(char *backtrace_ptr, size_t max_size) {
+bool generate_backtrace(char *backtrace_ptr, size_t start_index, size_t max_size) {
     // define the buffer which will hold pointers to stack memory addresses
     uintptr_t buffer[max_stack_frames];
     // we will now unwind the stack and capture all the memory addresses up to max_stack_frames in
     // the buffer
     const size_t number_of_captured_frames = capture_backtrace(buffer, max_stack_frames);
     std::string backtrace;
-    for (size_t idx = 0; idx < number_of_captured_frames; ++idx) {
+    for (size_t idx = start_index; idx < number_of_captured_frames; ++idx) {
         // we will iterate through all the stack addresses and translate each address in
         // readable information
-        get_info_from_address(idx, buffer[idx], &backtrace);
+        get_info_from_address(idx - start_index, buffer[idx], &backtrace);
     }
     return copyString(backtrace, backtrace_ptr, max_size);
 }

--- a/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.h
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.h
@@ -14,12 +14,13 @@
 extern "C" {
 #endif
 
-const size_t max_stack_frames = 100;
+const size_t stack_frames_start_index = 3;
+const size_t max_stack_frames = 100 + stack_frames_start_index;
 const size_t max_characters_per_stack_frame = 2048;
 const size_t max_stack_size = max_stack_frames * max_characters_per_stack_frame;
 
 // We cannot use a namespace here as this function will be called from C file (signal_monitor.c)
-bool generate_backtrace(char *backtrace_ptr, size_t max_size);
+bool generate_backtrace(char *backtrace_ptr, size_t start_index, size_t max_size);
 
 #ifdef __cplusplus
 }

--- a/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
@@ -152,7 +152,14 @@ void handle_signal(int signum, siginfo_t *info, void *user_context) {
         if (signal == signum) {
             char backtrace[max_stack_size];
             // in case the stacktrace is bigger than the required size it will be truncated
-            generate_backtrace(backtrace, max_stack_size);
+            // because we are unwinding the stack strace at this level we are always going to
+            // to have for the top 3 levels at the top of the trace the executed lines from our
+            // library: handle_signal, generate_backtrace and capture_backtrace.
+            // Make sure that if you are changing this make sure to start from the new frame
+            // index when generating the backtrace.
+            generate_backtrace(backtrace, stack_frames_start_index, max_stack_size);
+
+
             write_crash_report(signal,
                                handled_signals[i].signal_name,
                                handled_signals[i].signal_error_message,

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/crash/CrashFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/crash/CrashFragment.kt
@@ -20,8 +20,8 @@ import androidx.lifecycle.ViewModelProviders
 import com.datadog.android.sample.R
 
 class CrashFragment :
-        Fragment(),
-        View.OnClickListener {
+    Fragment(),
+    View.OnClickListener {
 
     private lateinit var viewModel: CrashViewModel
     private lateinit var spinner: AppCompatSpinner
@@ -47,9 +47,9 @@ class CrashFragment :
 
         spinner = rootView.findViewById(R.id.signal_type_spinner)
         val arrayAdapter = ArrayAdapter(
-                currentContext,
-                android.R.layout.simple_spinner_item,
-                NATIVE_SIGNALS
+            currentContext,
+            android.R.layout.simple_spinner_item,
+            NATIVE_SIGNALS
         )
         arrayAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item)
         spinner.adapter = arrayAdapter
@@ -126,9 +126,9 @@ class CrashFragment :
         const val SIGSEGV = 11 // "Segmentation violation (invalid memory reference)"
 
         private val NATIVE_SIGNALS = listOf(
-                NativeSignal(SIGSEGV, "Invalid Memory"),
-                NativeSignal(SIGABRT, "Abort Program"),
-                NativeSignal(SIGILL, "Illegal Instruction")
+            NativeSignal(SIGSEGV, "Invalid Memory"),
+            NativeSignal(SIGABRT, "Abort Program"),
+            NativeSignal(SIGILL, "Illegal Instruction")
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

The generated NDK stacktrace was always containing the first 3 frames coming from our `libdatadog-native-lib.so` file as the as part of the stacktrace generation code. In order to not send false informations in the Crash reports we need to remove these 3 frames from our NDK reports stacktrace. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

