### PR TITLE
RUMM-1873: Improve build pipeline speed

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -77,11 +77,10 @@ analysis:detekt:
   stage: analysis
   timeout: 30m
   cache:
-    key: $CI_PIPELINE_ID
+    key: $CI_COMMIT_REF_SLUG
     paths:
       - cache/caches/
       - cache/notifications/
-    policy: push
   script:
     - git fetch --depth=1 origin master
     - GRADLE_OPTS="-Xmx2560m" ./gradlew :detektAll --stacktrace --no-daemon --build-cache --gradle-user-home cache/
@@ -130,7 +129,7 @@ test:debug:
   stage: test
   timeout: 1h
   cache:
-    key: $CI_PIPELINE_ID
+    key: $CI_COMMIT_REF_SLUG
     paths:
       - cache/caches/
       - cache/notifications/
@@ -146,7 +145,7 @@ test:release:
   stage: test
   timeout: 1h
   cache:
-    key: $CI_PIPELINE_ID
+    key: $CI_COMMIT_REF_SLUG
     paths:
       - cache/caches/
       - cache/notifications/
@@ -162,7 +161,7 @@ test:tools:
   stage: test
   timeout: 1h
   cache:
-    key: $CI_PIPELINE_ID
+    key: $CI_COMMIT_REF_SLUG
     paths:
       - cache/caches/
       - cache/notifications/
@@ -178,11 +177,10 @@ test:kover:
   stage: test
   timeout: 1h
   cache:
-    key: $CI_PIPELINE_ID
+    key: $CI_COMMIT_REF_SLUG
     paths:
       - cache/caches/
       - cache/notifications/
-    policy: pull
   script:
     - pip3 install datadog
     - git fetch --depth=1 origin master

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,9 +76,15 @@ analysis:detekt:
   image: $CI_IMAGE_DOCKER
   stage: analysis
   timeout: 30m
+  cache:
+    key: $CI_PIPELINE_ID
+    paths:
+      - cache/caches/
+      - cache/notifications/
+    policy: push
   script:
     - git fetch --depth=1 origin master
-    - GRADLE_OPTS="-Xmx2560m" ./gradlew :detektAll --stacktrace --no-daemon
+    - GRADLE_OPTS="-Xmx2560m" ./gradlew :detektAll --stacktrace --no-daemon --build-cache --gradle-user-home cache/
 
 analysis:licenses:
   tags: [ "runner:main" ]
@@ -123,36 +129,60 @@ test:debug:
   image: $CI_IMAGE_DOCKER
   stage: test
   timeout: 1h
+  cache:
+    key: $CI_PIPELINE_ID
+    paths:
+      - cache/caches/
+      - cache/notifications/
+    policy: pull
   script:
     - git fetch --depth=1 origin master
     - rm -rf ~/.gradle/daemon/
-    - GRADLE_OPTS="-Xmx2560m" ./gradlew :unitTestDebug --stacktrace --no-daemon
+    - GRADLE_OPTS="-Xmx2560m" ./gradlew :unitTestDebug --stacktrace --no-daemon --build-cache --gradle-user-home cache/
 
 test:release:
   tags: [ "runner:main" ]
   image: $CI_IMAGE_DOCKER
   stage: test
   timeout: 1h
+  cache:
+    key: $CI_PIPELINE_ID
+    paths:
+      - cache/caches/
+      - cache/notifications/
+    policy: pull
   script:
     - git fetch --depth=1 origin master
     - rm -rf ~/.gradle/daemon/
-    - GRADLE_OPTS="-Xmx2560m" ./gradlew :unitTestRelease --stacktrace --no-daemon
+    - GRADLE_OPTS="-Xmx2560m" ./gradlew :unitTestRelease --stacktrace --no-daemon --build-cache --gradle-user-home cache/
 
 test:tools:
   tags: [ "runner:main" ]
   image: $CI_IMAGE_DOCKER
   stage: test
   timeout: 1h
+  cache:
+    key: $CI_PIPELINE_ID
+    paths:
+      - cache/caches/
+      - cache/notifications/
+    policy: pull
   script:
     - git fetch --depth=1 origin master
     - rm -rf ~/.gradle/daemon/
