### PR TITLE
RUMM-1580: Fix SDK initialization crash on KitKat for a minified build due to DexVerifier rejecting opcode

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
@@ -69,7 +69,9 @@ class ActivityViewTrackingStrategy @JvmOverloads constructor(
     }
 
     override fun onActivityPostResumed(activity: Activity) {
-        super.onActivityPostResumed(activity)
+        // this method doesn't call super, because having super call creates a crash
+        // during DD SDK initialization on KitKat with ProGuard enabled, default super is
+        // empty anyway
         // this method is only available from API 29 and above
         componentPredicate.runIfValid(activity) {
             viewLoadingTimer.onFinishedLoading(it)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -11,7 +11,6 @@ import android.content.Context
 import android.content.pm.ApplicationInfo
 import android.net.ConnectivityManager
 import android.util.Log as AndroidLog
-import android.view.Choreographer
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.internal.CoreFeature
@@ -27,6 +26,7 @@ import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.tracing.internal.TracesFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
+import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -34,7 +34,6 @@ import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.invokeMethod
-import com.datadog.tools.unit.setStaticValue
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
@@ -103,14 +102,7 @@ internal class DatadogTest {
             .doReturn(mockConnectivityMgr)
 
         // Prevent crash when initializing RumFeature
-        Choreographer::class.java.setStaticValue(
-            "sThreadInstance",
-            object : ThreadLocal<Choreographer>() {
-                override fun initialValue(): Choreographer {
-                    return mock()
-                }
-            }
-        )
+        mockChoreographerInstance()
     }
 
     @AfterEach

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.core.internal.data.upload
 
 import android.content.Context
-import android.view.Choreographer
 import androidx.work.ListenableWorker
 import androidx.work.Worker
 import androidx.work.WorkerParameters
@@ -28,16 +27,15 @@ import com.datadog.android.rum.internal.domain.event.RumEvent
 import com.datadog.android.tracing.internal.TracesFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
+import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.opentracing.DDSpan
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.invokeMethod
-import com.datadog.tools.unit.setStaticValue
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
@@ -114,14 +112,7 @@ internal class UploadWorkerTest {
         whenever(mockRumStrategy.getReader()) doReturn mockRumReader
 
         // Prevent crash when initializing RumFeature
-        Choreographer::class.java.setStaticValue(
-            "sThreadInstance",
-            object : ThreadLocal<Choreographer>() {
-                override fun initialValue(): Choreographer {
-                    return mock()
-                }
-            }
-        )
+        mockChoreographerInstance()
 
         Datadog.initialize(
             appContext.mockInstance,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -17,6 +17,7 @@ import com.datadog.android.core.internal.data.upload.UploadWorker
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
+import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -59,6 +60,8 @@ internal class WorkManagerUtilsTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
+        mockChoreographerInstance()
+
         Datadog.initialize(
             appContext.mockInstance,
             Credentials(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.error.internal
 
 import android.content.Context
 import android.util.Log
-import android.view.Choreographer
 import androidx.work.ExistingWorkPolicy
 import androidx.work.OneTimeWorkRequest
 import androidx.work.impl.WorkManagerImpl
@@ -38,6 +37,7 @@ import com.datadog.android.tracing.AndroidTracer
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
+import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -132,19 +132,10 @@ internal class DatadogExceptionHandlerTest {
     @BeforeEach
     fun `set up`() {
         mockDevLogHandler = mockDevLogHandler()
+        mockChoreographerInstance()
+
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
         whenever(mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
-
-        // To avoid java.lang.NoClassDefFoundError: android/hardware/display/DisplayManagerGlobal.
-        // This class is only available in a real android JVM at runtime and not in a JUnit env.
-        Choreographer::class.java.setStaticValue(
-            "sThreadInstance",
-            object : ThreadLocal<Choreographer>() {
-                override fun initialValue(): Choreographer {
-                    return mock()
-                }
-            }
-        )
 
         Datadog.initialize(
             appContext.mockInstance,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/VitalFrameCallbackTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/vitals/VitalFrameCallbackTest.kt
@@ -7,8 +7,8 @@
 package com.datadog.android.rum.internal.vitals
 
 import android.view.Choreographer
+import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.tools.unit.setStaticValue
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
@@ -44,14 +44,7 @@ internal class VitalFrameCallbackTest {
     fun `set up`() {
         testedFrameCallback = VitalFrameCallback(mockObserver) { true }
 
-        Choreographer::class.java.setStaticValue(
-            "sThreadInstance",
-            object : ThreadLocal<Choreographer>() {
-                override fun initialValue(): Choreographer {
-                    return mockChoreographer
-                }
-            }
-        )
+        mockChoreographerInstance(mockChoreographer)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.tracing.internal
 
 import android.content.Context
 import android.util.Log
-import android.view.Choreographer
 import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.log.LogAttributes
@@ -18,6 +17,7 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
+import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.opentracing.DDSpan
@@ -29,7 +29,6 @@ import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.getStaticValue
 import com.datadog.tools.unit.invokeMethod
 import com.datadog.tools.unit.setFieldValue
-import com.datadog.tools.unit.setStaticValue
 import com.datadog.trace.api.Config
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.inOrder
@@ -83,14 +82,7 @@ internal class AndroidTracerTest {
     @BeforeEach
     fun `set up`(forge: Forge) {
         // Prevent crash when initializing RumFeature
-        Choreographer::class.java.setStaticValue(
-            "sThreadInstance",
-            object : ThreadLocal<Choreographer>() {
-                override fun initialValue(): Choreographer {
-                    return mock()
-                }
-            }
-        )
+        mockChoreographerInstance()
 
         mockDevLogsHandler = mockDevLogHandler()
         fakeServiceName = forge.anAlphabeticalString()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/ChoreographerExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/extension/ChoreographerExt.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.extension
+
+import android.view.Choreographer
+import com.datadog.tools.unit.setStaticValue
+import com.nhaarman.mockitokotlin2.mock
+
+fun mockChoreographerInstance(mock: Choreographer = mock()) {
+    Choreographer::class.java.setStaticValue(
+        "sThreadInstance",
+        object : ThreadLocal<Choreographer>() {
+            override fun initialValue(): Choreographer {
+                return mock
+            }
+        }
+    )
+}


### PR DESCRIPTION
### What does this PR do?

Fixes #678. Crash happens only on KitKat with minified build due to `DexVerfier` rejecting bytecode of the class `ActivityViewTrackingStrategy`, specifically bytecode of this line https://github.com/DataDog/dd-sdk-android/blob/34933826d3b36988dee8e9fa8a76b829b4a70314/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt#L72

Error says:

```
I/dalvikvm: Could not find method android.app.Application$ActivityLifecycleCallbacks.onActivityPostResumed, referenced from method com.datadog.android.rum.tracking.ActivityViewTrackingStrategy.onActivityPostResumed
W/dalvikvm: VFY: unable to resolve virtual method 257: Landroid/app/Application$ActivityLifecycleCallbacks;.onActivityPostResumed (Landroid/app/Activity;)V
W/dalvikvm: VFY:  rejecting opcode 0x6f at 0x0005
W/dalvikvm: VFY:  rejected Lcom/datadog/android/rum/tracking/ActivityViewTrackingStrategy;.onActivityPostResumed (Landroid/app/Activity;)V
W/dalvikvm: Verifier rejected class Lcom/datadog/android/rum/tracking/ActivityViewTrackingStrategy;
```

Opcode `0x6f` corresponds to the [super](https://android.googlesource.com/platform/dalvik/+/android-4.4.2_r2/libdex/DexOpcodes.h#182) invocation. There is nothing special about this opcode, I can see other instances of this opcode being successfully replaced instead of being rejected. And this error happens only on KitKat (hence Dalvik), it doesn't repro with newer APIs (ART).

Not sure why it happens, probably there is something special about backporting `default` (`onActivityPostResumed` is a `default` method) methods to the pre-Lollipop APIs, but the easiest fix is just to remove `super` call and it is safe to do with current inheritance hierarchy because default implementation [is just empty](https://cs.android.com/android/platform/superproject/+/master:frameworks/base/core/java/android/app/Application.java;l=126;drc=5d123b67756dffcfdebdb936ab2de2b29c799321).

Things like using `RequiresApi`, `TargetApi`, wrapping in build version check condition didn't help. Adding ProGuard instructions also didn't help: APK explorer shows that the necessary class and method are there, but app still crashes.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

