### PR TITLE
Fix name used in rum_rummonitor_ignore_stop_background_resource_with_error_stacktrace test

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
@@ -835,7 +835,7 @@ class RumMonitorE2ETests {
      */
     @Test
     fun rum_rummonitor_ignore_stop_background_resource_with_error_stacktrace() {
-        val testMethodName = "rum_rummonitor_ignore_stop_background_resource_with_error"
+        val testMethodName = "rum_rummonitor_ignore_stop_background_resource_with_error_stacktrace"
         val resourceKey = forge.aResourceKey()
         val statusCode = forge.anInt(min = 400, max = 511)
         val message = forge.aResourceErrorMessage()


### PR DESCRIPTION
### What does this PR do?

Wrong name (from another test) was used.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

