### PR TITLE
Improving `NavigationViewTrackingStrategy` to allow dynamic `NavHostFrament` setup [#760]

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -155,6 +155,17 @@ internal class NavigationViewTrackingStrategyTest {
     }
 
     @Test
+    fun `registers navigation listener when nav controller added after activity started`() {
+        whenever(mockNavView.getTag(R.id.nav_controller_view_tag)) doReturn null
+        testedStrategy.onActivityStarted(mockActivity)
+        verifyZeroInteractions(mockNavController)
+
+        whenever(mockNavView.getTag(R.id.nav_controller_view_tag)) doReturn mockNavController
+        testedStrategy.startTracking()
+        verify(mockNavController).addOnDestinationChangedListener(testedStrategy)
+    }
+
+    @Test
     fun `registers fragment lifecycle callback onActivityStarted`() {
         testedStrategy.onActivityStarted(mockActivity)
 
@@ -165,10 +176,18 @@ internal class NavigationViewTrackingStrategyTest {
     }
 
     @Test
-    fun `unregisters navigation listener onActivityStopped`() {
+    fun `unregisters navigation listener onActivityStopped if activity was started`() {
+        testedStrategy.onActivityStarted(mockActivity)
         testedStrategy.onActivityStopped(mockActivity)
 
         verify(mockNavController).removeOnDestinationChangedListener(testedStrategy)
+    }
+
+    @Test
+    fun `doesn't unregister navigation listener onActivityStopped if activity not started`() {
+        testedStrategy.onActivityStopped(mockActivity)
+
+        verifyZeroInteractions(mockNavController)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

As discussed in #760, but without separate `LazyNavigationViewTrackingStrategy` - there's no need for a separate class, it will just confuse, especially since it would either need to re-implement all of the functionality of the base class, or need to be derived from it. Original implementation still works exactly the same as before, but exposes tracking functionality through public functions `startTracking` and `stopTracking`. This way, it's possible to use the strategy with programmatically created `NavHostFragment`.

In most cases, only a call to `startTracking` is needed, `stopTracking` is called automatically when activity stops. But we do call `stopTracking` in our custom implementation as well because we replace `NavHostFragment` multiple times during activity lifetime. Having it ensures there's no tracking left in case new nav host is not needed. Since `startedActivity` property is managed inside activity lifecycle callbacks, the two tracking functions can be called independently multiple times without an issue.

### Motivation

`NavigationViewTrackingStrategy` is only usable for static nav host controller without these changes so doesn't work for our project.

### Additional Notes

I implemented the changes based on the custom implementation suited for our project. I can't easily test local implementation within our project, too many changes required, but I tested it with sample project and works the same. Also ran `intrumented.integration` which opened an app but not much was happening other than that. And `instrumented.nightly-tests` which again built fine, but refused to run due to error `Could not identify launch activity: Default Activity not found`. I get the same results without my changes too though.

I only committed `NavigationViewTrackingStrategy`, but this change resulted in showing multiple other files as changed. `apiSurface` is the only one that actually shows changes (2 new functions added). I assume these are auto-generated, so don't include them here.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

