### PR TITLE
RUMM-2051 Android TV - get more information on action targets

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -318,6 +318,21 @@ publish:release-timber:
     - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
     - ./gradlew :dd-sdk-android-timber:publishToSonatype --stacktrace --no-daemon
 
+publish:release-android-tv:
+  tags: [ "runner:main" ]
+  only:
+    - tags
+  image: $CI_IMAGE_DOCKER
+  stage: publish
+  timeout: 30m
+  script:
+    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gradle-properties --with-decryption --query "Parameter.Value" --out text >> ./gradle.properties
+    - export GPG_PRIVATE_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.gpg_private_key --with-decryption --query "Parameter.Value" --out text)
+    - export GPG_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.gpg_passphrase --with-decryption --query "Parameter.Value" --out text)
+    - export OSSRH_USERNAME=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_username --with-decryption --query "Parameter.Value" --out text)
+    - export OSSRH_PASSWORD=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.signing.ossrh_password --with-decryption --query "Parameter.Value" --out text)
+    - ./gradlew :dd-sdk-android-tv:publishToSonatype --stacktrace --no-daemon
+
 # SLACK NOTIFICATIONS
 
 notify:release:

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -19,10 +19,12 @@ import,androidx.documentfile,Apache-2.0,Copyright 2018 The Android Open Source P
 import,androidx.drawerlayout,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.fragment,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.interpolator,Apache-2.0,Copyright 2018 The Android Open Source Project
+import,androidx.leanback,Apache-2.0,Copyright 2021 Datadog, Inc.
 import,androidx.legacy,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.lifecycle,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.loader,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.localbroadcastmanager,Apache-2.0,Copyright 2018 The Android Open Source Project
+import,androidx.media,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.multidex,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.navigation,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.print,Apache-2.0,Copyright 2018 The Android Open Source Project

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -77,7 +77,8 @@ tasks.register("assembleAll") {
         ":dd-sdk-android-ndk:assemble",
         ":dd-sdk-android-rx:assemble",
         ":dd-sdk-android-sqldelight:assemble",
-        ":dd-sdk-android-timber:assemble"
+        ":dd-sdk-android-timber:assemble",
+        ":dd-sdk-android-tv:assemble"
     )
 }
 
@@ -92,7 +93,8 @@ tasks.register("unitTestRelease") {
         ":dd-sdk-android-ndk:testReleaseUnitTest",
         ":dd-sdk-android-rx:testReleaseUnitTest",
         ":dd-sdk-android-sqldelight:testReleaseUnitTest",
-        ":dd-sdk-android-timber:testReleaseUnitTest"
+        ":dd-sdk-android-timber:testReleaseUnitTest",
+        ":dd-sdk-android-tv:testReleaseUnitTest"
     )
 }
 
@@ -108,6 +110,7 @@ tasks.register("unitTestDebug") {
         ":dd-sdk-android-rx:testDebugUnitTest",
         ":dd-sdk-android-sqldelight:testDebugUnitTest",
         ":dd-sdk-android-timber:testDebugUnitTest",
+        ":dd-sdk-android-tv:testDebugUnitTest"
     )
 }
 
@@ -139,6 +142,7 @@ tasks.register("ktlintCheckAll") {
         ":dd-sdk-android-rx:ktlintCheck",
         ":dd-sdk-android-sqldelight:ktlintCheck",
         ":dd-sdk-android-timber:ktlintCheck",
+        ":dd-sdk-android-tv:ktlintCheck",
         ":instrumented:integration:ktlintCheck",
         ":instrumented:nightly-tests:ktlintCheck",
         ":tools:detekt:ktlintCheck",
@@ -157,7 +161,8 @@ tasks.register("lintCheckAll") {
         ":dd-sdk-android-ndk:lintRelease",
         ":dd-sdk-android-rx:lintRelease",
         ":dd-sdk-android-sqldelight:lintRelease",
-        ":dd-sdk-android-timber:lintRelease"
+        ":dd-sdk-android-timber:lintRelease",
+        ":dd-sdk-android-tv:lintRelease"
     )
 }
 
@@ -172,7 +177,8 @@ tasks.register("checkThirdPartyLicensesAll") {
         ":dd-sdk-android-ndk:checkThirdPartyLicences",
         ":dd-sdk-android-rx:checkThirdPartyLicences",
         ":dd-sdk-android-sqldelight:checkThirdPartyLicences",
-        ":dd-sdk-android-timber:checkThirdPartyLicences"
+        ":dd-sdk-android-timber:checkThirdPartyLicences",
+        ":dd-sdk-android-tv:checkThirdPartyLicences"
     )
 }
 
@@ -187,7 +193,8 @@ tasks.register("checkApiSurfaceChangesAll") {
         ":dd-sdk-android-ndk:checkApiSurfaceChanges",
         ":dd-sdk-android-rx:checkApiSurfaceChanges",
         ":dd-sdk-android-sqldelight:checkApiSurfaceChanges",
-        ":dd-sdk-android-timber:checkApiSurfaceChanges"
+        ":dd-sdk-android-timber:checkApiSurfaceChanges",
+        ":dd-sdk-android-tv:checkApiSurfaceChanges"
     )
 }
 
