### PR TITLE
RUMM-1652 Fix the problem with the signal stack memory in NDK handler

### DIFF
--- a/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.h
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.h
@@ -15,8 +15,8 @@ extern "C" {
 #endif
 
 const size_t stack_frames_start_index = 3;
-const size_t max_stack_frames = 100 + stack_frames_start_index;
-const size_t max_characters_per_stack_frame = 2048;
+const size_t max_stack_frames = 70 + stack_frames_start_index;
+const size_t max_characters_per_stack_frame = 500;
 const size_t max_stack_size = max_stack_frames * max_characters_per_stack_frame;
 
 // We cannot use a namespace here as this function will be called from C file (signal_monitor.c)


### PR DESCRIPTION
### What does this PR do?

In Android 11 and Android 12 it seems that the signal stack overhead memory is reduced so when trying to unwind the stack frames in the signal handler we were running out of memory and the process exited without serializing the crash log. In order to fix that we are increasing the amount of memory for our signal stack and in the same time we are decreasing the memory allocated in the stack for unwinding and constructing the stacktrace. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

