### PR TITLE
RUMM-1837: Add org.json support for the event attributes

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -220,6 +220,8 @@ class com.datadog.android.log.Logger
   fun addAttribute(String, java.util.Date?)
   fun addAttribute(String, com.google.gson.JsonObject?)
   fun addAttribute(String, com.google.gson.JsonArray?)
+  fun addAttribute(String, org.json.JSONObject?)
+  fun addAttribute(String, org.json.JSONArray?)
   fun removeAttribute(String)
   fun addTag(String, String)
   fun addTag(String)

--- a/dd-sdk-android/build.gradle.kts
+++ b/dd-sdk-android/build.gradle.kts
@@ -162,6 +162,7 @@ unMock {
     keep("android.os.SystemProperties")
     keep("android.view.Choreographer")
     keep("android.view.DisplayEventReceiver")
+    keepStartingWith("org.json")
 }
 
 apply(from = "clone_dd_trace.gradle.kts")

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
@@ -12,6 +12,8 @@ import com.google.gson.JsonNull
 import com.google.gson.JsonObject
 import com.google.gson.JsonPrimitive
 import java.util.Date
+import org.json.JSONArray
+import org.json.JSONObject
 
 internal fun retryWithDelay(
     times: Int,
@@ -62,6 +64,8 @@ internal fun Any?.toJsonElement(): JsonElement {
         is JsonObject -> this
         is JsonArray -> this
         is JsonPrimitive -> this
+        is JSONObject -> this.toJsonObject()
+        is JSONArray -> this.toJsonArray()
         else -> JsonPrimitive(toString())
     }
 }
@@ -97,6 +101,22 @@ internal fun Map<*, *>.toJsonObject(): JsonElement {
     val obj = JsonObject()
     forEach {
         obj.add(it.key.toString(), it.value.toJsonElement())
+    }
+    return obj
+}
+
+internal fun JSONObject.toJsonObject(): JsonElement {
+    val obj = JsonObject()
+    for (key in keys()) {
+        obj.add(key, get(key).toJsonElement())
+    }
+    return obj
+}
+
+internal fun JSONArray.toJsonArray(): JsonElement {
+    val obj = JsonArray()
+    for (index in 0 until length()) {
+        obj.add(get(index).toJsonElement())
     }
     return obj
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -29,6 +29,8 @@ import com.google.gson.JsonObject
 import java.util.Date
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CopyOnWriteArraySet
+import org.json.JSONArray
+import org.json.JSONObject
 
 /**
  * A class enabling Datadog logging features.
@@ -494,6 +496,32 @@ internal constructor(internal val handler: LogHandler) {
      * @param value the (nullable) [JsonArray] value of this attribute
      */
     fun addAttribute(key: String, value: JsonArray?) {
+        safelyAddAttribute(key, value)
+    }
+
+    /**
+     * Add a custom attribute to all future logs sent by this logger.
+     *
+     * Values can be nested up to 10 levels deep. Keys
+     * using more than 10 levels will be sanitized by SDK.
+     *
+     * @param key the key for this attribute
+     * @param value the (nullable) [JSONObject] value of this attribute
+     */
+    fun addAttribute(key: String, value: JSONObject?) {
+        safelyAddAttribute(key, value)
+    }
+
+    /**
+     * Add a custom attribute to all future logs sent by this logger.
+     *
+     * Values can be nested up to 10 levels deep. Keys
+     * using more than 10 levels will be sanitized by SDK.
+     *
+     * @param key the key for this attribute
+     * @param value the (nullable) [JSONArray] value of this attribute
+     */
+    fun addAttribute(key: String, value: JSONArray?) {
         safelyAddAttribute(key, value)
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/MiscUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/MiscUtilsTest.kt
@@ -25,6 +25,8 @@ import java.util.concurrent.TimeUnit
 import kotlin.system.measureNanoTime
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -148,6 +150,10 @@ internal class MiscUtilsTest {
                     assertJsonElement(entry.value, it[entry.key.toString()])
                 }
             }
+            is JSONArray -> assertThat(jsonElement.asJsonArray.toString())
+                .isEqualTo(kotlinObject.toString())
+            is JSONObject -> assertThat(jsonElement.asJsonObject.toString())
+                .isEqualTo(kotlinObject.toString())
             else -> assertThat(jsonElement.asString).isEqualTo(kotlinObject.toString())
         }
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerTest.kt
@@ -25,6 +25,8 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.util.Date
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -392,7 +394,7 @@ internal class LoggerTest {
     }
 
     @Test