@@ -203,6 +210,7 @@ tasks.register("detektAll") {
         ":dd-sdk-android-rx:detektMain",
         ":dd-sdk-android-sqldelight:detektMain",
         ":dd-sdk-android-timber:detektMain",
+        ":dd-sdk-android-tv:detektMain",
         ":instrumented:integration:detekt",
         ":instrumented:nightly-tests:detekt",
         ":tools:unit:detekt"
@@ -220,7 +228,8 @@ tasks.register("koverReportAll") {
         ":dd-sdk-android-ndk:koverXmlProjectReport",
         ":dd-sdk-android-rx:koverXmlProjectReport",
         ":dd-sdk-android-sqldelight:koverXmlProjectReport",
-        ":dd-sdk-android-timber:koverXmlProjectReport"
+        ":dd-sdk-android-timber:koverXmlProjectReport",
+        ":dd-sdk-android-tv:koverXmlProjectReport"
     )
 }
 

--- a/dd-sdk-android-tv/.gitignore
+++ b/dd-sdk-android-tv/.gitignore
@@ -1,0 +1,18 @@
+# Built application files
+*.apk
+*.ap_
+*.aab
+
+# Files for the ART/Dalvik VM
+*.dex
+
+# Java class files
+*.class
+
+# Generated files
+bin/
+gen/
+out/
+
+# Gradle files
+build/

--- a/dd-sdk-android-tv/README.md
+++ b/dd-sdk-android-tv/README.md
@@ -1,0 +1,76 @@
+# Datadog Integration for Android TV applications
+
+## Getting Started 
+
+To include the Datadog integration for AndroidTv in your project, simply add the
+following to your application's `build.gradle` file.
+
+```groovy
+dependencies {
+    implementation "com.datadoghq:dd-sdk-android:<latest-version>"
+    implementation "com.datadoghq:dd-sdk-android-tv:<latest-version>"
+}
+```
+
+### Initial Setup
+
+Before you can use the SDK, you need to setup the library with your application
+context, your Client token and your Application ID. 
+To generate a Client token and an Application ID please check **UX Monitoring > RUM Applications > New Application**
+in the Datadog dashboard.
+
+To get more information in the RUM Action events for AndroidTV application you can provide the [AndroidTvViewAttributesProvider][1]
+when initializing the SDK.
+
+```kotlin
+    class SampleApplication : Application() {
+        override fun onCreate() {
+            super.onCreate()
+            val configuration = Configuration.Builder(
+                    logsEnabled = true,
+                    tracesEnabled = true,
+                    crashReportsEnabled = true,
+                    rumEnabled = true
+                )
+                .useSite(DatadogSite.US3)
+                .trackInteractions(touchTargetExtraAttributesProviders = arrayOf(AndroidTvViewAttributesProvider()))
+                .trackLongTasks(durationThreshold)
+                .useViewTrackingStrategy(strategy)
+                .build()
+            val credentials = Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>)
+            Datadog.initialize(this, credentials, configuration, trackingConsent)
+        }
+    }
+```
+
+```java
+public class SampleApplication extends Application {
+    @Override
+    public void onCreate() {
+        super.onCreate();
+        final Configuration configuration =
+                new Configuration.Builder(true, true, true, true)
+                        .trackInteractions(new ViewAttributesProvider[]{new AndroidTvViewAttributesProvider()})
+                        .trackLongTasks(durationThreshold)
+                        .useViewTrackingStrategy(strategy)
+                        .build();
+        final Credentials credentials = new Credentials( < CLIENT_TOKEN >, <ENV_NAME >, <
+        APP_VARIANT_NAME >, <APPLICATION_ID >);
+        Datadog.initialize(this, credentials, configuration, trackingConsent);
+    }
+}
+```
+
+
+
+## Contributing
+
+Pull requests are welcome, but please open an issue first to discuss what you
+would like to change. For more information, read the 
+[Contributing Guide](../CONTRIBUTING.md).
+
+## License
+
+[Apache License, v2.0](../LICENSE)
+
+[1]: https://github.com/DataDog/dd-sdk-android/dd-sdk-android-tv/src/main/com/datadog/android/tv/AndroidTvViewAttributesProvider.kt

--- a/dd-sdk-android-tv/README.md
+++ b/dd-sdk-android-tv/README.md
@@ -2,8 +2,7 @@
 
 ## Getting Started 
 
