### PR TITLE
RUMM-1797: Ignore kotlin.FunctionX.invoke calls in the UnsafeThirdPartyCall check

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -615,11 +615,9 @@ datadog:
       - "java.io.FileInputStream.use(kotlin.Function1):java.io.IOException"
       - "java.io.FileOutputStream.use(kotlin.Function1):java.io.IOException"
       - "java.io.FileOutputStream.write(kotlin.ByteArray):java.io.IOException"
-      - "java.io.InputStream.invoke():java.io.IOException"
       - "java.nio.channels.FileChannel.lock():java.io.IOException,java.lang.IllegalStateException"
       - "java.nio.channels.FileLock.use(kotlin.Function1):java.io.IOException"
       - "java.nio.channels.FileLock.release():java.io.IOException"
-      - "kotlin.Function1.invoke(java.nio.channels.FileLock):java.io.IOException"
       # endregion
       # region Java Concurrency
       - "java.lang.Thread.constructor(java.lang.Runnable, kotlin.String):java.lang.NullPointerException,java.lang.SecurityException,java.lang.IllegalArgumentException"
@@ -689,19 +687,6 @@ datadog:
       # endregion
       # region Gson
       - "com.google.gson.JsonParser.parseString(kotlin.String):com.google.gson.JsonParseException"
-      # endregion
-      # region Kotlin Invoke
-      - "io.opentracing.Span.invoke():java.lang.Exception"
-      - "kotlin.Function0.invoke():java.lang.Exception"
-      - "kotlin.Function1.invoke():java.lang.Exception"
-      - "kotlin.Function1.invoke(android.app.Fragment):java.lang.Exception"
-      - "kotlin.Function1.invoke(android.view.MotionEvent):java.lang.Exception"
-      - "kotlin.Function1.invoke(androidx.fragment.app.Fragment):java.lang.Exception"
-      - "kotlin.Function1.invoke(kotlin.Any):java.lang.Exception"
-      - "kotlin.Function2.invoke(kotlin.Int, kotlin.Throwable?):java.lang.Exception"
-      - "kotlin.Function1.invoke(kotlin.String):java.lang.Exception"
-      - "kotlin.Function1.invoke(java.io.Closeable):java.lang.Exception"
-      - "kotlin.Function1.invoke(com.datadog.android.sqldelight.TransactionWithSpanAndWithoutReturn):java.lang.Exception"
       # endregion
     knownSafeCalls:
       # region Android APIs

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/UnsafeThirdPartyFunctionCall.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/UnsafeThirdPartyFunctionCall.kt
@@ -235,7 +235,7 @@ class UnsafeThirdPartyFunctionCall(
 
         private val kotlinHelperMethods = arrayOf(
             "let", "run", "with", "apply", "also",
-            "print", "println", "toString"
+            "print", "println", "toString", "invoke"
         )
     }
 }

--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/UnsafeThirdPartyFunctionCallTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/UnsafeThirdPartyFunctionCallTest.kt
@@ -43,7 +43,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
             """
                 import java.io.File
                 
-                fun test(val f: File): Any {
+                fun test(f: File): Any {
                     return f.inputStream()
                 }
             """.trimIndent()
@@ -69,7 +69,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
             """
                 import java.io.File
                 
-                fun test(val f: File): Any {
+                fun test(f: File): Any {
                     return f.inputStream()
                 }
             """.trimIndent()
@@ -100,7 +100,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
                 import java.io.FilenameFilter
                 import java.io.FileFilter
                 
-                fun test(val f: File, val ff: FileFilter, val fnf: FilenameFilter) {
+                fun test(f: File, ff: FileFilter, fnf: FilenameFilter) {
                     f.listFiles(ff)
                     f.listFiles(fnf)
                 }
@@ -128,7 +128,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
                 import java.io.File
                 import java.lang.ArrayIndexOutOfBoundsException
                 
-                fun test(val f: File): Any {
+                fun test(f: File): Any {
                     try {
                         return f.inputStream()
                     } catch (e: ArrayIndexOutOfBoundsException) {
@@ -160,7 +160,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
                 import java.io.FileNotFoundException
                 import java.lang.ArrayIndexOutOfBoundsException
                 
-                fun test(val f: File): Any? {
+                fun test(f: File): Any? {
                     try {
                         return f.inputStream()
                     } catch (e: FileNotFoundException) {
@@ -194,7 +194,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
                 import java.io.FileNotFoundException
                 import java.lang.ArrayIndexOutOfBoundsException
                 
-                fun test(val f: File): Any? {
+                fun test(f: File): Any? {
                     try {
                         return f.inputStream()
                     } catch (e: Exception) {
@@ -226,7 +226,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
                 import java.io.FileNotFoundException
                 import java.lang.ArrayIndexOutOfBoundsException
                 
-                fun test(val f: File): Any? {
+                fun test(f: File): Any? {
                     try {
                         return f.inputStream()
                     } catch (e: Throwable) {
@@ -260,7 +260,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
                 
                 public actual typealias FNE = java.io.FileNotFoundException
                 
-                fun test(val f: File): Any? {
+                fun test(f: File): Any? {
                     try {
                         return f.inputStream()
                     } catch (e: FNE) {
@@ -293,7 +293,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
                 import java.io.IOException
                 import java.lang.ArrayIndexOutOfBoundsException
                 
-                fun test(val f: File): Any? {
+                fun test(f: File): Any? {
                     try {
                         try {
                             return f.inputStream()
@@ -331,7 +331,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
             """
                 import java.io.File
                 
-                fun test(val f: File): Any? {
+                fun test(f: File): Any? {
                     return f.inputStream()
                 }
             """.trimIndent()
@@ -354,7 +354,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
             """
                 import java.io.File
                 
-                fun test(val f: File): Any {
+                fun test(f: File): Any {
                     return f.inputStream()
                 }
             """.trimIndent()
@@ -377,7 +377,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
             """
                 import java.io.File
                 
-                fun test(val f: File): Any {
+                fun test(f: File): Any {
                     return f.inputStream()
                 }
             """.trimIndent()
@@ -437,18 +437,64 @@ internal class UnsafeThirdPartyFunctionCallTest {
     }
 
     @Test
-    fun `ignore kotlin helper calls`() {
+    fun `ignore kotlin helper calls { let + apply + println + toString }`() {
         // Given
         val code =
             """
                 import java.io.File
                 
-                fun test(val f: File?): Any {
+                fun test(f: File?): Any {
                     return f?.let{
                         it.apply {
                             println(this.toString())
                         }
                     }
+                }
+            """.trimIndent()
+
+        // When
+        val findings = UnsafeThirdPartyFunctionCall(Config.empty)
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `ignore kotlin helper calls { with + run + also + println }`() {
+        // Given
+        val code =
+            """
+                import java.io.File
+                
+                fun test(f: File?): Any {
+                    with(file) {
+                        this.run {
+                            this.readBytes().also { 
+                                println(it)
+                            }
+                        }
+                    } 
+                }
+            """.trimIndent()
+
+        // When
+        val findings = UnsafeThirdPartyFunctionCall(Config.empty)
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `ignore kotlin helper calls { invoke }`() {
+        // Given
+        val code =
+            """
+                import java.io.File
+                
+                fun test(file: File, predicate: File.() -> Boolean): Boolean {
+                    return predicate(file)
                 }
             """.trimIndent()
 


### PR DESCRIPTION
### What does this PR do?

This change makes `UnsafeThirdPartyCall` check skip `invoke` calls, because this is essentially synthetic wrapper around lambda invocation.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

