### PR TITLE
Fix the signal handler to use a statically allocated backtrace heap

### DIFF
--- a/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/backtrace-handler.cpp
@@ -81,10 +81,12 @@ namespace {
                 backtrace->append(" ");
                 backtrace->append("+");
                 backtrace->append(" ");
-                auto address_offset = reinterpret_cast<uintptr_t>(info.dli_fbase);
+                auto address_offset = address - reinterpret_cast<uintptr_t>(info.dli_fbase);
                 backtrace->append(std::to_string(address_offset));
             }
-
+        } else {
+            backtrace->append(" ");
+            backtrace->append(address_to_hexa(address));
         }
 
         backtrace->append("\\n");

--- a/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
@@ -24,11 +24,11 @@
 static const char *LOG_TAG = "DatadogNdkCrashReporter";
 static stack_t signal_stack;
 
-/* the datadog sigaction which overrides the original signal handler */
-static volatile struct sigaction *volatile datadog_sigaction;
-
 /* the original sigaction array which will hold the original handlers for each overridden signal */
-volatile struct sigaction *volatile original_sigaction;
+volatile struct sigaction *volatile original_sigactions = NULL;
+
+/* pre-allocated memory for working with the backtrace */
+char* backtrace_scratch = NULL;
 
 volatile bool handlers_installed = false;
 
