### PR TITLE
Add a flag that allows increased info when debugging

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -266,4 +266,4 @@ tasks.register("buildNdkIntegrationTestsArtifacts") {
     dependsOn(":instrumented:integration:assembleDebug")
 }
 
-nightlyTestsCoverageConfig(threshold = 0.94f)
+nightlyTestsCoverageConfig(threshold = 0.93f)

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -75,7 +75,7 @@ data class com.datadog.android.core.configuration.Configuration
   class Builder
     constructor(Boolean, Boolean, Boolean, Boolean)
     fun build(): Configuration
-    fun setVerboseDebugInfo(Boolean): Builder
+    fun setUseDeveloperModeWhenDebuggable(Boolean): Builder
     fun setFirstPartyHosts(List<String>): Builder
     fun useSite(com.datadog.android.DatadogSite): Builder
     DEPRECATED fun useEUEndpoints(): Builder

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -71,10 +71,11 @@ enum com.datadog.android.core.configuration.BatchSize
   - SMALL
   - MEDIUM
   - LARGE
-class com.datadog.android.core.configuration.Configuration
+data class com.datadog.android.core.configuration.Configuration
   class Builder
     constructor(Boolean, Boolean, Boolean, Boolean)
     fun build(): Configuration
+    fun setVerboseDebugInfo(Boolean): Builder
     fun setFirstPartyHosts(List<String>): Builder
     fun useSite(com.datadog.android.DatadogSite): Builder
     DEPRECATED fun useEUEndpoints(): Builder

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -9,8 +9,11 @@ package com.datadog.android
 import android.app.Application
 import android.content.Context
 import android.content.pm.ApplicationInfo
+import android.util.Log
+import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleCallback
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
@@ -76,16 +79,30 @@ object Datadog {
             return
         }
 
+        var mutableConfig = configuration
+        if (isDebug and configuration.coreConfig.verboseDebugInfo) {
+            mutableConfig = configuration.copy(
+                coreConfig = configuration.coreConfig.copy(
+                    batchSize = BatchSize.SMALL,
+                    uploadFrequency = UploadFrequency.FREQUENT
+                ),
+                rumConfig = configuration.rumConfig?.copy(
+                    samplingRate = 100.0f
+                )
+            )
+            Datadog.setVerbosity(Log.VERBOSE)
+        }
+
         // always initialize Core Features first
-        CoreFeature.initialize(appContext, credentials, configuration.coreConfig, trackingConsent)
+        CoreFeature.initialize(appContext, credentials, mutableConfig.coreConfig, trackingConsent)
 
-        applyAdditionalConfiguration(configuration.additionalConfig)
+        applyAdditionalConfiguration(mutableConfig.additionalConfig)
 
