### PR TITLE
RUMM-1920 Do not override 'service' property for WebView tracked events

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -450,7 +450,7 @@ data class com.datadog.android.rum.model.ActionEvent
   data class CiTest
     constructor(kotlin.String)
     fun toJson(): com.google.gson.JsonElement
-    companion object
+    companion object 
       fun fromJson(kotlin.String): CiTest
   data class Dd
     constructor(DdSession? = null, kotlin.String? = null)
@@ -511,7 +511,7 @@ data class com.datadog.android.rum.model.ActionEvent
     - FLUTTER
     - REACT_NATIVE
     fun toJson(): com.google.gson.JsonElement
-    companion object
+    companion object 
       fun fromJson(kotlin.String): Source
   enum ActionEventSessionType
     constructor(kotlin.String)
@@ -601,7 +601,7 @@ data class com.datadog.android.rum.model.ErrorEvent
   data class CiTest
     constructor(kotlin.String)
     fun toJson(): com.google.gson.JsonElement
-    companion object
+    companion object 
       fun fromJson(kotlin.String): CiTest
   data class Dd
     constructor(DdSession? = null, kotlin.String? = null)
@@ -652,7 +652,7 @@ data class com.datadog.android.rum.model.ErrorEvent
     - FLUTTER
     - REACT_NATIVE
     fun toJson(): com.google.gson.JsonElement
-    companion object
+    companion object 
       fun fromJson(kotlin.String): ErrorEventSource
   enum ErrorEventSessionType
     constructor(kotlin.String)
@@ -789,7 +789,7 @@ data class com.datadog.android.rum.model.LongTaskEvent
   data class CiTest
     constructor(kotlin.String)
     fun toJson(): com.google.gson.JsonElement
-    companion object
+    companion object 
       fun fromJson(kotlin.String): CiTest
   data class Dd
     constructor(DdSession? = null, kotlin.String? = null)
@@ -830,7 +830,7 @@ data class com.datadog.android.rum.model.LongTaskEvent
     - FLUTTER
     - REACT_NATIVE
     fun toJson(): com.google.gson.JsonElement
-    companion object
+    companion object 
       fun fromJson(kotlin.String): Source
   enum Type
     constructor(kotlin.String)
@@ -908,7 +908,7 @@ data class com.datadog.android.rum.model.ResourceEvent
   data class CiTest
     constructor(kotlin.String)
     fun toJson(): com.google.gson.JsonElement
