### PR TITLE
RUMM-1947 fix dogfooding script

### DIFF
--- a/dogfood.py
+++ b/dogfood.py
@@ -29,14 +29,14 @@ REPOSITORIES = {
 }
 
 FILE_PATH = {
-    TARGET_APP: os.path.join("dd-build", "dependencies", "src", "main", "java", "com", "datadog", "build", "dependency", "android", "Datadog.kt"),
+    TARGET_APP: os.path.join("gradle", "libs.versions.toml"),
     TARGET_DEMO: os.path.join("gradle", "libs.versions.toml"),
     TARGET_BRIDGE: os.path.join("gradle", "libs.versions.toml"),
     TARGET_GRADLE_PLUGIN: os.path.join("gradle", "libs.versions.toml")
 }
 
 PREFIX = {
-    TARGET_APP: "val version",
+    TARGET_APP: "datadog",
     TARGET_DEMO: "datadogSdk",
     TARGET_BRIDGE: "datadogSdk",
     TARGET_GRADLE_PLUGIN: "datadogSdk"


### PR DESCRIPTION
### What does this PR do?

Since the dependency management changed in the Mobile App repo, we needed to update our dogfooding script to point to Gradle's `libs.versions.toml` instead of the previously used `Datadog.kt` class. 