### PR TITLE
RUMM-1775 Ensure view is reported as active until it's fully complete

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -489,7 +489,7 @@ internal open class RumViewScope(
                 longTask = ViewEvent.LongTask(longTaskCount),
                 frozenFrame = ViewEvent.FrozenFrame(frozenFrameCount),
                 customTimings = timings,
-                isActive = !stopped,
+                isActive = !isViewComplete(),
                 cpuTicksCount = cpuTicks,
                 cpuTicksPerSecond = cpuTicks?.let { (it * ONE_SECOND_NS) / updatedDurationNs },
                 memoryAverage = memoryInfo?.meanValue,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -487,6 +487,114 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `𝕄 send event 𝕎 handleEvent(StopView) on active view { pending attributes are positive }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.pendingActionCount = forge.aLong(min = 0, max = 100)
+        testedScope.pendingResourceCount = forge.aLong(min = 0, max = 100)
+        testedScope.pendingErrorCount = forge.aLong(min = 0, max = 100)
+        testedScope.pendingLongTaskCount = forge.aLong(min = 0, max = 100)
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        val expectedAttributes = mutableMapOf<String, Any?>()
+        expectedAttributes.putAll(fakeAttributes)
+        expectedAttributes.putAll(attributes)
+
+        // When
+        val result = testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, attributes),
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(capture())
+            assertThat(lastValue)
+                .apply {
+                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
+                    hasName(fakeName)
+                    hasUrl(fakeUrl)
+                    hasDurationGreaterThan(1)
+                    hasVersion(2)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasResourceCount(0)
+                    hasActionCount(0)
+                    hasLongTaskCount(0)
+                    hasFrozenFrameCount(0)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(null, null)
+                    isActive(true)
+                    isSlowRendered(null)
+                    hasNoCustomTimings()
+                    hasUserInfo(fakeUserInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasLiteSessionPlan()
+                    containsExactlyContextAttributes(expectedAttributes)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
+    fun `𝕄 send event 𝕎 handleEvent(StopView) on active view { still has ongoing resources }`(
+        forge: Forge,
+        @StringForgery key: String
+    ) {
+        // Given
+        val mockResourceScope: RumScope = mock()
+        whenever(mockResourceScope.handleEvent(any(), any())) doReturn mockResourceScope
+        testedScope.activeResourceScopes[key] = mockResourceScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        val expectedAttributes = mutableMapOf<String, Any?>()
+        expectedAttributes.putAll(fakeAttributes)
+        expectedAttributes.putAll(attributes)
+
+        // When
+        val result = testedScope.handleEvent(
+            RumRawEvent.StopView(fakeKey, attributes),
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(capture())
+            assertThat(lastValue)
+                .apply {
+                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
+                    hasName(fakeName)
+                    hasUrl(fakeUrl)
+                    hasDurationGreaterThan(1)
+                    hasVersion(2)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasResourceCount(0)
+                    hasActionCount(0)
+                    hasLongTaskCount(0)
+                    hasFrozenFrameCount(0)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(null, null)
+                    isActive(true)
+                    isSlowRendered(null)
+                    hasNoCustomTimings()
+                    hasUserInfo(fakeUserInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasLiteSessionPlan()
+                    containsExactlyContextAttributes(expectedAttributes)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
     fun `𝕄 send event with user extra attributes 𝕎 handleEvent(StopView) on active view`() {
         // When
         val result = testedScope.handleEvent(
@@ -883,7 +991,7 @@ internal class RumViewScopeTest {
                     hasCpuMetric(null)
                     hasMemoryMetric(null, null)
                     hasRefreshRateMetric(null, null)
-                    isActive(false)
+                    isActive(true)
                     isSlowRendered(null)
                     hasNoCustomTimings()
                     hasUserInfo(fakeUserInfo)


### PR DESCRIPTION
### What does this PR do?

Only mark a view as not active when it's fully complete

### Motivation

The backend reducer marks the view as readonly after the first update where `is_active:false`, meaning that if we try to update it afterwards, it will be ignored and some data will be lost.