### PR TITLE
RUMM-1606 replace XHR by Native as default resource kind

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -371,6 +371,7 @@ enum com.datadog.android.rum.RumResourceKind
   - FETCH
   - XHR
   - DOCUMENT
+  - NATIVE
   - UNKNOWN
   - IMAGE
   - JS
@@ -924,6 +925,7 @@ data class com.datadog.android.rum.model.ResourceEvent
     - FONT
     - MEDIA
     - OTHER
+    - NATIVE
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): ResourceType

--- a/dd-sdk-android/src/main/json/rum/resource-schema.json
+++ b/dd-sdk-android/src/main/json/rum/resource-schema.json
@@ -38,7 +38,7 @@
             "type": {
               "type": "string",
               "description": "Resource type",
-              "enum": ["document", "xhr", "beacon", "fetch", "css", "js", "image", "font", "media", "other"],
+              "enum": ["document", "xhr", "beacon", "fetch", "css", "js", "image", "font", "media", "other", "native"],
               "readOnly": true
             },
             "method": {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
@@ -194,11 +194,9 @@ internal constructor(
     ) {
         val requestId = identifyRequest(request)
         val statusCode = response?.code()
-        val method = request.method()
         val mimeType = response?.header(HEADER_CT)
         val kind = when {
-            method in xhrMethods -> RumResourceKind.XHR
-            mimeType == null -> RumResourceKind.XHR
+            mimeType == null -> RumResourceKind.NATIVE
             else -> RumResourceKind.fromMimeType(mimeType)
         }
         val attributes = if (span == null) {
@@ -253,8 +251,6 @@ internal constructor(
         internal const val ERROR_MSG_FORMAT = "OkHttp request error %s %s"
 
         internal const val ORIGIN_RUM = "rum"
-
-        internal val xhrMethods = arrayOf("POST", "PUT", "DELETE")
 
         // We need to limit this value as the body will be loaded in memory
         private const val MAX_BODY_PEEK: Long = 32 * 1024L * 1024L

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumResourceKind.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumResourceKind.kt
@@ -20,6 +20,7 @@ enum class RumResourceKind(val value: String) {
     DOCUMENT("document"),
 
     // Common kinds
+    NATIVE("native"),
     UNKNOWN("unknown"),
     IMAGE("image"),
     JS("js"),
@@ -41,7 +42,7 @@ enum class RumResourceKind(val value: String) {
                 baseType == "font" -> FONT
                 baseType == "text" && subtype == "css" -> CSS
                 baseType == "text" && subtype == "javascript" -> JS
-                else -> XHR
+                else -> NATIVE
             }
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
@@ -48,6 +48,7 @@ internal fun RumResourceKind.toSchemaType(): ResourceEvent.ResourceType {
         RumResourceKind.FONT -> ResourceEvent.ResourceType.FONT
         RumResourceKind.CSS -> ResourceEvent.ResourceType.CSS
         RumResourceKind.MEDIA -> ResourceEvent.ResourceType.MEDIA
+        RumResourceKind.NATIVE -> ResourceEvent.ResourceType.NATIVE
         RumResourceKind.UNKNOWN,
         RumResourceKind.OTHER -> ResourceEvent.ResourceType.OTHER
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
@@ -108,9 +108,8 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type()
         val kind = when {
-            fakeMethod in DatadogInterceptor.xhrMethods -> RumResourceKind.XHR
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
-            else -> RumResourceKind.XHR
+            else -> RumResourceKind.NATIVE
         }
 
         // When
@@ -148,9 +147,8 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type()
         val kind = when {
-            fakeMethod in DatadogInterceptor.xhrMethods -> RumResourceKind.XHR
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
-            else -> RumResourceKind.XHR
+            else -> RumResourceKind.NATIVE
         }
 
         // When

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutTracesTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutTracesTest.kt
@@ -200,9 +200,8 @@ internal class DatadogInterceptorWithoutTracesTest {
         val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type()
         val kind = when {
-            fakeMethod in DatadogInterceptor.xhrMethods -> RumResourceKind.XHR
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
-            else -> RumResourceKind.UNKNOWN
+            else -> RumResourceKind.NATIVE
         }
 
         // When
@@ -237,9 +236,8 @@ internal class DatadogInterceptorWithoutTracesTest {
         val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type()
         val kind = when {
-            fakeMethod in DatadogInterceptor.xhrMethods -> RumResourceKind.XHR
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
-            else -> RumResourceKind.UNKNOWN
+            else -> RumResourceKind.NATIVE
         }
 
         // When

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumResourceKindTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumResourceKindTest.kt
@@ -90,7 +90,7 @@ internal class RumResourceKindTest {
     }
 
     @Test
-    fun `detect unknown MimeType as XHR`(
+    fun `detect unknown MimeType as NATIVE`(
         forge: Forge
     ) {
         val mimeType = forge.aWhitespaceString()
@@ -98,6 +98,6 @@ internal class RumResourceKindTest {
         val kind = RumResourceKind.fromMimeType(mimeType)
 
         assertThat(kind)
-            .isEqualTo(RumResourceKind.XHR)
+            .isEqualTo(RumResourceKind.NATIVE)
     }
 }


### PR DESCRIPTION
### What does this PR do?

Replace `xhr` by `native` as default resource kind, as `XHR` is a browser technology and doesn't really make sense in a mobile App