### PR TITLE
Remove flatDir usage in Gradle script

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,7 +36,6 @@ allprojects {
         google()
         mavenCentral()
         maven { setUrl(com.datadog.gradle.Dependencies.Repositories.Jitpack) }
-        flatDir { dirs("libs") }
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

This PR removes usage of `flatDir` in the Gradle script, because it was generating warnings during the builds. It wasn't useful anyway, because the only file in the `libs` folder is loaded as agent [here](https://github.com/DataDog/dd-sdk-android/blob/c19dd9e0eafd120d3707ee7fa71b7a484ee72d0a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt#L27) and there are no files there which are dependencies for the final build.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

