### PR TITLE
RUMM-1456 Session Listener

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -356,6 +356,7 @@ interface com.datadog.android.rum.RumMonitor
   fun addTiming(String)
   class Builder
     fun sampleRumSessions(Float): Builder
+    fun setSessionListener(RumSessionListener): Builder
     fun build(): RumMonitor
     companion object 
 interface com.datadog.android.rum.RumResourceAttributesProvider
@@ -374,6 +375,8 @@ enum com.datadog.android.rum.RumResourceKind
   - MEDIA
   - OTHER
   companion object 
+interface com.datadog.android.rum.RumSessionListener
+  fun onSessionStarted(String, Boolean)
 data class com.datadog.android.rum.model.ActionEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, ActionEventSession, View, Usr? = null, Connectivity? = null, Dd, Context? = null, Action)
   val type: kotlin.String

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -231,6 +231,7 @@ interface RumMonitor {
     class Builder {
 
         private var samplingRate: Float = RumFeature.samplingRate
+        private var sessionListener: RumSessionListener? = null
 
         /**
          * Sets the sampling rate for RUM Sessions.
@@ -240,6 +241,15 @@ interface RumMonitor {
          */
         fun sampleRumSessions(@FloatRange(from = 0.0, to = 100.0) samplingRate: Float): Builder {
             this.samplingRate = samplingRate
+            return this
+        }
+
+        /**
+         * Sets the Session listener.
+         * @param sessionListener the listener to notify whenever a new Session starts.
+         */
+        fun setSessionListener(sessionListener: RumSessionListener): Builder {
+            this.sessionListener = sessionListener
             return this
         }
 
@@ -265,7 +275,8 @@ interface RumMonitor {
                     memoryVitalMonitor = RumFeature.memoryVitalMonitor,
                     frameRateVitalMonitor = RumFeature.frameRateVitalMonitor,
                     backgroundTrackingEnabled = RumFeature.backgroundEventTracking,
-                    timeProvider = CoreFeature.timeProvider
+                    timeProvider = CoreFeature.timeProvider,
+                    sessionListener = sessionListener
                 )
             }
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumSessionListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumSessionListener.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum
+
+/**
+ * An interface to get informed whenever a new session is starting,
+ * providing you with Datadog's session id.
+ */
+interface RumSessionListener {
+
+    /**
+     * Called whenever a new session is started.
+     * @param sessionId the Session's id (matching the `session.id` attribute in Datadog's RUM events)
+     * @param isDiscarded whether or not the session is discarded by the sampling rate
+     * (when `true` it means no event in this session will be kept).
+     */
+    fun onSessionStarted(sessionId: String, isDiscarded: Boolean)
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.domain.scope
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -21,7 +22,8 @@ internal class RumApplicationScope(
     cpuVitalMonitor: VitalMonitor,
     memoryVitalMonitor: VitalMonitor,
     frameRateVitalMonitor: VitalMonitor,
-    timeProvider: TimeProvider
+    timeProvider: TimeProvider,
+    sessionListener: RumSessionListener?
 ) : RumScope {
 
     private val rumContext = RumContext(applicationId = applicationId)
@@ -33,7 +35,8 @@ internal class RumApplicationScope(
         cpuVitalMonitor,
         memoryVitalMonitor,
         frameRateVitalMonitor,
-        timeProvider
+        timeProvider,
+        sessionListener
     )
 
     // region RumScope

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -189,6 +189,7 @@ internal class RumSessionScope(
             keepSession = (random.nextFloat() * 100f) < samplingRate
             sessionStartNs.set(nanoTime)
             sessionId = UUID.randomUUID().toString()
+            sessionListener?.onSessionStarted(sessionId, !keepSession)
         }
 
         lastUserInteractionNs.set(nanoTime)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -16,6 +16,7 @@ import com.datadog.android.core.internal.persistence.NoOpDataWriter
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
@@ -34,6 +35,7 @@ internal class RumSessionScope(
     private val memoryVitalMonitor: VitalMonitor,
     private val frameRateVitalMonitor: VitalMonitor,
     private val timeProvider: TimeProvider,
+    internal val sessionListener: RumSessionListener?,
     private val sessionInactivityNanos: Long = DEFAULT_SESSION_INACTIVITY_NS,
     private val sessionMaxDurationNanos: Long = DEFAULT_SESSION_MAX_DURATION_NS
 ) : RumScope {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -15,6 +15,7 @@ import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.asTime
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
@@ -40,6 +41,7 @@ internal class DatadogRumMonitor(
     memoryVitalMonitor: VitalMonitor,
     frameRateVitalMonitor: VitalMonitor,
     timeProvider: TimeProvider,
+    sessionListener: RumSessionListener?,
     private val executorService: ExecutorService = Executors.newSingleThreadExecutor()
 ) : RumMonitor, AdvancedRumMonitor {
 
@@ -51,7 +53,8 @@ internal class DatadogRumMonitor(
         cpuVitalMonitor,
         memoryVitalMonitor,
         frameRateVitalMonitor,
-        timeProvider
+        timeProvider,
+        sessionListener
     )
 
     internal val keepAliveRunnable = Runnable {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.scope.RumApplicationScope
+import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
@@ -21,6 +22,7 @@ import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -110,6 +112,37 @@ internal class RumMonitorBuilderTest {
             }
         assertThat(monitor.handler.looper).isSameAs(Looper.getMainLooper())
         assertThat(monitor.samplingRate).isEqualTo(samplingRate)
+    }
+
+    @Test
+    fun `𝕄 builds a RumMonitor without session listener 𝕎 build()`() {
+        // When
+        val monitor = testedBuilder.build()
+
+        // Then
+        check(monitor is DatadogRumMonitor)
+        assertThat(monitor.rootScope).isInstanceOf(RumApplicationScope::class.java)
+        val appScope = monitor.rootScope as RumApplicationScope
+        assertThat(appScope.childScope).isInstanceOf(RumSessionScope::class.java)
+        val sessionScope = appScope.childScope as RumSessionScope
+        assertThat(sessionScope.sessionListener).isNull()
+    }
+
+    @Test
+    fun `𝕄 builds a RumMonitor with session callback 𝕎 setSessionListener() + build()`() {
+        // When
+        val mockListener: RumSessionListener = mock()
+        val monitor = testedBuilder
+            .setSessionListener(mockListener)
+            .build()
+
+        // Then
+        check(monitor is DatadogRumMonitor)
+        assertThat(monitor.rootScope).isInstanceOf(RumApplicationScope::class.java)
+        val appScope = monitor.rootScope as RumApplicationScope
+        assertThat(appScope.childScope).isInstanceOf(RumSessionScope::class.java)
+        val sessionScope = appScope.childScope as RumSessionScope
+        assertThat(sessionScope.sessionListener).isSameAs(mockListener)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.domain.scope
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.utils.forge.Configurator
@@ -65,6 +66,9 @@ internal class RumApplicationScopeTest {
     @Mock
     lateinit var mockTimeProvider: TimeProvider
 
+    @Mock
+    lateinit var mockSessionListener: RumSessionListener
+
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
 
@@ -84,7 +88,8 @@ internal class RumApplicationScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockTimeProvider
+            mockTimeProvider,
+            mockSessionListener
         )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -21,6 +21,7 @@ import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.RumEvent
@@ -106,6 +107,9 @@ internal class RumSessionScopeTest {
     @Mock
     lateinit var mockTimeProvider: TimeProvider
 
+    @Mock
+    lateinit var mockSessionListener: RumSessionListener
+
     lateinit var mockDevLogHandler: LogHandler
 
     @Forgery
@@ -141,6 +145,7 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -170,6 +175,7 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -268,6 +274,7 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -330,6 +337,7 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -514,6 +522,7 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -540,6 +549,7 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -575,6 +585,7 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -601,6 +612,7 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -627,6 +639,7 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -657,6 +670,7 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.domain.event.RumEvent
@@ -97,6 +98,9 @@ internal class DatadogRumMonitorTest {
     @Mock
     lateinit var mockTimeProvider: TimeProvider
 
+    @Mock
+    lateinit var mockSessionListener: RumSessionListener
+
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
 
@@ -124,7 +128,8 @@ internal class DatadogRumMonitorTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockTimeProvider
+            mockTimeProvider,
+            mockSessionListener
         )
         testedMonitor.setFieldValue("rootScope", mockScope)
     }
@@ -141,7 +146,8 @@ internal class DatadogRumMonitorTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockTimeProvider
+            mockTimeProvider,
+            mockSessionListener
         )
 
         val rootScope = testedMonitor.rootScope
@@ -1043,6 +1049,7 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             mockExecutor
         )
 
@@ -1070,6 +1077,7 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
+            mockSessionListener,
             mockExecutorService
         )
 
@@ -1098,7 +1106,8 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
-            mockExecutorService,
+            mockSessionListener,
+            mockExecutorService
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)
 


### PR DESCRIPTION
### What does this PR do?

Adds an optional `RumSessionListener` to the `RumMonitor`, letting the customer know: 
- when a new Session is starting
- whether the session is kept/discarded (bases on the sampling rate)
- what Datadog's Session id is

### Motivation

Inspired by this feature request: [Datadog/dd-sdk-ios#526](https://github.com/DataDog/dd-sdk-ios/issues/526)