### PR TITLE
RUMM-2103: Set Java 11 compilation target

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -81,7 +81,7 @@ gradlePlugin {
 }
 
 tasks.withType<KotlinCompile> {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
 }
 
 tasks {

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/DetektConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/DetektConfig.kt
@@ -26,7 +26,7 @@ fun Project.detektConfig(excludes: List<String> = emptyList()) {
     }
 
     tasks.withType<Detekt> {
-        jvmTarget = "1.8"
+        jvmTarget = "11"
 
         dependsOn(":tools:detekt:assemble")
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
@@ -16,7 +16,7 @@ fun Project.kotlinConfig(evaluateWarningsAsErrors: Boolean = true) {
 
     taskConfig<KotlinCompile> {
         kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_1_8.toString()
+            jvmTarget = JavaVersion.VERSION_11.toString()
             allWarningsAsErrors = evaluateWarningsAsErrors
             apiVersion = "1.6"
             languageVersion = "1.6"

--- a/dd-sdk-android-ndk/build.gradle.kts
+++ b/dd-sdk-android-ndk/build.gradle.kts
@@ -64,8 +64,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     testOptions {

--- a/dd-sdk-android/build.gradle.kts
+++ b/dd-sdk-android/build.gradle.kts
@@ -69,8 +69,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     testOptions {

--- a/dd-sdk-android/src/main/java/com/datadog/trace/api/Config.java
+++ b/dd-sdk-android/src/main/java/com/datadog/trace/api/Config.java
@@ -811,6 +811,7 @@ public class Config {
      * @deprecated This method should only be used internally. Use the instance getter instead {@link
      * #isJmxFetchIntegrationEnabled(SortedSet, boolean)}.
      */
+    @Deprecated
     public static boolean jmxFetchIntegrationEnabled(
             final SortedSet<String> integrationNames, final boolean defaultEnabled) {
         // If default is enabled, we want to enable individually,
@@ -840,6 +841,7 @@ public class Config {
      * @deprecated This method should only be used internally. Use the instance getter instead {@link
      * #isTraceAnalyticsIntegrationEnabled(SortedSet, boolean)}.
      */
+    @Deprecated
     public static boolean traceAnalyticsIntegrationEnabled(
             final SortedSet<String> integrationNames, final boolean defaultEnabled) {
         // If default is enabled, we want to enable individually,
@@ -868,6 +870,7 @@ public class Config {
      * @return
      * @deprecated This method should only be used internally. Use the explicit getter instead.
      */
+    @Deprecated
     public static String getSettingFromEnvironment(final String name, final String defaultValue) {
         String value;
         final String systemPropertyName = propertyNameToSystemPropertyName(name);
@@ -896,6 +899,7 @@ public class Config {
     /**
      * @deprecated This method should only be used internally. Use the explicit getter instead.
      */
+    @Deprecated
     private static Map<String, String> getMapSettingFromEnvironment(
             final String name, final String defaultValue) {
         return parseMap(
@@ -908,6 +912,7 @@ public class Config {
      *
      * @deprecated This method should only be used internally. Use the explicit getter instead.
      */
+    @Deprecated
     private static List<String> getListSettingFromEnvironment(
             final String name, final String defaultValue) {
         return parseList(getSettingFromEnvironment(name, defaultValue));
@@ -918,6 +923,7 @@ public class Config {
      *
      * @deprecated This method should only be used internally. Use the explicit getter instead.
      */
+    @Deprecated
     public static Boolean getBooleanSettingFromEnvironment(
             final String name, final Boolean defaultValue) {
         return getSettingFromEnvironmentWithLog(name, Boolean.class, defaultValue);
@@ -928,6 +934,7 @@ public class Config {
      *
      * @deprecated This method should only be used internally. Use the explicit getter instead.
      */
+    @Deprecated
     public static Float getFloatSettingFromEnvironment(final String name, final Float defaultValue) {
         return getSettingFromEnvironmentWithLog(name, Float.class, defaultValue);
     }

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -49,8 +49,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     packagingOptions {

--- a/instrumented/nightly-tests/build.gradle.kts
+++ b/instrumented/nightly-tests/build.gradle.kts
@@ -56,8 +56,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     packagingOptions {

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -91,8 +91,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     packagingOptions {


### PR DESCRIPTION
### What does this PR do?

This change aligns JVM target for both Java and Kotlin compilation to 11 to avoid the following warning during the build:

> 'compileJava' task (current target is 11) and 'compileKotlin' task (current target is 1.8) jvm target compatibility should be set to the same Java version.

This is completely safe change because AGP 7+ [supports de-sugaring Java 11 produced code](https://developer.android.com/studio/releases/gradle-plugin#java-11).

Also `Config.java` file requires adding `@Deprecated` annotation to the symbols having `deprecated` in their Javadoc to fix the warnings (some other symbols in this have this annotation already).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

