### PR TITLE
RUMM-1423: Fix flaky UploadWorkerTest setup

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -480,7 +480,7 @@ internal class UploadWorkerTest {
                 ids.add(batch.id)
             }
         }
-        return list
+        return list.distinctBy { it.data.asList() }
     }
 
     companion object {


### PR DESCRIPTION
### What does this PR do?

Mockito is using `Arrays.equal` to compare array arguments, so it is possible that test setup has 2 (or more) batches with the same content, this led to the tests failure (because non-successful upload should happen only for one batch).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

