### PR TITLE
RUMM-1898 RumMonitor#stopResourceWithError with stacktrace and errorType properties

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -364,6 +364,7 @@ interface com.datadog.android.rum.RumMonitor
   fun startResource(String, String, String, Map<String, Any?> = emptyMap())
   fun stopResource(String, Int?, Long?, RumResourceKind, Map<String, Any?>)
   fun stopResourceWithError(String, Int?, String, RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
+  fun stopResourceWithError(String, Int?, String, RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
   fun addError(String, RumErrorSource, Throwable?, Map<String, Any?>)
   fun addErrorWithStacktrace(String, RumErrorSource, String?, Map<String, Any?>)
   fun addTiming(String)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -208,7 +208,7 @@ interface RumMonitor {
         message: String,
         source: RumErrorSource,
         stackTrace: String,
-        errorType: String,
+        errorType: String?,
         attributes: Map<String, Any?> = emptyMap()
     )
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -185,6 +185,34 @@ interface RumMonitor {
     )
 
     /**
+     * Stops a previously started Resource that failed loading, linked with the [key] instance by
+     * providing the intercepted stacktrace.
+     * Note: This method should only be used from hybrid application.
+     * @param key the instance that represents the active view (usually your
+     * request or network call instance).
+     * @param statusCode the status code of the resource (if any)
+     * @param message a message explaining the error
+     * @param source the source of the error
+     * @param stackTrace the error stacktrace
+     * @param errorType the type of the error. Usually it should be the canonical name of the
+     * of the Exception class.
+     * @param attributes additional custom attributes to attach to the error. Attributes can be
+     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
+     * @see [startResource]
+     * @see [stopResource]
+     */
+    @SuppressWarnings("LongParameterList")
+    fun stopResourceWithError(
+        key: String,
+        statusCode: Int?,
+        message: String,
+        source: RumErrorSource,
+        stackTrace: String,
+        errorType: String,
+        attributes: Map<String, Any?> = emptyMap()
+    )
+
+    /**
      * Notifies that an error occurred in the active View.
      * @param message a message explaining the error
      * @param source the source of the error

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -74,7 +74,8 @@ internal class RumActionScope(
             event is RumRawEvent.StartResource -> onStartResource(event, now)
             event is RumRawEvent.StopResource -> onStopResource(event, now)
             event is RumRawEvent.AddError -> onError(event, now, writer)
-            event is RumRawEvent.StopResourceWithError -> onResourceError(event, now)
+            event is RumRawEvent.StopResourceWithError -> onResourceError(event.key, now)
+            event is RumRawEvent.StopResourceWithStackTrace -> onResourceError(event.key, now)
             event is RumRawEvent.AddLongTask -> onLongTask(now)
         }
 
@@ -152,8 +153,8 @@ internal class RumActionScope(
         }
     }
 
-    private fun onResourceError(event: RumRawEvent.StopResourceWithError, now: Long) {
-        val keyRef = ongoingResourceKeys.firstOrNull { it.get() == event.key }
+    private fun onResourceError(eventKey: String, now: Long) {
+        val keyRef = ongoingResourceKeys.firstOrNull { it.get() == eventKey }
         if (keyRef != null) {
             ongoingResourceKeys.remove(keyRef)
             lastInteractionNanos = now

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -84,6 +84,17 @@ internal sealed class RumRawEvent {
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
+    internal data class StopResourceWithStackTrace(
+        val key: String,
+        val statusCode: Long?,
+        val message: String,
+        val source: RumErrorSource,
+        val stackTrace: String,
+        val errorType: String?,
+        val attributes: Map<String, Any?>,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
     internal data class AddError(
         val message: String,
         val source: RumErrorSource,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -165,6 +165,28 @@ internal class DatadogRumMonitor(
         )
     }
 
+    override fun stopResourceWithError(
+        key: String,
+        statusCode: Int?,
+        message: String,
+        source: RumErrorSource,
+        stackTrace: String,
+        errorType: String?,
+        attributes: Map<String, Any?>
+    ) {
+        handleEvent(
+            RumRawEvent.StopResourceWithStackTrace(
+                key,
+                statusCode?.toLong(),
+                message,
+                source,
+                stackTrace,
+                errorType,
+                attributes
+            )
+        )
+    }
+
     override fun addError(
         message: String,
         source: RumErrorSource,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -250,6 +250,66 @@ internal class RumActionScopeTest {
     }
 
     @Test
+    fun `𝕄 send Action after threshold 𝕎 handleEvent(StartResource+StopResourceWithStackTrace)`(
+        @StringForgery key: String,
+        @StringForgery method: String,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
+        @LongForgery(200, 600) statusCode: Long,
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stackTrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val errorType = forge.aNullable { anAlphabeticalString() }
+
+        // When
+        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        Thread.sleep(TEST_INACTIVITY_MS * 2)
+        fakeEvent = RumRawEvent.StopResourceWithStackTrace(
+            key,
+            statusCode,
+            message,
+            source,
+            stackTrace,
+            errorType,
+            emptyMap()
+        )
+        val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
+        Thread.sleep(TEST_INACTIVITY_MS * 2)
+        val result3 = testedScope.handleEvent(mockEvent(), mockWriter)
+
+        // Then
+        argumentCaptor<ActionEvent> {
+            verify(mockWriter).write(capture())
+            assertThat(lastValue)
+                .apply {
+                    hasId(testedScope.actionId)
+                    hasTimestamp(resolveExpectedTimestamp())
+                    hasType(fakeType)
+                    hasTargetName(fakeName)
+                    hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(TEST_INACTIVITY_MS * 2))
+                    hasDurationLowerThan(TimeUnit.MILLISECONDS.toNanos(TEST_INACTIVITY_MS * 4))
+                    hasResourceCount(0)
+                    hasErrorCount(1)
+                    hasCrashCount(0)
+                    hasLongTaskCount(0)
+                    hasView(fakeParentContext)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasLiteSessionPlan()
+                    containsExactlyContextAttributes(fakeAttributes)
+                }
+        }
+        verify(mockParentScope, never()).handleEvent(any(), any())
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+        assertThat(result2).isSameAs(testedScope)
+        assertThat(result3).isNull()
+    }
+
+    @Test
     fun `𝕄 send Action 𝕎 handleEvent(StartResource+StopResourceWithError+any) {unknown key}`(
         @StringForgery key: String,
         @StringForgery key2: String,
@@ -270,6 +330,45 @@ internal class RumActionScopeTest {
             message,
             source,
             throwable,
+            emptyMap()
+        )
+        val result2 = testedScope.handleEvent(fakeEvent2, mockWriter)
+        Thread.sleep(TEST_INACTIVITY_MS * 2)
+        val result3 = testedScope.handleEvent(mockEvent(), mockWriter)
+
+        // Then
+        verifyZeroInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+        assertThat(result2).isSameAs(testedScope)
+        assertThat(result3).isSameAs(testedScope)
+    }
+
+    @Test
+    fun `𝕄 send Action 𝕎 handleEvent(StartResource+StopResourceWithStackTrace+any) {unknown key}`(
+        @StringForgery key: String,
+        @StringForgery key2: String,
+        @StringForgery method: String,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
+        @LongForgery(200, 600) statusCode: Long,
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @StringForgery stackTrace: String,
+        forge: Forge
+    ) {
+        // Given
+        val errorType = forge.aNullable { anAlphabeticalString() }
+
+        // When
+        fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+        Thread.sleep(TEST_INACTIVITY_MS * 2)
+        val fakeEvent2 = RumRawEvent.StopResourceWithStackTrace(
+            key2,
+            statusCode,
+            message,
+            source,
+            stackTrace,
+            errorType,
             emptyMap()
         )
         val result2 = testedScope.handleEvent(fakeEvent2, mockWriter)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -975,6 +975,16 @@ internal class RumSessionScopeTest {
                     attributes = emptyMap(),
                     eventTime = fakeEventTime
                 ),
+                RumRawEvent.StopResourceWithStackTrace(
+                    fakeKey,
+                    message = this.aString(),
+                    statusCode = null,
+                    source = this.aValueFrom(RumErrorSource::class.java),
+                    stackTrace = this.anAlphaNumericalString(),
+                    errorType = aNullable { anAlphabeticalString() },
+                    attributes = emptyMap(),
+                    eventTime = fakeEventTime
+                ),
                 RumRawEvent.StopView(
                     fakeKey,
                     emptyMap(),
@@ -1010,6 +1020,16 @@ internal class RumSessionScopeTest {
                     statusCode = null,
                     source = this.aValueFrom(RumErrorSource::class.java),
                     throwable = this.getForgery(),
+                    attributes = emptyMap(),
+                    eventTime = fakeEventTime
+                ),
+                RumRawEvent.StopResourceWithStackTrace(
+                    fakeKey,
+                    message = this.aString(),
+                    statusCode = null,
+                    source = this.aValueFrom(RumErrorSource::class.java),
+                    stackTrace = this.anAlphaNumericalString(),
+                    errorType = aNullable { anAlphabeticalString() },
                     attributes = emptyMap(),
                     eventTime = fakeEventTime
                 ),

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBackgroundE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBackgroundE2ETests.kt
@@ -236,6 +236,37 @@ class RumMonitorBackgroundE2ETests {
         }
     }
 
+    /**
+     * apiMethodSignature: com.datadog.android.rum.RumMonitor#fun stopResourceWithError(String, Int?, String, RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
+     */
+    @Test
+    fun rum_rummonitor_stop_background_resource_with_error_stacktrace() {
+        val testMethodName = "rum_rummonitor_stop_background_resource_with_error_stacktrace"
+        val resourceKey = forge.aResourceKey()
+        GlobalRum.get().startResource(
+            resourceKey,
+            forge.aResourceMethod(),
+            resourceKey,
+            attributes = defaultTestAttributes(testMethodName)
+        )
+        val anInt = forge.anInt(min = 400, max = 511)
+        val aResourceErrorMessage = forge.aResourceErrorMessage()
+        val stackTrace = forge.aString()
+        val errorType = forge.aNullable { forge.anAlphabeticalString() }
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        measure(testMethodName) {
+            GlobalRum.get().stopResourceWithError(
+                resourceKey,
+                anInt,
+                aResourceErrorMessage,
+                source,
+                stackTrace,
+                errorType,
+                defaultTestAttributes(testMethodName)
+            )
+        }
+    }
+
     // endregion
 
     // region Background Error

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
@@ -625,6 +625,41 @@ class RumMonitorE2ETests {
     }
 
     /**
+     * apiMethodSignature: com.datadog.android.rum.RumMonitor#fun stopResourceWithError(String, Int?, String, RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
+     */
+    @Test
+    fun rum_rummonitor_stop_resource_with_error_stacktrace() {
+        val testMethodName = "rum_rummonitor_stop_resource_with_error_stacktrace"
+        val viewKey = forge.aViewKey()
+        val viewName = forge.aViewName()
+        val resourceKey = forge.aResourceKey()
+        val statusCode = forge.anInt(min = 400, max = 511)
+        val message = forge.aResourceErrorMessage()
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        val stackTrace = forge.aString()
+        val errorType = forge.aNullable { forge.anAlphabeticalString() }
+        executeInsideView(viewKey, viewName, testMethodName) {
+            GlobalRum.get().startResource(
+                resourceKey,
+                forge.aResourceMethod(),
+                resourceKey,
+                attributes = defaultTestAttributes(testMethodName)
+            )
+            measure(testMethodName) {
+                GlobalRum.get().stopResourceWithError(
+                    resourceKey,
+                    statusCode,
+                    message,
+                    source,
+                    stackTrace,
+                    errorType,
+                    defaultTestAttributes(testMethodName)
+                )
+            }
+        }
+    }
+
+    /**
      * apiMethodSignature: com.datadog.android.rum.RumMonitor#fun stopResourceWithError(String, Int?, String, RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
      */
     @Test
@@ -647,6 +682,41 @@ class RumMonitorE2ETests {
                     forge.aResourceErrorMessage(),
                     forge.aValueFrom(RumErrorSource::class.java),
                     forge.aThrowable(),
+                    defaultTestAttributes(testMethodName)
+                )
+            }
+        }
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.rum.RumMonitor#fun stopResourceWithError(String, Int?, String, RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
+     */
+    @Test
+    fun rum_rummonitor_stop_resource_with_error_stacktrace_without_status_code() {
+        val testMethodName =
+            "rum_rummonitor_stop_resource_with_error_stacktrace_without_status_code"
+        val viewKey = forge.aViewKey()
+        val viewName = forge.aViewName()
+        val resourceKey = forge.aResourceKey()
+        val message = forge.aResourceErrorMessage()
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        val stackTrace = forge.aString()
+        val errorType = forge.aNullable { forge.anAlphabeticalString() }
+        executeInsideView(viewKey, viewName, testMethodName) {
+            GlobalRum.get().startResource(
+                resourceKey,
+                forge.aResourceMethod(),
+                resourceKey,
+                attributes = defaultTestAttributes(testMethodName)
+            )
+            measure(testMethodName) {
+                GlobalRum.get().stopResourceWithError(
+                    resourceKey,
+                    null,
+                    message,
+                    source,
+                    stackTrace,
+                    errorType,
                     defaultTestAttributes(testMethodName)
                 )
             }
@@ -701,6 +771,37 @@ class RumMonitorE2ETests {
                 forge.aResourceErrorMessage(),
                 forge.aValueFrom(RumErrorSource::class.java),
                 forge.aThrowable(),
+                defaultTestAttributes(testMethodName)
+            )
+        }
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.rum.RumMonitor#fun stopResourceWithError(String, Int?, String, RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
+     */
+    @Test
+    fun rum_rummonitor_ignore_stop_background_resource_with_error_stacktrace() {
+        val testMethodName = "rum_rummonitor_ignore_stop_background_resource_with_error"
+        val resourceKey = forge.aResourceKey()
+        val statusCode = forge.anInt(min = 400, max = 511)
+        val message = forge.aResourceErrorMessage()
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        val stackTrace = forge.aString()
+        val errorType = forge.aNullable { forge.anAlphabeticalString() }
+        GlobalRum.get().startResource(
+            resourceKey,
+            forge.aResourceMethod(),
+            resourceKey,
+            attributes = defaultTestAttributes(testMethodName)
+        )
+        measure(testMethodName) {
+            GlobalRum.get().stopResourceWithError(
+                resourceKey,
+                statusCode,
+                message,
+                source,
+                stackTrace,
+                errorType,
                 defaultTestAttributes(testMethodName)
             )
         }


### PR DESCRIPTION
### What does this PR do?

This PR introduces a new overloaded method in the `RumMonitor` interface:
```
fun stopResourceWithError(
        key: String,
        statusCode: Int?,
        message: String,
        source: RumErrorSource,
        stackTrace: String,
        errorType: String?,
        attributes: Map<String, Any?> = emptyMap()
    )
```
This method is mainly added for being used from hybrid apps/sdks.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

