### PR TITLE
RUMM-1717: Read custom error source type value

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -314,6 +314,7 @@ object com.datadog.android.rum.RumAttributes
   const val SDK_VERSION: String
   const val INTERNAL_ERROR_TYPE: String
   const val INTERNAL_TIMESTAMP: String
+  const val INTERNAL_ERROR_SOURCE_TYPE: String
   const val TRACE_ID: String
   const val SPAN_ID: String
   const val RESOURCE_TIMINGS: String
@@ -566,7 +567,7 @@ data class com.datadog.android.rum.model.ErrorEvent
     companion object 
       fun fromJson(kotlin.String): Context
   data class Error
-    constructor(kotlin.String? = null, kotlin.String, Source, kotlin.String? = null, kotlin.Boolean? = null, kotlin.String? = null, Handling? = null, kotlin.String? = null, Resource? = null)
+    constructor(kotlin.String? = null, kotlin.String, Source, kotlin.String? = null, kotlin.Boolean? = null, kotlin.String? = null, Handling? = null, kotlin.String? = null, SourceType? = null, Resource? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Error
@@ -643,6 +644,15 @@ data class com.datadog.android.rum.model.ErrorEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Handling
+  enum SourceType
+    constructor(kotlin.String)
+    - ANDROID
+    - BROWSER
+    - IOS
+    - REACT_NATIVE
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): SourceType
   enum Plan
     constructor(kotlin.Number)
     - PLAN_1

--- a/dd-sdk-android/src/main/json/rum/error-schema.json
+++ b/dd-sdk-android/src/main/json/rum/error-schema.json
@@ -71,6 +71,12 @@
               "description": "Handling call stack",
               "readOnly": true
             },
