### PR TITLE
RUMM-2039 Always send data when device has external power source

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
@@ -76,12 +76,15 @@ internal class BroadcastReceiverSystemInfoProvider(
         )
         val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
         val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, 100)
-
-        val resolvedBatteryStatus = SystemInfo.BatteryStatus.fromAndroidStatus(status)
-        val resolvedBatteryLevel = (level * 100) / scale
+        val pluggedStatus = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
+        val batteryStatus = SystemInfo.BatteryStatus.fromAndroidStatus(status)
+        val batteryLevel = (level * 100) / scale
+        val onExternalPowerSource = pluggedStatus in PLUGGED_IN_STATUS_VALUES
+        val batteryFullOrCharging = batteryStatus in batteryFullOrChargingStatus
         systemInfo = systemInfo.copy(
-            batteryStatus = resolvedBatteryStatus,
-            batteryLevel = resolvedBatteryLevel
+            batteryFullOrCharging = batteryFullOrCharging,
+            batteryLevel = batteryLevel,
+            onExternalPowerSource = onExternalPowerSource
         )
     }
 
@@ -97,4 +100,18 @@ internal class BroadcastReceiverSystemInfoProvider(
     }
 
     // endregion
+
+    companion object {
+
+        private val batteryFullOrChargingStatus = setOf(
+            SystemInfo.BatteryStatus.CHARGING,
+            SystemInfo.BatteryStatus.FULL
+        )
+
+        private val PLUGGED_IN_STATUS_VALUES = setOf(
+            BatteryManager.BATTERY_PLUGGED_AC,
+            BatteryManager.BATTERY_PLUGGED_WIRELESS,
+            BatteryManager.BATTERY_PLUGGED_USB
+        )
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/SystemInfo.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/SystemInfo.kt
@@ -9,9 +9,10 @@ package com.datadog.android.core.internal.system
 import android.os.BatteryManager
 
 internal data class SystemInfo(
-    val batteryStatus: BatteryStatus = BatteryStatus.UNKNOWN,
+    val batteryFullOrCharging: Boolean = false,
     val batteryLevel: Int = -1,
-    val powerSaveMode: Boolean = false
+    val powerSaveMode: Boolean = false,
+    val onExternalPowerSource: Boolean = false
 ) {
 
     internal enum class BatteryStatus {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/SystemInfoAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/assertj/SystemInfoAssert.kt
@@ -15,16 +15,6 @@ import org.assertj.core.data.Offset
 internal class SystemInfoAssert(actual: SystemInfo) :
     AbstractObjectAssert<SystemInfoAssert, SystemInfo>(actual, SystemInfoAssert::class.java) {
 
-    fun hasBatteryStatus(expected: SystemInfo.BatteryStatus): SystemInfoAssert {
-        assertThat(actual.batteryStatus)
-            .overridingErrorMessage(
-                "Expected systemInfo to have batteryStatus $expected " +
-                    "but was ${actual.batteryStatus}"
-            )
-            .isEqualTo(expected)
-        return this
-    }
-
     fun hasPowerSaveMode(expected: Boolean): SystemInfoAssert {
         assertThat(actual.powerSaveMode)
             .overridingErrorMessage(
@@ -43,6 +33,22 @@ internal class SystemInfoAssert(actual: SystemInfo) :
             )
             .isCloseTo(expected, Offset.offset(max(100 / scale, 1)))
 
+        return this
+    }
+
+    fun hasBatteryFullOrCharging(expected: Boolean): SystemInfoAssert {
+        assertThat(actual.batteryFullOrCharging).overridingErrorMessage(
+            "Expected systemInfo to have batteryFullOrCharging flag $expected " +
+                "but was ${actual.batteryFullOrCharging}"
+        ).isEqualTo(expected)
+        return this
+    }
+
+    fun hasOnExternalPowerSource(expected: Boolean): SystemInfoAssert {
+        assertThat(actual.onExternalPowerSource).overridingErrorMessage(
+            "Expected systemInfo to have onExternalPowerSource flag $expected " +
+                "but was ${actual.onExternalPowerSource}"
+        ).isEqualTo(expected)
         return this
     }
 


### PR DESCRIPTION
### What does this PR do?

We are currently conditioning the data upload on the device battery status but this creates a problem when the device has a different power supply than a battery. In that case the `BATTERY_STATUS` is usually unknown and the `BATTERY_LEVEL` usually 0 which means no data will ever be sent from that device. Such devices can be the Android TV or any other device using the Android OS and running on external power supply.

In this PR we are fixing this issue by taking into account also the `PLUGGED_STATUS` in the `BatteryManager` information Intent. This will usually return one of the values `BatteryManager.BATTERY_PLUGGED_AC`, `BatteryManager.BATTERY_PLUGGED_WIRELESS`, `BatteryManager.BATTERY_PLUGGED_USB` in case the device is running on external power source.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

