### PR TITLE
RUMM-1800: Use physical gesture direction definition

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -79,10 +79,7 @@ internal class GesturesListener(
         distanceY: Float
     ): Boolean {
         val rumMonitor = GlobalRum.get()
-        val decorView = windowReference.get()?.decorView
-        if (decorView == null) {
-            return false
-        }
+        val decorView = windowReference.get()?.decorView ?: return false
 
         // we only start the user action once
         if (scrollEventType == null) {
@@ -282,9 +279,9 @@ internal class GesturesListener(
         val diffY = endEvent.y - onTouchDownYPos
         return if (abs(diffX) > abs(diffY)) {
             if (diffX > 0) {
-                SCROLL_DIRECTION_LEFT
-            } else {
                 SCROLL_DIRECTION_RIGHT
+            } else {
+                SCROLL_DIRECTION_LEFT
             }
         } else {
             if (diffY > 0) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
@@ -382,7 +382,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
     }
 
     @Test
-    fun `M use the class simple name as target name W scrollDetected { cannonicalName is null }`(
+    fun `M use the class simple name as target name W scrollDetected { canonicalName is null }`(
         forge: Forge
     ) {
         val listSize = forge.anInt(1, 20)
@@ -405,7 +405,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
 
         // we will use a LocalViewClass to reproduce the behaviour when getCanonicalName function
         // can return a null object.
-        class LocalScrollableView() : ScrollableListView()
+        class LocalScrollableView : ScrollableListView()
 
         val scrollingTarget: LocalScrollableView = mockView(
             id = targetId,
@@ -805,11 +805,11 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
                 whenever(stopEvent.x).thenReturn(initialStartX)
                 whenever(stopEvent.y).thenReturn((initialStartY + 2))
             }
-            GesturesListener.SCROLL_DIRECTION_LEFT -> {
+            GesturesListener.SCROLL_DIRECTION_RIGHT -> {
                 whenever(stopEvent.x).thenReturn((initialStartX + 2))
                 whenever(stopEvent.y).thenReturn(initialStartY)
             }
-            GesturesListener.SCROLL_DIRECTION_RIGHT -> {
+            GesturesListener.SCROLL_DIRECTION_LEFT -> {
                 whenever(stopEvent.x).thenReturn((initialStartX - 2))
                 whenever(stopEvent.y).thenReturn(initialStartY)
             }


### PR DESCRIPTION
### What does this PR do?

This change aligns value of `action.gesture.direction` attribute with physical gesture (finger) direction.

It is done to remove the possible confusion: currently if finger is moved to the `right`, direction reported will be `left`, because we go to the beginning of the list in case of RTL layout (and vice versa). This makes sense for the scrollable list, but not for the swipe (element still goes to the `right`). Moreover, reporting logic for horizontal axis wasn't consistent with vertical axis in case of scroll.

Now the direction of the finger will be simply reported.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

