### PR TITLE
RUMM-2021: Support telemetry events in the events processing pipeline

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitor.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitor.kt
@@ -24,7 +24,7 @@ class KotlinFileVisitor {
 
     fun visitFile(file: File, printAst: Boolean = false) {
         val code = file.readText()
-        val source = AstSource.String(code)
+        val source = AstSource.String(description = "Content of file ${file.path}", content = code)
         val ast = KotlinGrammarAntlrKotlinParser.parseKotlinFile(source)
 
         if (printAst) ast.print()

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -110,8 +110,6 @@ data class com.datadog.android.core.configuration.Credentials
   constructor(String, String, String, String?, String? = null)
   companion object 
     const val NO_VARIANT: String
-object com.datadog.android.core.configuration.private
-const val VALID_IP_REGEX: String
 data class com.datadog.android.core.configuration.SecurityConfig
   constructor(com.datadog.android.security.Encryption?)
 enum com.datadog.android.core.configuration.UploadFrequency
@@ -397,11 +395,6 @@ enum com.datadog.android.rum.RumResourceKind
   companion object 
 interface com.datadog.android.rum.RumSessionListener
   fun onSessionStarted(String, Boolean)
-override fun onInitialize(android.content.Context, com.datadog.android.core.configuration.Configuration.Feature.RUM)
-override fun onStop()
-override fun createPersistenceStrategy(android.content.Context, com.datadog.android.core.configuration.Configuration.Feature.RUM): com.datadog.android.core.internal.persistence.PersistenceStrategy<Any>
-override fun createUploader(com.datadog.android.core.configuration.Configuration.Feature.RUM): com.datadog.android.core.internal.net.DataUploader
-override fun onPostInitialized(android.content.Context)
 data class com.datadog.android.rum.model.ActionEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, ActionEventSession, Source? = null, View, Usr? = null, Connectivity? = null, Synthetics? = null, CiTest? = null, Dd, Context? = null, Action)
   val type: kotlin.String
@@ -1333,15 +1326,15 @@ class com.datadog.android.sqlite.DatadogDatabaseErrorHandler : android.database.
   constructor(android.database.DatabaseErrorHandler = DefaultDatabaseErrorHandler())
   override fun onCorruption(android.database.sqlite.SQLiteDatabase)
   companion object 
-data class com.datadog.android.telemetry.model.DebugEvent
-  constructor(Dd, kotlin.Long, kotlin.String, kotlin.String, Application? = null, Session? = null, View? = null, Action? = null, kotlin.String)
-  val status: kotlin.String
+data class com.datadog.android.telemetry.model.TelemetryDebugEvent
+  constructor(Dd, kotlin.Long, kotlin.String, Source, kotlin.String, Application? = null, Session? = null, View? = null, Action? = null, Telemetry)
+  val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
-    fun fromJson(kotlin.String): DebugEvent
+    fun fromJson(kotlin.String): TelemetryDebugEvent
   class Dd
     constructor()
-    val eventType: kotlin.String
+    val formatVersion: kotlin.Long
     fun toJson(): com.google.gson.JsonElement
   data class Application
     constructor(kotlin.String)
@@ -1363,15 +1356,31 @@ data class com.datadog.android.telemetry.model.DebugEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Action
-data class com.datadog.android.telemetry.model.ErrorEvent
-  constructor(Dd, kotlin.Long, kotlin.String, kotlin.String, Application? = null, Session? = null, View? = null, Action? = null, kotlin.String, Error? = null)
-  val status: kotlin.String
+  data class Telemetry
+    constructor(kotlin.String)
+    val status: kotlin.String
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Telemetry
+  enum Source
+    constructor(kotlin.String)
+    - ANDROID
+    - IOS
+    - BROWSER
+    - FLUTTER
+    - REACT_NATIVE
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Source
+data class com.datadog.android.telemetry.model.TelemetryErrorEvent
+  constructor(Dd, kotlin.Long, kotlin.String, Source, kotlin.String, Application? = null, Session? = null, View? = null, Action? = null, Telemetry)
+  val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
-    fun fromJson(kotlin.String): ErrorEvent
+    fun fromJson(kotlin.String): TelemetryErrorEvent
   class Dd
     constructor()
-    val eventType: kotlin.String
+    val formatVersion: kotlin.Long
     fun toJson(): com.google.gson.JsonElement
   data class Application
     constructor(kotlin.String)
@@ -1393,11 +1402,27 @@ data class com.datadog.android.telemetry.model.ErrorEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Action
+  data class Telemetry
+    constructor(kotlin.String, Error? = null)
+    val status: kotlin.String
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Telemetry
   data class Error
     constructor(kotlin.String? = null, kotlin.String? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Error
+  enum Source
+    constructor(kotlin.String)
+    - ANDROID
+    - IOS
+    - BROWSER
+    - FLUTTER
+    - REACT_NATIVE
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Source
 class com.datadog.android.tracing.AndroidTracer : com.datadog.opentracing.DDTracer
   override fun buildSpan(String): DDSpanBuilder
   class Builder

--- a/dd-sdk-android/generate_telemetry_models.gradle.kts
+++ b/dd-sdk-android/generate_telemetry_models.gradle.kts
@@ -11,8 +11,8 @@ tasks.register(
     targetPackageName = "com.datadog.android.telemetry.model"
     ignoredFiles = arrayOf("_common-schema.json")
     inputNameMapping = mapOf(
-        "debug-schema.json" to "DebugEvent",
-        "error-schema.json" to "ErrorEvent"
+        "debug-schema.json" to "TelemetryDebugEvent",
+        "error-schema.json" to "TelemetryErrorEvent"
     )
 }
 

--- a/dd-sdk-android/src/main/json/telemetry/_common-schema.json
+++ b/dd-sdk-android/src/main/json/telemetry/_common-schema.json
@@ -4,19 +4,26 @@
   "title": "CommonTelemetryProperties",
   "type": "object",
   "description": "Schema of common properties of Telemetry events",
-  "required": ["_dd", "date", "service", "version"],
+  "required": ["_dd", "type", "date", "service", "source", "version"],
   "properties": {
     "_dd": {
       "type": "object",
       "description": "Internal properties",
-      "required": ["event_type"],
+      "required": ["format_version"],
       "properties": {
-        "event_type": {
-          "type": "string",
-          "const": "internal_telemetry",
-          "description": "Event type"
+        "format_version": {
+          "type": "integer",
+          "const": 2,
+          "description": "Version of the RUM event format",
+          "readOnly": true
         }
       }
+    },
+    "type": {
+      "type": "string",
+      "description": "Telemetry event type. Should specify telemetry only.",
+      "const": "telemetry",
+      "readOnly": true
     },
     "date": {
       "type": "integer",
@@ -26,6 +33,12 @@
     "service": {
       "type": "string",
       "description": "The SDK generating the telemetry event"
+    },
+    "source": {
+      "type": "string",
+      "description": "The source of this event",
+      "enum": ["android", "ios", "browser", "flutter", "react-native"],
+      "readOnly": true
     },
     "version": {
       "type": "string",

--- a/dd-sdk-android/src/main/json/telemetry/debug-schema.json
+++ b/dd-sdk-android/src/main/json/telemetry/debug-schema.json
@@ -9,19 +9,23 @@
       "$ref": "_common-schema.json"
     },
     {
-      "required": [
-        "status",
-        "message"
-      ],
+      "required": ["telemetry"],
       "properties": {
-        "status": {
-          "type": "string",
-          "description": "Level/severity of the log",
-          "const": "debug"
-        },
-        "message": {
-          "type": "string",
-          "description": "Body of the log"
+        "telemetry": {
+          "type": "object",
+          "description": "The telemetry information",
+          "required": ["status", "message"],
+          "properties": {
+            "status": {
+              "type": "string",
+              "description": "Level/severity of the log",
+              "const": "debug"
+            },
+            "message": {
+              "type": "string",
+              "description": "Body of the log"
+            }
+          }
         }
       }
     }

--- a/dd-sdk-android/src/main/json/telemetry/error-schema.json
+++ b/dd-sdk-android/src/main/json/telemetry/error-schema.json
@@ -9,31 +9,35 @@
       "$ref": "_common-schema.json"
     },
     {
-      "required": [
-        "status",
-        "message"
-      ],
+      "required": ["telemetry"],
       "properties": {
-        "status": {
-          "type": "string",
-          "description": "Level/severity of the log",
-          "const": "error"
-        },
-        "message": {
-          "type": "string",
-          "description": "Body of the log"
-        },
-        "error": {
+        "telemetry": {
           "type": "object",
-          "description": "Error properties",
+          "description": "The telemetry information",
+          "required": ["status", "message"],
           "properties": {
-            "stack": {
+            "status": {
               "type": "string",
-              "description": "The stack trace or the complementary information about the error"
+              "description": "Level/severity of the log",
+              "const": "error"
             },
-            "kind": {
+            "message": {
               "type": "string",
-              "description": "The error type or kind (or code in some cases)"
+              "description": "Body of the log"
+            },
+            "error": {
+              "type": "object",
+              "description": "Error properties",
+              "properties": {
+                "stack": {
+                  "type": "string",
+                  "description": "The stack trace or the complementary information about the error"
+                },
+                "kind": {
+                  "type": "string",
+                  "description": "The error type or kind (or code in some cases)"
+                }
+              }
             }
           }
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -14,7 +14,9 @@ import androidx.fragment.app.Fragment
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.domain.event.RumEventSourceProvider
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
+import com.datadog.android.telemetry.internal.TelemetryEventHandler
 import com.datadog.tools.annotation.NoOpImplementation
 
 /**
@@ -298,6 +300,12 @@ interface RumMonitor {
                     samplingRate = samplingRate,
                     writer = RumFeature.persistenceStrategy.getWriter(),
                     handler = Handler(Looper.getMainLooper()),
+                    telemetryEventHandler = TelemetryEventHandler(
+                        CoreFeature.serviceName,
+                        CoreFeature.sdkVersion,
+                        RumEventSourceProvider(CoreFeature.sourceName),
+                        CoreFeature.timeProvider
+                    ),
                     firstPartyHostDetector = CoreFeature.firstPartyHostDetector,
                     cpuVitalMonitor = RumFeature.cpuVitalMonitor,
                     memoryVitalMonitor = RumFeature.memoryVitalMonitor,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
@@ -15,6 +15,8 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.telemetry.model.TelemetryDebugEvent
+import com.datadog.android.telemetry.model.TelemetryErrorEvent
 import com.google.gson.JsonObject
 
 internal class RumEventSerializer(
@@ -39,6 +41,12 @@ internal class RumEventSerializer(
             }
             is LongTaskEvent -> {
                 serializeLongTaskEvent(model)
+            }
+            is TelemetryDebugEvent -> {
+                model.toJson().toString()
+            }
+            is TelemetryErrorEvent -> {
+                model.toJson().toString()
             }
             is JsonObject -> {
                 model.toString()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSourceProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSourceProvider.kt
@@ -12,6 +12,8 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.telemetry.model.TelemetryDebugEvent
+import com.datadog.android.telemetry.model.TelemetryErrorEvent
 import java.util.Locale
 
 internal class RumEventSourceProvider(source: String) {
@@ -55,6 +57,24 @@ internal class RumEventSourceProvider(source: String) {
     val resourceEventSource: ResourceEvent.Source? by lazy {
         try {
             ResourceEvent.Source.fromJson(source)
+        } catch (e: NoSuchElementException) {
+            devLogger.e(UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT.format(Locale.US, source), e)
+            null
+        }
+    }
+
+    val telemetryDebugEventSource: TelemetryDebugEvent.Source? by lazy {
+        try {
+            TelemetryDebugEvent.Source.fromJson(source)
+        } catch (e: NoSuchElementException) {
+            devLogger.e(UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT.format(Locale.US, source), e)
+            null
+        }
+    }
+
+    val telemetryErrorEventSource: TelemetryErrorEvent.Source? by lazy {
+        try {
+            TelemetryErrorEvent.Source.fromJson(source)
         } catch (e: NoSuchElementException) {
             devLogger.e(UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT.format(Locale.US, source), e)
             null

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -13,6 +13,7 @@ import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.telemetry.internal.TelemetryType
 
 internal sealed class RumRawEvent {
 
@@ -185,4 +186,11 @@ internal sealed class RumRawEvent {
     ) : RumRawEvent()
 
     internal data class WebViewEvent(override val eventTime: Time = Time()) : RumRawEvent()
+
+    internal data class SendTelemetry(
+        val type: TelemetryType,
+        val message: String,
+        val throwable: Throwable?,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -13,7 +13,7 @@ import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.tools.annotation.NoOpImplementation
 
-@SuppressWarnings("ComplexInterface")
+@SuppressWarnings("ComplexInterface", "TooManyFunctions")
 @NoOpImplementation
 internal interface AdvancedRumMonitor : RumMonitor {
 
@@ -40,4 +40,8 @@ internal interface AdvancedRumMonitor : RumMonitor {
     fun eventDropped(viewId: String, type: EventType)
 
     fun setDebugListener(listener: RumDebugListener?)
+
+    fun sendDebugTelemetryEvent(message: String)
+
+    fun sendErrorTelemetryEvent(message: String, throwable: Throwable?)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -1,0 +1,101 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.internal
+
+import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.rum.internal.domain.event.RumEventSourceProvider
+import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import com.datadog.android.telemetry.model.TelemetryDebugEvent
+import com.datadog.android.telemetry.model.TelemetryErrorEvent
+
+internal class TelemetryEventHandler(
+    private val serviceName: String,
+    private val sdkVersion: String,
+    private val sourceProvider: RumEventSourceProvider,
+    private val timeProvider: TimeProvider
+) {
+
+    fun handleEvent(event: RumRawEvent.SendTelemetry, writer: DataWriter<Any>) {
+
+        val timestamp = event.eventTime.timestamp + timeProvider.getServerOffsetMillis()
+
+        val rumContext = GlobalRum.getRumContext()
+
+        val telemetryEvent: Any = when (event.type) {
+            TelemetryType.DEBUG -> {
+                createDebugEvent(
+                    timestamp, rumContext, event.message
+                )
+            }
+            TelemetryType.ERROR -> {
+                createErrorEvent(
+                    timestamp,
+                    rumContext,
+                    event.message,
+                    event.throwable
+                )
+            }
+        }
+
+        writer.write(telemetryEvent)
+    }
+
+    private fun createDebugEvent(
+        timestamp: Long,
+        rumContext: RumContext,
+        message: String
+    ): TelemetryDebugEvent {
+        return TelemetryDebugEvent(
+            dd = TelemetryDebugEvent.Dd(),
+            date = timestamp,
+            source = sourceProvider.telemetryDebugEventSource
+                ?: TelemetryDebugEvent.Source.ANDROID,
+            service = serviceName,
+            version = sdkVersion,
+            application = TelemetryDebugEvent.Application(rumContext.applicationId),
+            session = TelemetryDebugEvent.Session(rumContext.sessionId),
+            view = rumContext.viewId?.let { TelemetryDebugEvent.View(it) },
+            action = rumContext.actionId?.let { TelemetryDebugEvent.Action(it) },
+            telemetry = TelemetryDebugEvent.Telemetry(
+                message = message
+            )
+        )
+    }
+
+    private fun createErrorEvent(
+        timestamp: Long,
+        rumContext: RumContext,
+        message: String,
+        throwable: Throwable?
+    ): TelemetryErrorEvent {
+        return TelemetryErrorEvent(
+            dd = TelemetryErrorEvent.Dd(),
+            date = timestamp,
+            source = sourceProvider.telemetryErrorEventSource
+                ?: TelemetryErrorEvent.Source.ANDROID,
+            service = serviceName,
+            version = sdkVersion,
+            application = TelemetryErrorEvent.Application(rumContext.applicationId),
+            session = TelemetryErrorEvent.Session(rumContext.sessionId),
+            view = rumContext.viewId?.let { TelemetryErrorEvent.View(it) },
+            action = rumContext.actionId?.let { TelemetryErrorEvent.Action(it) },
+            telemetry = TelemetryErrorEvent.Telemetry(
+                message = message,
+                error = throwable?.let {
+                    TelemetryErrorEvent.Error(
+                        stack = it.loggableStackTrace(),
+                        kind = it.javaClass.canonicalName ?: it.javaClass.simpleName,
+                    )
+                }
+            )
+        )
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryType.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryType.kt
@@ -1,0 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.internal
+
+internal enum class TelemetryType {
+    DEBUG,
+    ERROR
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -14,6 +14,8 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.telemetry.model.TelemetryDebugEvent
+import com.datadog.android.telemetry.model.TelemetryErrorEvent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.assertj.JsonObjectAssert.Companion.assertThat
 import com.google.gson.JsonObject
@@ -386,6 +388,137 @@ internal class RumEventSerializerTest {
             assertThat(jsonObject).hasField("context") {
                 containsAttributes(it)
             }
+        }
+    }
+
+    @RepeatedTest(8)
+    fun `𝕄 serialize RUM event 𝕎 serialize() with TelemetryDebugEvent`(
+        @Forgery event: TelemetryDebugEvent
+    ) {
+        val serialized = testedSerializer.serialize(event)
+        val jsonObject = JsonParser.parseString(serialized).asJsonObject
+        assertThat(jsonObject)
+            .hasField("type", "telemetry")
+            .hasField("_dd") {
+                hasField("format_version", 2L)
+            }
+            .hasField("date", event.date)
+            .hasField("source", event.source.name.lowercase(Locale.US).replace('_', '-'))
+            .hasField("service", event.service)
+            .hasField("version", event.version)
+            .hasField("telemetry") {
+                hasField("message", event.telemetry.message)
+                hasField("status", "debug")
+            }
+
+        val application = event.application
+        if (application != null) {
+            assertThat(jsonObject)
+                .hasField("application") {
+                    hasField("id", application.id)
+                }
+        } else {
+            assertThat(jsonObject).doesNotHaveField("application")
+        }
+
+        val session = event.session
+        if (session != null) {
+            assertThat(jsonObject)
+                .hasField("session") {
+                    hasField("id", session.id)
+                }
+        } else {
+            assertThat(jsonObject).doesNotHaveField("session")
+        }
+
+        val view = event.view
+        if (view != null) {
+            assertThat(jsonObject)
+                .hasField("view") {
+                    hasField("id", view.id)
+                }
+        } else {
+            assertThat(jsonObject).doesNotHaveField("view")
+        }
+
+        val action = event.action
+        if (action != null) {
+            assertThat(jsonObject)
+                .hasField("action") {
+                    hasField("id", action.id)
+                }
+        } else {
+            assertThat(jsonObject).doesNotHaveField("action")
+        }
+    }
+
+    @RepeatedTest(8)
+    fun `𝕄 serialize RUM event 𝕎 serialize() with TelemetryErrorEvent`(
+        @Forgery event: TelemetryErrorEvent
+    ) {
+        val serialized = testedSerializer.serialize(event)
+        val jsonObject = JsonParser.parseString(serialized).asJsonObject
+        assertThat(jsonObject)
+            .hasField("type", "telemetry")
+            .hasField("_dd") {
+                hasField("format_version", 2L)
+            }
+            .hasField("date", event.date)
+            .hasField("source", event.source.name.lowercase(Locale.US).replace('_', '-'))
+            .hasField("service", event.service)
+            .hasField("version", event.version)
+            .hasField("telemetry") {
+                hasField("status", "error")
+                hasField("message", event.telemetry.message)
+                val error = event.telemetry.error
+                if (error != null) {
+                    hasField("error") {
+                        hasNullableField("stack", error.stack)
+                        hasNullableField("kind", error.kind)
+                    }
+                } else {
+                    doesNotHaveField("error")
+                }
+            }
+
+        val application = event.application
+        if (application != null) {
+            assertThat(jsonObject)
+                .hasField("application") {
+                    hasField("id", application.id)
+                }
+        } else {
+            assertThat(jsonObject).doesNotHaveField("application")
+        }
+
+        val session = event.session
+        if (session != null) {
+            assertThat(jsonObject)
+                .hasField("session") {
+                    hasField("id", session.id)
+                }
+        } else {
+            assertThat(jsonObject).doesNotHaveField("session")
+        }
+
+        val view = event.view
+        if (view != null) {
+            assertThat(jsonObject)
+                .hasField("view") {
+                    hasField("id", view.id)
+                }
+        } else {
+            assertThat(jsonObject).doesNotHaveField("view")
+        }
+
+        val action = event.action
+        if (action != null) {
+            assertThat(jsonObject)
+                .hasField("action") {
+                    hasField("id", action.id)
+                }
+        } else {
+            assertThat(jsonObject).doesNotHaveField("action")
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSourceProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSourceProviderTest.kt
@@ -12,6 +12,8 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.telemetry.model.TelemetryDebugEvent
+import com.datadog.android.telemetry.model.TelemetryErrorEvent
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.aStringNotMatchingSet
@@ -267,6 +269,96 @@ internal class RumEventSourceProviderTest {
 
         // When
         testedRumEventSourceProvider.longTaskEventSource
+
+        // Then
+        verify(logger.mockDevLogHandler).handleLog(
+            eq(Log.ERROR),
+            eq(
+                RumEventSourceProvider.UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT
+                    .format(Locale.US, fakeInvalidSource)
+            ),
+            argThat { this is NoSuchElementException },
+            eq(emptyMap()),
+            eq(emptySet()),
+            eq(null)
+        )
+    }
+
+    // endregion
+
+    // region TelemetryDebugEvent
+
+    @Test
+    fun `M resolve the TelemetryDebugEvent source W telemetryDebugEventSource`() {
+        // Given
+        testedRumEventSourceProvider = RumEventSourceProvider(fakeValidSource)
+
+        // Then
+        assertThat(testedRumEventSourceProvider.telemetryDebugEventSource)
+            .isEqualTo(TelemetryDebugEvent.Source.fromJson(fakeValidSource))
+    }
+
+    @Test
+    fun `M return null W telemetryDebugEventSource { unknown source }`() {
+        // Given
+        testedRumEventSourceProvider = RumEventSourceProvider(fakeInvalidSource)
+
+        // Then
+        assertThat(testedRumEventSourceProvider.telemetryDebugEventSource).isNull()
+    }
+
+    @Test
+    fun `M send an error dev log W telemetryDebugEventSource { unknown source }`() {
+        // Given
+        testedRumEventSourceProvider = RumEventSourceProvider(fakeInvalidSource)
+
+        // When
+        testedRumEventSourceProvider.telemetryDebugEventSource
+
+        // Then
+        verify(logger.mockDevLogHandler).handleLog(
+            eq(Log.ERROR),
+            eq(
+                RumEventSourceProvider.UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT
+                    .format(Locale.US, fakeInvalidSource)
+            ),
+            argThat { this is NoSuchElementException },
+            eq(emptyMap()),
+            eq(emptySet()),
+            eq(null)
+        )
+    }
+
+    // endregion
+
+    // region TelemetryErrorEvent
+
+    @Test
+    fun `M resolve the TelemetryErrorEvent source W telemetryErrorEventSource`() {
+        // Given
+        testedRumEventSourceProvider = RumEventSourceProvider(fakeValidSource)
+
+        // Then
+        assertThat(testedRumEventSourceProvider.telemetryErrorEventSource)
+            .isEqualTo(TelemetryErrorEvent.Source.fromJson(fakeValidSource))
+    }
+
+    @Test
+    fun `M return null W telemetryErrorEventSource { unknown source }`() {
+        // Given
+        testedRumEventSourceProvider = RumEventSourceProvider(fakeInvalidSource)
+
+        // Then
+        assertThat(testedRumEventSourceProvider.telemetryErrorEventSource).isNull()
+    }
+
+    @Test
+    fun `M send an error dev log W telemetryErrorEventSource { unknown source }`() {
+        // Given
+        testedRumEventSourceProvider = RumEventSourceProvider(fakeInvalidSource)
+
+        // When
+        testedRumEventSourceProvider.telemetryErrorEventSource
 
         // Then
         verify(logger.mockDevLogHandler).handleLog(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryDebugEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryDebugEventAssert.kt
@@ -1,0 +1,105 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.assertj
+
+import com.datadog.android.telemetry.model.TelemetryDebugEvent
+import org.assertj.core.api.AbstractObjectAssert
+import org.assertj.core.api.Assertions.assertThat
+
+internal class TelemetryDebugEventAssert(actual: TelemetryDebugEvent) :
+    AbstractObjectAssert<TelemetryDebugEventAssert, TelemetryDebugEvent>(
+        actual,
+        TelemetryDebugEventAssert::class.java
+    ) {
+
+    fun hasDate(expected: Long): TelemetryDebugEventAssert {
+        assertThat(actual.date)
+            .overridingErrorMessage(
+                "Expected event data to have date $expected but was ${actual.date}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasSource(expected: TelemetryDebugEvent.Source): TelemetryDebugEventAssert {
+        assertThat(actual.source)
+            .overridingErrorMessage(
+                "Expected event data to have source $expected but was ${actual.source}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasService(expected: String): TelemetryDebugEventAssert {
+        assertThat(actual.service)
+            .overridingErrorMessage(
+                "Expected event data to have service $expected but was ${actual.service}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasVersion(expected: String): TelemetryDebugEventAssert {
+        assertThat(actual.version)
+            .overridingErrorMessage(
+                "Expected event data to have version $expected but was ${actual.version}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasApplicationId(expected: String?): TelemetryDebugEventAssert {
+        assertThat(actual.application?.id)
+            .overridingErrorMessage(
+                "Expected event data to have" +
+                    " application.id $expected but was ${actual.application?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasSessionId(expected: String?): TelemetryDebugEventAssert {
+        assertThat(actual.session?.id)
+            .overridingErrorMessage(
+                "Expected event data to have session.id $expected but was ${actual.session?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasViewId(expected: String?): TelemetryDebugEventAssert {
+        assertThat(actual.view?.id)
+            .overridingErrorMessage(
+                "Expected event data to have view.id $expected but was ${actual.view?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasActionId(expected: String?): TelemetryDebugEventAssert {
+        assertThat(actual.action?.id)
+            .overridingErrorMessage(
+                "Expected event data to have action.id $expected but was ${actual.action?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasMessage(expected: String): TelemetryDebugEventAssert {
+        assertThat(actual.telemetry.message)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.message $expected" +
+                    " but was ${actual.telemetry.message}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    companion object {
+        fun assertThat(actual: TelemetryDebugEvent) = TelemetryDebugEventAssert(actual)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryErrorEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryErrorEventAssert.kt
@@ -1,0 +1,125 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.assertj
+
+import com.datadog.android.telemetry.model.TelemetryErrorEvent
+import org.assertj.core.api.AbstractObjectAssert
+import org.assertj.core.api.Assertions.assertThat
+
+internal class TelemetryErrorEventAssert(actual: TelemetryErrorEvent) :
+    AbstractObjectAssert<TelemetryErrorEventAssert, TelemetryErrorEvent>(
+        actual,
+        TelemetryErrorEventAssert::class.java
+    ) {
+
+    fun hasDate(expected: Long): TelemetryErrorEventAssert {
+        assertThat(actual.date)
+            .overridingErrorMessage(
+                "Expected event data to have date $expected but was ${actual.date}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasSource(expected: TelemetryErrorEvent.Source): TelemetryErrorEventAssert {
+        assertThat(actual.source)
+            .overridingErrorMessage(
+                "Expected event data to have source $expected but was ${actual.source}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasService(expected: String): TelemetryErrorEventAssert {
+        assertThat(actual.service)
+            .overridingErrorMessage(
+                "Expected event data to have service $expected but was ${actual.service}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasVersion(expected: String): TelemetryErrorEventAssert {
+        assertThat(actual.version)
+            .overridingErrorMessage(
+                "Expected event data to have version $expected but was ${actual.version}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasApplicationId(expected: String?): TelemetryErrorEventAssert {
+        assertThat(actual.application?.id)
+            .overridingErrorMessage(
+                "Expected event data to have" +
+                    " application.id $expected but was ${actual.application?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasSessionId(expected: String?): TelemetryErrorEventAssert {
+        assertThat(actual.session?.id)
+            .overridingErrorMessage(
+                "Expected event data to have session.id $expected but was ${actual.session?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasViewId(expected: String?): TelemetryErrorEventAssert {
+        assertThat(actual.view?.id)
+            .overridingErrorMessage(
+                "Expected event data to have view.id $expected but was ${actual.view?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasActionId(expected: String?): TelemetryErrorEventAssert {
+        assertThat(actual.action?.id)
+            .overridingErrorMessage(
+                "Expected event data to have action ID $expected but was ${actual.action?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasMessage(expected: String): TelemetryErrorEventAssert {
+        assertThat(actual.telemetry.message)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.message $expected" +
+                    " but was ${actual.telemetry.message}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasErrorStack(expected: String?): TelemetryErrorEventAssert {
+        assertThat(actual.telemetry.error?.stack)
+            .overridingErrorMessage(
+                "Expected event data to have error.stack $expected" +
+                    " but was ${actual.telemetry.error?.stack}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasErrorKind(expected: String?): TelemetryErrorEventAssert {
+        assertThat(actual.telemetry.error?.kind)
+            .overridingErrorMessage(
+                "Expected event data to have error.kind $expected" +
+                    " but was ${actual.telemetry.error?.kind}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    companion object {
+        fun assertThat(actual: TelemetryErrorEvent) = TelemetryErrorEventAssert(actual)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -1,0 +1,171 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.internal
+
+import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.internal.domain.event.RumEventSourceProvider
+import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import com.datadog.android.telemetry.assertj.TelemetryDebugEventAssert
+import com.datadog.android.telemetry.assertj.TelemetryErrorEventAssert
+import com.datadog.android.telemetry.model.TelemetryDebugEvent
+import com.datadog.android.telemetry.model.TelemetryErrorEvent
+import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.datadog.tools.unit.forge.aThrowable
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class TelemetryEventHandlerTest {
+
+    private lateinit var testedTelemetryHandler: TelemetryEventHandler
+
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
+    @Mock
+    lateinit var mockWriter: DataWriter<Any>
+
+    @Mock
+    lateinit var mockSourceProvider: RumEventSourceProvider
+
+    @StringForgery
+    lateinit var mockServiceName: String
+
+    @StringForgery
+    lateinit var mockSdkVersion: String
+
+    private var fakeServerOffset: Long = 0L
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        fakeServerOffset = forge.aLong(-50000, 50000)
+
+        whenever(mockTimeProvider.getServerOffsetMillis()) doReturn fakeServerOffset
+
+        whenever(mockSourceProvider.telemetryDebugEventSource) doReturn
+            TelemetryDebugEvent.Source.ANDROID
+        whenever(mockSourceProvider.telemetryErrorEventSource) doReturn
+            TelemetryErrorEvent.Source.ANDROID
+
+        testedTelemetryHandler =
+            TelemetryEventHandler(
+                mockServiceName,
+                mockSdkVersion,
+                mockSourceProvider,
+                mockTimeProvider
+            )
+    }
+
+    @Test
+    fun `𝕄 create debug event 𝕎 handleEvent(SendTelemetry) { debug event status }`(forge: Forge) {
+        // Given
+        val debugRawEvent = forge.createRumRawTelemetryDebugEvent()
+
+        val rumContext = GlobalRum.getRumContext()
+
+        // When
+        testedTelemetryHandler.handleEvent(debugRawEvent, mockWriter)
+
+        // Then
+        argumentCaptor<TelemetryDebugEvent> {
+            verify(mockWriter).write(capture())
+            TelemetryDebugEventAssert.assertThat(lastValue).apply {
+                hasDate(debugRawEvent.eventTime.timestamp + fakeServerOffset)
+                hasSource(TelemetryDebugEvent.Source.ANDROID)
+                hasMessage(debugRawEvent.message)
+                hasService(mockServiceName)
+                hasVersion(mockSdkVersion)
+                hasApplicationId(rumContext.applicationId)
+                hasSessionId(rumContext.sessionId)
+                hasViewId(rumContext.viewId)
+                hasActionId(rumContext.actionId)
+            }
+        }
+    }
+
+    @Test
+    fun `𝕄 create error event 𝕎 handleEvent(SendTelemetry) { error event status }`(forge: Forge) {
+        // Given
+        val errorRawEvent = forge.createRumRawTelemetryErrorEvent()
+
+        val rumContext = GlobalRum.getRumContext()
+
+        // When
+        testedTelemetryHandler.handleEvent(errorRawEvent, mockWriter)
+
+        // Then
+        argumentCaptor<TelemetryErrorEvent> {
+            verify(mockWriter).write(capture())
+            TelemetryErrorEventAssert.assertThat(lastValue).apply {
+                hasDate(errorRawEvent.eventTime.timestamp + fakeServerOffset)
+                hasSource(TelemetryErrorEvent.Source.ANDROID)
+                hasMessage(errorRawEvent.message)
+                hasService(mockServiceName)
+                hasVersion(mockSdkVersion)
+                hasApplicationId(rumContext.applicationId)
+                hasSessionId(rumContext.sessionId)
+                hasViewId(rumContext.viewId)
+                hasActionId(rumContext.actionId)
+                hasErrorStack(errorRawEvent.throwable?.loggableStackTrace())
+                hasErrorKind(errorRawEvent.throwable?.javaClass?.canonicalName)
+            }
+        }
+    }
+
+    // region private
+
+    private fun Forge.createRumRawTelemetryDebugEvent(): RumRawEvent.SendTelemetry {
+        return RumRawEvent.SendTelemetry(
+            TelemetryType.DEBUG, aString(), null
+        )
+    }
+
+    private fun Forge.createRumRawTelemetryErrorEvent(): RumRawEvent.SendTelemetry {
+        return RumRawEvent.SendTelemetry(
+            TelemetryType.ERROR, aString(), aNullable { aThrowable() }
+        )
+    }
+
+    // endregion
+
+    companion object {
+        val rumMonitor = GlobalRumMonitorTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(rumMonitor)
+        }
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/model/TelemetryDebugEventTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/model/TelemetryDebugEventTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.model
+
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings
+@ForgeConfiguration(Configurator::class)
+class TelemetryDebugEventTest {
+
+    @RepeatedTest(8)
+    fun `M serialize deserialized event W toJson()+fromJson()`(
+        @Forgery event: TelemetryDebugEvent
+    ) {
+        // Given
+        val json = event.toJson().toString()
+
+        // When
+        val result = TelemetryDebugEvent.fromJson(json)
+
+        // Then
+        Assertions.assertThat(result).isEqualTo(result)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/model/TelemetryErrorEventTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/model/TelemetryErrorEventTest.kt
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.model
+
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings
+@ForgeConfiguration(Configurator::class)
+class TelemetryErrorEventTest {
+
+    @RepeatedTest(8)
+    fun `M serialize deserialized event W toJson()+fromJson()`(
+        @Forgery event: TelemetryErrorEvent
+    ) {
+        // Given
+        val json = event.toJson().toString()
+
+        // When
+        val result = TelemetryErrorEvent.fromJson(json)
+
+        // Then
+        Assertions.assertThat(result).isEqualTo(result)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -53,6 +53,10 @@ internal class Configurator :
         forge.addFactory(ViewEventForgeryFactory())
         forge.addFactory(VitalInfoForgeryFactory())
 
+        // Telemetry
+        forge.addFactory(TelemetryDebugEventForgeryFactory())
+        forge.addFactory(TelemetryErrorEventForgeryFactory())
+
         // NDK Crash
         forge.addFactory(NdkCrashLogForgeryFactory())
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/TelemetryDebugEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/TelemetryDebugEventForgeryFactory.kt
@@ -1,0 +1,49 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.telemetry.model.TelemetryDebugEvent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import fr.xgouchet.elmyr.jvm.ext.aTimestamp
+import java.util.UUID
+
+internal class TelemetryDebugEventForgeryFactory : ForgeryFactory<TelemetryDebugEvent> {
+
+    override fun getForgery(forge: Forge): TelemetryDebugEvent {
+        return TelemetryDebugEvent(
+            date = forge.aTimestamp(),
+            source = forge.aValueFrom(TelemetryDebugEvent.Source::class.java),
+            service = forge.anAlphabeticalString(),
+            version = forge.anAlphabeticalString(),
+            application = forge.aNullable {
+                TelemetryDebugEvent.Application(
+                    forge.getForgery<UUID>().toString()
+                )
+            },
+            session = forge.aNullable {
+                TelemetryDebugEvent.Session(
+                    forge.getForgery<UUID>().toString()
+                )
+            },
+            view = forge.aNullable {
+                TelemetryDebugEvent.View(
+                    forge.getForgery<UUID>().toString()
+                )
+            },
+            action = forge.aNullable {
+                TelemetryDebugEvent.Action(
+                    forge.getForgery<UUID>().toString()
+                )
+            },
+            dd = TelemetryDebugEvent.Dd(),
+            telemetry = TelemetryDebugEvent.Telemetry(
+                message = forge.anAlphabeticalString()
+            )
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/TelemetryErrorEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/TelemetryErrorEventForgeryFactory.kt
@@ -1,0 +1,59 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.telemetry.model.TelemetryErrorEvent
+import com.datadog.tools.unit.forge.aThrowable
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import fr.xgouchet.elmyr.jvm.ext.aTimestamp
+import java.util.UUID
+
+internal class TelemetryErrorEventForgeryFactory : ForgeryFactory<TelemetryErrorEvent> {
+
+    override fun getForgery(forge: Forge): TelemetryErrorEvent {
+        val throwable = forge.aThrowable()
+
+        return TelemetryErrorEvent(
+            date = forge.aTimestamp(),
+            source = forge.aValueFrom(TelemetryErrorEvent.Source::class.java),
+            service = forge.anAlphabeticalString(),
+            version = forge.anAlphabeticalString(),
+            application = forge.aNullable {
+                TelemetryErrorEvent.Application(
+                    forge.getForgery<UUID>().toString()
+                )
+            },
+            session = forge.aNullable {
+                TelemetryErrorEvent.Session(
+                    forge.getForgery<UUID>().toString()
+                )
+            },
+            view = forge.aNullable {
+                TelemetryErrorEvent.View(
+                    forge.getForgery<UUID>().toString()
+                )
+            },
+            action = forge.aNullable {
+                TelemetryErrorEvent.Action(
+                    forge.getForgery<UUID>().toString()
+                )
+            },
+            dd = TelemetryErrorEvent.Dd(),
+            telemetry = TelemetryErrorEvent.Telemetry(
+                message = forge.anAlphabeticalString(),
+                error = TelemetryErrorEvent.Error(
+                    stack = forge.aNullable { throwable.loggableStackTrace() },
+                    kind = forge.aNullable {
+                        throwable.javaClass.canonicalName ?: throwable.javaClass.simpleName
+                    }
+                )
+            )
+        )
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -59,7 +59,7 @@ versionsPluginGradle = "0.27.0"
 nexusPublishPluginGradle = "1.1.0"
 
 kotlinPoet = "1.9.0"
-kotlinGrammarParser = "c35b50fa44"
+kotlinGrammarParser = "9b264ee"
 jsonSchemaValidator = "1.12.1"
 
 # Integrations

--- a/instrumentation-tools/src/constants.py
+++ b/instrumentation-tools/src/constants.py
@@ -10,6 +10,6 @@ IGNORED_TYPES = [
     "com.datadog.android.rum.model.ActionEvent$Dd",
     "com.datadog.android.rum.model.ErrorEvent$Dd",
     "com.datadog.android.rum.model.LongTaskEvent$Dd",
-    "com.datadog.android.telemetry.model.DebugEvent$Dd",
-    "com.datadog.android.telemetry.model.ErrorEvent$Dd"
+    "com.datadog.android.telemetry.model.TelemetryDebugEvent$Dd",
+    "com.datadog.android.telemetry.model.TelemetryErrorEvent$Dd"
 ]


### PR DESCRIPTION
### What does this PR do?

This PR adds support of sending telemetry events as a part of general RUM events processing pipeline (because these events go to the RUM intake).

The necessary private methods are added to the `AdvancedRumMonitor` (they are quite basic ones for now, without support of stack as a string, for example, for now).

Processing happens outside of any RUM scope (to not depend on the scope being created) and also outside of application and session scopes (to avoid the possible confusion with taking RUM context of those, which will miss info about current view and action).

Also this change updates the version of the Kotlin AST parsing lib, because I've hit a bug with existing version (also update solves the issue with wrong entries in the `apiSurface`).

The rest of work like replacing the existing internal monitoring feature will be in other PRs.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

