### PR TITLE
Cherry-pick `sdk_version` and `source_type` features into `1.11.0` release

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -315,6 +315,7 @@ object com.datadog.android.rum.RumAttributes
   const val INTERNAL_ERROR_TYPE: String
   const val INTERNAL_TIMESTAMP: String
   const val INTERNAL_ERROR_SOURCE_TYPE: String
+  const val INTERNAL_ERROR_IS_CRASH: String
   const val TRACE_ID: String
   const val SPAN_ID: String
   const val RESOURCE_TIMINGS: String

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -314,6 +314,7 @@ object com.datadog.android.rum.RumAttributes
   const val SDK_VERSION: String
   const val INTERNAL_ERROR_TYPE: String
   const val INTERNAL_TIMESTAMP: String
+  const val INTERNAL_ERROR_SOURCE_TYPE: String
   const val TRACE_ID: String
   const val SPAN_ID: String
   const val RESOURCE_TIMINGS: String
@@ -566,7 +567,7 @@ data class com.datadog.android.rum.model.ErrorEvent
     companion object 
       fun fromJson(kotlin.String): Context
   data class Error
-    constructor(kotlin.String? = null, kotlin.String, Source, kotlin.String? = null, kotlin.Boolean? = null, kotlin.String? = null, Handling? = null, kotlin.String? = null, Resource? = null)
+    constructor(kotlin.String? = null, kotlin.String, Source, kotlin.String? = null, kotlin.Boolean? = null, kotlin.String? = null, Handling? = null, kotlin.String? = null, SourceType? = null, Resource? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Error
@@ -643,6 +644,15 @@ data class com.datadog.android.rum.model.ErrorEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Handling
+  enum SourceType
+    constructor(kotlin.String)
+    - ANDROID
+    - BROWSER
+    - IOS
+    - REACT_NATIVE
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): SourceType
   enum Plan
     constructor(kotlin.Number)
     - PLAN_1

--- a/dd-sdk-android/src/main/json/rum/error-schema.json
+++ b/dd-sdk-android/src/main/json/rum/error-schema.json
@@ -71,6 +71,12 @@
               "description": "Handling call stack",
               "readOnly": true
             },
