### PR TITLE
RUMM-1572: Handle null value in WindowCallbackWrapper#dispatchTouchEvent to prevent possible crash

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
@@ -27,15 +27,19 @@ internal class WindowCallbackWrapper(
     // region Window.Callback
 
     override fun dispatchTouchEvent(event: MotionEvent?): Boolean {
-        // we copy it and delegate it to the gesture detector for analysis
-        val copy = copyEvent(event)
-        @Suppress("TooGenericExceptionCaught")
-        try {
-            gesturesDetector.onTouchEvent(copy)
-        } catch (e: Exception) {
-            sdkLogger.e("Error processing MotionEvent", e)
-        } finally {
-            copy.recycle()
+        if (event != null) {
+            // we copy it and delegate it to the gesture detector for analysis
+            val copy = copyEvent(event)
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                gesturesDetector.onTouchEvent(copy)
+            } catch (e: Exception) {
+                sdkLogger.e("Error processing MotionEvent", e)
+            } finally {
+                copy.recycle()
+            }
+        } else {
+            sdkLogger.e("Received MotionEvent=null")
         }
         return wrappedCallback.dispatchTouchEvent(event)
     }
@@ -76,7 +80,7 @@ internal class WindowCallbackWrapper(
 
     // region Internal
 
-    internal fun copyEvent(event: MotionEvent?) = MotionEvent.obtain(event)
+    internal fun copyEvent(event: MotionEvent) = MotionEvent.obtain(event)
 
     // endregion
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapperTest.kt
@@ -27,6 +27,7 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.spy
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
@@ -115,6 +116,20 @@ internal class WindowCallbackWrapperTest {
         // Then
         verify(mockGestureDetector).onTouchEvent(copyMotionEvent)
         verify(copyMotionEvent).recycle()
+    }
+
+    @Test
+    fun `dispatchTouchEvent won't call gesture detector when null is received`() {
+        // Given
+        val spyTest = spy(testedWrapper)
+
+        // When
+        spyTest.dispatchTouchEvent(null)
+
+        // Then
+        verifyZeroInteractions(mockGestureDetector)
+        verify(spyTest, never()).copyEvent(any())
+        verify(mockCallback).dispatchTouchEvent(null)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This change adds a special handling of `null` argument of `WindowCallbackWrapper#dispatchTouchEvent` to prevent possible crash. Although it is not clear if `dispatchTouchEvent` can receive `null` (all Google code I've checked makes an assumption that argument is never `null`), at least we will have a visibility if it happens and if it happens indeed, it won't crash.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

