### PR TITLE
RUMM-2128 update 403 FORBIDDEN logcat message

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2.kt
@@ -133,7 +133,7 @@ internal abstract class DataOkHttpUploaderV2(
             HTTP_ACCEPTED -> UploadStatus.SUCCESS
             HTTP_BAD_REQUEST -> UploadStatus.HTTP_CLIENT_ERROR
             HTTP_UNAUTHORIZED -> UploadStatus.INVALID_TOKEN_ERROR
-            HTTP_FORBIDDEN -> UploadStatus.HTTP_CLIENT_ERROR
+            HTTP_FORBIDDEN -> UploadStatus.INVALID_TOKEN_ERROR
             HTTP_CLIENT_TIMEOUT -> UploadStatus.HTTP_CLIENT_RATE_LIMITING
             HTTP_ENTITY_TOO_LARGE -> UploadStatus.HTTP_CLIENT_ERROR
             HTTP_TOO_MANY_REQUESTS -> UploadStatus.HTTP_CLIENT_RATE_LIMITING

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/UploadStatus.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/UploadStatus.kt
@@ -40,7 +40,8 @@ internal enum class UploadStatus(val shouldRetry: Boolean) {
             INVALID_TOKEN_ERROR -> if (!ignoreInfo) {
                 logger.e(
                     "$batchInfo failed because your token is invalid. " +
-                        "Make sure that the provided token still exists."
+                        "Make sure that the provided token still exists " +
+                        "and you're targeting the relevant Datadog site."
                 )
             }
             HTTP_REDIRECTION -> logger.w(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2Test.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/DataOkHttpUploaderV2Test.kt
@@ -169,7 +169,7 @@ internal abstract class DataOkHttpUploaderV2Test<T : DataOkHttpUploaderV2> {
         val result = testedUploader.upload(fakeData.toByteArray(Charsets.UTF_8))
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.HTTP_CLIENT_ERROR)
+        assertThat(result).isEqualTo(UploadStatus.INVALID_TOKEN_ERROR)
         verifyRequest()
         verifyResponseIsClosed()
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/UploadStatusTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/net/UploadStatusTest.kt
@@ -144,7 +144,8 @@ internal class UploadStatusTest {
             .handleLog(
                 Log.ERROR,
                 "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
-                    "because your token is invalid. Make sure that the provided token still exists."
+                    "because your token is invalid. Make sure that the provided token still " +
+                    "exists and you're targeting the relevant Datadog site."
             )
     }
 


### PR DESCRIPTION
### What does this PR do?

When a client token is unknown, the upload request receives a `403 FORBIDDEN` status code. We need to make it clearer and actionnable in the logcat message we provide the developers
