### PR TITLE
RUMM-1708: Allow to specify custom SDK version

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -278,8 +278,14 @@ object Datadog {
         // so some things may yet not be initialized -> not accessible, some things may already be
         // initialized and be not mutable anymore
         additionalConfiguration[DD_SOURCE_TAG]?.let {
-            if (it.toString().isNotBlank()) {
-                CoreFeature.sourceName = it.toString()
+            if (it is String && it.isNotBlank()) {
+                CoreFeature.sourceName = it
+            }
+        }
+
+        additionalConfiguration[DD_SDK_VERSION_TAG]?.let {
+            if (it is String && it.isNotBlank()) {
+                CoreFeature.sdkVersion = it
             }
         }
     }
@@ -339,6 +345,7 @@ object Datadog {
             "In this case the Datadog SDK will not be initialised."
 
     internal const val DD_SOURCE_TAG = "_dd.source"
+    internal const val DD_SDK_VERSION_TAG = "_dd.sdk_version"
 
     // endregion
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -10,6 +10,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.os.Build
 import android.os.Process
+import com.datadog.android.BuildConfig
 import com.datadog.android.DatadogEndpoint
 import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.Configuration
@@ -74,6 +75,7 @@ internal object CoreFeature {
     // possibility to override it which is useful when SDK is used via bridge, say
     // from React Native integration
     internal const val DEFAULT_SOURCE_NAME = "android"
+    internal const val DEFAULT_SDK_VERSION = BuildConfig.SDK_VERSION_NAME
 
     // endregion
 
@@ -95,6 +97,7 @@ internal object CoreFeature {
     internal var packageVersion: String = ""
     internal var serviceName: String = ""
     internal var sourceName: String = DEFAULT_SOURCE_NAME
+    internal var sdkVersion: String = DEFAULT_SDK_VERSION
     internal var rumApplicationId: String? = null
     internal var isMainProcess: Boolean = true
     internal var envName: String = ""
@@ -195,6 +198,7 @@ internal object CoreFeature {
                     networkInfoProvider,
                     userInfoProvider,
                     timeProvider,
+                    sdkVersion,
                     envName,
                     packageVersion
                 ),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.core.internal.net
 
 import android.os.Build
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.log.Logger
 import java.util.Locale
@@ -18,8 +17,9 @@ import okhttp3.RequestBody
 
 internal abstract class DataOkHttpUploaderV2(
     internal var intakeUrl: String,
-    internal var clientToken: String,
-    internal var source: String,
+    internal val clientToken: String,
+    internal val source: String,
+    internal val sdkVersion: String,
     internal val callFactory: Call.Factory,
     internal val contentType: String,
     internal val internalLogger: Logger
@@ -36,7 +36,7 @@ internal abstract class DataOkHttpUploaderV2(
     private val userAgent by lazy {
         System.getProperty(DataOkHttpUploader.SYSTEM_UA).let {
             if (it.isNullOrBlank()) {
-                "Datadog/${BuildConfig.SDK_VERSION_NAME} " +
+                "Datadog/$sdkVersion " +
                     "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
                     "${Build.MODEL} Build/${Build.ID})"
             } else {
@@ -100,7 +100,7 @@ internal abstract class DataOkHttpUploaderV2(
     private fun buildHeaders(builder: Request.Builder, requestId: String) {
         builder.addHeader(HEADER_API_KEY, clientToken)
         builder.addHeader(HEADER_EVP_ORIGIN, source)
-        builder.addHeader(HEADER_EVP_ORIGIN_VERSION, BuildConfig.SDK_VERSION_NAME)
+        builder.addHeader(HEADER_EVP_ORIGIN_VERSION, sdkVersion)
         builder.addHeader(HEADER_USER_AGENT, userAgent)
         builder.addHeader(HEADER_CONTENT_TYPE, contentType)
         builder.addHeader(HEADER_REQUEST_ID, requestId)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -50,6 +50,7 @@ internal object CrashReportsFeature : SdkFeature<LogEvent, Configuration.Feature
             configuration.endpointUrl,
             CoreFeature.clientToken,
             CoreFeature.sourceName,
+            CoreFeature.sdkVersion,
             CoreFeature.okHttpClient,
             sdkLogger
         )
@@ -74,6 +75,7 @@ internal object CrashReportsFeature : SdkFeature<LogEvent, Configuration.Feature
                 CoreFeature.networkInfoProvider,
                 CoreFeature.userInfoProvider,
                 CoreFeature.timeProvider,
+                CoreFeature.sdkVersion,
                 CoreFeature.envName,
                 CoreFeature.packageVersion
             ),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -353,6 +353,7 @@ internal constructor(internal val handler: LogHandler) {
                 netInfoProvider,
                 CoreFeature.userInfoProvider,
                 CoreFeature.timeProvider,
+                CoreFeature.sdkVersion,
                 CoreFeature.envName,
                 CoreFeature.packageVersion
             )
@@ -370,6 +371,7 @@ internal constructor(internal val handler: LogHandler) {
                 netInfoProvider,
                 NoOpUserInfoProvider(), // we don't want to track our customer's users
                 CoreFeature.timeProvider,
+                CoreFeature.sdkVersion,
                 InternalLogsFeature.ENV_NAME,
                 CoreFeature.packageVersion
             )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -41,6 +41,7 @@ internal object LogsFeature : SdkFeature<LogEvent, Configuration.Feature.Logs>()
             configuration.endpointUrl,
             CoreFeature.clientToken,
             CoreFeature.sourceName,
+            CoreFeature.sdkVersion,
             CoreFeature.okHttpClient,
             sdkLogger
         )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogGenerator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogGenerator.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.log.internal.domain
 
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.NetworkInfo
@@ -27,6 +26,7 @@ internal class LogGenerator(
     internal val networkInfoProvider: NetworkInfoProvider?,
     internal val userInfoProvider: UserInfoProvider,
     internal val timeProvider: TimeProvider,
+    internal val sdkVersion: String,
     envName: String,
     appVersion: String
 ) {
@@ -75,7 +75,7 @@ internal class LogGenerator(
         val loggerInfo = LogEvent.Logger(
             name = loggerName,
             threadName = threadName ?: Thread.currentThread().name,
-            version = BuildConfig.SDK_VERSION_NAME
+            version = sdkVersion
         )
         return LogEvent(
             service = serviceName,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploaderV2.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploaderV2.kt
@@ -14,12 +14,14 @@ internal open class LogsOkHttpUploaderV2(
     endpoint: String,
     clientToken: String,
     source: String,
+    sdkVersion: String,
     callFactory: Call.Factory,
     internalLogger: Logger
 ) : DataOkHttpUploaderV2(
     buildUrl(endpoint, TrackType.LOGS),
     clientToken,
     source,
+    sdkVersion,
     callFactory,
     CONTENT_TYPE_JSON,
     internalLogger

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/monitoring/internal/InternalLogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/monitoring/internal/InternalLogsFeature.kt
@@ -58,6 +58,7 @@ internal object InternalLogsFeature : SdkFeature<LogEvent, Configuration.Feature
             configuration.endpointUrl,
             configuration.internalClientToken,
             CoreFeature.sourceName,
+            CoreFeature.sdkVersion,
             CoreFeature.okHttpClient,
             Logger(NoOpLogHandler())
         )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -120,6 +120,7 @@ internal object RumFeature : SdkFeature<Any, Configuration.Feature.RUM>() {
             configuration.endpointUrl,
             CoreFeature.clientToken,
             CoreFeature.sourceName,
+            CoreFeature.sdkVersion,
             CoreFeature.okHttpClient
         )
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderV2.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderV2.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.rum.internal.net
 
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.DataOkHttpUploaderV2
 import com.datadog.android.core.internal.utils.sdkLogger
@@ -17,11 +16,13 @@ internal open class RumOkHttpUploaderV2(
     endpoint: String,
     clientToken: String,
     source: String,
+    sdkVersion: String,
     callFactory: Call.Factory
 ) : DataOkHttpUploaderV2(
     buildUrl(endpoint, TrackType.RUM),
     clientToken,
     source,
+    sdkVersion,
     callFactory,
     CONTENT_TYPE_TEXT_UTF8,
     sdkLogger
@@ -31,7 +32,7 @@ internal open class RumOkHttpUploaderV2(
         val elements = mutableListOf(
             "${RumAttributes.SERVICE_NAME}:${CoreFeature.serviceName}",
             "${RumAttributes.APPLICATION_VERSION}:${CoreFeature.packageVersion}",
-            "${RumAttributes.SDK_VERSION}:${BuildConfig.SDK_VERSION_NAME}",
+            "${RumAttributes.SDK_VERSION}:$sdkVersion",
             "${RumAttributes.ENV}:${CoreFeature.envName}"
         )
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
@@ -337,7 +337,7 @@ internal constructor(
                 "Configuration.Builder::setFirstPartyHosts() method."
         internal const val WARNING_TRACING_DISABLED =
             "You added a TracingInterceptor to your OkHttpClient, " +
-                "but you did not enable the TracesFeature. " +
+                "but you did not enable the TracingFeature. " +
                 "Your requests won't be traced."
         internal const val WARNING_DEFAULT_TRACER =
             "You added a TracingInterceptor to your OkHttpClient, " +

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracingFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracingFeature.kt
@@ -45,6 +45,7 @@ internal object TracingFeature : SdkFeature<DDSpan, Configuration.Feature.Tracin
             configuration.endpointUrl,
             CoreFeature.clientToken,
             CoreFeature.sourceName,
+            CoreFeature.sdkVersion,
             CoreFeature.okHttpClient
         )
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapper.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.tracing.internal.domain.event
 
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.Mapper
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
@@ -76,7 +75,7 @@ internal class DdSpanToSpanEventMapper(
             dd = SpanEvent.Dd(),
             span = SpanEvent.Span(),
             tracer = SpanEvent.Tracer(
-                version = BuildConfig.SDK_VERSION_NAME
+                version = CoreFeature.sdkVersion
             ),
             usr = usrMeta,
             network = networkInfoMeta,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderV2.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderV2.kt
@@ -14,17 +14,14 @@ internal open class TracesOkHttpUploaderV2(
     endpoint: String,
     clientToken: String,
     source: String,
+    sdkVersion: String,
     callFactory: Call.Factory
 ) : DataOkHttpUploaderV2(
     buildUrl(endpoint, TrackType.SPANS),
     clientToken,
     source,
+    sdkVersion,
     callFactory,
     CONTENT_TYPE_TEXT_UTF8,
     sdkLogger
-) {
-
-    companion object {
-        private const val TRACK_TYPE = "spans"
-    }
-}
+)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -98,6 +98,9 @@ internal class DatadogTest {
 
         // Prevent crash when initializing RumFeature
         mockChoreographerInstance()
+
+        CoreFeature.sdkVersion = CoreFeature.DEFAULT_SDK_VERSION
+        CoreFeature.sourceName = CoreFeature.DEFAULT_SOURCE_NAME
     }
 
     @AfterEach
@@ -482,6 +485,38 @@ internal class DatadogTest {
     }
 
     @Test
+    fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { with source name !string }`(
+        forge: Forge
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to forge.anInt()))
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracingFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).source }
+        )
+            .containsOnly(CoreFeature.DEFAULT_SOURCE_NAME)
+    }
+
+    @Test
     fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { without source name }`(
         forge: Forge
     ) {
@@ -511,6 +546,136 @@ internal class DatadogTest {
                 .map { (it as DataOkHttpUploaderV2).source }
         )
             .containsOnly(CoreFeature.DEFAULT_SOURCE_NAME)
+    }
+
+    @Test
+    fun `𝕄 apply sdk version 𝕎 applyAdditionalConfig(config) { with sdk version }`(
+        @StringForgery sdkVersion: String
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion))
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sdkVersion).isEqualTo(sdkVersion)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracingFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).sdkVersion }
+        )
+            .containsOnly(sdkVersion)
+    }
+
+    @Test
+    fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { with empty sdk version }`(
+        forge: Forge
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(
+                mapOf(Datadog.DD_SDK_VERSION_TAG to forge.aWhitespaceString())
+            )
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracingFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).sdkVersion }
+        )
+            .containsOnly(CoreFeature.DEFAULT_SDK_VERSION)
+    }
+
+    @Test
+    fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { with sdk version !string }`(
+        forge: Forge
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SDK_VERSION_TAG to forge.anInt()))
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracingFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).sdkVersion }
+        )
+            .containsOnly(CoreFeature.DEFAULT_SDK_VERSION)
+    }
+
+    @Test
+    fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { without sdk version }`(
+        forge: Forge
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(forge.aMap { anAsciiString() to aString() })
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracingFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).sdkVersion }
+        )
+            .containsOnly(CoreFeature.DEFAULT_SDK_VERSION)
     }
 
     // region Internal

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2Test.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2Test.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.core.internal.net
 
 import android.os.Build
-import com.datadog.android.BuildConfig
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.setStaticValue
 import com.nhaarman.mockitokotlin2.any
@@ -71,6 +70,9 @@ internal abstract class DataOkHttpUploaderV2Test<T : DataOkHttpUploaderV2> {
 
     @StringForgery
     lateinit var fakeSource: String
+
+    @StringForgery
+    lateinit var fakeSdkVersion: String
 
     lateinit var fakeUserAgent: String
 
@@ -359,7 +361,7 @@ internal abstract class DataOkHttpUploaderV2Test<T : DataOkHttpUploaderV2> {
     private fun verifyRequestHeaders(headers: Headers) {
         assertThat(headers.get("DD-API-KEY")).isEqualTo(fakeClientToken)
         assertThat(headers.get("DD-EVP-ORIGIN")).isEqualTo(fakeSource)
-        assertThat(headers.get("DD-EVP-ORIGIN-VERSION")).isEqualTo(BuildConfig.SDK_VERSION_NAME)
+        assertThat(headers.get("DD-EVP-ORIGIN-VERSION")).isEqualTo(fakeSdkVersion)
         assertThat(headers.get("DD-REQUEST-ID")).matches {
             UUID.fromString(it) != UUID(0, 0)
         }
@@ -367,7 +369,7 @@ internal abstract class DataOkHttpUploaderV2Test<T : DataOkHttpUploaderV2> {
         assertThat(headers.get("Content-Type")).isEqualTo(testedUploader.contentType)
 
         val expectedUserAgent = if (fakeUserAgent.isBlank()) {
-            "Datadog/${BuildConfig.SDK_VERSION_NAME} " +
+            "Datadog/$fakeSdkVersion " +
                 "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
                 "${Build.MODEL} Build/${Build.ID})"
         } else {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -158,6 +158,7 @@ internal class DatadogExceptionHandlerTest {
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                CoreFeature.sdkVersion,
                 CoreFeature.envName,
                 CoreFeature.packageVersion
             ),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/LogGeneratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/LogGeneratorTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.log.internal.domain
 
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.NetworkInfo
@@ -86,6 +85,9 @@ internal class LogGeneratorTest {
     lateinit var fakeLogMessage: String
     lateinit var fakeThrowable: Throwable
 
+    @StringForgery
+    lateinit var fakeSdkVersion: String
+
     @StringForgery(StringForgeryType.HEXADECIMAL)
     lateinit var fakeSpanId: String
 
@@ -134,6 +136,7 @@ internal class LogGeneratorTest {
             mockNetworkInfoProvider,
             mockUserInfoProvider,
             mockTimeProvider,
+            fakeSdkVersion,
             fakeEnvName,
             fakeAppVersion
         )
@@ -221,7 +224,7 @@ internal class LogGeneratorTest {
         )
 
         // THEN
-        assertThat(log).hasLoggerVersion(BuildConfig.SDK_VERSION_NAME)
+        assertThat(log).hasLoggerVersion(fakeSdkVersion)
     }
 
     @Test
@@ -379,6 +382,7 @@ internal class LogGeneratorTest {
             null,
             mockUserInfoProvider,
             mockTimeProvider,
+            fakeSdkVersion,
             fakeEnvName,
             fakeAppVersion
         )
@@ -407,6 +411,7 @@ internal class LogGeneratorTest {
             null,
             mockUserInfoProvider,
             mockTimeProvider,
+            fakeSdkVersion,
             fakeEnvName,
             fakeAppVersion
         )
@@ -451,6 +456,7 @@ internal class LogGeneratorTest {
             mockNetworkInfoProvider,
             mockUserInfoProvider,
             mockTimeProvider,
+            fakeSdkVersion,
             "",
             fakeAppVersion
         )
@@ -497,6 +503,7 @@ internal class LogGeneratorTest {
             mockNetworkInfoProvider,
             mockUserInfoProvider,
             mockTimeProvider,
+            fakeSdkVersion,
             fakeEnvName,
             ""
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -111,6 +111,8 @@ internal class DatadogLogHandlerTest {
 
     lateinit var fakeEnvName: String
 
+    lateinit var fakeSdkVersion: String
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         // To avoid java.lang.NoClassDefFoundError: android/hardware/display/DisplayManagerGlobal.
@@ -131,6 +133,8 @@ internal class DatadogLogHandlerTest {
         fakeLevel = forge.anInt(2, 8)
         fakeAttributes = forge.aMap { anAlphabeticalString() to anInt() }
         fakeTags = forge.aList { anAlphabeticalString() }.toSet()
+        fakeSdkVersion = forge.anAlphabeticalString()
+        CoreFeature.sdkVersion = fakeSdkVersion
         CoreFeature.envName = fakeEnvName
         CoreFeature.packageVersion = fakeAppVersion
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
@@ -143,6 +147,7 @@ internal class DatadogLogHandlerTest {
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -404,6 +409,7 @@ internal class DatadogLogHandlerTest {
                 null,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -457,6 +463,7 @@ internal class DatadogLogHandlerTest {
                 null,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -613,6 +620,7 @@ internal class DatadogLogHandlerTest {
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -649,6 +657,7 @@ internal class DatadogLogHandlerTest {
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -682,6 +691,7 @@ internal class DatadogLogHandlerTest {
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploaderV2Test.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploaderV2Test.kt
@@ -33,6 +33,7 @@ internal class LogsOkHttpUploaderV2Test : DataOkHttpUploaderV2Test<LogsOkHttpUpl
             fakeEndpoint,
             fakeClientToken,
             fakeSource,
+            fakeSdkVersion,
             callFactory,
             Logger(mock())
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderV2Test.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderV2Test.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.rum.internal.net
 
 import android.app.Application
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.DataOkHttpUploaderV2
 import com.datadog.android.core.internal.net.DataOkHttpUploaderV2Test
 import com.datadog.android.rum.RumAttributes
@@ -40,6 +39,7 @@ internal class RumOkHttpUploaderV2Test : DataOkHttpUploaderV2Test<RumOkHttpUploa
             fakeEndpoint,
             fakeClientToken,
             fakeSource,
+            fakeSdkVersion,
             callFactory
         )
     }
@@ -52,7 +52,7 @@ internal class RumOkHttpUploaderV2Test : DataOkHttpUploaderV2Test<RumOkHttpUploa
         val tags = mutableListOf(
             "${RumAttributes.SERVICE_NAME}:${coreFeature.fakeServiceName}",
             "${RumAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}",
-            "${RumAttributes.SDK_VERSION}:${BuildConfig.SDK_VERSION_NAME}",
+            "${RumAttributes.SDK_VERSION}:$fakeSdkVersion",
             "${RumAttributes.ENV}:${coreFeature.fakeEnvName}"
         )
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapperTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.tracing.internal.domain.event
 
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
@@ -65,12 +64,16 @@ internal class DdSpanToSpanEventMapperTest {
     @StringForgery(regex = "[0-9]\\.[0-9]\\.[0-9]")
     lateinit var fakeClientPackageVersion: String
 
+    @StringForgery
+    lateinit var fakeSdkVersion: String
+
     @LongForgery
     var fakeServerOffsetNanos: Long = 0L
 
     @BeforeEach
     fun `set up`() {
         CoreFeature.packageVersion = fakeClientPackageVersion
+        CoreFeature.sdkVersion = fakeSdkVersion
         whenever(mockTimeProvider.getServerOffsetNanos()).thenReturn(fakeServerOffsetNanos)
         whenever(mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
@@ -101,7 +104,7 @@ internal class DdSpanToSpanEventMapperTest {
             .hasErrorFlag(fakeSpan.error.toLong())
             .hasSpanStartTime(fakeSpan.startTime + fakeServerOffsetNanos)
             .hasSpanDuration(fakeSpan.durationNano)
-            .hasTracerVersion(BuildConfig.SDK_VERSION_NAME)
+            .hasTracerVersion(fakeSdkVersion)
             .hasClientPackageVersion(fakeClientPackageVersion)
             .hasNetworkInfo(fakeNetworkInfo)
             .hasUserInfo(fakeUserInfo)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderV2Test.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderV2Test.kt
@@ -30,6 +30,7 @@ internal class TracesOkHttpUploaderV2Test : DataOkHttpUploaderV2Test<TracesOkHtt
             fakeEndpoint,
             fakeClientToken,
             fakeSource,
+            fakeSdkVersion,
             callFactory
         )
     }


### PR DESCRIPTION
### What does this PR do?

This change introduces a possibility to override native SDK version which is need for other SDKs using the native one, like React Native SDK.

This is achieved by having a new property `_dd.sdk_version` in the `additionalConfiguration` dictionary which is passed during the native SDK initialization.

We are going to use custom SDK version only for API v2 uploaders, API v1 uploaders are left untouched.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

