### PR TITLE
Specify android DSL compile options explicitly

### DIFF
--- a/dd-sdk-android-coil/build.gradle.kts
+++ b/dd-sdk-android-coil/build.gradle.kts
@@ -55,6 +55,11 @@ android {
         java.srcDir("src/androidTest/kotlin")
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     testOptions {
         unitTests.isReturnDefaultValues = true
     }

--- a/dd-sdk-android-compose/build.gradle.kts
+++ b/dd-sdk-android-compose/build.gradle.kts
@@ -67,6 +67,11 @@ android {
         java.srcDir("src/androidTest/kotlin")
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     testOptions {
         unitTests.isReturnDefaultValues = true
     }

--- a/dd-sdk-android-fresco/build.gradle.kts
+++ b/dd-sdk-android-fresco/build.gradle.kts
@@ -55,6 +55,11 @@ android {
         java.srcDir("src/androidTest/kotlin")
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     testOptions {
         unitTests.isReturnDefaultValues = true
     }

--- a/dd-sdk-android-glide/build.gradle.kts
+++ b/dd-sdk-android-glide/build.gradle.kts
@@ -56,6 +56,11 @@ android {
         java.srcDir("src/androidTest/kotlin")
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     testOptions {
         unitTests.isReturnDefaultValues = true
     }

--- a/dd-sdk-android-ktx/build.gradle.kts
+++ b/dd-sdk-android-ktx/build.gradle.kts
@@ -55,6 +55,11 @@ android {
         java.srcDir("src/androidTest/kotlin")
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     testOptions {
         unitTests.isReturnDefaultValues = true
     }

--- a/dd-sdk-android-rx/build.gradle.kts
+++ b/dd-sdk-android-rx/build.gradle.kts
@@ -55,6 +55,11 @@ android {
         java.srcDir("src/androidTest/kotlin")
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     testOptions {
         unitTests.isReturnDefaultValues = true
     }

--- a/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/dd-sdk-android-sqldelight/build.gradle.kts
@@ -55,6 +55,11 @@ android {
         java.srcDir("src/androidTest/kotlin")
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     testOptions {
         unitTests.isReturnDefaultValues = true
     }

--- a/dd-sdk-android-timber/build.gradle.kts
+++ b/dd-sdk-android-timber/build.gradle.kts
@@ -55,6 +55,11 @@ android {
         java.srcDir("src/androidTest/kotlin")
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     testOptions {
         unitTests.isReturnDefaultValues = true
     }

--- a/dd-sdk-android-tv/build.gradle.kts
+++ b/dd-sdk-android-tv/build.gradle.kts
@@ -55,6 +55,11 @@ android {
         java.srcDir("src/androidTest/kotlin")
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     testOptions {
         unitTests.isReturnDefaultValues = true
     }

--- a/tools/unit/build.gradle.kts
+++ b/tools/unit/build.gradle.kts
@@ -29,6 +29,11 @@ android {
         targetSdk = AndroidConfig.TARGET_SDK
     }
 
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
+    }
+
     sourceSets.named("main") {
         java.srcDir("src/main/kotlin")
     }


### PR DESCRIPTION
### What does this PR do?

Follow-up for #890. It turns out some modules didn't specify `compileOptions` explicitly and default value for `source/targetCompatibility` was Java 8 (and I didn't noticed that because of task caching). This PR aligns that.

Note: it will be still a warning for `buildSrc` compilation because of the following issue https://github.com/gradle/gradle/issues/18935, which should be fixed in Gradle 7.5.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

