### PR TITLE
RUMM-1753: Apply custom source tag for the API v2 uploaders setup

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -78,13 +78,13 @@ object Datadog {
         // always initialize Core Features first
         CoreFeature.initialize(appContext, credentials, configuration.coreConfig, trackingConsent)
 
+        applyAdditionalConfiguration(configuration.additionalConfig)
+
         initializeLogsFeature(configuration.logsConfig, appContext)
         initializeTracingFeature(configuration.tracesConfig, appContext)
         initializeRumFeature(configuration.rumConfig, appContext)
         initializeCrashReportFeature(configuration.crashReportConfig, appContext)
         initializeInternalLogsFeature(configuration.internalLogsConfig, appContext)
-
-        applyAdditionalConfiguration(configuration.additionalConfig)
 
         CoreFeature.ndkCrashHandler.handleNdkCrash(
             LogsFeature.persistenceStrategy.getWriter(),
@@ -272,8 +272,11 @@ object Datadog {
     }
 
     private fun applyAdditionalConfiguration(
-        @Suppress("UNUSED_PARAMETER") additionalConfiguration: Map<String, Any>
+        additionalConfiguration: Map<String, Any>
     ) {
+        // NOTE: be careful with the logic in this method - it is a part of initialization sequence,
+        // so some things may yet not be initialized -> not accessible, some things may already be
+        // initialized and be not mutable anymore
         additionalConfiguration[DD_SOURCE_TAG]?.let {
             if (it.toString().isNotBlank()) {
                 CoreFeature.sourceName = it.toString()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -14,6 +14,7 @@ import android.util.Log as AndroidLog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.internal.CoreFeature
+import com.datadog.android.core.internal.net.DataOkHttpUploaderV2
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.core.model.UserInfo
 import com.datadog.android.error.internal.CrashReportsFeature
@@ -442,6 +443,16 @@ internal class DatadogTest {
 
         // Then
         assertThat(CoreFeature.sourceName).isEqualTo(source)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracesFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).source }
+        )
+            .containsOnly(source)
     }
 
     @Test
@@ -464,6 +475,16 @@ internal class DatadogTest {
 
         // Then
         assertThat(CoreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracesFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).source }
+        )
+            .containsOnly(CoreFeature.DEFAULT_SOURCE_NAME)
     }
 
     @Test
@@ -486,6 +507,16 @@ internal class DatadogTest {
 
         // Then
         assertThat(CoreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracesFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).source }
+        )
+            .containsOnly(CoreFeature.DEFAULT_SOURCE_NAME)
     }
 
     // region Internal


### PR DESCRIPTION
### What does this PR do?

This change fixes the issue reported here https://github.com/DataDog/dd-sdk-reactnative/issues/123: custom `source` tag wasn't applied after migration to API v2. This happens because after API v2 migration we apply `additionalConfig` too late.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