-    fun `add JsonObject attribute to logger`(forge: Forge, @Forgery value: JsonObject) {
+    fun `add  GSON JsonObject attribute to logger`(forge: Forge, @Forgery value: JsonObject) {
         val key = forge.anAlphabeticalString()
 
         testedLogger.addAttribute(key, value)
@@ -409,7 +411,41 @@ internal class LoggerTest {
     }
 
     @Test
-    fun `add JsonArray attribute to logger`(forge: Forge, @Forgery value: JsonArray) {
+    fun `add GSON JsonArray attribute to logger`(forge: Forge, @Forgery value: JsonArray) {
+        val key = forge.anAlphabeticalString()
+
+        testedLogger.addAttribute(key, value)
+        testedLogger.i(fakeMessage)
+
+        verify(mockLogHandler)
+            .handleLog(
+                Log.INFO,
+                fakeMessage,
+                null,
+                mapOf(key to value),
+                emptySet()
+            )
+    }
+
+    @Test
+    fun `add OrgJson JSONObject attribute to logger`(forge: Forge, @Forgery value: JSONObject) {
+        val key = forge.anAlphabeticalString()
+
+        testedLogger.addAttribute(key, value)
+        testedLogger.i(fakeMessage)
+
+        verify(mockLogHandler)
+            .handleLog(
+                Log.INFO,
+                fakeMessage,
+                null,
+                mapOf(key to value),
+                emptySet()
+            )
+    }
+
+    @Test
+    fun `add OrgJson JSONArray attribute to logger`(forge: Forge, @Forgery value: JSONArray) {
         val key = forge.anAlphabeticalString()
 
         testedLogger.addAttribute(key, value)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/JsonObjectAssertExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/JsonObjectAssertExt.kt
@@ -13,6 +13,8 @@ import com.datadog.tools.unit.assertj.JsonObjectAssert
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import java.util.Date
+import org.json.JSONArray
+import org.json.JSONObject
 
 fun JsonObjectAssert.containsExtraAttributes(
     attributes: Map<String, Any?>,
@@ -36,6 +38,8 @@ fun JsonObjectAssert.containsExtraAttributes(
                 is JsonArray -> hasField(key, value)
                 is Iterable<*> -> hasField(key, value.toJsonArray())
                 is Map<*, *> -> hasField(key, value.toJsonObject())
+                is JSONArray -> hasField(key, value.toJsonArray())
+                is JSONObject -> hasField(key, value.toJsonObject())
                 else -> hasField(key, value.toString())
             }
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/assertj/JsonElementAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/assertj/JsonElementAssert.kt
@@ -15,6 +15,8 @@ import com.google.gson.JsonObject
 import java.util.Date
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.Assertions
+import org.json.JSONArray
+import org.json.JSONObject
 
 internal class JsonElementAssert(actual: JsonElement) :
     AbstractAssert<JsonElementAssert, JsonElement>(
@@ -39,6 +41,12 @@ internal class JsonElementAssert(actual: JsonElement) :
                 expected.toJsonArray()
             )
             is Map<*, *> -> Assertions.assertThat(actual.asJsonObject).isEqualTo(
+                expected.toJsonObject()
+            )
+            is JSONArray -> Assertions.assertThat(actual.asJsonArray).isEqualTo(
+                expected.toJsonArray()
+            )
+            is JSONObject -> Assertions.assertThat(actual.asJsonObject).isEqualTo(
                 expected.toJsonObject()
             )
             else -> Assertions.assertThat(actual.asString).isEqualTo(expected.toString())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -57,9 +57,11 @@ internal class Configurator :
 
         // MISC
         forge.addFactory(BigIntegerFactory())
-        forge.addFactory(JsonArrayForgeryFactory())
-        forge.addFactory(JsonObjectForgeryFactory())
-        forge.addFactory(JsonPrimitiveForgeryFactory())
+        forge.addFactory(GsonJsonArrayForgeryFactory())
+        forge.addFactory(GsonJsonObjectForgeryFactory())
+        forge.addFactory(GsonJsonPrimitiveForgeryFactory())
+        forge.addFactory(OrgJSONObjectForgeryFactory())
+        forge.addFactory(OrgJSONArrayForgeryFactory())
 
         forge.useJvmFactories()
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ForgeExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ForgeExt.kt
@@ -19,6 +19,8 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.jupiter.api.Assumptions.assumeTrue
 
 /**
@@ -113,6 +115,8 @@ private fun generateMapWithExhaustiveValues(forge: Forge): Map<String, Any?> {
             getForgery<File>(),
             getForgery<JsonObject>(),
             getForgery<JsonArray>(),
+            getForgery<JSONObject>(),
+            getForgery<JSONArray>(),
             aList { anAlphabeticalString() },
             aList { aDouble() },
             null

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/GsonJsonArrayForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/GsonJsonArrayForgeryFactory.kt
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.google.gson.JsonArray
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class GsonJsonArrayForgeryFactory : ForgeryFactory<JsonArray> {
+
+    override fun getForgery(forge: Forge): JsonArray {
+        return forge.anElementFrom(
+            JsonArray(),
+            forge.aStringArray(),
+            forge.anIntArray(),
+            forge.aDoubleArray()
+        )
+    }
+
+    // region Internal
+
+    private fun Forge.aStringArray(): JsonArray {
+        return JsonArray().apply {
+            aList { anAlphabeticalString() }
+                .forEach { add(it) }
+        }
+    }
+
+    private fun Forge.anIntArray(): JsonArray {
+        return JsonArray().apply {
+            aList { anInt() }
+                .forEach { add(it) }
+        }
+    }
+
+    private fun Forge.aDoubleArray(): JsonArray {
+        return JsonArray().apply {
+            aList { aDouble() }
+                .forEach { add(it) }
+        }
+    }
+
+    // endregion
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/GsonJsonArrayForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/GsonJsonArrayForgeryFactory.kt
@@ -17,7 +17,8 @@ class GsonJsonArrayForgeryFactory : ForgeryFactory<JsonArray> {
             JsonArray(),
             forge.aStringArray(),
             forge.anIntArray(),
-            forge.aDoubleArray()
+            forge.aDoubleArray(),
+            forge.aBooleanArray()
         )
     }
 
@@ -40,6 +41,13 @@ class GsonJsonArrayForgeryFactory : ForgeryFactory<JsonArray> {
     private fun Forge.aDoubleArray(): JsonArray {
         return JsonArray().apply {
             aList { aDouble() }
+                .forEach { add(it) }
+        }
+    }
+
+    private fun Forge.aBooleanArray(): JsonArray {
+        return JsonArray().apply {
+            aList { aBool() }
                 .forEach { add(it) }
         }
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/GsonJsonObjectForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/GsonJsonObjectForgeryFactory.kt
@@ -12,7 +12,7 @@ import com.google.gson.JsonPrimitive
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-class JsonObjectForgeryFactory : ForgeryFactory<JsonObject> {
+class GsonJsonObjectForgeryFactory : ForgeryFactory<JsonObject> {
 
     override fun getForgery(forge: Forge): JsonObject {
         return JsonObject().apply {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/GsonJsonPrimitiveForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/GsonJsonPrimitiveForgeryFactory.kt
@@ -10,7 +10,7 @@ import com.google.gson.JsonPrimitive
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-class JsonPrimitiveForgeryFactory : ForgeryFactory<JsonPrimitive> {
+class GsonJsonPrimitiveForgeryFactory : ForgeryFactory<JsonPrimitive> {
 
     override fun getForgery(forge: Forge): JsonPrimitive {
         return forge.anElementFrom(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/OrgJSONArrayForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/OrgJSONArrayForgeryFactory.kt
@@ -17,7 +17,8 @@ class OrgJSONArrayForgeryFactory : ForgeryFactory<JSONArray> {
             JSONArray(),
             forge.aStringArray(),
             forge.anIntArray(),
-            forge.aDoubleArray()
+            forge.aDoubleArray(),
+            forge.aBooleanArray()
         )
     }
 
@@ -40,6 +41,13 @@ class OrgJSONArrayForgeryFactory : ForgeryFactory<JSONArray> {
     private fun Forge.aDoubleArray(): JSONArray {
         return JSONArray().apply {
             aList { aDouble() }
+                .forEach { put(it) }
+        }
+    }
+
+    private fun Forge.aBooleanArray(): JSONArray {
+        return JSONArray().apply {
+            aList { aBool() }
                 .forEach { put(it) }
         }
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/OrgJSONArrayForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/OrgJSONArrayForgeryFactory.kt
@@ -6,15 +6,15 @@
 
 package com.datadog.android.utils.forge
 
-import com.google.gson.JsonArray
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
+import org.json.JSONArray
 
-class JsonArrayForgeryFactory : ForgeryFactory<JsonArray> {
+class OrgJSONArrayForgeryFactory : ForgeryFactory<JSONArray> {
 
-    override fun getForgery(forge: Forge): JsonArray {
+    override fun getForgery(forge: Forge): JSONArray {
         return forge.anElementFrom(
-            JsonArray(),
+            JSONArray(),
             forge.aStringArray(),
             forge.anIntArray(),
             forge.aDoubleArray()
@@ -23,24 +23,24 @@ class JsonArrayForgeryFactory : ForgeryFactory<JsonArray> {
 
     // region Internal
 
-    private fun Forge.aStringArray(): JsonArray {
-        return JsonArray().apply {
+    private fun Forge.aStringArray(): JSONArray {
+        return JSONArray().apply {
             aList { anAlphabeticalString() }
-                .forEach { add(it) }
+                .forEach { put(it) }
         }
     }
 
-    private fun Forge.anIntArray(): JsonArray {
-        return JsonArray().apply {
+    private fun Forge.anIntArray(): JSONArray {
+        return JSONArray().apply {
             aList { anInt() }
-                .forEach { add(it) }
+                .forEach { put(it) }
         }
     }
 
-    private fun Forge.aDoubleArray(): JsonArray {
-        return JsonArray().apply {
+    private fun Forge.aDoubleArray(): JSONArray {
+        return JSONArray().apply {
             aList { aDouble() }
-                .forEach { add(it) }
+                .forEach { put(it) }
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/OrgJSONObjectForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/OrgJSONObjectForgeryFactory.kt
@@ -22,6 +22,7 @@ class OrgJSONObjectForgeryFactory : ForgeryFactory<JSONObject> {
                     forge.anElementFrom(
                         forge.anInt(),
                         forge.aLong(),
+                        forge.aBool(),
                         forge.anAlphaNumericalString(),
                         forge.aDouble(),
                         forge.getForgery<JSONArray>()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/OrgJSONObjectForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/OrgJSONObjectForgeryFactory.kt
@@ -1,0 +1,33 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import org.json.JSONArray
+import org.json.JSONObject
+
+class OrgJSONObjectForgeryFactory : ForgeryFactory<JSONObject> {
+
+    override fun getForgery(forge: Forge): JSONObject {
+        return JSONObject().apply {
+            val fieldCount = forge.aTinyInt()
+            for (i in 0..fieldCount) {
+                put(
+                    forge.anAlphabeticalString(),
+                    forge.anElementFrom(
+                        forge.anInt(),
+                        forge.aLong(),
+                        forge.anAlphaNumericalString(),
+                        forge.aDouble(),
+                        forge.getForgery<JSONArray>()
+                    )
+                )
+            }
+        }
+    }
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -761,6 +761,8 @@ datadog:
       - "android.view.Window.Callback.dispatchKeyEvent(android.view.KeyEvent)"
       - "android.view.Window.Callback.dispatchTouchEvent(android.view.MotionEvent)"
       - "android.view.Window.Callback.onMenuItemSelected(kotlin.Int, android.view.MenuItem)"
+      - "org.json.JSONArray.toJsonArray()"
+      - "org.json.JSONObject.toJsonObject()"
       # endregion
       # region Android Webview APIs
       - "android.webkit.ConsoleMessage.MessageLevel.toLogLevel()"

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
@@ -34,6 +34,8 @@ import fr.xgouchet.elmyr.junit4.ForgeRule
 import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.TimeZone
+import org.json.JSONArray
+import org.json.JSONObject
 import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
@@ -366,10 +368,10 @@ class LoggerE2ETests {
      * apiMethodSignature: com.datadog.android.log.Logger#fun addAttribute(String, com.google.gson.JsonArray?)
      */
     @Test
-    fun logs_logger_add_jsonarray_attribute() {
-        val testMethodName = "logs_logger_add_jsonarray_attribute"
+    fun logs_logger_add_gson_jsonarray_attribute() {
+        val testMethodName = "logs_logger_add_gson_jsonarray_attribute"
         measure(testMethodName) {
-            logger.addAttribute(SPECIAL_JSONARRAY_ATTRIBUTE_NAME, CUSTOM_JSON_ARRAY_ATTRIBUTE)
+            logger.addAttribute(SPECIAL_JSONARRAY_ATTRIBUTE_NAME, CUSTOM_GSON_JSON_ARRAY_ATTRIBUTE)
         }
         logger.sendRandomLog(testMethodName, forge)
     }
@@ -378,8 +380,8 @@ class LoggerE2ETests {
      * apiMethodSignature: com.datadog.android.log.Logger#fun addAttribute(String, com.google.gson.JsonArray?)
      */
     @Test
-    fun logs_logger_add_jsonarray_null_attribute() {
-        val testMethodName = "logs_logger_add_jsonarray_null_attribute"
+    fun logs_logger_add_gson_jsonarray_null_attribute() {
+        val testMethodName = "logs_logger_add_gson_jsonarray_null_attribute"
         val nullJsonArray: JsonArray? = null
         measure(testMethodName) {
             logger.addAttribute(SPECIAL_JSONARRAY_ATTRIBUTE_NAME, nullJsonArray)
@@ -391,10 +393,13 @@ class LoggerE2ETests {
      * apiMethodSignature: com.datadog.android.log.Logger#fun addAttribute(String, com.google.gson.JsonObject?)
      */
     @Test
-    fun logs_logger_add_jsonobject_attribute() {
-        val testMethodName = "logs_logger_add_jsonobject_attribute"
+    fun logs_logger_add_gson_jsonobject_attribute() {
+        val testMethodName = "logs_logger_add_gson_jsonobject_attribute"
         measure(testMethodName) {
-            logger.addAttribute(SPECIAL_JSONOBJECT_ATTRIBUTE_NAME, CUSTOM_JSON_OBJECT_ATTRIBUTE)
+            logger.addAttribute(
+                SPECIAL_JSONOBJECT_ATTRIBUTE_NAME,
+                CUSTOM_GSON_JSON_OBJECT_ATTRIBUTE
+            )
         }
         logger.sendRandomLog(testMethodName, forge)
     }
@@ -403,9 +408,65 @@ class LoggerE2ETests {
      * apiMethodSignature: com.datadog.android.log.Logger#fun addAttribute(String, com.google.gson.JsonObject?)
      */
     @Test
-    fun logs_logger_add_jsonobject_null_attribute() {
-        val testMethodName = "logs_logger_add_jsonobject_null_attribute"
+    fun logs_logger_add_gson_jsonobject_null_attribute() {
+        val testMethodName = "logs_logger_add_gson_jsonobject_null_attribute"
         val nullJsonObject: JsonObject? = null
+        measure(testMethodName) {
+            logger.addAttribute(SPECIAL_JSONOBJECT_ATTRIBUTE_NAME, nullJsonObject)
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.log.Logger#fun addAttribute(String, org.json.JSONArray?)
+     */
+    @Test
+    fun logs_logger_add_org_json_jsonarray_attribute() {
+        val testMethodName = "logs_logger_add_org_json_jsonarray_attribute"
+        measure(testMethodName) {
+            logger.addAttribute(
+                SPECIAL_JSONARRAY_ATTRIBUTE_NAME,
+                CUSTOM_ORG_JSON_JSON_ARRAY_ATTRIBUTE
+            )
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.log.Logger#fun addAttribute(String, org.json.JSONArray?)
+     */
+    @Test
+    fun logs_logger_add_org_json_jsonarray_null_attribute() {
+        val testMethodName = "logs_logger_add_org_json_jsonarray_null_attribute"
+        val nullJsonArray: JSONArray? = null
+        measure(testMethodName) {
+            logger.addAttribute(SPECIAL_JSONARRAY_ATTRIBUTE_NAME, nullJsonArray)
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.log.Logger#fun addAttribute(String, org.json.JSONObject?)
+     */
+    @Test
+    fun logs_logger_add_org_json_jsonobject_attribute() {
+        val testMethodName = "logs_logger_add_org_json_jsonobject_attribute"
+        measure(testMethodName) {
+            logger.addAttribute(
+                SPECIAL_JSONOBJECT_ATTRIBUTE_NAME,
+                CUSTOM_ORG_JSON_JSON_OBJECT_ATTRIBUTE
+            )
+        }
+        logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.log.Logger#fun addAttribute(String, org.json.JSONObject?)
+     */
+    @Test
+    fun logs_logger_add_org_json_jsonobject_null_attribute() {
+        val testMethodName = "logs_logger_add_org_json_jsonobject_null_attribute"
+        val nullJsonObject: JSONObject? = null
         measure(testMethodName) {
             logger.addAttribute(SPECIAL_JSONOBJECT_ATTRIBUTE_NAME, nullJsonObject)
         }
@@ -443,7 +504,7 @@ class LoggerE2ETests {
     @Test
     fun logs_logger_remove_attribute() {
         val testMethodName = "logs_logger_remove_attribute"
-        when (forge.anInt(min = 1, max = 9)) {
+        when (forge.anInt(min = 1, max = 11)) {
             1 -> logger.addAttribute(
                 SPECIAL_ATTRIBUTE_NAME,
                 forge.aNullable { forge.anAlphabeticalString() }
@@ -454,13 +515,21 @@ class LoggerE2ETests {
             5 -> logger.addAttribute(SPECIAL_ATTRIBUTE_NAME, forge.aBool())
             6 -> logger.addAttribute(
                 SPECIAL_ATTRIBUTE_NAME,
-                forge.aNullable { CUSTOM_JSON_OBJECT_ATTRIBUTE }
+                forge.aNullable { CUSTOM_GSON_JSON_OBJECT_ATTRIBUTE }
             )
             7 -> logger.addAttribute(
                 SPECIAL_ATTRIBUTE_NAME,
-                forge.aNullable { CUSTOM_JSON_ARRAY_ATTRIBUTE }
+                forge.aNullable { CUSTOM_GSON_JSON_ARRAY_ATTRIBUTE }
             )
             8 -> logger.addAttribute(
+                SPECIAL_ATTRIBUTE_NAME,
+                forge.aNullable { CUSTOM_ORG_JSON_JSON_OBJECT_ATTRIBUTE }
+            )
+            9 -> logger.addAttribute(
+                SPECIAL_ATTRIBUTE_NAME,
+                forge.aNullable { CUSTOM_ORG_JSON_JSON_ARRAY_ATTRIBUTE }
+            )
+            10 -> logger.addAttribute(
                 SPECIAL_ATTRIBUTE_NAME,
                 forge.aNullable { CUSTOM_DATE_ATTRIBUTE }
             )
@@ -544,15 +613,23 @@ class LoggerE2ETests {
 
     companion object {
         const val CUSTOM_STRING_TAG: String = "custom_tag"
-        const val CUSTOM_INT_ATTRIBUTE: Int = 1
+        private const val CUSTOM_INT_ATTRIBUTE: Int = 1
         private const val CUSTOM_JSON_OBJECT_PROPERTY = "custom_json_property"
-        val CUSTOM_JSON_ARRAY_ATTRIBUTE: JsonArray = JsonArray().apply {
+        val CUSTOM_GSON_JSON_ARRAY_ATTRIBUTE: JsonArray = JsonArray().apply {
             this.add(
                 CUSTOM_INT_ATTRIBUTE
             )
         }
-        val CUSTOM_JSON_OBJECT_ATTRIBUTE: JsonObject = JsonObject().apply {
+        val CUSTOM_GSON_JSON_OBJECT_ATTRIBUTE: JsonObject = JsonObject().apply {
             addProperty(CUSTOM_JSON_OBJECT_PROPERTY, CUSTOM_INT_ATTRIBUTE)
+        }
+        val CUSTOM_ORG_JSON_JSON_ARRAY_ATTRIBUTE: JSONArray = JSONArray().apply {
+            this.put(
+                CUSTOM_INT_ATTRIBUTE
+            )
+        }
+        val CUSTOM_ORG_JSON_JSON_OBJECT_ATTRIBUTE: JSONObject = JSONObject().apply {
+            put(CUSTOM_JSON_OBJECT_PROPERTY, CUSTOM_INT_ATTRIBUTE)
         }
         val CUSTOM_DATE_ATTRIBUTE: Date = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
             .apply { timeZone = TimeZone.getTimeZone("UTC") }


### PR DESCRIPTION
### What does this PR do?

Closes #588. This change adds support of `org.json.JSONArray` and `org.json.JSONObject` classes (which come with Android SDK) in the `Logger#addAttribute` call.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

