### PR TITLE
RUMM-1611: Track clicks in Jetpack Compose

### DIFF
--- a/dd-sdk-android-compose/README.md
+++ b/dd-sdk-android-compose/README.md
@@ -79,6 +79,19 @@ val configuration = Configuration.Builder(
     .build()
 ```
 
+#### Action tracking
+
+There is no automated instrumentation support for the action tracking in Jetpack Compose. However, report clicks using `trackClicks` method using this example:
+
+```kotlin
+Button(
+    onClick = trackClicks(targetName = "Open View") { ...click logic... }
+    ...
+) {
+    ...layout...
+}
+```
+
 ## Contributing
 
 For details on contributing, read the

--- a/dd-sdk-android-compose/README.md
+++ b/dd-sdk-android-compose/README.md
@@ -81,11 +81,11 @@ val configuration = Configuration.Builder(
 
 #### Action tracking
 
-There is no automated instrumentation support for the action tracking in Jetpack Compose. However, report clicks using `trackClicks` method using this example:
+There is no automated instrumentation support for the action tracking in Jetpack Compose. However, report clicks using `trackClick` method using this example:
 
 ```kotlin
 Button(
-    onClick = trackClicks(targetName = "Open View") { ...click logic... }
+    onClick = trackClick(targetName = "Open View") { ...click logic... }
     ...
 ) {
     ...layout...

--- a/dd-sdk-android-compose/apiSurface
+++ b/dd-sdk-android-compose/apiSurface
@@ -1,3 +1,3 @@
 class com.datadog.android.compose.ExperimentalTrackingApi
-fun trackClicks(String, Map<String, Any?> = remember { emptyMap() }, () -> Unit): () -> Unit
+fun trackClick(String, Map<String, Any?> = remember { emptyMap() }, () -> Unit): () -> Unit
 fun DatadogViewTrackingEffect(androidx.navigation.NavController, Boolean = true, com.datadog.android.rum.tracking.ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())

--- a/dd-sdk-android-compose/apiSurface
+++ b/dd-sdk-android-compose/apiSurface
@@ -1,1 +1,2 @@
+fun trackClicks(String, Map<String, Any?> = remember { emptyMap() }, () -> Unit): () -> Unit
 fun DatadogViewTrackingEffect(androidx.navigation.NavController, Boolean = true, com.datadog.android.rum.tracking.ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())

--- a/dd-sdk-android-compose/apiSurface
+++ b/dd-sdk-android-compose/apiSurface
@@ -1,2 +1,3 @@
+class com.datadog.android.compose.ExperimentalTrackingApi
 fun trackClicks(String, Map<String, Any?> = remember { emptyMap() }, () -> Unit): () -> Unit
 fun DatadogViewTrackingEffect(androidx.navigation.NavController, Boolean = true, com.datadog.android.rum.tracking.ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())

--- a/dd-sdk-android-compose/build.gradle.kts
+++ b/dd-sdk-android-compose/build.gradle.kts
@@ -14,6 +14,7 @@ import com.datadog.gradle.config.kotlinConfig
 import com.datadog.gradle.config.ktLintConfig
 import com.datadog.gradle.config.publishingConfig
 import com.datadog.gradle.config.setLibraryVersion
+import com.datadog.gradle.config.taskConfig
 
 plugins {
     // Build
@@ -100,6 +101,11 @@ unMock {
 }
 
 kotlinConfig()
+taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs += listOf("-Xopt-in=kotlin.RequiresOptIn")
+    }
+}
 detektConfig()
 ktLintConfig()
 junitConfig()

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/ExperimentalTrackingApi.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/ExperimentalTrackingApi.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+/**
+ * Marker for the experimental API.
+ */
+@RequiresOptIn(
+    message = "This is an experimental Jetpack Compose observability API." +
+        " It may change in the future.",
+    level = RequiresOptIn.Level.WARNING
+)
+annotation class ExperimentalTrackingApi

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
@@ -25,7 +25,7 @@ import com.datadog.android.rum.RumMonitor
  */
 @ExperimentalTrackingApi
 @Composable
-fun trackClicks(
+fun trackClick(
     targetName: String,
     attributes: Map<String, Any?> = remember { emptyMap() },
     onClick: () -> Unit

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.State
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.RumAttributes
+import com.datadog.android.rum.RumMonitor
+
+/**
+ * Creates a proxy around click listener, which will report clicks to Datadog.
+ *
+ * @param targetName Name of the click target.
+ * @param attributes additional custom attributes to attach to the action. Attributes can be
+ * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
+ * @param onClick Click listener.
+ */
+@Composable
+fun trackClicks(
+    targetName: String,
+    attributes: Map<String, Any?> = remember { emptyMap() },
+    onClick: () -> Unit
+): () -> Unit {
+    val onTapState = rememberUpdatedState(newValue = onClick)
+    return remember(targetName, attributes) {
+        TapActionTracker(targetName, attributes, onTapState)
+    }
+}
+
+internal class TapActionTracker(
+    private val targetName: String,
+    private val attributes: Map<String, Any?> = emptyMap(),
+    private val onTap: State<() -> Unit>,
+    private val rumMonitor: RumMonitor = GlobalRum.get()
+) : () -> Unit {
+    override fun invoke() {
+        rumMonitor.addUserAction(
+            RumActionType.TAP,
+            targetName,
+            attributes + mapOf(
+                RumAttributes.ACTION_TARGET_TITLE to targetName
+            )
+        )
+        onTap.value.invoke()
+    }
+}

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
@@ -50,6 +50,8 @@ internal class TapActionTracker(
                 RumAttributes.ACTION_TARGET_TITLE to targetName
             )
         )
+        // that is user code, not ours
+        @Suppress("UnsafeThirdPartyFunctionCall")
         onTap.value.invoke()
     }
 }

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
@@ -23,6 +23,7 @@ import com.datadog.android.rum.RumMonitor
  * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
  * @param onClick Click listener.
  */
