### PR TITLE
RUMM-1853 Report the correct source for spans

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapper.kt
@@ -72,7 +72,7 @@ internal class DdSpanToSpanEventMapper(
         )
         return SpanEvent.Meta(
             version = CoreFeature.packageVersion,
-            dd = SpanEvent.Dd(),
+            dd = SpanEvent.Dd(source = CoreFeature.sourceName),
             span = SpanEvent.Span(),
             tracer = SpanEvent.Tracer(
                 version = CoreFeature.sdkVersion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapperTest.kt
@@ -68,6 +68,9 @@ internal class DdSpanToSpanEventMapperTest {
     @StringForgery
     lateinit var fakeSdkVersion: String
 
+    @StringForgery
+    lateinit var fakeSource: String
+
     @LongForgery
     var fakeServerOffsetNanos: Long = 0L
 
@@ -75,11 +78,15 @@ internal class DdSpanToSpanEventMapperTest {
     fun `set up`() {
         CoreFeature.packageVersion = fakeClientPackageVersion
         CoreFeature.sdkVersion = fakeSdkVersion
+        CoreFeature.sourceName = fakeSource
         whenever(mockTimeProvider.getServerOffsetNanos()).thenReturn(fakeServerOffsetNanos)
         whenever(mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
-        testedMapper =
-            DdSpanToSpanEventMapper(mockTimeProvider, mockNetworkInfoProvider, mockUserInfoProvider)
+        testedMapper = DdSpanToSpanEventMapper(
+            mockTimeProvider,
+            mockNetworkInfoProvider,
+            mockUserInfoProvider
+        )
     }
 
     @RepeatedTest(4)
@@ -101,7 +108,7 @@ internal class DdSpanToSpanEventMapperTest {
             .hasOperationName(fakeSpan.operationName)
             .hasResourceName(fakeSpan.resourceName)
             .hasSpanType("custom")
-            .hasSpanSource("android")
+            .hasSpanSource(fakeSource)
             .hasErrorFlag(fakeSpan.error.toLong())
             .hasSpanStartTime(fakeSpan.startTime + fakeServerOffsetNanos)
             .hasSpanDuration(fakeSpan.durationNano)


### PR DESCRIPTION
### What does this PR do?

Report the correct `_dd.source` for spans.

### Motivation

The `source` attribute can be changed by our cross platform SDKs (React Native, Flutter, …). We do take it into account for logs and RUM but didn't yet for spans.