### PR TITLE
Rename DatadogViewTrackingEffect to NavigationViewTrackingEffect

### DIFF
--- a/dd-sdk-android-compose/README.md
+++ b/dd-sdk-android-compose/README.md
@@ -52,7 +52,7 @@ If you have an app with only Compose elements, you can add support of view track
 
 ```kotlin
 val navController = rememberNavController().apply {
-    DatadogViewTrackingEffect(navController = this, trackArguments = ..., destinationPredicate = ...)
+    NavigationViewTrackingEffect(navController = this, trackArguments = ..., destinationPredicate = ...)
 }
 ```
 

--- a/dd-sdk-android-compose/apiSurface
+++ b/dd-sdk-android-compose/apiSurface
@@ -6,4 +6,4 @@ sealed class com.datadog.android.compose.InteractionType
     constructor(androidx.compose.material.SwipeableState<T>, androidx.compose.foundation.gestures.Orientation, Boolean = false)
   class Scroll : InteractionType
     constructor(androidx.compose.foundation.gestures.ScrollableState, androidx.compose.foundation.gestures.Orientation, Boolean = false)
-fun DatadogViewTrackingEffect(androidx.navigation.NavController, Boolean = true, com.datadog.android.rum.tracking.ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())
+fun NavigationViewTrackingEffect(androidx.navigation.NavController, Boolean = true, com.datadog.android.rum.tracking.ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation.kt
@@ -108,7 +108,7 @@ internal class ComposeNavigationObserver(
 @ExperimentalTrackingApi
 @Composable
 @NonRestartableComposable
-fun DatadogViewTrackingEffect(
+fun NavigationViewTrackingEffect(
     navController: NavController,
     trackArguments: Boolean = true,
     destinationPredicate: ComponentPredicate<NavDestination> = AcceptAllNavDestinations()

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/NavigationFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/NavigationFragment.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -33,7 +32,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
-import com.datadog.android.compose.DatadogViewTrackingEffect
+import com.datadog.android.compose.NavigationViewTrackingEffect
 import com.datadog.android.compose.ExperimentalTrackingApi
 import com.datadog.android.compose.trackClick
 import com.datadog.android.rum.tracking.AcceptAllNavDestinations
@@ -63,7 +62,7 @@ class ComposeFragment : Fragment() {
 @Composable
 fun ComposeNavigationExample() {
     val navController = rememberNavController().apply {
-        DatadogViewTrackingEffect(
+        NavigationViewTrackingEffect(
             navController = this,
             trackArguments = true,
             destinationPredicate = AcceptAllNavDestinations()


### PR DESCRIPTION
### What does this PR do?

This change renames `DatadogViewTrackingEffect` to `NavigationViewTrackingEffect` to better emphasize that this effect relies on navigation mechanism and to remove redundant `Datadog` mention (other public elements in `compose` module are not using it).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

