### PR TITLE
RUMM-2090 Print logcat error message when using NoOp implementations

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -379,14 +379,14 @@ object Datadog {
             "(\"<CLIENT_TOKEN>\", \"<ENVIRONMENT>\", \"<VARIANT>\", \"<APPLICATION_ID>\")\n" +
             "Datadog.initialize(context, credentials, configuration, trackingConsent);"
 
-    internal const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized.\n" +
+    internal const val MESSAGE_SDK_INITIALIZATION_GUIDE =
         "Please add the following code in your application's onCreate() method:\n" +
-        "val credentials = Credentials" +
-        "(\"<CLIENT_TOKEN>\", \"<ENVIRONMENT>\", \"<VARIANT>\", \"<APPLICATION_ID>\")\n" +
-        "Datadog.initialize(context, credentials, configuration, trackingConsent);"
+            "val credentials = Credentials" +
+            "(\"<CLIENT_TOKEN>\", \"<ENVIRONMENT>\", \"<VARIANT>\", \"<APPLICATION_ID>\")\n" +
+            "Datadog.initialize(context, credentials, configuration, trackingConsent);"
 
-    internal const val MESSAGE_DEPRECATED = "%s has been deprecated. " +
-        "If you need it, submit an issue at https://github.com/DataDog/dd-sdk-android/issues/"
+    internal const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized.\n " +
+        MESSAGE_SDK_INITIALIZATION_GUIDE
 
     internal const val SHUTDOWN_THREAD = "datadog_shutdown"
     internal const val ENV_NAME_VALIDATION_REG_EX = "[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -309,7 +309,10 @@ internal constructor(internal var handler: LogHandler) {
             return if (LogsFeature.isInitialized()) {
                 LogsFeature.persistenceStrategy.getWriter()
             } else {
-                devLogger.e(Datadog.MESSAGE_NOT_INITIALIZED)
+                devLogger.e(
+                    SDK_NOT_INITIALIZED_WARNING_MESSAGE + "\n" +
+                        Datadog.MESSAGE_SDK_INITIALIZATION_GUIDE
+                )
                 null
             }
         }
@@ -584,4 +587,12 @@ internal constructor(internal var handler: LogHandler) {
     }
 
     // endregion
