### PR TITLE
RUMM-1933 Java Error nested stack trace

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/ThrowableExtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/ThrowableExtTest.kt
@@ -2,10 +2,10 @@ package com.datadog.android.core.internal.utils
 
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.io.PrintWriter
-import java.io.StringWriter
+import java.lang.RuntimeException
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -20,15 +20,61 @@ import org.mockito.junit.jupiter.MockitoExtension
 internal class ThrowableExtTest {
 
     @Forgery
-    lateinit var throwable: Throwable
+    lateinit var fakeThrowable: Throwable
 
     @Test
-    fun `get loggable stack trace`() {
-        val sw = StringWriter()
-        val pw = PrintWriter(sw)
-        throwable.printStackTrace(pw)
+    fun `M return stack trace W loggableStackTrace() {simple exception}`() {
+        // Given
+        val stack = fakeThrowable.stackTrace
 
-        assertThat(throwable.loggableStackTrace())
-            .isEqualTo(sw.toString())
+        // When
+        val result = fakeThrowable.loggableStackTrace()
+
+        // Then
+        val lines = result.lines()
+        assertThat(lines.first()).contains(fakeThrowable.message)
+        stack.forEachIndexed { i, it ->
+            assertThat(lines[i + 1])
+                .contains(it.className)
+                .contains(it.methodName)
+        }
+    }
+
+    @Test
+    fun `M return stack trace W loggableStackTrace() {nested exception}`(
+        @StringForgery message: String
+    ) {
+        // Given
+        val topThrowable = RuntimeException(message, fakeThrowable)
+        val topStack = topThrowable.stackTrace
+        val stack = fakeThrowable.stackTrace
+
+        // When
+        val result = topThrowable.loggableStackTrace()
+
+        // Then
+        val lines = result.lines()
+        assertThat(lines.first()).contains(message)
+        topStack.forEachIndexed { i, it ->
+            assertThat(lines[i + 1])
+                .contains(it.className)
+                .contains(it.methodName)
+        }
+
+        val offset = topStack.size + 1
+        assertThat(lines.get(offset))
+            .contains("Caused by")
+            .contains(fakeThrowable.message)
+        stack.forEachIndexed { i, it ->
+            // When the "Caused by …" stacktrace has common frames with the previous one,
+            // those are not displayed and replaced with "… n more"
+            // In this test, there are at least 8 non common frames between the fakeThrowable
+            // and topThrowable
+            if (i < 8) {
+                assertThat(lines[i + offset + 1])
+                    .contains(it.className)
+                    .contains(it.methodName)
+            }
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Ensure that nested exception stack trace prints everything (including the `Caused by` parts).