### PR TITLE
Track static mocks left

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -192,13 +192,20 @@ internal object CoreFeature {
             contextRef.clear()
 
             trackingConsentProvider.unregisterAllCallbacks()
-            kronosClock.shutdown()
+            try {
+                kronosClock.shutdown()
+            } catch (ise: IllegalStateException) {
+                // this may be called from the test
+                // when Kronos is already shut down
+                sdkLogger.e("Trying to shut down Kronos when it is already not running", ise)
+            }
 
             cleanupApplicationInfo()
             cleanupProviders()
             shutDownExecutors()
             initialized.set(false)
             ndkCrashHandler = NoOpNdkCrashHandler()
+            trackingConsentProvider = NoOpConsentProvider()
         }
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -22,7 +22,7 @@ internal object CrashReportsFeature : SdkFeature<LogEvent, Configuration.Feature
 
     internal const val CRASH_FEATURE_NAME = "crash"
 
-    private var originalUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
+    internal var originalUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
 
     // region SdkFeature
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -29,6 +29,7 @@ import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
+import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
 import com.datadog.android.utils.extension.mockChoreographerInstance
@@ -36,7 +37,9 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.webview.internal.log.WebViewLogsFeature
 import com.datadog.android.webview.internal.rum.WebViewRumFeature
 import com.datadog.opentracing.DDSpan
