### PR TITLE
Sync Detekt Gradle plugin version with lib version

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 
     // Dependencies used to configure the gradle plugins
     implementation(embeddedKotlin("gradle-plugin"))
-    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.1.1")
+    implementation("io.gitlab.arturbosch.detekt:detekt-gradle-plugin:1.17.0")
     implementation("org.jlleitschuh.gradle:ktlint-gradle:9.4.0")
     implementation("com.android.tools.build:gradle:4.1.2")
     implementation("com.github.ben-manes:gradle-versions-plugin:0.27.0")

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
@@ -200,7 +200,7 @@ fun <T : Any> T.invokeGenericMethod(
     return output
 }
 
-@Suppress("TooGenericExceptionCaught", "SwallowedException", "SpreadOperator")
+@Suppress("TooGenericExceptionCaught", "SwallowedException", "SpreadOperator", "ComplexMethod")
 private fun <T : Any> T.getDeclaredMethodRecursively(
     methodName: String,
     matchingParams: Boolean,

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/annotations/TestTargetApi.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/annotations/TestTargetApi.kt
@@ -11,6 +11,7 @@ import com.datadog.tools.unit.extensions.ApiLevelExtension
 
 /**
  * Declares a test method as targeting a specific Android API level.
+ * @param value Android API level.
  *
  * @see [ApiLevelExtension]
  */


### PR DESCRIPTION
### What does this PR do?

It turns out that for a long time version of Detekt Gradle plugin wasn't in sync with lib version we are using, causing the miss in the scan of some files. This change aligns version of plugin with the version of the library.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

