### PR TITLE
RUMM-1746 Upgrade ktlint

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -39,7 +39,7 @@ import,androidx.versionedparcelable,Apache-2.0,Copyright 2018 The Android Open S
 import,androidx.viewpager,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,androidx.work,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,com.github.bumptech.glide,"Simplified BSD License/The Apache Software License, Version 2.0","Copyright 2014 Google, Inc. All rights reserved, Copyright (c) 2013. Bump Technologies Inc. All Rights Reserved."
-import,com.facebook.fresco,MIT,Copyright (c) Facebook, Inc. and its affiliates
+import,com.facebook.fresco,MIT,"Copyright (c) Facebook, Inc. and its affiliates"
 import,com.google.android.material,Apache-2.0,Copyright 2018 The Android Open Source Project
 import,com.google.code.gson,Apache-2.0,Copyright 2008 Google Inc
 import,com.google.guava,Apache-2.0,Copyright 2009 The Guava Authors
@@ -49,12 +49,12 @@ import,com.squareup.okhttp3,Apache-2.0,"Copyright 2019 Square, Inc"
 import,com.squareup.okio,Apache-2.0,"Copyright 2013 Square, Inc"
 import,com.squareup.moshi,Apache-2.0,"Copyright 2013 Square, Inc"
 import,com.squareup.sqldelight,Apache-2.0,"Copyright 2016 Square, Inc"
-import,com.fasterxml.jackson,Apache-2.0,Copyright 2020 Datadog, Inc.
-import,com.datadoghq,Apache-2.0,Copyright 2017 Datadog, Inc
+import,com.fasterxml.jackson,Apache-2.0,"Copyright 2020 Datadog, Inc."
+import,com.datadoghq,Apache-2.0,"Copyright 2017 Datadog, Inc"
 import,io.coil-kt,Apache-2.0,Copyright 2021 Coil Contributors
 import,io.opentracing,Apache-2.0,Copyright 2016-2017 The OpenTracing Authors
 import,io.opentracing.contrib,Apache-2.0,Copyright 2016-2017 The OpenTracing Authors
-import,io.reactivex.rxjava3,Apache-2.0,Copyright (c) 2016-present, RxJava Contributors
+import,io.reactivex.rxjava3,Apache-2.0,"Copyright (c) 2016-present, RxJava Contributors"
 import,io.reactivex.rxjava3.android,Apache-2.0,Copyright 2015 The RxAndroid authors
 import,org.jetbrains,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors
 import,org.jetbrains.kotlin,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors
@@ -70,12 +70,13 @@ import(test),androidx.test.services,Apache-2.0,Copyright 2018 The Android Open S
 import(test),androidx.tracing,Apache-2.0,Copyright 2018 The Android Open Source Project
 import(test),androidx.viewpager2,Apache-2.0,Copyright 2018 The Android Open Source Project
 import(test),com.android.support,Apache-2.0,Copyright 2018 The Android Open Source Project
-import(test),com.facebook.soloader,Apache-2.0,Copyright (c) Facebook, Inc. and its affiliates
+import(test),com.facebook.soloader,Apache-2.0,"Copyright (c) Facebook, Inc. and its affiliates"
 import(test),com.github.xgouchet.Elmyr,MIT,Copyright 2017-2019 Xavier F. Gouchet
 import(test),com.google.android.apps.common.testing.accessibility.framework,Apache-2.0,Copyright 2018 The Android Open Source Project
 import(test),com.google.code.findbugs,Apache-2.0,__
 import(test),com.nhaarman.mockitokotlin2,MIT,"Copyright (c) 2018 Niek Haarman, Copyright (c) 2007 Mockito contributors"
-import(test),com.parse.bolts,"BSD License",Copyright (c) Facebook, Inc. and its affiliates.
+import(test),com.parse.bolts,"BSD License","Copyright (c) Facebook, Inc. and its affiliates."
+import(test),greatest,ICT,"Copyright (c) 2011-2018 Scott Vokes <vokes.s@gmail.com>"
 import(test),javax.inject,Apache-2.0,Copyright (C) 2009 The JSR-330 Expert Group
 import(test),junit,EPL-1.0,Copyright © 2002-2019 JUnit
 import(test),net.bytebuddy,Apache-2.0,Copyright 2014 - 2019 Rafael Winterhalter
@@ -85,7 +86,7 @@ import(test),org.apiguardian,Apache-2.0,Copyright 2002-2017 the original author 
 import(test),org.assertj,Apache-2.0,Copyright 2012-2019 the original author or authors
 import(test),org.ccil.cowan.tagsoup,Apache-2.0,__
 import(test),org.hamcrest,BSD-3-Clause,Copyright (c) 2000-2015 www.hamcrest.org
-import(test),org.jacoco,EPL-2.0,Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors
+import(test),org.jacoco,EPL-2.0,"Copyright (c) 2009, 2019 Mountainminds GmbH & Co. KG and Contributors"
 import(test),org.junit,EPL-2.0,Copyright 2015-2019 the original author or authors
 import(test),org.junit.jupiter,EPL-2.0,Copyright 2015-2019 the original author or authors
 import(test),org.junit.platform,EPL-2.0,Copyright 2015-2019 the original author or authors
@@ -94,14 +95,17 @@ import(test),org.mockito,MIT,Copyright (c) 2007 Mockito contributors
 import(test),org.objenesis,Apache-2.0,"Copyright (c) 2003-2013, Objenesis Team and all contributors"
 import(test),org.opentest4j,Apache-2.0,Copyright 2015-2018 the original author or authors
 import(test),org.robolectric,Apache-2.0,Copyright 2015-2018 the original author or authors
-import(test),org.sonatype.oss,Apache-2.0,Copyright (c) 2008-present Sonatype, Inc.
+import(test),org.sonatype.oss,Apache-2.0,"Copyright (c) 2008-present Sonatype, Inc."
 build,androidx.compose.compiler,Apache-2.0,Copyright 2019 The Android Open Source Project
+build,ch.qos.logback,EPL-1.0,"Copyright (C) 1999-2015, QOS.ch"
 build,com.android.tools.build,Apache-2.0,Copyright (C) 2013 The Android Open Source Project
 build,com.android.tools.lint,Apache-2.0,Copyright (C) 2013 The Android Open Source Project
 build,com.pinterest,MIT,"Copyright 2019 Pinterest Inc, Copyright 2016-2019 Stanley Shyiko"
 build,com.pinterest.ktlint,MIT,"Copyright 2019 Pinterest Inc, Copyright 2016-2019 Stanley Shyiko"
+build,io.github.microutils,Apache-2.0,Copyright (c) 2016-2018 Ohad Shai
 build,io.gitlab.arturbosch.detekt,Apache-2.0,Copyright 2016-2019 the original author or authors
+build,net.java.dev.jna,"Apache-2.0","Copyright (c) 2007 Timothy Wall, All Rights Reserved"
 build,org.ec4j.core,Apache-2.0,"Copyright (c) 2017 Angelo Zerr and other contributors"
 build,org.jetbrains.dokka,Apache-2.0,"Copyright 2014-2019 JetBrains s.r.o. and Dokka project contributors."
 build,org.jetbrains.intellij.deps,LGPL-2.1-only,"Copyright (c) 2001-2002, Eric D. Friedman, Jason Baldridge, Copyright (c) 1999 CERN - European Organization for Nuclear Research"