-To include the Datadog integration for AndroidTv in your project, simply add the
-following to your application's `build.gradle` file.
+To include the Datadog integration for Android TV in your project, add the following to your application's `build.gradle` file.
 
 ```groovy
 dependencies {
@@ -14,13 +13,13 @@ dependencies {
 
 ### Initial Setup
 
-Before you can use the SDK, you need to setup the library with your application
-context, your Client token and your Application ID. 
-To generate a Client token and an Application ID please check **UX Monitoring > RUM Applications > New Application**
-in the Datadog dashboard.
+Before using the SDK, you need to setup the library with your application context, client token, and application ID.
+ 
+To generate a client token and an application ID, navigate to **UX Monitoring** > **RUM Applications** and click [**New Application**][2].
 
-To get more information in the RUM Action events for AndroidTV application you can provide the [AndroidTvViewAttributesProvider][1]
-when initializing the SDK.
+To receive more information about RUM action events for Android TV applications, provide the [`LeanbackViewAttributesProvider`][1] when initializing the SDK.
+
+#### Kotlin Example
 
 ```kotlin
     class SampleApplication : Application() {
@@ -32,8 +31,8 @@ when initializing the SDK.
                     crashReportsEnabled = true,
                     rumEnabled = true
                 )
-                .useSite(DatadogSite.US3)
-                .trackInteractions(touchTargetExtraAttributesProviders = arrayOf(AndroidTvViewAttributesProvider()))
+                .useSite(DatadogSite.US1)
+                .trackInteractions(touchTargetExtraAttributesProviders = arrayOf(LeanbackViewAttributesProvider()))
                 .trackLongTasks(durationThreshold)
                 .useViewTrackingStrategy(strategy)
                 .build()
