### PR TITLE
RUMM-1754: Use API v2 for Crash Reports feature

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -14,7 +14,7 @@ import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.internal.domain.LogGenerator
-import com.datadog.android.log.internal.net.LogsOkHttpUploader
+import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
 import com.datadog.android.log.model.LogEvent
 
 internal object CrashReportsFeature : SdkFeature<LogEvent, Configuration.Feature.CrashReport>() {
@@ -44,10 +44,12 @@ internal object CrashReportsFeature : SdkFeature<LogEvent, Configuration.Feature
     }
 
     override fun createUploader(configuration: Configuration.Feature.CrashReport): DataUploader {
-        return LogsOkHttpUploader(
+        return LogsOkHttpUploaderV2(
             configuration.endpointUrl,
             CoreFeature.clientToken,
-            CoreFeature.okHttpClient
+            CoreFeature.sourceName,
+            CoreFeature.okHttpClient,
+            sdkLogger
         )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -9,7 +9,7 @@ package com.datadog.android.error.internal
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.SdkFeatureTest
-import com.datadog.android.log.internal.net.LogsOkHttpUploader
+import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.extensions.ApiLevelExtension
@@ -75,11 +75,11 @@ internal class CrashReportsFeatureTest :
         val uploader = testedFeature.createUploader(fakeConfigurationFeature)
 
         // Then
-        assertThat(uploader).isInstanceOf(LogsOkHttpUploader::class.java)
-        val crashUploader = uploader as LogsOkHttpUploader
-        assertThat(crashUploader.url).startsWith(fakeConfigurationFeature.endpointUrl)
-        assertThat(crashUploader.url).endsWith(CoreFeature.clientToken)
-        assertThat(crashUploader.callFactory).isSameAs(CoreFeature.okHttpClient)
+        assertThat(uploader).isInstanceOf(LogsOkHttpUploaderV2::class.java)
+        val crashReportsUploader = uploader as LogsOkHttpUploaderV2
+        assertThat(crashReportsUploader.intakeUrl).startsWith(fakeConfigurationFeature.endpointUrl)
+        assertThat(crashReportsUploader.intakeUrl).endsWith("/api/v2/logs")
+        assertThat(crashReportsUploader.callFactory).isSameAs(CoreFeature.okHttpClient)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This change switches from API v1 to API v2 for the Crash Reports feature as it was done for other features in #671 before.

I validated this change in the sample app by triggering a crash - it was displayed in the Logs with stacktrace and `Emergency` level.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