+import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.ProhibitLeavingStaticMocksExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.google.gson.JsonObject
@@ -70,10 +73,20 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
+    ExtendWith(ProhibitLeavingStaticMocksExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
+@ProhibitLeavingStaticMocksIn(
+    CoreFeature::class,
+    RumFeature::class,
+    LogsFeature::class,
+    TracingFeature::class,
+    WebViewLogsFeature::class,
+    WebViewRumFeature::class,
+    CrashReportsFeature::class
+)
 internal class DatadogTest {
 
     @Mock
@@ -845,11 +858,12 @@ internal class DatadogTest {
         val appContext = ApplicationContextTestConfiguration(Application::class.java)
         val mainLooper = MainLooperTestConfiguration()
         val logger = LoggerTestConfiguration()
+        val coreFeature = CoreFeatureTestConfiguration(appContext)
 
         @TestConfigurationsProvider
         @JvmStatic
         fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(logger, appContext, mainLooper)
+            return listOf(logger, appContext, mainLooper, coreFeature)
         }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -16,12 +16,20 @@ import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.persistence.DataReader
 import com.datadog.android.core.internal.persistence.NoOpPersistenceStrategy
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
+import com.datadog.android.error.internal.CrashReportsFeature
+import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.plugin.DatadogPluginConfig
 import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.webview.internal.log.WebViewLogsFeature
+import com.datadog.android.webview.internal.rum.WebViewRumFeature
+import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.ProhibitLeavingStaticMocksExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.any
@@ -55,10 +63,20 @@ import org.mockito.quality.Strictness
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class),
+    ExtendWith(ProhibitLeavingStaticMocksExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
+@ProhibitLeavingStaticMocksIn(
+    CoreFeature::class,
+    RumFeature::class,
+    LogsFeature::class,
+    TracingFeature::class,
+    WebViewLogsFeature::class,
+    WebViewRumFeature::class,
+    CrashReportsFeature::class
+)
 internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : SdkFeature<T, C>> {
 
     lateinit var testedFeature: F

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -47,6 +47,7 @@ internal class CrashReportsFeatureTest :
     @AfterEach
     fun `tear down crash reports`() {
         Thread.setDefaultUncaughtExceptionHandler(jvmExceptionHandler)
+        CrashReportsFeature.originalUncaughtExceptionHandler = jvmExceptionHandler
     }
 
     override fun createTestedFeature(): CrashReportsFeature {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/GlobalRumTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/GlobalRumTest.kt
@@ -7,8 +7,11 @@
 package com.datadog.android.rum
 
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
+import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn
+import com.datadog.tools.unit.extensions.ProhibitLeavingStaticMocksExtension
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -17,8 +20,12 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
 
-@Extensions(ExtendWith(MockitoExtension::class))
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ProhibitLeavingStaticMocksExtension::class)
+)
 @MockitoSettings(strictness = Strictness.LENIENT)
+@ProhibitLeavingStaticMocksIn(GlobalRum::class)
 internal class GlobalRumTest {
 
     @Mock
@@ -26,6 +33,11 @@ internal class GlobalRumTest {
 
     @Mock
     lateinit var mockAdvancedRumMonitor: AdvancedRumMonitor
+
+    @AfterEach
+    fun tearDown() {
+        GlobalRum.monitor = NoOpRumMonitor()
+    }
 
     @Test
     fun `M delegate to monitor W notifyIngestedWebViewEvent(){ AdvancedRumMonitor }`() {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
@@ -15,6 +15,7 @@ import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.log.internal.user.MutableUserInfoProvider
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.lyft.kronos.KronosClock
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import fr.xgouchet.elmyr.Forge
@@ -35,6 +36,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
     lateinit var mockUploadExecutor: ScheduledThreadPoolExecutor
     lateinit var mockOkHttpClient: OkHttpClient
     lateinit var mockPersistenceExecutor: ExecutorService
+    lateinit var mockKronosClock: KronosClock
 
     lateinit var mockTimeProvider: TimeProvider
     lateinit var mockNetworkInfoProvider: NetworkInfoProvider
@@ -51,6 +53,10 @@ internal class CoreFeatureTestConfiguration<T : Context>(
     }
 
     override fun tearDown(forge: Forge) {
+        if (!CoreFeature.initialized.get()) {
+            // If test didn't initialize it, we need to do that, to make `stop` run.
+            CoreFeature.initialized.set(true)
+        }
         CoreFeature.stop()
     }
 
@@ -69,6 +75,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
         mockPersistenceExecutor = mock()
         mockUploadExecutor = mock()
         mockOkHttpClient = mock()
+        mockKronosClock = mock()
 
         mockTimeProvider = mock()
         mockNetworkInfoProvider = mock()
@@ -91,6 +98,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
         CoreFeature.persistenceExecutorService = mockPersistenceExecutor
         CoreFeature.uploadExecutorService = mockUploadExecutor
         CoreFeature.okHttpClient = mockOkHttpClient
+        CoreFeature.kronosClock = mockKronosClock
 
         CoreFeature.timeProvider = mockTimeProvider
         CoreFeature.networkInfoProvider = mockNetworkInfoProvider

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/annotations/ProhibitLeavingStaticMocksIn.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/annotations/ProhibitLeavingStaticMocksIn.kt
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.tools.unit.annotations
+
+import java.lang.annotation.Inherited
+import kotlin.reflect.KClass
+
+/**
+ * Annotation for [ProhibitLeavingStaticMocksIn]. Can be applied to both class and method, will
+ * instruct extension to check that no object starting from the roots specified has a mock left
+ * in a static field (Java) or in a property of object class/companion object (Kotlin).
+ *
+ * NB: Lateinit properties will be just reported to console, because it is not possible to
+ * reset them to the original state.
+ */
+@Target(AnnotationTarget.FUNCTION, AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+@Inherited
+annotation class ProhibitLeavingStaticMocksIn(
+    /**
+     * Classes to watch.
+     */
+    vararg val value: KClass<*>,
+    /**
+     * Package prefixes to process.
+     */
+    val packagePrefixes: Array<String> = ["com.datadog"]
+)

--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/extensions/ProhibitLeavingStaticMocksExtension.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/extensions/ProhibitLeavingStaticMocksExtension.kt
@@ -1,0 +1,244 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.tools.unit.extensions
+
+import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn
+import java.lang.reflect.Field
+import java.lang.reflect.Modifier
+import java.util.LinkedList
+import java.util.logging.Logger
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.companionObject
+import kotlin.reflect.full.companionObjectInstance
+import kotlin.reflect.full.memberProperties
+import kotlin.reflect.jvm.isAccessible
+import kotlin.reflect.jvm.javaField
+import kotlin.reflect.jvm.javaGetter
+import kotlin.reflect.jvm.jvmName
+import org.junit.jupiter.api.extension.AfterEachCallback
+import org.junit.jupiter.api.extension.ExtensionContext
+
+/**
+ * Extension which allows to see mocks left in static fields after test run.
+ * Check [ProhibitLeavingStaticMocksIn] for more details.
+ *
+ * **NOTE**: JUnit extensions are executed in the declaration order for beforeXXX callbacks, but
+ * in the reversed order for afterXXX callbacks. So since this extension relies on the afterEach,
+ * it should be declared before TestConfigurationExtension, so that classes referenced
+ * by TestConfiguration could be reset before running this extension.
+ */
+class ProhibitLeavingStaticMocksExtension : AfterEachCallback {
+
+    private val logger = Logger.getLogger(ProhibitLeavingStaticMocksExtension::class.jvmName)
+
+    override fun afterEach(context: ExtensionContext) {
+        val annotationOnMethod =
+            context.requiredTestMethod
+                .getAnnotation(ProhibitLeavingStaticMocksIn::class.java)
+        val annotationOnClass =
+            context.requiredTestClass
+                .getAnnotation(ProhibitLeavingStaticMocksIn::class.java)
+
+        val scanRoots = mutableListOf<KClass<*>>().apply {
+            addAll(annotationOnMethod?.value ?: emptyArray())
+            addAll(annotationOnClass?.value ?: emptyArray())
+        }
+
+        val packagePrefixes = mutableListOf<String>().apply {
+            addAll(annotationOnMethod?.packagePrefixes ?: emptyArray())
+            addAll(annotationOnClass?.packagePrefixes ?: emptyArray())
+        }
+
+        scanForStaticMocksLeft(scanRoots, packagePrefixes)
+    }
+
+    internal fun scanForStaticMocksLeft(
+        roots: List<KClass<*>>,
+        packagePrefixes: List<String>
+    ) {
+        val visited = mutableSetOf<KClass<*>>()
+
+        val queue = LinkedList<VisitEntry>()
+        queue.addAll(roots.map { VisitEntry(it, emptyList()) })
+
+        while (!queue.isEmpty()) {
+            val visitEntry = queue.pollFirst()!!
+
+            val visitedClass = visitEntry.clazz
+            visited.add(visitedClass)
+
+            val watchFields = findFieldsToWatch(visitedClass)
+
+            for (fieldInstanceSpec in watchFields) {
+                val value = fieldInstanceSpec.fieldValue ?: continue
+
+                if (value::class.jvmName.contains("\$MockitoMock\$")) {
+                    reportViolation(
+                        fieldInstanceSpec.fieldDescriptor,
+                        fieldInstanceSpec.hostClass,
+                        visitEntry.pathUntil,
+                        fieldInstanceSpec.isLateinit
+                    )
+                }
+                if (packagePrefixes.any { value::class.java.name.startsWith(it) } &&
+                    !visited.contains(value::class.java.kotlin)
+                ) {
+                    val nextEntry = VisitEntry(
+                        value::class,
+                        pathUntil = visitEntry.pathUntil + CallStackEntry(
+                            fieldInstanceSpec.hostClass,
+                            fieldInstanceSpec.fieldDescriptor
+                        )
+                    )
+                    queue.add(nextEntry)
+                }
+            }
+        }
+    }
+
+    private fun findFieldsToWatch(visitedClass: KClass<*>): List<FieldCallSpec> {
+        val kotlinObjectFields = if (visitedClass.objectInstance != null) {
+            findTargetFieldsInKotlin(
+                visitedClass,
+                visitedClass.objectInstance
+            )
+        } else {
+            emptyList()
+        }
+
+        val kotlinCompanionObjectFields = if (visitedClass.companionObjectInstance != null) {
+            findTargetFieldsInKotlin(
+                visitedClass.companionObject!!,
+                visitedClass.companionObjectInstance
+            )
+        } else {
+            emptyList()
+        }
+
+        val plainStaticFields =
+            if (kotlinObjectFields.isEmpty() && kotlinCompanionObjectFields.isEmpty()) {
+                findTargetPlainStaticFields(visitedClass.java)
+            } else {
+                emptyList()
+            }
+
+        return mutableListOf<FieldCallSpec>().apply {
+            addAll(kotlinObjectFields)
+            addAll(kotlinCompanionObjectFields)
+            addAll(plainStaticFields)
+        }
+    }
+
+    private fun reportViolation(
+        fieldDescriptor: FieldDescriptor,
+        hostClass: KClass<*>,
+        pathUntil: List<CallStackEntry>,
+        isLateinit: Boolean
+    ) {
+        var message = "Unexpected mock remaining in the field" +
+            " ${fieldDescriptor.fieldName} of ${hostClass.jvmName}."
+
+        if (pathUntil.isNotEmpty()) {
+            val callingSequence = pathUntil.reversed()
+                .joinToString(separator = "\n") {
+                    "${it.hostClass.jvmName}.${it.fieldDescriptor.fieldName}"
+                }
+            message += "\nCalling sequence:\n$callingSequence"
+        }
+
+        if (isLateinit) {
+            logger.info(message)
+        } else {
+            throw UnwantedStaticMockException(message)
+        }
+    }
+
+    private fun findTargetFieldsInKotlin(
+        clazz: KClass<*>,
+        hostInstance: Any?
+    ): List<FieldCallSpec> {
+        return clazz.memberProperties
+            .filterNot { it.isConst }
+            .map {
+                FieldCallSpec(FieldDescriptor.Kotlin(it), it.isLateinit, hostInstance, clazz)
+            }
+    }
+
+    private fun findTargetPlainStaticFields(
+        clazz: Class<*>
+    ): List<FieldCallSpec> {
+        return clazz.declaredFields
+            .filter {
+                Modifier.isStatic(it.modifiers) && !Modifier.isFinal(it.modifiers)
+            }
+            .map {
+                FieldCallSpec(FieldDescriptor.Java(it), false, null, clazz.kotlin)
+            }
+    }
+
+    private data class FieldCallSpec(
+        val fieldDescriptor: FieldDescriptor,
+        val isLateinit: Boolean,
+        val hostInstance: Any?,
+        val hostClass: KClass<*>
+    ) {
+        val fieldValue: Any?
+            get() {
+                return when (fieldDescriptor) {
+                    is FieldDescriptor.Java -> {
+                        fieldDescriptor.field.isAccessible = true
+                        fieldDescriptor.field.get(hostInstance)
+                    }
+                    is FieldDescriptor.Kotlin -> {
+                        val property = fieldDescriptor.property
+                        property.isAccessible = true
+                        // this place is extremely fragile: for lateinit we cannot call getter
+                        // if property is not initialized - we get an error. Also some properties
+                        // don't require instance to get the value and it is not clear how to
+                        // understand that, thing with javaGetter check is just a quick
+                        // solution (but probably not the proper one).
+                        if (isLateinit && property.javaField?.get(hostInstance) == null) {
+                            null
+                        } else {
+                            if (property.javaGetter == null) {
+                                property.getter.call()
+                            } else {
+                                property.getter.call(hostInstance)
+                            }
+                        }
+                    }
+                }
+            }
+    }
+
+    private sealed class FieldDescriptor {
+        data class Java(val field: Field) : FieldDescriptor()
+        data class Kotlin(val property: KProperty1<*, *>) : FieldDescriptor()
+
+        val fieldName: String
+            get() {
+                return when (this) {
+                    is Java -> this.field.name
+                    is Kotlin -> property.name
+                }
+            }
+    }
+
+    private data class CallStackEntry(
+        val hostClass: KClass<*>,
+        val fieldDescriptor: FieldDescriptor
+    )
+
+    private data class VisitEntry(val clazz: KClass<*>, val pathUntil: List<CallStackEntry>)
+}
+
+/**
+ * Exception thrown by [ProhibitLeavingStaticMocksExtension] if any mocks found in the static
+ * fields after test run.
+ */
+class UnwantedStaticMockException(message: String) : IllegalStateException(message)

--- a/tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/JavaClassWithNestedStaticMock.java
+++ b/tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/JavaClassWithNestedStaticMock.java
@@ -1,0 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.tools.unit.extensions;
+
+public class JavaClassWithNestedStaticMock {
+    @SuppressWarnings({"InstantiationOfUtilityClass", "unused"})
+    static JavaClassWithStaticMock NESTED_WITH_MOCK = new JavaClassWithStaticMock();
+}

--- a/tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/JavaClassWithStaticMock.java
+++ b/tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/JavaClassWithStaticMock.java
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.tools.unit.extensions;
+
+import org.mockito.Mockito;
+
+public class JavaClassWithStaticMock {
+    @SuppressWarnings("unused")
+    static Object BAD_MOCK = Mockito.mock(Object.class);
+}

--- a/tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/ProhibitLeavingStaticMocksExtensionTest.kt
+++ b/tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/ProhibitLeavingStaticMocksExtensionTest.kt
@@ -1,0 +1,247 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.tools.unit.extensions
+
+import com.nhaarman.mockitokotlin2.mock
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertDoesNotThrow
+import org.junit.jupiter.api.assertThrows
+
+class ProhibitLeavingStaticMocksExtensionTest {
+
+    private val testedExtension = ProhibitLeavingStaticMocksExtension()
+
+    @Test
+    fun `M throw an error W mock in object class`() {
+        val roots = listOf(MockInObjectClass::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in object class { mock belongs to the parent class }`() {
+        val roots = listOf(MockInParentClass::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in object class { property with custom getter }`() {
+        val roots = listOf(MockInObjectClassPropertyWithCustomGetter::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in object class { delegate property }`() {
+        val roots = listOf(MockInObjectClassPropertyDelegate::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in java class`() {
+        val roots = listOf(JavaClassWithStaticMock::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in companion object`() {
+        val roots = listOf(MockInCompanionObject::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in nested object`() {
+        val roots = listOf(MockInNestedObject::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M exception thrown has valid message W mock in nested object`() {
+        val roots = listOf(MockInNestedObject::class)
+        val exception = assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+
+        assertThat(exception.message)
+            .isEqualTo(
+                "Unexpected mock remaining in the field badMock of com.datadog.tools.unit." +
+                    "extensions.ProhibitLeavingStaticMocksExtensionTest\$MockInObjectClass.\n" +
+                    "Calling sequence:\ncom.datadog.tools.unit.extensions." +
+                    "ProhibitLeavingStaticMocksExtensionTest\$MockInNestedObject.nested"
+            )
+    }
+
+    @Test
+    fun `M throw an error W mock in nested of java object`() {
+        val roots = listOf(JavaClassWithNestedStaticMock::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in nested java object`() {
+        val roots = listOf(MockInNestedJavaObject::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in nested companion object`() {
+        val roots = listOf(MockInNestedCompanionObject::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in nested object of companion object`() {
+        val roots = listOf(MockInNestedOfCompanionObject::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in nested java object of companion object`() {
+        val roots = listOf(MockInJavaNestedOfCompanionObject::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M throw an error W mock in nested companion object of companion object`() {
+        val roots = listOf(MockInCompanionInNestedOfCompanionObject::class)
+        assertThrows<UnwantedStaticMockException> {
+            testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES)
+        }
+    }
+
+    @Test
+    fun `M not throw an error W mock in a non-object class`() {
+        val roots = listOf(MockInNonObjectClass::class)
+        assertDoesNotThrow { testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES) }
+    }
+
+    @Test
+    fun `M not throw an error W mock in a lateinit field`() {
+        val roots = listOf(MockInObjectClassLateinitField::class)
+        assertDoesNotThrow { testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES) }
+    }
+
+    // region fake classes for test
+
+    @Suppress("unused")
+    object MockInObjectClass {
+        private const val CONST_VAL = 2022L
+        private val NON_CONST_VAL = Any()
+        internal val INTERNAL_NON_CONST_VAL = Any()
+
+        val badMock: Any = mock()
+    }
+
+    open class ParentClassWithMock {
+        @Suppress("unused")
+        val badMock: Any = mock()
+    }
+
+    object MockInParentClass : ParentClassWithMock()
+
+    class MockInCompanionObject {
+        companion object {
+            @Suppress("unused")
+            val badMock: Any = mock()
+        }
+    }
+
+    object MockInObjectClassLateinitField {
+        @Suppress("unused", "UNNECESSARY_LATEINIT")
+        lateinit var badMock: Any
+
+        init {
+            @Suppress("JoinDeclarationAndAssignment")
+            badMock = mock()
+        }
+    }
+
+    object MockInObjectClassPropertyWithCustomGetter {
+        @Suppress("unused")
+        val badMock: Any
+            get() {
+                return mock()
+            }
+    }
+
+    object MockInObjectClassPropertyDelegate {
+        @Suppress("unused")
+        val badMock by lazy {
+            mock<Any>()
+        }
+    }
+
+    object MockInNestedObject {
+        @Suppress("unused")
+        val nested = MockInObjectClass
+    }
+
+    object MockInNestedJavaObject {
+        @Suppress("unused")
+        val nested = JavaClassWithStaticMock()
+    }
+
+    object MockInNestedCompanionObject {
+        @Suppress("unused")
+        val nested = MockInCompanionObject
+    }
+
+    class MockInNestedOfCompanionObject {
+        companion object {
+            @Suppress("unused")
+            val nested = MockInObjectClass
+        }
+    }
+
+    class MockInJavaNestedOfCompanionObject {
+        companion object {
+            @Suppress("unused")
+            val nested =
+                JavaClassWithStaticMock()
+        }
+    }
+
+    class MockInCompanionInNestedOfCompanionObject {
+        companion object {
+            @Suppress("unused")
+            val nested = MockInCompanionObject
+        }
+    }
+
+    class MockInNonObjectClass(
+        @Suppress("unused") val mock: Any = mock()
+    )
+
+    companion object {
+        val PACKAGE_PREFIXES = listOf("com.datadog")
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

This PR brings a `JUnit` extension, which will track mocks left in the static fields (Java) or fields of `object` of `companion object` (Kotlin), trying to search for me starting from the specified class roots.

This may help in tracking down issue when some static field has mock left and it is causing unexpected behavior in another test. It is mostly for the debugging than for the usage everywhere, because:

1) It is using the reflection and scan full reference hierarchy.
2) It requires you to respect extension declaration order (described in the annotation docs).
3) Most important: in case of `lateinit` properties there is no way to reset them, there is no API for that, so such properties may still have mocks - in such cases extension will just report violation in the log.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