+@ExperimentalTrackingApi
 @Composable
 fun trackClicks(
     targetName: String,

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation.kt
@@ -105,6 +105,7 @@ internal class ComposeNavigationObserver(
  * @param destinationPredicate to accept the [NavDestination] that will be taken into account as
  * valid RUM View events.
  */
+@ExperimentalTrackingApi
 @Composable
 @NonRestartableComposable
 fun DatadogViewTrackingEffect(

--- a/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/TapActionTrackerTest.kt
+++ b/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/TapActionTrackerTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+import androidx.compose.runtime.State
+import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.RumAttributes
+import com.datadog.android.rum.RumMonitor
+import com.datadog.tools.unit.forge.BaseConfigurator
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.annotation.AdvancedForgery
+import fr.xgouchet.elmyr.annotation.MapForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(
+        MockitoExtension::class,
+        ForgeExtension::class
+    )
+)
+@ForgeConfiguration(value = BaseConfigurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class TapActionTrackerTest {
+
+    private lateinit var testedTracker: TapActionTracker
+
+    @Mock
+    lateinit var mockRumMonitor: RumMonitor
+
+    @MapForgery(
+        key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+        value = AdvancedForgery(string = [StringForgery(StringForgeryType.ASCII)])
+    )
+    lateinit var fakeAttributes: Map<String, String>
+
+    @Mock
+    lateinit var mockOnClickState: State<() -> Unit>
+
+    @Mock
+    lateinit var mockOnClick: () -> Unit
+
+    @StringForgery
+    lateinit var fakeTargetName: String
+
+    @BeforeEach
+    fun setUp() {
+        whenever(mockOnClickState.value) doReturn mockOnClick
+
+        testedTracker =
+            TapActionTracker(fakeTargetName, fakeAttributes, mockOnClickState, mockRumMonitor)
+    }
+
+    @Test
+    fun `M call addAction W invoke`() {
+
+        // When
+        testedTracker.invoke()
+
+        // Then
+        verify(mockRumMonitor).addUserAction(
+            RumActionType.TAP,
+            fakeTargetName,
+            fakeAttributes + mapOf(RumAttributes.ACTION_TARGET_TITLE to fakeTargetName)
+        )
+    }
+}

--- a/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/TapActionTrackerTest.kt
+++ b/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/TapActionTrackerTest.kt
@@ -20,7 +20,6 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -182,11 +182,20 @@ internal class GesturesListener(
         val queue = LinkedList<View>()
         queue.addFirst(decorView)
         var target: View? = null
+        var notifyMissingTarget = true
 
         while (queue.isNotEmpty()) {
             // removeFirst can't fail because we checked isNotEmpty
             @Suppress("UnsafeThirdPartyFunctionCall")
             val view = queue.removeFirst()
+            if (queue.isEmpty() &&
+                view::class.java.name.startsWith("androidx.compose.ui.platform.ComposeView")
+            ) {
+                // startsWith here is to make testing easier: mocks don't have name exactly
+                // like this, and writing manual stub is not possible, because some necessary
+                // methods are final.
+                notifyMissingTarget = false
+            }
 
             if (isValidTapTarget(view)) {
                 target = view
@@ -197,7 +206,7 @@ internal class GesturesListener(
             }
         }
 
-        if (target == null) {
+        if (target == null && notifyMissingTarget) {
             devLogger.i(MSG_NO_TARGET_TAP)
         }
         return target

--- a/dd-sdk-android/src/test/kotlin/androidx/compose/ui/platform/ComposeView.kt
+++ b/dd-sdk-android/src/test/kotlin/androidx/compose/ui/platform/ComposeView.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package androidx.compose.ui.platform
+
+import android.content.Context
+import android.util.AttributeSet
+import android.view.ViewGroup
+
+abstract class ComposeView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : ViewGroup(context, attrs, defStyleAttr)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -13,6 +13,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.view.Window
+import androidx.compose.ui.platform.ComposeView
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
@@ -271,6 +272,39 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
                 Log.INFO,
                 GesturesListener.MSG_NO_TARGET_TAP
             )
+        verifyZeroInteractions(rumMonitor.mockInstance)
+    }
+
+    @Test
+    fun `onTap does nothing and no log triggered if no target found { target inside ComposeView } `(
+        forge: Forge
+    ) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        val composeView: ComposeView = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            forge = forge
+        )
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            forge = forge
+        ) {
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(composeView)
+        }
+        testedListener = GesturesListener(
+            WeakReference(mockWindow)
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        verifyZeroInteractions(mockDevLogHandler)
         verifyZeroInteractions(rumMonitor.mockInstance)
     }
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -703,6 +703,7 @@ datadog:
       - "java.util.LinkedList.add(com.datadog.android.privacy.TrackingConsentProviderCallback)"
       - "java.util.LinkedList.clear()"
       - "java.util.LinkedList.forEach(kotlin.Function1)"
+      - "java.util.LinkedList.isEmpty()"
       - "java.util.LinkedList.isNotEmpty()"
       - "java.util.LinkedList.add(android.view.View)"
       - "java.util.WeakHashMap.containsKey(kotlin.Any)"

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -13,6 +13,7 @@ import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 import com.datadog.gradle.config.ktLintConfig
+import com.datadog.gradle.config.taskConfig
 
 plugins {
     id("com.android.application")
@@ -178,6 +179,11 @@ dependencies {
 }
 
 kotlinConfig(evaluateWarningsAsErrors = false)
+taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
+    kotlinOptions {
+        freeCompilerArgs += listOf("-Xopt-in=kotlin.RequiresOptIn")
+    }
+}
 detektConfig()
 ktLintConfig()
 junitConfig()

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/ComposeFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/ComposeFragment.kt
@@ -35,6 +35,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.datadog.android.compose.DatadogViewTrackingEffect
+import com.datadog.android.compose.ExperimentalTrackingApi
 import com.datadog.android.compose.trackClicks
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
 import com.google.accompanist.appcompattheme.AppCompatTheme
@@ -59,6 +60,7 @@ class ComposeFragment : Fragment() {
     }
 }
 
+@OptIn(ExperimentalTrackingApi::class)
 @Composable
 fun ComposeNavigationExample() {
     val navController = rememberNavController().apply {
@@ -76,6 +78,7 @@ class SimpleViewIdPreviewProvider : PreviewParameterProvider<String> {
         get() = sequenceOf("one", "two", "three")
 }
 
+@OptIn(ExperimentalTrackingApi::class)
 @Preview
 @Composable
 fun SimpleView(

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/ComposeFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/ComposeFragment.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sample.compose
 
+import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -20,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -33,6 +35,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.datadog.android.compose.DatadogViewTrackingEffect
+import com.datadog.android.compose.trackClicks
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
 import com.google.accompanist.appcompattheme.AppCompatTheme
 import java.lang.IllegalArgumentException
@@ -85,7 +88,16 @@ fun SimpleView(
         modifier = Modifier.fillMaxSize()
     ) {
         Text("View $viewId")
-        Button(onClick = onNavigate, modifier = Modifier.padding(top = 32.dp)) {
+        val viewTreeObserver = (LocalContext.current as Activity).window.decorView.viewTreeObserver
+        Button(
+            onClick = trackClicks(targetName = "Open View", onClick = {
+                // TODO RUMM-1764 this is temporary, just for side-effect
+                viewTreeObserver.dispatchOnGlobalLayout()
+                onNavigate.invoke()
+            }),
+            modifier = Modifier
+                .padding(top = 32.dp)
+        ) {
             Text("Open Next Random View")
         }
     }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/ComposeFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/ComposeFragment.kt
@@ -36,7 +36,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import com.datadog.android.compose.DatadogViewTrackingEffect
 import com.datadog.android.compose.ExperimentalTrackingApi
-import com.datadog.android.compose.trackClicks
+import com.datadog.android.compose.trackClick
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
 import com.google.accompanist.appcompattheme.AppCompatTheme
 import java.lang.IllegalArgumentException
@@ -93,7 +93,7 @@ fun SimpleView(
         Text("View $viewId")
         val viewTreeObserver = (LocalContext.current as Activity).window.decorView.viewTreeObserver
         Button(
-            onClick = trackClicks(targetName = "Open View", onClick = {
+            onClick = trackClick(targetName = "Open View", onClick = {
                 // TODO RUMM-1764 this is temporary, just for side-effect
                 viewTreeObserver.dispatchOnGlobalLayout()
                 onNavigate.invoke()


### PR DESCRIPTION
### What does this PR do?

This change add a small utility function which may simplify click tracking with Jetpack Compose.

Unfortunately, it seems there is no good way to do auto-instrumentation by using public Compose API, so this change is about the manual instrumentation: user has to use it explicitly on the element.

It is worth mentioning that there is very small added value, because it can be just written as:

```
Button(onClick = {
  GloralRum.get().addUserAction(...)
  ...rest of onClick logic...
})
```

But because we proxying original `() -> Unit` type with the help of class with `fun operator invoke()` overload and we have to capture the variables, to avoid new objects creation during the re-composition event, we have to add a bunch of `remember` calls.

~~Another pitfall is `RumActionType` usage. If we use `TAP` and this action had no side-effects, it will be dropped. This is probably fine in the auto-instrumentation approach (because we can indeed have false-positive events which shouldn't be sent and not meaningful), but in case of manual instrumentation I guess user would expect this action to be sent. If we use `CUSTOM` type, then action is sent (we allow `CUSTOM` types to fly even if there is no side-effects), but then in the dashboard it would be just `%action_name%` instead of `tap on %target_name%` as in case of `TAP` usage.~~

~~Maybe we can leverage `attributes` parameter with some internal attribute to allow `TAP` action to be sent even if there is no side-effects in case of manual instrumentation?~~

This PR is using `TAP` action type, question of side-effects will be reviewed in another task.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

