### PR TITLE
Fix tracked webview hosts in the sample app

### DIFF
--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -52,7 +52,7 @@ class SampleApplication : Application() {
     )
 
     private val webViewTrackingHosts = listOf(
-        "datadoghq.com"
+        "datadoghq.dev"
     )
 
     private val okHttpClient = OkHttpClient.Builder()
@@ -129,7 +129,6 @@ class SampleApplication : Application() {
             rumEnabled = true
         )
             .setFirstPartyHosts(tracedHosts)
-            .setWebViewTrackingHosts(listOf("datadoghq.dev"))
             .addPlugin(NdkCrashReportsPlugin(), Feature.CRASH)
             .setWebViewTrackingHosts(webViewTrackingHosts)
             .useViewTrackingStrategy(


### PR DESCRIPTION
### What does this PR do?

`setWebViewTrackingHosts` was called twice and second time it was called with a wrong host, so `DatadogEventBridge` wasn't receiving any events.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

