### PR TITLE
RUMM-1677: Prevent native updateTrackingConsent call if libdatadog-native-lib is not loaded

### DIFF
--- a/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/NdkCrashReportsPlugin.kt
+++ b/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/NdkCrashReportsPlugin.kt
@@ -70,6 +70,9 @@ class NdkCrashReportsPlugin : DatadogPlugin {
     // region TrackingConsentProviderCallback
 
     override fun onConsentUpdated(previousConsent: TrackingConsent, newConsent: TrackingConsent) {
+        if (!nativeLibraryLoaded) {
+            return
+        }
         updateTrackingConsent(consentToInt(newConsent))
     }
 


### PR DESCRIPTION
### What does this PR do?

This change prevents a crash if during `updateTrackingConsent` call in the NDK plugin native library is not loaded.

### Additional Notes

No test for this change, because it seems spying/mocking native methods is not possible without `PowerMock`.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

