### PR TITLE
Use common Android SDKs versions in the Java Sample app buildscript

### DIFF
--- a/sample/java/build.gradle
+++ b/sample/java/build.gradle
@@ -1,3 +1,5 @@
+import com.datadog.gradle.config.AndroidConfig
+
 import static com.datadog.gradle.config.FlavorBuildConfigKt.configureFlavorForSampleApp
 
 
@@ -19,10 +21,10 @@ def getGitHash = { ->
 }
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion AndroidConfig.TARGET_SDK
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 29
+        minSdkVersion AndroidConfig.MIN_SDK
+        targetSdkVersion AndroidConfig.TARGET_SDK
         versionCode = 1
         versionName = "1.0"
         applicationId = "com.datadog.android.sample"


### PR DESCRIPTION
### What does this PR do?

This change makes the usage of common project-wise Android SDKs versions. Otherwise we have 2 Android SDKs linked currently: 29 and 30.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