@@ -74,13 +74,13 @@ size_t handled_signals_size() { return sizeof(handled_signals) / sizeof(handled_
 
 
 void free_up_memory() {
-    if (datadog_sigaction != NULL) {
-        free((void *) datadog_sigaction);
-        datadog_sigaction = NULL;
+    if (backtrace_scratch != NULL) {
+        free((void*) backtrace_scratch);
+        backtrace_scratch = NULL;
     }
-    if (original_sigaction != NULL) {
-        free((void *) original_sigaction);
-        original_sigaction = NULL;
+    if (original_sigactions != NULL) {
+        free((void *) original_sigactions);
+        original_sigactions = NULL;
     }
     if (signal_stack.ss_sp != NULL) {
         free(signal_stack.ss_sp);
@@ -98,7 +98,7 @@ void invoke_previous_handler(int signum, siginfo_t *info, void *user_context) {
     for (int i = 0; i < signals_array_size; ++i) {
         const int signal = handled_signals[i].signal_value;
         if (signal == signum) {
-            struct sigaction previous = original_sigaction[i];
+            struct sigaction previous = original_sigactions[i];
             // From sigaction(2):
             //  > If act is non-zero, it specifies an action (SIG_DFL, SIG_IGN, or a
             //  handler routine)
@@ -131,7 +131,7 @@ void uninstall_handlers() {
     }
     const size_t signals_array_size = handled_signals_size();
     for (int i = 0; i < signals_array_size; i++) {
-        volatile struct sigaction *volatile original_action = &original_sigaction[i];
+        volatile struct sigaction *volatile original_action = &original_sigactions[i];
         if (original_action) {
             const int signal = handled_signals[i].signal_value;
             sigaction(signal, (struct sigaction *) original_action, 0);
@@ -146,20 +146,20 @@ void handle_signal(int signum, siginfo_t *info, void *user_context) {
     for (int i = 0; i < signals_array_size; i++) {
         const int signal = handled_signals[i].signal_value;
         if (signal == signum) {
-            char backtrace[max_stack_size];
+
             // in case the stacktrace is bigger than the required size it will be truncated
             // because we are unwinding the stack strace at this level we are always going to
             // to have for the top 3 levels at the top of the trace the executed lines from our
             // library: handle_signal, generate_backtrace and capture_backtrace.
             // If you are changing this code make sure to start from the new frame
             // index when generating the backtrace.
-            generate_backtrace(backtrace, stack_frames_start_index, max_stack_size);
+            generate_backtrace(backtrace_scratch, stack_frames_start_index, max_stack_size);
 
 
             write_crash_report(signal,
                                handled_signals[i].signal_name,
                                handled_signals[i].signal_error_message,
-                               backtrace);
+                               backtrace_scratch);
 
             break;
         }
@@ -180,8 +180,8 @@ bool configure_signal_stack() {
     // Art is already allocating memory for the signal stack here:
     // https://android.googlesource.com/platform/art/+/master/runtime/thread_linux.cc#35) but
     // because we need a bit more than that we will re - allocate it on our end.
-
-    static size_t stack_size = max_stack_size < MINSIGSTKSZ ? MINSIGSTKSZ : max_stack_size;
+    size_t expected_stack_size = 32 * 1024; // 32K -- same as the ART but on  our own dedicated stack
+    size_t stack_size = expected_stack_size < MINSIGSTKSZ ? MINSIGSTKSZ : expected_stack_size;
     if ((signal_stack.ss_sp = calloc(1, stack_size)) == NULL) {
         return false;
     }
@@ -192,41 +192,35 @@ bool configure_signal_stack() {
         signal_stack.ss_sp=NULL;
         return false;
     }
-    return true;
-}
 
-bool init_datadog_signal_handler() {
-    datadog_sigaction = malloc(sizeof(struct sigaction));
-    if (datadog_sigaction == NULL) {
-        return false;
-    }
-    if (sigemptyset((sigset_t *) &datadog_sigaction->sa_mask) != 0) {
-        return false;
-    }
-    datadog_sigaction->sa_sigaction = handle_signal;
-    // we will use the SA_ONSTACK mask here to handle the signal in a freshly new signal stack.
-    datadog_sigaction->sa_flags = SA_SIGINFO | SA_ONSTACK;
-
+    // Create a scratch area for grabbing the backtrace
+    backtrace_scratch = malloc(max_stack_size * sizeof(char));
     return true;
 }
 
 bool override_native_signal_handlers() {
-    if (!init_datadog_signal_handler()) {
+    struct sigaction datadog_sigaction = {};
+
+    if (sigemptyset((sigset_t *) &datadog_sigaction.sa_mask) != 0) {
         __android_log_write(ANDROID_LOG_ERROR, LOG_TAG,
                             "Not able to initialize the Datadog signal handler");
         return false;
     }
+    datadog_sigaction.sa_sigaction = handle_signal;
+    // we will use the SA_ONSTACK mask here to handle the signal in a freshly new signal stack.
+    datadog_sigaction.sa_flags = SA_SIGINFO | SA_ONSTACK;
+
     const size_t signals_array_size = handled_signals_size();
-    original_sigaction = calloc(signals_array_size, sizeof(struct sigaction));
-    if (original_sigaction == NULL) {
+    original_sigactions = calloc(signals_array_size, sizeof(struct sigaction));
+    if (original_sigactions == NULL) {
         __android_log_write(ANDROID_LOG_ERROR, LOG_TAG,
                             "Not able to allocate the memory to persist the original handlers");
         return false;
     }
     for (int i = 0; i < signals_array_size; i++) {
         const int signal = handled_signals[i].signal_value;
-        int success = sigaction(signal, (struct sigaction *) datadog_sigaction,
-                                (struct sigaction *) &original_sigaction[i]);
+        int success = sigaction(signal, &datadog_sigaction,
+                                (struct sigaction *) &original_sigactions[i]);
         if (success != 0) {
             __android_log_print(ANDROID_LOG_ERROR,
                                 LOG_TAG,

--- a/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
@@ -65,7 +65,8 @@ static const struct signal handled_signals[] = {
         {SIGBUS,  "SIGBUS",  "Bus error (bad memory access)"},
         {SIGFPE,  "SIGFPE",  "Floating-point exception"},
         {SIGABRT, "SIGABRT", "The process was terminated"},
-        {SIGSEGV, "SIGSEGV", "Segmentation violation (invalid memory reference)"}
+        {SIGSEGV, "SIGSEGV", "Segmentation violation (invalid memory reference)"},
+        {SIGTRAP, "SIGTRAP", "Signal trap"}
 };
 
 static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -142,6 +143,8 @@ void uninstall_handlers() {
 }
 
 void handle_signal(int signum, siginfo_t *info, void *user_context) {
+    __android_log_write(ANDROID_LOG_INFO, LOG_TAG, "Handling signal in Datadog Crash Handler");
+
     const size_t signals_array_size = handled_signals_size();
     for (int i = 0; i < signals_array_size; i++) {
         const int signal = handled_signals[i].signal_value;
@@ -243,6 +246,13 @@ bool try_to_install_handlers() {
 bool start_monitoring() {
     pthread_mutex_lock(&mutex);
     bool installed = try_to_install_handlers();
+    if (installed) {
+        __android_log_write(ANDROID_LOG_ERROR, LOG_TAG,
+                            "Successfully installed Datadog signal handlers");
+    } else {
+        __android_log_write(ANDROID_LOG_ERROR, LOG_TAG,
+                            "Unable to install signal handlers");
+    }
     pthread_mutex_unlock(&mutex);
     return installed;
 }

--- a/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
+++ b/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
@@ -143,8 +143,6 @@ void uninstall_handlers() {
 }
 
 void handle_signal(int signum, siginfo_t *info, void *user_context) {
-    __android_log_write(ANDROID_LOG_INFO, LOG_TAG, "Handling signal in Datadog Crash Handler");
-
     const size_t signals_array_size = handled_signals_size();
     for (int i = 0; i < signals_array_size; i++) {
         const int signal = handled_signals[i].signal_value;
@@ -198,6 +196,10 @@ bool configure_signal_stack() {
 
     // Create a scratch area for grabbing the backtrace
     backtrace_scratch = malloc(max_stack_size * sizeof(char));
+    if (backtrace_scratch == NULL) {
+        return false;
+    }
+
     return true;
 }
 
@@ -247,11 +249,11 @@ bool start_monitoring() {
     pthread_mutex_lock(&mutex);
     bool installed = try_to_install_handlers();
     if (installed) {
-        __android_log_write(ANDROID_LOG_ERROR, LOG_TAG,
-                            "Successfully installed Datadog signal handlers");
+        __android_log_write(ANDROID_LOG_INFO, LOG_TAG,
+                            "Successfully installed Datadog NDK signal handlers");
     } else {
         __android_log_write(ANDROID_LOG_ERROR, LOG_TAG,
-                            "Unable to install signal handlers");
+                            "Unable to install Datadog NDK signal handlers");
     }
     pthread_mutex_unlock(&mutex);
     return installed;

--- a/dd-sdk-android-ndk/src/test/cpp/test-signal-monitor.cpp
+++ b/dd-sdk-android-ndk/src/test/cpp/test-signal-monitor.cpp
@@ -6,7 +6,7 @@
 #include "utils/signal-monitor.h"
 
 extern bool handlers_installed;
-extern struct sigaction *original_sigaction;
+extern struct sigaction *original_sigactions;
 
 
 #ifndef NDEBUG
@@ -108,8 +108,8 @@ TEST calling_start_monitor_from_different_threads_will_not_corrupt_the_memory(vo
     sleep(5);
     int sigactions_size = 0;
     const int handled_signals = 6;
-    struct sigaction *end_pointer = original_sigaction + handled_signals;
-    struct sigaction *pointer = original_sigaction;
+    struct sigaction *end_pointer = original_sigactions + handled_signals;
+    struct sigaction *pointer = original_sigactions;
     while (pointer != end_pointer && pointer != nullptr) {
         sigactions_size++;
         pointer++;


### PR DESCRIPTION
### What does this PR do?

This changes the NDK signal handler to use a statically allocated buffer for recording the backtrace string instead of using the Stack. The way it was configured before, we used exactly the amount of allocated stack just for our backtrace string, which would overflow when any other variables were put on the stack, causing a SIGSEGV loop.

### Motivation

Fix bugs that were popping up when using the crash handler in Flutter.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