+            "source_type": {
+              "type": "string",
+              "description": "Source type of the error (the language or platform impacting the error stacktrace format)",
+              "enum": ["android", "browser", "ios", "react-native"],
+              "readOnly": true
+            },
             "resource": {
               "type": "object",
               "description": "Resource properties of the error",

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -69,6 +69,11 @@ object RumAttributes {
      */
     const val INTERNAL_TIMESTAMP: String = "_dd.timestamp"
 
+    /**
+     * Overrides the default RUM error source type with a custom one.
+     */
+    const val INTERNAL_ERROR_SOURCE_TYPE: String = "_dd.error.source_type"
+
     // endregion
 
     // region Resource

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumErrorSourceType.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumErrorSourceType.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal
+
+/**
+ * Source type of the error (the language or platform impacting the error stacktrace format).
+ * @see [RumMonitor]
+*/
+internal enum class RumErrorSourceType {
+    ANDROID,
+    BROWSER,
+    REACT_NATIVE
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
@@ -176,7 +176,8 @@ internal class RumEventSerializer(
 
         internal val ignoredAttributes = setOf(
             RumAttributes.INTERNAL_TIMESTAMP,
-            RumAttributes.INTERNAL_ERROR_TYPE
+            RumAttributes.INTERNAL_ERROR_TYPE,
+            RumAttributes.INTERNAL_ERROR_SOURCE_TYPE
         )
 
         internal const val GLOBAL_ATTRIBUTE_PREFIX: String = "context"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
@@ -12,6 +12,7 @@ import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
@@ -62,6 +63,14 @@ internal fun RumErrorSource.toSchemaSource(): ErrorEvent.Source {
         RumErrorSource.LOGGER -> ErrorEvent.Source.LOGGER
         RumErrorSource.AGENT -> ErrorEvent.Source.AGENT
         RumErrorSource.WEBVIEW -> ErrorEvent.Source.WEBVIEW
+    }
+}
+
+internal fun RumErrorSourceType.toSchemaSourceType(): ErrorEvent.SourceType {
+    return when (this) {
+        RumErrorSourceType.ANDROID -> ErrorEvent.SourceType.ANDROID
+        RumErrorSourceType.BROWSER -> ErrorEvent.SourceType.BROWSER
+        RumErrorSourceType.REACT_NATIVE -> ErrorEvent.SourceType.REACT_NATIVE
     }
 }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.domain.scope
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.model.ViewEvent
@@ -91,7 +92,8 @@ internal sealed class RumRawEvent {
         val isFatal: Boolean,
         val attributes: Map<String, Any?>,
         override val eventTime: Time = Time(),
-        val type: String? = null
+        val type: String? = null,
+        val sourceType: RumErrorSourceType = RumErrorSourceType.ANDROID
     ) : RumRawEvent()
 
     internal data class UpdateViewLoadingTime(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -221,7 +221,8 @@ internal class RumResourceScope(
                     statusCode = statusCode ?: 0,
                     provider = resolveErrorProvider()
                 ),
-                type = resolveErrorType(statusCode, throwable)
+                type = resolveErrorType(statusCode, throwable),
+                sourceType = ErrorEvent.SourceType.ANDROID
             ),
             action = context.actionId?.let { ErrorEvent.Action(it) },
             view = ErrorEvent.View(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -112,7 +112,7 @@ internal open class RumViewScope(
 
     private var refreshRateScale: Double = 1.0
     private var lastFrameRateInfo: VitalInfo? = null
-    private var frameRateVitalListenr: VitalListener = object : VitalListener {
+    private var frameRateVitalListener: VitalListener = object : VitalListener {
         override fun onVitalUpdate(info: VitalInfo) {
             lastFrameRateInfo = info
         }
@@ -125,7 +125,7 @@ internal open class RumViewScope(
         attributes.putAll(GlobalRum.globalAttributes)
         cpuVitalMonitor.register(cpuVitalListener)
         memoryVitalMonitor.register(memoryVitalListener)
-        frameRateVitalMonitor.register(frameRateVitalListenr)
+        frameRateVitalMonitor.register(frameRateVitalListener)
 
         detectRefreshRateScale(key)
     }
@@ -284,7 +284,8 @@ internal open class RumViewScope(
                 source = event.source.toSchemaSource(),
                 stack = event.stacktrace ?: event.throwable?.loggableStackTrace(),
                 isCrash = event.isFatal,
-                type = errorType
+                type = errorType,
+                sourceType = event.sourceType.toSchemaSourceType()
             ),
             action = context.actionId?.let { ErrorEvent.Action(it) },
             view = ErrorEvent.View(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
@@ -268,7 +268,8 @@ internal class DatadogNdkCrashHandler(
                 source = ErrorEvent.Source.SOURCE,
                 stack = ndkCrashLog.stacktrace,
                 isCrash = true,
-                type = ndkCrashLog.signalName
+                type = ndkCrashLog.signalName,
+                sourceType = ErrorEvent.SourceType.ANDROID
             )
         )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -332,6 +332,15 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
+    fun hasErrorSourceType(expected: ErrorEvent.SourceType?): ErrorEventAssert {
+        assertThat(actual.error.sourceType)
+            .overridingErrorMessage(
+                "Expected event data to have error source type $expected" +
+                    " but was ${actual.error.sourceType}"
+            ).isEqualTo(expected)
+        return this
+    }
+
     fun hasLiteSessionPlan(): ErrorEventAssert {
         assertThat(actual.dd.session?.plan)
             .overridingErrorMessage(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -526,10 +526,12 @@ internal class RumEventSerializerTest {
         // GIVEN
         val fakeInternalTimestamp = forge.aLong()
         val fakeErrorType = forge.aString()
+        val fakeErrorSourceType = forge.aString()
         val fakeEventWithInternalGlobalAttributes = forge.forgeRumEvent(
             attributes = mapOf(
                 RumAttributes.INTERNAL_ERROR_TYPE to fakeErrorType,
-                RumAttributes.INTERNAL_TIMESTAMP to fakeInternalTimestamp
+                RumAttributes.INTERNAL_TIMESTAMP to fakeInternalTimestamp,
+                RumAttributes.INTERNAL_ERROR_SOURCE_TYPE to fakeErrorSourceType
             )
         )
         // WHEN
@@ -545,6 +547,11 @@ internal class RumEventSerializerTest {
             .doesNotHaveField(
                 RumEventSerializer.GLOBAL_ATTRIBUTE_PREFIX + "." + RumAttributes.INTERNAL_ERROR_TYPE
             )
+        assertThat(jsonObject)
+            .doesNotHaveField(
+                RumEventSerializer.GLOBAL_ATTRIBUTE_PREFIX +
+                    "." + RumAttributes.INTERNAL_ERROR_SOURCE_TYPE
+            )
     }
 
     @Test
@@ -554,10 +561,12 @@ internal class RumEventSerializerTest {
         // GIVEN
         val fakeInternalTimestamp = forge.aLong()
         val fakeErrorType = forge.aString()
+        val fakeErrorSourceType = forge.aString()
         val fakeEventWithInternalUserAttributes = forge.forgeRumEvent(
             userAttributes = mapOf(
                 RumAttributes.INTERNAL_ERROR_TYPE to fakeErrorType,
-                RumAttributes.INTERNAL_TIMESTAMP to fakeInternalTimestamp
+                RumAttributes.INTERNAL_TIMESTAMP to fakeInternalTimestamp,
+                RumAttributes.INTERNAL_ERROR_SOURCE_TYPE to fakeErrorSourceType
             )
         )
 
@@ -573,6 +582,11 @@ internal class RumEventSerializerTest {
         assertThat(jsonObject)
             .doesNotHaveField(
                 RumEventSerializer.USER_ATTRIBUTE_PREFIX + "." + RumAttributes.INTERNAL_ERROR_TYPE
+            )
+        assertThat(jsonObject)
+            .doesNotHaveField(
+                RumEventSerializer.GLOBAL_ATTRIBUTE_PREFIX +
+                    "." + RumAttributes.INTERNAL_ERROR_SOURCE_TYPE
             )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExtTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.utils.forge.Configurator
@@ -107,6 +108,17 @@ internal class RumEventExtTest {
     ) {
         // When
         val result = kind.toSchemaSource()
+
+        // Then
+        assertThat(kind.name).isEqualTo(result.name)
+    }
+
+    @RepeatedTest(6)
+    fun `𝕄 return error source type 𝕎 toSchemaSourceType()`(
+        @Forgery kind: RumErrorSourceType
+    ) {
+        // When
+        val result = kind.toSchemaSourceType()
 
         // Then
         assertThat(kind.name).isEqualTo(result.name)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -773,6 +773,7 @@ internal class RumResourceScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(expectedAttributes)
                 }
@@ -839,6 +840,7 @@ internal class RumResourceScopeTest {
                     hasProviderDomain(brokenUrl)
                     hasProviderType(ErrorEvent.ProviderType.FIRST_PARTY)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(expectedAttributes)
                 }
@@ -895,6 +897,7 @@ internal class RumResourceScopeTest {
                     hasProviderDomain(URL(fakeUrl).host)
                     hasProviderType(ErrorEvent.ProviderType.FIRST_PARTY)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(expectedAttributes)
                 }
@@ -949,6 +952,7 @@ internal class RumResourceScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                     doesNotHaveAResourceProvider()
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(expectedAttributes)
@@ -1010,6 +1014,7 @@ internal class RumResourceScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                     doesNotHaveAResourceProvider()
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(expectedAttributes)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -28,6 +28,7 @@ import com.datadog.android.rum.assertj.ActionEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.ErrorEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.LongTaskEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.ViewEventAssert.Companion.assertThat
+import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.vitals.VitalInfo
@@ -2629,6 +2630,7 @@ internal class RumViewScopeTest {
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         testedScope.activeActionScope = mockActionScope
@@ -2639,7 +2641,8 @@ internal class RumViewScopeTest {
             throwable,
             null,
             false,
-            attributes
+            attributes,
+            sourceType = sourceType
         )
 
         // When
@@ -2664,6 +2667,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2676,12 +2680,15 @@ internal class RumViewScopeTest {
     fun `𝕄 send event 𝕎 handleEvent(AddError) {throwable=null, stacktrace=null, fatal=false}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
-        fakeEvent = RumRawEvent.AddError(message, source, null, null, false, attributes)
+        fakeEvent = RumRawEvent.AddError(
+            message, source, null, null, false, attributes, sourceType = sourceType
+        )
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
@@ -2704,6 +2711,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(null)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2716,12 +2724,16 @@ internal class RumViewScopeTest {
     fun `𝕄 send event 𝕎 handleEvent(AddError) {throwable=null, stacktrace=null, fatal=true}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
-        fakeEvent = RumRawEvent.AddError(message, source, null, null, true, attributes)
+        fakeEvent = RumRawEvent.AddError(
+            message, source, null, null, true, attributes,
+            sourceType = sourceType
+        )
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
@@ -2743,6 +2755,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(null)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2784,6 +2797,7 @@ internal class RumViewScopeTest {
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
@@ -2794,7 +2808,8 @@ internal class RumViewScopeTest {
             throwable,
             null,
             false,
-            emptyMap()
+            emptyMap(),
+            sourceType = sourceType
         )
         val attributes = forgeGlobalAttributes(forge, fakeAttributes)
         GlobalRum.globalAttributes.putAll(attributes)
@@ -2821,6 +2836,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2834,6 +2850,7 @@ internal class RumViewScopeTest {
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
@@ -2845,7 +2862,8 @@ internal class RumViewScopeTest {
             throwable,
             null,
             true,
-            attributes
+            attributes,
+            sourceType = sourceType
         )
 
         // When
@@ -2869,6 +2887,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2911,6 +2930,7 @@ internal class RumViewScopeTest {
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
         @StringForgery errorType: String,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
@@ -2923,7 +2943,8 @@ internal class RumViewScopeTest {
             null,
             false,
             attributes,
-            type = errorType
+            type = errorType,
+            sourceType = sourceType
         )
 
         // When
@@ -2948,6 +2969,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(errorType)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2961,6 +2983,7 @@ internal class RumViewScopeTest {
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
@@ -2971,7 +2994,8 @@ internal class RumViewScopeTest {
             throwable,
             null,
             true,
-            emptyMap()
+            emptyMap(),
+            sourceType = sourceType
         )
         val attributes = forgeGlobalAttributes(forge, fakeAttributes)
         GlobalRum.globalAttributes.putAll(attributes)
@@ -2997,6 +3021,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
@@ -380,6 +380,7 @@ internal class DatadogNdkCrashHandlerTest {
                 .hasStackTrace(ndkCrashLog.stacktrace)
                 .isCrash(true)
                 .hasSource(RumErrorSource.SOURCE)
+                .hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                 .hasTimestamp(ndkCrashLog.timestamp + fakeServerOffset)
                 .hasUserInfo(
                     UserInfo(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
@@ -29,7 +29,8 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                         method = getForgery(),
                         statusCode = aLong(200, 600)
                     )
-                }
+                },
+                sourceType = forge.getForgery()
             ),
             view = ErrorEvent.View(
                 id = forge.getForgery<UUID>().toString(),


### PR DESCRIPTION
### What does this PR do?

This change introduces the possibility for specify custom error source type, so that we can distinguish errors coming from native Android apps vs another layer calling Android SDK (like Browser or React Native SDK).

This is done by adding `_dd.error.source_type` key to the `attributes` which can be supplied to the `addError` or `addErrorWithStacktrace` calls (`stopResourceWithError` is out of scope, because it is not used currently by non-native SDKs). Provided value will override the default one `Android`. Supported values are `react-native` and `browser` for now, `iOS` is out of scope, because it is not technically possible to have it.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

