### PR TITLE
RUMM-1732: Enable back LogcatLogHandler#resolves_nested_stack_trace_element_from_caller test

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
@@ -16,7 +16,6 @@ import java.util.Locale
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -71,21 +70,18 @@ internal class LogcatLogHandlerTest {
             .isEqualTo(javaClass.canonicalName)
     }
 
-    // TODO RUMM-1732
-    @Disabled(
-        "Check this test later. After update to Gradle 7 it seems there is some change to" +
-            " the test run mechanism, because .className returns parent enclosing class" +
-            " without any anonymous classes, and anonymous class itself is called \$lambda-0" +
-            " instead of \$1"
-    )
     @Test
     fun `resolves nested stack trace element from caller`() {
         Datadog.isDebug = true
 
         var element: StackTraceElement? = null
 
-        val runnable = Runnable {
-            element = testedHandler.getCallerStackElement()
+        // Don't convert it to lambda, because Kotlin won't create wrapper class,
+        // read more https://kotlinlang.org/docs/whatsnew15.html#sam-adapters-via-invokedynamic
+        @Suppress("ObjectLiteralToLambda") val runnable = object : Runnable {
+            override fun run() {
+                element = testedHandler.getCallerStackElement()
+            }
         }
         runnable.run()
 


### PR DESCRIPTION
### What does this PR do?

Kotlin 1.5 brought the following feature https://kotlinlang.org/docs/whatsnew15.html#sam-adapters-via-invokedynamic, which will skip wrapper class generation for SAM-compatible declarations. This made the referenced test to fail, because there is no anonymous class generated.

This change enables this test back by avoiding SAM-compatible declaration.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

