### PR TITLE
RUMM-1776: Add swipe and scroll manual instrumentation to jetpack compose

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -8,6 +8,7 @@ import,androidx.cardview,Apache-2.0,Copyright 2018 The Android Open Source Proje
 import,androidx.collection,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.compose.animation,Apache-2.0,Copyright 2019 The Android Open Source Project
 import,androidx.compose.foundation,Apache-2.0,Copyright 2019 The Android Open Source Project
+import,androidx.compose.material,Apache-2.0,Copyright 2019 The Android Open Source Project
 import,androidx.compose.runtime,Apache-2.0,Copyright 2019 The Android Open Source Project
 import,androidx.compose.ui,Apache-2.0,Copyright 2019 The Android Open Source Project
 import,androidx.coordinatorlayout,Apache-2.0,Copyright 2018 The Android Open Source Project

--- a/dd-sdk-android-compose/README.md
+++ b/dd-sdk-android-compose/README.md
@@ -92,6 +92,41 @@ Button(
 }
 ```
 
+Swipe and scroll events can be reported by using `TrackInteractionsEffect`. Here is an example of its usage with `Modifier.swipeable`:
+
+```kotlin
+
+val swipeableState = rememberSwipeableState(...)
+val swipeOrientation = Orientation.Horizontal
+
+val interactionSource = remember {
+    MutableInteractionSource()
+}.apply {
+    TrackInteractionEffect(
+        targetName = "Item row",
+        interactionSource = this,
+        interactionType = InteractionType.Swipe(
+            swipeableState,
+            orientation = swipeOrientation
+        ),
+        attributes = mapOf("foo" to "bar")
+    )
+}
+
+Box(
+    modifier = Modifier
+        .swipeable(
+            interactionSource = interactionSource,
+            state = swipeableState,
+            orientation = swipeOrientation,
+            ...
+        )
+        .offset { IntOffset(swipeableState.offset.value.roundToInt(), 0) }
+) {
+    ...
+}
+```
+
 ## Contributing
 
 For details on contributing, read the

--- a/dd-sdk-android-compose/apiSurface
+++ b/dd-sdk-android-compose/apiSurface
@@ -1,3 +1,9 @@
 class com.datadog.android.compose.ExperimentalTrackingApi
 fun trackClick(String, Map<String, Any?> = remember { emptyMap() }, () -> Unit): () -> Unit
+fun TrackInteractionEffect(String, androidx.compose.foundation.interaction.InteractionSource, InteractionType, Map<String, Any?> = emptyMap())
+sealed class com.datadog.android.compose.InteractionType
+  class Swipe<T: Any> : InteractionType
+    constructor(androidx.compose.material.SwipeableState<T>, androidx.compose.foundation.gestures.Orientation, Boolean = false)
+  class Scroll : InteractionType
+    constructor(androidx.compose.foundation.gestures.ScrollableState, androidx.compose.foundation.gestures.Orientation, Boolean = false)
 fun DatadogViewTrackingEffect(androidx.navigation.NavController, Boolean = true, com.datadog.android.rum.tracking.ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())

--- a/dd-sdk-android-compose/build.gradle.kts
+++ b/dd-sdk-android-compose/build.gradle.kts
@@ -56,7 +56,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.0.2"
+        kotlinCompilerExtensionVersion = libs.versions.androidXComposeRuntime.get()
     }
 
     sourceSets.named("main") {
@@ -85,6 +85,7 @@ dependencies {
     api(project(":dd-sdk-android"))
     implementation(libs.kotlin)
     implementation(libs.androidXComposeRuntime)
+    implementation(libs.androidXComposeMaterial)
     implementation(libs.androidXComposeNavigation)
 
     testImplementation(project(":tools:unit"))

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
@@ -275,9 +275,6 @@ internal suspend fun <T> trackDragInteraction(
     }
 }
 
-internal const val FROM_SWIPE_STATE_ATTRIBUTE = "from_state"
-internal const val TO_SWIPE_STATE_ATTRIBUTE = "to_state"
-
 // endregion
 
 // region private
@@ -323,12 +320,12 @@ private fun resolveSwipeChangeAttributes(
     )
 
     return mapOf(
-        FROM_SWIPE_STATE_ATTRIBUTE to swipeStartProps.anchorState,
+        RumAttributes.ACTION_GESTURE_FROM_STATE to swipeStartProps.anchorState,
         // https://issuetracker.google.com/issues/149549482
         // There is a Compose bug: if drag stopped (pointer up) and threshold for the next value is
         // not yet reached, but there is enough velocity to continue the fling, this will
         // still report current value, this affects reporting direction as well
-        TO_SWIPE_STATE_ATTRIBUTE to swipeableState.targetValue,
+        RumAttributes.ACTION_GESTURE_TO_STATE to swipeableState.targetValue,
         RumAttributes.ACTION_GESTURE_DIRECTION to direction
     )
 }

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
@@ -29,6 +29,7 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumMonitor
 import java.lang.Exception
+import kotlin.coroutines.cancellation.CancellationException
 import kotlin.math.roundToInt
 import kotlinx.coroutines.flow.collect
 
@@ -227,14 +228,7 @@ internal suspend fun trackScroll(
     )
 }
 
-internal const val FROM_SWIPE_STATE_ATTRIBUTE = "from_state"
-internal const val TO_SWIPE_STATE_ATTRIBUTE = "to_state"
-
-// endregion
-
-// region private
-
-private suspend fun <T> trackDragInteraction(
+internal suspend fun <T> trackDragInteraction(
     interactionSource: InteractionSource,
     onStart: (
         interactions: MutableMap<DragInteraction.Start, T>,
@@ -273,10 +267,20 @@ private suspend fun <T> trackDragInteraction(
                 }
             }
         }
+    } catch (ce: CancellationException) {
+        @Suppress("ThrowingInternalException")
+        throw ce
     } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
         Log.e(LOG_TAG, "Exception during drag interactions tracking", e)
     }
 }
+
+internal const val FROM_SWIPE_STATE_ATTRIBUTE = "from_state"
+internal const val TO_SWIPE_STATE_ATTRIBUTE = "to_state"
+
+// endregion
+
+// region private
 
 private val ScrollableState.currentPosition: Int?
     get() {

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
@@ -4,22 +4,39 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+@file:OptIn(ExperimentalMaterialApi::class, ExperimentalTrackingApi::class)
+
 package com.datadog.android.compose
 
+import android.util.Log
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.SwipeableState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumMonitor
+import java.lang.Exception
+import kotlin.math.roundToInt
+import kotlinx.coroutines.flow.collect
 
 /**
  * Creates a proxy around click listener, which will report clicks to Datadog.
  *
  * @param targetName Name of the click target.
- * @param attributes additional custom attributes to attach to the action. Attributes can be
+ * @param attributes Additional custom attributes to attach to the action. Attributes can be
  * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
  * @param onClick Click listener.
  */
@@ -35,6 +52,96 @@ fun trackClick(
         TapActionTracker(targetName, attributes, onTapState)
     }
 }
+
+/**
+ * When [TrackInteractionEffect] enters composition, it will start tracking interactions (swipe or
+ * scroll) emitted by the given interaction source in the composition's [CoroutineContext].
+ * Tracking will be cancelled once effect leaves the composition.
+ *
+ * For tracking clicks check [trackClick].
+ *
+ * @param targetName Name of the tracking target.
+ * @param interactionSource [InteractionSource] which hosts the flow of interactions happening.
+ * @param interactionType Type of the interaction, either [InteractionType.Scroll]
+ * or [InteractionType.Swipe]
+ * @param attributes Additional custom attributes to attach to the action. Attributes can be
+ * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
+ */
+@ExperimentalTrackingApi
+@Composable
+fun TrackInteractionEffect(
+    targetName: String,
+    interactionSource: InteractionSource,
+    interactionType: InteractionType,
+    attributes: Map<String, Any?> = emptyMap()
+) {
+    val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
+
+    LaunchedEffect(interactionSource, interactionType, isRtl) {
+        val rumMonitor = GlobalRum.get()
+        when (interactionType) {
+            is InteractionType.Swipe<*> -> trackSwipe(
+                rumMonitor,
+                targetName,
+                interactionSource,
+                interactionType,
+                isRtl,
+                attributes
+            )
+            is InteractionType.Scroll -> trackScroll(
+                rumMonitor,
+                targetName,
+                interactionSource,
+                interactionType,
+                isRtl,
+                attributes
+            )
+        }
+    }
+}
+
+/**
+ * Type of the interaction, either swipe or scroll.
+ */
+sealed class InteractionType {
+
+    /**
+     * Swipe interaction type.
+     *
+     * @param swipeableState Instance of [SwipeableState] to query for the current values
+     * of interaction.
+     * @param orientation The orientation in which the swipeable can be swiped.
+     * @param reverseDirection Whether the direction of the swipe is reversed. Tracking
+     * automatically supports RTL layout direction, so this parameter needs to be set only if
+     * result of the swipe is not natural for the current layout direction (element moves in
+     * the opposite direction to the finger gesture).
+     */
+    class Swipe<T : Any>(
+        internal val swipeableState: SwipeableState<T>,
+        internal val orientation: Orientation,
+        internal val reverseDirection: Boolean = false
+    ) : InteractionType()
+
+    /**
+     * Scroll interaction type.
+     *
+     * @param scrollableState Instance of [ScrollableState] to query for the current values
+     * of interaction.
+     * @param orientation The orientation in which the scrollable can be scrolled.
+     * @param reverseDirection Whether the direction of the scroll (and layout) is reversed,
+     * same as the value of [Modifier.verticalScroll] or [Modifier.horizontalScroll], for example.
+     * Tracking automatically supports RTL layout direction, so this parameter needs to be set only
+     * if scrolling/layout is made in the direction which is not natural for the current layout
+     * direction.
+     */
+    class Scroll(
+        internal val scrollableState: ScrollableState,
+        internal val orientation: Orientation,
+        internal val reverseDirection: Boolean = false
+    ) : InteractionType()
+}
+
+// region Internal
 
 internal class TapActionTracker(
     private val targetName: String,
@@ -55,3 +162,273 @@ internal class TapActionTracker(
         onTap.value.invoke()
     }
 }
+
+@Suppress("LongParameterList")
+internal suspend fun trackSwipe(
+    rumMonitor: RumMonitor,
+    targetName: String,
+    interactionSource: InteractionSource,
+    interactionType: InteractionType.Swipe<*>,
+    isRtl: Boolean,
+    attributes: Map<String, Any?>
+) {
+    trackDragInteraction<SwipeStartProps>(
+        interactionSource,
+        onStart = { interactions, start ->
+            interactions[start] = SwipeStartProps(
+                interactionType.swipeableState.currentValue,
+                // roundToInt can throw exception for Float.NaN, but we won't get such value
+                @Suppress("UnsafeThirdPartyFunctionCall")
+                interactionType.swipeableState.offset.value.roundToInt()
+            )
+            rumMonitor.startUserAction(RumActionType.SWIPE, targetName, emptyMap())
+        },
+        onStopOrCancel = { startProps ->
+            reportSwipeInteraction(
+                rumMonitor,
+                targetName,
+                startProps,
+                interactionType,
+                isRtl,
+                attributes
+            )
+        }
+    )
+}
+
+@Suppress("LongParameterList")
+internal suspend fun trackScroll(
+    rumMonitor: RumMonitor,
+    targetName: String,
+    interactionSource: InteractionSource,
+    interactionType: InteractionType.Scroll,
+    isRtl: Boolean,
+    attributes: Map<String, Any?>
+) {
+    trackDragInteraction<ScrollStartProps>(
+        interactionSource,
+        onStart = { interactions, start ->
+            interactions[start] =
+                ScrollStartProps(
+                    interactionType.scrollableState.currentPosition
+                )
+            rumMonitor.startUserAction(RumActionType.SCROLL, targetName, emptyMap())
+        },
+        onStopOrCancel = { startProps ->
+            reportScrollInteraction(
+                rumMonitor,
+                targetName,
+                startProps,
+                interactionType,
+                isRtl,
+                attributes
+            )
+        }
+    )
+}
+
+internal const val FROM_SWIPE_STATE_ATTRIBUTE = "from_state"
+internal const val TO_SWIPE_STATE_ATTRIBUTE = "to_state"
+
+// endregion
+
+// region private
+
+private suspend fun <T> trackDragInteraction(
+    interactionSource: InteractionSource,
+    onStart: (
+        interactions: MutableMap<DragInteraction.Start, T>,
+        start: DragInteraction.Start
+    ) -> Unit,
+    onStopOrCancel: (startProps: T) -> Unit
+) {
+    val ongoingInteractions = mutableMapOf<DragInteraction.Start, T>()
+    try {
+        interactionSource.interactions.collect { interaction ->
+            when (interaction) {
+                is DragInteraction.Start -> {
+                    @Suppress("UnsafeThirdPartyFunctionCall")
+                    onStart(ongoingInteractions, interaction)
+                }
+                is DragInteraction.Stop, is DragInteraction.Cancel -> {
+                    val start = when (interaction) {
+                        is DragInteraction.Stop -> interaction.start
+                        is DragInteraction.Cancel -> interaction.start
+                        else -> {
+                            // this will never happen, let's just make compiler happy and
+                            // give a fake start
+                            Log.e(
+                                LOG_TAG,
+                                "Unexpected branch reached" +
+                                    " for the drag interaction start"
+                            )
+                            DragInteraction.Start()
+                        }
+                    }
+
+                    ongoingInteractions.remove(start)?.let {
+                        @Suppress("UnsafeThirdPartyFunctionCall")
+                        onStopOrCancel(it)
+                    }
+                }
+            }
+        }
+    } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+        Log.e(LOG_TAG, "Exception during drag interactions tracking", e)
+    }
+}
+
+private val ScrollableState.currentPosition: Int?
+    get() {
+        return when (this) {
+            is LazyListState -> {
+                this.firstVisibleItemIndex
+            }
+            is ScrollState -> {
+                this.value
+            }
+            else -> {
+                null
+            }
+        }
+    }
+
+private fun resolveSwipeChangeAttributes(
+    swipeStartProps: SwipeStartProps,
+    swipeableState: SwipeableState<*>,
+    orientation: Orientation,
+    reverseDirection: Boolean,
+    isRtl: Boolean
+): Map<String, Any?> {
+
+    // normally should use .direction property of SwipeableState, but it is affected by the
+    // same bug as described below
+    // roundToInt can throw exception for Float.NaN, but we won't get such value
+    @Suppress("UnsafeThirdPartyFunctionCall")
+    val directionSign = swipeableState.offset.value.roundToInt() - swipeStartProps.offset
+    val direction = resolveDragDirection(
+        if (reverseDirection) -directionSign else directionSign,
+        orientation,
+        isRtl
+    )
+
+    return mapOf(
+        FROM_SWIPE_STATE_ATTRIBUTE to swipeStartProps.anchorState,
+        // https://issuetracker.google.com/issues/149549482
+        // There is a Compose bug: if drag stopped (pointer up) and threshold for the next value is
+        // not yet reached, but there is enough velocity to continue the fling, this will
+        // still report current value, this affects reporting direction as well
+        TO_SWIPE_STATE_ATTRIBUTE to swipeableState.targetValue,
+        RumAttributes.ACTION_GESTURE_DIRECTION to direction
+    )
+}
+
+private fun resolveScrollChangeAttributes(
+    scrollStartProps: ScrollStartProps,
+    scrollableState: ScrollableState,
+    orientation: Orientation,
+    reverseDirection: Boolean,
+    isRtl: Boolean
+): Map<String, Any?> {
+
+    val startOffset = scrollStartProps.position
+    val endOffset = scrollableState.currentPosition
+
+    return if (startOffset != null && endOffset != null) {
+        val directionSign = -(endOffset - startOffset)
+        mapOf(
+            RumAttributes.ACTION_GESTURE_DIRECTION to
+                resolveDragDirection(
+                    if (reverseDirection) -directionSign else directionSign,
+                    orientation,
+                    isRtl
+                )
+        )
+    } else {
+        emptyMap()
+    }
+}
+
+private fun resolveDragDirection(
+    directionSign: Int,
+    orientation: Orientation,
+    isRtl: Boolean
+): String {
+
+    val isDirectionPositive = directionSign > 0
+
+    return when (orientation) {
+        Orientation.Vertical -> if (isDirectionPositive) {
+            "down"
+        } else {
+            "up"
+        }
+        Orientation.Horizontal -> if (isDirectionPositive) {
+            if (!isRtl) "right" else "left"
+        } else {
+            if (!isRtl) "left" else "right"
+        }
+    }
+}
+
+@Suppress("LongParameterList")
+private fun reportSwipeInteraction(
+    rumMonitor: RumMonitor,
+    targetName: String,
+    startProps: SwipeStartProps,
+    interaction: InteractionType.Swipe<*>,
+    isRtl: Boolean,
+    attributes: Map<String, Any?>
+) {
+    rumMonitor.stopUserAction(
+        RumActionType.SWIPE,
+        targetName,
+        attributes.toMutableMap().apply {
+            put(RumAttributes.ACTION_TARGET_TITLE, targetName)
+            putAll(
+                resolveSwipeChangeAttributes(
+                    startProps,
+                    interaction.swipeableState,
+                    interaction.orientation,
+                    interaction.reverseDirection,
+                    isRtl
+                )
+            )
+        }
+    )
+}
+
+@Suppress("LongParameterList")
+private fun reportScrollInteraction(
+    rumMonitor: RumMonitor,
+    targetName: String,
+    startProps: ScrollStartProps,
+    interaction: InteractionType.Scroll,
+    isRtl: Boolean,
+    attributes: Map<String, Any?>
+) {
+    rumMonitor.stopUserAction(
+        RumActionType.SCROLL,
+        targetName,
+        attributes.toMutableMap().apply {
+            put(RumAttributes.ACTION_TARGET_TITLE, targetName)
+            putAll(
+                resolveScrollChangeAttributes(
+                    startProps,
+                    interaction.scrollableState,
+                    interaction.orientation,
+                    interaction.reverseDirection,
+                    isRtl
+                )
+            )
+        }
+    )
+}
+
+private data class SwipeStartProps(val anchorState: Any, val offset: Int)
+
+private data class ScrollStartProps(val position: Int?)
+
+private const val LOG_TAG = "Datadog-Compose"
+
+// endregion

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
@@ -282,7 +282,13 @@ private val ScrollableState.currentPosition: Int?
     get() {
         return when (this) {
             is LazyListState -> {
-                this.firstVisibleItemIndex
+                // We may do the scroll, but still be in the current item, so we need more precise
+                // tracking. We will pack item index in the first 16 bits, and item offset
+                // in another 15 bits (int in Java is using 2's complement) => we have space for
+                // 65,535 elements and 32,767 max offset in each. NB: firstVisibleItemScrollOffset
+                // is offset relative to the item start, not to the list start.
+                (this.firstVisibleItemIndex shl 15) or
+                    (this.firstVisibleItemScrollOffset and 0x7FFF)
             }
             is ScrollState -> {
                 this.value

--- a/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/SwipeAndScrollActionTrackerTest.kt
+++ b/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/SwipeAndScrollActionTrackerTest.kt
@@ -1,0 +1,557 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.compose
+
+import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.ScrollableState
+import androidx.compose.foundation.interaction.DragInteraction
+import androidx.compose.foundation.interaction.InteractionSource
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.SwipeableState
+import androidx.compose.runtime.State
+import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.RumAttributes
+import com.datadog.android.rum.RumMonitor
+import com.datadog.tools.unit.forge.BaseConfigurator
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.doReturnConsecutively
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.AdvancedForgery
+import fr.xgouchet.elmyr.annotation.MapForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.Locale
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(
+        MockitoExtension::class,
+        ForgeExtension::class
+    )
+)
+@ForgeConfiguration(value = BaseConfigurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@OptIn(ExperimentalMaterialApi::class, ExperimentalTrackingApi::class)
+class SwipeAndScrollActionTrackerTest {
+
+    @Mock
+    lateinit var mockRumMonitor: RumMonitor
+
+    @Mock
+    lateinit var mockInteractionSource: InteractionSource
+
+    @StringForgery
+    lateinit var fakeTargetName: String
+
+    @MapForgery(
+        key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+        value = AdvancedForgery(string = [StringForgery(StringForgeryType.ASCII)])
+    )
+    lateinit var fakeAttributes: Map<String, String>
+
+    @RepeatedTest(10)
+    fun `M report SWIPE action W trackSwipe { Start - Stop }`(
+        forge: Forge
+    ) {
+        // Given
+        val interactionsFlow = flow {
+            val start = DragInteraction.Start()
+            emit(start)
+            emit(DragInteraction.Stop(start))
+        }
+
+        val swipeDirection = forge.aValueFrom(Direction::class.java)
+        val swipeOrientation = swipeDirection.orientation
+
+        val startState = forge.anInt()
+        val endState = forge.anInt()
+
+        val reverseDirection = forge.aBool()
+        val isRtl = forge.aBool()
+        val swipeableState =
+            forge.aSwipeableState(startState, endState, swipeDirection, reverseDirection, isRtl)
+
+        whenever(mockInteractionSource.interactions) doReturn interactionsFlow
+
+        val expectedAttributes = fakeAttributes +
+            mapOf(
+                RumAttributes.ACTION_TARGET_TITLE to fakeTargetName,
+                RumAttributes.ACTION_GESTURE_DIRECTION
+                    to swipeDirection.name.lowercase(Locale.US),
+                FROM_SWIPE_STATE_ATTRIBUTE to startState,
+                TO_SWIPE_STATE_ATTRIBUTE to endState
+            )
+
+        // When
+        runBlocking {
+            trackSwipe(
+                mockRumMonitor,
+                fakeTargetName,
+                mockInteractionSource,
+                InteractionType.Swipe(swipeableState, swipeOrientation, reverseDirection),
+                isRtl,
+                fakeAttributes
+            )
+        }
+
+        // Then
+        inOrder(mockRumMonitor) {
+            verify(mockRumMonitor)
+                .startUserAction(RumActionType.SWIPE, fakeTargetName, emptyMap())
+            verify(mockRumMonitor)
+                .stopUserAction(RumActionType.SWIPE, fakeTargetName, expectedAttributes)
+        }
+    }
+
+    @RepeatedTest(10)
+    fun `M report SWIPE action W trackSwipe { Start - Cancel }`(
+        forge: Forge
+    ) {
+        // Given
+        val interactionsFlow = flow {
+            val start = DragInteraction.Start()
+            emit(start)
+            emit(DragInteraction.Cancel(start))
+        }
+
+        val swipeDirection = forge.aValueFrom(Direction::class.java)
+        val swipeOrientation = swipeDirection.orientation
+
+        val startState = forge.anInt()
+        val endState = forge.anInt()
+
+        val reverseDirection = forge.aBool()
+        val isRtl = forge.aBool()
+        val swipeableState =
+            forge.aSwipeableState(startState, endState, swipeDirection, reverseDirection, isRtl)
+
+        whenever(mockInteractionSource.interactions) doReturn interactionsFlow
+
+        val expectedAttributes = fakeAttributes +
+            mapOf(
+                RumAttributes.ACTION_TARGET_TITLE to fakeTargetName,
+                RumAttributes.ACTION_GESTURE_DIRECTION
+                    to swipeDirection.name.lowercase(Locale.US),
+                FROM_SWIPE_STATE_ATTRIBUTE to startState,
+                TO_SWIPE_STATE_ATTRIBUTE to endState
+            )
+
+        // When
+        runBlocking {
+            trackSwipe(
+                mockRumMonitor,
+                fakeTargetName,
+                mockInteractionSource,
+                InteractionType.Swipe(swipeableState, swipeOrientation, reverseDirection),
+                isRtl,
+                fakeAttributes
+            )
+        }
+
+        // Then
+        inOrder(mockRumMonitor) {
+            verify(mockRumMonitor)
+                .startUserAction(RumActionType.SWIPE, fakeTargetName, emptyMap())
+            verify(mockRumMonitor)
+                .stopUserAction(RumActionType.SWIPE, fakeTargetName, expectedAttributes)
+        }
+    }
+
+    @Test
+    fun `M not report SWIPE stop action W trackSwipe { Start - Start }`(
+        forge: Forge
+    ) {
+        // Given
+        val interactionsFlow = flow {
+            emit(DragInteraction.Start())
+            emit(DragInteraction.Start())
+        }
+
+        val swipeDirection = forge.aValueFrom(Direction::class.java)
+        val swipeOrientation = swipeDirection.orientation
+
+        val startState = forge.anInt()
+        val endState = forge.anInt()
+
+        val reverseDirection = forge.aBool()
+        val isRtl = forge.aBool()
+
+        val swipeableState =
+            forge.aSwipeableState(startState, endState, swipeDirection, reverseDirection, isRtl)
+
+        whenever(mockInteractionSource.interactions) doReturn interactionsFlow
+
+        // When
+        runBlocking {
+            trackSwipe(
+                mockRumMonitor,
+                fakeTargetName,
+                mockInteractionSource,
+                InteractionType.Swipe(swipeableState, swipeOrientation, reverseDirection),
+                isRtl,
+                fakeAttributes
+            )
+        }
+
+        // Then
+        verify(mockRumMonitor, times(2))
+            .startUserAction(RumActionType.SWIPE, fakeTargetName, emptyMap())
+        verifyNoMoreInteractions(mockRumMonitor)
+    }
+
+    @Test
+    fun `M not report SWIPE stop action W trackSwipe { Start - Stop for another Start }`(
+        forge: Forge
+    ) {
+        // Given
+        val interactionsFlow = flow {
+            emit(DragInteraction.Start())
+            emit(DragInteraction.Stop(DragInteraction.Start()))
+        }
+
+        val swipeDirection = forge.aValueFrom(Direction::class.java)
+        val swipeOrientation = swipeDirection.orientation
+
+        val startState = forge.anInt()
+        val endState = forge.anInt()
+
+        val reverseDirection = forge.aBool()
+        val isRtl = forge.aBool()
+
+        val swipeableState =
+            forge.aSwipeableState(startState, endState, swipeDirection, reverseDirection, isRtl)
+
+        whenever(mockInteractionSource.interactions) doReturn interactionsFlow
+
+        // When
+        runBlocking {
+            trackSwipe(
+                mockRumMonitor,
+                fakeTargetName,
+                mockInteractionSource,
+                InteractionType.Swipe(swipeableState, swipeOrientation, reverseDirection),
+                isRtl,
+                fakeAttributes
+            )
+        }
+
+        // Then
+        verify(mockRumMonitor)
+            .startUserAction(RumActionType.SWIPE, fakeTargetName, emptyMap())
+        verifyNoMoreInteractions(mockRumMonitor)
+    }
+
+    @RepeatedTest(10)
+    fun `M report SCROLL action W trackScroll { Start - Stop }`(
+        forge: Forge
+    ) {
+        // Given
+        val interactionsFlow = flow {
+            val start = DragInteraction.Start()
+            emit(start)
+            emit(DragInteraction.Stop(start))
+        }
+
+        whenever(mockInteractionSource.interactions) doReturn interactionsFlow
+
+        val scrollDirection = forge.aValueFrom(Direction::class.java)
+        val scrollOrientation = scrollDirection.orientation
+
+        val reverseLayout = forge.aBool()
+        val isRtl = forge.aBool()
+        val mockScrollableState = forge.aScrollableState(scrollDirection, reverseLayout, isRtl)
+
+        val expectedAttributes = fakeAttributes.run {
+            val map = this.toMutableMap()
+            map += RumAttributes.ACTION_TARGET_TITLE to fakeTargetName
+            if (mockScrollableState is LazyListState || mockScrollableState is ScrollState) {
+                map += RumAttributes.ACTION_GESTURE_DIRECTION to scrollDirection.name.lowercase(
+                    Locale.US
+                )
+            }
+            map
+        }
+
+        // When
+        runBlocking {
+            trackScroll(
+                mockRumMonitor,
+                fakeTargetName,
+                mockInteractionSource,
+                InteractionType.Scroll(mockScrollableState, scrollOrientation, reverseLayout),
+                isRtl,
+                fakeAttributes
+            )
+        }
+
+        // Then
+        inOrder(mockRumMonitor) {
+            verify(mockRumMonitor)
+                .startUserAction(RumActionType.SCROLL, fakeTargetName, emptyMap())
+            verify(mockRumMonitor)
+                .stopUserAction(RumActionType.SCROLL, fakeTargetName, expectedAttributes)
+        }
+    }
+
+    @RepeatedTest(10)
+    fun `M report SCROLL action W trackScroll { Start - Cancel }`(
+        forge: Forge
+    ) {
+        // Given
+        val interactionsFlow = flow {
+            val start = DragInteraction.Start()
+            emit(start)
+            emit(DragInteraction.Cancel(start))
+        }
+
+        whenever(mockInteractionSource.interactions) doReturn interactionsFlow
+
+        val scrollDirection = forge.aValueFrom(Direction::class.java)
+        val scrollOrientation = scrollDirection.orientation
+
+        val reverseLayout = forge.aBool()
+        val isRtl = forge.aBool()
+        val mockScrollableState = forge.aScrollableState(scrollDirection, reverseLayout, isRtl)
+
+        val expectedAttributes = fakeAttributes.run {
+            val map = toMutableMap()
+            map += RumAttributes.ACTION_TARGET_TITLE to fakeTargetName
+            if (mockScrollableState is LazyListState || mockScrollableState is ScrollState) {
+                map += RumAttributes.ACTION_GESTURE_DIRECTION to scrollDirection.name.lowercase(
+                    Locale.US
+                )
+            }
+            map
+        }
+
+        // When
+        runBlocking {
+            trackScroll(
+                mockRumMonitor,
+                fakeTargetName,
+                mockInteractionSource,
+                InteractionType.Scroll(mockScrollableState, scrollOrientation, reverseLayout),
+                isRtl,
+                fakeAttributes
+            )
+        }
+
+        // Then
+        inOrder(mockRumMonitor) {
+            verify(mockRumMonitor)
+                .startUserAction(RumActionType.SCROLL, fakeTargetName, emptyMap())
+            verify(mockRumMonitor)
+                .stopUserAction(RumActionType.SCROLL, fakeTargetName, expectedAttributes)
+        }
+    }
+
+    @Test
+    fun `M not report SCROLL stop action W trackScroll { Start - Start }`(
+        forge: Forge
+    ) {
+        // Given
+        val interactionsFlow = flow {
+            emit(DragInteraction.Start())
+            emit(DragInteraction.Start())
+        }
+
+        whenever(mockInteractionSource.interactions) doReturn interactionsFlow
+
+        val scrollDirection = forge.aValueFrom(Direction::class.java)
+        val scrollOrientation = scrollDirection.orientation
+
+        val reverseLayout = forge.aBool()
+        val isRtl = forge.aBool()
+        val mockScrollableState = forge.aScrollableState(scrollDirection, reverseLayout, isRtl)
+
+        // When
+        runBlocking {
+            trackScroll(
+                mockRumMonitor,
+                fakeTargetName,
+                mockInteractionSource,
+                InteractionType.Scroll(mockScrollableState, scrollOrientation, reverseLayout),
+                isRtl,
+                fakeAttributes
+            )
+        }
+
+        // Then
+        verify(mockRumMonitor, times(2))
+            .startUserAction(RumActionType.SCROLL, fakeTargetName, emptyMap())
+        verifyNoMoreInteractions(mockRumMonitor)
+    }
+
+    @Test
+    fun `M not report SCROLL stop action W trackScroll { Start - Stop for another Start }`(
+        forge: Forge
+    ) {
+        // Given
+        val interactionsFlow = flow {
+            emit(DragInteraction.Start())
+            emit(DragInteraction.Stop(DragInteraction.Start()))
+        }
+
+        whenever(mockInteractionSource.interactions) doReturn interactionsFlow
+
+        val scrollDirection = forge.aValueFrom(Direction::class.java)
+        val scrollOrientation = scrollDirection.orientation
+
+        val reverseLayout = forge.aBool()
+        val isRtl = forge.aBool()
+        val mockScrollableState = forge.aScrollableState(scrollDirection, reverseLayout, isRtl)
+
+        // When
+        runBlocking {
+            trackScroll(
+                mockRumMonitor,
+                fakeTargetName,
+                mockInteractionSource,
+                InteractionType.Scroll(mockScrollableState, scrollOrientation, reverseLayout),
+                isRtl,
+                fakeAttributes
+            )
+        }
+
+        // Then
+        verify(mockRumMonitor)
+            .startUserAction(RumActionType.SCROLL, fakeTargetName, emptyMap())
+        verifyNoMoreInteractions(mockRumMonitor)
+    }
+
+    // region private
+
+    private fun Forge.aScrollableState(
+        direction: Direction,
+        reverseLayout: Boolean,
+        isRtl: Boolean
+    ): ScrollableState {
+        return anElementFrom(
+            mock<LazyListState>().apply {
+                // LazyList relies on the item index. Scroll DOWN - index decreases, UP - increases.
+                // Same logic for the RIGHT/LEFT. If we have reversed layout (first element at
+                // the bottom, not at the top, and we start from the bottom), logic is the opposite.
+                val (startIndex, endIndex) = scrollStartAndStopPoints(
+                    direction,
+                    reverseLayout,
+                    isRtl
+                )
+                whenever(firstVisibleItemIndex) doReturnConsecutively listOf(startIndex, endIndex)
+            },
+            mock<ScrollState>().apply {
+                // for ScrollState it is overall scroll offset, unlike for LazyList,
+                // where it is index
+                val (startOffset, endOffset) = scrollStartAndStopPoints(
+                    direction,
+                    reverseLayout,
+                    isRtl
+                )
+                whenever(value) doReturnConsecutively listOf(startOffset, endOffset)
+            },
+            mock()
+        )
+    }
+
+    private fun <T> Forge.aSwipeableState(
+        startState: T,
+        endState: T,
+        direction: Direction,
+        // if true, this will make element move left if we do swipe right, for example
+        reverseDirection: Boolean,
+        isRtl: Boolean
+    ): SwipeableState<T> {
+        return mock<SwipeableState<T>>().apply {
+            whenever(currentValue) doReturn startState
+            whenever(targetValue) doReturn endState
+
+            val (startOffset, endOffset) = twoAscendingPoints().let {
+                var points = if (direction == Direction.DOWN || direction == Direction.RIGHT) {
+                    it.first to it.second
+                } else {
+                    it.second to it.first
+                }
+
+                if (reverseDirection) {
+                    points = points.second to points.first
+                }
+
+                if (isRtl && (direction.orientation == Orientation.Horizontal)) {
+                    points = points.second to points.first
+                }
+                points
+            }
+
+            val mockOffsetState = mock<State<Float>>()
+            whenever(mockOffsetState.value) doReturnConsecutively listOf(
+                startOffset.toFloat(),
+                endOffset.toFloat()
+            )
+
+            whenever(offset) doReturn mockOffsetState
+        }
+    }
+
+    private fun Forge.scrollStartAndStopPoints(
+        direction: Direction,
+        reverseLayout: Boolean,
+        isRtl: Boolean
+    ): Pair<Int, Int> {
+        return twoAscendingPoints().let {
+            var points = if (direction == Direction.DOWN || direction == Direction.RIGHT) {
+                it.second to it.first
+            } else {
+                it.first to it.second
+            }
+
+            if (reverseLayout) {
+                points = points.second to points.first
+            }
+
+            if (isRtl && (direction.orientation == Orientation.Horizontal)) {
+                // on RTL right gesture will decrease offset instead of increasing it, same for left
+                points = points.second to points.first
+            }
+            points
+        }
+    }
+
+    // generates 2 points, second is larger than first
+    private fun Forge.twoAscendingPoints(): Pair<Int, Int> {
+        val first = anInt(min = 0, max = Int.MAX_VALUE / 2)
+        val second = anInt(min = first + 1)
+        return first to second
+    }
+
+    @Suppress("unused")
+    private enum class Direction(val orientation: Orientation) {
+        UP(orientation = Orientation.Vertical),
+        DOWN(orientation = Orientation.Vertical),
+        RIGHT(orientation = Orientation.Horizontal),
+        LEFT(orientation = Orientation.Horizontal)
+    }
+
+    // endregion
+}

--- a/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/SwipeAndScrollActionTrackerTest.kt
+++ b/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/SwipeAndScrollActionTrackerTest.kt
@@ -107,8 +107,8 @@ class SwipeAndScrollActionTrackerTest {
                 RumAttributes.ACTION_TARGET_TITLE to fakeTargetName,
                 RumAttributes.ACTION_GESTURE_DIRECTION
                     to swipeDirection.name.lowercase(Locale.US),
-                FROM_SWIPE_STATE_ATTRIBUTE to startState,
-                TO_SWIPE_STATE_ATTRIBUTE to endState
+                RumAttributes.ACTION_GESTURE_FROM_STATE to startState,
+                RumAttributes.ACTION_GESTURE_TO_STATE to endState
             )
 
         // When
@@ -161,8 +161,8 @@ class SwipeAndScrollActionTrackerTest {
                 RumAttributes.ACTION_TARGET_TITLE to fakeTargetName,
                 RumAttributes.ACTION_GESTURE_DIRECTION
                     to swipeDirection.name.lowercase(Locale.US),
-                FROM_SWIPE_STATE_ATTRIBUTE to startState,
-                TO_SWIPE_STATE_ATTRIBUTE to endState
+                RumAttributes.ACTION_GESTURE_FROM_STATE to startState,
+                RumAttributes.ACTION_GESTURE_TO_STATE to endState
             )
 
         // When

--- a/dd-sdk-android-compose/transitiveDependencies
+++ b/dd-sdk-android-compose/transitiveDependencies
@@ -7,16 +7,20 @@ androidx.annotation:annotation-experimental:1.1.0               :   16 Kb
 androidx.annotation:annotation:1.2.0                            :   28 Kb
 androidx.arch.core:core-common:2.1.0                            :   10 Kb
 androidx.collection:collection:1.1.0                            :   41 Kb
-androidx.compose.animation:animation-core:1.0.1                 : 1257 Kb
-androidx.compose.animation:animation:1.0.1                      : 1220 Kb
-androidx.compose.foundation:foundation-layout:1.0.1             :  308 Kb
-androidx.compose.runtime:runtime-saveable:1.0.1                 : 1039 Kb
+androidx.compose.animation:animation-core:1.0.2                 : 1257 Kb
+androidx.compose.animation:animation:1.0.2                      : 1220 Kb
+androidx.compose.foundation:foundation-layout:1.0.2             :  308 Kb
+androidx.compose.foundation:foundation:1.0.2                    : 1177 Kb
+androidx.compose.material:material-icons-core:1.0.2             :  669 Kb
+androidx.compose.material:material-ripple:1.0.2                 :   71 Kb
+androidx.compose.material:material:1.0.2                        :    2 Mb
+androidx.compose.runtime:runtime-saveable:1.0.2                 : 1039 Kb
 androidx.compose.runtime:runtime:1.0.2                          : 1814 Kb
-androidx.compose.ui:ui-geometry:1.0.1                           :   36 Kb
-androidx.compose.ui:ui-graphics:1.0.1                           : 1336 Kb
-androidx.compose.ui:ui-text:1.0.1                               :  446 Kb
-androidx.compose.ui:ui-unit:1.0.1                               :   57 Kb
-androidx.compose.ui:ui:1.0.1                                    :    3 Mb
+androidx.compose.ui:ui-geometry:1.0.2                           :   36 Kb
+androidx.compose.ui:ui-graphics:1.0.2                           : 1336 Kb
+androidx.compose.ui:ui-text:1.0.2                               :  446 Kb
+androidx.compose.ui:ui-unit:1.0.2                               :   57 Kb
+androidx.compose.ui:ui:1.0.2                                    :    3 Mb
 androidx.core:core-ktx:1.1.0                                    :  152 Kb
 androidx.core:core:1.6.0                                        :  905 Kb
 androidx.lifecycle:lifecycle-common:2.3.1                       :   22 Kb
@@ -43,5 +47,5 @@ org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.0          :   19 Kb
 org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.5.0         : 1447 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :   16 Mb
+Total transitive dependencies size                              :   20 Mb
 

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -331,6 +331,8 @@ object com.datadog.android.rum.RumAttributes
   const val ACTION_TARGET_PARENT_RESOURCE_ID: String
   const val ACTION_TARGET_RESOURCE_ID: String
   const val ACTION_GESTURE_DIRECTION: String
+  const val ACTION_GESTURE_FROM_STATE: String
+  const val ACTION_GESTURE_TO_STATE: String
   const val LONG_TASK_TARGET: String
   const val NETWORK_CARRIER_ID: String
   const val NETWORK_CARRIER_NAME: String

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -191,6 +191,16 @@ object RumAttributes {
      */
     const val ACTION_GESTURE_DIRECTION: String = "action.gesture.direction"
 
+    /**
+     * The gesture event start state.
+     */
+    const val ACTION_GESTURE_FROM_STATE: String = "action.gesture.from_state"
+
+    /**
+     * The gesture event final state.
+     */
+    const val ACTION_GESTURE_TO_STATE: String = "action.gesture.to_state"
+
     // endregion
 
     // region Long Task

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
@@ -163,6 +163,8 @@ internal class RumEventSerializer(
     companion object {
         internal val knownAttributes = setOf(
             RumAttributes.ACTION_GESTURE_DIRECTION,
+            RumAttributes.ACTION_GESTURE_FROM_STATE,
+            RumAttributes.ACTION_GESTURE_TO_STATE,
             RumAttributes.ACTION_TARGET_PARENT_RESOURCE_ID,
             RumAttributes.ACTION_TARGET_PARENT_CLASSNAME,
             RumAttributes.ACTION_TARGET_PARENT_INDEX,

--- a/detekt.yml
+++ b/detekt.yml
@@ -660,6 +660,7 @@ datadog:
       # endregion
       # region Kotlin Coroutines
       - "kotlinx.coroutines.Deferred.await():java.util.concurrent.CancellationException"
+      - "kotlinx.coroutines.flow.Flow.collect(kotlin.coroutines.SuspendFunction1):java.lang.Exception"
       # endregion
       # region OkHttp
       - "okhttp3.Call.execute():java.io.IOException"
@@ -839,6 +840,7 @@ datadog:
       - "kotlin.collections.MutableMap.putAll(kotlin.collections.Map)"
       - "kotlin.collections.MutableMap.remove(kotlin.String)"
       - "kotlin.collections.MutableMap.remove(com.datadog.android.rum.internal.vitals.VitalListener)"
+      - "kotlin.collections.MutableMap.remove(androidx.compose.foundation.interaction.DragInteraction.Start)"
       - "kotlin.collections.MutableSet.add(kotlin.String)"
       - "kotlin.collections.MutableSet.filter(kotlin.Function1)"
       - "kotlin.collections.MutableSet.forEach(kotlin.Function1)"
@@ -928,6 +930,7 @@ datadog:
       - "io.opentracing.util.GlobalTracer.get()"
       # endregion
       # region Androidx APIs
+      - "androidx.compose.foundation.interaction.DragInteraction.Start()"
       - "androidx.core.view.GestureDetectorCompat.onTouchEvent(android.view.MotionEvent)"
       - "androidx.fragment.app.FragmentManager.registerFragmentLifecycleCallbacks(androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks, kotlin.Boolean)"
       - "androidx.fragment.app.FragmentManager.unregisterFragmentLifecycleCallbacks(androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks)"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ androidXConstraintLayout = "2.0.4"
 androidXComposeRuntime = "1.0.2"
 androidXComposeNavigation = "2.4.0-alpha10"
 androidXComposeUi = "1.0.2"
+androidXComposeMaterial = "1.0.2"
 googleMaterial = "1.3.0"
 
 # DD-TRACE-OT
@@ -116,6 +117,7 @@ androidXComposeRuntime = { module = "androidx.compose.runtime:runtime", version.
 androidXComposeNavigation = { module = "androidx.navigation:navigation-compose", version.ref = "androidXComposeNavigation" }
 androidXComposeUi = { module = "androidx.compose.ui:ui", version.ref = "androidXComposeUi" }
 androidXComposeUiTooling = { module = "androidx.compose.ui:ui-tooling", version.ref = "androidXComposeUi" }
+androidXComposeMaterial = { module = "androidx.compose.material:material", version.ref = "androidXComposeMaterial" }
 googleMaterial = { module = "com.google.android.material:material", version.ref = "googleMaterial" }
 
 # DD-TRACE-OT

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -61,7 +61,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.0.2"
+        kotlinCompilerExtensionVersion = libs.versions.androidXComposeRuntime.get()
     }
 
     testOptions {
@@ -134,9 +134,9 @@ dependencies {
     implementation(libs.androidXComposeNavigation)
     implementation(libs.androidXComposeUi)
     implementation(libs.androidXComposeUiTooling)
+    implementation(libs.androidXComposeMaterial)
     implementation(libs.googleMaterial)
     implementation("com.google.accompanist:accompanist-appcompat-theme:0.16.0")
-    implementation("androidx.compose.material:material:1.0.2")
     implementation("androidx.media:media:1.3.1")
     implementation("androidx.vectordrawable:vectordrawable:1.1.0")
     implementation("androidx.legacy:legacy-support-v4:1.0.0")

--- a/sample/kotlin/src/main/AndroidManifest.xml
+++ b/sample/kotlin/src/main/AndroidManifest.xml
@@ -38,6 +38,7 @@
             </intent-filter>
         </activity>
         <activity android:name=".ViewPagerActivity" />
+        <activity android:name=".compose.JetpackComposeActivity" />
 
         <service
             android:name=".service.LogsForegroundService" />

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/ViewPagerActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/ViewPagerActivity.kt
@@ -43,6 +43,14 @@ class ViewPagerActivity : AppCompatActivity() {
             }
         }
 
+        override fun getPageTitle(position: Int): CharSequence {
+            return when (position) {
+                0 -> FragmentA.NAME
+                1 -> FragmentB.NAME
+                else -> FragmentC.NAME
+            }
+        }
+
         override fun getCount(): Int {
             return 3
         }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/InteractionFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/InteractionFragment.kt
@@ -1,0 +1,175 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+@file:OptIn(ExperimentalMaterialApi::class)
+
+package com.datadog.android.sample.compose
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.background
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.FractionalThreshold
+import androidx.compose.material.Text
+import androidx.compose.material.rememberSwipeableState
+import androidx.compose.material.swipeable
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.datadog.android.compose.ExperimentalTrackingApi
+import com.datadog.android.compose.InteractionType
+import com.datadog.android.compose.TrackInteractionEffect
+import com.datadog.android.rum.GlobalRum
+import com.google.accompanist.appcompattheme.AppCompatTheme
+import kotlin.math.roundToInt
+
+class InteractionFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                AppCompatTheme {
+                    InteractionView()
+                }
+            }
+        }
+    }
+}
+
+private const val VIEW_NAME = "Compose Interaction View"
+
+@OptIn(ExperimentalTrackingApi::class)
+@Preview
+@Composable
+fun InteractionView() {
+
+    val lifecycleOwner = LocalLifecycleOwner.current
+    DisposableEffect(lifecycleOwner) {
+        val observer = LifecycleEventObserver { _, event ->
+            val rumMonitor = GlobalRum.get()
+            if (event == Lifecycle.Event.ON_RESUME) {
+                rumMonitor.startView(VIEW_NAME, VIEW_NAME)
+            } else if (event == Lifecycle.Event.ON_PAUSE) {
+                rumMonitor.stopView(VIEW_NAME)
+            }
+        }
+
+        lifecycleOwner.lifecycle.addObserver(observer)
+
+        onDispose {
+            lifecycleOwner.lifecycle.removeObserver(observer)
+        }
+    }
+
+    val collection = remember { mutableStateListOf<Int>().apply { addAll(1..100) } }
+
+    val scrollState = rememberLazyListState().apply {
+        TrackInteractionEffect(
+            targetName = "Items list",
+            interactionSource = interactionSource,
+            interactionType = InteractionType.Scroll(this, Orientation.Vertical)
+        )
+    }
+
+    LazyColumn(verticalArrangement = Arrangement.spacedBy(8.dp), state = scrollState) {
+        items(collection, key = { it }) { index ->
+            ItemRow(index = index, onDismissed = { collection.remove(index) })
+        }
+    }
+}
+
+@OptIn(ExperimentalTrackingApi::class)
+@Composable
+fun ItemRow(index: Int, onDismissed: () -> Unit) {
+
+    val swipeableState = rememberSwipeableState(DragStates.VISIBLE)
+
+    val startState = DragStates.VISIBLE
+    val terminalState = DragStates.DISMISSED
+
+    if (swipeableState.currentValue == terminalState) {
+        onDismissed.invoke()
+    } else {
+        val screenSize = LocalConfiguration.current.screenWidthDp.dp
+        val swipeAnchors = mapOf(
+            0f to startState,
+            with(LocalDensity.current) { screenSize.toPx() } to terminalState
+        )
+        val swipeOrientation = Orientation.Horizontal
+
+        val interactionSource = remember {
+            MutableInteractionSource()
+        }.apply {
+            TrackInteractionEffect(
+                targetName = "Item row",
+                interactionSource = this,
+                interactionType = InteractionType.Swipe(
+                    swipeableState,
+                    orientation = swipeOrientation
+                ),
+                attributes = mapOf("item" to index)
+            )
+        }
+
+        Box(
+            modifier = Modifier
+                .swipeable(
+                    interactionSource = interactionSource,
+                    state = swipeableState,
+                    orientation = swipeOrientation,
+                    anchors = swipeAnchors,
+                    thresholds = { _, _ -> FractionalThreshold(0.5f) }
+                )
+                .offset { IntOffset(swipeableState.offset.value.roundToInt(), 0) }
+        ) {
+            Text(
+                text = "Item: $index",
+                textAlign = TextAlign.Center,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .background(color = Color.Cyan)
+                    .padding(vertical = 8.dp)
+            )
+        }
+    }
+}
+
+private enum class DragStates {
+    VISIBLE,
+    DISMISSED
+}

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/JetpackComposeActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/JetpackComposeActivity.kt
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sample.compose
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentManager
+import androidx.fragment.app.FragmentPagerAdapter
+import androidx.viewpager.widget.ViewPager
+import com.datadog.android.sample.R
+
+class JetpackComposeActivity : AppCompatActivity() {
+
+    lateinit var viewPager: ViewPager
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_compose)
+        viewPager = findViewById(R.id.view_pager)
+        viewPager.adapter = ViewPagerAdapter(supportFragmentManager)
+    }
+
+    internal inner class ViewPagerAdapter(fragmentManager: FragmentManager) :
+        FragmentPagerAdapter(fragmentManager, BEHAVIOR_RESUME_ONLY_CURRENT_FRAGMENT) {
+        override fun getItem(position: Int): Fragment {
+            return when (position) {
+                0 -> ComposeFragment()
+                else -> InteractionFragment()
+            }
+        }
+
+        override fun getPageTitle(position: Int): CharSequence {
+            return when (position) {
+                0 -> "Navigation"
+                else -> "Interactions"
+            }
+        }
+
+        override fun getCount(): Int {
+            return 2
+        }
+    }
+}

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/NavigationFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/NavigationFragment.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.sample.compose
 
-import android.app.Activity
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
@@ -91,11 +90,8 @@ fun SimpleView(
         modifier = Modifier.fillMaxSize()
     ) {
         Text("View $viewId")
-        val viewTreeObserver = (LocalContext.current as Activity).window.decorView.viewTreeObserver
         Button(
             onClick = trackClick(targetName = "Open View", onClick = {
-                // TODO RUMM-1764 this is temporary, just for side-effect
-                viewTreeObserver.dispatchOnGlobalLayout()
                 onNavigate.invoke()
             }),
             modifier = Modifier

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/home/HomeFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/home/HomeFragment.kt
@@ -62,7 +62,7 @@ class HomeFragment :
             R.id.navigation_data_list -> R.id.fragment_data_list
             R.id.navigation_view_pager -> R.id.activity_view_pager
             R.id.navigation_picture -> R.id.fragment_picture
-            R.id.navigation_compose -> R.id.fragment_compose
+            R.id.navigation_compose -> R.id.activity_jetpack_compose
             R.id.navigation_about -> R.id.fragment_about
             else -> null
         }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/viewpager/FragmentA.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/viewpager/FragmentA.kt
@@ -22,7 +22,11 @@ internal class FragmentA : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val view = inflater.inflate(R.layout.view_pager_child_fragment_layout, container, false)
-        view.findViewById<TextView>(R.id.textView).text = "Fragment A"
+        view.findViewById<TextView>(R.id.textView).text = NAME
         return view
+    }
+
+    companion object {
+        const val NAME = "Fragment A"
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/viewpager/FragmentB.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/viewpager/FragmentB.kt
@@ -22,7 +22,11 @@ internal class FragmentB : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val view = inflater.inflate(R.layout.view_pager_child_fragment_layout, container, false)
-        view.findViewById<TextView>(R.id.textView).text = "Fragment B"
+        view.findViewById<TextView>(R.id.textView).text = NAME
         return view
+    }
+
+    companion object {
+        const val NAME = "Fragment B"
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/viewpager/FragmentC.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/viewpager/FragmentC.kt
@@ -22,7 +22,11 @@ internal class FragmentC : Fragment() {
         savedInstanceState: Bundle?
     ): View? {
         val view = inflater.inflate(R.layout.view_pager_child_fragment_layout, container, false)
-        view.findViewById<TextView>(R.id.textView).text = "Fragment C"
+        view.findViewById<TextView>(R.id.textView).text = NAME
         return view
+    }
+
+    companion object {
+        const val NAME = "Fragment C"
     }
 }

--- a/sample/kotlin/src/main/res/layout/activity_compose.xml
+++ b/sample/kotlin/src/main/res/layout/activity_compose.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-Present Datadog, Inc.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <androidx.viewpager.widget.ViewPager
+        android:id="@+id/view_pager"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <com.google.android.material.tabs.TabLayout
+            android:id="@+id/tab_layout"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" />
+    </androidx.viewpager.widget.ViewPager>
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/kotlin/src/main/res/navigation/nav_graph.xml
+++ b/sample/kotlin/src/main/res/navigation/nav_graph.xml
@@ -58,10 +58,9 @@
         android:name="com.datadog.android.sample.user.UserFragment"
         android:label="@string/title_user_info"/>
 
-    <fragment
-        android:id="@+id/fragment_compose"
-        android:name="com.datadog.android.sample.compose.ComposeFragment"
-        android:label="@string/title_compose" />
+    <activity android:id="@+id/activity_jetpack_compose"
+        android:name="com.datadog.android.sample.compose.JetpackComposeActivity"
+        android:label="@string/title_compose"/>
 
     <fragment android:id="@+id/fragment_about"
               android:name="com.datadog.android.sample.about.AboutFragment"


### PR DESCRIPTION
### What does this PR do?

This change brings support of manual instrumentation of Swipe and Scroll actions in Jetpack Compose.

It works by listening for the interactions happening with a help of [InteractionSource](https://developer.android.com/reference/kotlin/androidx/compose/foundation/interaction/InteractionSource) and then reading the current state of Swipe/Scroll when certain interaction happens.

Under the hood of Jetpack Compose both scroll and swipe rely on the generic `drag` operation, so code for their tracking have some similarities. However, there are also differences: 

* Direction: swiping down will **increase** offset from the base point, however scrolling down will **decrease** offset from the base point.
* Anchors: scroll doesn't have anchors, but swipe should have at least one anchor is `Modifier.swipeable` is used. Anchors are used to know the current state of the swipe (say in case of the `Switch`), and serve as sticky points  to come to, when finger is up.

Also 2 attributes are added `from_state` and `to_state` for the swipe interaction: they can be useful later in the scrubbing API is user wants to filter out swipe events which didn't result in the state change. They are not in the `action` namespace yet, but I think we should add them there.

Also the UI is added in the sample app to play with Swipe/Scroll actions reporting.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

