### PR TITLE
RUMM-1915 Fix the Java code snippets in the docs

### DIFF
--- a/docs/integrated_libraries_android.md
+++ b/docs/integrated_libraries_android.md
@@ -89,7 +89,6 @@ RUM error event for it.
 {{% tab "Java" %}}
    ```java
        public class <YourOwnSqliteOpenHelper> extends SqliteOpenHelper {
-            
             public <YourOwnSqliteOpenHelper>(){
                 super(<Context>,
                       <DATABASE_NAME>,

--- a/docs/log_collection.md
+++ b/docs/log_collection.md
@@ -40,7 +40,7 @@ Send logs to Datadog from your Android applications with [Datadog's `dd-sdk-andr
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-```Java
+```java
     public class SampleApplication extends Application {
         @Override
         public void onCreate() {

--- a/docs/native_crash_collection.md
+++ b/docs/native_crash_collection.md
@@ -37,7 +37,6 @@ Java
 
 ```java
 public class SampleApplication extends Application {
-   
     @Override
     public void onCreate() {
       super.onCreate();

--- a/docs/rum_getting_started.md
+++ b/docs/rum_getting_started.md
@@ -67,21 +67,20 @@ To ensure the safety of your data, you must use a client token. You cannot use o
 {{% /tab %}}
 {{% tab "Java" %}}
 ```java
-      public class SampleApplication extends Application {
-      
-            @Override
-            public void onCreate() {
-               super.onCreate();
-               final Configuration configuration =
-                       new Configuration.Builder(true, true, true, true)
-                               .trackInteractions()
-                               .trackLongTasks(durationThreshold)
-                               .useViewTrackingStrategy(strategy)
-                               .build();
+    public class SampleApplication extends Application { 
+        @Override 
+        public void onCreate() { 
+            super.onCreate();
+            final Configuration configuration = 
+                    new Configuration.Builder(true, true, true, true)
+                            .trackInteractions()
+                            .trackLongTasks(durationThreshold)
+                            .useViewTrackingStrategy(strategy)
+                            .build();
                final Credentials credentials = new Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>);
-               Datadog.initialize(this, credentials, configuration, trackingConsent);
-            }
-      }
+               Datadog.initialize(this, credentials, configuration, trackingConsent); 
+        }
+    }
 ```
 {{% /tab %}}
 {{< /tabs >}}
@@ -112,24 +111,23 @@ To ensure the safety of your data, you must use a client token. You cannot use o
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-   ```java
-      public class SampleApplication extends Application {
-      
-            @Override
-            public void onCreate() {
-               super.onCreate();
-               final Configuration configuration =
-                       new Configuration.Builder(true, true, true, true)
-                               .trackInteractions()
-                               .trackLongTasks(durationThreshold)
-                               .useViewTrackingStrategy(strategy)
-                               .useSite(DatadogSite.EU1)
-                               .build();
-               Credentials credentials = new Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>);
-               Datadog.initialize(this, credentials, configuration, trackingConsent);
-            }
-      }
-   ```
+```java
+    public class SampleApplication extends Application { 
+        @Override 
+        public void onCreate() { 
+            super.onCreate();
+            final Configuration configuration = 
+                    new Configuration.Builder(true, true, true, true)
+                            .trackInteractions()
+                            .trackLongTasks(durationThreshold)
+                            .useViewTrackingStrategy(strategy)
+                            .useSite(DatadogSite.EU1)
+                            .build();
+            Credentials credentials = new Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>);
+            Datadog.initialize(this, credentials, configuration, trackingConsent); 
+        }
+    }
+```
 {{% /tab %}}
 {{< /tabs >}}
 {{< /site-region >}}
@@ -159,24 +157,23 @@ To ensure the safety of your data, you must use a client token. You cannot use o
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-   ```java
-      public class SampleApplication extends Application {
-
-            @Override
-            public void onCreate() {
-               super.onCreate();
-               final Configuration configuration =
-                       new Configuration.Builder(true, true, true, true)
-                               .trackInteractions()
-                               .trackLongTasks(durationThreshold)
-                               .useViewTrackingStrategy(strategy)
-                               .useSite(DatadogSite.US3)
-                               .build();
-               Credentials credentials = new Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>);
-               Datadog.initialize(this, credentials, configuration, trackingConsent);
-            }
-      }
-   ```
+```java
+    public class SampleApplication extends Application { 
+        @Override 
+        public void onCreate() { 
+            super.onCreate();
+            final Configuration configuration = 
+                    new Configuration.Builder(true, true, true, true)
+                            .trackInteractions()
+                            .trackLongTasks(durationThreshold)
+                            .useViewTrackingStrategy(strategy)
+                            .useSite(DatadogSite.US3)
+                            .build();
+            Credentials credentials = new Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>);
+            Datadog.initialize(this, credentials, configuration, trackingConsent); 
+        }
+    }
+```
 {{% /tab %}}
 {{< /tabs >}}
 {{< /site-region >}}
@@ -206,24 +203,23 @@ To ensure the safety of your data, you must use a client token. You cannot use o
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-   ```java
-      public class SampleApplication extends Application {
-
-            @Override
-            public void onCreate() {
-               super.onCreate();
-               final Configuration configuration =
-                       new Configuration.Builder(true, true, true, true)
-                               .trackInteractions()
-                               .trackLongTasks(durationThreshold)
-                               .useViewTrackingStrategy(strategy)
-                               .useSite(DatadogSite.US5)
-                               .build();
-               Credentials credentials = new Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>);
-               Datadog.initialize(this, credentials, configuration, trackingConsent);
-            }
-      }
-   ```
+```java
+    public class SampleApplication extends Application { 
+        @Override 
+        public void onCreate() { 
+            super.onCreate();
+            final Configuration configuration = 
+                    new Configuration.Builder(true, true, true, true)
+                            .trackInteractions()
+                            .trackLongTasks(durationThreshold)
+                            .useViewTrackingStrategy(strategy)
+                            .useSite(DatadogSite.US5)
+                            .build();
+            Credentials credentials = new Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>);
+            Datadog.initialize(this, credentials, configuration, trackingConsent); 
+        }
+    }
+```
 {{% /tab %}}
 {{< /tabs >}}
 {{< /site-region >}}
@@ -253,24 +249,23 @@ To ensure the safety of your data, you must use a client token. You cannot use o
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
-   ```java
-      public class SampleApplication extends Application {
-
-            @Override
-            public void onCreate() {
-               super.onCreate();
-               final Configuration configuration =
-                       new Configuration.Builder(true, true, true, true)
-                               .trackInteractions()
-                               .trackLongTasks(durationThreshold)
-                               .useViewTrackingStrategy(strategy)
-                               .useSite(DatadogSite.US1_FED)
-                               .build();
-               Credentials credentials = new Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>);
-               Datadog.initialize(this, credentials, configuration, trackingConsent);
-            }
-      }
-   ```
+```java
+    public class SampleApplication extends Application { 
+        @Override 
+        public void onCreate() { 
+            super.onCreate();
+            final Configuration configuration = 
+                    new Configuration.Builder(true, true, true, true)
+                            .trackInteractions()
+                            .trackLongTasks(durationThreshold)
+                            .useViewTrackingStrategy(strategy)
+                            .useSite(DatadogSite.US1_FED)
+                            .build();
+            Credentials credentials = new Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>);
+            Datadog.initialize(this, credentials, configuration, trackingConsent); 
+        }
+    }
+```
 {{% /tab %}}
 {{< /tabs >}}
 {{< /site-region >}}

--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -23,8 +23,7 @@ dependencies {
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
-class SampleApplication : Application() { 
-    
+class SampleApplication : Application() {
     override fun onCreate() {
       super.onCreate()
       val configuration = Configuration.Builder(


### PR DESCRIPTION
### What does this PR do?

This PR fixes the format for Java code snippets in the RUM docs pages:
[See here](https://docs.datadoghq.com/real_user_monitoring/android/?tab=java#initialize-the-library-with-application-context)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

