### PR TITLE
RUMM-1535 Add remaining nightly tests on AndroidTracer.Builder

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -234,4 +234,4 @@ tasks.register("buildNdkIntegrationTestsArtifacts") {
     dependsOn(":instrumented:integration:assembleDebug")
 }
 
-nightlyTestsCoverageConfig(threshold = 0.76f)
+nightlyTestsCoverageConfig(threshold = 0.8f)


### PR DESCRIPTION
### What does this PR do?

In this PR we are adding the remaining nightly tests related with the non - instrumented part of the RUM Tracer feature.
The `AndroidTracer#Builder#setPartialFlushThreshold` configuration option lets the user specify when a pending trace can flush (persist) the already closed child spans and we added 2 use - cases here which assert both situations:
1. When the trace has a pending span (is pending) and a closed Span but the threshold was not reached
2. When the trace has a pending span (is pending) and 2 closed Spans and the threshold was reached

For each of these 2 use cases a monitor was created: 
`[RUM] [Android] Nightly - trace_config_flush_threshold_not_reached: number of spans is above expected value`
`[RUM] [Android] Nightly - trace_config_flush_threshold_reached: number of spans is below expected value`

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

