### PR TITLE
RUMM-1760 create rule to detekt invalid String.Format

### DIFF
--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/DatadogProvider.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/DatadogProvider.kt
@@ -7,6 +7,7 @@
 package com.datadog.tools.detekt
 
 import com.datadog.tools.detekt.rules.CheckInternal
+import com.datadog.tools.detekt.rules.InvalidStringFormat
 import com.datadog.tools.detekt.rules.RequireInternal
 import com.datadog.tools.detekt.rules.ThrowingInternalException
 import com.datadog.tools.detekt.rules.TodoWithoutTask
@@ -31,6 +32,7 @@ class DatadogProvider : RuleSetProvider {
                 CheckInternal(),
                 RequireInternal(),
                 TodoWithoutTask(),
+                InvalidStringFormat(),
                 UnsafeThirdPartyFunctionCall(config),
                 UnsafeCallOnNullableType()
             )

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/ext/KotlinTypeExt.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/ext/KotlinTypeExt.kt
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.tools.detekt.ext
+
+import org.jetbrains.kotlin.descriptors.buildPossiblyInnerType
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+import org.jetbrains.kotlin.types.KotlinType
+import org.jetbrains.kotlin.types.isNullable
+import org.jetbrains.kotlin.types.typeUtil.supertypes
+
+internal fun KotlinType.fullType(): String? {
+    val descriptor = if (toString() == "T" || toString() == "C") {
+        // Treat generic types as their closest supertype (usually Any)
+        supertypes().firstOrNull()?.buildPossiblyInnerType()?.classifierDescriptor
+    } else {
+        buildPossiblyInnerType()?.classifierDescriptor
+    }
+    val fqName = descriptor?.fqNameOrNull()
+    return if (fqName != null) {
+        val nullableSuffix = if (isNullable()) "?" else ""
+        "$fqName$nullableSuffix"
+    } else {
+        val supertypes = this.supertypes().joinToString()
+        println("Unable to get fqName for ${this.javaClass} $this: $supertypes")
+        null
+    }
+}

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/ext/ReceiverExt.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/ext/ReceiverExt.kt
@@ -1,0 +1,37 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.tools.detekt.ext
+
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
+import org.jetbrains.kotlin.resolve.scopes.receivers.ClassQualifier
+import org.jetbrains.kotlin.resolve.scopes.receivers.ExpressionReceiver
+import org.jetbrains.kotlin.resolve.scopes.receivers.Receiver
+import org.jetbrains.kotlin.types.FlexibleType
+import org.jetbrains.kotlin.types.lowerIfFlexible
+import org.jetbrains.kotlin.types.typeUtil.makeNotNullable
+
+internal fun Receiver?.type(bindingContext: BindingContext): String? {
+    if (this == null) return null
+    if (this is ExpressionReceiver) {
+        val resolvedType = expression.getType(bindingContext)
+        return if (resolvedType is FlexibleType) {
+            // types from java are flexible because the Kotlin Compiler doesn't know whether
+            // they're nullable or not.Using the lowerBound makes it nonNullable
+            resolvedType.lowerIfFlexible().fullType()
+        } else {
+            // Convert all types to nonNullable
+            resolvedType?.makeNotNullable()?.fullType()
+        }
+    } else if (this is ClassQualifier) {
+        return descriptor.fqNameOrNull()?.toString()
+    } else {
+        println("DD: Unknown receiver type ${this.javaClass}")
+        return null
+    }
+}

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/InvalidStringFormat.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/InvalidStringFormat.kt
@@ -1,0 +1,289 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.tools.detekt.rules
+
+import com.datadog.tools.detekt.ext.fullType
+import com.datadog.tools.detekt.ext.type
+import io.gitlab.arturbosch.detekt.api.CodeSmell
+import io.gitlab.arturbosch.detekt.api.Debt
+import io.gitlab.arturbosch.detekt.api.Entity
+import io.gitlab.arturbosch.detekt.api.Issue
+import io.gitlab.arturbosch.detekt.api.Rule
+import io.gitlab.arturbosch.detekt.api.Severity
+import java.util.Locale
+import org.jetbrains.kotlin.descriptors.CallableDescriptor
+import org.jetbrains.kotlin.descriptors.VariableDescriptor
+import org.jetbrains.kotlin.psi.KtCallExpression
+import org.jetbrains.kotlin.psi.KtDotQualifiedExpression
+import org.jetbrains.kotlin.psi.KtExpression
+import org.jetbrains.kotlin.psi.KtReferenceExpression
+import org.jetbrains.kotlin.psi.KtStringTemplateExpression
+import org.jetbrains.kotlin.psi.psiUtil.children
+import org.jetbrains.kotlin.resolve.BindingContext
+import org.jetbrains.kotlin.resolve.bindingContextUtil.getReferenceTargets
+import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
+import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.resolve.calls.model.ResolvedCall
+import org.jetbrains.kotlin.resolve.calls.model.VarargValueArgument
+import org.jetbrains.kotlin.resolve.scopes.receivers.ClassQualifier
+import org.jetbrains.kotlin.resolve.scopes.receivers.ExpressionReceiver
+import org.jetbrains.kotlin.types.lowerIfFlexible
+import org.jetbrains.kotlin.utils.addToStdlib.firstIsInstanceOrNull
+
+/**
+ * A rule to detekt invalid String.format() calls (that is calls where the number of arguments
+ * does not match the template string).
+ *
+ * @active
+ */
+class InvalidStringFormat : Rule() {
+
+    // region Rule
+
+    override val issue: Issue = Issue(
+        javaClass.simpleName,
+        Severity.Defect,
+        "This rule reports when a String format pattern does not match the provided arguments.",
+        Debt.TWENTY_MINS
+    )
+
+    override fun visitCallExpression(expression: KtCallExpression) {
+        super.visitCallExpression(expression)
+        if (bindingContext == BindingContext.EMPTY) {
+            return
+        }
+
+        val resolvedCall = expression.getResolvedCall(bindingContext) ?: return
+        val call = resolvedCall.call
+
+        // check receiver type
+        val explicitReceiver = call.explicitReceiver
+        val receiverType = explicitReceiver?.type(bindingContext)
+        if (receiverType != STRING_CLASS) return
+
+        // check method call
+        val calleeExpression = call.calleeExpression?.node?.text
+        if (calleeExpression != FORMAT_METHOD) return
+
+        val formatString = extractFormatString(resolvedCall)
+        val formatArgs = extractFormatArgs(resolvedCall)
+
+        checkFormat(expression, formatString, formatArgs)
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun extractFormatString(
+        resolvedCall: ResolvedCall<out CallableDescriptor>
+    ): String? {
+        val call = resolvedCall.call
+        val explicitReceiver = call.explicitReceiver
+        val stringExpression = when (explicitReceiver) {
+            is ClassQualifier -> {
+                // String.format(…)
+                val arguments = resolvedCall.valueArguments.toList().firstOrNull {
+                    it.first.type.fullType().toString() == STRING_CLASS
+                }?.second?.arguments
+                if (arguments != null && arguments.size == 1) {
+                    arguments.first().getArgumentExpression()
+                } else {
+                    null
+                }
+            }
+            is ExpressionReceiver -> {
+                // "…".format(…)
+                explicitReceiver.expression
+            }
+            else -> {
+                println("Unknown receiver:$explicitReceiver")
+                null
+            }
+        }
+
+        val expression = if (stringExpression is KtDotQualifiedExpression) {
+            // Referencing a constant from another class
+            stringExpression.selectorExpression
+        } else {
+            stringExpression
+        }
+        return resolveStringExpression(expression)
+    }
+
+    private fun resolveStringExpression(stringExpression: KtExpression?): String? {
+        return if (stringExpression is KtStringTemplateExpression) {
+            stringExpression.node
+                .children()
+                .filter { it.text != "\"" }
+                .joinToString("") { it.text }
+        } else if (stringExpression is KtReferenceExpression) {
+            val referenceTarget = stringExpression.getReferenceTargets(bindingContext)
+                .firstIsInstanceOrNull<VariableDescriptor>()
+
+            if (referenceTarget is VariableDescriptor && !referenceTarget.isVar) {
+                val compileTimeInitializer = referenceTarget.compileTimeInitializer
+                if (compileTimeInitializer != null) {
+                    compileTimeInitializer.value as? String
+                } else {
+                    println("Unable to get compileTimeInitializer for $referenceTarget")
+                    null
+                }
+            } else {
+                println("Unknown referenceTarget:$referenceTarget")
+                null
+            }
+        } else {
+            println("Unknown string expression: $stringExpression")
+            null
+        }
+    }
+
+    private fun extractFormatArgs(
+        resolvedCall: ResolvedCall<out CallableDescriptor>
+    ): List<String?> {
+        val receiver = resolvedCall.call.explicitReceiver
+        val formatParams = resolvedCall.valueArgumentsByIndex?.last() as? VarargValueArgument
+
+        val rawTypes = formatParams?.arguments.orEmpty()
+            .map {
+                it.getArgumentExpression()?.getType(bindingContext)?.lowerIfFlexible()?.fullType()
+            }
+        return if (receiver is ClassQualifier && rawTypes.firstOrNull() == LOCALE_CLASS) {
+            rawTypes.subList(1, rawTypes.size)
+        } else {
+            rawTypes
+        }
+    }
+
+    private fun checkFormat(
+        expression: KtCallExpression,
+        formatString: String?,
+        formatArgs: List<String?>
+    ) {
+        if (formatString == null) {
+            report(CodeSmell(issue, Entity.from(expression), ERROR_UNKNOWN_FORMAT_STRING))
+        } else if (formatArgs.isEmpty()) {
+            report(CodeSmell(issue, Entity.from(expression), ERROR_UNKNOWN_FORMAT_STRING))
+        } else {
+            val specifiers = SPECIFIER_REGEX.findAll(formatString).toList()
+            checkSpecifiers(expression, specifiers, formatArgs)
+        }
+    }
+
+    private fun checkSpecifiers(
+        expression: KtCallExpression,
+        specifiers: List<MatchResult>,
+        formatArgs: List<String?>
+    ) {
+        var indexNoRef = 0
+        specifiers.forEach { matchResult ->
+            val type = matchResult.groupValues[INDEX_TYPE].lowercase(Locale.US).first()
+            val ref = matchResult.groupValues[INDEX_REF].toIntOrNull()
+
+            val argIndex = (ref ?: ++indexNoRef) - 1
+            if (argIndex >= formatArgs.size) {
+                val message = ERROR_INVALID_ARGUMENT_COUNT.format(Locale.US, matchResult.value)
+                report(CodeSmell(issue, Entity.from(expression), message))
+            } else {
+                val argType = formatArgs[argIndex]
+                checkArgumentType(expression, argType, type)
+            }
+        }
+    }
+
+    @Suppress("ReplaceArrayEqualityOpWithArraysEquals")
+    private fun checkArgumentType(
+        expression: KtCallExpression,
+        argType: String?,
+        type: Char
+    ) {
+        val allowedTypes: Array<String>? = when (type) {
+            SPECIFIER_DECIMAL_INT,
+            SPECIFIER_OCTAL_INT,
+            SPECIFIER_HEXADECIMAL_INT -> INTEGER_TYPES
+
+            SPECIFIER_DECIMAL_FLOAT,
+            SPECIFIER_SCIENTIFIC_FLOAT,
+            SPECIFIER_HEXADECIMAL_FLOAT,
+            SPECIFIER_GENERAL_FLOAT -> FLOAT_TYPES
+
+            SPECIFIER_CHARACTER -> CHAR_TYPES
+
+            SPECIFIER_BOOLEAN,
+            SPECIFIER_HASHCODE,
+            SPECIFIER_STRING -> ANY_TYPES
+
+            else -> null
+        }
+
+        if (allowedTypes == null) {
+            val message = ERROR_INVALID_ARGUMENT_TYPE +
+                "Unknown specifier %$type."
+            report(CodeSmell(issue, Entity.from(expression), message))
+        } else if (allowedTypes != ANY_TYPES && argType !in allowedTypes) {
+            val message = ERROR_INVALID_ARGUMENT_TYPE +
+                " Expected one of ${allowedTypes.joinToString()}; but was $argType."
+            report(CodeSmell(issue, Entity.from(expression), message))
+        }
+    }
+
+    // endregion
+
+    companion object {
+        private const val LOCALE_CLASS = "java.util.Locale"
+        private const val STRING_CLASS = "kotlin.String"
+        private const val FORMAT_METHOD = "format"
+
+        private const val SPECIFIER_STRING = 's'
+        private const val SPECIFIER_BOOLEAN = 'b'
+        private const val SPECIFIER_HASHCODE = 'h'
+
+        private const val SPECIFIER_CHARACTER = 'c'
+
+        private const val SPECIFIER_DECIMAL_INT = 'd'
+        private const val SPECIFIER_OCTAL_INT = 'o'
+        private const val SPECIFIER_HEXADECIMAL_INT = 'x'
+
+        private const val SPECIFIER_SCIENTIFIC_FLOAT = 'e'
+        private const val SPECIFIER_GENERAL_FLOAT = 'g'
+        private const val SPECIFIER_DECIMAL_FLOAT = 'f'
+        private const val SPECIFIER_HEXADECIMAL_FLOAT = 'a'
+
+        private val INTEGER_TYPES = arrayOf(
+            "kotlin.Byte", "kotlin.Short", "kotlin.Int", "kotlin.Long", "java.math.BigInteger",
+            "kotlin.Byte?", "kotlin.Short?", "kotlin.Int?", "kotlin.Long?", "java.math.BigInteger?"
+        )
+        private val FLOAT_TYPES = arrayOf(
+            "kotlin.Float", "kotlin.Double", "java.math.BigDecimal",
+            "kotlin.Float?", "kotlin.Double?", "java.math.BigDecimal?"
+        )
+        private val CHAR_TYPES = arrayOf(
+            "kotlin.Byte", "kotlin.Short", "kotlin.Int", "kotlin.Char",
+            "kotlin.Byte?", "kotlin.Short?", "kotlin.Int?", "kotlin.Char?"
+        )
+        private val ANY_TYPES = emptyArray<String>()
+
+        // %[ref][flags][width][.precision]type
+        private val SPECIFIER_REGEX = Regex(
+            "%(\\d+\\$)?([flags]+)?(\\d+)?(\\.\\d+)?([sbhcdoxegfa])"
+        )
+
+        // TODO check flags, width and precision for invalid use?
+        private val INDEX_REF = 1
+        private val INDEX_FLAGS = 2
+        private val INDEX_WIDTH = 3
+        private val INDEX_PRECISION = 4
+        private val INDEX_TYPE = 5
+
+        private const val ERROR_UNKNOWN_FORMAT_STRING = "Unable to detect the format string value."
+        private const val ERROR_INVALID_ARGUMENT_COUNT = "An argument is missing for specifier " +
+            "'%s' in the format String."
+        private const val ERROR_INVALID_ARGUMENT_TYPE = "Argument provided doesn't match the " +
+            "type specifier in the format String."
+    }
+}

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/InvalidStringFormat.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/InvalidStringFormat.kt
@@ -154,7 +154,7 @@ class InvalidStringFormat : Rule() {
                 it.getArgumentExpression()?.getType(bindingContext)?.lowerIfFlexible()?.fullType()
             }
         return if (receiver is ClassQualifier && rawTypes.firstOrNull() == LOCALE_CLASS) {
-            rawTypes.subList(1, rawTypes.size)
+            rawTypes.drop(1)
         } else {
             rawTypes
         }

--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/InvalidStringFormatTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/InvalidStringFormatTest.kt
@@ -1,0 +1,623 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.tools.detekt.rules
+
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.github.detekt.test.utils.KotlinCoreEnvironmentWrapper
+import io.github.detekt.test.utils.createEnvironment
+import io.gitlab.arturbosch.detekt.test.assertThat
+import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ForgeExtension::class)
+internal class InvalidStringFormatTest {
+
+    lateinit var kotlinEnv: KotlinCoreEnvironmentWrapper
+
+    @BeforeEach
+    fun setup() {
+        kotlinEnv = createEnvironment()
+    }
+
+    @AfterEach
+    fun tearDown() {
+        kotlinEnv.dispose()
+    }
+
+    // region Test unresolved format string
+
+    @Test
+    fun `Warns unresolved String format {variable, ext}`() {
+        // Given
+        val code =
+            """ 
+                fun test(s: String): String {
+                    var pattern = "Called %s with %s"
+                    return pattern.format(s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns unresolved String format {variable, static}`() {
+        // Given
+        val code =
+            """ 
+                fun test(s: String): String {
+                    var pattern = "Called %s with %s"
+                    return String.format(pattern, s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns unresolved String format {argument, ext}`() {
+        // Given
+        val code =
+            """ 
+                fun test(pattern: String, s: String): String {
+                    return pattern.format(s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns unresolved String format {argument, static}`() {
+        // Given
+        val code =
+            """ 
+                fun test(pattern: String, s: String): String {
+                    return String.format(pattern, s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns unresolved String format {argument with defaults, ext}`() {
+        // Given
+        val code =
+            """ 
+                fun test(pattern: String = "%s", s: String): String {
+                    return pattern.format(s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns unresolved String format {argument with defaults, static}`() {
+        // Given
+        val code =
+            """ 
+                fun test(pattern: String = "%s", s: String): String {
+                    return String.format(pattern, s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    // endregion
+
+    // region Test invalid number of args
+
+    @Test
+    fun `Warns invalid argument count {ext, magic string, no locale}`() {
+        // Given
+        val code =
+            """ 
+                fun test(s: String): String {
+                    return "Called %s with %s".format(s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {ext, magic string, with locale}`() {
+        // Given
+        val code =
+            """ 
+                import java.util.Locale
+                fun test(s: String): String {
+                    return "Called %s with %s".format(Locale.US, s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {ext, local val, no locale}`() {
+        // Given
+        val code =
+            """ 
+                fun test(s: String): String {
+                    val pattern = "Called %s with %s"
+                    return pattern.format(s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {ext, local val, with locale}`() {
+        // Given
+        val code =
+            """ 
+                import java.util.Locale
+                fun test(s: String): String {
+                    val pattern = "Called %s with %s"
+                    return pattern.format(Locale.US, s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {ext, constant, no locale}`() {
+        // Given
+        val code =
+            """ 
+                const val PATTERN = "Called %s with %s"
+                
+                fun test(s: String): String {
+                    return PATTERN.format(s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {ext, constant, with locale}`() {
+        // Given
+        val code =
+            """ 
+                import java.util.Locale
+                
+                const val PATTERN = "Called %s with %s"
+                
+                fun test(s: String): String {
+                    return PATTERN.format(Locale.US, s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {static, magic string, no locale}`() {
+        // Given
+        val code =
+            """ 
+                fun test(s: String): String {
+                    return String.format("Called %s with %s", s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {static, magic string, with locale}`() {
+        // Given
+        val code =
+            """ 
+                import java.util.Locale
+                fun test(s: String): String {
+                    return String.format(Locale.US, "Called %s with %s", s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {static, local val, no locale}`() {
+        // Given
+        val code =
+            """ 
+                fun test(s: String): String {
+                    val pattern = "Called %s with %s"
+                    return String.format(pattern, s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {static, local val, with locale}`() {
+        // Given
+        val code =
+            """ 
+                import java.util.Locale
+                fun test(s: String): String {
+                    val pattern = "Called %s with %s"
+                    return String.format(Locale.US, pattern, s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {static, constant, no locale}`() {
+        // Given
+        val code =
+            """ 
+                const val PATTERN = "Called %s with %s"
+                
+                fun test(s: String): String {
+                    return String.format(PATTERN, s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `Warns invalid argument count {static, constant, with locale}`() {
+        // Given
+        val code =
+            """ 
+                import java.util.Locale
+                
+                const val PATTERN = "Called %s with %s"
+                
+                fun test(s: String): String {
+                    return String.format(Locale.US, PATTERN, s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    // endregion
+
+    // region Test invalid arg types
+
+    @Test
+    fun `Warns invalid String format args type {indexed args}`() {
+        // Given
+        val code =
+            """ 
+                fun test(): String {
+                    return String.format("Called %1${"$"}d / %2${"$"}f", 3.14f, 42)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(2)
+    }
+
+    @Test
+    fun `Warns invalid String format args type {ints, positional args}`() {
+        // Given
+        val code =
+            """ 
+                fun test(): String {
+                    return String.format("Ints %d %o %x", "not", "an", "int")
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(3)
+    }
+
+    @Test
+    fun `Warns invalid String format args type {floats, positional args}`() {
+        // Given
+        val code =
+            """ 
+                fun test(): String {
+                    return String.format("Floats %e %g %f %a", "not", "a", "float", "here")
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(4)
+    }
+
+    @Test
+    fun `Warns invalid String format args type {chars, positional args}`() {
+        // Given
+        val code =
+            """ 
+                fun test(): String {
+                    return String.format("Chars %c", "not a char")
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    // endregion
+
+    // region Test not relevant
+
+    @Test
+    fun `Ignores valid String format args type {ints, positional args}`() {
+        // Given
+        val code =
+            """ 
+                import java.math.BigInteger
+                
+                fun test(): String {
+                    val l: Long = 4815162342L
+                    val i: Int = 1337
+                    val s: Short = 42
+                    val b: Byte = 7
+                    val bd: BigInteger = BigInteger.ONE
+                    return String.format("Ints %d %o %x %d %X", l, i, s, b, bd)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `Ignores valid String format args type {floats, positional args}`() {
+        // Given
+        val code =
+            """ 
+                import java.math.BigDecimal
+                
+                fun test(): String {
+                    val f: Float = 3.1415f
+                    val d: Double = 1.61803398874989
+                    val bd: BigDecimal = BigDecimal.ONE
+                    val nf: Float? = null
+                    return String.format("Floats %e %g %f %a", f, d, bd, nf)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `Ignores valid String format args type {chars, positional args}`() {
+        // Given
+        val code =
+            """ 
+                fun test(): String {
+                    val i: Int = 1337
+                    val s: Short = 42
+                    val b: Byte = 7
+                    val c: Char = 'x'
+                    return String.format("Chars %c %c %c %c", i, s, b, c)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `Ignores format on non String class {fun}`() {
+        // Given
+        val code =
+            """ 
+                class Foo {
+                    fun format(s: String) {
+                    }
+                }
+                
+                fun test(s: String): String {
+                    val f = Foo()
+                    return f.format(s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `Ignores format on non String class {static fun}`() {
+        // Given
+        val code =
+            """ 
+                class Foo {
+                    companion object {
+                        fun format(s: String) {
+                        }
+                    }
+                }
+                
+                fun test(s: String): String {
+                    return Foo.format(s)
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `Ignores non format fun on String class {fun}`() {
+        // Given
+        val code =
+            """ 
+                fun test(s: String): String {
+                    return s.toLowercase()
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `Ignores non format fun on String class {ext}`() {
+        // Given
+        val code =
+            """ 
+                fun test(s: String): String {
+                    return s.lowercase()
+                }
+            """.trimIndent()
+
+        // When
+        val findings = InvalidStringFormat()
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(0)
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

Add a check to ensure `String.format()` calls are valid: 
- checks number of argument matches the provided specifiers
- checks the type of arguments matches the provided specifiers

### Motivation

Add checks on the code we ship