### PR TITLE
RUMM-1531 Support json float fields in test assertions

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/assertj/JsonElementAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/assertj/JsonElementAssert.kt
@@ -12,6 +12,8 @@ import com.google.gson.JsonArray
 import com.google.gson.JsonElement
 import com.google.gson.JsonNull
 import com.google.gson.JsonObject
+import com.google.gson.JsonPrimitive
+import com.google.gson.internal.LazilyParsedNumber
 import java.util.Date
 import org.assertj.core.api.AbstractAssert
 import org.assertj.core.api.Assertions
@@ -24,6 +26,8 @@ internal class JsonElementAssert(actual: JsonElement) :
         JsonElementAssert::class.java
     ) {
 
+    // region Assert
+
     override fun isEqualTo(expected: Any?): JsonElementAssert {
         when (expected) {
             null -> Assertions.assertThat(actual).isEqualTo(JsonNull.INSTANCE)
@@ -35,25 +39,68 @@ internal class JsonElementAssert(actual: JsonElement) :
             is String -> Assertions.assertThat(actual.asString).isEqualTo(expected)
             is Date -> Assertions.assertThat(actual.asLong).isEqualTo(expected.time)
             is JsonNull -> Assertions.assertThat(actual).isEqualTo(JsonNull.INSTANCE)
-            is JsonObject -> Assertions.assertThat(actual.asJsonObject).isEqualTo(expected)
-            is JsonArray -> Assertions.assertThat(actual.asJsonArray).isEqualTo(expected)
-            is Iterable<*> -> Assertions.assertThat(actual.asJsonArray).isEqualTo(
-                expected.toJsonArray()
-            )
-            is Map<*, *> -> Assertions.assertThat(actual.asJsonObject).isEqualTo(
-                expected.toJsonObject()
-            )
-            is JSONArray -> Assertions.assertThat(actual.asJsonArray).isEqualTo(
-                expected.toJsonArray()
-            )
-            is JSONObject -> Assertions.assertThat(actual.asJsonObject).isEqualTo(
-                expected.toJsonObject()
-            )
+            is JsonObject -> Assertions.assertThat(actual.asJsonObject)
+                .usingRecursiveComparison()
+                .withComparatorForType(jsonPrimitivesComparator, JsonPrimitive::class.java)
+                .isEqualTo(expected)
+            is JsonArray -> Assertions.assertThat(actual.asJsonArray)
+                .usingRecursiveComparison()
+                .withComparatorForType(jsonPrimitivesComparator, JsonPrimitive::class.java)
+                .isEqualTo(expected)
+            is Iterable<*> -> Assertions.assertThat(actual.asJsonArray)
+                .usingRecursiveComparison()
+                .withComparatorForType(jsonPrimitivesComparator, JsonPrimitive::class.java)
+                .isEqualTo(expected.toJsonArray())
+            is Map<*, *> -> Assertions.assertThat(actual.asJsonObject)
+                .usingRecursiveComparison()
+                .withComparatorForType(jsonPrimitivesComparator, JsonPrimitive::class.java)
+                .isEqualTo(expected.toJsonObject())
+            is JSONArray -> Assertions.assertThat(actual.asJsonArray)
+                .usingRecursiveComparison()
+                .withComparatorForType(jsonPrimitivesComparator, JsonPrimitive::class.java)
+                .isEqualTo(expected.toJsonArray())
+            is JSONObject -> Assertions.assertThat(actual.asJsonObject)
+                .usingRecursiveComparison()
+                .withComparatorForType(jsonPrimitivesComparator, JsonPrimitive::class.java)
+                .isEqualTo(expected.toJsonObject())
             else -> Assertions.assertThat(actual.asString).isEqualTo(expected.toString())
         }
         return this
     }
 
+    // endregion
+
+    // region Internal
+
+    private val jsonPrimitivesComparator: (o1: JsonPrimitive, o2: JsonPrimitive) -> Int =
+        { o1, o2 ->
+            if (comparingFloatAndLazilyParsedNumber(o1, o2)) {
+                // when comparing a float with a LazilyParsedNumber the `JsonPrimitive#equals`
+                // method uses Double.parseValue(value) to convert the value from the
+                // LazilyParsedNumber and this method uses an extra precision. This will
+                // create assertion issues because even though the original values
+                // are the same the parsed values are no longer matching.
+                if (o1.asString.toDouble() == o2.asString.toDouble()) {
+                    0
+                } else {
+                    -1
+                }
+            } else {
+                if (o1.equals(o2)) {
+                    0
+                } else {
+                    -1
+                }
+            }
+        }
+
+    private fun comparingFloatAndLazilyParsedNumber(o1: JsonPrimitive, o2: JsonPrimitive): Boolean {
+        return (o1.isNumber && o2.isNumber) &&
+            (o1.asNumber is Float || o2.asNumber is Float) &&
+            (o1.asNumber is LazilyParsedNumber || o2.asNumber is LazilyParsedNumber)
+    }
+
+    // endregion
     companion object {
         fun assertThat(actual: JsonElement): JsonElementAssert {
             return JsonElementAssert(actual)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ForgeExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ForgeExt.kt
@@ -105,8 +105,7 @@ private fun generateMapWithExhaustiveValues(forge: Forge): Map<String, Any?> {
             aBool(),
             anInt(),
             aLong(),
-            // TODO RUMM-1531 put it back once proper JSON assertions are ready
-            // aFloat(),
+            aFloat(),
             aDouble(),
             anAsciiString(),
             getForgery<Date>(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/GsonJsonPrimitiveForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/GsonJsonPrimitiveForgeryFactory.kt
@@ -16,8 +16,7 @@ class GsonJsonPrimitiveForgeryFactory : ForgeryFactory<JsonPrimitive> {
         return forge.anElementFrom(
             JsonPrimitive(forge.aBool()),
             JsonPrimitive(forge.anInt()),
-            // TODO RUMM-1531 put it back once proper JSON assertions are ready
-            // JsonPrimitive(forge.aFloat()),
+            JsonPrimitive(forge.aFloat()),
             JsonPrimitive(forge.aLong()),
             JsonPrimitive(forge.aDouble()),
             JsonPrimitive(forge.anAlphabeticalString()),


### PR DESCRIPTION
### What does this PR do?

When deserializing a json string to a RUM event we are using the `JsonParser` from Gson internal libraries. The `JsonParser` will bundle any property value in a `JsonPrimitive` and will force that value to a `String`. Now when trying to match a deserialized object with a serialized one `AssertJ` uses the `JsonPrimitive#equals` method under the hood which has a special case for `Double` and `Float`:
 ```
 double a = getAsNumber().doubleValue();
 double b = other.getAsNumber().doubleValue();
 return a == b || (Double.isNaN(a) && Double.isNaN(b));
```
Problem is that when using a `Float` in the deserialized object we will get a `String` representation of that value and the `other.getAsNumber().doubleValue()` uses `Double.parseDouble(value)` under the hood which returns the float conversion but with an extra precision which will not match the original value.

We are providing a special comparator for AssertJ to threat this case separately.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

