### PR TITLE
RUMM-1774 Add the GlobalRum#checkForSessionUpdate method

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/GlobalRum.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/GlobalRum.kt
@@ -21,7 +21,6 @@ import com.datadog.android.tracing.internal.TracingFeature
 import java.util.concurrent.Callable
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicBoolean
-import java.util.concurrent.atomic.AtomicLong
 import java.util.concurrent.atomic.AtomicReference
 
 /**
@@ -37,8 +36,6 @@ import java.util.concurrent.atomic.AtomicReference
 object GlobalRum {
 
     internal val globalAttributes: MutableMap<String, Any?> = ConcurrentHashMap()
-
-    internal val sessionStartNs = AtomicLong(0L)
 
     internal val isRegistered = AtomicBoolean(false)
     internal var monitor: RumMonitor = NoOpRumMonitor()
@@ -142,6 +139,10 @@ object GlobalRum {
     }
 
     // region Internal
+
+    internal fun notifyIngestedWebViewEvent() {
+        (monitor as? AdvancedRumMonitor)?.sendWebViewEvent()
+    }
 
     internal fun getRumContext(): RumContext {
         return activeContext.get()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -174,4 +174,6 @@ internal sealed class RumRawEvent {
     internal data class SendCustomActionNow(
         override val eventTime: Time = Time()
     ) : RumRawEvent()
+
+    internal data class WebViewEvent(override val eventTime: Time = Time()) : RumRawEvent()
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -13,10 +13,13 @@ import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.tools.annotation.NoOpImplementation
 
+@SuppressWarnings("ComplexInterface")
 @NoOpImplementation
 internal interface AdvancedRumMonitor : RumMonitor {
 
     fun resetSession()
+
+    fun sendWebViewEvent()
 
     fun viewTreeChanged(eventTime: Time)
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -204,6 +204,10 @@ internal class DatadogRumMonitor(
 
     // region AdvancedRumMonitor
 
+    override fun sendWebViewEvent() {
+        handleEvent(RumRawEvent.WebViewEvent())
+    }
+
     override fun resetSession() {
         handleEvent(
             RumRawEvent.ResetSession()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/webview/WebRumEventContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/webview/WebRumEventContextProvider.kt
@@ -19,6 +19,7 @@ internal class WebRumEventContextProvider {
         if (rumFeatureDisabled) {
             return null
         }
+        GlobalRum.notifyIngestedWebViewEvent()
         val rumContext = GlobalRum.getRumContext()
         return if (
             rumContext.applicationId == RumContext.NULL_UUID ||

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/GlobalRumTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/GlobalRumTest.kt
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum
+
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(ExtendWith(MockitoExtension::class))
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class GlobalRumTest {
+
+    @Mock
+    lateinit var mockNoOpRumMonitor: NoOpRumMonitor
+
+    @Mock
+    lateinit var mockAdvancedRumMonitor: AdvancedRumMonitor
+
+    @Test
+    fun `M delegate to monitor W notifyIngestedWebViewEvent(){ AdvancedRumMonitor }`() {
+        // Given
+        GlobalRum.monitor = mockAdvancedRumMonitor
+
+        // When
+        GlobalRum.notifyIngestedWebViewEvent()
+
+        // Then
+        verify(mockAdvancedRumMonitor).sendWebViewEvent()
+    }
+
+    @Test
+    fun `M do nothing W notifyIngestedWebViewEvent(){ NoOpMonitor }`() {
+        // Given
+        GlobalRum.monitor = mockNoOpRumMonitor
+
+        // When
+        GlobalRum.notifyIngestedWebViewEvent()
+
+        // Then
+        verifyZeroInteractions(mockNoOpRumMonitor)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1098,6 +1098,20 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
+    fun `M delegate event to rootScope W sendWebViewEvent()`() {
+        // When
+        testedMonitor.sendWebViewEvent()
+        Thread.sleep(PROCESSING_DELAY)
+
+        // Then
+        verify(mockScope).handleEvent(
+            argThat { this is RumRawEvent.WebViewEvent },
+            same(mockWriter)
+        )
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
     fun `M shutdown with wait the persistence executor W drainAndShutdownExecutors()`() {
         // Given
         val mockExecutorService: ExecutorService = mock()


### PR DESCRIPTION
### What does this PR do?

In this PR we are introducing the `GlobalRum#notifyIngestedWebViewEvent` internal method. The purpose of this method is to trigger an asynchronous `EmptyEvent` at the `SessionScope` level which will check if the session needs to be updated or not. This should be triggered whenever a new RUM event is received through the JS bridge.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

