### PR TITLE
RUMM-1850: Remove flakiness in RUM E2E tests backed by multi-alert (by group) monitors

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/GdprRumE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/GdprRumE2ETests.kt
@@ -57,7 +57,7 @@ class GdprRumE2ETests {
                 consent = TrackingConsent.GRANTED
             )
         }
-        sendRandomRumEvent(forge, testMethodName)
+        sendAllRumEvents(forge, testMethodName)
     }
 
     /**
@@ -87,7 +87,7 @@ class GdprRumE2ETests {
                 consent = TrackingConsent.PENDING
             )
         }
-        sendRandomRumEvent(forge, testMethodName)
+        sendAllRumEvents(forge, testMethodName)
         measureSetTrackingConsent {
             Datadog.setTrackingConsent(TrackingConsent.GRANTED)
         }
@@ -162,7 +162,7 @@ class GdprRumE2ETests {
         measureSetTrackingConsent {
             Datadog.setTrackingConsent(TrackingConsent.GRANTED)
         }
-        sendRandomRumEvent(forge, testMethodName)
+        sendAllRumEvents(forge, testMethodName)
     }
 
     /**

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
@@ -75,7 +75,7 @@ class RumConfigE2ETests {
                 ).build()
             )
         }
-        sendRandomRumEvent(forge, testMethodName)
+        sendAllRumEvents(forge, testMethodName)
     }
 
     /**
@@ -96,7 +96,7 @@ class RumConfigE2ETests {
                 ).setBatchSize(forge.aValueFrom(BatchSize::class.java)).build()
             )
         }
-        sendRandomRumEvent(forge, testMethodName)
+        sendAllRumEvents(forge, testMethodName)
     }
 
     /**
@@ -590,7 +590,7 @@ class RumConfigE2ETests {
             )
         }
 
-        sendRandomRumEvent(forge, testMethodName)
+        sendAllRumEvents(forge, testMethodName)
     }
 
     /**
@@ -612,7 +612,7 @@ class RumConfigE2ETests {
             )
         }
 
-        sendRandomRumEvent(forge, testMethodName)
+        sendAllRumEvents(forge, testMethodName)
     }
 
     /**

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBuilderE2ETests.kt
@@ -48,7 +48,7 @@ class RumMonitorBuilderE2ETests {
             }
         )
 
-        sendRandomRumEvent(forge, testMethodName)
+        sendAllRumEvents(forge, testMethodName)
     }
 
     /**
@@ -66,7 +66,7 @@ class RumMonitorBuilderE2ETests {
                 }
             }
         )
-        sendRandomRumEvent(forge, testMethodName)
+        sendAllRumEvents(forge, testMethodName)
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

This change affects nightly RUM E2E tests which are backed by multi-alert (by group) monitors: before monitors were failing because they expect events of all types to be received, so this change will send all the possible event types in such tests.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