-        initializeLogsFeature(configuration.logsConfig, appContext)
-        initializeTracingFeature(configuration.tracesConfig, appContext)
-        initializeRumFeature(configuration.rumConfig, appContext)
-        initializeCrashReportFeature(configuration.crashReportConfig, appContext)
-        initializeInternalLogsFeature(configuration.internalLogsConfig, appContext)
+        initializeLogsFeature(mutableConfig.logsConfig, appContext)
+        initializeTracingFeature(mutableConfig.tracesConfig, appContext)
+        initializeRumFeature(mutableConfig.rumConfig, appContext)
+        initializeCrashReportFeature(mutableConfig.crashReportConfig, appContext)
+        initializeInternalLogsFeature(mutableConfig.internalLogsConfig, appContext)
 
         CoreFeature.ndkCrashHandler.handleNdkCrash(
             LogsFeature.persistenceStrategy.getWriter(),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -80,16 +80,8 @@ object Datadog {
         }
 
         var mutableConfig = configuration
-        if (isDebug and configuration.coreConfig.verboseDebugInfo) {
-            mutableConfig = configuration.copy(
-                coreConfig = configuration.coreConfig.copy(
-                    batchSize = BatchSize.SMALL,
-                    uploadFrequency = UploadFrequency.FREQUENT
-                ),
-                rumConfig = configuration.rumConfig?.copy(
-                    samplingRate = 100.0f
-                )
-            )
+        if (isDebug and configuration.coreConfig.enableDeveloperModeWhenDebuggable) {
+            mutableConfig = modifyConfigurationForDeveloperDebug(configuration)
             Datadog.setVerbosity(Log.VERBOSE)
         }
 
@@ -300,6 +292,19 @@ object Datadog {
         if (configuration != null) {
             InternalLogsFeature.initialize(appContext, configuration)
         }
+    }
+
+    @Suppress("FunctionMaxLength")
+    private fun modifyConfigurationForDeveloperDebug(configuration: Configuration): Configuration {
+        return configuration.copy(
+            coreConfig = configuration.coreConfig.copy(
+                batchSize = BatchSize.SMALL,
+                uploadFrequency = UploadFrequency.FREQUENT
+            ),
+            rumConfig = configuration.rumConfig?.copy(
+                samplingRate = 100.0f
+            )
+        )
     }
 
     private fun applyAdditionalConfiguration(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -65,7 +65,7 @@ internal constructor(
 
     internal data class Core(
         var needsClearTextHttp: Boolean,
-        val verboseDebugInfo: Boolean,
+        val enableDeveloperModeWhenDebuggable: Boolean,
         val firstPartyHosts: List<String>,
         val batchSize: BatchSize,
         val uploadFrequency: UploadFrequency,
@@ -160,10 +160,11 @@ internal constructor(
          *   setUploadFrequency(UploadFrequency.FREQUENT)
          *   Datadog.setVerbosity(Log.VERBOSE)
          * These settings will override your configuration, but only when the application is `debuggable`
-         * @param verboseDebugInfo Enable or disable verbose info when debugging
+         * @param developerModeEnabled Enable or disable extra debug info when an app is debuggable
          */
-        fun setVerboseDebugInfo(verboseDebugInfo: Boolean): Builder {
-            coreConfig = coreConfig.copy(verboseDebugInfo = verboseDebugInfo)
+        @Suppress("FunctionMaxLength")
+        fun setUseDeveloperModeWhenDebuggable(developerModeEnabled: Boolean): Builder {
+            coreConfig = coreConfig.copy(enableDeveloperModeWhenDebuggable = developerModeEnabled)
             return this
         }
 
@@ -648,7 +649,7 @@ internal constructor(
 
         internal val DEFAULT_CORE_CONFIG = Core(
             needsClearTextHttp = false,
-            verboseDebugInfo = false,
+            enableDeveloperModeWhenDebuggable = false,
             firstPartyHosts = emptyList(),
             batchSize = BatchSize.MEDIUM,
             uploadFrequency = UploadFrequency.AVERAGE,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -52,7 +52,7 @@ import okhttp3.Authenticator
  *
  * This is necessary to initialize the SDK with the [Datadog.initialize] method.
  */
-class Configuration
+data class Configuration
 internal constructor(
     internal var coreConfig: Core,
     internal val logsConfig: Feature.Logs?,
@@ -65,6 +65,7 @@ internal constructor(
 
     internal data class Core(
         var needsClearTextHttp: Boolean,
+        val verboseDebugInfo: Boolean,
         val firstPartyHosts: List<String>,
         val batchSize: BatchSize,
         val uploadFrequency: UploadFrequency,
@@ -149,6 +150,21 @@ internal constructor(
                 internalLogsConfig = internalLogsConfig,
                 additionalConfig = additionalConfig
             )
+        }
+
+        /**
+         * Sets the DataDog SDK to be more verbose when an application is set to `debuggable`.
+         * This is equivalent to setting:
+         *   sampleRumSessions(100)
+         *   setBatchSize(BatchSize.SMALL)
+         *   setUploadFrequency(UploadFrequency.FREQUENT)
+         *   Datadog.setVerbosity(Log.VERBOSE)
+         * These settings will override your configuration, but only when the application is `debuggable`
+         * @param verboseDebugInfo Enable or disable verbose info when debugging
+         */
+        fun setVerboseDebugInfo(verboseDebugInfo: Boolean): Builder {
+            coreConfig = coreConfig.copy(verboseDebugInfo = verboseDebugInfo)
+            return this
         }
 
         /**
@@ -632,6 +648,7 @@ internal constructor(
 
         internal val DEFAULT_CORE_CONFIG = Core(
             needsClearTextHttp = false,
+            verboseDebugInfo = false,
             firstPartyHosts = emptyList(),
             batchSize = BatchSize.MEDIUM,
             uploadFrequency = UploadFrequency.AVERAGE,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -233,6 +233,9 @@ internal class DatadogTest {
 
     @Test
     fun `M no changes W initialize() { verboseDebug } in non debug mode`() {
+        // Given
+        appContext.fakeAppInfo.flags =
+            appContext.fakeAppInfo.flags and ApplicationInfo.FLAG_DEBUGGABLE.inv()
         val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, fakeApplicationId, null)
         val configuration = Configuration.Builder(
             logsEnabled = true,
@@ -240,12 +243,14 @@ internal class DatadogTest {
             crashReportsEnabled = true,
             rumEnabled = true
         )
-            .setVerboseDebugInfo(true)
+            .setUseDeveloperModeWhenDebuggable(true)
             .sampleRumSessions(75.0f)
             .build()
 
+        // When
         Datadog.initialize(appContext.mockInstance, credentials, configuration, fakeConsent)
 
+        // Then
         assertThat(Datadog.libraryVerbosity).isEqualTo(Int.MAX_VALUE)
         assertThat(RumFeature.samplingRate).isEqualTo(75.0f)
         assertThat(CoreFeature.batchSize).isEqualTo(BatchSize.MEDIUM)
@@ -254,6 +259,7 @@ internal class DatadogTest {
 
     @Test
     fun `M overrides configuration W initialize() { verboseDebug } in debug mode`() {
+        // Given
         appContext.fakeAppInfo.flags =
             appContext.fakeAppInfo.flags or ApplicationInfo.FLAG_DEBUGGABLE
 
@@ -264,12 +270,14 @@ internal class DatadogTest {
             crashReportsEnabled = true,
             rumEnabled = true
         )
-            .setVerboseDebugInfo(true)
+            .setUseDeveloperModeWhenDebuggable(true)
             .sampleRumSessions(75.0f)
             .build()
 
+        // When
         Datadog.initialize(appContext.mockInstance, credentials, configuration, fakeConsent)
 
+        // Then
         assertThat(Datadog.libraryVerbosity).isEqualTo(AndroidLog.VERBOSE)
         assertThat(RumFeature.samplingRate).isEqualTo(100.0f)
         assertThat(CoreFeature.batchSize).isEqualTo(BatchSize.SMALL)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -102,6 +102,7 @@ internal class ConfigurationBuilderTest {
         assertThat(config.coreConfig).isEqualTo(
             Configuration.Core(
                 needsClearTextHttp = false,
+                verboseDebugInfo = false,
                 firstPartyHosts = emptyList(),
                 batchSize = BatchSize.MEDIUM,
                 uploadFrequency = UploadFrequency.AVERAGE,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -102,7 +102,7 @@ internal class ConfigurationBuilderTest {
         assertThat(config.coreConfig).isEqualTo(
             Configuration.Core(
                 needsClearTextHttp = false,
-                verboseDebugInfo = false,
+                enableDeveloperModeWhenDebuggable = false,
                 firstPartyHosts = emptyList(),
                 batchSize = BatchSize.MEDIUM,
                 uploadFrequency = UploadFrequency.AVERAGE,
@@ -1485,6 +1485,23 @@ internal class ConfigurationBuilderTest {
         assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
         assertThat(config.internalLogsConfig).isNull()
         assertThat(config.additionalConfig).isEmpty()
+    }
+
+    @Test
+    fun `M developer flag set W setUseDeveloperModeWhenDebuggable()`(
+        @BoolForgery enableDeveloperDebugInfo: Boolean
+    ) {
+        // When
+        val config = testedBuilder
+            .setUseDeveloperModeWhenDebuggable(enableDeveloperDebugInfo)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(
+            Configuration.DEFAULT_CORE_CONFIG.copy(
+                enableDeveloperModeWhenDebuggable = enableDeveloperDebugInfo
+            )
+        )
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
@@ -25,6 +25,7 @@ internal class ConfigurationCoreForgeryFactory :
 
         return Configuration.Core(
             needsClearTextHttp = forge.aBool(),
+            verboseDebugInfo = forge.aBool(),
             firstPartyHosts = forge.aList { getForgery<URL>().host },
             batchSize = forge.getForgery(),
             uploadFrequency = forge.getForgery(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
@@ -25,7 +25,7 @@ internal class ConfigurationCoreForgeryFactory :
 
         return Configuration.Core(
             needsClearTextHttp = forge.aBool(),
-            verboseDebugInfo = forge.aBool(),
+            enableDeveloperModeWhenDebuggable = forge.aBool(),
             firstPartyHosts = forge.aList { getForgery<URL>().host },
             batchSize = forge.getForgery(),
             uploadFrequency = forge.getForgery(),


### PR DESCRIPTION
The `verboseDebugInfo` flag will override any other user settings to increase upload frequency, disable sampling, and set logging to verbose, but only when the application is marked as `debuggable` in the manifest.

Implements RUMM-1773 

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

