### PR TITLE
Fix NDK Crash E2E test failure caused by missing RUM view at the time of crash

### DIFF
--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashService.kt
@@ -23,6 +23,8 @@ internal abstract class CrashService : Service() {
             }
         }
         GlobalRum.get().startView(this, this.javaClass.simpleName.toString())
+        // this is a hack to write RUM view to the disk, so that file exists by the time NDK crashes
+        GlobalRum.get().addTiming("foo")
     }
 
     protected fun getCredentials() = Credentials(


### PR DESCRIPTION
### What does this PR do?

Recent https://github.com/DataDog/dd-sdk-android/pull/791 changed the way `appLaunch` event is sent (so that now it cannot be send from background process) and it impacted E2E test `ndk_crash_reports_rum_enabled`.

The issue is that since this test spins a service in another process (so it has background status), and just start a view, by the time NDK crash happens there is no yet view written to the disk (it was written before because of `appLaunch` event, which is not triggered now for this setup).

So solution is just to add `addTiming` call which will cause view event dump to the disk (via `sendViewUpdate`). It could be done with actions as well, but actions are saved only when another action arrives, so it would be more code.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

