### PR TITLE
RUMM-1897: Update DD Java Agent to 0.98.1

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,8 @@ variables:
   DD_SERVICE: "dd-sdk-android"
   DD_ENV_TESTS: "ci"
   DD_INTEGRATION_JUNIT_5_ENABLED: "true"
+  DD_CIVISIBILITY_ENABLED: "true"
+  DD_INSIDE_CI: "true"
 
 stages:
   - ci-image

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
@@ -24,7 +24,7 @@ fun Project.kotlinConfig(evaluateWarningsAsErrors: Boolean = true) {
     }
 
     val moduleName = this@kotlinConfig.name
-    val javaAgentJar = File(File(rootDir, "libs"), "dd-java-agent-0.67.0.jar")
+    val javaAgentJar = File(File(rootDir, "libs"), "dd-java-agent-0.98.1.jar")
     taskConfig<AndroidUnitTest> {
         if (environment["DD_INTEGRATION_JUNIT_5_ENABLED"] == "true") {
             val variant = variantName.substringBeforeLast("UnitTest")


### PR DESCRIPTION
### What does this PR do?

This PR bumps `dd-java-agent` version used from `0.67.0` to `0.98.1`, unlocking the possibility to use JUnit 5.8+, which wasn't possible because of the bug which was fixed only in `0.92.0`.

Test and pipeline runs are reported fine after this change.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