-test,greatest,ICT,"Copyright (c) 2011-2018 Scott Vokes <vokes.s@gmail.com>"
+build,org.slf4j,MIT,"Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)"

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KtLintConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/KtLintConfig.kt
@@ -12,11 +12,12 @@ import org.jlleitschuh.gradle.ktlint.KtlintExtension
 fun Project.ktLintConfig() {
 
     extensionConfig<KtlintExtension> {
+        version.set("0.44.0")
         debug.set(false)
         android.set(true)
         outputToConsole.set(true)
         ignoreFailures.set(false)
-        enableExperimentalRules.set(false)
+        enableExperimentalRules.set(true)
         additionalEditorconfigFile.set(file("${project.rootDir}/script/config/.editorconfig"))
         filter {
             exclude("**/generated/**")

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
@@ -307,7 +307,6 @@ private fun resolveSwipeChangeAttributes(
     reverseDirection: Boolean,
     isRtl: Boolean
 ): Map<String, Any?> {
-
     // normally should use .direction property of SwipeableState, but it is affected by the
     // same bug as described below
     // roundToInt can throw exception for Float.NaN, but we won't get such value
@@ -337,7 +336,6 @@ private fun resolveScrollChangeAttributes(
     reverseDirection: Boolean,
     isRtl: Boolean
 ): Map<String, Any?> {
-
     val startOffset = scrollStartProps.position
     val endOffset = scrollableState.currentPosition
 
@@ -361,7 +359,6 @@ private fun resolveDragDirection(
     orientation: Orientation,
     isRtl: Boolean
 ): String {
-
     val isDirectionPositive = directionSign > 0
 
     return when (orientation) {

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation.kt
@@ -5,6 +5,7 @@
  */
 
 @file:Suppress("MatchingDeclarationName")
+
 package com.datadog.android.compose
 
 import android.os.Bundle
@@ -113,7 +114,6 @@ fun NavigationViewTrackingEffect(
     trackArguments: Boolean = true,
     destinationPredicate: ComponentPredicate<NavDestination> = AcceptAllNavDestinations()
 ) {
-
     val currentTrackArguments by rememberUpdatedState(newValue = trackArguments)
     val currentDestinationPredicate by rememberUpdatedState(newValue = destinationPredicate)
 

--- a/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/TapActionTrackerTest.kt
+++ b/dd-sdk-android-compose/src/test/kotlin/com/datadog/android/compose/TapActionTrackerTest.kt
@@ -69,7 +69,6 @@ internal class TapActionTrackerTest {
 
     @Test
     fun `M call addAction W invoke`() {
-
         // When
         testedTracker.invoke()
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogEventListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogEventListener.kt
@@ -162,7 +162,6 @@ internal constructor(val key: String) : EventListener() {
     }
 
     private fun sendTiming() {
-
         val timing = buildTiming()
         (GlobalRum.get() as? AdvancedRumMonitor)?.addResourceTiming(key, timing)
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/HostsSanitizer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/HostsSanitizer.kt
@@ -15,7 +15,7 @@ internal class HostsSanitizer {
 
     internal fun sanitizeHosts(
         hosts: List<String>,
-        feature: String,
+        feature: String
     ): List<String> {
         val validHostNameRegEx = Regex(VALID_HOSTNAME_REGEX)
         val validUrlRegex = Regex(URL_REGEX)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/UploadFrequency.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/UploadFrequency.kt
@@ -15,8 +15,10 @@ enum class UploadFrequency(
 
     /** Try to upload batch data frequently. */
     FREQUENT(1000L),
+
     /** Try to upload batch data with a medium frequency. */
     AVERAGE(5000L),
+
     /** Try to upload batch data rarely. */
     RARE(10000L)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -155,7 +155,6 @@ internal object CoreFeature {
         configuration: Configuration.Core,
         consent: TrackingConsent
     ) {
-
         if (initialized.get()) {
             return
         }
@@ -205,8 +204,8 @@ internal object CoreFeature {
         )
     }
 
-    @Suppress("UnsafeThirdPartyFunctionCall") // Used in Nightly tests only
     @Throws(UnsupportedOperationException::class, InterruptedException::class)
+    @Suppress("UnsafeThirdPartyFunctionCall") // Used in Nightly tests only
     fun drainAndShutdownExecutors() {
         val tasks = arrayListOf<Runnable>()
         (persistenceExecutorService as? ThreadPoolExecutor)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/constraints/DatadogDataConstraints.kt
@@ -38,7 +38,6 @@ internal class DatadogDataConstraints : DataConstraints {
         attributesGroupName: String?,
         reservedKeys: Set<String>
     ): Map<String, T> {
-
         // prefix = "a.b" => dotCount = 1+1 ("a.b." + key)
         val prefixDotCount = keyPrefix?.let { it.count { character -> character == '.' } + 1 } ?: 0
         val convertedAttributes = attributes.mapNotNull {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnable.kt
@@ -25,7 +25,7 @@ internal class DataUploadRunnable(
     private val dataUploader: DataUploader,
     private val networkInfoProvider: NetworkInfoProvider,
     private val systemInfoProvider: SystemInfoProvider,
-    uploadFrequency: UploadFrequency,
+    uploadFrequency: UploadFrequency
 ) : UploadRunnable {
 
     internal var currentDelayIntervalMs = DEFAULT_DELAY_FACTOR * uploadFrequency.baseStepMs

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadScheduler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataUploadScheduler.kt
@@ -21,7 +21,7 @@ internal class DataUploadScheduler(
     networkInfoProvider: NetworkInfoProvider,
     systemInfoProvider: SystemInfoProvider,
     uploadFrequency: UploadFrequency,
-    private val scheduledThreadPoolExecutor: ScheduledThreadPoolExecutor,
+    private val scheduledThreadPoolExecutor: ScheduledThreadPoolExecutor
 ) : UploadScheduler {
 
     private val runnable = DataUploadRunnable(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploader.kt
@@ -25,7 +25,6 @@ internal abstract class DataOkHttpUploader(
 
     @Suppress("TooGenericExceptionCaught")
     override fun upload(data: ByteArray): UploadStatus {
-
         return try {
             val request = buildRequest(data)
             val call = callFactory.newCall(request)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/EncryptedFileHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/EncryptedFileHandler.kt
@@ -33,7 +33,6 @@ internal class EncryptedFileHandler(
         append: Boolean,
         separator: ByteArray?
     ): Boolean {
-
         if (separator != null && !checkSeparator(separator)) {
             internalLogger.e(INVALID_SEPARATOR_MESSAGE)
             return false
@@ -68,7 +67,6 @@ internal class EncryptedFileHandler(
         suffix: ByteArray?,
         separator: ByteArray?
     ): ByteArray {
-
         if (separator != null && !checkSeparator(separator)) {
             internalLogger.e(INVALID_SEPARATOR_MESSAGE)
             return EMPTY_BYTE_ARRAY
@@ -202,7 +200,6 @@ internal class EncryptedFileHandler(
     }
 
     private fun ByteArray.splitBy(separator: ByteArray): List<ByteArray> {
-
         val result = mutableListOf<ByteArray>()
 
         var chunkStart = 0

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileHandler.kt
@@ -36,7 +36,6 @@ internal class BatchFileHandler(
         append: Boolean,
         separator: ByteArray?
     ): Boolean {
-
         return try {
             lockFileAndWriteData(file, append, separator, data)
             true
@@ -105,8 +104,8 @@ internal class BatchFileHandler(
 
     // region Internal
 
-    @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
     @Throws(IOException::class)
+    @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
     private fun lockFileAndWriteData(
         file: File,
         append: Boolean,
@@ -123,8 +122,8 @@ internal class BatchFileHandler(
         }
     }
 
-    @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
     @Throws(IOException::class)
+    @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
     private fun readFileData(
         file: File,
         prefix: ByteArray,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/receiver/ThreadSafeReceiver.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/receiver/ThreadSafeReceiver.kt
@@ -20,7 +20,6 @@ internal abstract class ThreadSafeReceiver : BroadcastReceiver() {
         context: Context,
         filter: IntentFilter
     ): Intent? {
-
         val intent = context.registerReceiver(this, filter)
         isRegistered.set(true)
         return intent

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ByteArrayExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ByteArrayExt.kt
@@ -52,7 +52,6 @@ internal fun ByteArray.indexOf(b: Byte, startIndex: Int = 0): Int {
  * @return true if the copy was successful.
  */
 internal fun ByteArray.copyTo(srcPos: Int, dest: ByteArray, destPos: Int, length: Int): Boolean {
-
     if (destPos + length > dest.size) {
         sdkLogger.w("Cannot copy ByteArray, dest doesn't have enough space")
         return false

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExt.kt
@@ -28,7 +28,7 @@ internal fun ScheduledExecutorService.scheduleSafe(
     operationName: String,
     delay: Long,
     unit: TimeUnit,
-    runnable: Runnable,
+    runnable: Runnable
 ): ScheduledFuture<*>? {
     return try {
         @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/FileLockExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/FileLockExt.kt
@@ -9,8 +9,8 @@ package com.datadog.android.core.internal.utils
 import java.io.IOException
 import java.nio.channels.FileLock
 
-@Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
 @Throws(IOException::class)
+@Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
 internal inline fun <reified R> FileLock.use(block: (FileLock) -> R): R {
     try {
         return block(this)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -194,7 +194,6 @@ internal constructor(internal var handler: LogHandler) {
          * Builds a [Logger] based on the current state of this Builder.
          */
         fun build(): Logger {
-
             val handler = when {
                 datadogLogsEnabled && logcatLogsEnabled -> {
                     CombinedLogHandler(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/net/LogsOkHttpUploader.kt
@@ -16,7 +16,7 @@ internal class LogsOkHttpUploader(
     endpoint: String,
     token: String,
     callFactory: Call.Factory,
-    androidInfoProvider: AndroidInfoProvider,
+    androidInfoProvider: AndroidInfoProvider
 ) : DataOkHttpUploader(buildUrl(endpoint, token), callFactory, androidInfoProvider) {
 
     // region DataOkHttpUploader

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumActionType.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumActionType.kt
@@ -13,12 +13,16 @@ package com.datadog.android.rum
 enum class RumActionType {
     /** User tapped on a widget. */
     TAP,
+
     /** User scrolled a view. */
     SCROLL,
+
     /** User swiped on a view. */
     SWIPE,
+
     /** User clicked on a widget (not used on Mobile). */
     CLICK,
+
     /** A custom action. */
     CUSTOM
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumErrorSource.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumErrorSource.kt
@@ -13,14 +13,19 @@ package com.datadog.android.rum
 enum class RumErrorSource {
     /** Error originated in the Network layer. */
     NETWORK,
+
     /** Error originated in the source code (usually a crash). */
     SOURCE,
+
     /** Error originated in a console (e.g.: in a webview). */
     CONSOLE,
+
     /** Error extracted from a logged error. */
     LOGGER,
+
     /** Error originated in an Agent. */
     AGENT,
+
     /** Error originated in a WebView. */
     WEBVIEW
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -111,7 +111,7 @@ internal object RumFeature : SdkFeature<Any, Configuration.Feature.RUM>() {
 
     override fun createPersistenceStrategy(
         context: Context,
-        configuration: Configuration.Feature.RUM,
+        configuration: Configuration.Feature.RUM
     ): PersistenceStrategy<Any> {
         return RumFilePersistenceStrategy(
             CoreFeature.trackingConsentProvider,
@@ -197,7 +197,7 @@ internal object RumFeature : SdkFeature<Any, Configuration.Feature.RUM>() {
 
     private fun initializeVitalMonitor(
         vitalReader: VitalReader,
-        vitalObserver: VitalObserver,
+        vitalObserver: VitalObserver
     ) {
         val readerRunnable = VitalReaderRunnable(
             vitalReader,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt
@@ -26,7 +26,6 @@ internal class ANRDetectorRunnable(
     // region Runnable
 
     override fun run() {
-
         while (!Thread.interrupted()) {
             if (shouldStop) return
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/debug/UiRumDebugListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/debug/UiRumDebugListener.kt
@@ -62,7 +62,6 @@ internal class UiRumDebugListener :
     }
 
     override fun onActivityResumed(activity: Activity) {
-
         if (advancedRumMonitor is NoOpAdvancedRumMonitor) {
             return
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimings.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimings.kt
@@ -26,7 +26,6 @@ private const val START_TIME_KEY = "startTime"
 private const val DURATION_KEY = "duration"
 
 internal fun extractResourceTiming(timingsPayload: Map<String, Any?>?): ResourceTiming? {
-
     if (timingsPayload == null) {
         return null
     }
@@ -59,7 +58,6 @@ private fun createResourceTiming(timings: Map<String, Timing?>): ResourceTiming 
 }
 
 private fun extractTiming(name: String, source: Map<String, Any?>): Timing? {
-
     val timing = source[name]
 
     return if (timing != null && timing is Map<*, *>) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -333,8 +333,8 @@ internal class DatadogRumMonitor(
 
     // region Internal
 
-    @Suppress("UnsafeThirdPartyFunctionCall") // Used in Nightly tests only
     @Throws(UnsupportedOperationException::class, InterruptedException::class)
+    @Suppress("UnsafeThirdPartyFunctionCall") // Used in Nightly tests only
     internal fun drainExecutorService() {
         val tasks = arrayListOf<Runnable>()
         (executorService as? ThreadPoolExecutor)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/webview/RumWebChromeClient.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/webview/RumWebChromeClient.kt
@@ -22,7 +22,7 @@ import com.datadog.android.rum.RumErrorSource
  *
  * This class is deprecated and you should use the new
  * [com.datadog.android.webview.DatadogEventBridge] to track your WebViews:
-
+ *
  * ```kotlin
  * val configuration = Configuration.Builder().setWebViewTrackingHosts(listOf(<YOUR_HOSTS>))
  * Datadog.initialize(this, credentials, configuration, trackingConsent)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/webview/RumWebViewClient.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/webview/RumWebViewClient.kt
@@ -29,7 +29,7 @@ import com.datadog.android.rum.RumResourceKind
  *
  * This class is deprecated and you should use the new
  * [com.datadog.android.webview.DatadogEventBridge] to track your WebViews:
-
+ *
  * ```kotlin
  * val configuration = Configuration.Builder().setWebViewTrackingHosts(listOf(<YOUR_HOSTS>))
  * Datadog.initialize(this, credentials, configuration, trackingConsent)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -24,16 +24,13 @@ internal class TelemetryEventHandler(
 ) {
 
     fun handleEvent(event: RumRawEvent.SendTelemetry, writer: DataWriter<Any>) {
-
         val timestamp = event.eventTime.timestamp + timeProvider.getServerOffsetMillis()
 
         val rumContext = GlobalRum.getRumContext()
 
         val telemetryEvent: Any = when (event.type) {
             TelemetryType.DEBUG -> {
-                createDebugEvent(
-                    timestamp, rumContext, event.message
-                )
+                createDebugEvent(timestamp, rumContext, event.message)
             }
             TelemetryType.ERROR -> {
                 createErrorEvent(
@@ -92,7 +89,7 @@ internal class TelemetryEventHandler(
                 error = throwable?.let {
                     TelemetryErrorEvent.Error(
                         stack = it.loggableStackTrace(),
-                        kind = it.javaClass.canonicalName ?: it.javaClass.simpleName,
+                        kind = it.javaClass.canonicalName ?: it.javaClass.simpleName
                     )
                 }
             )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapper.kt
@@ -25,7 +25,6 @@ internal class WebViewRumEventMapper {
         context: RumContext?,
         timeOffset: Long
     ): JsonObject {
-
         event.get(DATE_KEY_NAME)?.asLong?.let {
             event.addProperty(DATE_KEY_NAME, it + timeOffset)
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogEventListenerFactoryTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogEventListenerFactoryTest.kt
@@ -45,7 +45,6 @@ class DatadogEventListenerFactoryTest {
 
     @BeforeEach
     fun `set up`() {
-
         fakeRequest = Request.Builder()
             .get().url("https://$fakeDomain/")
             .build()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -130,7 +130,7 @@ internal class DatadogTest {
     fun `𝕄 update userInfoProvider 𝕎 setUserInfo()`(
         @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
         @StringForgery name: String,
-        @StringForgery(regex = "\\w+@\\w+") email: String,
+        @StringForgery(regex = "\\w+@\\w+") email: String
     ) {
         // Given
         val mockUserInfoProvider = mock<MutableUserInfoProvider>()
@@ -153,7 +153,7 @@ internal class DatadogTest {
     fun `𝕄 clears userInfoProvider 𝕎 setUserInfo() with defaults`(
         @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
         @StringForgery name: String,
-        @StringForgery(regex = "\\w+@\\w+") email: String,
+        @StringForgery(regex = "\\w+@\\w+") email: String
     ) {
         // Given
         val mockUserInfoProvider = mock<MutableUserInfoProvider>()
@@ -308,7 +308,7 @@ internal class DatadogTest {
 
     @Test
     fun `M return false and log an error W initialize() {envName not valid, isDebug=false}`(
-        forge: Forge,
+        forge: Forge
     ) {
         // Given
         stubApplicationInfo(appContext.mockInstance, isDebuggable = false)
@@ -341,7 +341,7 @@ internal class DatadogTest {
 
     @Test
     fun `M throw an exception W initialize() {envName not valid, isDebug=true}`(
-        forge: Forge,
+        forge: Forge
     ) {
         // Given
         stubApplicationInfo(appContext.mockInstance, isDebuggable = true)
@@ -400,7 +400,7 @@ internal class DatadogTest {
         @BoolForgery logsEnabled: Boolean,
         @BoolForgery tracesEnabled: Boolean,
         @BoolForgery crashReportEnabled: Boolean,
-        @BoolForgery rumEnabled: Boolean,
+        @BoolForgery rumEnabled: Boolean
     ) {
         // Given
         val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, fakeApplicationId, null)
@@ -489,7 +489,7 @@ internal class DatadogTest {
     @Test
     fun `𝕄 initialize InternalLogs 𝕎 initialize() { Internal logs configured }`(
         @StringForgery(StringForgeryType.HEXADECIMAL) clientToken: String,
-        @StringForgery(regex = "https://[a-z]+\\.com") url: String,
+        @StringForgery(regex = "https://[a-z]+\\.com") url: String
     ) {
         // Given
         val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
@@ -519,7 +519,7 @@ internal class DatadogTest {
 
     @Test
     fun `𝕄 apply source name 𝕎 applyAdditionalConfig(config) { with source name }`(
-        @StringForgery source: String,
+        @StringForgery source: String
     ) {
         // Given
         val config = Configuration.Builder(
@@ -544,7 +544,7 @@ internal class DatadogTest {
                 TracingFeature.uploader,
                 CrashReportsFeature.uploader,
                 WebViewRumFeature.uploader,
-                WebViewLogsFeature.uploader,
+                WebViewLogsFeature.uploader
             )
                 .map { (it as DataOkHttpUploaderV2).source }
         )
@@ -553,7 +553,7 @@ internal class DatadogTest {
 
     @Test
     fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { with empty source name }`(
-        forge: Forge,
+        forge: Forge
     ) {
         // Given
         val config = Configuration.Builder(
@@ -587,7 +587,7 @@ internal class DatadogTest {
 
     @Test
     fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { with source name !string }`(
-        forge: Forge,
+        forge: Forge
     ) {
         // Given
         val config = Configuration.Builder(
@@ -619,7 +619,7 @@ internal class DatadogTest {
 
     @Test
     fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { without source name }`(
-        forge: Forge,
+        forge: Forge
     ) {
         // Given
         val config = Configuration.Builder(
@@ -651,7 +651,7 @@ internal class DatadogTest {
 
     @Test
     fun `𝕄 apply sdk version 𝕎 applyAdditionalConfig(config) { with sdk version }`(
-        @StringForgery sdkVersion: String,
+        @StringForgery sdkVersion: String
     ) {
         // Given
         val config = Configuration.Builder(
@@ -685,7 +685,7 @@ internal class DatadogTest {
 
     @Test
     fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { with empty sdk version }`(
-        forge: Forge,
+        forge: Forge
     ) {
         // Given
         val config = Configuration.Builder(
@@ -721,7 +721,7 @@ internal class DatadogTest {
 
     @Test
     fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { with sdk version !string }`(
-        forge: Forge,
+        forge: Forge
     ) {
         // Given
         val config = Configuration.Builder(
@@ -755,7 +755,7 @@ internal class DatadogTest {
 
     @Test
     fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { without sdk version }`(
-        forge: Forge,
+        forge: Forge
     ) {
         // Given
         val config = Configuration.Builder(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/HostsSanitizerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/HostsSanitizerTest.kt
@@ -114,7 +114,6 @@ internal class HostsSanitizerTest {
                 "|(([a-zA-Z0-9-]*[a-zA-Z0-9])\\.)+([A-Za-z0-9]*[-+=~><?])"
         ) hosts: List<String>
     ) {
-
         // When
         testedSanitizer.sanitizeHosts(
             hosts,
@@ -142,7 +141,6 @@ internal class HostsSanitizerTest {
                 "|(25[6-9]\\.([0-9]{3}\\.){2}[0.9]{3})"
         ) hosts: List<String>
     ) {
-
         // When
         testedSanitizer.sanitizeHosts(
             hosts,
@@ -169,7 +167,6 @@ internal class HostsSanitizerTest {
                 "| (([a-zA-Z0-9-]*[a-zA-Z0-9])\\.)+([A-Za-z0-9]*[-+=~><?])"
         ) hosts: List<String>
     ) {
-
         // When
         val sanitizedHosts = testedSanitizer.sanitizeHosts(
             hosts,
@@ -188,7 +185,6 @@ internal class HostsSanitizerTest {
                 "|(25[6-9]\\.([0-9]{3}\\.){2}[0.9]{3})"
         ) hosts: List<String>
     ) {
-
         // When
         val sanitizedHosts = testedSanitizer.sanitizeHosts(
             hosts,
@@ -247,7 +243,6 @@ internal class HostsSanitizerTest {
             regex = "(https|http)://([a-z][a-z0-9-]{3,9}\\.){1,4}[a-z][a-z0-9]{2,3}:-8[0-9]{1}"
         ) hosts: List<String>
     ) {
-
         // When
         testedSanitizer.sanitizeHosts(
             hosts,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -891,7 +891,6 @@ internal class CoreFeatureTest {
 
     @Test
     fun `M initialize webViewTrackingHosts W initialize()`() {
-
         // When
         CoreFeature.initialize(
             appContext.mockInstance,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -89,7 +89,7 @@ internal class DataUploadRunnableTest {
             batteryFullOrCharging = true,
             batteryLevel = forge.anInt(min = 20, max = 100),
             powerSaveMode = false,
-            onExternalPowerSource = true,
+            onExternalPowerSource = true
         )
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleMonitorTest.kt
@@ -186,7 +186,6 @@ internal class ProcessLifecycleMonitorTest {
 
     @Test
     fun `when starting activities from 2 different threads will only call onResumed once`() {
-
         // Given
         val countDownLatch = CountDownLatch(2)
 
@@ -212,7 +211,6 @@ internal class ProcessLifecycleMonitorTest {
 
     @Test
     fun `when stopped from 2 different threads will only call onStooped once`() {
-
         // Given
         testedMonitor.onActivityStarted(mockActivity1)
         testedMonitor.onActivityResumed(mockActivity1)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/CurlInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/CurlInterceptorTest.kt
@@ -184,7 +184,7 @@ internal class CurlInterceptorTest {
     fun `M output curl command W intercept() {POST, content type}`(
         @IntForgery(200, 600) statusCode: Int,
         @StringForgery type: String,
-        @StringForgery subtype: String,
+        @StringForgery subtype: String
     ) {
         // Given
         testedInterceptor = CurlInterceptor(true, mockOutput)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderTest.kt
@@ -70,7 +70,6 @@ internal abstract class DataOkHttpUploaderTest<T : DataOkHttpUploader> {
 
     @BeforeEach
     open fun `set up`(forge: Forge) {
-
         whenever(mockCallFactory.newCall(any())) doReturn mockCall
 
         whenever(mockAndroidInfoProvider.getDeviceVersion()) doReturn fakeDeviceVersion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2Test.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2Test.kt
@@ -90,7 +90,6 @@ internal abstract class DataOkHttpUploaderV2Test<T : DataOkHttpUploaderV2> {
 
     @BeforeEach
     open fun `set up`(forge: Forge) {
-
         whenever(mockCallFactory.newCall(any())) doReturn mockCall
 
         whenever(mockAndroidInfoProvider.getDeviceVersion()) doReturn fakeDeviceVersion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/UploadStatusTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/UploadStatusTest.kt
@@ -119,6 +119,7 @@ internal class UploadStatusTest {
         // Then
         verifyZeroInteractions(mockLogHandler)
     }
+
     @Test
     fun `𝕄 log INVALID_TOKEN_ERROR 𝕎 logStatus()`() {
         // When

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/EncryptedFileHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/EncryptedFileHandlerTest.kt
@@ -68,7 +68,6 @@ internal class EncryptedFileHandlerTest {
 
     @BeforeEach
     fun setUp() {
-
         whenever(mockFileHandlerDelegate.writeData(any(), any(), any(), anyOrNull())) doReturn true
 
         whenever(mockEncryption.encrypt(any())) doAnswer {
@@ -276,7 +275,7 @@ internal class EncryptedFileHandlerTest {
     fun `𝕄 decrypt data 𝕎 readData() { single item in a file with suffix and prefix }`(
         @StringForgery data: String,
         @StringForgery prefix: String,
-        @StringForgery suffix: String,
+        @StringForgery suffix: String
     ) {
         // Given
         val prefixBytes = prefix.toByteArray()
@@ -474,10 +473,13 @@ internal class EncryptedFileHandlerTest {
         )
 
         verify(mockInternalLogger).e(
-            EncryptedFileHandler.BASE64_DECODING_ERROR_MESSAGE, decodingException
+            EncryptedFileHandler.BASE64_DECODING_ERROR_MESSAGE,
+            decodingException
         )
         verify(logger.mockDevLogHandler).handleLog(
-            Log.ERROR, EncryptedFileHandler.BASE64_DECODING_ERROR_MESSAGE, decodingException
+            Log.ERROR,
+            EncryptedFileHandler.BASE64_DECODING_ERROR_MESSAGE,
+            decodingException
         )
 
         verifyZeroInteractions(mockEncryption)
@@ -540,10 +542,13 @@ internal class EncryptedFileHandlerTest {
         assertThat(result).isEqualTo(decorate(expected, prefixBytes, suffixBytes))
 
         verify(mockInternalLogger, times(failCounter)).e(
-            EncryptedFileHandler.BASE64_DECODING_ERROR_MESSAGE, decodingException
+            EncryptedFileHandler.BASE64_DECODING_ERROR_MESSAGE,
+            decodingException
         )
         verify(logger.mockDevLogHandler, times(failCounter)).handleLog(
-            Log.ERROR, EncryptedFileHandler.BASE64_DECODING_ERROR_MESSAGE, decodingException
+            Log.ERROR,
+            EncryptedFileHandler.BASE64_DECODING_ERROR_MESSAGE,
+            decodingException
         )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileHandlerTest.kt
@@ -662,7 +662,6 @@ internal class BatchFileHandlerTest {
 
     @Test
     fun `𝕄 create BatchFileHandler 𝕎 create() { without encryption }`() {
-
         // When
         val fileHandler = BatchFileHandler.create(Logger(mockLogHandler), null)
         // Then
@@ -672,7 +671,6 @@ internal class BatchFileHandlerTest {
 
     @Test
     fun `𝕄 create BatchFileHandler 𝕎 create() { with encryption }`() {
-
         // When
         val mockEncryption = mock<Encryption>()
         val fileHandler = BatchFileHandler.create(Logger(mockLogHandler), mockEncryption)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/ConcurrencyExtTest.kt
@@ -47,7 +47,7 @@ internal class ConcurrencyExtTest {
 
     @Test
     fun `M execute task W executeSafe()`(
-        @StringForgery name: String,
+        @StringForgery name: String
     ) {
         // Given
         val service: ExecutorService = mock()
@@ -64,7 +64,7 @@ internal class ConcurrencyExtTest {
     @Test
     fun `M not throw W executeSafe() {rejected exception}`(
         @StringForgery name: String,
-        @StringForgery message: String,
+        @StringForgery message: String
     ) {
         // Given
         val service: ExecutorService = mock()
@@ -88,7 +88,7 @@ internal class ConcurrencyExtTest {
     fun `M schedule task W scheduleSafe()`(
         @StringForgery name: String,
         @LongForgery delay: Long,
-        @Forgery unit: TimeUnit,
+        @Forgery unit: TimeUnit
     ) {
         // Given
         val service: ScheduledExecutorService = mock()
@@ -109,7 +109,7 @@ internal class ConcurrencyExtTest {
         @StringForgery name: String,
         @LongForgery delay: Long,
         @Forgery unit: TimeUnit,
-        @StringForgery message: String,
+        @StringForgery message: String
     ) {
         // Given
         val service: ScheduledExecutorService = mock()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -245,7 +245,6 @@ internal class DatadogExceptionHandlerTest {
 
     @Test
     fun `M schedule the worker W logging an exception`() {
-
         whenever(
             mockWorkManager.enqueueUniqueWork(
                 ArgumentMatchers.anyString(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerTest.kt
@@ -622,7 +622,6 @@ internal class LoggerTest {
 
     @Test
     fun `log message with local attributes`(forge: Forge) {
-
         val key = forge.anAlphabeticalString()
         val value = forge.anInt()
 
@@ -660,7 +659,6 @@ internal class LoggerTest {
 
     @Test
     fun `log message with local attributes (null value)`(forge: Forge) {
-
         val key = forge.anAlphabeticalString()
         val value: Any? = null
 
@@ -678,7 +676,6 @@ internal class LoggerTest {
 
     @Test
     fun `log message with local attributes override logger value`(forge: Forge) {
-
         val key = forge.anAlphabeticalString()
         val loggerValue = forge.aFloat()
         val localValue = forge.anAlphabeticalString()
@@ -698,7 +695,6 @@ internal class LoggerTest {
 
     @Test
     fun `log message without local attributes after message with local attributes`(forge: Forge) {
-
         val key = forge.anAlphabeticalString()
         val value = forge.anInt()
         val message1 = forge.anAlphabeticalString()
@@ -869,7 +865,6 @@ internal class LoggerTest {
         val countDownLatch = CountDownLatch(asyncOperations)
         var logDebugExecutionCalls = 0
         repeat(asyncOperations) {
-
             val closure = when (forge.anInt(min = 0, max = 3)) {
                 0 -> {
                     {
@@ -940,7 +935,6 @@ internal class LoggerTest {
         val countDownLatch = CountDownLatch(asyncOperations)
         var logDebugExecutionCalls = 0
         repeat(asyncOperations) {
-
             val closure = when (forge.anInt(min = 0, max = 2)) {
                 0 -> {
                     {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventSerializerTest.kt
@@ -210,7 +210,6 @@ internal class LogEventSerializerTest {
     private fun JsonObjectAssert.hasUserInfo(
         userInfo: LogEvent.Usr
     ) {
-
         val userName = userInfo.name
         val userEmail = userInfo.email
         val userId = userInfo.id

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -270,7 +270,6 @@ internal class DatadogLogHandlerTest {
     @ParameterizedTest
     @ValueSource(ints = [AndroidLog.ERROR, AndroidLog.ASSERT])
     fun `forward error log to RumMonitor`(logLevel: Int) {
-
         testedHandler.handleLog(
             logLevel,
             fakeMessage,
@@ -290,7 +289,6 @@ internal class DatadogLogHandlerTest {
     @ParameterizedTest
     @ValueSource(ints = [AndroidLog.ERROR, AndroidLog.ASSERT])
     fun `forward error log to RumMonitor with throwable`(logLevel: Int) {
-
         testedHandler.handleLog(
             logLevel,
             fakeMessage,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandlerTest.kt
@@ -78,7 +78,8 @@ internal class LogcatLogHandlerTest {
 
         // Don't convert it to lambda, because Kotlin won't create wrapper class,
         // read more https://kotlinlang.org/docs/whatsnew15.html#sam-adapters-via-invokedynamic
-        @Suppress("ObjectLiteralToLambda") val runnable = object : Runnable {
+        @Suppress("ObjectLiteralToLambda")
+        val runnable = object : Runnable {
             override fun run() {
                 element = testedHandler.getCallerStackElement()
             }
@@ -95,14 +96,12 @@ internal class LogcatLogHandlerTest {
 
     @RepeatedTest(4)
     fun `resolves valid stack trace element when wrapped in timber`(forge: Forge) {
-
         // Given
         val forgeFileName: Forge.() -> String = {
             "${this.anAlphabeticalString(Case.ANY)}.${this.aStringMatching("(kt|java)")}"
         }
 
         val ignoredElements = forge.aList {
-
             val className = if (aBool()) {
                 // generate from ignored class names pattern
                 LogcatLogHandler.IGNORED_CLASS_NAMES.random()
@@ -125,7 +124,6 @@ internal class LogcatLogHandlerTest {
         }
 
         val validElements = forge.aList {
-
             val className = "com.${anAlphabeticalString(Case.LOWER, 5)}" +
                 ".${anAlphabeticalString(Case.LOWER, 6)}" +
                 ".${anAlphabeticalString(Case.LOWER, 7)}" +

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/MixedViewTrackingStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/MixedViewTrackingStrategyTest.kt
@@ -57,7 +57,6 @@ internal class MixedViewTrackingStrategyTest :
 
     @Test
     fun `when created will delegate to the bundled strategies`() {
-
         // Whenever
         testedStrategy.onActivityCreated(mockActivity, mockBundle)
 
@@ -82,7 +81,6 @@ internal class MixedViewTrackingStrategyTest :
 
     @Test
     fun `when started will delegate to the bundled strategies`() {
-
         // Whenever
         testedStrategy.onActivityStarted(mockActivity)
 
@@ -107,7 +105,6 @@ internal class MixedViewTrackingStrategyTest :
 
     @Test
     fun `when resumed will delegate to the bundled strategies`() {
-
         // Whenever
         testedStrategy.onActivityResumed(mockActivity)
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ActionEventAssert.kt
@@ -281,7 +281,8 @@ internal class ActionEventAssert(actual: ActionEvent) :
             .overridingErrorMessage(
                 "Expected event to have a source %s" +
                     " instead it was %s",
-                source ?: "null", actual.source ?: "null"
+                source ?: "null",
+                actual.source ?: "null"
             )
             .isEqualTo(source)
         return this

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -356,7 +356,8 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
             .overridingErrorMessage(
                 "Expected event to have a source %s" +
                     " instead it was %s",
-                source ?: "null", actual.source ?: "null"
+                source ?: "null",
+                actual.source ?: "null"
             )
             .isEqualTo(source)
         return this

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
@@ -233,7 +233,8 @@ internal class LongTaskEventAssert(actual: LongTaskEvent) :
             .overridingErrorMessage(
                 "Expected event to have a source %s" +
                     " instead it was %s",
-                source ?: "null", actual.source ?: "null"
+                source ?: "null",
+                actual.source ?: "null"
             )
             .isEqualTo(source)
         return this

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ResourceEventAssert.kt
@@ -444,7 +444,8 @@ internal class ResourceEventAssert(actual: ResourceEvent) :
             .overridingErrorMessage(
                 "Expected event to have a source %s" +
                     " instead it was %s",
-                source ?: "null", actual.source ?: "null"
+                source ?: "null",
+                actual.source ?: "null"
             )
             .isEqualTo(source)
         return this

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -401,7 +401,8 @@ internal class ViewEventAssert(actual: ViewEvent) :
             .overridingErrorMessage(
                 "Expected event to have a source %s" +
                     " instead it was %s",
-                actual.source ?: "null", source ?: "null"
+                actual.source ?: "null",
+                source ?: "null"
             )
             .isEqualTo(source)
         return this

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
@@ -74,7 +74,6 @@ internal class ANRDetectorRunnableTest {
 
     @Test
     fun `𝕄 report RUM error 𝕎 run() {ANR detected}`() {
-
         // When
         Thread(testedRunnable).start()
         Thread.sleep(TEST_ANR_TEST_DELAY_MS)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
@@ -93,7 +93,6 @@ internal class RumDataWriterTest {
     fun `𝕄 do not notify the RumMonitor 𝕎 onDataWritten() { ViewEvent }`(
         @Forgery viewEvent: ViewEvent
     ) {
-
         // When
         testedWriter.onDataWritten(viewEvent, fakeSerializedData)
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/TimeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/TimeTest.kt
@@ -22,7 +22,6 @@ internal class TimeTest {
 
     @Test
     fun `creates Time with current millis and nanos`() {
-
         val startMs = System.currentTimeMillis()
         val startNs = System.nanoTime()
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializerTest.kt
@@ -626,7 +626,6 @@ internal class RumEventSerializerTest {
     fun `M use the attributes group verbose name W validateAttributes { ViewEvent }`(
         @Forgery fakeEvent: ViewEvent
     ) {
-
         // GIVEN
         val mockedDataConstrains: DataConstraints = mock()
         testedSerializer = RumEventSerializer(mockedDataConstrains)
@@ -649,7 +648,6 @@ internal class RumEventSerializerTest {
     fun `M use the attributes group verbose name W validateAttributes { ActionEvent }`(
         @Forgery fakeEvent: ActionEvent
     ) {
-
         // GIVEN
         val mockedDataConstrains: DataConstraints = mock()
         testedSerializer = RumEventSerializer(mockedDataConstrains)
@@ -672,7 +670,6 @@ internal class RumEventSerializerTest {
     fun `M use the attributes group verbose name W validateAttributes { ResourceEvent }`(
         @Forgery fakeEvent: ResourceEvent
     ) {
-
         // GIVEN
         val mockedDataConstrains: DataConstraints = mock()
         testedSerializer = RumEventSerializer(mockedDataConstrains)
@@ -695,7 +692,6 @@ internal class RumEventSerializerTest {
     fun `M use the attributes group verbose name W validateAttributes { ErrorEvent }`(
         @Forgery fakeEvent: ErrorEvent
     ) {
-
         // GIVEN
         val mockedDataConstrains: DataConstraints = mock()
         testedSerializer = RumEventSerializer(mockedDataConstrains)
@@ -718,7 +714,6 @@ internal class RumEventSerializerTest {
     fun `M use the attributes group verbose name W validateAttributes { LongTaskEvent }`(
         @Forgery fakeEvent: LongTaskEvent
     ) {
-
         // GIVEN
         val mockedDataConstrains: DataConstraints = mock()
         testedSerializer = RumEventSerializer(mockedDataConstrains)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimingsKtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/ExternalResourceTimingsKtTest.kt
@@ -27,7 +27,6 @@ internal class ExternalResourceTimingsKtTest {
 
     @Test
     fun `𝕄 create timings 𝕎 extractResourceTiming`(@Forgery reference: ResourceTiming) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -57,7 +56,6 @@ internal class ExternalResourceTimingsKtTest {
         missingTiming: String,
         @Forgery timing: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = timing.asTimingsPayload()
         timingsPayload.remove(missingTiming)
@@ -88,7 +86,6 @@ internal class ExternalResourceTimingsKtTest {
         timingPartToRemove: String,
         @Forgery reference: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -129,7 +126,6 @@ internal class ExternalResourceTimingsKtTest {
         timingPartToRemove: String,
         @Forgery reference: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -147,7 +143,6 @@ internal class ExternalResourceTimingsKtTest {
         assertThat(timings).isNotNull
 
         timings!!.let {
-
             assertThat(it.sslStart).isEqualTo(timingsPayload.startTimeOf("ssl"))
             assertThat(it.sslDuration).isEqualTo(timingsPayload.durationOf("ssl"))
 
@@ -171,7 +166,6 @@ internal class ExternalResourceTimingsKtTest {
         timingPartToRemove: String,
         @Forgery reference: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -212,7 +206,6 @@ internal class ExternalResourceTimingsKtTest {
         timingPartToRemove: String,
         @Forgery reference: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -253,7 +246,6 @@ internal class ExternalResourceTimingsKtTest {
         timingPartToRemove: String,
         @Forgery reference: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -294,7 +286,6 @@ internal class ExternalResourceTimingsKtTest {
         timingPartWithWrongType: String,
         @Forgery reference: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -334,7 +325,6 @@ internal class ExternalResourceTimingsKtTest {
         timingPartWithWrongType: String,
         @Forgery reference: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -374,7 +364,6 @@ internal class ExternalResourceTimingsKtTest {
         timingPartWithWrongType: String,
         @Forgery reference: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -414,7 +403,6 @@ internal class ExternalResourceTimingsKtTest {
         timingPartWithWrongType: String,
         @Forgery reference: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -454,7 +442,6 @@ internal class ExternalResourceTimingsKtTest {
         timingPartWithWrongType: String,
         @Forgery reference: ResourceTiming
     ) {
-
         // Given
         val timingsPayload = reference.asTimingsPayload()
 
@@ -490,7 +477,6 @@ internal class ExternalResourceTimingsKtTest {
 
     @Test
     fun `𝕄 not create timings 𝕎 extractResourceTiming { payload is null }`() {
-
         // When
         val timings = extractResourceTiming(null)
 
@@ -500,7 +486,6 @@ internal class ExternalResourceTimingsKtTest {
 
     @Test
     fun `𝕄 not create timings 𝕎 extractResourceTiming { payload is empty }`() {
-
         // When
         val timings = extractResourceTiming(emptyMap())
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -1615,7 +1615,6 @@ internal class RumResourceScopeTest {
         @Forgery timing: ResourceTiming,
         forge: Forge
     ) {
-
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys) +
             mapOf(
@@ -1645,7 +1644,6 @@ internal class RumResourceScopeTest {
         @Forgery timing: ResourceTiming,
         forge: Forge
     ) {
-
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys) +
             mapOf("_dd.resource_timings" to timing.asTimingsPayload())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -1093,7 +1093,7 @@ internal class RumSessionScopeTest {
                 RumRawEvent.ActionDropped(fakeId),
                 RumRawEvent.ErrorDropped(fakeId),
                 RumRawEvent.LongTaskDropped(fakeId),
-                RumRawEvent.ResourceDropped(fakeId),
+                RumRawEvent.ResourceDropped(fakeId)
             )
         )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -166,7 +166,6 @@ internal class RumViewScopeTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-
         fakeSourceViewEvent = forge.aNullable { aValueFrom(ViewEvent.Source::class.java) }
         fakeSourceErrorEvent = forge.aNullable {
             aValueFrom(ErrorEvent.ErrorEventSource::class.java)
@@ -895,7 +894,7 @@ internal class RumViewScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockTimeProvider,
-            rumEventSourceProvider = mockRumEventSourceProvider,
+            rumEventSourceProvider = mockRumEventSourceProvider
         )
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
@@ -2089,7 +2088,6 @@ internal class RumViewScopeTest {
         @StringForgery name: String,
         forge: Forge
     ) {
-
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         testedScope.activeActionScope = mockChildScope
@@ -2855,7 +2853,13 @@ internal class RumViewScopeTest {
         testedScope.activeActionScope = mockActionScope
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(
-            message, source, null, null, false, attributes, sourceType = sourceType
+            message,
+            source,
+            null,
+            null,
+            false,
+            attributes,
+            sourceType = sourceType
         )
 
         // When
@@ -2900,7 +2904,12 @@ internal class RumViewScopeTest {
         testedScope.activeActionScope = mockActionScope
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         fakeEvent = RumRawEvent.AddError(
-            message, source, null, null, true, attributes,
+            message,
+            source,
+            null,
+            null,
+            true,
+            attributes,
             sourceType = sourceType
         )
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AbstractGesturesListenerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AbstractGesturesListenerTest.kt
@@ -103,7 +103,6 @@ internal abstract class AbstractGesturesListenerTest {
         forge: Forge,
         applyOthers: (T) -> Unit = {}
     ): T {
-
         val failHitTestBecauseOfXY = forge.aBool()
         val failHitTestBecauseOfWidthHeight = !failHitTestBecauseOfXY
         val locationOnScreenArray = IntArray(2)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -593,7 +593,6 @@ internal class DatadogRumMonitorTest {
 
     @Test
     fun `M delegate event to rootScope W resetSession()`() {
-
         testedMonitor.resetSession()
         Thread.sleep(PROCESSING_DELAY)
 
@@ -1320,7 +1319,10 @@ internal class DatadogRumMonitorTest {
         testedMonitor.debugListener = listener
 
         whenever(mockRumApplicationScope.childScope) doReturn forge.anElementFrom(
-            mock(), mock<RumViewScope>(), mock<RumActionScope>(), mock<RumResourceScope>()
+            mock(),
+            mock<RumViewScope>(),
+            mock<RumActionScope>(),
+            mock<RumResourceScope>()
         )
 
         // When
@@ -1336,8 +1338,11 @@ internal class DatadogRumMonitorTest {
     ) {
         // Given
         testedMonitor.rootScope = forge.anElementFrom(
-            mock(), mock<RumViewScope>(), mock<RumActionScope>(),
-            mock<RumResourceScope>(), mock<RumSessionScope>()
+            mock(),
+            mock<RumViewScope>(),
+            mock<RumActionScope>(),
+            mock<RumResourceScope>(),
+            mock<RumSessionScope>()
         )
 
         val listener = mock<RumDebugListener>()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
@@ -187,7 +187,6 @@ internal class DatadogNdkCrashHandlerTest {
     fun `𝕄 read last RUM View event 𝕎 prepareData() { with encryption }`(
         @StringForgery viewEvent: String
     ) {
-
         testedHandler = DatadogNdkCrashHandler(
             mockContext,
             mockExecutorService,
@@ -240,7 +239,6 @@ internal class DatadogNdkCrashHandlerTest {
     fun `𝕄 read network info 𝕎 prepareData() { with encryption }`(
         @StringForgery networkInfo: String
     ) {
-
         testedHandler = DatadogNdkCrashHandler(
             mockContext,
             mockExecutorService,
@@ -293,7 +291,6 @@ internal class DatadogNdkCrashHandlerTest {
     fun `𝕄 read user info 𝕎 prepareData() { with encryption }`(
         @StringForgery userInfo: String
     ) {
-
         testedHandler = DatadogNdkCrashHandler(
             mockContext,
             mockExecutorService,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -335,7 +335,6 @@ internal class NavigationViewTrackingStrategyTest {
         forge: Forge,
         @StringForgery newDestinationName: String
     ) {
-
         val newDestination = mockNavDestination(forge, newDestinationName)
         whenever(mockPredicate.accept(mockNavDestination)) doReturn true
         whenever(mockPredicate.accept(newDestination)) doReturn true

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -147,13 +147,17 @@ internal class TelemetryEventHandlerTest {
 
     private fun Forge.createRumRawTelemetryDebugEvent(): RumRawEvent.SendTelemetry {
         return RumRawEvent.SendTelemetry(
-            TelemetryType.DEBUG, aString(), null
+            TelemetryType.DEBUG,
+            aString(),
+            null
         )
     }
 
     private fun Forge.createRumRawTelemetryErrorEvent(): RumRawEvent.SendTelemetry {
         return RumRawEvent.SendTelemetry(
-            TelemetryType.ERROR, aString(), aNullable { aThrowable() }
+            TelemetryType.ERROR,
+            aString(),
+            aNullable { aThrowable() }
         )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/event/DdSpanToSpanEventMapperTest.kt
@@ -40,7 +40,6 @@ import org.mockito.quality.Strictness
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class)
 )
-
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 @ForgeConfiguration(Configurator::class)
 internal class DdSpanToSpanEventMapperTest {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/event/SpanEventSerializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/domain/event/SpanEventSerializerTest.kt
@@ -38,7 +38,6 @@ import org.mockito.quality.Strictness
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class)
 )
-
 @MockitoSettings(strictness = Strictness.STRICT_STUBS)
 @ForgeConfiguration(Configurator::class)
 internal class SpanEventSerializerTest {
@@ -276,7 +275,6 @@ internal class SpanEventSerializerTest {
     private fun JsonObjectAssert.hasUserInfo(
         spanEvent: SpanEvent
     ) {
-
         val userName = spanEvent.meta.usr.name
         val userEmail = spanEvent.meta.usr.email
         val userId = spanEvent.meta.usr.id

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/handlers/AndroidSpanLogsHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/handlers/AndroidSpanLogsHandlerTest.kt
@@ -38,7 +38,6 @@ import org.mockito.quality.Strictness
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class)
 )
-
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
 internal class AndroidSpanLogsHandlerTest {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/utils/TracerExtensionsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/utils/TracerExtensionsTest.kt
@@ -27,7 +27,6 @@ import org.mockito.quality.Strictness
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class)
 )
-
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
 class TracerExtensionsTest {
@@ -42,6 +41,7 @@ class TracerExtensionsTest {
     @AfterEach
     fun `tear down`() {
         val activeSpan = tracer.activeSpan()
+
         @Suppress("DEPRECATION")
         val activeScope = tracer.scopeManager().active()
         activeSpan?.finish()
@@ -52,7 +52,6 @@ class TracerExtensionsTest {
 
     @Test
     fun `it will return the trace id and span id if there is an active span`(forge: Forge) {
-
         // When
         val span = tracer.buildSpan(forge.anAlphabeticalString()).start() as DDSpan
         tracer.activateSpan(span)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
@@ -43,7 +43,7 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                 isCrash = forge.aNullable { aBool() },
                 type = forge.aNullable { anAlphabeticalString() },
                 handling = forge.aNullable { getForgery() },
-                handlingStack = forge.aNullable { aThrowable().loggableStackTrace() },
+                handlingStack = forge.aNullable { aThrowable().loggableStackTrace() }
             ),
             view = ErrorEvent.View(
                 id = forge.getForgery<UUID>().toString(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ForgeExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ForgeExt.kt
@@ -71,7 +71,6 @@ internal fun <K, V> Forge.aFilteredMap(
     filterThreshold: Float = 0.5f,
     forging: Forge.() -> Pair<K, V>
 ): Map<K, V> {
-
     val base = aMap(size, forging)
 
     val filtered = base.filterKeys { it !in excludedKeys }
@@ -111,7 +110,6 @@ internal fun Forge.aRumEventAsJson(): JsonObject {
 }
 
 private fun assumeDifferenceIsNoMore(result: Int, base: Int, maxDifference: Float) {
-
     check(result <= base) {
         "Number of elements after filtering cannot exceed the number of original elements."
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/MotionEventForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/MotionEventForgeryFactory.kt
@@ -15,7 +15,6 @@ import fr.xgouchet.elmyr.ForgeryFactory
 internal class MotionEventForgeryFactory : ForgeryFactory<MotionEvent> {
 
     override fun getForgery(forge: Forge): MotionEvent {
-
         return mock {
             whenever(it.x).thenReturn(
                 forge.aFloat(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumEventMapperFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumEventMapperFactory.kt
@@ -14,7 +14,6 @@ import fr.xgouchet.elmyr.ForgeryFactory
 internal class RumEventMapperFactory : ForgeryFactory<RumEventMapper> {
 
     override fun getForgery(forge: Forge): RumEventMapper {
-
         return RumEventMapper(
             viewEventMapper = mock(),
             actionEventMapper = mock(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/DatadogEventBridgeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/DatadogEventBridgeTest.kt
@@ -29,7 +29,7 @@ import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class),
+    ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
@@ -112,7 +112,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        argumentCaptor<JsonObject>() {
+        argumentCaptor<JsonObject> {
             verify(mockUserLogsWriter).write(capture())
             assertThat(firstValue).hasField(WebViewLogEventConsumer.DATE_KEY_NAME, expectedDate)
             assertThat(firstValue).hasField(
@@ -138,7 +138,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        argumentCaptor<JsonObject>() {
+        argumentCaptor<JsonObject> {
             verify(mockInternalLogsWriter).write(capture())
             assertThat(firstValue).hasField(WebViewLogEventConsumer.DATE_KEY_NAME, expectedDate)
             assertThat(firstValue).hasField(
@@ -167,7 +167,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        argumentCaptor<JsonObject>() {
+        argumentCaptor<JsonObject> {
             verify(mockUserLogsWriter).write(capture())
             assertThat(firstValue).hasField(WebViewLogEventConsumer.DATE_KEY_NAME, expectedDate)
             assertThat(firstValue).hasField(
@@ -204,7 +204,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        argumentCaptor<JsonObject>() {
+        argumentCaptor<JsonObject> {
             verify(mockInternalLogsWriter).write(capture())
             assertThat(firstValue).hasField(WebViewLogEventConsumer.DATE_KEY_NAME, expectedDate)
             assertThat(firstValue).hasField(
@@ -237,7 +237,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        argumentCaptor<JsonObject>() {
+        argumentCaptor<JsonObject> {
             verify(mockUserLogsWriter).write(capture())
             assertThat(firstValue).doesNotHaveField(WebViewLogEventConsumer.DATE_KEY_NAME)
             assertThat(firstValue).hasField(
@@ -262,7 +262,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        argumentCaptor<JsonObject>() {
+        argumentCaptor<JsonObject> {
             verify(mockInternalLogsWriter).write(capture())
             assertThat(firstValue).doesNotHaveField(WebViewLogEventConsumer.DATE_KEY_NAME)
             assertThat(firstValue).hasField(
@@ -339,7 +339,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        argumentCaptor<JsonObject>() {
+        argumentCaptor<JsonObject> {
             verify(mockUserLogsWriter).write(capture())
             assertThat(firstValue).hasField(WebViewLogEventConsumer.DATE_KEY_NAME, expectedDate)
             assertThat(firstValue).hasField(
@@ -363,7 +363,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        argumentCaptor<JsonObject>() {
+        argumentCaptor<JsonObject> {
             verify(mockInternalLogsWriter).write(capture())
             assertThat(firstValue).hasField(WebViewLogEventConsumer.DATE_KEY_NAME, expectedDate)
             assertThat(firstValue).hasField(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,7 +47,7 @@ kover="0.5.0-RC"
 
 # Tools
 detekt = "1.18.0"
-ktLint = "10.2.0"
+ktLint = "10.2.1"
 dokka = "1.5.30"
 unmock = "0.7.9"
 robolectric = "4.4_r1-robolectric-r2"

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/CPUProfileForLogs.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/CPUProfileForLogs.kt
@@ -26,8 +26,10 @@ internal class CPUProfileForLogs {
 
     @get:Rule
     val mockServerRule = MockServerActivityTestRule(ActivityProfiling::class.java)
+
     @get:Rule
     val cpuProfilingRule = CPUProfilingRule()
+
     @get:Rule
     val forge = ForgeRule().withFactory(ThrowableForgeryFactory())
 
@@ -59,7 +61,6 @@ internal class CPUProfileForLogs {
     @Test
     @Ignore("Not ran on CI, run locally whenever we build a new release.")
     fun profileLoggingWithThrowable() {
-
         cpuProfilingRule.profile(
             runThreshold = 15.0, // allow up to 15% usage above normal
             runConfig = AbstractProfilingRule.ProfilingConfig(

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/ConsentGrantedLogsTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/ConsentGrantedLogsTest.kt
@@ -29,7 +29,6 @@ internal class ConsentGrantedLogsTest : LogsTest() {
 
     @Test
     fun verifyActivityLogs() {
-
         // Wait to make sure all batches are consumed
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
 

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/ConsentPendingGrantedLogsTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/ConsentPendingGrantedLogsTest.kt
@@ -30,7 +30,6 @@ internal class ConsentPendingGrantedLogsTest : LogsTest() {
 
     @Test
     fun verifyActivityLogs() {
-
         // update the tracking consent
         Datadog.setTrackingConsent(TrackingConsent.GRANTED)
 

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/MemoryProfileForLogs.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/log/MemoryProfileForLogs.kt
@@ -26,8 +26,10 @@ internal class MemoryProfileForLogs {
 
     @get:Rule
     val mockServerRule = MockServerActivityTestRule(ActivityProfiling::class.java)
+
     @get:Rule
     val memoryProfilingRule = MemoryProfilingRule()
+
     @get:Rule
     val forge = ForgeRule().withFactory(ThrowableForgeryFactory())
 
@@ -59,7 +61,6 @@ internal class MemoryProfileForLogs {
     @Test
     @Ignore("Not ran on CI, run locally whenever we build a new release.")
     fun profileLoggingWithThrowable() {
-
         memoryProfilingRule.profile(
             runThreshold = 1536.0, // 1.5 Mb during processing of large batches
             runConfig = AbstractProfilingRule.ProfilingConfig(

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingTest.kt
@@ -19,7 +19,6 @@ internal abstract class ActivityTrackingTest :
     override fun runInstrumentationScenario(
         mockServerRule: RumMockServerActivityTestRule<ActivityTrackingPlaygroundActivity>
     ): MutableList<ExpectedEvent> {
-
         val expectedEvents = mutableListOf<ExpectedEvent>()
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         val activity = mockServerRule.activity

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/GesturesTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/GesturesTrackingTest.kt
@@ -27,7 +27,6 @@ internal abstract class GesturesTrackingTest :
     override fun runInstrumentationScenario(
         mockServerRule: GesturesTrackingActivityTestRule<GesturesTrackingPlaygroundActivity>
     ): List<ExpectedEvent> {
-
         val activity = mockServerRule.activity
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         instrumentation.waitForIdleSync()

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ResourceTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ResourceTrackingTest.kt
@@ -49,7 +49,6 @@ internal class ResourceTrackingTest {
 
     @Before
     fun setUp() {
-
         extraAttributes = forge.exhaustiveAttributes()
 
         okHttpClient = OkHttpClient.Builder()
@@ -69,7 +68,6 @@ internal class ResourceTrackingTest {
 
     @Test
     fun verifyAttributesAreSentWhenRequestIsSuccessful() {
-
         val resourceUrl = "${mockServerRule.getConnectionUrl()}/nyan-cat.gif"
 
         okHttpClient.newCall(
@@ -98,7 +96,6 @@ internal class ResourceTrackingTest {
 
     @Test
     fun verifyAttributesAreSentWhenRequestHasException() {
-
         val resourceUrl = mockServerRule.getConnectionUrl() +
             MockServerActivityTestRule.CONNECTION_ISSUE_PATH
 

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -49,7 +49,6 @@ internal class EncryptionTest {
 
     @Test
     fun must_encrypt_all_data() {
-
         val targetContext = InstrumentationRegistry.getInstrumentation().targetContext
 
         val configuration = createSdkConfiguration()
@@ -134,7 +133,6 @@ internal class EncryptionTest {
     }
 
     private fun createSdkConfiguration(): Configuration {
-
         val encryption = object : Encryption {
             override fun encrypt(data: ByteArray): ByteArray {
                 return ENCRYPTION_MARKER.toByteArray() + data
@@ -183,7 +181,9 @@ internal class EncryptionTest {
         )
 
         rumMonitor.addUserAction(
-            RumActionType.CUSTOM, "rumAction-${forge.aString()}", emptyMap()
+            RumActionType.CUSTOM,
+            "rumAction-${forge.aString()}",
+            emptyMap()
         )
         logger.w("Action added")
 

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/ConsentGrantedTracesTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/ConsentGrantedTracesTest.kt
@@ -29,7 +29,6 @@ internal class ConsentGrantedTracesTest : TracesTest() {
 
     @Test
     fun verifyExpectedActivitySpansAndLogs() {
-
         runInstrumentationScenario(mockServerRule)
 
         // Wait to make sure all batches are consumed

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/ConsentPendingGrantedTracesTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/ConsentPendingGrantedTracesTest.kt
@@ -30,7 +30,6 @@ internal class ConsentPendingGrantedTracesTest : TracesTest() {
 
     @Test
     fun verifyExpectedActivitySpansAndLogs() {
-
         runInstrumentationScenario(mockServerRule)
 
         // update the tracking consent

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/ConsentPendingNotGrantedTracesTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/trace/ConsentPendingNotGrantedTracesTest.kt
@@ -32,7 +32,6 @@ internal class ConsentPendingNotGrantedTracesTest : TracesTest() {
 
     @Test
     fun verifyAllTracesAreDropped() {
-
         runInstrumentationScenario(mockServerRule)
 
         // update the tracking consent

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/AbstractProfilingRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/AbstractProfilingRule.kt
@@ -53,7 +53,6 @@ internal abstract class AbstractProfilingRule(
         warmupConfig: ProfilingConfig,
         action: () -> Unit
     ) {
-
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
 
         // Warmup

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingPlaygroundActivity.kt
@@ -5,6 +5,7 @@
  */
 
 @file:Suppress("DEPRECATION")
+
 package com.datadog.android.sdk.integration.rum
 
 import android.os.Bundle

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
@@ -628,6 +628,7 @@ class LoggerE2ETests {
         val CUSTOM_ORG_JSON_JSON_OBJECT_ATTRIBUTE: JSONObject = JSONObject().apply {
             put(CUSTOM_JSON_OBJECT_PROPERTY, CUSTOM_INT_ATTRIBUTE)
         }
+
         @SuppressWarnings("UnsafeCallOnNullableType")
         val CUSTOM_DATE_ATTRIBUTE: Date = SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSS")
             .apply { timeZone = TimeZone.getTimeZone("UTC") }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -8,9 +8,12 @@ package com.datadog.android.nightly.main
 
 /**
  * apiMethodSignature: com.datadog.android.Datadog#fun clearAllData()
+ * apiMethodSignature: com.datadog.android.Datadog#fun enableRumDebugging(Boolean)
  * apiMethodSignature: com.datadog.android.Datadog#fun isInitialized(): Boolean
  * apiMethodSignature: com.datadog.android.Datadog#fun setVerbosity(Int)
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setUploadFrequency(UploadFrequency): Builder
+ * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setProxy(java.net.Proxy, okhttp3.Authenticator?): Builder
+ * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setUseDeveloperModeWhenDebuggable(Boolean): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setInternalLogsEnabled(String, String): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setAdditionalConfiguration(Map<String, Any>): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useCustomCrashReportsEndpoint(String): Builder

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/GlobalRumE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/GlobalRumE2ETests.kt
@@ -200,7 +200,6 @@ class GlobalRumE2ETests {
         val intAttrValue = forge.anInt()
 
         executeInsideView(viewKey, viewName, testMethodName) {
-
             addAttributes(strAttrValue, intAttrValue)
             removeAttributesMeasured()
             GlobalRum.get().startResource(
@@ -262,7 +261,6 @@ class GlobalRumE2ETests {
         val intAttrValue = forge.anInt()
 
         executeInsideView(viewKey, viewName, testMethodName) {
-
             addAttributes(strAttrValue, intAttrValue)
             removeAttributesMeasured()
             GlobalRum.get().addError(

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBuilderE2ETests.kt
@@ -33,7 +33,6 @@ class RumMonitorBuilderE2ETests {
      * apiMethodSignature: com.datadog.android.rum.RumMonitor$Builder#fun sampleRumSessions(Float): Builder
      * apiMethodSignature: com.datadog.android.rum.RumMonitor$Builder#fun build(): RumMonitor
      * apiMethodSignature: com.datadog.android.rum.GlobalRum#fun registerIfAbsent(java.util.concurrent.Callable<RumMonitor>): Boolean
-
      */
     @Test
     fun rum_rummonitor_builder_sample_all_in() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumUtils.kt
@@ -94,7 +94,6 @@ fun sendAllRumEvents(
     forge: Forge,
     testMethodName: String
 ) {
-
     val aViewKey = forge.aViewKey()
     GlobalRum.get().startView(
         aViewKey,
@@ -112,7 +111,6 @@ fun sendAllRumEvents(
 }
 
 private fun sendResourceEvent(forge: Forge, testMethodName: String) {
-
     val aResourceKey = forge.aResourceKey()
     GlobalRum.get().startResource(
         aResourceKey,

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -71,7 +71,6 @@ fun sendRandomActionOutcomeEvent(forge: Forge) {
 }
 
 fun stopSdk() {
-
     // Call Datadog.stop()
     val instance = Datadog.javaClass.getDeclaredField("INSTANCE")
     instance.isAccessible = true

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/TestEncryption.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/TestEncryption.kt
@@ -35,7 +35,8 @@ class TestEncryption : Encryption {
                 return (keyStore.getEntry(KEY_ALIAS, null) as KeyStore.SecretKeyEntry).secretKey
             } else {
                 val keyGenerator = KeyGenerator.getInstance(
-                    KeyProperties.KEY_ALGORITHM_AES, "AndroidKeyStore"
+                    KeyProperties.KEY_ALGORITHM_AES,
+                    "AndroidKeyStore"
                 )
 
                 val keySpec = KeyGenParameterSpec

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
@@ -159,7 +159,6 @@ internal class WebViewTrackingE2ETests {
             rumEnabled = true
         ).setWebViewTrackingHosts(listOf("datadoghq.dev")).build()
     ) {
-
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/utils/MeasureUtils.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/utils/MeasureUtils.kt
@@ -23,7 +23,6 @@ internal inline fun <reified R> measure(methodName: String, codeBlock: () -> R):
 }
 
 internal fun measureSdkInitialize(codeBlock: () -> Unit) {
-
     val start = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis())
     codeBlock()
     val stop = TimeUnit.MILLISECONDS.toMicros(System.currentTimeMillis())

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/InvalidStringFormat.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/InvalidStringFormat.kt
@@ -255,16 +255,34 @@ class InvalidStringFormat : Rule() {
         private const val SPECIFIER_HEXADECIMAL_FLOAT = 'a'
 
         private val INTEGER_TYPES = arrayOf(
-            "kotlin.Byte", "kotlin.Short", "kotlin.Int", "kotlin.Long", "java.math.BigInteger",
-            "kotlin.Byte?", "kotlin.Short?", "kotlin.Int?", "kotlin.Long?", "java.math.BigInteger?"
+            "kotlin.Byte",
+            "kotlin.Short",
+            "kotlin.Int",
+            "kotlin.Long",
+            "java.math.BigInteger",
+            "kotlin.Byte?",
+            "kotlin.Short?",
+            "kotlin.Int?",
+            "kotlin.Long?",
+            "java.math.BigInteger?"
         )
         private val FLOAT_TYPES = arrayOf(
-            "kotlin.Float", "kotlin.Double", "java.math.BigDecimal",
-            "kotlin.Float?", "kotlin.Double?", "java.math.BigDecimal?"
+            "kotlin.Float",
+            "kotlin.Double",
+            "java.math.BigDecimal",
+            "kotlin.Float?",
+            "kotlin.Double?",
+            "java.math.BigDecimal?"
         )
         private val CHAR_TYPES = arrayOf(
-            "kotlin.Byte", "kotlin.Short", "kotlin.Int", "kotlin.Char",
-            "kotlin.Byte?", "kotlin.Short?", "kotlin.Int?", "kotlin.Char?"
+            "kotlin.Byte",
+            "kotlin.Short",
+            "kotlin.Int",
+            "kotlin.Char",
+            "kotlin.Byte?",
+            "kotlin.Short?",
+            "kotlin.Int?",
+            "kotlin.Char?"
         )
         private val ANY_TYPES = emptyArray<String>()
 

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/ReflectUtils.kt
@@ -33,7 +33,6 @@ fun <T, R> Class<T>.setStaticValue(
  * @param fieldName the name of the field
  */
 inline fun <reified T, reified R> Class<T>.getStaticValue(fieldName: String): R {
-
     val field = getDeclaredField(fieldName)
 
     // make it accessible

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/CollectionAssertExt.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/CollectionAssertExt.kt
@@ -15,7 +15,6 @@ import org.assertj.core.api.ListAssert
  *  @param clazz the class object
  */
 fun <T> ListAssert<T>.containsInstanceOf(clazz: Class<*>): ListAssert<T> {
-
     overridingErrorMessage(
         "Expected list to have at least one instance of ${clazz.simpleName} " +
             "but found none."

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/assertj/JsonObjectAssert.kt
@@ -64,7 +64,6 @@ class JsonObjectAssert(actual: JsonObject) :
      *  @param expectedValue the expected value of the field
      */
     fun hasNullableField(name: String, expectedValue: Any?): JsonObjectAssert {
-
         when (expectedValue) {
             null -> hasNullField(name)
             is String -> hasField(name, expectedValue)

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/forge/Throwable.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/forge/Throwable.kt
@@ -27,6 +27,7 @@ fun Forge.aThrowable(): Throwable {
         anException()
     )
 }
+
 /**
  * @return a random [Error] instance with a forged message.
  */

--- a/tools/unit/src/test/kotlin/com/datadog/tools/unit/ConditionWatcherTest.kt
+++ b/tools/unit/src/test/kotlin/com/datadog/tools/unit/ConditionWatcherTest.kt
@@ -20,7 +20,6 @@ internal class ConditionWatcherTest {
 
     @Test
     fun `M timeout W condition is never satisfied`(forge: Forge) {
-
         // Given + When + Then
         assertThrows<ConditionWatcher.TimeoutException> {
             ConditionWatcher(pollingIntervalMs = TEST_POLLING_MS) { false }.doWait(
@@ -31,7 +30,6 @@ internal class ConditionWatcherTest {
 
     @Test
     fun `M instantly fail W condition throws non-assertion throwable`(forge: Forge) {
-
         val fakeThrowable = forge.aThrowable()
 
         // just a coherence check that we have a good throwable in case if underlying aThrowable
@@ -61,7 +59,6 @@ internal class ConditionWatcherTest {
 
     @Test
     fun `M not instantly fail W condition throws assertion throwable`(forge: Forge) {
-
         // Given
         val condition = object : Function0<Boolean> {
 
@@ -89,7 +86,6 @@ internal class ConditionWatcherTest {
 
     @Test
     fun `M passes W condition is satisfied after some time`(forge: Forge) {
-
         // Given
         val invocationsWhenSatisfied = forge.anInt(min = 3, max = 5)
 


### PR DESCRIPTION
### What does this PR do?

Upgrade KtLint to ensure we don't use trailing commas in our code.

### Motivation

Trailing commas break the parser we use to generate the api surface (and they don't look nice)

### Additional Notes

A bunch of other experimental rules are part of the bundle, including a few about allowed/forbidden blank lines around code