### PR TITLE
Fix nightly run for encryption tests

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/ReflectUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/ReflectUtils.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.nightly.utils
 
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.configuration.SecurityConfig
 import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
@@ -124,4 +126,16 @@ private fun <T : Any> T.getDeclaredMethodRecursively(
     }
 
     return method
+}
+
+/**
+ * Helper method to access security config while it's still private.
+ * @param securityConfig the [SecurityConfig] to use
+ */
+fun Configuration.Builder.setSecurityConfig(
+    securityConfig: SecurityConfig
+): Configuration.Builder {
+    val method = this.javaClass.declaredMethods.find { it.name == "setSecurityConfig" }
+    method?.isAccessible = true
+    return method?.invoke(this, securityConfig) as? Configuration.Builder ?: this
 }


### PR DESCRIPTION
### What does this PR do?

Encryption tests in the night run were failing with error:

```
java.lang.NoSuchMethodError: No static method setSecurityConfig(Lcom/datadog/android/core/configuration/Configuration$Builder;Lcom/datadog/android/core/configuration/d;)Lcom/datadog/android/core/configuration/Configuration$Builder; in class Lcom/datadog/android/nightly/utils/ReflectUtilsKt; or its super classes (declaration of 'com.datadog.android.nightly.utils.ReflectUtilsKt'
```

This PR fixes that by adding the necessary method to the necessary location.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