@@ -43,6 +42,8 @@ when initializing the SDK.
     }
 ```
 
+#### Java Example
+
 ```java
 public class SampleApplication extends Application {
     @Override
@@ -50,9 +51,10 @@ public class SampleApplication extends Application {
         super.onCreate();
         final Configuration configuration =
                 new Configuration.Builder(true, true, true, true)
-                        .trackInteractions(new ViewAttributesProvider[]{new AndroidTvViewAttributesProvider()})
+                        .trackInteractions(new ViewAttributesProvider[]{new LeanbackViewAttributesProvider()})
                         .trackLongTasks(durationThreshold)
                         .useViewTrackingStrategy(strategy)
+                        .useSite(DatadogSite.US1)
                         .build();
         final Credentials credentials = new Credentials( < CLIENT_TOKEN >, <ENV_NAME >, <
         APP_VARIANT_NAME >, <APPLICATION_ID >);
@@ -61,16 +63,16 @@ public class SampleApplication extends Application {
 }
 ```
 
-
-
 ## Contributing
 
-Pull requests are welcome, but please open an issue first to discuss what you
-would like to change. For more information, read the 
-[Contributing Guide](../CONTRIBUTING.md).
+Pull requests are welcome. Open an issue first to discuss what you would like to change. For more information, see our [Contributing Guide][4].
 
 ## License
 
-[Apache License, v2.0](../LICENSE)
+[Apache License, v2.0][5]
 
-[1]: https://github.com/DataDog/dd-sdk-android/dd-sdk-android-tv/src/main/com/datadog/android/tv/AndroidTvViewAttributesProvider.kt
+[1]: https://github.com/DataDog/dd-sdk-android/blob/master/dd-sdk-android-tv/src/main/kotlin/com/datadog/android/tv/LeanbackViewAttributesProvider.kt
+[2]: https://app.datadoghq.com/rum/application/create
+[3]: https://github.com/DataDog/dd-sdk-android/blob/master/dd-sdk-android-tv/README.md
+[4]: https://github.com/DataDog/dd-sdk-android/blob/master/CONTRIBUTING.md
+[5]: https://github.com/DataDog/dd-sdk-android/blob/master/LICENSE

--- a/dd-sdk-android-tv/apiSurface
+++ b/dd-sdk-android-tv/apiSurface
@@ -1,0 +1,8 @@
+class com.datadog.android.tv.LeanbackViewAttributesProvider : com.datadog.android.rum.tracking.ViewAttributesProvider
+  override fun extractAttributes(android.view.View, MutableMap<String, Any?>)
+  override fun equals(Any?): Boolean
+  override fun hashCode(): Int
+  companion object 
+    const val ACTION_TARGET_ACTION_ID: String
+    const val ACTION_TARGET_LABEL1: String
+    const val ACTION_TARGET_LABEL2: String

--- a/dd-sdk-android-tv/build.gradle.kts
+++ b/dd-sdk-android-tv/build.gradle.kts
@@ -87,5 +87,5 @@ junitConfig()
 javadocConfig()
 dependencyUpdateConfig()
 publishingConfig(
-    "A RxJava integration to use with the Datadog monitoring library for Android applications."
+    "An Android TV integration to use with the Datadog monitoring library for Android applications."
 )

--- a/dd-sdk-android-tv/build.gradle.kts
+++ b/dd-sdk-android-tv/build.gradle.kts
@@ -1,0 +1,91 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-2019 Datadog, Inc.
+ */
+
+import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.detektConfig
+import com.datadog.gradle.config.javadocConfig
+import com.datadog.gradle.config.junitConfig
+import com.datadog.gradle.config.kotlinConfig
+import com.datadog.gradle.config.ktLintConfig
+import com.datadog.gradle.config.publishingConfig
+import com.datadog.gradle.config.setLibraryVersion
+
+plugins {
+    // Build
+    id("com.android.library")
+    kotlin("android")
+
+    // Publish
+    `maven-publish`
+    signing
+    id("org.jetbrains.dokka")
+
+    // Analysis tools
+    id("com.github.ben-manes.versions")
+    id("io.gitlab.arturbosch.detekt")
+    id("org.jlleitschuh.gradle.ktlint")
+
+    // Internal Generation
+    id("thirdPartyLicences")
+    id("apiSurface")
+    id("transitiveDependencies")
+}
+
+android {
+    compileSdk = AndroidConfig.TARGET_SDK
+    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
+
+    defaultConfig {
+        minSdk = AndroidConfig.MIN_SDK
+        targetSdk = AndroidConfig.TARGET_SDK
+        setLibraryVersion()
+    }
+
+    sourceSets.named("main") {
+        java.srcDir("src/main/kotlin")
+    }
+    sourceSets.named("test") {
+        java.srcDir("src/test/kotlin")
+    }
+    sourceSets.named("androidTest") {
+        java.srcDir("src/androidTest/kotlin")
+    }
+
+    testOptions {
+        unitTests.isReturnDefaultValues = true
+    }
+
+    lint {
+        isWarningsAsErrors = true
+        isAbortOnError = true
+        isCheckReleaseBuilds = false
+        isCheckGeneratedSources = true
+    }
+}
+
+dependencies {
+    api(project(":dd-sdk-android"))
+    implementation(libs.kotlin)
+    implementation(libs.androidXLeanback)
+
+    testImplementation(project(":tools:unit"))
+    testImplementation(libs.bundles.jUnit5)
+    testImplementation(libs.bundles.testTools)
+
+    detekt(project(":tools:detekt"))
+    detekt(libs.detektCli)
+}
+
+kotlinConfig()
+detektConfig()
+ktLintConfig()
+junitConfig()
+javadocConfig()
+dependencyUpdateConfig()
+publishingConfig(
+    "A RxJava integration to use with the Datadog monitoring library for Android applications."
+)

--- a/dd-sdk-android-tv/src/main/AndroidManifest.xml
+++ b/dd-sdk-android-tv/src/main/AndroidManifest.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-2019 Datadog, Inc.
+  -->
+
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    package="com.datadog.android.tv"
+    tools:ignore="ImpliedTouchscreenHardware,MissingLeanbackLauncher,MissingLeanbackSupport">
+
+</manifest>

--- a/dd-sdk-android-tv/src/main/kotlin/com/datadog/android/tv/LeanbackViewAttributesProvider.kt
+++ b/dd-sdk-android-tv/src/main/kotlin/com/datadog/android/tv/LeanbackViewAttributesProvider.kt
@@ -1,0 +1,123 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.tv
+
+import android.view.View
+import androidx.leanback.widget.Action
+import androidx.leanback.widget.ItemBridgeAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.datadog.android.rum.tracking.ViewAttributesProvider
+
+/**
+ * Provides extra attributes for the touch target View.
+ * Those special attributes are specifically related with Android TV [Action].
+ * @see [ACTION_TARGET_ACTION_ID]
+ * @see [ACTION_TARGET_LABEL1]
+ * @see [ACTION_TARGET_LABEL2]
+ */
+class LeanbackViewAttributesProvider :
+    ViewAttributesProvider {
+
+    // region ViewAttributesProvider
+
+    override fun extractAttributes(
+        view: View,
+        attributes: MutableMap<String, Any?>
+    ) {
+        // traverse the target parents
+        var parent = view.parent
+        var child: View? = view
+        while (parent != null) {
+            if (parent is RecyclerView && child != null) {
+                addActionInfoIfAny(parent, child, attributes)
+                break
+            }
+            child = parent as? View
+            parent = parent.parent
+        }
+    }
+
+    // endregion
+
+    // region Object
+
+    private fun addActionInfoIfAny(
+        parent: RecyclerView,
+        child: View,
+        attributes: MutableMap<String, Any?>
+    ) {
+        parent.findAction(child)?.let {
+            attributes[ACTION_TARGET_ACTION_ID] = it.id
+            it.label1?.let {
+                attributes[ACTION_TARGET_LABEL1] = it
+            }
+            it.label2?.let {
+                attributes[ACTION_TARGET_LABEL2] = it
+            }
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        return true
+    }
+
+    override fun hashCode(): Int {
+        return javaClass.hashCode()
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun RecyclerView.ViewHolder.isBridgeAdapterViewHolder(): Boolean {
+        return ItemBridgeAdapter.ViewHolder::class.java.isAssignableFrom(this::class.java)
+    }
+
+    private fun RecyclerView.findActionViewHolder(view: View): ItemBridgeAdapter.ViewHolder? {
+        val viewHolder = findContainingViewHolder(view)
+        if (viewHolder?.isBridgeAdapterViewHolder() == true) {
+            return viewHolder as ItemBridgeAdapter.ViewHolder
+        }
+        return null
+    }
+
+    private fun RecyclerView.findAction(view: View): Action? {
+        return findActionViewHolder(view)?.action()
+    }
+
+    private fun ItemBridgeAdapter.ViewHolder.action(): Action? {
+        if (Action::class.java.isAssignableFrom(item::class.java)) {
+            return item as Action
+        }
+        return null
+    }
+
+    // endregion
+
+    companion object {
+
+        /**
+         * The action id assigned for the current target.
+         * @see [Action]
+         */
+        const val ACTION_TARGET_ACTION_ID: String = "action.target.actionid"
+
+        /**
+         * The label displayed on the first line of the current target Action.
+         * @see [Action]
+         */
+        const val ACTION_TARGET_LABEL1: String = "action.target.label1"
+
+        /**
+         * The label displayed on the second line of the current target Action.
+         * @see [Action]
+         */
+        const val ACTION_TARGET_LABEL2: String = "action.target.label2"
+    }
+}

--- a/dd-sdk-android-tv/src/test/kotlin/com/datadog/android/tv/LeanbackViewAttributesProviderTest.kt
+++ b/dd-sdk-android-tv/src/test/kotlin/com/datadog/android/tv/LeanbackViewAttributesProviderTest.kt
@@ -1,0 +1,327 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.tv
+
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewParent
+import androidx.leanback.widget.Action
+import androidx.leanback.widget.ItemBridgeAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.datadog.tools.unit.ObjectTest
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(MockitoExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class LeanbackViewAttributesProviderTest : ObjectTest<LeanbackViewAttributesProvider>() {
+
+    lateinit var testedAttributesProvider: LeanbackViewAttributesProvider
+
+    @Mock
+    lateinit var mockRecyclerView: RecyclerView
+
+    @Mock
+    lateinit var mockTarget: View
+
+    @LongForgery
+    var fakeActionId: Long = 0
+
+    @StringForgery
+    lateinit var fakeActionLabel1: String
+
+    @StringForgery
+    lateinit var fakeActionLabel2: String
+
+    lateinit var fakeAction: Action
+
+    @Mock
+    lateinit var mockViewHolder: ItemBridgeAdapter.ViewHolder
+
+    lateinit var fakeAttributes: MutableMap<String, Any?>
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        fakeAttributes = forge.exhaustiveAttributes().toMutableMap()
+        fakeAction = Action(fakeActionId, fakeActionLabel1, fakeActionLabel2)
+        whenever(mockViewHolder.item).thenReturn(fakeAction)
+        testedAttributesProvider =
+            LeanbackViewAttributesProvider()
+    }
+
+    override fun createInstance(forge: Forge): LeanbackViewAttributesProvider {
+        return LeanbackViewAttributesProvider()
+    }
+
+    override fun createEqualInstance(
+        source: LeanbackViewAttributesProvider,
+        forge: Forge
+    ): LeanbackViewAttributesProvider {
+        return LeanbackViewAttributesProvider()
+    }
+
+    override fun createUnequalInstance(
+        source: LeanbackViewAttributesProvider,
+        forge: Forge
+    ): LeanbackViewAttributesProvider? = null
+
+    @Test
+    fun `M add action details W extractAttributes`() {
+        // Given
+        whenever(mockRecyclerView.findContainingViewHolder(mockTarget)).thenReturn(
+            mockViewHolder
+        )
+        whenever(mockTarget.parent).thenReturn(mockRecyclerView)
+
+        // When
+        testedAttributesProvider.extractAttributes(mockTarget, fakeAttributes)
+
+        // Then
+        assertThat(fakeAttributes).containsAllEntriesOf(fakeAttributes)
+        assertThat(fakeAttributes).containsAllEntriesOf(
+            mapOf(
+                LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID to fakeAction.id,
+                LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1 to fakeAction.label1,
+                LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2 to fakeAction.label2,
+            )
+        )
+    }
+
+    @Test
+    fun `M not add action label1 W extractAttributes {Action Label 1 is null}`() {
+        // Given
+        fakeAction.label1 = null
+        whenever(mockRecyclerView.findContainingViewHolder(mockTarget)).thenReturn(
+            mockViewHolder
+        )
+        whenever(mockTarget.parent).thenReturn(mockRecyclerView)
+
+        // When
+        testedAttributesProvider.extractAttributes(mockTarget, fakeAttributes)
+
+        // Then
+        assertThat(fakeAttributes).containsAllEntriesOf(fakeAttributes)
+        assertThat(fakeAttributes).containsAllEntriesOf(
+            mapOf(
+                LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID to fakeAction.id,
+                LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2 to fakeAction.label2
+            )
+        )
+        assertThat(fakeAttributes).doesNotContainKey(
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1
+        )
+    }
+
+    @Test
+    fun `M not add action label2 W extractAttributes {Action Label 2 is null}`() {
+        // Given
+        fakeAction.label2 = null
+        whenever(mockRecyclerView.findContainingViewHolder(mockTarget)).thenReturn(
+            mockViewHolder
+        )
+        whenever(mockTarget.parent).thenReturn(mockRecyclerView)
+
+        // When
+        testedAttributesProvider.extractAttributes(mockTarget, fakeAttributes)
+
+        // Then
+        assertThat(fakeAttributes).containsAllEntriesOf(fakeAttributes)
+        assertThat(fakeAttributes).containsAllEntriesOf(
+            mapOf(
+                LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID to fakeAction.id,
+                LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1 to fakeAction.label1
+            )
+        )
+        assertThat(fakeAttributes).doesNotContainKey(
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2
+        )
+    }
+
+    @Test
+    fun `M not add action labels W extractAttributes {both labels are null}`() {
+        // Given
+        fakeAction.label2 = null
+        fakeAction.label1 = null
+        whenever(mockRecyclerView.findContainingViewHolder(mockTarget)).thenReturn(
+            mockViewHolder
+        )
+        whenever(mockTarget.parent).thenReturn(mockRecyclerView)
+
+        // When
+        testedAttributesProvider.extractAttributes(mockTarget, fakeAttributes)
+
+        // Then
+        assertThat(fakeAttributes).containsAllEntriesOf(fakeAttributes)
+        assertThat(fakeAttributes).containsAllEntriesOf(
+            mapOf(
+                LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID to fakeAction.id,
+            )
+        )
+        assertThat(fakeAttributes).doesNotContainKeys(
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2
+        )
+    }
+
+    @Test
+    fun `M add action details W extractAttributes {target is a RecyclerView nested child}`() {
+        // Given
+        val mockParent: ViewGroup = mock {
+            whenever(it.parent).thenReturn(mockRecyclerView)
+        }
+        whenever(mockRecyclerView.findContainingViewHolder(mockParent)).thenReturn(
+            mockViewHolder
+        )
+        whenever(mockTarget.parent).thenReturn(mockParent)
+
+        // When
+        testedAttributesProvider.extractAttributes(mockTarget, fakeAttributes)
+
+        // Then
+        assertThat(fakeAttributes).containsAllEntriesOf(fakeAttributes)
+        assertThat(fakeAttributes).containsAllEntriesOf(
+            mapOf(
+                LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID to fakeAction.id,
+                LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1 to fakeAction.label1,
+                LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2 to fakeAction.label2,
+            )
+        )
+    }
+
+    @Test
+    fun `M do nothing W extractAttributes {target is not a RecyclerView descendant}`() {
+        // Given
+        val mockParent: ViewParent = mock()
+        whenever(mockTarget.parent).thenReturn(mockParent)
+
+        // When
+        testedAttributesProvider.extractAttributes(mockTarget, fakeAttributes)
+
+        // Then
+        assertThat(fakeAttributes).containsAllEntriesOf(fakeAttributes)
+        assertThat(fakeAttributes).doesNotContainKeys(
+            LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2
+        )
+    }
+
+    @Test
+    fun `M do nothing W extractAttributes {target parent is null}`() {
+        // Given
+        whenever(mockTarget.parent).thenReturn(null)
+
+        // When
+        testedAttributesProvider.extractAttributes(mockTarget, fakeAttributes)
+
+        // Then
+        assertThat(fakeAttributes).containsAllEntriesOf(fakeAttributes)
+        assertThat(fakeAttributes).doesNotContainKeys(
+            LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2
+        )
+    }
+
+    @Test
+    fun `M do nothing W extractAttributes {target viewHolder not ItemBridgeAdapterViewHolder}`() {
+        // Given
+        whenever(mockTarget.parent).thenReturn(mockRecyclerView)
+        whenever(mockRecyclerView.findContainingViewHolder(mockTarget)).thenReturn(mock())
+
+        // When
+        testedAttributesProvider.extractAttributes(mockTarget, fakeAttributes)
+
+        // Then
+        assertThat(fakeAttributes).containsAllEntriesOf(fakeAttributes)
+        assertThat(fakeAttributes).doesNotContainKeys(
+            LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2
+        )
+    }
+
+    @Test
+    fun `M do nothing W extractAttributes {target viewHolder item not of type Action}`() {
+        // Given
+        whenever(mockTarget.parent).thenReturn(mockRecyclerView)
+        whenever(mockRecyclerView.findContainingViewHolder(mockTarget)).thenReturn(mockViewHolder)
+        whenever(mockViewHolder.item).thenReturn(Any())
+
+        // When
+        testedAttributesProvider.extractAttributes(mockTarget, fakeAttributes)
+
+        // Then
+        assertThat(fakeAttributes).containsAllEntriesOf(fakeAttributes)
+        assertThat(fakeAttributes).doesNotContainKeys(
+            LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2
+        )
+    }
+
+    @Test
+    fun `M do nothing W extractAttributes {target viewHolder is null}`() {
+        // Given
+        whenever(mockTarget.parent).thenReturn(mockRecyclerView)
+        whenever(mockRecyclerView.findContainingViewHolder(mockTarget)).thenReturn(null)
+
+        // When
+        testedAttributesProvider.extractAttributes(mockTarget, fakeAttributes)
+
+        // Then
+        assertThat(fakeAttributes).containsAllEntriesOf(fakeAttributes)
+        assertThat(fakeAttributes).doesNotContainKeys(
+            LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1,
+            LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2
+        )
+    }
+
+    // region Internal
+
+    private fun Forge.exhaustiveAttributes(): Map<String, Any?> {
+        return listOf(
+            aBool(),
+            anInt(),
+            aLong(),
+            aFloat(),
+            aDouble(),
+            anAsciiString(),
+            aList { anAlphabeticalString() },
+            null
+        ).associateBy { anAlphabeticalString() }.removeActionAttributes()
+    }
+
+    private fun Map<String, Any?>.removeActionAttributes(): Map<String, Any?> {
+        return filter {
+            it.key !in setOf(
+                LeanbackViewAttributesProvider.ACTION_TARGET_ACTION_ID,
+                LeanbackViewAttributesProvider.ACTION_TARGET_LABEL2,
+                LeanbackViewAttributesProvider.ACTION_TARGET_LABEL1
+            )
+        }
+    }
+
+    // endregion
+}

--- a/dd-sdk-android-tv/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/dd-sdk-android-tv/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline

--- a/dd-sdk-android-tv/transitiveDependencies
+++ b/dd-sdk-android-tv/transitiveDependencies
@@ -1,0 +1,42 @@
+Dependencies List
+
+androidx.activity:activity:1.1.0                                :   13 Kb
+androidx.annotation:annotation-experimental:1.1.0               :   16 Kb
+androidx.annotation:annotation:1.2.0                            :   28 Kb
+androidx.arch.core:core-common:2.1.0                            :   10 Kb
+androidx.arch.core:core-runtime:2.1.0                           :    5 Kb
+androidx.asynclayoutinflater:asynclayoutinflater:1.0.0          :    7 Kb
+androidx.collection:collection:1.1.0                            :   41 Kb
+androidx.coordinatorlayout:coordinatorlayout:1.0.0              :   43 Kb
+androidx.core:core:1.6.0                                        :  905 Kb
+androidx.cursoradapter:cursoradapter:1.0.0                      :   10 Kb
+androidx.customview:customview:1.0.0                            :   32 Kb
+androidx.documentfile:documentfile:1.0.0                        :   10 Kb
+androidx.drawerlayout:drawerlayout:1.0.0                        :   31 Kb
+androidx.fragment:fragment:1.2.4                                :  221 Kb
+androidx.interpolator:interpolator:1.0.0                        :    7 Kb
+androidx.leanback:leanback:1.0.0                                : 1329 Kb
+androidx.legacy:legacy-support-core-ui:1.0.0                    :   11 Kb
+androidx.legacy:legacy-support-core-utils:1.0.0                 :    4 Kb
+androidx.lifecycle:lifecycle-common:2.2.0                       :   21 Kb
+androidx.lifecycle:lifecycle-livedata-core:2.2.0                :    8 Kb
+androidx.lifecycle:lifecycle-livedata:2.1.0                     :   10 Kb
+androidx.lifecycle:lifecycle-runtime:2.2.0                      :   10 Kb
+androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0         :   13 Kb
+androidx.lifecycle:lifecycle-viewmodel:2.2.0                    :    9 Kb
+androidx.loader:loader:1.0.0                                    :   32 Kb
+androidx.localbroadcastmanager:localbroadcastmanager:1.0.0      :    6 Kb
+androidx.media:media:1.0.0                                      :  330 Kb
+androidx.print:print:1.0.0                                      :   15 Kb
+androidx.recyclerview:recyclerview:1.1.0                        :  349 Kb
+androidx.savedstate:savedstate:1.0.0                            :    9 Kb
+androidx.slidingpanelayout:slidingpanelayout:1.0.0              :   22 Kb
+androidx.swiperefreshlayout:swiperefreshlayout:1.0.0            :   32 Kb
+androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
+androidx.viewpager:viewpager:1.0.0                              :   52 Kb
+org.jetbrains.kotlin:kotlin-stdlib-common:1.5.31                :  193 Kb
+org.jetbrains.kotlin:kotlin-stdlib:1.5.31                       : 1470 Kb
+org.jetbrains:annotations:13.0                                  :   17 Kb
+
+Total transitive dependencies size                              :    5 Mb
+

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesTracker.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/DatadogGesturesTracker.kt
@@ -32,7 +32,8 @@ internal class DatadogGesturesTracker(
             window,
             toWrap,
             gesturesDetector,
-            interactionPredicate
+            interactionPredicate,
+            targetAttributesProviders = targetAttributesProviders
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapper.kt
@@ -16,6 +16,7 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.tracking.InteractionPredicate
 import com.datadog.android.rum.tracking.NoOpInteractionPredicate
+import com.datadog.android.rum.tracking.ViewAttributesProvider
 import java.lang.ref.WeakReference
 import kotlin.Exception
 
@@ -28,7 +29,8 @@ internal class WindowCallbackWrapper(
     val copyEvent: (MotionEvent) -> MotionEvent = {
         @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
         MotionEvent.obtain(it)
-    }
+    },
+    val targetAttributesProviders: Array<ViewAttributesProvider> = emptyArray()
 ) : Window.Callback by wrappedCallback {
 
     internal val windowReference = WeakReference(window)
@@ -109,6 +111,9 @@ internal class WindowCallbackWrapper(
                 RumAttributes.ACTION_TARGET_CLASS_NAME to it.targetClassName(),
                 RumAttributes.ACTION_TARGET_RESOURCE_ID to resourceIdName(it.id)
             )
+            targetAttributesProviders.forEach { provider ->
+                provider.extractAttributes(it, attributes)
+            }
             val targetName = resolveTargetName(interactionPredicate, it)
             GlobalRum.get().addUserAction(RumActionType.CLICK, targetName, attributes)
         }

--- a/docs/integrated_libraries_android.md
+++ b/docs/integrated_libraries_android.md
@@ -124,6 +124,10 @@ If you use Apollo, let it use your `OkHttpClient` for RUM and APM information ab
 {{% /tab %}}
 {{< /tabs >}}
 
+### Android TV (Leanback)
+
+If you use the Leanback API to add actions into your Android TV application, take a look at Datadog's [dedicated Android TV library][6].
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -133,3 +137,4 @@ If you use Apollo, let it use your `OkHttpClient` for RUM and APM information ab
 [3]: https://github.com/DataDog/dd-sdk-android/tree/master/dd-sdk-android-glide
 [4]: https://github.com/DataDog/dd-sdk-android/tree/master/dd-sdk-android-sqldelight
 [5]: https://developer.android.com/reference/android/database/sqlite/SQLiteOpenHelper
+[6]: https://github.com/DataDog/dd-sdk-android/tree/master/dd-sdk-android-tv

--- a/docs/rum_getting_started.md
+++ b/docs/rum_getting_started.md
@@ -59,7 +59,7 @@ See [`ViewTrackingStrategy`][5] to enable automatic tracking of all your views (
                     crashReportsEnabled = true,
                     rumEnabled = true
                 )
-                .useSite(DatadogSite.US3)
+                .useSite(DatadogSite.US1)
                 .trackInteractions()
                 .trackLongTasks(durationThreshold)
                 .useViewTrackingStrategy(strategy)
@@ -81,6 +81,7 @@ See [`ViewTrackingStrategy`][5] to enable automatic tracking of all your views (
                             .trackInteractions()
                             .trackLongTasks(durationThreshold)
                             .useViewTrackingStrategy(strategy)
+                            .useSite(DatadogSite.US1)
                             .build();
                final Credentials credentials = new Credentials(<CLIENT_TOKEN>, <ENV_NAME>, <APP_VARIANT_NAME>, <APPLICATION_ID>);
                Datadog.initialize(this, credentials, configuration, trackingConsent); 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ androidXComposeUi = "1.0.5"
 androidXComposeMaterial = "1.0.5"
 googleAccompanist = "0.20.2"
 googleMaterial = "1.3.0"
+androidXLeanback = "1.0.0"
 
 # DD-TRACE-OT
 openTracing = "0.32.0"
@@ -124,6 +125,7 @@ googleAccompanistAppCompatTheme = { module = "com.google.accompanist:accompanist
 googleAccompanistPager = { module = "com.google.accompanist:accompanist-pager", version.ref = "googleAccompanist" }
 googleAccompanistPagerIndicators = { module = "com.google.accompanist:accompanist-pager-indicators", version.ref = "googleAccompanist" }
 googleMaterial = { module = "com.google.android.material:material", version.ref = "googleMaterial" }
+androidXLeanback = { module = "androidx.leanback:leanback", version.ref = "androidXLeanback" }
 
 # DD-TRACE-OT
 openTracingApi = { module = "io.opentracing:opentracing-api", version.ref = "openTracing" }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -16,6 +16,7 @@ include(":dd-sdk-android-ndk")
 include(":dd-sdk-android-rx")
 include(":dd-sdk-android-sqldelight")
 include(":dd-sdk-android-timber")
+include(":dd-sdk-android-tv")
 
 include(":instrumented:integration")
 include(":instrumented:nightly-tests")


### PR DESCRIPTION
### What does this PR do?

We are currently missing some relevant information for the intercepted RUM Action events in the Android TV applications. 
In this PR we are adding 2 extra features to enrich that information:

1. We are using the existing `JetpackViewAttributesProvider` also for the DPAD (remote control) intercepted action events. By doing this we will provide additional information as the parent class name or the adapter position in case the target is rendered inside a `RecyclerView`
2. We are introducing the `dd-sdk-android-tv` module in which we provide the `LeanbackViewAttributesProvider`. The latter will add extra information as the `actionId` or `actionLabel` in case the target is an action item added through the default Leanback API.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