+            "source_type": {
+              "type": "string",
+              "description": "Source type of the error (the language or platform impacting the error stacktrace format)",
+              "enum": ["android", "browser", "ios", "react-native"],
+              "readOnly": true
+            },
             "resource": {
               "type": "object",
               "description": "Resource properties of the error",

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -278,8 +278,14 @@ object Datadog {
         // so some things may yet not be initialized -> not accessible, some things may already be
         // initialized and be not mutable anymore
         additionalConfiguration[DD_SOURCE_TAG]?.let {
-            if (it.toString().isNotBlank()) {
-                CoreFeature.sourceName = it.toString()
+            if (it is String && it.isNotBlank()) {
+                CoreFeature.sourceName = it
+            }
+        }
+
+        additionalConfiguration[DD_SDK_VERSION_TAG]?.let {
+            if (it is String && it.isNotBlank()) {
+                CoreFeature.sdkVersion = it
             }
         }
     }
@@ -339,6 +345,7 @@ object Datadog {
             "In this case the Datadog SDK will not be initialised."
 
     internal const val DD_SOURCE_TAG = "_dd.source"
+    internal const val DD_SDK_VERSION_TAG = "_dd.sdk_version"
 
     // endregion
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -10,6 +10,7 @@ import android.app.ActivityManager
 import android.content.Context
 import android.os.Build
 import android.os.Process
+import com.datadog.android.BuildConfig
 import com.datadog.android.DatadogEndpoint
 import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.Configuration
@@ -74,6 +75,7 @@ internal object CoreFeature {
     // possibility to override it which is useful when SDK is used via bridge, say
     // from React Native integration
     internal const val DEFAULT_SOURCE_NAME = "android"
+    internal const val DEFAULT_SDK_VERSION = BuildConfig.SDK_VERSION_NAME
 
     // endregion
 
@@ -95,6 +97,7 @@ internal object CoreFeature {
     internal var packageVersion: String = ""
     internal var serviceName: String = ""
     internal var sourceName: String = DEFAULT_SOURCE_NAME
+    internal var sdkVersion: String = DEFAULT_SDK_VERSION
     internal var rumApplicationId: String? = null
     internal var isMainProcess: Boolean = true
     internal var envName: String = ""
@@ -195,6 +198,7 @@ internal object CoreFeature {
                     networkInfoProvider,
                     userInfoProvider,
                     timeProvider,
+                    sdkVersion,
                     envName,
                     packageVersion
                 ),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.core.internal.net
 
 import android.os.Build
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.log.Logger
 import java.util.Locale
@@ -18,8 +17,9 @@ import okhttp3.RequestBody
 
 internal abstract class DataOkHttpUploaderV2(
     internal var intakeUrl: String,
-    internal var clientToken: String,
-    internal var source: String,
+    internal val clientToken: String,
+    internal val source: String,
+    internal val sdkVersion: String,
     internal val callFactory: Call.Factory,
     internal val contentType: String,
     internal val internalLogger: Logger
@@ -36,7 +36,7 @@ internal abstract class DataOkHttpUploaderV2(
     private val userAgent by lazy {
         System.getProperty(DataOkHttpUploader.SYSTEM_UA).let {
             if (it.isNullOrBlank()) {
-                "Datadog/${BuildConfig.SDK_VERSION_NAME} " +
+                "Datadog/$sdkVersion " +
                     "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
                     "${Build.MODEL} Build/${Build.ID})"
             } else {
@@ -100,7 +100,7 @@ internal abstract class DataOkHttpUploaderV2(
     private fun buildHeaders(builder: Request.Builder, requestId: String) {
         builder.addHeader(HEADER_API_KEY, clientToken)
         builder.addHeader(HEADER_EVP_ORIGIN, source)
-        builder.addHeader(HEADER_EVP_ORIGIN_VERSION, BuildConfig.SDK_VERSION_NAME)
+        builder.addHeader(HEADER_EVP_ORIGIN_VERSION, sdkVersion)
         builder.addHeader(HEADER_USER_AGENT, userAgent)
         builder.addHeader(HEADER_CONTENT_TYPE, contentType)
         builder.addHeader(HEADER_REQUEST_ID, requestId)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -48,6 +48,7 @@ internal object CrashReportsFeature : SdkFeature<LogEvent, Configuration.Feature
             configuration.endpointUrl,
             CoreFeature.clientToken,
             CoreFeature.sourceName,
+            CoreFeature.sdkVersion,
             CoreFeature.okHttpClient,
             sdkLogger
         )
@@ -68,6 +69,7 @@ internal object CrashReportsFeature : SdkFeature<LogEvent, Configuration.Feature
                 CoreFeature.networkInfoProvider,
                 CoreFeature.userInfoProvider,
                 CoreFeature.timeProvider,
+                CoreFeature.sdkVersion,
                 CoreFeature.envName,
                 CoreFeature.packageVersion
             ),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -353,6 +353,7 @@ internal constructor(internal val handler: LogHandler) {
                 netInfoProvider,
                 CoreFeature.userInfoProvider,
                 CoreFeature.timeProvider,
+                CoreFeature.sdkVersion,
                 CoreFeature.envName,
                 CoreFeature.packageVersion
             )
@@ -370,6 +371,7 @@ internal constructor(internal val handler: LogHandler) {
                 netInfoProvider,
                 NoOpUserInfoProvider(), // we don't want to track our customer's users
                 CoreFeature.timeProvider,
+                CoreFeature.sdkVersion,
                 InternalLogsFeature.ENV_NAME,
                 CoreFeature.packageVersion
             )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -39,6 +39,7 @@ internal object LogsFeature : SdkFeature<LogEvent, Configuration.Feature.Logs>()
             configuration.endpointUrl,
             CoreFeature.clientToken,
             CoreFeature.sourceName,
+            CoreFeature.sdkVersion,
             CoreFeature.okHttpClient,
             sdkLogger
         )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogGenerator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogGenerator.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.log.internal.domain
 
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.NetworkInfo
@@ -27,6 +26,7 @@ internal class LogGenerator(
     internal val networkInfoProvider: NetworkInfoProvider?,
     internal val userInfoProvider: UserInfoProvider,
     internal val timeProvider: TimeProvider,
+    internal val sdkVersion: String,
     envName: String,
     appVersion: String
 ) {
@@ -75,7 +75,7 @@ internal class LogGenerator(
         val loggerInfo = LogEvent.Logger(
             name = loggerName,
             threadName = threadName ?: Thread.currentThread().name,
-            version = BuildConfig.SDK_VERSION_NAME
+            version = sdkVersion
         )
         return LogEvent(
             service = serviceName,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploaderV2.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploaderV2.kt
@@ -14,12 +14,14 @@ internal open class LogsOkHttpUploaderV2(
     endpoint: String,
     clientToken: String,
     source: String,
+    sdkVersion: String,
     callFactory: Call.Factory,
     internalLogger: Logger
 ) : DataOkHttpUploaderV2(
     buildUrl(endpoint, TrackType.LOGS),
     clientToken,
     source,
+    sdkVersion,
     callFactory,
     CONTENT_TYPE_JSON,
     internalLogger

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/monitoring/internal/InternalLogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/monitoring/internal/InternalLogsFeature.kt
@@ -55,6 +55,7 @@ internal object InternalLogsFeature : SdkFeature<LogEvent, Configuration.Feature
             configuration.endpointUrl,
             configuration.internalClientToken,
             CoreFeature.sourceName,
+            CoreFeature.sdkVersion,
             CoreFeature.okHttpClient,
             Logger(NoOpLogHandler())
         )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -74,6 +74,11 @@ object RumAttributes {
      */
     const val INTERNAL_ERROR_SOURCE_TYPE: String = "_dd.error.source_type"
 
+    /**
+     * Overrides the default RUM error source `is_crash` with a custom one.
+     */
+    const val INTERNAL_ERROR_IS_CRASH: String = "_dd.error.is_crash"
+
     // endregion
 
     // region Resource

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -69,6 +69,11 @@ object RumAttributes {
      */
     const val INTERNAL_TIMESTAMP: String = "_dd.timestamp"
 
+    /**
+     * Overrides the default RUM error source type with a custom one.
+     */
+    const val INTERNAL_ERROR_SOURCE_TYPE: String = "_dd.error.source_type"
+
     // endregion
 
     // region Resource

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumErrorSourceType.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumErrorSourceType.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal
+
+/**
+ * Source type of the error (the language or platform impacting the error stacktrace format).
+ * @see [RumMonitor]
+*/
+internal enum class RumErrorSourceType {
+    ANDROID,
+    BROWSER,
+    REACT_NATIVE
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -118,6 +118,7 @@ internal object RumFeature : SdkFeature<Any, Configuration.Feature.RUM>() {
             configuration.endpointUrl,
             CoreFeature.clientToken,
             CoreFeature.sourceName,
+            CoreFeature.sdkVersion,
             CoreFeature.okHttpClient
         )
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
@@ -177,7 +177,8 @@ internal class RumEventSerializer(
         internal val ignoredAttributes = setOf(
             RumAttributes.INTERNAL_TIMESTAMP,
             RumAttributes.INTERNAL_ERROR_TYPE,
-            RumAttributes.INTERNAL_ERROR_SOURCE_TYPE
+            RumAttributes.INTERNAL_ERROR_SOURCE_TYPE,
+            RumAttributes.INTERNAL_ERROR_IS_CRASH
         )
 
         internal const val GLOBAL_ATTRIBUTE_PREFIX: String = "context"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
@@ -176,7 +176,8 @@ internal class RumEventSerializer(
 
         internal val ignoredAttributes = setOf(
             RumAttributes.INTERNAL_TIMESTAMP,
-            RumAttributes.INTERNAL_ERROR_TYPE
+            RumAttributes.INTERNAL_ERROR_TYPE,
+            RumAttributes.INTERNAL_ERROR_SOURCE_TYPE
         )
 
         internal const val GLOBAL_ATTRIBUTE_PREFIX: String = "context"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
@@ -12,6 +12,7 @@ import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
@@ -62,6 +63,14 @@ internal fun RumErrorSource.toSchemaSource(): ErrorEvent.Source {
         RumErrorSource.LOGGER -> ErrorEvent.Source.LOGGER
         RumErrorSource.AGENT -> ErrorEvent.Source.AGENT
         RumErrorSource.WEBVIEW -> ErrorEvent.Source.WEBVIEW
+    }
+}
+
+internal fun RumErrorSourceType.toSchemaSourceType(): ErrorEvent.SourceType {
+    return when (this) {
+        RumErrorSourceType.ANDROID -> ErrorEvent.SourceType.ANDROID
+        RumErrorSourceType.BROWSER -> ErrorEvent.SourceType.BROWSER
+        RumErrorSourceType.REACT_NATIVE -> ErrorEvent.SourceType.REACT_NATIVE
     }
 }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.domain.scope
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.model.ViewEvent
@@ -91,7 +92,8 @@ internal sealed class RumRawEvent {
         val isFatal: Boolean,
         val attributes: Map<String, Any?>,
         override val eventTime: Time = Time(),
-        val type: String? = null
+        val type: String? = null,
+        val sourceType: RumErrorSourceType = RumErrorSourceType.ANDROID
     ) : RumRawEvent()
 
     internal data class UpdateViewLoadingTime(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -221,7 +221,8 @@ internal class RumResourceScope(
                     statusCode = statusCode ?: 0,
                     provider = resolveErrorProvider()
                 ),
-                type = resolveErrorType(statusCode, throwable)
+                type = resolveErrorType(statusCode, throwable),
+                sourceType = ErrorEvent.SourceType.ANDROID
             ),
             action = context.actionId?.let { ErrorEvent.Action(it) },
             view = ErrorEvent.View(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -271,10 +271,16 @@ internal open class RumViewScope(
         val updatedAttributes = addExtraAttributes(event.attributes)
         val networkInfo = CoreFeature.networkInfoProvider.getLatestNetworkInfo()
         val errorType = event.type ?: event.throwable?.javaClass?.canonicalName
+        val throwableMessage = event.throwable?.message ?: ""
+        val message = if (throwableMessage.isNotBlank() && event.message != throwableMessage) {
+            "${event.message}: $throwableMessage"
+        } else {
+            event.message
+        }
         val errorEvent = ErrorEvent(
             date = event.eventTime.timestamp + serverTimeOffsetInMs,
             error = ErrorEvent.Error(
-                message = event.message,
+                message = message,
                 source = event.source.toSchemaSource(),
                 stack = event.stacktrace ?: event.throwable?.loggableStackTrace(),
                 isCrash = event.isFatal,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -112,7 +112,7 @@ internal open class RumViewScope(
 
     private var refreshRateScale: Double = 1.0
     private var lastFrameRateInfo: VitalInfo? = null
-    private var frameRateVitalListenr: VitalListener = object : VitalListener {
+    private var frameRateVitalListener: VitalListener = object : VitalListener {
         override fun onVitalUpdate(info: VitalInfo) {
             lastFrameRateInfo = info
         }
@@ -125,7 +125,7 @@ internal open class RumViewScope(
         attributes.putAll(GlobalRum.globalAttributes)
         cpuVitalMonitor.register(cpuVitalListener)
         memoryVitalMonitor.register(memoryVitalListener)
-        frameRateVitalMonitor.register(frameRateVitalListenr)
+        frameRateVitalMonitor.register(frameRateVitalListener)
 
         detectRefreshRateScale(key)
     }
@@ -278,7 +278,8 @@ internal open class RumViewScope(
                 source = event.source.toSchemaSource(),
                 stack = event.stacktrace ?: event.throwable?.loggableStackTrace(),
                 isCrash = event.isFatal,
-                type = errorType
+                type = errorType,
+                sourceType = event.sourceType.toSchemaSourceType()
             ),
             action = context.actionId?.let { ErrorEvent.Action(it) },
             view = ErrorEvent.View(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -337,7 +337,7 @@ internal class DatadogRumMonitor(
         return if (sourceType == null) {
             return null
         } else {
-            when (sourceType.lowercase(Locale.US)) {
+            when (sourceType.toLowerCase(Locale.US)) {
                 "android" -> RumErrorSourceType.ANDROID
                 "react-native" -> RumErrorSourceType.REACT_NATIVE
                 "browser" -> RumErrorSourceType.BROWSER

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
@@ -268,7 +268,8 @@ internal class DatadogNdkCrashHandler(
                 source = ErrorEvent.Source.SOURCE,
                 stack = ndkCrashLog.stacktrace,
                 isCrash = true,
-                type = ndkCrashLog.signalName
+                type = ndkCrashLog.signalName,
+                sourceType = ErrorEvent.SourceType.ANDROID
             )
         )
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderV2.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderV2.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.rum.internal.net
 
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.DataOkHttpUploaderV2
 import com.datadog.android.core.internal.utils.sdkLogger
@@ -17,11 +16,13 @@ internal open class RumOkHttpUploaderV2(
     endpoint: String,
     clientToken: String,
     source: String,
+    sdkVersion: String,
     callFactory: Call.Factory
 ) : DataOkHttpUploaderV2(
     buildUrl(endpoint, TrackType.RUM),
     clientToken,
     source,
+    sdkVersion,
     callFactory,
     CONTENT_TYPE_TEXT_UTF8,
     sdkLogger
@@ -31,7 +32,7 @@ internal open class RumOkHttpUploaderV2(
         val elements = mutableListOf(
             "${RumAttributes.SERVICE_NAME}:${CoreFeature.serviceName}",
             "${RumAttributes.APPLICATION_VERSION}:${CoreFeature.packageVersion}",
-            "${RumAttributes.SDK_VERSION}:${BuildConfig.SDK_VERSION_NAME}",
+            "${RumAttributes.SDK_VERSION}:$sdkVersion",
             "${RumAttributes.ENV}:${CoreFeature.envName}"
         )
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
@@ -337,7 +337,7 @@ internal constructor(
                 "Configuration.Builder::setFirstPartyHosts() method."
         internal const val WARNING_TRACING_DISABLED =
             "You added a TracingInterceptor to your OkHttpClient, " +
-                "but you did not enable the TracesFeature. " +
+                "but you did not enable the TracingFeature. " +
                 "Your requests won't be traced."
         internal const val WARNING_DEFAULT_TRACER =
             "You added a TracingInterceptor to your OkHttpClient, " +

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracesFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracesFeature.kt
@@ -43,6 +43,7 @@ internal object TracesFeature : SdkFeature<DDSpan, Configuration.Feature.Tracing
             configuration.endpointUrl,
             CoreFeature.clientToken,
             CoreFeature.sourceName,
+            CoreFeature.sdkVersion,
             CoreFeature.okHttpClient
         )
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapper.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.tracing.internal.domain.event
 
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.Mapper
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
@@ -76,7 +75,7 @@ internal class DdSpanToSpanEventMapper(
             dd = SpanEvent.Dd(),
             span = SpanEvent.Span(),
             tracer = SpanEvent.Tracer(
-                version = BuildConfig.SDK_VERSION_NAME
+                version = CoreFeature.sdkVersion
             ),
             usr = usrMeta,
             network = networkInfoMeta,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderV2.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderV2.kt
@@ -14,17 +14,14 @@ internal open class TracesOkHttpUploaderV2(
     endpoint: String,
     clientToken: String,
     source: String,
+    sdkVersion: String,
     callFactory: Call.Factory
 ) : DataOkHttpUploaderV2(
     buildUrl(endpoint, TrackType.SPANS),
     clientToken,
     source,
+    sdkVersion,
     callFactory,
     CONTENT_TYPE_TEXT_UTF8,
     sdkLogger
-) {
-
-    companion object {
-        private const val TRACK_TYPE = "spans"
-    }
-}
+)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -104,6 +104,9 @@ internal class DatadogTest {
 
         // Prevent crash when initializing RumFeature
         mockChoreographerInstance()
+
+        CoreFeature.sdkVersion = CoreFeature.DEFAULT_SDK_VERSION
+        CoreFeature.sourceName = CoreFeature.DEFAULT_SOURCE_NAME
     }
 
     @AfterEach
@@ -488,6 +491,38 @@ internal class DatadogTest {
     }
 
     @Test
+    fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { with source name !string }`(
+        forge: Forge
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to forge.anInt()))
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracingFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).source }
+        )
+            .containsOnly(CoreFeature.DEFAULT_SOURCE_NAME)
+    }
+
+    @Test
     fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { without source name }`(
         forge: Forge
     ) {
@@ -517,6 +552,136 @@ internal class DatadogTest {
                 .map { (it as DataOkHttpUploaderV2).source }
         )
             .containsOnly(CoreFeature.DEFAULT_SOURCE_NAME)
+    }
+
+    @Test
+    fun `𝕄 apply sdk version 𝕎 applyAdditionalConfig(config) { with sdk version }`(
+        @StringForgery sdkVersion: String
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion))
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sdkVersion).isEqualTo(sdkVersion)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracingFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).sdkVersion }
+        )
+            .containsOnly(sdkVersion)
+    }
+
+    @Test
+    fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { with empty sdk version }`(
+        forge: Forge
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(
+                mapOf(Datadog.DD_SDK_VERSION_TAG to forge.aWhitespaceString())
+            )
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracingFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).sdkVersion }
+        )
+            .containsOnly(CoreFeature.DEFAULT_SDK_VERSION)
+    }
+
+    @Test
+    fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { with sdk version !string }`(
+        forge: Forge
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SDK_VERSION_TAG to forge.anInt()))
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracingFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).sdkVersion }
+        )
+            .containsOnly(CoreFeature.DEFAULT_SDK_VERSION)
+    }
+
+    @Test
+    fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { without sdk version }`(
+        forge: Forge
+    ) {
+        // Given
+        val config = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(forge.aMap { anAsciiString() to aString() })
+            .build()
+        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+
+        // When
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
+
+        // Then
+        assertThat(CoreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
+        assertThat(
+            arrayOf(
+                LogsFeature.uploader,
+                RumFeature.uploader,
+                TracingFeature.uploader,
+                CrashReportsFeature.uploader
+            )
+                .map { (it as DataOkHttpUploaderV2).sdkVersion }
+        )
+            .containsOnly(CoreFeature.DEFAULT_SDK_VERSION)
     }
 
     // region Internal

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -514,7 +514,7 @@ internal class DatadogTest {
             arrayOf(
                 LogsFeature.uploader,
                 RumFeature.uploader,
-                TracingFeature.uploader,
+                TracesFeature.uploader,
                 CrashReportsFeature.uploader
             )
                 .map { (it as DataOkHttpUploaderV2).source }
@@ -578,7 +578,7 @@ internal class DatadogTest {
             arrayOf(
                 LogsFeature.uploader,
                 RumFeature.uploader,
-                TracingFeature.uploader,
+                TracesFeature.uploader,
                 CrashReportsFeature.uploader
             )
                 .map { (it as DataOkHttpUploaderV2).sdkVersion }
@@ -612,7 +612,7 @@ internal class DatadogTest {
             arrayOf(
                 LogsFeature.uploader,
                 RumFeature.uploader,
-                TracingFeature.uploader,
+                TracesFeature.uploader,
                 CrashReportsFeature.uploader
             )
                 .map { (it as DataOkHttpUploaderV2).sdkVersion }
@@ -644,7 +644,7 @@ internal class DatadogTest {
             arrayOf(
                 LogsFeature.uploader,
                 RumFeature.uploader,
-                TracingFeature.uploader,
+                TracesFeature.uploader,
                 CrashReportsFeature.uploader
             )
                 .map { (it as DataOkHttpUploaderV2).sdkVersion }
@@ -676,7 +676,7 @@ internal class DatadogTest {
             arrayOf(
                 LogsFeature.uploader,
                 RumFeature.uploader,
-                TracingFeature.uploader,
+                TracesFeature.uploader,
                 CrashReportsFeature.uploader
             )
                 .map { (it as DataOkHttpUploaderV2).sdkVersion }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2Test.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2Test.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.core.internal.net
 
 import android.os.Build
-import com.datadog.android.BuildConfig
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.setStaticValue
 import com.nhaarman.mockitokotlin2.any
@@ -71,6 +70,9 @@ internal abstract class DataOkHttpUploaderV2Test<T : DataOkHttpUploaderV2> {
 
     @StringForgery
     lateinit var fakeSource: String
+
+    @StringForgery
+    lateinit var fakeSdkVersion: String
 
     lateinit var fakeUserAgent: String
 
@@ -359,7 +361,7 @@ internal abstract class DataOkHttpUploaderV2Test<T : DataOkHttpUploaderV2> {
     private fun verifyRequestHeaders(headers: Headers) {
         assertThat(headers.get("DD-API-KEY")).isEqualTo(fakeClientToken)
         assertThat(headers.get("DD-EVP-ORIGIN")).isEqualTo(fakeSource)
-        assertThat(headers.get("DD-EVP-ORIGIN-VERSION")).isEqualTo(BuildConfig.SDK_VERSION_NAME)
+        assertThat(headers.get("DD-EVP-ORIGIN-VERSION")).isEqualTo(fakeSdkVersion)
         assertThat(headers.get("DD-REQUEST-ID")).matches {
             UUID.fromString(it) != UUID(0, 0)
         }
@@ -367,7 +369,7 @@ internal abstract class DataOkHttpUploaderV2Test<T : DataOkHttpUploaderV2> {
         assertThat(headers.get("Content-Type")).isEqualTo(testedUploader.contentType)
 
         val expectedUserAgent = if (fakeUserAgent.isBlank()) {
-            "Datadog/${BuildConfig.SDK_VERSION_NAME} " +
+            "Datadog/$fakeSdkVersion " +
                 "(Linux; U; Android ${Build.VERSION.RELEASE}; " +
                 "${Build.MODEL} Build/${Build.ID})"
         } else {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -158,6 +158,7 @@ internal class DatadogExceptionHandlerTest {
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                CoreFeature.sdkVersion,
                 CoreFeature.envName,
                 CoreFeature.packageVersion
             ),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/LogGeneratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/LogGeneratorTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.log.internal.domain
 
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.NetworkInfo
@@ -86,6 +85,9 @@ internal class LogGeneratorTest {
     lateinit var fakeLogMessage: String
     lateinit var fakeThrowable: Throwable
 
+    @StringForgery
+    lateinit var fakeSdkVersion: String
+
     @StringForgery(StringForgeryType.HEXADECIMAL)
     lateinit var fakeSpanId: String
 
@@ -134,6 +136,7 @@ internal class LogGeneratorTest {
             mockNetworkInfoProvider,
             mockUserInfoProvider,
             mockTimeProvider,
+            fakeSdkVersion,
             fakeEnvName,
             fakeAppVersion
         )
@@ -221,7 +224,7 @@ internal class LogGeneratorTest {
         )
 
         // THEN
-        assertThat(log).hasLoggerVersion(BuildConfig.SDK_VERSION_NAME)
+        assertThat(log).hasLoggerVersion(fakeSdkVersion)
     }
 
     @Test
@@ -379,6 +382,7 @@ internal class LogGeneratorTest {
             null,
             mockUserInfoProvider,
             mockTimeProvider,
+            fakeSdkVersion,
             fakeEnvName,
             fakeAppVersion
         )
@@ -407,6 +411,7 @@ internal class LogGeneratorTest {
             null,
             mockUserInfoProvider,
             mockTimeProvider,
+            fakeSdkVersion,
             fakeEnvName,
             fakeAppVersion
         )
@@ -451,6 +456,7 @@ internal class LogGeneratorTest {
             mockNetworkInfoProvider,
             mockUserInfoProvider,
             mockTimeProvider,
+            fakeSdkVersion,
             "",
             fakeAppVersion
         )
@@ -497,6 +503,7 @@ internal class LogGeneratorTest {
             mockNetworkInfoProvider,
             mockUserInfoProvider,
             mockTimeProvider,
+            fakeSdkVersion,
             fakeEnvName,
             ""
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -111,6 +111,8 @@ internal class DatadogLogHandlerTest {
 
     lateinit var fakeEnvName: String
 
+    lateinit var fakeSdkVersion: String
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         // To avoid java.lang.NoClassDefFoundError: android/hardware/display/DisplayManagerGlobal.
@@ -131,6 +133,8 @@ internal class DatadogLogHandlerTest {
         fakeLevel = forge.anInt(2, 8)
         fakeAttributes = forge.aMap { anAlphabeticalString() to anInt() }
         fakeTags = forge.aList { anAlphabeticalString() }.toSet()
+        fakeSdkVersion = forge.anAlphabeticalString()
+        CoreFeature.sdkVersion = fakeSdkVersion
         CoreFeature.envName = fakeEnvName
         CoreFeature.packageVersion = fakeAppVersion
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
@@ -143,6 +147,7 @@ internal class DatadogLogHandlerTest {
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -404,6 +409,7 @@ internal class DatadogLogHandlerTest {
                 null,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -457,6 +463,7 @@ internal class DatadogLogHandlerTest {
                 null,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -613,6 +620,7 @@ internal class DatadogLogHandlerTest {
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -649,6 +657,7 @@ internal class DatadogLogHandlerTest {
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),
@@ -682,6 +691,7 @@ internal class DatadogLogHandlerTest {
                 mockNetworkInfoProvider,
                 mockUserInfoProvider,
                 mockTimeProvider,
+                fakeSdkVersion,
                 fakeEnvName,
                 fakeAppVersion
             ),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploaderV2Test.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploaderV2Test.kt
@@ -33,6 +33,7 @@ internal class LogsOkHttpUploaderV2Test : DataOkHttpUploaderV2Test<LogsOkHttpUpl
             fakeEndpoint,
             fakeClientToken,
             fakeSource,
+            fakeSdkVersion,
             callFactory,
             Logger(mock())
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -332,6 +332,15 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
+    fun hasErrorSourceType(expected: ErrorEvent.SourceType?): ErrorEventAssert {
+        assertThat(actual.error.sourceType)
+            .overridingErrorMessage(
+                "Expected event data to have error source type $expected" +
+                    " but was ${actual.error.sourceType}"
+            ).isEqualTo(expected)
+        return this
+    }
+
     fun hasLiteSessionPlan(): ErrorEventAssert {
         assertThat(actual.dd.session?.plan)
             .overridingErrorMessage(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -526,10 +526,12 @@ internal class RumEventSerializerTest {
         // GIVEN
         val fakeInternalTimestamp = forge.aLong()
         val fakeErrorType = forge.aString()
+        val fakeErrorSourceType = forge.aString()
         val fakeEventWithInternalGlobalAttributes = forge.forgeRumEvent(
             attributes = mapOf(
                 RumAttributes.INTERNAL_ERROR_TYPE to fakeErrorType,
-                RumAttributes.INTERNAL_TIMESTAMP to fakeInternalTimestamp
+                RumAttributes.INTERNAL_TIMESTAMP to fakeInternalTimestamp,
+                RumAttributes.INTERNAL_ERROR_SOURCE_TYPE to fakeErrorSourceType
             )
         )
         // WHEN
@@ -545,6 +547,11 @@ internal class RumEventSerializerTest {
             .doesNotHaveField(
                 RumEventSerializer.GLOBAL_ATTRIBUTE_PREFIX + "." + RumAttributes.INTERNAL_ERROR_TYPE
             )
+        assertThat(jsonObject)
+            .doesNotHaveField(
+                RumEventSerializer.GLOBAL_ATTRIBUTE_PREFIX +
+                    "." + RumAttributes.INTERNAL_ERROR_SOURCE_TYPE
+            )
     }
 
     @Test
@@ -554,10 +561,12 @@ internal class RumEventSerializerTest {
         // GIVEN
         val fakeInternalTimestamp = forge.aLong()
         val fakeErrorType = forge.aString()
+        val fakeErrorSourceType = forge.aString()
         val fakeEventWithInternalUserAttributes = forge.forgeRumEvent(
             userAttributes = mapOf(
                 RumAttributes.INTERNAL_ERROR_TYPE to fakeErrorType,
-                RumAttributes.INTERNAL_TIMESTAMP to fakeInternalTimestamp
+                RumAttributes.INTERNAL_TIMESTAMP to fakeInternalTimestamp,
+                RumAttributes.INTERNAL_ERROR_SOURCE_TYPE to fakeErrorSourceType
             )
         )
 
@@ -573,6 +582,11 @@ internal class RumEventSerializerTest {
         assertThat(jsonObject)
             .doesNotHaveField(
                 RumEventSerializer.USER_ATTRIBUTE_PREFIX + "." + RumAttributes.INTERNAL_ERROR_TYPE
+            )
+        assertThat(jsonObject)
+            .doesNotHaveField(
+                RumEventSerializer.GLOBAL_ATTRIBUTE_PREFIX +
+                    "." + RumAttributes.INTERNAL_ERROR_SOURCE_TYPE
             )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExtTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.utils.forge.Configurator
@@ -107,6 +108,17 @@ internal class RumEventExtTest {
     ) {
         // When
         val result = kind.toSchemaSource()
+
+        // Then
+        assertThat(kind.name).isEqualTo(result.name)
+    }
+
+    @RepeatedTest(6)
+    fun `𝕄 return error source type 𝕎 toSchemaSourceType()`(
+        @Forgery kind: RumErrorSourceType
+    ) {
+        // When
+        val result = kind.toSchemaSourceType()
 
         // Then
         assertThat(kind.name).isEqualTo(result.name)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -773,6 +773,7 @@ internal class RumResourceScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(expectedAttributes)
                 }
@@ -839,6 +840,7 @@ internal class RumResourceScopeTest {
                     hasProviderDomain(brokenUrl)
                     hasProviderType(ErrorEvent.ProviderType.FIRST_PARTY)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(expectedAttributes)
                 }
@@ -895,6 +897,7 @@ internal class RumResourceScopeTest {
                     hasProviderDomain(URL(fakeUrl).host)
                     hasProviderType(ErrorEvent.ProviderType.FIRST_PARTY)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(expectedAttributes)
                 }
@@ -949,6 +952,7 @@ internal class RumResourceScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                     doesNotHaveAResourceProvider()
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(expectedAttributes)
@@ -1010,6 +1014,7 @@ internal class RumResourceScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeParentContext.actionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                     doesNotHaveAResourceProvider()
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(expectedAttributes)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -2533,7 +2533,13 @@ internal class RumViewScopeTest {
         testedScope.activeActionScope = mockActionScope
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(
-            message, source, null, null, false, attributes, sourceType = sourceType
+            message,
+            source,
+            null,
+            null,
+            false,
+            attributes,
+            sourceType = sourceType
         )
 
         // When
@@ -2577,7 +2583,12 @@ internal class RumViewScopeTest {
         testedScope.activeActionScope = mockActionScope
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(
-            message, source, null, null, true, attributes,
+            message,
+            source,
+            null,
+            null,
+            true,
+            attributes,
             sourceType = sourceType
         )
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -28,6 +28,7 @@ import com.datadog.android.rum.assertj.ActionEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.ErrorEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.LongTaskEventAssert.Companion.assertThat
 import com.datadog.android.rum.assertj.ViewEventAssert.Companion.assertThat
+import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.vitals.VitalInfo
@@ -2476,6 +2477,7 @@ internal class RumViewScopeTest {
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         testedScope.activeActionScope = mockActionScope
@@ -2486,7 +2488,8 @@ internal class RumViewScopeTest {
             throwable,
             null,
             false,
-            attributes
+            attributes,
+            sourceType = sourceType
         )
 
         // When
@@ -2510,6 +2513,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2522,12 +2526,15 @@ internal class RumViewScopeTest {
     fun `𝕄 send event 𝕎 handleEvent(AddError) {throwable=null, stacktrace=null, fatal=false}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
-        fakeEvent = RumRawEvent.AddError(message, source, null, null, false, attributes)
+        fakeEvent = RumRawEvent.AddError(
+            message, source, null, null, false, attributes, sourceType = sourceType
+        )
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
@@ -2550,6 +2557,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(null)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2562,12 +2570,16 @@ internal class RumViewScopeTest {
     fun `𝕄 send event 𝕎 handleEvent(AddError) {throwable=null, stacktrace=null, fatal=true}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
         testedScope.activeActionScope = mockActionScope
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
-        fakeEvent = RumRawEvent.AddError(message, source, null, null, true, attributes)
+        fakeEvent = RumRawEvent.AddError(
+            message, source, null, null, true, attributes,
+            sourceType = sourceType
+        )
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
@@ -2589,6 +2601,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(null)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2630,6 +2643,7 @@ internal class RumViewScopeTest {
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
@@ -2640,7 +2654,8 @@ internal class RumViewScopeTest {
             throwable,
             null,
             false,
-            emptyMap()
+            emptyMap(),
+            sourceType = sourceType
         )
         val attributes = forgeGlobalAttributes(forge, fakeAttributes)
         GlobalRum.globalAttributes.putAll(attributes)
@@ -2666,6 +2681,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2679,6 +2695,7 @@ internal class RumViewScopeTest {
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
@@ -2690,7 +2707,8 @@ internal class RumViewScopeTest {
             throwable,
             null,
             true,
-            attributes
+            attributes,
+            sourceType = sourceType
         )
 
         // When
@@ -2713,6 +2731,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2755,6 +2774,7 @@ internal class RumViewScopeTest {
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
         @StringForgery errorType: String,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
@@ -2767,7 +2787,8 @@ internal class RumViewScopeTest {
             null,
             false,
             attributes,
-            type = errorType
+            type = errorType,
+            sourceType = sourceType
         )
 
         // When
@@ -2791,6 +2812,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(errorType)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }
@@ -2804,6 +2826,7 @@ internal class RumViewScopeTest {
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable,
+        @Forgery sourceType: RumErrorSourceType,
         forge: Forge
     ) {
         // Given
@@ -2814,7 +2837,8 @@ internal class RumViewScopeTest {
             throwable,
             null,
             true,
-            emptyMap()
+            emptyMap(),
+            sourceType = sourceType
         )
         val attributes = forgeGlobalAttributes(forge, fakeAttributes)
         GlobalRum.globalAttributes.putAll(attributes)
@@ -2839,6 +2863,7 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
                     hasLiteSessionPlan()
                     containsExactlyContextAttributes(attributes)
                 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -2936,6 +2936,112 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `𝕄 send event 𝕎 handleEvent(AddError) {internal is_crash=true}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @Forgery throwable: Throwable,
+        @Forgery sourceType: RumErrorSourceType,
+        forge: Forge
+    ) {
+        // Given
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        val attributesWithCrash = attributes.toMutableMap()
+        attributesWithCrash["_dd.error.is_crash"] = true
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            null,
+            false,
+            attributesWithCrash,
+            sourceType = sourceType
+        )
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        val expectedMessage = "$message: ${throwable.message}"
+        argumentCaptor<Any> {
+            verify(mockWriter).write(capture())
+            assertThat(firstValue as ErrorEvent)
+                .apply {
+                    hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
+                    hasMessage(expectedMessage)
+                    hasSource(source)
+                    hasStackTrace(throwable.loggableStackTrace())
+                    isCrash(true)
+                    hasUserInfo(fakeUserInfo)
+                    hasConnectivityInfo(fakeNetworkInfo)
+                    hasView(testedScope.viewId, testedScope.name, testedScope.url)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasActionId(fakeActionId)
+                    hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
+                    hasLiteSessionPlan()
+                    containsExactlyContextAttributes(attributes)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
+    fun `𝕄 send event 𝕎 handleEvent(AddError) {internal is_crash=false}`(
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @Forgery throwable: Throwable,
+        @Forgery sourceType: RumErrorSourceType,
+        forge: Forge
+    ) {
+        // Given
+        testedScope.activeActionScope = mockActionScope
+        val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
+        val attributesWithCrash = attributes.toMutableMap()
+        attributesWithCrash["_dd.error.is_crash"] = false
+        fakeEvent = RumRawEvent.AddError(
+            message,
+            source,
+            throwable,
+            null,
+            false,
+            attributesWithCrash,
+            sourceType = sourceType
+        )
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        val expectedMessage = "$message: ${throwable.message}"
+        argumentCaptor<Any> {
+            verify(mockWriter).write(capture())
+            assertThat(firstValue as ErrorEvent)
+                .apply {
+                    hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
+                    hasMessage(expectedMessage)
+                    hasSource(source)
+                    hasStackTrace(throwable.loggableStackTrace())
+                    isCrash(false)
+                    hasUserInfo(fakeUserInfo)
+                    hasConnectivityInfo(fakeNetworkInfo)
+                    hasView(testedScope.viewId, testedScope.name, testedScope.url)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasActionId(fakeActionId)
+                    hasErrorType(throwable.javaClass.canonicalName)
+                    hasErrorSourceType(sourceType.toSchemaSourceType())
+                    hasLiteSessionPlan()
+                    containsExactlyContextAttributes(attributes)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
     fun `𝕄 send event 𝕎 handleEvent(AddError) {custom error type}`(
         @StringForgery message: String,
         @Forgery source: RumErrorSource,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
@@ -380,6 +380,7 @@ internal class DatadogNdkCrashHandlerTest {
                 .hasStackTrace(ndkCrashLog.stacktrace)
                 .isCrash(true)
                 .hasSource(RumErrorSource.SOURCE)
+                .hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
                 .hasTimestamp(ndkCrashLog.timestamp + fakeServerOffset)
                 .hasUserInfo(
                     UserInfo(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderV2Test.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/net/RumOkHttpUploaderV2Test.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.rum.internal.net
 
 import android.app.Application
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.net.DataOkHttpUploaderV2
 import com.datadog.android.core.internal.net.DataOkHttpUploaderV2Test
 import com.datadog.android.rum.RumAttributes
@@ -40,6 +39,7 @@ internal class RumOkHttpUploaderV2Test : DataOkHttpUploaderV2Test<RumOkHttpUploa
             fakeEndpoint,
             fakeClientToken,
             fakeSource,
+            fakeSdkVersion,
             callFactory
         )
     }
@@ -52,7 +52,7 @@ internal class RumOkHttpUploaderV2Test : DataOkHttpUploaderV2Test<RumOkHttpUploa
         val tags = mutableListOf(
             "${RumAttributes.SERVICE_NAME}:${coreFeature.fakeServiceName}",
             "${RumAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}",
-            "${RumAttributes.SDK_VERSION}:${BuildConfig.SDK_VERSION_NAME}",
+            "${RumAttributes.SDK_VERSION}:$fakeSdkVersion",
             "${RumAttributes.ENV}:${coreFeature.fakeEnvName}"
         )
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapperTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.tracing.internal.domain.event
 
-import com.datadog.android.BuildConfig
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
@@ -65,12 +64,16 @@ internal class DdSpanToSpanEventMapperTest {
     @StringForgery(regex = "[0-9]\\.[0-9]\\.[0-9]")
     lateinit var fakeClientPackageVersion: String
 
+    @StringForgery
+    lateinit var fakeSdkVersion: String
+
     @LongForgery
     var fakeServerOffsetNanos: Long = 0L
 
     @BeforeEach
     fun `set up`() {
         CoreFeature.packageVersion = fakeClientPackageVersion
+        CoreFeature.sdkVersion = fakeSdkVersion
         whenever(mockTimeProvider.getServerOffsetNanos()).thenReturn(fakeServerOffsetNanos)
         whenever(mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
@@ -101,7 +104,7 @@ internal class DdSpanToSpanEventMapperTest {
             .hasErrorFlag(fakeSpan.error.toLong())
             .hasSpanStartTime(fakeSpan.startTime + fakeServerOffsetNanos)
             .hasSpanDuration(fakeSpan.durationNano)
-            .hasTracerVersion(BuildConfig.SDK_VERSION_NAME)
+            .hasTracerVersion(fakeSdkVersion)
             .hasClientPackageVersion(fakeClientPackageVersion)
             .hasNetworkInfo(fakeNetworkInfo)
             .hasUserInfo(fakeUserInfo)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderV2Test.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/net/TracesOkHttpUploaderV2Test.kt
@@ -30,6 +30,7 @@ internal class TracesOkHttpUploaderV2Test : DataOkHttpUploaderV2Test<TracesOkHtt
             fakeEndpoint,
             fakeClientToken,
             fakeSource,
+            fakeSdkVersion,
             callFactory
         )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
@@ -29,7 +29,8 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                         method = getForgery(),
                         statusCode = aLong(200, 600)
                     )
-                }
+                },
+                sourceType = forge.getForgery()
             ),
             view = ErrorEvent.View(
                 id = forge.getForgery<UUID>().toString(),


### PR DESCRIPTION
### What does this PR do?

This change cherry-picks `sdk_version`, `source_type`, `error.is_crash`, enrich RUM message features into `1.11.0` release, plus adds the necessary commit to adjust the code to be able to compile.

Commits takes from `master`:

https://github.com/DataDog/dd-sdk-android/commit/09bc8be8675ae7d30b5e1350212cdce3944e1fa6
https://github.com/DataDog/dd-sdk-android/commit/883aa7eda5c5d6505e15f3f5953fb8dbf6c6eefb
https://github.com/DataDog/dd-sdk-android/commit/db5033f1616fd42ba32592412249db55440b520a
https://github.com/DataDog/dd-sdk-android/commit/f70328e978a702492ea97787499e568100fd27ff
https://github.com/DataDog/dd-sdk-android/commit/5f1ffe9d49d1fdf23654b4c745a1a9bc81ee2194

I tested this change with the `sample` app, everything works fine - I can see `sdk_version` and `source_type` attributes in the corresponding events.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

