### PR TITLE
RUMM-1621: Remove jcenter repo references

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -16,7 +16,6 @@ buildscript {
         google()
         mavenCentral()
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Gradle) }
-        jcenter()
     }
 
     dependencies {
@@ -36,7 +35,6 @@ allprojects {
         google()
         mavenCentral()
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Jitpack) }
-        jcenter()
         flatDir { dirs("libs") }
     }
 }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -37,7 +37,7 @@ dependencies {
     implementation("com.android.tools.build:gradle:4.1.2")
     implementation("com.github.ben-manes:gradle-versions-plugin:0.27.0")
     implementation("me.xdrop:fuzzywuzzy:1.2.0")
-    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.10")
+    implementation("org.jetbrains.dokka:dokka-gradle-plugin:1.4.32")
     implementation("org.apache.maven:maven-model:3.6.3")
     implementation("io.github.gradle-nexus:publish-plugin:1.1.0")
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -42,9 +42,9 @@ object Dependencies {
         const val JetpackBenchmark = "1.0.0"
 
         // Tools
-        const val Detekt = "1.6.0"
+        const val Detekt = "1.17.0"
         const val KtLint = "9.4.0"
-        const val Dokka = "1.4.10"
+        const val Dokka = "1.4.32"
         const val Unmock = "0.7.5"
         const val Robolectric = "4.4_r1-robolectric-r2" // Use lowest API
 
@@ -63,7 +63,7 @@ object Dependencies {
         const val Fresco = "2.3.0"
         const val Glide = "4.11.0"
         const val Picasso = "2.8"
-        const val Realm = "6.0.2"
+        const val Realm = "10.4.0"
         const val Room = "2.2.5"
         const val RxJava = "3.0.0"
         const val SQLDelight = "1.4.3"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogEventListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogEventListener.kt
@@ -36,6 +36,7 @@ import okhttp3.Response
  *       .build();
  * ```
  *
+ * @param key Call identity.
  * @see [Factory]
  */
 class DatadogEventListener

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/DatadogContext.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/DatadogContext.kt
@@ -8,6 +8,7 @@ package com.datadog.android.plugin
 
 /**
  * Provides general information about the current context of the library.
+ * @param rum RUM Context.
  * @see DatadogRumContext
  */
 data class DatadogContext(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/DatadogPluginConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/DatadogPluginConfig.kt
@@ -11,6 +11,10 @@ import com.datadog.android.privacy.TrackingConsent
 
 /**
  * Used to deliver the context from the SDK internals to a [DatadogPlugin] implementation.
+ * @param context [Context] object.
+ * @param envName Environment name.
+ * @param serviceName Service name.
+ * @param trackingConsent Tracking consent.
  */
 class DatadogPluginConfig(
     val context: Context,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/Feature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/Feature.kt
@@ -9,7 +9,7 @@ package com.datadog.android.plugin
 /**
  * Provides the available feature for which a [DatadogPlugin] can be assigned.
  */
-enum class Feature(val featureName: String) {
+enum class Feature(internal val featureName: String) {
     LOG("Logging"),
     CRASH("Crash Reporting"),
     TRACE("Tracing"),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumResourceKind.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumResourceKind.kt
@@ -12,7 +12,7 @@ import java.util.Locale
  * Describe the category of a RUM Resource.
  * @see [RumMonitor]
  */
-enum class RumResourceKind(val value: String) {
+enum class RumResourceKind(internal val value: String) {
     // Specific kind of JS resources loading
     BEACON("beacon"),
     FETCH("fetch"),

--- a/detekt.yml
+++ b/detekt.yml
@@ -8,7 +8,7 @@ build:
 
 processors:
   active: true
-  exclude:
+  exclude: [ ]
   # - 'DetektProgressListener'
   # - 'FunctionCountProcessor'
   # - 'PropertyCountProcessor'
@@ -28,7 +28,7 @@ console-reports:
 
 comments:
   active: true
-  excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+  excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
   CommentOverPrivateFunction:
     active: true
   CommentOverPrivateProperty:
@@ -63,7 +63,7 @@ complexity:
     ignoreSimpleWhenEntries: true
   LabeledExpression:
     active: true
-    ignoredLabels: ""
+    ignoredLabels: [ ]
   LargeClass:
     active: true
     threshold: 600
@@ -72,7 +72,8 @@ complexity:
     threshold: 60
   LongParameterList:
     active: true
-    threshold: 6
+    constructorThreshold: 12
+    functionThreshold: 6
     ignoreDefaultParameters: true
   MethodOverloading:
     active: true
@@ -82,14 +83,14 @@ complexity:
     threshold: 4
   StringLiteralDuplication:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     threshold: 3
     ignoreAnnotation: true
     excludeStringsWithLessThan5Characters: true
     ignoreStringsRegex: '$^'
   TooManyFunctions:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     thresholdInFiles: 11
     thresholdInClasses: 11
     thresholdInInterfaces: 11
@@ -136,10 +137,10 @@ exceptions:
   active: true
   ExceptionRaisedInUnexpectedLocation:
     active: true
-    methodNames: 'toString,hashCode,equals,finalize'
+    methodNames: [ 'toString','hashCode','equals','finalize' ]
   InstanceOfCheckForException:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
   NotImplementedDeclaration:
     active: true
   PrintStackTrace:
@@ -151,7 +152,7 @@ exceptions:
     ignoreLabeled: true
   SwallowedException:
     active: true
-    ignoredExceptionTypes: 'InterruptedException,NumberFormatException,ParseException,MalformedURLException'
+    ignoredExceptionTypes: [ 'InterruptedException','NumberFormatException','ParseException','MalformedURLException' ]
     allowedExceptionNameRegex: "^(_|(ignore|expected).*)"
   ThrowingExceptionFromFinally:
     active: true
@@ -159,12 +160,12 @@ exceptions:
     active: true
   ThrowingExceptionsWithoutMessageOrCause:
     active: true
-    exceptions: 'IllegalArgumentException,IllegalStateException,IOException'
+    exceptions: [ 'IllegalArgumentException','IllegalStateException','IOException' ]
   ThrowingNewInstanceOfSameException:
     active: true
   TooGenericExceptionCaught:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     exceptionNames:
       - ArrayIndexOutOfBoundsException
       - Error
@@ -290,39 +291,39 @@ naming:
   active: true
   ClassNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     classPattern: '[A-Z$][a-zA-Z0-9$]*'
   ConstructorParameterNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     parameterPattern: '[a-z][A-Za-z0-9]*'
     privateParameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
   EnumNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     enumEntryPattern: '^[A-Z][_a-zA-Z0-9]*'
   ForbiddenClassName:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    forbiddenName: ''
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
+    forbiddenName: [ ]
   FunctionMaxLength:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     maximumFunctionNameLength: 30
   FunctionMinLength:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     minimumFunctionNameLength: 3
   FunctionNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     functionPattern: '^([a-z$][a-zA-Z$0-9]*)|(`.*`)$'
     excludeClassPattern: '$^'
     ignoreOverridden: true
   FunctionParameterNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     parameterPattern: '[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
     ignoreOverridden: true
@@ -336,31 +337,31 @@ naming:
     ignoreOverridden: true
   ObjectPropertyNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     constantPattern: '[A-Za-z][_A-Za-z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '(_)?[A-Za-z][_A-Za-z0-9]*'
   PackageNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     packagePattern: '^[a-z]+(\.[a-z][A-Za-z0-9]*)*$'
   TopLevelPropertyNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     constantPattern: '[A-Z][_A-Z0-9]*'
     propertyPattern: '[A-Za-z][_A-Za-z0-9]*'
     privatePropertyPattern: '_?[A-Za-z][_A-Za-z0-9]*'
   VariableMaxLength:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     maximumVariableNameLength: 64
   VariableMinLength:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     minimumVariableNameLength: 1
   VariableNaming:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
     variablePattern: '[a-z][A-Za-z0-9]*'
     privateVariablePattern: '(_)?[a-z][A-Za-z0-9]*'
     excludeClassPattern: '$^'
@@ -372,10 +373,10 @@ performance:
     active: true
   ForEachOnRange:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
   SpreadOperator:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
   UnnecessaryTemporaryInstantiation:
     active: true
 
@@ -401,8 +402,8 @@ potential-bugs:
     active: true
   LateinitUsage:
     active: false
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    excludeAnnotatedProperties: ""
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
+    excludeAnnotatedProperties: [ ]
     ignoreOnClassesPattern: ""
   MissingWhenCase:
     active: true
@@ -441,11 +442,11 @@ style:
     includeLineWrapping: false
   ForbiddenComment:
     active: true
-    values: 'TODO:,FIXME:,STOPSHIP:'
+    values: [ 'TODO:','FIXME:','STOPSHIP:' ]
     allowedPatterns: ""
   ForbiddenImport:
     active: true
-    imports: ''
+    imports: [ ]
     forbiddenPatterns: ""
   ForbiddenVoid:
     active: true
@@ -455,7 +456,7 @@ style:
     active: true
     ignoreOverridableFunction: true
     excludedFunctions: 'describeContents'
-    excludeAnnotatedFunction: "dagger.Provides"
+    excludeAnnotatedFunction: [ "dagger.Provides" ]
   LibraryCodeMustSpecifyReturnType:
     active: true
   LoopWithTooManyJumpStatements:
@@ -463,8 +464,8 @@ style:
     maxJumpCount: 1
   MagicNumber:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    ignoreNumbers: '-1,0,1,2'
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
+    ignoreNumbers: [ '-1','0','1','2' ]
     ignoreHashCodeFunction: true
     ignorePropertyDeclaration: false
     ignoreConstantDeclaration: true
@@ -528,7 +529,7 @@ style:
     acceptableDecimalLength: 5
   UnnecessaryAbstractClass:
     active: true
-    excludeAnnotatedClasses: "dagger.Module"
+    excludeAnnotatedClasses: [ "dagger.Module" ]
   UnnecessaryApply:
     active: true
   UnnecessaryInheritance:
@@ -552,7 +553,7 @@ style:
     active: true
   UseDataClass:
     active: true
-    excludeAnnotatedClasses: ""
+    excludeAnnotatedClasses: [ ]
     allowVars: true
   UseIfInsteadOfWhen:
     active: true
@@ -566,5 +567,5 @@ style:
     active: true
   WildcardImport:
     active: true
-    excludes: "**/test/**,**/androidTest/**,**/*.Test.kt,**/*.Spec.kt,**/*.Spek.kt"
-    excludeImports: 'java.util.*,kotlinx.android.synthetic.*'
+    excludes: [ "**/test/**","**/androidTest/**","**/*.Test.kt","**/*.Spec.kt","**/*.Spek.kt" ]
+    excludeImports: [ 'java.util.*','kotlinx.android.synthetic.*' ]

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/TodoWithoutTask.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/TodoWithoutTask.kt
@@ -50,7 +50,7 @@ class TodoWithoutTask : Rule() {
         super.visitProperty(property)
     }
 
-    override fun visitComment(comment: PsiComment?) {
+    override fun visitComment(comment: PsiComment) {
         reportIfInvalid(comment)
 
         super.visitComment(comment)


### PR DESCRIPTION
### What does this PR do?

This change removes all JCenter repo references, because JFrog is sunsetting it and it had an outage on September 16th, causing the failure of our CI pipeline.

The following libs were updated, because they (or their transitive dependencies) were hosted on JCenter before:

* `Detekt`
* `Realm`
* `Dokka`

Update of `Detekt` required some code changes, because the following rules are changed in the new version:

* `LongParameterList` - the following PR https://github.com/detekt/detekt/pull/2410 added constructor validation, which wasn't there before. Solved by adding `constructorThreshold: 12` to the rule configuration, no code changes were made.
* `UndocumentedPublicProperty` - the following PR https://github.com/detekt/detekt/pull/2475 added constructor validation, which wasn't there before. Solved by adding the necessary descriptions.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

