### PR TITLE
RUMM-2028 Reduce number of views updates in payloads

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/DefaultViewUpdatePredicate.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/DefaultViewUpdatePredicate.kt
@@ -13,8 +13,13 @@ internal class DefaultViewUpdatePredicate(
 ) : ViewUpdatePredicate {
     private var lastViewUpdateTimestamp = System.nanoTime() - VIEW_UPDATE_THRESHOLD_IN_NS
 
-    override fun canUpdateView(isViewComplete: Boolean): Boolean {
-        if (isViewComplete || System.nanoTime() - lastViewUpdateTimestamp > viewUpdateThreshold) {
+    override fun canUpdateView(isViewComplete: Boolean, event: RumRawEvent): Boolean {
+        val isFatalError = event is RumRawEvent.AddError && event.isFatal
+        val isThresholdReached = System.nanoTime() - lastViewUpdateTimestamp > viewUpdateThreshold
+        if (isViewComplete ||
+            isFatalError ||
+            isThresholdReached
+        ) {
             lastViewUpdateTimestamp = System.nanoTime()
             return true
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/DefaultViewUpdatePredicate.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/DefaultViewUpdatePredicate.kt
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.scope
+
+import java.util.concurrent.TimeUnit
+
+internal class DefaultViewUpdatePredicate(
+    private val viewUpdateThreshold: Long = VIEW_UPDATE_THRESHOLD_IN_NS
+) : ViewUpdatePredicate {
+    private var lastViewUpdateTimestamp = System.nanoTime() - VIEW_UPDATE_THRESHOLD_IN_NS
+
+    override fun canUpdateView(isViewComplete: Boolean): Boolean {
+        if (isViewComplete || System.nanoTime() - lastViewUpdateTimestamp > viewUpdateThreshold) {
+            lastViewUpdateTimestamp = System.nanoTime()
+            return true
+        }
+        return false
+    }
+
+    companion object {
+        internal val VIEW_UPDATE_THRESHOLD_IN_NS = TimeUnit.SECONDS.toNanos(30)
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -480,7 +480,7 @@ internal open class RumViewScope(
     @Suppress("LongMethod")
     private fun sendViewUpdate(event: RumRawEvent, writer: DataWriter<Any>) {
         val viewComplete = isViewComplete()
-        if (!viewUpdatePredicate.canUpdateView(viewComplete)) {
+        if (!viewUpdatePredicate.canUpdateView(viewComplete, event)) {
             return
         }
         attributes.putAll(GlobalRum.globalAttributes)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -53,7 +53,8 @@ internal open class RumViewScope(
     internal val frameRateVitalMonitor: VitalMonitor,
     internal val timeProvider: TimeProvider,
     private val rumEventSourceProvider: RumEventSourceProvider,
-    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider()
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider(),
+    private val viewUpdatePredicate: ViewUpdatePredicate = DefaultViewUpdatePredicate()
 ) : RumScope {
 
     internal val url = key.resolveViewUrl().replace('.', '/')
@@ -478,24 +479,19 @@ internal open class RumViewScope(
 
     @Suppress("LongMethod")
     private fun sendViewUpdate(event: RumRawEvent, writer: DataWriter<Any>) {
+        val viewComplete = isViewComplete()
+        if (!viewUpdatePredicate.canUpdateView(viewComplete)) {
+            return
+        }
         attributes.putAll(GlobalRum.globalAttributes)
         version++
         val updatedDurationNs = event.eventTime.nanoTime - startedNanos
         val context = getRumContext()
         val user = CoreFeature.userInfoProvider.getUserInfo()
-        val timings = if (customTimings.isNotEmpty()) {
-            ViewEvent.CustomTimings(LinkedHashMap(customTimings))
-        } else {
-            null
-        }
-
+        val timings = resolveCustomTimings()
         val memoryInfo = lastMemoryInfo
         val refreshRateInfo = lastFrameRateInfo
-        val isSlowRendered = if (refreshRateInfo == null) {
-            null
-        } else {
-            refreshRateInfo.meanValue < SLOW_RENDERED_THRESHOLD_FPS
-        }
+        val isSlowRendered = resolveRefreshRateInfo(refreshRateInfo)
         val viewEvent = ViewEvent(
             date = eventTimestamp,
             view = ViewEvent.View(
@@ -512,7 +508,7 @@ internal open class RumViewScope(
                 longTask = ViewEvent.LongTask(longTaskCount),
                 frozenFrame = ViewEvent.FrozenFrame(frozenFrameCount),
                 customTimings = timings,
-                isActive = !isViewComplete(),
+                isActive = !viewComplete,
                 cpuTicksCount = cpuTicks,
                 cpuTicksPerSecond = cpuTicks?.let { (it * ONE_SECOND_NS) / updatedDurationNs },
                 memoryAverage = memoryInfo?.meanValue,
@@ -541,6 +537,19 @@ internal open class RumViewScope(
         )
 
         writer.write(viewEvent)
+    }
+
+    private fun resolveRefreshRateInfo(refreshRateInfo: VitalInfo?) =
+        if (refreshRateInfo == null) {
+            null
+        } else {
+            refreshRateInfo.meanValue < SLOW_RENDERED_THRESHOLD_FPS
+        }
+
+    private fun resolveCustomTimings() = if (customTimings.isNotEmpty()) {
+        ViewEvent.CustomTimings(LinkedHashMap(customTimings))
+    } else {
+        null
     }
 
     private fun addExtraAttributes(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/ViewUpdatePredicate.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/ViewUpdatePredicate.kt
@@ -7,5 +7,5 @@
 package com.datadog.android.rum.internal.domain.scope
 
 internal interface ViewUpdatePredicate {
-    fun canUpdateView(isViewComplete: Boolean): Boolean
+    fun canUpdateView(isViewComplete: Boolean, event: RumRawEvent): Boolean
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/ViewUpdatePredicate.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/ViewUpdatePredicate.kt
@@ -1,0 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.scope
+
+internal interface ViewUpdatePredicate {
+    fun canUpdateView(isViewComplete: Boolean): Boolean
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/DefaultViewPredicateTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/DefaultViewPredicateTest.kt
@@ -1,0 +1,82 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.scope
+
+import java.util.concurrent.TimeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+
+internal class DefaultViewPredicateTest {
+
+    lateinit var testedViewPredicate: DefaultViewUpdatePredicate
+
+    @Before
+    fun `set up`() {
+        testedViewPredicate = DefaultViewUpdatePredicate()
+    }
+
+    @Test
+    fun `M return true W canUpdateView { first call, isViewComplete false }`() {
+        // When
+        val canUpdateView = testedViewPredicate.canUpdateView(false)
+
+        // Then
+        assertThat(canUpdateView).isTrue
+    }
+
+    @Test
+    fun `M return true W canUpdateView { first call, isViewComplete true }`() {
+        // When
+        val canUpdateView = testedViewPredicate.canUpdateView(true)
+
+        // Then
+        assertThat(canUpdateView).isTrue
+    }
+
+    @Test
+    fun `M return true W canUpdateView { second call after threshold, isViewComplete false }`() {
+        // Given
+        testedViewPredicate = DefaultViewUpdatePredicate(TimeUnit.MILLISECONDS.toNanos(300))
+        val canUpdateViewFirst = testedViewPredicate.canUpdateView(false)
+
+        // When
+        Thread.sleep(400)
+        val canUpdateViewSecond = testedViewPredicate.canUpdateView(false)
+
+        // Then
+        assertThat(canUpdateViewFirst).isTrue
+        assertThat(canUpdateViewSecond).isTrue
+    }
+
+    @Test
+    fun `M return true W canUpdateView { second call before threshold, isViewComplete true }`() {
+        // Given
+        val canUpdateViewFirst = testedViewPredicate.canUpdateView(false)
+
+        // When
+        val canUpdateViewSecond = testedViewPredicate.canUpdateView(true)
+
+        // Then
+        assertThat(canUpdateViewFirst).isTrue
+        assertThat(canUpdateViewSecond).isTrue
+    }
+
+    @Test
+    fun `M return false W canUpdateView { second call before threshold, isViewComplete false }`() {
+        // Given
+        testedViewPredicate = DefaultViewUpdatePredicate(TimeUnit.MILLISECONDS.toNanos(300))
+        val canUpdateViewFirst = testedViewPredicate.canUpdateView(false)
+
+        // When
+        val canUpdateViewSecond = testedViewPredicate.canUpdateView(false)
+
+        // Then
+        assertThat(canUpdateViewFirst).isTrue
+        assertThat(canUpdateViewSecond).isFalse
+    }
+}

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingTest.kt
@@ -34,7 +34,7 @@ internal abstract class ActivityTrackingTest :
             ExpectedApplicationStart()
         )
 
-        // one for application start update
+        // one for view start
         expectedEvents.add(
             ExpectedViewEvent(
                 viewUrl,
@@ -43,28 +43,11 @@ internal abstract class ActivityTrackingTest :
             )
         )
 
-        // one for view loading time update
-        expectedEvents.add(
-            ExpectedViewEvent(
-                viewUrl,
-                docVersion = 3,
-                viewArguments = expectedViewArguments,
-                extraViewAttributes = mapOf(
-                    "loading_type" to "activity_display"
-                ),
-                extraViewAttributesWithPredicate = mapOf(
-                    "loading_time" to { time ->
-                        time.asLong >= 0
-                    }
-                )
-            )
-        )
-
         // one for view stopped
         expectedEvents.add(
             ExpectedViewEvent(
                 viewUrl,
-                docVersion = 4,
+                docVersion = 3,
                 viewArguments = expectedViewArguments
             )
         )

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingTest.kt
@@ -31,7 +31,7 @@ internal abstract class FragmentTrackingTest :
         val instrumentation = InstrumentationRegistry.getInstrumentation()
         instrumentation.waitForIdleSync()
         val fragmentAViewUrl = currentFragmentViewUrl(activity)
-        // one for application start update
+        // one for view start
         expectedEvents.add(
             ExpectedViewEvent(
                 fragmentAViewUrl,
@@ -40,28 +40,11 @@ internal abstract class FragmentTrackingTest :
             )
         )
 
-        // for update view time
-        expectedEvents.add(
-            ExpectedViewEvent(
-                fragmentAViewUrl,
-                3,
-                currentFragmentExtras(activity),
-                extraViewAttributes = mapOf(
-                    "loading_type" to "fragment_display"
-                ),
-                extraViewAttributesWithPredicate = mapOf(
-                    "loading_time" to { time ->
-                        time.asLong >= 0
-                    }
-                )
-            )
-        )
-
         // view stopped
         expectedEvents.add(
             ExpectedViewEvent(
                 fragmentAViewUrl,
-                4,
+                3,
                 currentFragmentExtras(activity),
                 extraViewAttributes = mapOf(
                     "loading_type" to "fragment_display"

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/GesturesTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/GesturesTrackingTest.kt
@@ -95,10 +95,6 @@ internal abstract class GesturesTrackingTest :
                         "recyclerView"
                 )
             ),
-            ExpectedViewEvent(
-                viewUrl,
-                3
-            ),
             ExpectedGestureEvent(
                 Gesture.SWIPE,
                 activity.recyclerView.targetName(),
@@ -106,10 +102,6 @@ internal abstract class GesturesTrackingTest :
                 extraAttributes = mapOf(
                     RumAttributes.ACTION_GESTURE_DIRECTION to "down"
                 )
-            ),
-            ExpectedViewEvent(
-                viewUrl,
-                4
             )
         )
     }


### PR DESCRIPTION
### What does this PR do?

During a `ViewScope` lifecycle we are sending too many `ViewEvent` updates which are significantly increasing the size of our payloads and also increasing the data traffic. Above all these extra `ViewEvents` are affecting our reducers performance in the backend. We are currently introducing a special `predicate` that will limit the `ViewEvent` updates to 1/30 seconds with a wildcard in case the scope `ViewScope` was finalized.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

