### PR TITLE
Set log levels for licenses check, ignore project-type dependencies

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/checklicenses/CheckThirdPartyLicensesTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/checklicenses/CheckThirdPartyLicensesTask.kt
@@ -45,17 +45,17 @@ open class CheckThirdPartyLicensesTask : DefaultTask() {
 
         listedDependencies.filter { it.license is License.Empty }
             .forEach {
-                System.err.println("License for ${it.origin} is empty")
+                logger.warn("License for ${it.origin} is empty")
             }
 
         listedDependencies.filter { it.license is License.Raw }
             .forEach {
-                System.err.println("License for ${it.origin} is not valid : ${it.license}")
+                logger.warn("License for ${it.origin} is not valid : ${it.license}")
             }
 
         listedDependencies.filter { it.copyright == "__" }
             .forEach {
-                System.err.println("Copyright for ${it.origin} is missing")
+                logger.warn("Copyright for ${it.origin} is missing")
             }
     }
 
@@ -76,9 +76,9 @@ open class CheckThirdPartyLicensesTask : DefaultTask() {
 
             if (known == null && knownInOtherComponent == null) {
                 error = true
-                System.err.println("✗ $check dependency in ${extension.csvFile.name} : $dep")
+                logger.error("✗ $check dependency in ${extension.csvFile.name} : $dep")
             } else if (knownInOtherComponent != null) {
-                System.err.println(
+                logger.info(
                     "✗ $dep $check but exist in component ${knownInOtherComponent.component}"
                 )
             }


### PR DESCRIPTION
### What does this PR do?

This small change does the following:

* Set log levels for different messages. Before they were all logged as errors, significantly polluting log output and making it harder finding real errors.
* Ignore `project`-type dependencies (like `api(project(...))`), because they don't have `pom.xml` files yet (it is not a final artifact) and belong to us anyway.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