-    - GRADLE_OPTS="-Xmx2560m" ./gradlew :unitTestTools --stacktrace --no-daemon
+    - GRADLE_OPTS="-Xmx2560m" ./gradlew :unitTestTools --stacktrace --no-daemon --build-cache --gradle-user-home cache/
 
 test:kover:
   tags: [ "runner:main" ]
   image: $CI_IMAGE_DOCKER
   stage: test
   timeout: 1h
+  cache:
+    key: $CI_PIPELINE_ID
+    paths:
+      - cache/caches/
+      - cache/notifications/
+    policy: pull
   script:
     - pip3 install datadog
     - git fetch --depth=1 origin master
@@ -160,7 +190,7 @@ test:kover:
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.api_key --with-decryption --query "Parameter.Value" --out text)
     - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.app_key --with-decryption --query "Parameter.Value" --out text)
     - CODECOV_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.codecov-token  --with-decryption --query "Parameter.Value" --out text)
-    - GRADLE_OPTS="-Xmx2560m" ./gradlew :koverReportAll --stacktrace --no-daemon
+    - GRADLE_OPTS="-Xmx2560m" ./gradlew :koverReportAll --stacktrace --no-daemon --build-cache --gradle-user-home cache/
     - python3 ddcoverage.py --prefix dd-sdk-android
     - bash <(cat ./codecov.sh) -t $CODECOV_TOKEN
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -113,7 +113,7 @@ tasks.register("unitTestDebug") {
 
 tasks.register("unitTestTools") {
     dependsOn(
-        ":sample:kotlin:assembleRelease",
+        ":sample:kotlin:assembleUs1Release",
         ":tools:detekt:test",
         ":tools:unit:testReleaseUnitTest"
     )

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/GenerateJsonSchemaTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/jsonschema/GenerateJsonSchemaTask.kt
@@ -9,9 +9,12 @@ package com.datadog.gradle.plugin.jsonschema
 import java.io.File
 import org.gradle.api.DefaultTask
 import org.gradle.api.Task
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.InputFiles
 import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
 import org.gradle.api.tasks.TaskAction
 
 // TODO test all from https://github.com/json-schema-org/JSON-Schema-Test-Suite/tree/master/tests/draft2019-09
@@ -21,6 +24,7 @@ import org.gradle.api.tasks.TaskAction
  *
  * It will read source JsonSchema files and generate the relevant Kotlin data classes.
  */
+@CacheableTask
 open class GenerateJsonSchemaTask : DefaultTask() {
 
     init {
@@ -33,6 +37,7 @@ open class GenerateJsonSchemaTask : DefaultTask() {
     /**
      * The [InputFiles] (E.g.: all the json files in `resources/json`).
      */
+    @PathSensitive(PathSensitivity.RELATIVE)
     @InputFiles
     fun getInputFiles(): List<File> {
         return getInputDir().listFiles().orEmpty().toList()


### PR DESCRIPTION
### What does this PR do?

This change improves build pipeline speed by doing the following:

* Enables [Gitlab cache](https://docs.gitlab.com/ee/ci/caching/) between `analysis` and `test` stages.
* Makes `test:tools` to build only `US1` variant, because we don't have different source code sets for the flavors, so this will be enough.

#### Notes on the caching strategy

Cache is **only produced** by `analysis:detekt` job (as it covers most of task graph among executions in the `analysis` stage), and **only consumed** by `test` group.

Cache is not consumed by the `publish` stage, because this stage is executed very rarely.

Cache is valid only inside the certain pipeline (because it has pipeline ID as a key, check [Gitlab predefined variables](https://docs.gitlab.com/ee/ci/variables/predefined_variables.html)), so we will monitor `test` stage execution trend to see if there is any gain (few executions is not enough to make a decision), so after some time we may:

* keep everything as it is
* expand cache to be valid, say, for the branch, not only for pipeline. This theoretically may make building for subsequent pushes faster (if we allow `analysis` stage also to consume cache)
* remove cache if there is no performance gain. This is also possible, because to use the cache it should be uploaded for S3 and then downloaded in another job and unpacked, it takes time.

What is cached: simply [Gradle build cache](https://docs.gradle.org/current/userguide/build_cache.html) is cached for now, which includes dependencies and compilation units.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