-    companion object
+    companion object 
       fun fromJson(kotlin.String): CiTest
   data class Dd
     constructor(DdSession? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
@@ -984,7 +984,7 @@ data class com.datadog.android.rum.model.ResourceEvent
     - FLUTTER
     - REACT_NATIVE
     fun toJson(): com.google.gson.JsonElement
-    companion object
+    companion object 
       fun fromJson(kotlin.String): Source
   enum ResourceEventSessionType
     constructor(kotlin.String)
@@ -1108,7 +1108,7 @@ data class com.datadog.android.rum.model.ViewEvent
   data class CiTest
     constructor(kotlin.String)
     fun toJson(): com.google.gson.JsonElement
-    companion object
+    companion object 
       fun fromJson(kotlin.String): CiTest
   data class Dd
     constructor(DdSession? = null, kotlin.String? = null, kotlin.Long)
@@ -1179,7 +1179,7 @@ data class com.datadog.android.rum.model.ViewEvent
     - FLUTTER
     - REACT_NATIVE
     fun toJson(): com.google.gson.JsonElement
-    companion object
+    companion object 
       fun fromJson(kotlin.String): Source
   enum Type
     constructor(kotlin.String)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapper.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.webview.internal.rum
 
-import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
@@ -25,7 +24,6 @@ internal class WebViewRumEventMapper {
         return event.copy(
             application = event.application.copy(id = context.applicationId),
             session = event.session.copy(id = context.sessionId),
-            service = CoreFeature.serviceName,
             date = event.date + timeOffset,
             dd = event.dd.copy(session = ViewEvent.DdSession(ViewEvent.Plan.PLAN_1))
         )
@@ -40,7 +38,6 @@ internal class WebViewRumEventMapper {
         return event.copy(
             application = event.application.copy(id = context.applicationId),
             session = event.session.copy(id = context.sessionId),
-            service = CoreFeature.serviceName,
             date = event.date + timeOffset,
             dd = event.dd.copy(session = ActionEvent.DdSession(ActionEvent.Plan.PLAN_1))
         )
@@ -54,7 +51,6 @@ internal class WebViewRumEventMapper {
         return event.copy(
             application = event.application.copy(id = context.applicationId),
             session = event.session.copy(id = context.sessionId),
-            service = CoreFeature.serviceName,
             date = event.date + timeOffset,
             dd = event.dd.copy(
                 session = ResourceEvent.DdSession(plan = ResourceEvent.Plan.PLAN_1)
@@ -70,7 +66,6 @@ internal class WebViewRumEventMapper {
         return event.copy(
             application = event.application.copy(id = context.applicationId),
             session = event.session.copy(id = context.sessionId),
-            service = CoreFeature.serviceName,
             date = event.date + timeOffset,
             dd = event.dd.copy(session = LongTaskEvent.DdSession(LongTaskEvent.Plan.PLAN_1))
 
@@ -85,7 +80,6 @@ internal class WebViewRumEventMapper {
         return event.copy(
             application = event.application.copy(id = context.applicationId),
             session = event.session.copy(id = context.sessionId),
-            service = CoreFeature.serviceName,
             date = event.date + timeOffset,
             dd = event.dd.copy(session = ErrorEvent.DdSession(ErrorEvent.Plan.PLAN_1))
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapperTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.webview.internal.rum
 
-import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
@@ -19,7 +18,6 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.LongForgery
-import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -44,9 +42,6 @@ internal class WebViewRumEventMapperTest {
 
     @LongForgery
     var fakeServerTimeOffset: Long = 0L
-
-    @StringForgery
-    lateinit var fakeServiceName: String
     lateinit var fakeTags: Map<String, String>
 
     @BeforeEach
@@ -59,7 +54,6 @@ internal class WebViewRumEventMapperTest {
             emptyMap()
         }
         testedWebViewRumEventMapper = WebViewRumEventMapper()
-        CoreFeature.serviceName = fakeServiceName
     }
 
     @Test
@@ -80,7 +74,6 @@ internal class WebViewRumEventMapperTest {
             .ignoringFields(
                 CONTEXT_KEY,
                 APPLICATION_KEY,
-                SERVICE_KEY,
                 SESSION_KEY,
                 DATE_KEY,
                 DD_KEY
@@ -89,7 +82,6 @@ internal class WebViewRumEventMapperTest {
 
         assertThat(mappedEvent.application.id).isEqualTo(rumMonitor.context.applicationId)
         assertThat(mappedEvent.session.id).isEqualTo(rumMonitor.context.sessionId)
-        assertThat(mappedEvent.service).isEqualTo(fakeServiceName)
         assertThat(mappedEvent.date).isEqualTo(fakeViewEvent.date + fakeServerTimeOffset)
         assertThat(mappedEvent.dd).isEqualTo(
             fakeViewEvent.dd.copy(
@@ -116,7 +108,6 @@ internal class WebViewRumEventMapperTest {
             .ignoringFields(
                 CONTEXT_KEY,
                 APPLICATION_KEY,
-                SERVICE_KEY,
                 SESSION_KEY,
                 DATE_KEY,
                 DD_KEY
@@ -124,7 +115,6 @@ internal class WebViewRumEventMapperTest {
             .isEqualTo(fakeActionEvent)
         assertThat(mappedEvent.application.id).isEqualTo(rumMonitor.context.applicationId)
         assertThat(mappedEvent.session.id).isEqualTo(rumMonitor.context.sessionId)
-        assertThat(mappedEvent.service).isEqualTo(fakeServiceName)
         assertThat(mappedEvent.date).isEqualTo(fakeActionEvent.date + fakeServerTimeOffset)
         assertThat(mappedEvent.dd).isEqualTo(
             fakeActionEvent.dd.copy(
@@ -151,7 +141,6 @@ internal class WebViewRumEventMapperTest {
             .ignoringFields(
                 CONTEXT_KEY,
                 APPLICATION_KEY,
-                SERVICE_KEY,
                 SESSION_KEY,
                 DATE_KEY,
                 DD_KEY
@@ -159,7 +148,6 @@ internal class WebViewRumEventMapperTest {
             .isEqualTo(fakeErrorEvent)
         assertThat(mappedEvent.application.id).isEqualTo(rumMonitor.context.applicationId)
         assertThat(mappedEvent.session.id).isEqualTo(rumMonitor.context.sessionId)
-        assertThat(mappedEvent.service).isEqualTo(fakeServiceName)
         assertThat(mappedEvent.date).isEqualTo(fakeErrorEvent.date + fakeServerTimeOffset)
         assertThat(mappedEvent.dd).isEqualTo(
             fakeErrorEvent.dd.copy(
@@ -186,7 +174,6 @@ internal class WebViewRumEventMapperTest {
             .ignoringFields(
                 CONTEXT_KEY,
                 APPLICATION_KEY,
-                SERVICE_KEY,
                 SESSION_KEY,
                 DATE_KEY,
                 DD_KEY
@@ -194,7 +181,6 @@ internal class WebViewRumEventMapperTest {
             .isEqualTo(fakeResourceEvent)
         assertThat(mappedEvent.application.id).isEqualTo(rumMonitor.context.applicationId)
         assertThat(mappedEvent.session.id).isEqualTo(rumMonitor.context.sessionId)
-        assertThat(mappedEvent.service).isEqualTo(fakeServiceName)
         assertThat(mappedEvent.date).isEqualTo(fakeResourceEvent.date + fakeServerTimeOffset)
         assertThat(mappedEvent.dd).isEqualTo(
             fakeResourceEvent.dd.copy(
@@ -221,7 +207,6 @@ internal class WebViewRumEventMapperTest {
             .ignoringFields(
                 CONTEXT_KEY,
                 APPLICATION_KEY,
-                SERVICE_KEY,
                 SESSION_KEY,
                 DATE_KEY,
                 DD_KEY
@@ -229,7 +214,6 @@ internal class WebViewRumEventMapperTest {
             .isEqualTo(fakeLongTaskEvent)
         assertThat(mappedEvent.application.id).isEqualTo(rumMonitor.context.applicationId)
         assertThat(mappedEvent.session.id).isEqualTo(rumMonitor.context.sessionId)
-        assertThat(mappedEvent.service).isEqualTo(fakeServiceName)
         assertThat(mappedEvent.date).isEqualTo(fakeLongTaskEvent.date + fakeServerTimeOffset)
         assertThat(mappedEvent.dd).isEqualTo(
             fakeLongTaskEvent.dd.copy(
@@ -250,7 +234,6 @@ internal class WebViewRumEventMapperTest {
         private const val CONTEXT_KEY = "context"
         private const val APPLICATION_KEY = "application"
         private const val SESSION_KEY = "session"
-        private const val SERVICE_KEY = "service"
         private const val DATE_KEY = "date"
         private const val DD_KEY = "dd"
     }


### PR DESCRIPTION
### What does this PR do?

We do not override anymore the `service` property in the RUM events received through the `JSBridge` with out own internal value. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

