### PR TITLE
Fix missing value in the options of dogfood script

### DIFF
--- a/dogfood.py
+++ b/dogfood.py
@@ -48,7 +48,7 @@ def parse_arguments(args: list) -> Namespace:
 
     parser.add_argument("-v", "--version", required=True, help="the version of the SDK")
     parser.add_argument("-t", "--target", required=True,
-                        choices=[TARGET_APP, TARGET_DEMO, TARGET_BRIDGE],
+                        choices=[TARGET_APP, TARGET_DEMO, TARGET_BRIDGE, TARGET_GRADLE_PLUGIN],
                         help="the target repository")
 
     return parser.parse_args(args)


### PR DESCRIPTION
### What does this PR do?

This change adds the missing `gradle-plugin` to the list of dogfood script targets.

This is a minor issue, no need to cherry pick into `1.11.0` release branch.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

