### PR TITLE
RUMM-1858: Use parametrized test instead of anElementFrom/aValueFrom calls

### DIFF
--- a/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/ComposeNavigationObserverTest.kt
+++ b/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/ComposeNavigationObserverTest.kt
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -254,16 +256,15 @@ internal class ComposeNavigationObserverTest {
         verifyZeroInteractions(mockRumMonitor)
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(
+        Lifecycle.Event::class,
+        names = ["ON_PAUSE", "ON_RESUME"],
+        mode = EnumSource.Mode.EXCLUDE
+    )
     fun `M do nothing W neither ON_PAUSE or ON_RESUME event`(
-        forge: Forge
+        lifecycleEvent: Lifecycle.Event
     ) {
-        // Given
-        val lifecycleEvent = forge.aValueFrom(
-            Lifecycle.Event::class.java,
-            exclude = listOf(Lifecycle.Event.ON_PAUSE, Lifecycle.Event.ON_RESUME)
-        )
-
         // When
         testedObserver.onStateChanged(mock(), lifecycleEvent)
 

--- a/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/SwipeAndScrollActionTrackerTest.kt
+++ b/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/SwipeAndScrollActionTrackerTest.kt
@@ -34,17 +34,20 @@ import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.util.Locale
+import java.util.stream.Stream
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.runBlocking
-import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.Mockito.verify
 import org.mockito.Mockito.verifyNoMoreInteractions
@@ -78,8 +81,12 @@ class SwipeAndScrollActionTrackerTest {
     )
     lateinit var fakeAttributes: Map<String, String>
 
-    @RepeatedTest(10)
+    @ParameterizedTest
+    @MethodSource("directionToReverseToRtl")
     fun `M report SWIPE action W trackSwipe { Start - Stop }`(
+        swipeDirection: Direction,
+        reverseDirection: Boolean,
+        isRtl: Boolean,
         forge: Forge
     ) {
         // Given
@@ -89,14 +96,11 @@ class SwipeAndScrollActionTrackerTest {
             emit(DragInteraction.Stop(start))
         }
 
-        val swipeDirection = forge.aValueFrom(Direction::class.java)
         val swipeOrientation = swipeDirection.orientation
 
         val startState = forge.anInt()
         val endState = forge.anInt()
 
-        val reverseDirection = forge.aBool()
-        val isRtl = forge.aBool()
         val swipeableState =
             forge.aSwipeableState(startState, endState, swipeDirection, reverseDirection, isRtl)
 
@@ -132,8 +136,12 @@ class SwipeAndScrollActionTrackerTest {
         }
     }
 
-    @RepeatedTest(10)
+    @ParameterizedTest
+    @MethodSource("directionToReverseToRtl")
     fun `M report SWIPE action W trackSwipe { Start - Cancel }`(
+        swipeDirection: Direction,
+        reverseDirection: Boolean,
+        isRtl: Boolean,
         forge: Forge
     ) {
         // Given
@@ -143,14 +151,11 @@ class SwipeAndScrollActionTrackerTest {
             emit(DragInteraction.Cancel(start))
         }
 
-        val swipeDirection = forge.aValueFrom(Direction::class.java)
         val swipeOrientation = swipeDirection.orientation
 
         val startState = forge.anInt()
         val endState = forge.anInt()
 
-        val reverseDirection = forge.aBool()
-        val isRtl = forge.aBool()
         val swipeableState =
             forge.aSwipeableState(startState, endState, swipeDirection, reverseDirection, isRtl)
 
@@ -186,8 +191,12 @@ class SwipeAndScrollActionTrackerTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("directionToReverseToRtl")
     fun `M not report SWIPE stop action W trackSwipe { Start - Start }`(
+        swipeDirection: Direction,
+        reverseDirection: Boolean,
+        isRtl: Boolean,
         forge: Forge
     ) {
         // Given
@@ -196,14 +205,10 @@ class SwipeAndScrollActionTrackerTest {
             emit(DragInteraction.Start())
         }
 
-        val swipeDirection = forge.aValueFrom(Direction::class.java)
         val swipeOrientation = swipeDirection.orientation
 
         val startState = forge.anInt()
         val endState = forge.anInt()
-
-        val reverseDirection = forge.aBool()
-        val isRtl = forge.aBool()
 
         val swipeableState =
             forge.aSwipeableState(startState, endState, swipeDirection, reverseDirection, isRtl)
@@ -228,8 +233,12 @@ class SwipeAndScrollActionTrackerTest {
         verifyNoMoreInteractions(mockRumMonitor)
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("directionToReverseToRtl")
     fun `M not report SWIPE stop action W trackSwipe { Start - Stop for another Start }`(
+        swipeDirection: Direction,
+        reverseDirection: Boolean,
+        isRtl: Boolean,
         forge: Forge
     ) {
         // Given
@@ -238,14 +247,10 @@ class SwipeAndScrollActionTrackerTest {
             emit(DragInteraction.Stop(DragInteraction.Start()))
         }
 
-        val swipeDirection = forge.aValueFrom(Direction::class.java)
         val swipeOrientation = swipeDirection.orientation
 
         val startState = forge.anInt()
         val endState = forge.anInt()
-
-        val reverseDirection = forge.aBool()
-        val isRtl = forge.aBool()
 
         val swipeableState =
             forge.aSwipeableState(startState, endState, swipeDirection, reverseDirection, isRtl)
@@ -270,8 +275,12 @@ class SwipeAndScrollActionTrackerTest {
         verifyNoMoreInteractions(mockRumMonitor)
     }
 
-    @RepeatedTest(10)
+    @ParameterizedTest
+    @MethodSource("directionToReverseToRtl")
     fun `M report SCROLL action W trackScroll { Start - Stop }`(
+        scrollDirection: Direction,
+        reverseLayout: Boolean,
+        isRtl: Boolean,
         forge: Forge
     ) {
         // Given
@@ -283,11 +292,8 @@ class SwipeAndScrollActionTrackerTest {
 
         whenever(mockInteractionSource.interactions) doReturn interactionsFlow
 
-        val scrollDirection = forge.aValueFrom(Direction::class.java)
         val scrollOrientation = scrollDirection.orientation
 
-        val reverseLayout = forge.aBool()
-        val isRtl = forge.aBool()
         val mockScrollableState = forge.aScrollableState(scrollDirection, reverseLayout, isRtl)
 
         val expectedAttributes = fakeAttributes.run {
@@ -322,8 +328,12 @@ class SwipeAndScrollActionTrackerTest {
         }
     }
 
-    @RepeatedTest(10)
+    @ParameterizedTest
+    @MethodSource("directionToReverseToRtl")
     fun `M report SCROLL action W trackScroll { Start - Cancel }`(
+        scrollDirection: Direction,
+        reverseLayout: Boolean,
+        isRtl: Boolean,
         forge: Forge
     ) {
         // Given
@@ -335,11 +345,8 @@ class SwipeAndScrollActionTrackerTest {
 
         whenever(mockInteractionSource.interactions) doReturn interactionsFlow
 
-        val scrollDirection = forge.aValueFrom(Direction::class.java)
         val scrollOrientation = scrollDirection.orientation
 
-        val reverseLayout = forge.aBool()
-        val isRtl = forge.aBool()
         val mockScrollableState = forge.aScrollableState(scrollDirection, reverseLayout, isRtl)
 
         val expectedAttributes = fakeAttributes.run {
@@ -374,8 +381,12 @@ class SwipeAndScrollActionTrackerTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("directionToReverseToRtl")
     fun `M not report SCROLL stop action W trackScroll { Start - Start }`(
+        scrollDirection: Direction,
+        reverseLayout: Boolean,
+        isRtl: Boolean,
         forge: Forge
     ) {
         // Given
@@ -386,11 +397,8 @@ class SwipeAndScrollActionTrackerTest {
 
         whenever(mockInteractionSource.interactions) doReturn interactionsFlow
 
-        val scrollDirection = forge.aValueFrom(Direction::class.java)
         val scrollOrientation = scrollDirection.orientation
 
-        val reverseLayout = forge.aBool()
-        val isRtl = forge.aBool()
         val mockScrollableState = forge.aScrollableState(scrollDirection, reverseLayout, isRtl)
 
         // When
@@ -411,8 +419,12 @@ class SwipeAndScrollActionTrackerTest {
         verifyNoMoreInteractions(mockRumMonitor)
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("directionToReverseToRtl")
     fun `M not report SCROLL stop action W trackScroll { Start - Stop for another Start }`(
+        scrollDirection: Direction,
+        reverseLayout: Boolean,
+        isRtl: Boolean,
         forge: Forge
     ) {
         // Given
@@ -423,11 +435,8 @@ class SwipeAndScrollActionTrackerTest {
 
         whenever(mockInteractionSource.interactions) doReturn interactionsFlow
 
-        val scrollDirection = forge.aValueFrom(Direction::class.java)
         val scrollOrientation = scrollDirection.orientation
 
-        val reverseLayout = forge.aBool()
-        val isRtl = forge.aBool()
         val mockScrollableState = forge.aScrollableState(scrollDirection, reverseLayout, isRtl)
 
         // When
@@ -626,7 +635,7 @@ class SwipeAndScrollActionTrackerTest {
     }
 
     @Suppress("unused")
-    private enum class Direction(val orientation: Orientation) {
+    enum class Direction(val orientation: Orientation) {
         UP(orientation = Orientation.Vertical),
         DOWN(orientation = Orientation.Vertical),
         RIGHT(orientation = Orientation.Horizontal),
@@ -636,6 +645,21 @@ class SwipeAndScrollActionTrackerTest {
     companion object {
         const val MAX_LAZY_LIST_STATE_ITEM_INDEX = 0xFFFF
         const val MAX_LAZY_LIST_STATE_ITEM_OFFSET = 0x7FFF
+
+        @Suppress("unused")
+        @JvmStatic
+        fun directionToReverseToRtl(): Stream<Arguments> {
+            return Direction.values()
+                .flatMap {
+                    listOf(
+                        Arguments.of(it, true, true),
+                        Arguments.of(it, true, false),
+                        Arguments.of(it, false, true),
+                        Arguments.of(it, false, false)
+                    )
+                }
+                .stream()
+        }
     }
 
     // endregion

--- a/dd-sdk-android-ndk/src/test/kotlin/NdkCrashReportsPluginTest.kt
+++ b/dd-sdk-android-ndk/src/test/kotlin/NdkCrashReportsPluginTest.kt
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.api.io.TempDir
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
@@ -62,8 +64,10 @@ internal class NdkCrashReportsPluginTest {
         )
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(TrackingConsent::class)
     fun `M create the NDK crash reports directory W register { nativeLibrary loaded }`(
+        trackingConsent: TrackingConsent,
         forge: Forge
     ) {
         // GIVEN
@@ -74,7 +78,7 @@ internal class NdkCrashReportsPluginTest {
             mockedContext,
             forge.anAlphabeticalString(),
             forge.anAlphabeticalString(),
-            forge.aValueFrom(TrackingConsent::class.java)
+            trackingConsent
         )
         testedPlugin.setFieldValue("nativeLibraryLoaded", true)
 
@@ -90,8 +94,10 @@ internal class NdkCrashReportsPluginTest {
         assertThat(ndkCrashDirectory.exists()).isTrue()
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(TrackingConsent::class)
     fun `M do nothing  W register { nativeLibrary not loaded }`(
+        trackingConsent: TrackingConsent,
         forge: Forge
     ) {
         // GIVEN
@@ -102,7 +108,7 @@ internal class NdkCrashReportsPluginTest {
             mockedContext,
             forge.anAlphabeticalString(),
             forge.anAlphabeticalString(),
-            forge.aValueFrom(TrackingConsent::class.java)
+            trackingConsent
         )
 
         // WHEN

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
@@ -18,12 +18,15 @@ import android.os.Build
 import android.telephony.TelephonyManager
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.receiver.ThreadSafeReceiver
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
 import com.datadog.android.core.model.NetworkInfo
 
 @Suppress("DEPRECATION")
 @SuppressLint("InlinedApi")
 internal class BroadcastReceiverNetworkInfoProvider(
-    private val dataWriter: DataWriter<NetworkInfo>
+    private val dataWriter: DataWriter<NetworkInfo>,
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider()
 ) :
     ThreadSafeReceiver(),
     NetworkInfoProvider {
@@ -101,7 +104,7 @@ internal class BroadcastReceiverNetworkInfoProvider(
         }
         val cellularTechnology = getCellularTechnology(subtype)
 
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        return if (buildSdkVersionProvider.version() >= Build.VERSION_CODES.P) {
             val telephonyMgr =
                 context.getSystemService(Context.TELEPHONY_SERVICE) as? TelephonyManager
             val carrierName = telephonyMgr?.simCarrierIdName ?: UNKNOWN_CARRIER_NAME

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProvider.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.core.internal.net.info
 
+import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Context
 import android.net.ConnectivityManager
@@ -13,12 +14,15 @@ import android.net.Network
 import android.net.NetworkCapabilities
 import android.os.Build
 import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.model.NetworkInfo
 
 @TargetApi(Build.VERSION_CODES.N)
 internal class CallbackNetworkInfoProvider(
-    private val dataWriter: DataWriter<NetworkInfo>
+    private val dataWriter: DataWriter<NetworkInfo>,
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider()
 ) :
     ConnectivityManager.NetworkCallback(),
     NetworkInfoProvider {
@@ -128,8 +132,9 @@ internal class CallbackNetworkInfoProvider(
         }
     }
 
+    @SuppressLint("NewApi")
     private fun resolveStrength(networkCapabilities: NetworkCapabilities): Long? {
-        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
+        return if (buildSdkVersionProvider.version() >= Build.VERSION_CODES.Q &&
             networkCapabilities.signalStrength != NetworkCapabilities.SIGNAL_STRENGTH_UNSPECIFIED
         ) {
             networkCapabilities.signalStrength.toLong()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.core.internal.system
 
+import android.annotation.SuppressLint
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
@@ -15,7 +16,9 @@ import android.os.PowerManager
 import com.datadog.android.core.internal.receiver.ThreadSafeReceiver
 import com.datadog.android.core.internal.utils.sdkLogger
 
-internal class BroadcastReceiverSystemInfoProvider :
+internal class BroadcastReceiverSystemInfoProvider(
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider()
+) :
     ThreadSafeReceiver(), SystemInfoProvider {
 
     private var systemInfo: SystemInfo = SystemInfo()
@@ -40,9 +43,10 @@ internal class BroadcastReceiverSystemInfoProvider :
 
     // region SystemInfoProvider
 
+    @SuppressLint("InlinedApi")
     override fun register(context: Context) {
         registerIntentFilter(context, Intent.ACTION_BATTERY_CHANGED)
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (buildSdkVersionProvider.version() >= Build.VERSION_CODES.LOLLIPOP) {
             registerIntentFilter(context, PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
         }
     }
@@ -81,8 +85,9 @@ internal class BroadcastReceiverSystemInfoProvider :
         )
     }
 
+    @SuppressLint("NewApi")
     private fun handlePowerSaveIntent(context: Context) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (buildSdkVersionProvider.version() >= Build.VERSION_CODES.LOLLIPOP) {
             val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
             val powerSaveMode = powerManager?.isPowerSaveMode ?: false
             systemInfo = systemInfo.copy(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BuildSdkVersionProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BuildSdkVersionProvider.kt
@@ -1,0 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.system
+
+internal interface BuildSdkVersionProvider {
+    fun version(): Int
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/DefaultBuildSdkVersionProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/DefaultBuildSdkVersionProvider.kt
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.system
+
+import android.os.Build
+
+internal class DefaultBuildSdkVersionProvider : BuildSdkVersionProvider {
+    override fun version(): Int = Build.VERSION.SDK_INT
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
+import android.annotation.SuppressLint
 import android.app.Activity
 import android.content.Context
 import android.os.Build
@@ -14,6 +15,8 @@ import androidx.fragment.app.Fragment
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.loggableStackTrace
@@ -47,7 +50,8 @@ internal open class RumViewScope(
     internal val cpuVitalMonitor: VitalMonitor,
     internal val memoryVitalMonitor: VitalMonitor,
     internal val frameRateVitalMonitor: VitalMonitor,
-    internal val timeProvider: TimeProvider
+    internal val timeProvider: TimeProvider,
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider()
 ) : RumScope {
 
     internal val url = key.resolveViewUrl().replace('.', '/')
@@ -644,6 +648,7 @@ internal open class RumViewScope(
      * - it requires a context with a UI (we can't get this from the application context);
      * - it can change between different activities (based on window configuration)
      */
+    @SuppressLint("NewApi")
     @Suppress("DEPRECATION")
     private fun detectRefreshRateScale(key: Any) {
         val activity = when (key) {
@@ -653,7 +658,7 @@ internal open class RumViewScope(
             else -> null
         } ?: return
 
-        val display = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+        val display = if (buildSdkVersionProvider.version() >= Build.VERSION_CODES.R) {
             activity.display
         } else {
             (activity.getSystemService(Context.WINDOW_SERVICE) as? WindowManager)?.defaultDisplay

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/OreoFragmentLifecycleCallbacks.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/OreoFragmentLifecycleCallbacks.kt
@@ -10,6 +10,8 @@ import android.content.Context
 import android.os.Build
 import android.os.Bundle
 import androidx.annotation.RequiresApi
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
 import com.datadog.android.core.internal.utils.resolveViewName
 import com.datadog.android.core.internal.utils.runIfValid
 import com.datadog.android.rum.RumMonitor
@@ -25,19 +27,20 @@ internal class OreoFragmentLifecycleCallbacks(
     private val componentPredicate: ComponentPredicate<Fragment>,
     private val viewLoadingTimer: ViewLoadingTimer = ViewLoadingTimer(),
     private val rumMonitor: RumMonitor,
-    private val advancedRumMonitor: AdvancedRumMonitor
+    private val advancedRumMonitor: AdvancedRumMonitor,
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider()
 ) : FragmentLifecycleCallbacks<Activity>, FragmentManager.FragmentLifecycleCallbacks() {
 
     // region FragmentLifecycleCallbacks
 
     override fun register(activity: Activity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (buildSdkVersionProvider.version() >= Build.VERSION_CODES.O) {
             activity.fragmentManager.registerFragmentLifecycleCallbacks(this, true)
         }
     }
 
     override fun unregister(activity: Activity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        if (buildSdkVersionProvider.version() >= Build.VERSION_CODES.O) {
             activity.fragmentManager.unregisterFragmentLifecycleCallbacks(this)
         }
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -57,6 +57,8 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -218,10 +220,10 @@ internal class DatadogTest {
         assertThat(CoreFeature.trackingConsentProvider.getConsent()).isEqualTo(fakeConsent)
     }
 
-    @Test
-    fun `M update the ConsentProvider W setConsent`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(TrackingConsent::class)
+    fun `M update the ConsentProvider W setConsent`(fakeConsent: TrackingConsent) {
         // GIVEN
-        val fakeConsent = forge.aValueFrom(TrackingConsent::class.java)
         val mockedConsentProvider: ConsentProvider = mock()
         CoreFeature.trackingConsentProvider = mockedConsentProvider
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -33,7 +33,6 @@ import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.invokeMethod
@@ -67,7 +66,6 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -22,12 +22,10 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
-import com.nhaarman.mockitokotlin2.capture
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
@@ -57,7 +55,6 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/privacy/TrackingConsentProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/privacy/TrackingConsentProviderTest.kt
@@ -26,6 +26,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -54,11 +56,9 @@ internal class TrackingConsentProviderTest {
         assertThat(testedConsentProvider.getConsent()).isEqualTo(TrackingConsent.PENDING)
     }
 
-    @Test
-    fun `M update last consent W required`(forge: Forge) {
-        // GIVEN
-        val fakeConsent = forge.aValueFrom(TrackingConsent::class.java)
-
+    @ParameterizedTest
+    @EnumSource(TrackingConsent::class)
+    fun `M update last consent W required`(fakeConsent: TrackingConsent) {
         // WHEN
         testedConsentProvider.setConsent(fakeConsent)
 
@@ -66,11 +66,10 @@ internal class TrackingConsentProviderTest {
         assertThat(testedConsentProvider.getConsent()).isEqualTo(fakeConsent)
     }
 
-    @Test
-    fun `M notify callbacks W updating consent`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(TrackingConsent::class, names = ["PENDING"], mode = EnumSource.Mode.EXCLUDE)
+    fun `M notify callbacks W updating consent`(fakeConsent: TrackingConsent) {
         // GIVEN
-        val fakeConsent =
-            forge.aValueFrom(TrackingConsent::class.java, listOf(TrackingConsent.PENDING))
         testedConsentProvider.registerCallback(mockedCallback)
 
         // WHEN
@@ -81,11 +80,10 @@ internal class TrackingConsentProviderTest {
         verifyNoMoreInteractions(mockedCallback)
     }
 
-    @Test
-    fun `M not notify callbacks W updating consent with same value`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(TrackingConsent::class, names = ["PENDING"], mode = EnumSource.Mode.EXCLUDE)
+    fun `M not notify callbacks W updating consent with same value`(fakeConsent: TrackingConsent) {
         // GIVEN
-        val fakeConsent =
-            forge.aValueFrom(TrackingConsent::class.java, listOf(TrackingConsent.PENDING))
         testedConsentProvider.registerCallback(mockedCallback)
         testedConsentProvider.setConsent(fakeConsent)
 
@@ -97,11 +95,10 @@ internal class TrackingConsentProviderTest {
         verifyNoMoreInteractions(mockedCallback)
     }
 
-    @Test
-    fun `M unregister all callbacks W requested`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(TrackingConsent::class, names = ["PENDING"], mode = EnumSource.Mode.EXCLUDE)
+    fun `M unregister all callbacks W requested`(fakeConsent: TrackingConsent) {
         // GIVEN
-        val fakeConsent =
-            forge.aValueFrom(TrackingConsent::class.java, listOf(TrackingConsent.PENDING))
         val anotherMockedCallback: TrackingConsentProviderCallback = mock()
         testedConsentProvider.registerCallback(anotherMockedCallback)
         testedConsentProvider.registerCallback(mockedCallback)
@@ -115,13 +112,10 @@ internal class TrackingConsentProviderTest {
         verifyZeroInteractions(anotherMockedCallback)
     }
 
-    @Test
-    fun `M unregister first W called asynchronously`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(TrackingConsent::class, names = ["PENDING"], mode = EnumSource.Mode.EXCLUDE)
+    fun `M unregister first W called asynchronously`(fakeConsent: TrackingConsent) {
         // GIVEN
-        val fakeConsent = forge.aValueFrom(
-            TrackingConsent::class.java,
-            listOf(TrackingConsent.PENDING)
-        )
         testedConsentProvider.registerCallback(mockedCallback)
         val countDownLatch = CountDownLatch(2)
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -48,6 +48,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -178,18 +180,15 @@ internal class UploadWorkerTest {
             .isEqualTo(ListenableWorker.Result.success())
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(UploadStatus::class, names = ["SUCCESS"], mode = EnumSource.Mode.EXCLUDE)
     fun `𝕄 send and keep batches 𝕎 doWork() {single batch per feature with error}`(
+        status: UploadStatus,
         @Forgery logsBatch: Batch,
         @Forgery tracesBatch: Batch,
         @Forgery rumBatch: Batch,
-        @Forgery crashReportsBatch: Batch,
-        forge: Forge
+        @Forgery crashReportsBatch: Batch
     ) {
-        val status = forge.aValueFrom(
-            UploadStatus::class.java,
-            exclude = listOf(UploadStatus.SUCCESS)
-        )
         whenever(mockLogsReader.lockAndReadNext()).doReturn(logsBatch, null)
         whenever(mockLogsUploader.upload(logsBatch.data)) doReturn status
         whenever(mockTracesReader.lockAndReadNext()).doReturn(tracesBatch, null)
@@ -326,13 +325,13 @@ internal class UploadWorkerTest {
             .isEqualTo(ListenableWorker.Result.success())
     }
 
-    @Test
-    fun `𝕄 send batches 𝕎 doWork() {multiple Log batches, first fails}`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(UploadStatus::class, names = ["SUCCESS"], mode = EnumSource.Mode.EXCLUDE)
+    fun `𝕄 send batches 𝕎 doWork() {multiple Log batches, first fails}`(
+        status: UploadStatus,
+        forge: Forge
+    ) {
         val batches = forge.aBatchList()
-        val status = forge.aValueFrom(
-            UploadStatus::class.java,
-            exclude = listOf(UploadStatus.SUCCESS)
-        )
         val firstBatch = batches.first()
         val otherBatchesThenNull = Array(batches.size) {
             batches.getOrNull(it + 1)
@@ -362,13 +361,13 @@ internal class UploadWorkerTest {
             .isEqualTo(ListenableWorker.Result.success())
     }
 
-    @Test
-    fun `𝕄 send batches 𝕎 doWork() {multiple Trace batches, first fails}`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(UploadStatus::class, names = ["SUCCESS"], mode = EnumSource.Mode.EXCLUDE)
+    fun `𝕄 send batches 𝕎 doWork() {multiple Trace batches, first fails}`(
+        status: UploadStatus,
+        forge: Forge
+    ) {
         val batches = forge.aBatchList()
-        val status = forge.aValueFrom(
-            UploadStatus::class.java,
-            exclude = listOf(UploadStatus.SUCCESS)
-        )
         val firstBatch = batches.first()
         val otherBatchesThenNull = Array(batches.size) {
             batches.getOrNull(it + 1)
@@ -398,13 +397,13 @@ internal class UploadWorkerTest {
             .isEqualTo(ListenableWorker.Result.success())
     }
 
-    @Test
-    fun `𝕄 send batches 𝕎 doWork() {multiple Rum batches, first fails}`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(UploadStatus::class, names = ["SUCCESS"], mode = EnumSource.Mode.EXCLUDE)
+    fun `𝕄 send batches 𝕎 doWork() {multiple Rum batches, first fails}`(
+        status: UploadStatus,
+        forge: Forge
+    ) {
         val batches = forge.aBatchList()
-        val status = forge.aValueFrom(
-            UploadStatus::class.java,
-            exclude = listOf(UploadStatus.SUCCESS)
-        )
         val firstBatch = batches.first()
         val otherBatchesThenNull = Array(batches.size) {
             batches.getOrNull(it + 1)
@@ -434,13 +433,13 @@ internal class UploadWorkerTest {
             .isEqualTo(ListenableWorker.Result.success())
     }
 
-    @Test
-    fun `𝕄 send batches 𝕎 doWork() {multiple Crash batches, first fails}`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(UploadStatus::class, names = ["SUCCESS"], mode = EnumSource.Mode.EXCLUDE)
+    fun `𝕄 send batches 𝕎 doWork() {multiple Crash batches, first fails}`(
+        status: UploadStatus,
+        forge: Forge
+    ) {
         val batches = forge.aBatchList()
-        val status = forge.aValueFrom(
-            UploadStatus::class.java,
-            exclude = listOf(UploadStatus.SUCCESS)
-        )
         val firstBatch = batches.first()
         val otherBatchesThenNull = Array(batches.size) {
             batches.getOrNull(it + 1)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProviderTest.kt
@@ -15,11 +15,10 @@ import android.net.NetworkInfo as AndroidNetworkInfo
 import android.os.Build
 import android.telephony.TelephonyManager
 import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.log.assertj.NetworkInfoAssert.Companion.assertThat
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.tools.unit.annotations.TestTargetApi
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
@@ -44,8 +43,7 @@ import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class)
+    ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
@@ -72,6 +70,9 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
     @Mock
     lateinit var mockIntent: Intent
 
+    @Mock
+    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+
     @BeforeEach
     fun `set up`() {
         whenever(mockContext.getSystemService(Context.CONNECTIVITY_SERVICE))
@@ -79,8 +80,12 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
         whenever(mockContext.getSystemService(Context.TELEPHONY_SERVICE))
             .doReturn(mockTelephonyManager)
         whenever(mockConnectivityManager.activeNetworkInfo) doReturn mockNetworkInfo
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.BASE
 
-        testedProvider = BroadcastReceiverNetworkInfoProvider(mockWriter)
+        testedProvider = BroadcastReceiverNetworkInfoProvider(
+            mockWriter,
+            mockBuildSdkVersionProvider
+        )
     }
 
     @Test
@@ -234,20 +239,24 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
 
     @ParameterizedTest
     @MethodSource("2gSubtypeToMobileTypes")
-    @TestTargetApi(Build.VERSION_CODES.P)
     fun `connected to mobile 2G API 28+`(
         subtype: NetworkType,
         mobileType: MobileType,
         forge: Forge
     ) {
+        // GIVEN
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.P
+
         val carrierName = forge.anAlphabeticalString()
         val carrierId = forge.aPositiveInt(strict = true)
         stubNetworkInfo(mobileType.id, subtype.id)
         stubTelephonyManager(carrierName, carrierId)
         testedProvider.onReceive(mockContext, mockIntent)
 
+        // WHEN
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
+        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_2G)
             .hasCarrierName(carrierName)
@@ -275,20 +284,24 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
 
     @ParameterizedTest
     @MethodSource("3gSubtypeToMobileTypes")
-    @TestTargetApi(Build.VERSION_CODES.P)
     fun `connected to mobile 3G API 28+`(
         subtype: NetworkType,
         mobileType: MobileType,
         forge: Forge
     ) {
+        // GIVEN
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.P
+
         val carrierName = forge.anAlphabeticalString()
         val carrierId = forge.aPositiveInt(strict = true)
         stubNetworkInfo(mobileType.id, subtype.id)
         stubTelephonyManager(carrierName, carrierId)
         testedProvider.onReceive(mockContext, mockIntent)
 
+        // WHEN
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
+        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_3G)
             .hasCarrierName(carrierName)
@@ -316,20 +329,24 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
 
     @ParameterizedTest
     @MethodSource("4gSubtypeToMobileTypes")
-    @TestTargetApi(Build.VERSION_CODES.P)
     fun `connected to mobile 4G API 28+`(
         subtype: NetworkType,
         mobileType: MobileType,
         forge: Forge
     ) {
+        // GIVEN
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.P
+
         val carrierName = forge.anAlphabeticalString()
         val carrierId = forge.aPositiveInt(strict = true)
         stubNetworkInfo(mobileType.id, subtype.id)
         stubTelephonyManager(carrierName, carrierId)
         testedProvider.onReceive(mockContext, mockIntent)
 
+        // WHEN
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
+        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_4G)
             .hasCarrierName(carrierName)
@@ -357,20 +374,24 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
 
     @ParameterizedTest
     @MethodSource("5gSubtypeToMobileTypes")
-    @TestTargetApi(Build.VERSION_CODES.P)
     fun `connected to mobile 5G API 28+`(
         subtype: NetworkType,
         mobileType: MobileType,
         forge: Forge
     ) {
+        // GIVEN
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.P
+
         val carrierName = forge.anAlphabeticalString()
         val carrierId = forge.aPositiveInt(strict = true)
         stubNetworkInfo(mobileType.id, subtype.id)
         stubTelephonyManager(carrierName, carrierId)
         testedProvider.onReceive(mockContext, mockIntent)
 
+        // WHEN
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
+        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_5G)
             .hasCarrierName(carrierName)
@@ -399,8 +420,10 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
 
     @ParameterizedTest
     @MethodSource("getKnownMobileTypes")
-    @TestTargetApi(Build.VERSION_CODES.P)
     fun `connected to mobile unknown API 28+`(mobileType: MobileType, forge: Forge) {
+        // GIVEN
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.P
+
         val subtype = forge.anInt(min = 32)
         val carrierName = forge.anAlphabeticalString()
         val carrierId = forge.aPositiveInt(strict = true)
@@ -408,8 +431,10 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
         stubTelephonyManager(carrierName, carrierId)
         testedProvider.onReceive(mockContext, mockIntent)
 
+        // WHEN
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
+        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_MOBILE_OTHER)
             .hasCarrierName(carrierName)
@@ -419,8 +444,10 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
 
     @ParameterizedTest
     @MethodSource("getKnownMobileTypes")
-    @TestTargetApi(Build.VERSION_CODES.P)
     fun `connected to mobile unknown carrier`(mobileType: MobileType) {
+        // GIVEN
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.P
+
         stubNetworkInfo(
             mobileType.id,
             TelephonyManager.NETWORK_TYPE_UNKNOWN
@@ -428,8 +455,10 @@ internal class BroadcastReceiverNetworkInfoProviderTest {
         stubTelephonyManager(null, 0)
         testedProvider.onReceive(mockContext, mockIntent)
 
+        // WHEN
         val networkInfo = testedProvider.getLatestNetworkInfo()
 
+        // THEN
         assertThat(networkInfo)
             .hasConnectivity(NetworkInfo.Connectivity.NETWORK_MOBILE_OTHER)
             .hasCarrierName("Unknown Carrier Name")

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
@@ -12,7 +12,6 @@ import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -40,8 +39,7 @@ import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class)
+    ExtendWith(ForgeExtension::class)
 )
 @ForgeConfiguration(Configurator::class)
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategyTest.kt
@@ -14,7 +14,6 @@ import com.datadog.android.core.internal.persistence.file.advanced.ScheduledWrit
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.whenever
@@ -34,8 +33,7 @@ import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class)
+    ExtendWith(ForgeExtension::class)
 )
 @ForgeConfiguration(Configurator::class)
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/RuntimeUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/RuntimeUtilsTest.kt
@@ -19,7 +19,6 @@ import com.datadog.android.monitoring.internal.InternalLogsFeature
 import com.datadog.android.utils.extension.EnableLogcat
 import com.datadog.android.utils.extension.EnableLogcatExtension
 import com.datadog.android.utils.mockDevLogHandler
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.setFieldValue
 import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -37,8 +36,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(EnableLogcatExtension::class),
-    ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class)
+    ExtendWith(ForgeExtension::class)
 )
 class RuntimeUtilsTest {
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -12,7 +12,6 @@ import com.datadog.android.core.internal.SdkFeatureTest
 import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.nhaarman.mockitokotlin2.mock
 import fr.xgouchet.elmyr.Forge
@@ -31,7 +30,6 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -41,7 +41,6 @@ import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.invokeMethod
@@ -84,7 +83,6 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -18,7 +18,6 @@ import com.datadog.android.log.internal.domain.event.LogEventMapperWrapper
 import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.getFieldValue
 import fr.xgouchet.elmyr.Forge
@@ -35,7 +34,6 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -60,6 +60,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -266,12 +268,12 @@ internal class DatadogLogHandlerTest {
         verifyZeroInteractions(rumMonitor.mockInstance)
     }
 
-    @Test
-    fun `forward error log to RumMonitor`(forge: Forge) {
-        fakeLevel = forge.anElementFrom(AndroidLog.ERROR, AndroidLog.ASSERT)
+    @ParameterizedTest
+    @ValueSource(ints = [AndroidLog.ERROR, AndroidLog.ASSERT])
+    fun `forward error log to RumMonitor`(logLevel: Int) {
 
         testedHandler.handleLog(
-            fakeLevel,
+            logLevel,
             fakeMessage,
             null,
             fakeAttributes,
@@ -286,12 +288,12 @@ internal class DatadogLogHandlerTest {
         )
     }
 
-    @Test
-    fun `forward error log to RumMonitor with throwable`(forge: Forge) {
-        fakeLevel = forge.anElementFrom(AndroidLog.ERROR, AndroidLog.ASSERT)
+    @ParameterizedTest
+    @ValueSource(ints = [AndroidLog.ERROR, AndroidLog.ASSERT])
+    fun `forward error log to RumMonitor with throwable`(logLevel: Int) {
 
         testedHandler.handleLog(
-            fakeLevel,
+            logLevel,
             fakeMessage,
             fakeThrowable,
             fakeAttributes,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/monitoring/internal/InternalLogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/monitoring/internal/InternalLogsFeatureTest.kt
@@ -13,7 +13,6 @@ import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -29,7 +28,6 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -22,7 +22,6 @@ import com.datadog.android.rum.tracking.NoOpViewTrackingStrategy
 import com.datadog.android.rum.tracking.TrackingStrategy
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -42,7 +41,6 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -16,7 +16,6 @@ import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.assertj.JsonObjectAssert.Companion.assertThat
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.google.gson.JsonParser
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -36,8 +35,7 @@ import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class)
+    ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimingsKtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimingsKtTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.rum.internal.domain.scope
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.utils.asTimingsPayload
 import com.datadog.android.utils.forge.Configurator
-import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -17,6 +16,8 @@ import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
 
 @Extensions(
     ExtendWith(ForgeExtension::class)
@@ -50,15 +51,16 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["ssl", "firstByte", "download", "connect", "dns"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { some timing is missing }`(
-        @Forgery timing: ResourceTiming,
-        forge: Forge
+        missingTiming: String,
+        @Forgery timing: ResourceTiming
     ) {
 
         // Given
         val timingsPayload = timing.asTimingsPayload()
-        timingsPayload.remove(forge.anElementFrom("ssl", "firstByte", "download", "connect", "dns"))
+        timingsPayload.remove(missingTiming)
 
         // When
         val timings = extractResourceTiming(timingsPayload)
@@ -80,10 +82,11 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["startTime", "duration"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { ssl timing info is incomplete }`(
-        @Forgery reference: ResourceTiming,
-        forge: Forge
+        timingPartToRemove: String,
+        @Forgery reference: ResourceTiming
     ) {
 
         // Given
@@ -94,7 +97,7 @@ internal class ExternalResourceTimingsKtTest {
         @Suppress("UNCHECKED_CAST")
         val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
 
-        timing.remove(forge.anElementFrom("startTime", "duration"))
+        timing.remove(timingPartToRemove)
 
         // When
         val timings = extractResourceTiming(timingsPayload)
@@ -120,10 +123,11 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["startTime", "duration"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { connect timing info is incomplete }`(
-        @Forgery reference: ResourceTiming,
-        forge: Forge
+        timingPartToRemove: String,
+        @Forgery reference: ResourceTiming
     ) {
 
         // Given
@@ -134,7 +138,7 @@ internal class ExternalResourceTimingsKtTest {
         @Suppress("UNCHECKED_CAST")
         val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
 
-        timing.remove(forge.anElementFrom("startTime", "duration"))
+        timing.remove(timingPartToRemove)
 
         // When
         val timings = extractResourceTiming(timingsPayload)
@@ -161,10 +165,11 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["startTime", "duration"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { download timing info is incomplete }`(
-        @Forgery reference: ResourceTiming,
-        forge: Forge
+        timingPartToRemove: String,
+        @Forgery reference: ResourceTiming
     ) {
 
         // Given
@@ -175,7 +180,7 @@ internal class ExternalResourceTimingsKtTest {
         @Suppress("UNCHECKED_CAST")
         val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
 
-        timing.remove(forge.anElementFrom("startTime", "duration"))
+        timing.remove(timingPartToRemove)
 
         // When
         val timings = extractResourceTiming(timingsPayload)
@@ -201,10 +206,11 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["startTime", "duration"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { dns timing info is incomplete }`(
-        @Forgery reference: ResourceTiming,
-        forge: Forge
+        timingPartToRemove: String,
+        @Forgery reference: ResourceTiming
     ) {
 
         // Given
@@ -215,7 +221,7 @@ internal class ExternalResourceTimingsKtTest {
         @Suppress("UNCHECKED_CAST")
         val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
 
-        timing.remove(forge.anElementFrom("startTime", "duration"))
+        timing.remove(timingPartToRemove)
 
         // When
         val timings = extractResourceTiming(timingsPayload)
@@ -241,10 +247,11 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["startTime", "duration"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { firstByte timing info is incomplete }`(
-        @Forgery reference: ResourceTiming,
-        forge: Forge
+        timingPartToRemove: String,
+        @Forgery reference: ResourceTiming
     ) {
 
         // Given
@@ -255,7 +262,7 @@ internal class ExternalResourceTimingsKtTest {
         @Suppress("UNCHECKED_CAST")
         val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
 
-        timing.remove(forge.anElementFrom("startTime", "duration"))
+        timing.remove(timingPartToRemove)
 
         // When
         val timings = extractResourceTiming(timingsPayload)
@@ -281,10 +288,11 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["startTime", "duration"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { ssl timing info with wrong structure }`(
-        @Forgery reference: ResourceTiming,
-        forge: Forge
+        timingPartWithWrongType: String,
+        @Forgery reference: ResourceTiming
     ) {
 
         // Given
@@ -294,7 +302,7 @@ internal class ExternalResourceTimingsKtTest {
 
         @Suppress("UNCHECKED_CAST")
         val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
-        timing[forge.anElementFrom("startTime", "duration")] = true
+        timing[timingPartWithWrongType] = true
 
         // When
         val timings = extractResourceTiming(timingsPayload)
@@ -320,10 +328,11 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["startTime", "duration"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { connect timing info with wrong structure }`(
-        @Forgery reference: ResourceTiming,
-        forge: Forge
+        timingPartWithWrongType: String,
+        @Forgery reference: ResourceTiming
     ) {
 
         // Given
@@ -333,7 +342,7 @@ internal class ExternalResourceTimingsKtTest {
 
         @Suppress("UNCHECKED_CAST")
         val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
-        timing[forge.anElementFrom("startTime", "duration")] = true
+        timing[timingPartWithWrongType] = true
 
         // When
         val timings = extractResourceTiming(timingsPayload)
@@ -359,10 +368,11 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["startTime", "duration"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { download timing info with wrong structure }`(
-        @Forgery reference: ResourceTiming,
-        forge: Forge
+        timingPartWithWrongType: String,
+        @Forgery reference: ResourceTiming
     ) {
 
         // Given
@@ -372,7 +382,7 @@ internal class ExternalResourceTimingsKtTest {
 
         @Suppress("UNCHECKED_CAST")
         val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
-        timing[forge.anElementFrom("startTime", "duration")] = true
+        timing[timingPartWithWrongType] = true
 
         // When
         val timings = extractResourceTiming(timingsPayload)
@@ -398,10 +408,11 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["startTime", "duration"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { dns timing info with wrong structure }`(
-        @Forgery reference: ResourceTiming,
-        forge: Forge
+        timingPartWithWrongType: String,
+        @Forgery reference: ResourceTiming
     ) {
 
         // Given
@@ -411,7 +422,7 @@ internal class ExternalResourceTimingsKtTest {
 
         @Suppress("UNCHECKED_CAST")
         val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
-        timing[forge.anElementFrom("startTime", "duration")] = true
+        timing[timingPartWithWrongType] = true
 
         // When
         val timings = extractResourceTiming(timingsPayload)
@@ -437,10 +448,11 @@ internal class ExternalResourceTimingsKtTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(strings = ["startTime", "duration"])
     fun `𝕄 create timings 𝕎 extractResourceTiming { firstByte timing info with wrong structure }`(
-        @Forgery reference: ResourceTiming,
-        forge: Forge
+        timingPartWithWrongType: String,
+        @Forgery reference: ResourceTiming
     ) {
 
         // Given
@@ -450,7 +462,7 @@ internal class ExternalResourceTimingsKtTest {
 
         @Suppress("UNCHECKED_CAST")
         val timing = timingsPayload[badTiming] as MutableMap<String, Any?>
-        timing[forge.anElementFrom("startTime", "duration")] = true
+        timing[timingPartWithWrongType] = true
 
         // When
         val timings = extractResourceTiming(timingsPayload)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -47,6 +47,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -1086,11 +1088,10 @@ internal class RumContinuousActionScopeTest {
         assertThat(result3).isNull()
     }
 
-    @Test
-    fun `𝕄 send Action 𝕎 handleEvent(StopView) {no side effect}`(
-        forge: Forge
-    ) {
-        testedScope.type = forge.aValueFrom(RumActionType::class.java, listOf(RumActionType.CUSTOM))
+    @ParameterizedTest
+    @EnumSource(RumActionType::class, names = ["CUSTOM"], mode = EnumSource.Mode.EXCLUDE)
+    fun `𝕄 send Action 𝕎 handleEvent(StopView) {no side effect}`(actionType: RumActionType) {
+        testedScope.type = actionType
 
         // Given
         testedScope.resourceCount = 0

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.NoOpDataWriter
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.core.model.UserInfo
@@ -34,8 +35,6 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
-import com.datadog.tools.unit.annotations.TestTargetApi
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.any
@@ -73,7 +72,6 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -112,6 +110,9 @@ internal class RumSessionScopeTest {
     @Mock
     lateinit var mockSessionListener: RumSessionListener
 
+    @Mock
+    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+
     lateinit var mockDevLogHandler: LogHandler
 
     @Forgery
@@ -138,6 +139,7 @@ internal class RumSessionScopeTest {
             .thenReturn(fakeNetworkInfo)
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.BASE
 
         CoreFeature.processImportance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND
 
@@ -151,6 +153,7 @@ internal class RumSessionScopeTest {
             mockFrameRateVitalMonitor,
             mockTimeProvider,
             mockSessionListener,
+            mockBuildSdkVersionProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -183,6 +186,7 @@ internal class RumSessionScopeTest {
             mockFrameRateVitalMonitor,
             mockTimeProvider,
             mockSessionListener,
+            mockBuildSdkVersionProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -282,6 +286,7 @@ internal class RumSessionScopeTest {
             mockFrameRateVitalMonitor,
             mockTimeProvider,
             mockSessionListener,
+            mockBuildSdkVersionProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -369,6 +374,7 @@ internal class RumSessionScopeTest {
             mockFrameRateVitalMonitor,
             mockTimeProvider,
             mockSessionListener,
+            mockBuildSdkVersionProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -454,17 +460,20 @@ internal class RumSessionScopeTest {
         verifyZeroInteractions(mockWriter)
     }
 
-    @TestTargetApi(Build.VERSION_CODES.KITKAT)
     @Test
     fun `M send ApplicationStarted event W applicationDisplayed`(
         @StringForgery key: String,
         @StringForgery name: String
     ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.KITKAT
         val childView: RumViewScope = mock()
         val startViewEvent = RumRawEvent.StartView(key, name, emptyMap())
 
+        // When
         testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(childView).handleEvent(capture(), same(mockWriter))
 
@@ -474,17 +483,20 @@ internal class RumSessionScopeTest {
         verifyZeroInteractions(mockWriter)
     }
 
-    @TestTargetApi(Build.VERSION_CODES.N)
     @Test
     fun `M send ApplicationStarted event W applicationDisplayed {API 24+}`(
         @StringForgery key: String,
         @StringForgery name: String
     ) {
+        // Given
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.N
         val childView: RumViewScope = mock()
         val startViewEvent = RumRawEvent.StartView(key, name, emptyMap())
 
+        // When
         testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
 
+        // Then
         argumentCaptor<RumRawEvent> {
             verify(childView).handleEvent(capture(), same(mockWriter))
 
@@ -582,6 +594,7 @@ internal class RumSessionScopeTest {
             mockFrameRateVitalMonitor,
             mockTimeProvider,
             mockSessionListener,
+            mockBuildSdkVersionProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -609,6 +622,7 @@ internal class RumSessionScopeTest {
             mockFrameRateVitalMonitor,
             mockTimeProvider,
             mockSessionListener,
+            mockBuildSdkVersionProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -761,6 +775,7 @@ internal class RumSessionScopeTest {
             mockFrameRateVitalMonitor,
             mockTimeProvider,
             mockSessionListener,
+            mockBuildSdkVersionProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )
@@ -788,6 +803,7 @@ internal class RumSessionScopeTest {
             mockFrameRateVitalMonitor,
             mockTimeProvider,
             mockSessionListener,
+            mockBuildSdkVersionProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -82,6 +82,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -1989,23 +1991,19 @@ internal class RumViewScopeTest {
             .isEqualTo((testedScope.activeActionScope as RumActionScope).actionId)
     }
 
-    @Test
+    @ParameterizedTest
+    @EnumSource(RumActionType::class, names = ["CUSTOM"], mode = EnumSource.Mode.EXCLUDE)
     fun `𝕄 do nothing + log warning 𝕎 handleEvent(StartAction+!CUSTOM)+active child ActionScope`(
+        actionType: RumActionType,
         @StringForgery name: String,
         @BoolForgery waitForStop: Boolean,
         forge: Forge
     ) {
-
-        val type = forge.aValueFrom(
-            RumActionType::class.java,
-            exclude = listOf(RumActionType.CUSTOM)
-        )
-
         // Given
         val mockDevLogHandler = mockDevLogHandler()
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         testedScope.activeActionScope = mockChildScope
-        fakeEvent = RumRawEvent.StartAction(type, name, waitForStop, attributes)
+        fakeEvent = RumRawEvent.StartAction(actionType, name, waitForStop, attributes)
         whenever(mockChildScope.handleEvent(fakeEvent, mockWriter)) doReturn mockChildScope
 
         // When
@@ -3736,11 +3734,14 @@ internal class RumViewScopeTest {
 
     // region Loading Time
 
-    @Test
-    fun `𝕄 send event 𝕎 handleEvent(UpdateViewLoadingTime) on active view`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(ViewEvent.LoadingType::class)
+    fun `𝕄 send event 𝕎 handleEvent(UpdateViewLoadingTime) on active view`(
+        loadingType: ViewEvent.LoadingType,
+        forge: Forge
+    ) {
         // Given
         val loadingTime = forge.aLong(min = 1)
-        val loadingType = forge.aValueFrom(ViewEvent.LoadingType::class.java)
 
         // When
         val result = testedScope.handleEvent(
@@ -3783,12 +3784,15 @@ internal class RumViewScopeTest {
         assertThat(result).isSameAs(testedScope)
     }
 
-    @Test
-    fun `𝕄 send event 𝕎 handleEvent(UpdateViewLoadingTime) on stopped view`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(ViewEvent.LoadingType::class)
+    fun `𝕄 send event 𝕎 handleEvent(UpdateViewLoadingTime) on stopped view`(
+        loadingType: ViewEvent.LoadingType,
+        forge: Forge
+    ) {
         // Given
         testedScope.stopped = true
         val loadingTime = forge.aLong(min = 1)
-        val loadingType = forge.aValueFrom(ViewEvent.LoadingType::class.java)
 
         // When
         val result = testedScope.handleEvent(
@@ -3831,12 +3835,15 @@ internal class RumViewScopeTest {
         assertThat(result).isNull()
     }
 
-    @Test
-    fun `𝕄 do nothing 𝕎 handleEvent(UpdateViewLoadingTime) with different key`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(ViewEvent.LoadingType::class)
+    fun `𝕄 do nothing 𝕎 handleEvent(UpdateViewLoadingTime) with different key`(
+        loadingType: ViewEvent.LoadingType,
+        forge: Forge
+    ) {
         // Given
         val differentKey = fakeKey + "different".toByteArray()
         val loadingTime = forge.aLong(min = 1)
-        val loadingType = forge.aValueFrom(ViewEvent.LoadingType::class.java)
 
         // When
         val result = testedScope.handleEvent(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -15,6 +15,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.internal.utils.resolveViewUrl
@@ -46,8 +47,6 @@ import com.datadog.android.utils.forge.aFilteredMap
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.utils.mockDevLogHandler
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
-import com.datadog.tools.unit.annotations.TestTargetApi
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.any
@@ -92,8 +91,7 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(TestConfigurationExtension::class),
-    ExtendWith(ApiLevelExtension::class)
+    ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
@@ -155,6 +153,9 @@ internal class RumViewScopeTest {
     @Mock
     lateinit var mockTimeProvider: TimeProvider
 
+    @Mock
+    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+
     @BeforeEach
     fun `set up`(forge: Forge) {
 
@@ -183,6 +184,7 @@ internal class RumViewScopeTest {
         whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
         whenever(mockActionScope.handleEvent(any(), any())) doReturn mockActionScope
         whenever(mockActionScope.actionId) doReturn fakeActionId
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.BASE
 
         testedScope = RumViewScope(
             mockParentScope,
@@ -194,7 +196,8 @@ internal class RumViewScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockTimeProvider
+            mockTimeProvider,
+            mockBuildSdkVersionProvider
         )
 
         assertThat(GlobalRum.getRumContext()).isEqualTo(testedScope.getRumContext())
@@ -4230,7 +4233,6 @@ internal class RumViewScopeTest {
         assertThat(result).isSameAs(testedScope)
     }
 
-    @TestTargetApi(Build.VERSION_CODES.R)
     @Test
     fun `𝕄 detect slow refresh rate 𝕎 init()+onVitalUpdate()+handleEvent(KeepAlive) {Activity}`(
         @FloatForgery(120.0f, 240.0f) deviceRefreshRate: Float,
@@ -4247,6 +4249,7 @@ internal class RumViewScopeTest {
         whenever(mockTimeProvider.getServerOffsetMillis())
             .thenReturn(fakeServerOffset)
             .thenReturn(fakeServerOffsetSecond)
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.R
         val testedScope = RumViewScope(
             mockParentScope,
             mockActivity,
@@ -4257,7 +4260,8 @@ internal class RumViewScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockTimeProvider
+            mockTimeProvider,
+            mockBuildSdkVersionProvider
         )
         val listenerCaptor = argumentCaptor<VitalListener> {
             verify(mockFrameRateVitalMonitor).register(capture())
@@ -4303,7 +4307,6 @@ internal class RumViewScopeTest {
         assertThat(result).isSameAs(testedScope)
     }
 
-    @TestTargetApi(Build.VERSION_CODES.R)
     @Test
     fun `𝕄 detect high refresh rate 𝕎 init()+onVitalUpdate()+handleEvent(KeepAlive) {Activity}`(
         @FloatForgery(120.0f, 240.0f) deviceRefreshRate: Float,
@@ -4320,6 +4323,7 @@ internal class RumViewScopeTest {
         whenever(mockTimeProvider.getServerOffsetMillis())
             .thenReturn(fakeServerOffset)
             .thenReturn(fakeServerOffsetSecond)
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.R
         val testedScope = RumViewScope(
             mockParentScope,
             mockActivity,
@@ -4330,7 +4334,8 @@ internal class RumViewScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockTimeProvider
+            mockTimeProvider,
+            mockBuildSdkVersionProvider
         )
         val listenerCaptor = argumentCaptor<VitalListener> {
             verify(mockFrameRateVitalMonitor).register(capture())
@@ -4376,7 +4381,6 @@ internal class RumViewScopeTest {
         assertThat(result).isSameAs(testedScope)
     }
 
-    @TestTargetApi(Build.VERSION_CODES.R)
     @Test
     fun `𝕄 detect low refresh rate 𝕎 init()+onVitalUpdate()+handleEvent(KeepAlive) {Frag X}`(
         @FloatForgery(120.0f, 240.0f) deviceRefreshRate: Float,
@@ -4395,6 +4399,7 @@ internal class RumViewScopeTest {
         whenever(mockTimeProvider.getServerOffsetMillis())
             .thenReturn(fakeServerOffset)
             .thenReturn(fakeServerOffsetSecond)
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.R
         val testedScope = RumViewScope(
             mockParentScope,
             mockFragment,
@@ -4405,7 +4410,8 @@ internal class RumViewScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockTimeProvider
+            mockTimeProvider,
+            mockBuildSdkVersionProvider
         )
         val listenerCaptor = argumentCaptor<VitalListener> {
             verify(mockFrameRateVitalMonitor).register(capture())
@@ -4451,7 +4457,6 @@ internal class RumViewScopeTest {
         assertThat(result).isSameAs(testedScope)
     }
 
-    @TestTargetApi(Build.VERSION_CODES.R)
     @Test
     fun `𝕄 detect high refresh rate 𝕎 init()+onVitalUpdate()+handleEvent(KeepAlive) {Frag X}`(
         @FloatForgery(120.0f, 240.0f) deviceRefreshRate: Float,
@@ -4470,6 +4475,7 @@ internal class RumViewScopeTest {
         whenever(mockTimeProvider.getServerOffsetMillis())
             .thenReturn(fakeServerOffset)
             .thenReturn(fakeServerOffsetSecond)
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.R
         val testedScope = RumViewScope(
             mockParentScope,
             mockFragment,
@@ -4480,7 +4486,8 @@ internal class RumViewScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockTimeProvider
+            mockTimeProvider,
+            mockBuildSdkVersionProvider
         )
         val listenerCaptor = argumentCaptor<VitalListener> {
             verify(mockFrameRateVitalMonitor).register(capture())
@@ -4527,7 +4534,6 @@ internal class RumViewScopeTest {
     }
 
     @Suppress("DEPRECATION")
-    @TestTargetApi(Build.VERSION_CODES.R)
     @Test
     fun `𝕄 detect low refresh rate 𝕎 init()+onVitalUpdate()+handleEvent(KeepAlive) {Fragment}`(
         @FloatForgery(120.0f, 240.0f) deviceRefreshRate: Float,
@@ -4546,6 +4552,7 @@ internal class RumViewScopeTest {
         whenever(mockTimeProvider.getServerOffsetMillis())
             .thenReturn(fakeServerOffset)
             .thenReturn(fakeServerOffsetSecond)
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.R
         val testedScope = RumViewScope(
             mockParentScope,
             mockFragment,
@@ -4556,7 +4563,8 @@ internal class RumViewScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockTimeProvider
+            mockTimeProvider,
+            mockBuildSdkVersionProvider
         )
         val listenerCaptor = argumentCaptor<VitalListener> {
             verify(mockFrameRateVitalMonitor).register(capture())
@@ -4603,7 +4611,6 @@ internal class RumViewScopeTest {
     }
 
     @Suppress("DEPRECATION")
-    @TestTargetApi(Build.VERSION_CODES.R)
     @Test
     fun `𝕄 detect high refresh rate 𝕎 init()+onVitalUpdate()+handleEvent(KeepAlive) {Fragment}`(
         @FloatForgery(120.0f, 240.0f) deviceRefreshRate: Float,
@@ -4622,6 +4629,7 @@ internal class RumViewScopeTest {
         whenever(mockTimeProvider.getServerOffsetMillis())
             .thenReturn(fakeServerOffset)
             .thenReturn(fakeServerOffsetSecond)
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.R
         val testedScope = RumViewScope(
             mockParentScope,
             mockFragment,
@@ -4632,7 +4640,8 @@ internal class RumViewScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockTimeProvider
+            mockTimeProvider,
+            mockBuildSdkVersionProvider
         )
         val listenerCaptor = argumentCaptor<VitalListener> {
             verify(mockFrameRateVitalMonitor).register(capture())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerScrollSwipeTest.kt
@@ -35,11 +35,16 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.lang.ref.WeakReference
+import java.util.stream.Stream
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
@@ -63,8 +68,19 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
 
     // region Tests
 
-    @Test
-    fun `it will send an scroll rum event if fling not detected`(forge: Forge) {
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            GesturesListener.SCROLL_DIRECTION_DOWN,
+            GesturesListener.SCROLL_DIRECTION_UP,
+            GesturesListener.SCROLL_DIRECTION_LEFT,
+            GesturesListener.SCROLL_DIRECTION_RIGHT
+        ]
+    )
+    fun `it will send an scroll rum event if fling not detected`(
+        expectedDirection: String,
+        forge: Forge
+    ) {
         val startDownEvent: MotionEvent = forge.getForgery()
         val listSize = forge.anInt(1, 20)
         val intermediaryEvents =
@@ -73,12 +89,6 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         val distancesY = forge.aList(listSize) { forge.aFloat() }
         val targetId = forge.anInt()
         val endUpEvent = intermediaryEvents[intermediaryEvents.size - 1]
-        val expectedDirection = forge.anElementFrom(
-            GesturesListener.SCROLL_DIRECTION_DOWN,
-            GesturesListener.SCROLL_DIRECTION_UP,
-            GesturesListener.SCROLL_DIRECTION_LEFT,
-            GesturesListener.SCROLL_DIRECTION_RIGHT
-        )
         stubStopMotionEvent(endUpEvent, startDownEvent, expectedDirection)
 
         val scrollingTarget: ScrollableView = mockView(
@@ -129,8 +139,19 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         verifyNoMoreInteractions(rumMonitor.mockInstance)
     }
 
-    @Test
-    fun `it will send a scroll rum event if target is a ListView`(forge: Forge) {
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            GesturesListener.SCROLL_DIRECTION_DOWN,
+            GesturesListener.SCROLL_DIRECTION_UP,
+            GesturesListener.SCROLL_DIRECTION_LEFT,
+            GesturesListener.SCROLL_DIRECTION_RIGHT
+        ]
+    )
+    fun `it will send a scroll rum event if target is a ListView`(
+        expectedDirection: String,
+        forge: Forge
+    ) {
         val startDownEvent: MotionEvent = forge.getForgery()
         val listSize = forge.anInt(1, 20)
         val intermediaryEvents =
@@ -139,12 +160,6 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         val distancesY = forge.aList(listSize) { forge.aFloat() }
         val targetId = forge.anInt()
         val endUpEvent = intermediaryEvents[intermediaryEvents.size - 1]
-        val expectedDirection = forge.anElementFrom(
-            GesturesListener.SCROLL_DIRECTION_DOWN,
-            GesturesListener.SCROLL_DIRECTION_UP,
-            GesturesListener.SCROLL_DIRECTION_LEFT,
-            GesturesListener.SCROLL_DIRECTION_RIGHT
-        )
         stubStopMotionEvent(endUpEvent, startDownEvent, expectedDirection)
 
         val scrollingTarget: ScrollableListView = mockView(
@@ -195,8 +210,13 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         verifyNoMoreInteractions(rumMonitor.mockInstance)
     }
 
-    @Test
-    fun `it will reset the scroll data between 2 consecutive gestures`(forge: Forge) {
+    @ParameterizedTest
+    @MethodSource("twoDirections")
+    fun `it will reset the scroll data between 2 consecutive gestures`(
+        expectedDirection1: String,
+        expectedDirection2: String,
+        forge: Forge
+    ) {
         val startDownEvent: MotionEvent = forge.getForgery()
         val listSize = forge.anInt(1, 20)
         val intermediaryEvents =
@@ -205,18 +225,7 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         val distancesY = forge.aList(listSize) { forge.aFloat() }
         val targetId = forge.anInt()
         val endUpEvent = intermediaryEvents[intermediaryEvents.size - 1]
-        val expectedDirection1 = forge.anElementFrom(
-            GesturesListener.SCROLL_DIRECTION_DOWN,
-            GesturesListener.SCROLL_DIRECTION_UP,
-            GesturesListener.SCROLL_DIRECTION_LEFT,
-            GesturesListener.SCROLL_DIRECTION_RIGHT
-        )
-        val expectedDirection2 = forge.anElementFrom(
-            GesturesListener.SCROLL_DIRECTION_DOWN,
-            GesturesListener.SCROLL_DIRECTION_UP,
-            GesturesListener.SCROLL_DIRECTION_LEFT,
-            GesturesListener.SCROLL_DIRECTION_RIGHT
-        )
+
         val scrollingTarget: ScrollableListView = mockView(
             id = targetId,
             forEvent = startDownEvent,
@@ -374,19 +383,21 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         verifyZeroInteractions(rumMonitor.mockInstance)
     }
 
-    @Test
-    fun `it will send a swipe rum event if detected`(forge: Forge) {
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            GesturesListener.SCROLL_DIRECTION_DOWN,
+            GesturesListener.SCROLL_DIRECTION_UP,
+            GesturesListener.SCROLL_DIRECTION_LEFT,
+            GesturesListener.SCROLL_DIRECTION_RIGHT
+        ]
+    )
+    fun `it will send a swipe rum event if detected`(expectedDirection: String, forge: Forge) {
         val listSize = forge.anInt(1, 20)
         val startDownEvent: MotionEvent = forge.getForgery()
         val intermediaryEvents =
             forge.aList(size = listSize) { forge.getForgery(MotionEvent::class.java) }
         val endUpEvent = intermediaryEvents[intermediaryEvents.size - 1]
-        val expectedDirection = forge.anElementFrom(
-            GesturesListener.SCROLL_DIRECTION_DOWN,
-            GesturesListener.SCROLL_DIRECTION_UP,
-            GesturesListener.SCROLL_DIRECTION_LEFT,
-            GesturesListener.SCROLL_DIRECTION_RIGHT
-        )
         stubStopMotionEvent(endUpEvent, startDownEvent, expectedDirection)
         val distancesX = forge.aList(listSize) { forge.aFloat() }
         val distancesY = forge.aList(listSize) { forge.aFloat() }
@@ -442,8 +453,17 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         verifyNoMoreInteractions(rumMonitor.mockInstance)
     }
 
-    @Test
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            GesturesListener.SCROLL_DIRECTION_DOWN,
+            GesturesListener.SCROLL_DIRECTION_UP,
+            GesturesListener.SCROLL_DIRECTION_LEFT,
+            GesturesListener.SCROLL_DIRECTION_RIGHT
+        ]
+    )
     fun `M use the class simple name as target name W scrollDetected { canonicalName is null }`(
+        expectedDirection: String,
         forge: Forge
     ) {
         val listSize = forge.anInt(1, 20)
@@ -451,12 +471,6 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         val intermediaryEvents =
             forge.aList(size = listSize) { forge.getForgery(MotionEvent::class.java) }
         val endUpEvent = intermediaryEvents[intermediaryEvents.size - 1]
-        val expectedDirection = forge.anElementFrom(
-            GesturesListener.SCROLL_DIRECTION_DOWN,
-            GesturesListener.SCROLL_DIRECTION_UP,
-            GesturesListener.SCROLL_DIRECTION_LEFT,
-            GesturesListener.SCROLL_DIRECTION_RIGHT
-        )
         stubStopMotionEvent(endUpEvent, startDownEvent, expectedDirection)
         val distancesX = forge.aList(listSize) { forge.aFloat() }
         val distancesY = forge.aList(listSize) { forge.aFloat() }
@@ -686,25 +700,19 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
         verifyNoMoreInteractions(rumMonitor.mockInstance)
     }
 
-    @Test
-    fun `it will reset the swipe data between 2 consecutive gestures`(forge: Forge) {
+    @ParameterizedTest
+    @MethodSource("twoDirections")
+    fun `it will reset the swipe data between 2 consecutive gestures`(
+        expectedDirection1: String,
+        expectedDirection2: String,
+        forge: Forge
+    ) {
         val listSize = forge.anInt(1, 20)
         val startDownEvent: MotionEvent = forge.getForgery()
         val intermediaryEvents =
             forge.aList(size = listSize) { forge.getForgery(MotionEvent::class.java) }
         val endUpEvent = intermediaryEvents[intermediaryEvents.size - 1]
-        val expectedDirection1 = forge.anElementFrom(
-            GesturesListener.SCROLL_DIRECTION_DOWN,
-            GesturesListener.SCROLL_DIRECTION_UP,
-            GesturesListener.SCROLL_DIRECTION_LEFT,
-            GesturesListener.SCROLL_DIRECTION_RIGHT
-        )
-        val expectedDirection2 = forge.anElementFrom(
-            GesturesListener.SCROLL_DIRECTION_DOWN,
-            GesturesListener.SCROLL_DIRECTION_UP,
-            GesturesListener.SCROLL_DIRECTION_LEFT,
-            GesturesListener.SCROLL_DIRECTION_RIGHT
-        )
+
         val distancesX = forge.aList(listSize) { forge.aFloat() }
         val distancesY = forge.aList(listSize) { forge.aFloat() }
         val velocityX = forge.aFloat()
@@ -874,6 +882,24 @@ internal class GesturesListenerScrollSwipeTest : AbstractGesturesListenerTest() 
                 whenever(stopEvent.x).thenReturn((initialStartX - 2))
                 whenever(stopEvent.y).thenReturn(initialStartY)
             }
+        }
+    }
+
+    companion object {
+
+        @Suppress("unused")
+        @JvmStatic
+        fun twoDirections(): Stream<Arguments> {
+            val directions = listOf(
+                GesturesListener.SCROLL_DIRECTION_DOWN,
+                GesturesListener.SCROLL_DIRECTION_UP,
+                GesturesListener.SCROLL_DIRECTION_LEFT,
+                GesturesListener.SCROLL_DIRECTION_RIGHT
+            )
+
+            return directions.flatMap { first ->
+                directions.map { second -> Arguments.of(first, second) }
+            }.stream()
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -65,6 +65,8 @@ import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -525,11 +527,14 @@ internal class DatadogRumMonitorTest {
         verifyNoMoreInteractions(mockScope, mockWriter)
     }
 
-    @Test
-    fun `M delegate event to rootScope W updateViewLoadingTime()`(forge: Forge) {
+    @ParameterizedTest
+    @EnumSource(ViewEvent.LoadingType::class)
+    fun `M delegate event to rootScope W updateViewLoadingTime()`(
+        loadingType: ViewEvent.LoadingType,
+        forge: Forge
+    ) {
         val key = forge.anAsciiString()
         val loadingTime = forge.aLong(min = 1)
-        val loadingType = forge.aValueFrom(ViewEvent.LoadingType::class.java)
 
         testedMonitor.updateViewLoadingTime(key, loadingTime, loadingType)
         Thread.sleep(PROCESSING_DELAY)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -30,7 +30,6 @@ import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.setFieldValue
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argThat
@@ -74,8 +73,7 @@ import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class)
+    ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/tracking/OreoFragmentLifecycleCallbacksTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/tracking/OreoFragmentLifecycleCallbacksTest.kt
@@ -15,6 +15,7 @@ import android.app.Fragment
 import android.app.FragmentManager
 import android.os.Build
 import android.view.Window
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.utils.resolveViewUrl
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.internal.RumFeature
@@ -22,8 +23,6 @@ import com.datadog.android.rum.internal.instrumentation.gestures.GesturesTracker
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.tracking.ComponentPredicate
-import com.datadog.tools.unit.annotations.TestTargetApi
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
@@ -47,8 +46,7 @@ import org.mockito.quality.Strictness
 @Suppress("DEPRECATION")
 @Extensions(
     ExtendWith(ForgeExtension::class),
-    ExtendWith(MockitoExtension::class),
-    ExtendWith(ApiLevelExtension::class)
+    ExtendWith(MockitoExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 internal class OreoFragmentLifecycleCallbacksTest {
@@ -88,6 +86,9 @@ internal class OreoFragmentLifecycleCallbacksTest {
     @Mock
     lateinit var mockPredicate: ComponentPredicate<Fragment>
 
+    @Mock
+    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+
     lateinit var fakeAttributes: Map<String, Any?>
 
     @BeforeEach
@@ -97,6 +98,7 @@ internal class OreoFragmentLifecycleCallbacksTest {
 
         whenever(mockActivity.fragmentManager).thenReturn(mockFragmentManager)
         whenever(mockActivity.window).thenReturn(mockWindow)
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.BASE
 
         fakeAttributes = forge.aMap { forge.aString() to forge.aString() }
         testedLifecycleCallbacks = OreoFragmentLifecycleCallbacks(
@@ -104,7 +106,8 @@ internal class OreoFragmentLifecycleCallbacksTest {
             mockPredicate,
             viewLoadingTimer = mockViewLoadingTimer,
             rumMonitor = mockRumMonitor,
-            advancedRumMonitor = mockAdvancedRumMonitor
+            advancedRumMonitor = mockAdvancedRumMonitor,
+            buildSdkVersionProvider = mockBuildSdkVersionProvider
         )
     }
 
@@ -446,8 +449,10 @@ internal class OreoFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.O)
     fun `it will register the callback to fragment manager on O`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.O
+
         // When
         testedLifecycleCallbacks.register(mockActivity)
 
@@ -459,8 +464,10 @@ internal class OreoFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.O)
     fun `it will unregister the callback from fragment manager on O`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.O
+
         // When
         testedLifecycleCallbacks.unregister(mockActivity)
 
@@ -469,8 +476,10 @@ internal class OreoFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.M)
     fun `it will do nothing when calling register on M`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.M
+
         // When
         testedLifecycleCallbacks.register(mockActivity)
 
@@ -479,8 +488,10 @@ internal class OreoFragmentLifecycleCallbacksTest {
     }
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.M)
     fun `it will do nothing when calling unregister on M`() {
+        // Given
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.M
+
         // When
         testedLifecycleCallbacks.unregister(mockActivity)
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -26,7 +26,6 @@ import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.setFieldValue
@@ -58,7 +57,6 @@ internal typealias NavLifecycleCallbacks =
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ApiLevelExtension::class),
     ExtendWith(ForgeExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracingFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracingFeatureTest.kt
@@ -18,7 +18,6 @@ import com.datadog.android.tracing.internal.domain.event.SpanMapperSerializer
 import com.datadog.android.tracing.internal.net.TracesOkHttpUploaderV2
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.opentracing.DDSpan
-import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.getFieldValue
 import fr.xgouchet.elmyr.Forge
@@ -35,7 +34,6 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
-    ExtendWith(ApiLevelExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)


### PR DESCRIPTION
### What does this PR do?

This change switches to `ParametrizedTest` annotation instead of using `Forge#aValueFrom/anElementFrom` calls for the places where set of elements is finite and can be resolved at the compile time or in the static context to make coverage more stable.

Some calls to `aValueFrom/anElementFrom` still stay in places where complex objects are forged or if calls are made in the `setUp` context.

Also this change bumps versions of JUnit and Mockito.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

