### PR TITLE
RUMM-1942 Improve the perfs measurements methods in nightly tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -315,5 +315,11 @@ fun $EXP$(){
 
 Because of our crash handling [test cases](instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash), when running the nightly tests through gradle,  
 the process does not finish properly so it may happen that will keep hanging until it will eventually timeout.To avoid this issue you should run the tests through adb shell directly 
-using the instrumentation tool: `adb shell am instrumentation -w -e package com.datadog.android.nightly.[package] com.datadog.android.nightly.test/androidx.test.runner.AndroidJUnitRunner`
-or through your IDE (AndroidStudio, IntelliJ).
+using the instrumentation tool: 
+```
+./gradlew :instrumented:nightly-tests:installDebug
+./gradlew :instrumented:nightly-tests:installDebugAndroidTest
+adb shell am instrument -w -e package com.datadog.android.nightly.[feature] com.datadog.android.nightly.test/androidx.test.runner.AndroidJUnitRunner
+```
+where `feature` refers to the specific collection of tests (feature to test) and can take one of the following values: `rum`, `crash`, `log`, `trace`. If you want to run
+all the nightly tests just omit the feature in the `package` definition.

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
@@ -67,11 +67,12 @@ class RumMonitorE2ETests {
         val testMethodName = "rum_rummonitor_start_view"
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
+        val attributes = defaultTestAttributes(testMethodName)
         measure(testMethodName) {
             GlobalRum.get().startView(
                 viewKey,
                 viewName,
-                defaultTestAttributes(testMethodName)
+                attributes
             )
         }
         GlobalRum.get().stopView(viewKey)
@@ -85,10 +86,11 @@ class RumMonitorE2ETests {
         val testMethodName = "rum_rummonitor_stop_view"
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
+        val attributes = defaultTestAttributes(testMethodName)
         GlobalRum.get().startView(
             viewKey,
             viewName,
-            defaultTestAttributes(testMethodName)
+            attributes
         )
         measure(testMethodName) {
             GlobalRum.get().stopView(viewKey)
@@ -104,16 +106,17 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val resourceKey = forge.aResourceKey()
+        val attributes = defaultTestAttributes(testMethodName)
         GlobalRum.get().startView(
             viewKey,
             viewName,
-            defaultTestAttributes(testMethodName)
+            attributes
         )
         GlobalRum.get().startResource(
             resourceKey,
             forge.aResourceMethod(),
             resourceKey,
-            attributes = defaultTestAttributes(testMethodName)
+            attributes = attributes
         )
         measure(testMethodName) {
             GlobalRum.get().stopView(viewKey)
@@ -123,7 +126,7 @@ class RumMonitorE2ETests {
             forge.aNullable { forge.anInt(min = 200, max = 500) },
             forge.aNullable { forge.aLong(min = 1) },
             forge.aValueFrom(RumResourceKind::class.java),
-            defaultTestAttributes(testMethodName)
+            attributes
         )
     }
 
@@ -137,15 +140,16 @@ class RumMonitorE2ETests {
         val viewName = forge.aViewName()
         val actionName = forge.anAlphabeticalString()
         val actionType = forge.aValueFrom(RumActionType::class.java)
+        val attributes = defaultTestAttributes(testMethodName)
         GlobalRum.get().startView(
             viewKey,
             viewName,
-            defaultTestAttributes(testMethodName)
+            attributes
         )
         GlobalRum.get().startUserAction(
             actionType,
             actionName,
-            attributes = defaultTestAttributes(testMethodName)
+            attributes = attributes
         )
         measure(testMethodName) {
             GlobalRum.get().stopView(viewKey)
@@ -153,7 +157,7 @@ class RumMonitorE2ETests {
         GlobalRum.get().stopUserAction(
             actionType,
             actionName,
-            defaultTestAttributes(testMethodName)
+            attributes
         )
     }
 
@@ -187,15 +191,17 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val actionName = forge.anAlphabeticalString()
+        val actionType = forge.aValueFrom(
+            RumActionType::class.java,
+            exclude = listOf(RumActionType.CUSTOM)
+        )
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().startUserAction(
-                    forge.aValueFrom(
-                        RumActionType::class.java,
-                        exclude = listOf(RumActionType.CUSTOM)
-                    ),
+                    actionType,
                     actionName,
-                    attributes = defaultTestAttributes(testMethodName)
+                    attributes = attributes
                 )
             }
             // wait for the action to be inactive
@@ -212,12 +218,13 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().startUserAction(
                     RumActionType.CUSTOM,
                     actionName,
-                    attributes = defaultTestAttributes(testMethodName)
+                    attributes = attributes
                 )
             }
         }
@@ -232,12 +239,14 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
+        val attributes = defaultTestAttributes(testMethodName)
+        val actionType = forge.aValueFrom(RumActionType::class.java)
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().startUserAction(
-                    forge.aValueFrom(RumActionType::class.java),
+                    actionType,
                     actionName,
-                    attributes = defaultTestAttributes(testMethodName)
+                    attributes = attributes
                 )
             }
             sendRandomActionOutcomeEvent(forge)
@@ -255,18 +264,19 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
-        val type = forge.aValueFrom(
+        val actionType = forge.aValueFrom(
             RumActionType::class.java,
             exclude = listOf(RumActionType.CUSTOM)
         )
+        val stopActionAttributes = forge.exhaustiveAttributes()
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startUserAction(
-                type,
+                actionType,
                 actionName,
                 attributes = defaultTestAttributes(testMethodName)
             )
             measure(testMethodName) {
-                GlobalRum.get().stopUserAction(type, actionName, forge.exhaustiveAttributes())
+                GlobalRum.get().stopUserAction(actionType, actionName, stopActionAttributes)
             }
             // wait for the action to be inactive
             Thread.sleep(ACTION_INACTIVITY_THRESHOLD_MS)
@@ -282,6 +292,7 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
+        val stopActionAttributes = forge.exhaustiveAttributes()
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startUserAction(
                 RumActionType.CUSTOM,
@@ -292,7 +303,7 @@ class RumMonitorE2ETests {
                 GlobalRum.get().stopUserAction(
                     RumActionType.CUSTOM,
                     actionName,
-                    forge.exhaustiveAttributes()
+                    stopActionAttributes
                 )
             }
             // wait for the action to be inactive
@@ -310,6 +321,7 @@ class RumMonitorE2ETests {
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
         val type = forge.aValueFrom(RumActionType::class.java)
+        val stopActionAttributes = forge.exhaustiveAttributes()
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startUserAction(
                 type,
@@ -318,7 +330,7 @@ class RumMonitorE2ETests {
             )
             sendRandomActionOutcomeEvent(forge)
             measure(testMethodName) {
-                GlobalRum.get().stopUserAction(type, actionName, forge.exhaustiveAttributes())
+                GlobalRum.get().stopUserAction(type, actionName, stopActionAttributes)
             }
             // wait for the action to be inactive
             Thread.sleep(ACTION_INACTIVITY_THRESHOLD_MS)
@@ -334,15 +346,17 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
+        val actionType = forge.aValueFrom(
+            RumActionType::class.java,
+            exclude = listOf(RumActionType.CUSTOM)
+        )
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().addUserAction(
-                    forge.aValueFrom(
-                        RumActionType::class.java,
-                        exclude = listOf(RumActionType.CUSTOM)
-                    ),
+                    actionType,
                     actionName,
-                    attributes = defaultTestAttributes(testMethodName)
+                    attributes = attributes
                 )
             }
             // wait for the action to be inactive
@@ -359,12 +373,13 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().addUserAction(
                     RumActionType.CUSTOM,
                     actionName,
-                    attributes = defaultTestAttributes(testMethodName)
+                    attributes = attributes
                 )
             }
             // wait for the action to be inactive
@@ -381,12 +396,14 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
+        val attributes = defaultTestAttributes(testMethodName)
+        val actionType = forge.aValueFrom(RumActionType::class.java)
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().addUserAction(
-                    forge.aValueFrom(RumActionType::class.java),
+                    actionType,
                     actionName,
-                    attributes = defaultTestAttributes(testMethodName)
+                    attributes = attributes
                 )
             }
             sendRandomActionOutcomeEvent(forge)
@@ -405,24 +422,29 @@ class RumMonitorE2ETests {
         val viewName = forge.aViewName()
         val activeActionName = forge.anActionName(prefix = "rumActiveAction")
         val customActionName = forge.anActionName()
-        val type = forge.aValueFrom(RumActionType::class.java)
+        val actionType = forge.aValueFrom(RumActionType::class.java)
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startUserAction(
-                type,
+                actionType,
                 activeActionName,
-                attributes = defaultTestAttributes(testMethodName)
+                attributes = attributes
             )
             measure(testMethodName) {
                 GlobalRum.get().addUserAction(
                     RumActionType.CUSTOM,
                     customActionName,
-                    attributes = defaultTestAttributes(testMethodName)
+                    attributes = attributes
                 )
             }
             sendRandomActionOutcomeEvent(forge)
             // wait for the action to be inactive
             Thread.sleep(ACTION_INACTIVITY_THRESHOLD_MS)
-            GlobalRum.get().stopUserAction(type, activeActionName, forge.exhaustiveAttributes())
+            GlobalRum.get().stopUserAction(
+                actionType,
+                activeActionName,
+                forge.exhaustiveAttributes()
+            )
         }
     }
 
@@ -451,8 +473,9 @@ class RumMonitorE2ETests {
         sendRandomActionOutcomeEvent(forge)
         // wait for the action to be inactive
         Thread.sleep(ACTION_INACTIVITY_THRESHOLD_MS)
+        val stopActionAttributes = forge.exhaustiveAttributes()
         measure(testMethodName) {
-            GlobalRum.get().stopUserAction(type, actionName, forge.exhaustiveAttributes())
+            GlobalRum.get().stopUserAction(type, actionName, stopActionAttributes)
         }
     }
 
@@ -464,14 +487,16 @@ class RumMonitorE2ETests {
         val testMethodName =
             "rum_rummonitor_ignore_add_background_non_custom_action_with_no_outcome"
         val actionName = forge.anActionName()
+        val actionType = forge.aValueFrom(
+            RumActionType::class.java,
+            exclude = listOf(RumActionType.CUSTOM)
+        )
+        val attributes = defaultTestAttributes(testMethodName)
         measure(testMethodName) {
             GlobalRum.get().addUserAction(
-                forge.aValueFrom(
-                    RumActionType::class.java,
-                    exclude = listOf(RumActionType.CUSTOM)
-                ),
+                actionType,
                 actionName,
-                attributes = defaultTestAttributes(testMethodName)
+                attributes = attributes
             )
         }
     }
@@ -483,11 +508,12 @@ class RumMonitorE2ETests {
     fun rum_rummonitor_ignore_add_background_custom_action_with_no_outcome() {
         val testMethodName = "rum_rummonitor_ignore_add_background_custom_action_with_no_outcome"
         val actionName = forge.anActionName()
+        val attributes = defaultTestAttributes(testMethodName)
         measure(testMethodName) {
             GlobalRum.get().addUserAction(
                 RumActionType.CUSTOM,
                 actionName,
-                attributes = defaultTestAttributes(testMethodName)
+                attributes = attributes
             )
         }
         // wait for the action to be inactive
@@ -501,11 +527,12 @@ class RumMonitorE2ETests {
     fun rum_rummonitor_ignore_add_background_custom_action_with_outcome() {
         val testMethodName = "rum_rummonitor_ignore_add_background_custom_action_with_outcome"
         val actionName = forge.anActionName()
+        val attributes = defaultTestAttributes(testMethodName)
         measure(testMethodName) {
             GlobalRum.get().addUserAction(
                 RumActionType.CUSTOM,
                 actionName,
-                attributes = defaultTestAttributes(testMethodName)
+                attributes = attributes
             )
         }
         // wait for the action to be inactive
@@ -523,14 +550,16 @@ class RumMonitorE2ETests {
     fun rum_rummonitor_ignore_add_background_non_custom_action_with_outcome() {
         val testMethodName = "rum_rummonitor_ignore_add_background_non_custom_action_with_outcome"
         val actionName = forge.anActionName()
+        val actionType = forge.aValueFrom(
+            RumActionType::class.java,
+            exclude = listOf(RumActionType.CUSTOM)
+        )
+        val attributes = defaultTestAttributes(testMethodName)
         measure(testMethodName) {
             GlobalRum.get().addUserAction(
-                forge.aValueFrom(
-                    RumActionType::class.java,
-                    exclude = listOf(RumActionType.CUSTOM)
-                ),
+                actionType,
                 actionName,
-                attributes = defaultTestAttributes(testMethodName)
+                attributes = attributes
             )
         }
         // wait for the action to be inactive
@@ -555,13 +584,15 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val resourceKey = forge.aResourceKey()
+        val method = forge.aResourceMethod()
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().startResource(
                     resourceKey,
-                    forge.aResourceMethod(),
+                    method,
                     resourceKey,
-                    attributes = defaultTestAttributes(testMethodName)
+                    attributes = attributes
                 )
             }
         }
@@ -576,20 +607,23 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val resourceKey = forge.aResourceKey()
+        val size = forge.aLong(min = 1)
+        val kind = forge.aValueFrom(RumResourceKind::class.java)
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startResource(
                 resourceKey,
                 forge.aResourceMethod(),
                 resourceKey,
-                attributes = defaultTestAttributes(testMethodName)
+                attributes = attributes
             )
             measure(testMethodName) {
                 GlobalRum.get().stopResource(
                     resourceKey,
                     200,
-                    forge.aLong(min = 1),
-                    forge.aValueFrom(RumResourceKind::class.java),
-                    defaultTestAttributes(testMethodName)
+                    size,
+                    kind,
+                    attributes
                 )
             }
         }
@@ -604,21 +638,26 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val resourceKey = forge.aResourceKey()
+        val statusCode = forge.anInt(min = 400, max = 511)
+        val message = forge.aResourceErrorMessage()
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        val throwable = forge.aThrowable()
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startResource(
                 resourceKey,
                 forge.aResourceMethod(),
                 resourceKey,
-                attributes = defaultTestAttributes(testMethodName)
+                attributes = attributes
             )
             measure(testMethodName) {
                 GlobalRum.get().stopResourceWithError(
                     resourceKey,
-                    forge.anInt(min = 400, max = 511),
-                    forge.aResourceErrorMessage(),
-                    forge.aValueFrom(RumErrorSource::class.java),
-                    forge.aThrowable(),
-                    defaultTestAttributes(testMethodName)
+                    statusCode,
+                    message,
+                    source,
+                    throwable,
+                    attributes
                 )
             }
         }
@@ -638,12 +677,13 @@ class RumMonitorE2ETests {
         val source = forge.aValueFrom(RumErrorSource::class.java)
         val stackTrace = forge.aString()
         val errorType = forge.aNullable { forge.anAlphabeticalString() }
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startResource(
                 resourceKey,
                 forge.aResourceMethod(),
                 resourceKey,
-                attributes = defaultTestAttributes(testMethodName)
+                attributes = attributes
             )
             measure(testMethodName) {
                 GlobalRum.get().stopResourceWithError(
@@ -653,7 +693,7 @@ class RumMonitorE2ETests {
                     source,
                     stackTrace,
                     errorType,
-                    defaultTestAttributes(testMethodName)
+                    attributes
                 )
             }
         }
@@ -668,21 +708,25 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val resourceKey = forge.aResourceKey()
+        val message = forge.aResourceErrorMessage()
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        val throwable = forge.aThrowable()
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startResource(
                 resourceKey,
                 forge.aResourceMethod(),
                 resourceKey,
-                attributes = defaultTestAttributes(testMethodName)
+                attributes = attributes
             )
             measure(testMethodName) {
                 GlobalRum.get().stopResourceWithError(
                     resourceKey,
                     null,
-                    forge.aResourceErrorMessage(),
-                    forge.aValueFrom(RumErrorSource::class.java),
-                    forge.aThrowable(),
-                    defaultTestAttributes(testMethodName)
+                    message,
+                    source,
+                    throwable,
+                    attributes
                 )
             }
         }
@@ -702,12 +746,13 @@ class RumMonitorE2ETests {
         val source = forge.aValueFrom(RumErrorSource::class.java)
         val stackTrace = forge.aString()
         val errorType = forge.aNullable { forge.anAlphabeticalString() }
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startResource(
                 resourceKey,
                 forge.aResourceMethod(),
                 resourceKey,
-                attributes = defaultTestAttributes(testMethodName)
+                attributes = attributes
             )
             measure(testMethodName) {
                 GlobalRum.get().stopResourceWithError(
@@ -717,7 +762,7 @@ class RumMonitorE2ETests {
                     source,
                     stackTrace,
                     errorType,
-                    defaultTestAttributes(testMethodName)
+                    attributes
                 )
             }
         }
@@ -734,19 +779,22 @@ class RumMonitorE2ETests {
     fun rum_rummonitor_ignore_stop_background_resource() {
         val testMethodName = "rum_rummonitor_ignore_stop_background_resource"
         val resourceKey = forge.aResourceKey()
+        val size = forge.aLong(min = 1)
+        val kind = forge.aValueFrom(RumResourceKind::class.java)
+        val attributes = defaultTestAttributes(testMethodName)
         GlobalRum.get().startResource(
             resourceKey,
             forge.aResourceMethod(),
             resourceKey,
-            attributes = defaultTestAttributes(testMethodName)
+            attributes = attributes
         )
         measure(testMethodName) {
             GlobalRum.get().stopResource(
                 resourceKey,
                 200,
-                forge.aLong(min = 1),
-                forge.aValueFrom(RumResourceKind::class.java),
-                defaultTestAttributes(testMethodName)
+                size,
+                kind,
+                attributes
             )
         }
     }
@@ -758,20 +806,25 @@ class RumMonitorE2ETests {
     fun rum_rummonitor_ignore_stop_background_resource_with_error() {
         val testMethodName = "rum_rummonitor_ignore_stop_background_resource_with_error"
         val resourceKey = forge.aResourceKey()
+        val attributes = defaultTestAttributes(testMethodName)
+        val statusCode = forge.anInt(min = 400, max = 511)
+        val message = forge.aResourceErrorMessage()
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        val throwable = forge.aThrowable()
         GlobalRum.get().startResource(
             resourceKey,
             forge.aResourceMethod(),
             resourceKey,
-            attributes = defaultTestAttributes(testMethodName)
+            attributes = attributes
         )
         measure(testMethodName) {
             GlobalRum.get().stopResourceWithError(
                 resourceKey,
-                forge.anInt(min = 400, max = 511),
-                forge.aResourceErrorMessage(),
-                forge.aValueFrom(RumErrorSource::class.java),
-                forge.aThrowable(),
-                defaultTestAttributes(testMethodName)
+                statusCode,
+                message,
+                source,
+                throwable,
+                attributes
             )
         }
     }
@@ -788,11 +841,12 @@ class RumMonitorE2ETests {
         val source = forge.aValueFrom(RumErrorSource::class.java)
         val stackTrace = forge.aString()
         val errorType = forge.aNullable { forge.anAlphabeticalString() }
+        val attributes = defaultTestAttributes(testMethodName)
         GlobalRum.get().startResource(
             resourceKey,
             forge.aResourceMethod(),
             resourceKey,
-            attributes = defaultTestAttributes(testMethodName)
+            attributes = attributes
         )
         measure(testMethodName) {
             GlobalRum.get().stopResourceWithError(
@@ -802,7 +856,7 @@ class RumMonitorE2ETests {
                 source,
                 stackTrace,
                 errorType,
-                defaultTestAttributes(testMethodName)
+                attributes
             )
         }
     }
@@ -820,13 +874,16 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val errorMessage = forge.anErrorMessage()
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        val throwable = forge.aNullable { forge.aThrowable() }
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().addError(
                     errorMessage,
-                    forge.aValueFrom(RumErrorSource::class.java),
-                    forge.aNullable { forge.aThrowable() },
-                    defaultTestAttributes(testMethodName)
+                    source,
+                    throwable,
+                    attributes
                 )
             }
         }
@@ -841,13 +898,16 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val errorMessage = forge.anErrorMessage()
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        val stacktrace = forge.aNullable { forge.aThrowable().stackTraceToString() }
+        val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().addErrorWithStacktrace(
                     errorMessage,
-                    forge.aValueFrom(RumErrorSource::class.java),
-                    forge.aNullable { forge.aThrowable().stackTraceToString() },
-                    defaultTestAttributes(testMethodName)
+                    source,
+                    stacktrace,
+                    attributes
                 )
             }
         }
@@ -864,12 +924,15 @@ class RumMonitorE2ETests {
     fun rum_rummonitor_ignore_add_background_error() {
         val testMethodName = "rum_rummonitor_ignore_add_background_error"
         val errorMessage = forge.anErrorMessage()
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        val throwable = forge.aNullable { forge.aThrowable() }
+        val attributes = defaultTestAttributes(testMethodName)
         measure(testMethodName) {
             GlobalRum.get().addError(
                 errorMessage,
-                forge.aValueFrom(RumErrorSource::class.java),
-                forge.aNullable { forge.aThrowable() },
-                defaultTestAttributes(testMethodName)
+                source,
+                throwable,
+                attributes
             )
         }
     }
@@ -881,12 +944,15 @@ class RumMonitorE2ETests {
     fun rum_rummonitor_ignore_add_background_error_with_stacktrace() {
         val testMethodName = "rum_rummonitor_ignore_add_background_error_with_stacktrace"
         val errorMessage = forge.anErrorMessage()
+        val source = forge.aValueFrom(RumErrorSource::class.java)
+        val stacktrace = forge.aNullable { forge.aThrowable().stackTraceToString() }
+        val attributes = defaultTestAttributes(testMethodName)
         measure(testMethodName) {
             GlobalRum.get().addErrorWithStacktrace(
                 errorMessage,
-                forge.aValueFrom(RumErrorSource::class.java),
-                forge.aNullable { forge.aThrowable().stackTraceToString() },
-                defaultTestAttributes(testMethodName)
+                source,
+                stacktrace,
+                attributes
             )
         }
     }


### PR DESCRIPTION
### What does this PR do?

In some of our perfs measurement methods we were also taking int account the time to forge the fake method parameters. 
This PR fixes this problem by generating all the parameters outside of the measurement block.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

