### PR TITLE
Check if host directory exists instead of file existence for writing last view event file

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -65,12 +65,15 @@ internal class RumDataWriter(
     // region Internal
 
     private fun persistViewEvent(data: ByteArray) {
-        // file may not exist: currently it is a file which is located in NDK reports folder, so
-        // if NDK reporting plugin is not initialized, this file won't exist (and no need to write).
-        if (lastViewEventFile.existsSafe()) {
+        // directory structure may not exist: currently it is a file which is located in NDK reports
+        // folder, so if NDK reporting plugin is not initialized, this NDK reports dir won't exist
+        // as well (and no need to write).
+        if (lastViewEventFile.parentFile?.existsSafe() == true) {
             handler.writeData(lastViewEventFile, data, false, null)
         } else {
-            sdkLogger.i(LAST_VIEW_EVENT_FILE_MISSING_MESSAGE.format(Locale.US, lastViewEventFile))
+            sdkLogger.i(
+                LAST_VIEW_EVENT_DIR_MISSING_MESSAGE.format(Locale.US, lastViewEventFile.parent)
+            )
         }
     }
 
@@ -82,7 +85,7 @@ internal class RumDataWriter(
     }
 
     companion object {
-        const val LAST_VIEW_EVENT_FILE_MISSING_MESSAGE = "Target file %s for writing" +
+        const val LAST_VIEW_EVENT_DIR_MISSING_MESSAGE = "Directory structure %s for writing" +
             " last view event doesn't exist."
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
@@ -28,6 +28,7 @@ import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
@@ -106,11 +107,13 @@ internal class RumDataWriterTest {
     }
 
     @Test
-    fun `𝕄 persist the event into the NDK crash folder 𝕎 onDataWritten(){ViewEvent+file exists}`(
+    fun `𝕄 persist the event into the NDK crash folder 𝕎 onDataWritten(){ViewEvent+dir exists}`(
         @Forgery viewEvent: ViewEvent
     ) {
         // Given
-        whenever(fakeLastViewEventFile.exists()) doReturn true
+        val ndkReportsFolder = mock<File>()
+        whenever(ndkReportsFolder.exists()) doReturn true
+        whenever(fakeLastViewEventFile.parentFile) doReturn ndkReportsFolder
 
         // When
         testedWriter.onDataWritten(viewEvent, fakeSerializedData)
@@ -122,11 +125,11 @@ internal class RumDataWriterTest {
     }
 
     @Test
-    fun `𝕄 log info when writing last view event 𝕎 onDataWritten(){ ViewEvent+no file }`(
+    fun `𝕄 log info when writing last view event 𝕎 onDataWritten(){ ViewEvent+no crash dir }`(
         @Forgery viewEvent: ViewEvent
     ) {
         // Given
-        whenever(fakeLastViewEventFile.exists()) doReturn false
+        whenever(fakeLastViewEventFile.parentFile) doReturn null
 
         // When
         testedWriter.onDataWritten(viewEvent, fakeSerializedData)
@@ -136,9 +139,9 @@ internal class RumDataWriterTest {
         verify(logger.mockSdkLogHandler)
             .handleLog(
                 Log.INFO,
-                RumDataWriter.LAST_VIEW_EVENT_FILE_MISSING_MESSAGE.format(
+                RumDataWriter.LAST_VIEW_EVENT_DIR_MISSING_MESSAGE.format(
                     Locale.US,
-                    fakeLastViewEventFile
+                    fakeLastViewEventFile.parent
                 )
             )
     }


### PR DESCRIPTION
### What does this PR do?

Fix for the change introduced in #880. At the moment of writing file won't exist, it will be created on the file system only after the write, so we need to check existence of the parent directory instead.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

