### PR TITLE
RUMM-2066: Silently drop cross-platform RUM attributes before event serialization

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
@@ -134,7 +134,9 @@ internal class RumEventSerializer(
 
     private fun validateContextAttributes(attributes: Map<String, Any?>): Map<String, Any?> {
         return dataConstraints.validateAttributes(
-            attributes,
+            attributes.filterKeys {
+                it !in crossPlatformTransitAttributes
+            },
             keyPrefix = GLOBAL_ATTRIBUTE_PREFIX,
             reservedKeys = ignoredAttributes
         )
@@ -180,6 +182,15 @@ internal class RumEventSerializer(
         )
 
         internal val ignoredAttributes = setOf(
+            RumAttributes.INTERNAL_TIMESTAMP,
+            RumAttributes.INTERNAL_ERROR_TYPE,
+            RumAttributes.INTERNAL_ERROR_SOURCE_TYPE,
+            RumAttributes.INTERNAL_ERROR_IS_CRASH
+        )
+
+        // this are attributes which may come after the calls made by cross-platform SDKs (they are
+        // needed only for the SDK internals) and we may silently drop them
+        internal val crossPlatformTransitAttributes = setOf(
             RumAttributes.INTERNAL_TIMESTAMP,
             RumAttributes.INTERNAL_ERROR_TYPE,
             RumAttributes.INTERNAL_ERROR_SOURCE_TYPE,


### PR DESCRIPTION
### What does this PR do?

We currently have some internal attributes which are coming from cross-platform calls (ex. React Native SDK) and these attributes are needed only for the SDK (not for the backend). However, in the current sanitization logic these attributes are considered as reserved and dropped during event serialization with logging an error entry, which leads to the log pollution.

This change silently drops such attributes at the `RumEventSerializer` level, keeping current `ignoredAttributes` collection untouched (to avoid breaking the things on the server side and in case if at some point `ignoredAttributes` != `crossPlatformTransitAttributes`) and applies such logic only to the context attributes (not user-ones, because these internal attributes are coming only through events).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

