### PR TITLE
RUMM-1869: Make encryption API private

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -105,7 +105,6 @@ data class com.datadog.android.core.configuration.Configuration
     fun setInternalLogsEnabled(String, String): Builder
     fun setAdditionalConfiguration(Map<String, Any>): Builder
     fun setProxy(java.net.Proxy, okhttp3.Authenticator?): Builder
-    fun setSecurityConfig(SecurityConfig): Builder
   companion object 
 data class com.datadog.android.core.configuration.Credentials
   constructor(String, String, String, String?, String? = null)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -637,7 +637,8 @@ internal constructor(
          * @param config Security config to use. If not provided, default one will be used (no
          * encryption for local data storage).
          */
-        fun setSecurityConfig(config: SecurityConfig): Builder {
+        @Suppress("unused", "CommentOverPrivateFunction")
+        private fun setSecurityConfig(config: SecurityConfig): Builder {
             coreConfig = coreConfig.copy(
                 securityConfig = config
             )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -1660,6 +1660,14 @@ internal class ConfigurationBuilderTest {
         assertThat(config.internalLogsConfig).isNull()
     }
 
+    private fun Configuration.Builder.setSecurityConfig(
+        securityConfig: SecurityConfig
+    ): Configuration.Builder {
+        val method = this.javaClass.declaredMethods.find { it.name == "setSecurityConfig" }
+        method!!.isAccessible = true
+        return method.invoke(this, securityConfig) as Configuration.Builder
+    }
+
     companion object {
         val logger = LoggerTestConfiguration()
 

--- a/instrumented/integration/proguard-rules.pro
+++ b/instrumented/integration/proguard-rules.pro
@@ -10,6 +10,10 @@
 -keepnames class com.datadog.android.Datadog {
     *;
 }
+# Required because we need access to Configuration.Builder.setSecurityConfig()
+-keepnames class com.datadog.android.core.configuration.Configuration$Builder {
+    private com.datadog.android.core.configuration.Configuration$Builder setSecurityConfig(com.datadog.android.core.configuration.SecurityConfig);
+}
 # Required because we need access to GlobalRum.activeContext and GlobalRum.isRegistered by reflection
 -keepnames class com.datadog.android.rum.GlobalRum {
     private java.util.concurrent.atomic.AtomicReference activeContext;

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -226,6 +226,14 @@ internal class EncryptionTest {
         callMethod.invoke(instance.get(null))
     }
 
+    private fun Configuration.Builder.setSecurityConfig(
+        securityConfig: SecurityConfig
+    ): Configuration.Builder {
+        val method = this.javaClass.declaredMethods.find { it.name == "setSecurityConfig" }
+        method!!.isAccessible = true
+        return method.invoke(this, securityConfig) as Configuration.Builder
+    }
+
     // endregion
 
     companion object {

--- a/instrumented/nightly-tests/proguard-rules.pro
+++ b/instrumented/nightly-tests/proguard-rules.pro
@@ -14,6 +14,10 @@
 -keepnames class com.datadog.android.Datadog {
     *;
 }
+# Required because we need access to Configuration.Builder.setSecurityConfig()
+-keepnames class com.datadog.android.core.configuration.Configuration$Builder {
+    private com.datadog.android.core.configuration.Configuration$Builder setSecurityConfig(com.datadog.android.core.configuration.SecurityConfig);
+}
 # Required because we need access to GlobalRum.activeContext and GlobalRum.isRegistered by reflection
 -keepnames class com.datadog.android.rum.GlobalRum {
     private java.util.concurrent.atomic.AtomicReference activeContext;

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash/NdkCrashHandlerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash/NdkCrashHandlerE2ETests.kt
@@ -20,6 +20,7 @@ import com.datadog.android.nightly.services.RumEnabledNdkCrashService
 import com.datadog.android.nightly.services.RumEncryptionEnabledNdkCrashService
 import com.datadog.android.nightly.utils.NeverUseThatEncryption
 import com.datadog.android.nightly.utils.initializeSdk
+import com.datadog.android.nightly.utils.setSecurityConfig
 import com.datadog.android.nightly.utils.stopSdk
 import org.junit.Rule
 import org.junit.Test

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
@@ -21,6 +21,7 @@ import com.datadog.android.nightly.utils.initializeSdk
 import com.datadog.android.nightly.utils.measure
 import com.datadog.android.nightly.utils.measureLoggerInitialize
 import com.datadog.android.nightly.utils.measureSdkInitialize
+import com.datadog.android.nightly.utils.setSecurityConfig
 import com.datadog.android.privacy.TrackingConsent
 import fr.xgouchet.elmyr.junit4.ForgeRule
 import org.junit.Rule

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
@@ -31,6 +31,7 @@ import com.datadog.android.nightly.utils.initializeSdk
 import com.datadog.android.nightly.utils.invokeMethod
 import com.datadog.android.nightly.utils.measureSdkInitialize
 import com.datadog.android.nightly.utils.sendRandomActionOutcomeEvent
+import com.datadog.android.nightly.utils.setSecurityConfig
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
@@ -21,6 +21,7 @@ import com.datadog.android.nightly.utils.initializeSdk
 import com.datadog.android.nightly.utils.measure
 import com.datadog.android.nightly.utils.measureSdkInitialize
 import com.datadog.android.nightly.utils.sendRandomActionOutcomeEvent
+import com.datadog.android.nightly.utils.setSecurityConfig
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.tracing.AndroidTracer

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -12,6 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.core.configuration.SecurityConfig
 import com.datadog.android.nightly.BuildConfig
 import com.datadog.android.nightly.ENV_NAME
 import com.datadog.android.nightly.TEST_METHOD_NAME_KEY
@@ -116,6 +117,14 @@ fun cleanStorageFiles() {
 
 fun cleanGlobalAttributes() {
     GlobalRum.removeAttribute(TEST_METHOD_NAME_KEY)
+}
+
+fun Configuration.Builder.setSecurityConfig(
+    securityConfig: SecurityConfig
+): Configuration.Builder {
+    val method = this.javaClass.declaredMethods.find { it.name == "setSecurityConfig" }
+    method!!.isAccessible = true
+    return method.invoke(this, securityConfig) as Configuration.Builder
 }
 
 private fun createDatadogCredentials(): Credentials {


### PR DESCRIPTION
### What does this PR do?

### Motivation

This change makes encryption API delivered in #826 private for the following reasons:

* iOS counterpart is not there yet
* It will be changed in the upcoming API v2 re-work
* Keeping encryption feature in the dedicated branch makes it hard to keep it in sync with `develop`. So if this change is accepted, we will be able to merge encryption feature to the `develop` branch without exposing it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

