### PR TITLE
RUMM-1593 Remove SIGQUIT(ANR) signal handler from NDK plugin

### DIFF
--- a/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
@@ -22,7 +22,6 @@
 #include "datadog-native-lib.h"
 
 static const char *LOG_TAG = "DatadogNdkCrashReporter";
-static sigset_t signals_mask;
 static stack_t signal_stack;
 
 /* the datadog sigaction which overrides the original signal handler */
@@ -30,8 +29,6 @@ static volatile struct sigaction *volatile datadog_sigaction;
 
 /* the original sigaction array which will hold the original handlers for each overridden signal */
 volatile struct sigaction *volatile original_sigaction;
-
-static pthread_t override_signal_handlers_thread;
 
 volatile bool handlers_installed = false;
 
@@ -68,8 +65,7 @@ static const struct signal handled_signals[] = {
         {SIGBUS,  "SIGBUS",  "Bus error (bad memory access)"},
         {SIGFPE,  "SIGFPE",  "Floating-point exception"},
         {SIGABRT, "SIGABRT", "The process was terminated"},
-        {SIGSEGV, "SIGSEGV", "Segmentation violation (invalid memory reference)"},
-        {SIGQUIT, "SIGQUIT", "Application Not Responding"}
+        {SIGSEGV, "SIGSEGV", "Segmentation violation (invalid memory reference)"}
 };
 
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -155,7 +151,7 @@ void handle_signal(int signum, siginfo_t *info, void *user_context) {
             // because we are unwinding the stack strace at this level we are always going to
             // to have for the top 3 levels at the top of the trace the executed lines from our
             // library: handle_signal, generate_backtrace and capture_backtrace.
-            // Make sure that if you are changing this make sure to start from the new frame
+            // If you are changing this code make sure to start from the new frame
             // index when generating the backtrace.
             generate_backtrace(backtrace, stack_frames_start_index, max_stack_size);
 
@@ -194,7 +190,9 @@ bool init_datadog_signal_handler() {
     if (datadog_sigaction == NULL) {
         return false;
     }
-    sigemptyset((sigset_t *) &datadog_sigaction->sa_mask);
+    if (sigemptyset((sigset_t *) &datadog_sigaction->sa_mask) != 0) {
+        return false;
+    }
     datadog_sigaction->sa_sigaction = handle_signal;
     // we will use the SA_ONSTACK mask here to handle the signal in a freshly new stack.
     datadog_sigaction->sa_flags = SA_SIGINFO | SA_ONSTACK;
@@ -202,20 +200,17 @@ bool init_datadog_signal_handler() {
     return true;
 }
 
-/*
- * Overriding the signal handlers from the new spawned thread. This will allow us to block (handle)
- * also the `SIQGUIT` signal triggered when the process is unresponsive - ANR.
- * This function should be called inside a locked mutex for Thread safety
- */
 bool override_native_signal_handlers() {
-    if (handlers_installed) {
+    if (!init_datadog_signal_handler()) {
+        __android_log_write(ANDROID_LOG_ERROR, LOG_TAG,
+                            "Not able to initialize the Datadog signal handler");
         return false;
     }
-    init_datadog_signal_handler();
     const size_t signals_array_size = handled_signals_size();
     original_sigaction = calloc(signals_array_size, sizeof(struct sigaction));
     if (original_sigaction == NULL) {
-        __android_log_write(ANDROID_LOG_ERROR, LOG_TAG, "Was not able to initialise.");
+        __android_log_write(ANDROID_LOG_ERROR, LOG_TAG,
+                            "Not able to allocate the memory to persist the original handlers");
         return false;
     }
     for (int i = 0; i < signals_array_size; i++) {
@@ -225,64 +220,20 @@ bool override_native_signal_handlers() {
         if (success != 0) {
             __android_log_print(ANDROID_LOG_ERROR,
                                 LOG_TAG,
-                                "Was not able to catch the signal: %d",
+                                "Not able to catch the signal: %d",
                                 signal);
         }
     }
-    handlers_installed = true;
     recordInstallOp();
     return true;
-}
-
-void *override_handlers_runnable() {
-    pthread_mutex_lock(&mutex);
-    override_native_signal_handlers();
-    pthread_mutex_unlock(&mutex);
-    return NULL;
-}
-/*
- * We need to perform the handlers override operation in this new thread as the main thread does
- * not block by default the SIGQUIT signals so we will have to
- * block it and start a new thread for signals handling. When starting a new thread
- * from main thread the new one will take the signals mask of the parent.
- */
-bool spawn_thread_to_override_signal_handlers() {
-    bool success = false;
-    sigemptyset(&signals_mask);
-    sigaddset(&signals_mask, SIGQUIT);
-    // try to modify main thread signal masks by marking the `SIGQUIT` as blockable
-    if (pthread_sigmask(SIG_BLOCK, &signals_mask, NULL) == 0) {
-        // spawning a new thread will take the current signal mask from the main thread
-        if (pthread_create(&override_signal_handlers_thread, NULL,
-                           override_handlers_runnable, NULL) != 0) {
-            __android_log_write(ANDROID_LOG_ERROR,
-                                LOG_TAG,
-                                "Was not able to create the watchdog thread");
-        }
-
-        // we restore the defaults on the main thread
-        if (pthread_sigmask(SIG_UNBLOCK, &signals_mask, NULL) != 0) {
-            __android_log_write(ANDROID_LOG_ERROR,
-                                LOG_TAG,
-                                "Was not able to restore the mask on SIGQUIT signal");
-        }
-        success = true;
-
-    } else {
-        __android_log_write(ANDROID_LOG_ERROR,
-                            LOG_TAG,
-                            "Was not able to mask SIGQUIT signal");
-    }
-
-    return success;
 }
 
 bool try_to_install_handlers() {
     if (handlers_installed) {
         return true;
     }
-    return (configure_signal_stack() &&
-            spawn_thread_to_override_signal_handlers());
+    handlers_installed = configure_signal_stack() && override_native_signal_handlers();
+    return handlers_installed;
 }
 
 bool start_monitoring() {

--- a/dd-sdk-android-ndk/src/test/cpp/test-signal-monitor.cpp
+++ b/dd-sdk-android-ndk/src/test/cpp/test-signal-monitor.cpp
@@ -39,17 +39,9 @@ bool performedInstall(int times) {
 #endif
 }
 
-void waitf_for_signal_handlers_override_thread() {
-    // we cannot join on the override_signal_handlers_thread as in case this is not joinable
-    // meaning that it already finished, on Android API < 26 this will crash the process:
-    // See here: [https://android.googlesource.com/platform/bionic/+/master/libc/bionic/pthread_internal.cpp#106]
-    // Furthermore there is no way in C to tell if a thread is joinable :(
-    sleep(5);
-}
 
 TEST calling_start_monitoring_will_install_signal_handlers(void) {
     start_monitoring();
-    waitf_for_signal_handlers_override_thread();
             ASSERT(handlers_installed);
     clear_tests();
             PASS();
@@ -59,7 +51,6 @@ TEST calling_start_monitoring_more_times_in_a_row_will_only_install_once(void) {
     start_monitoring();
     start_monitoring();
     start_monitoring();
-    waitf_for_signal_handlers_override_thread();
             ASSERT(handlers_installed);
             ASSERT(performedInstall(1));
     clear_tests();
@@ -70,7 +61,6 @@ TEST calling_start_monitoring_more_times_in_a_row_will_only_install_once(void) {
 TEST calling_stop_monitoring_will_uninstall_the_handlers(void) {
     // given
     start_monitoring();
-    waitf_for_signal_handlers_override_thread();
     // when
     stop_monitoring();
             ASSERT_FALSE(handlers_installed);
@@ -81,7 +71,6 @@ TEST calling_stop_monitoring_will_uninstall_the_handlers(void) {
 TEST calling_stop_monitoring_more_times_in_a_row_will_only_uninstall_once(void) {
     // given
     start_monitoring();
-    waitf_for_signal_handlers_override_thread();
     // when
     stop_monitoring();
     stop_monitoring();
@@ -100,7 +89,6 @@ TEST calling_start_monitor_from_different_threads_will_only_install_once(void) {
     std::thread t2 = std::thread(start_monitoring_lambda);
     t1.join();
     t2.join();
-    waitf_for_signal_handlers_override_thread();
             ASSERT(handlers_installed);
             ASSERT(performedInstall(1));
     clear_tests();
@@ -136,7 +124,6 @@ TEST calling_start_monitor_from_different_threads_will_not_corrupt_the_memory(vo
 TEST calling_stop_monitoring_from_2_different_threads_will_only_uninstall_once(void) {
     // given
     start_monitoring();
-    waitf_for_signal_handlers_override_thread();
     // when
     auto stop_monitoring_lambda = [] {
         stop_monitoring();


### PR DESCRIPTION
### What does this PR do?

In this PR we are removing the ANR handling at the NDK level as it overrides the Google current implementation [more details here](https://github.com/bugsnag/bugsnag-android/blob/next/bugsnag-plugin-android-anr/src/main/jni/anr_google.c). Google is handling the ANRs adding its own signal catcher at [runtime](https://android.googlesource.com/platform/art/+/master/runtime/signal_catcher.h) . 

### Additional Notes

We are already covering the ANR error at the JVM level so there is no need for this here.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

