### PR TITLE
RUMM-2055: Remove view from Global RUM context when it is stopped

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/GlobalRum.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/GlobalRum.kt
@@ -149,7 +149,12 @@ object GlobalRum {
         return activeContext.get()
     }
 
-    internal fun updateRumContext(newContext: RumContext) {
+    internal fun updateRumContext(
+        newContext: RumContext,
+        applyOnlyIf: (currentContext: RumContext) -> Boolean = { true }
+    ) {
+        if (!applyOnlyIf(activeContext.get())) return
+
         activeContext.set(newContext)
         val pluginContext = DatadogContext(
             DatadogRumContext(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/GlobalRumTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/GlobalRumTest.kt
@@ -6,11 +6,14 @@
 
 package com.datadog.android.rum
 
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn
 import com.datadog.tools.unit.extensions.ProhibitLeavingStaticMocksExtension
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -61,5 +64,29 @@ internal class GlobalRumTest {
 
         // Then
         verifyZeroInteractions(mockNoOpRumMonitor)
+    }
+
+    @Test
+    fun `M update RUM context W updateRumContext()`() {
+        // Given
+        val newContext = mock<RumContext>()
+
+        // When
+        GlobalRum.updateRumContext(newContext)
+
+        // Then
+        assertThat(GlobalRum.getRumContext()).isEqualTo(newContext)
+    }
+
+    @Test
+    fun `M not update RUM context W updateRumContext() { applyOnlyIf predicate returns false }`() {
+        // Given
+        val newContext = mock<RumContext>()
+
+        // When
+        GlobalRum.updateRumContext(newContext, applyOnlyIf = { false })
+
+        // Then
+        assertThat(GlobalRum.getRumContext()).isNotEqualTo(newContext)
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR makes sure that the view is removed from the global RUM context once stopped.

Additionally, the following was added:

* Action context is also removed. This makes sense as it is `parent-child` relationship, even if action can outlive the view (view may be stopped, but may wait for the action to complete). This may have an impact on the events, which may start when view is active as a consequence of some action and only complete when action completes after view is stopped (so it won't be reference to the action in the global context), but overall this change makes relationship between view and action more strict and will prevent the situations when action has no parent reference.

* Add a check for updating global RUM context - it should contain the reference to the current view. This will prevent the situations when global RUM context is already taken by another view (shouldn't happen with auto-instrumentation we have, but may happen with the manual instrumentation), and also updating the context when actions arrive after view is already stopped.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

