### PR TITLE
RUMM-1748: Update dogfood script to target Gradle version catalogs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -355,3 +355,15 @@ notify:dogfood-bridge:
     - pip3 install GitPython requests
     - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_token --with-decryption --query "Parameter.Value" --out text >> ./gh_token
     - python3 dogfood.py -v $CI_COMMIT_TAG -t bridge
+
+notify:dogfood-gradle-plugin:
+  tags: [ "runner:main" ]
+  only:
+    - tags
+  image: $CI_IMAGE_DOCKER
+  stage: notify
+  when: on_success
+  script:
+    - pip3 install GitPython requests
+    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_token --with-decryption --query "Parameter.Value" --out text >> ./gh_token
+    - python3 dogfood.py -v $CI_COMMIT_TAG -t gradle-plugin

--- a/dogfood.py
+++ b/dogfood.py
@@ -19,19 +19,27 @@ from git import Repo
 TARGET_APP = "app"
 TARGET_DEMO = "demo"
 TARGET_BRIDGE = "bridge"
+TARGET_GRADLE_PLUGIN = "gradle-plugin"
 
-REPOSITORIES = {TARGET_APP: "datadog-android", TARGET_DEMO: "shopist-android", TARGET_BRIDGE: "dd-bridge-android"}
+REPOSITORIES = {
+    TARGET_APP: "datadog-android",
+    TARGET_DEMO: "shopist-android",
+    TARGET_BRIDGE: "dd-bridge-android",
+    TARGET_GRADLE_PLUGIN: "dd-sdk-android-gradle-plugin"
+}
 
 FILE_PATH = {
     TARGET_APP: os.path.join("dd-build", "dependencies", "src", "main", "java", "com", "datadog", "build", "dependency", "android", "Datadog.kt"),
-    TARGET_DEMO: os.path.join("buildSrc", "src", "main", "kotlin", "com", "datadog", "gradle", "Dependencies.kt"),
-    TARGET_BRIDGE: os.path.join("buildSrc", "src", "main", "kotlin", "com", "datadog", "gradle", "Dependencies.kt")
+    TARGET_DEMO: os.path.join("gradle", "libs.versions.toml"),
+    TARGET_BRIDGE: os.path.join("gradle", "libs.versions.toml"),
+    TARGET_GRADLE_PLUGIN: os.path.join("gradle", "libs.versions.toml")
 }
 
 PREFIX = {
     TARGET_APP: "val version",
-    TARGET_DEMO: "val Datadog",
-    TARGET_BRIDGE: "val DatadogSdkVersion"
+    TARGET_DEMO: "datadogSdk",
+    TARGET_BRIDGE: "datadogSdk",
+    TARGET_GRADLE_PLUGIN: "datadogSdk"
 }
 
 


### PR DESCRIPTION
### What does this PR do?

This change updates dogfood script to target Gradle version catalogs, which are introduced with the recent Gradle 7 upgrades.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

