### PR TITLE
RUMM-1711 Enrich RUM error with throwable message

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -271,10 +271,16 @@ internal open class RumViewScope(
         val updatedAttributes = addExtraAttributes(event.attributes)
         val networkInfo = CoreFeature.networkInfoProvider.getLatestNetworkInfo()
         val errorType = event.type ?: event.throwable?.javaClass?.canonicalName
+        val throwableMessage = event.throwable?.message ?: ""
+        val message = if (throwableMessage.isNotBlank() && event.message != throwableMessage) {
+            "${event.message}: $throwableMessage"
+        } else {
+            event.message
+        }
         val errorEvent = ErrorEvent(
             date = event.eventTime.timestamp + serverTimeOffsetInMs,
             error = ErrorEvent.Error(
-                message = event.message,
+                message = message,
                 source = event.source.toSchemaSource(),
                 stack = event.stacktrace ?: event.throwable?.loggableStackTrace(),
                 isCrash = event.isFatal,


### PR DESCRIPTION
### What does this PR do?

Copy the `throwable`‘s message into the RUM Error message field to get a better visibility for customers.