+
+    internal companion object {
+        internal const val SDK_NOT_INITIALIZED_WARNING_MESSAGE =
+            "You're trying to create a Logger instance, but the SDK was not yet initialized. " +
+                "This Logger will not be able to send any messages. " +
+                "Please initialize the Datadog SDK first before" +
+                " creating a new Logger instance."
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -11,6 +11,7 @@ import android.os.Handler
 import android.os.Looper
 import androidx.annotation.FloatRange
 import androidx.fragment.app.Fragment
+import com.datadog.android.Datadog
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.rum.internal.RumFeature
@@ -289,10 +290,13 @@ interface RumMonitor {
         fun build(): RumMonitor {
             val rumApplicationId = CoreFeature.rumApplicationId
             return if (!RumFeature.isInitialized()) {
-                devLogger.e(RUM_NOT_ENABLED_ERROR_MESSAGE)
+                devLogger.e(
+                    RUM_NOT_ENABLED_ERROR_MESSAGE + "\n" +
+                        Datadog.MESSAGE_SDK_INITIALIZATION_GUIDE
+                )
                 NoOpRumMonitor()
             } else if (rumApplicationId.isNullOrBlank()) {
-                devLogger.e(RUM_NOT_ENABLED_ERROR_MESSAGE)
+                devLogger.e(INVALID_APPLICATION_ID_ERROR_MESSAGE)
                 NoOpRumMonitor()
             } else {
                 DatadogRumMonitor(
@@ -320,8 +324,11 @@ interface RumMonitor {
         companion object {
             internal const val RUM_NOT_ENABLED_ERROR_MESSAGE =
                 "You're trying to create a RumMonitor instance, " +
-                    "but the RUM feature was disabled in your Configuration. " +
-                    "No RUM data will be sent."
+                    "but the SDK was not initialized or RUM feature was disabled " +
+                    "in your Configuration. No RUM data will be sent."
+            internal const val INVALID_APPLICATION_ID_ERROR_MESSAGE =
+                "You're trying to create a RumMonitor instance, " +
+                    "but the RUM application id was null or empty. No RUM data will be sent."
         }
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.tracing
 
+import com.datadog.android.Datadog
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.log.LogAttributes
@@ -77,7 +78,10 @@ class AndroidTracer internal constructor(
          */
         fun build(): AndroidTracer {
             if (!TracingFeature.isInitialized()) {
-                devLogger.e(TRACING_NOT_ENABLED_ERROR_MESSAGE)
+                devLogger.e(
+                    TRACING_NOT_ENABLED_ERROR_MESSAGE + "\n" +
+                        Datadog.MESSAGE_SDK_INITIALIZATION_GUIDE
+                )
             }
             if (bundleWithRumEnabled && !RumFeature.isInitialized()) {
                 devLogger.e(RUM_NOT_ENABLED_ERROR_MESSAGE)
@@ -182,8 +186,8 @@ class AndroidTracer internal constructor(
     companion object {
         internal const val TRACING_NOT_ENABLED_ERROR_MESSAGE =
             "You're trying to create an AndroidTracer instance, " +
-                "but the Tracing feature was disabled in your Configuration. " +
-                "No tracing data will be sent."
+                "but either the SDK was not initialized or the Tracing feature was " +
+                "disabled in your Configuration. No tracing data will be sent."
         internal const val RUM_NOT_ENABLED_ERROR_MESSAGE =
             "You're trying to bundle the traces with a RUM context, " +
                 "but the RUM feature was disabled in your Configuration. " +

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -69,8 +69,11 @@ internal class LoggerBuilderTest {
         val handler: LogHandler = testedLogger.handler
 
         assertThat(handler).isInstanceOf(NoOpLogHandler::class.java)
-        verify(logger.mockDevLogHandler)
-            .handleLog(AndroidLog.ERROR, Datadog.MESSAGE_NOT_INITIALIZED)
+        verify(logger.mockDevLogHandler).handleLog(
+            AndroidLog.ERROR,
+            Logger.SDK_NOT_INITIALIZED_WARNING_MESSAGE + "\n" +
+                Datadog.MESSAGE_SDK_INITIALIZATION_GUIDE
+        )
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
@@ -9,7 +9,9 @@ package com.datadog.android.rum
 import android.content.Context
 import android.os.Looper
 import android.util.Log
+import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.scope.RumApplicationScope
 import com.datadog.android.rum.internal.domain.scope.RumSessionScope
@@ -152,7 +154,24 @@ internal class RumMonitorBuilderTest {
         // Then
         verify(logger.mockDevLogHandler).handleLog(
             Log.ERROR,
-            RumMonitor.Builder.RUM_NOT_ENABLED_ERROR_MESSAGE
+            RumMonitor.Builder.RUM_NOT_ENABLED_ERROR_MESSAGE + "\n" +
+                Datadog.MESSAGE_SDK_INITIALIZATION_GUIDE
+        )
+        check(monitor is NoOpRumMonitor)
+    }
+
+    @Test
+    fun `𝕄 builds nothing 𝕎 build() { rumApplicationId is null }`() {
+        // Given
+        CoreFeature.rumApplicationId = null
+
+        // When
+        val monitor = testedBuilder.build()
+
+        // Then
+        verify(logger.mockDevLogHandler).handleLog(
+            Log.ERROR,
+            RumMonitor.Builder.INVALID_APPLICATION_ID_ERROR_MESSAGE
         )
         check(monitor is NoOpRumMonitor)
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
@@ -119,7 +119,8 @@ internal class AndroidTracerTest {
         // THEN
         verify(logger.mockDevLogHandler).handleLog(
             Log.ERROR,
-            AndroidTracer.TRACING_NOT_ENABLED_ERROR_MESSAGE
+            AndroidTracer.TRACING_NOT_ENABLED_ERROR_MESSAGE + "\n" +
+                Datadog.MESSAGE_SDK_INITIALIZATION_GUIDE
         )
     }
 


### PR DESCRIPTION
### What does this PR do?

In this PR we are aligning the error log messages displayed in the console when the `NoOp` implementation is used for `Logger`, `AndroidTracer` or `RumMonitor` due to the SDK not being initialized yet or the feature not being enabled.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

