### PR TITLE
Ignore IO exceptions in Kronos for telemetry reporting

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/LoggingSyncListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/LoggingSyncListener.kt
@@ -9,7 +9,7 @@ package com.datadog.android.core.internal.time
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.internal.utils.errorWithTelemetry
 import com.lyft.kronos.SyncListener
-import java.net.SocketTimeoutException
+import java.io.IOException
 
 internal class LoggingSyncListener : SyncListener {
     override fun onStartSync(host: String) {
@@ -23,7 +23,7 @@ internal class LoggingSyncListener : SyncListener {
     override fun onError(host: String, throwable: Throwable) {
         val message = "Kronos onError @host:$host"
         val attributes = mapOf("kronos.sync.host" to host)
-        if (throwable is SocketTimeoutException) {
+        if (throwable is IOException) {
             sdkLogger.e(message, throwable, attributes)
         } else {
             sdkLogger.errorWithTelemetry(message, throwable, attributes)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/time/LoggingSyncListenerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/time/LoggingSyncListenerTest.kt
@@ -17,7 +17,7 @@ import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.net.SocketTimeoutException
+import java.io.IOException
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -39,7 +39,7 @@ internal class LoggingSyncListenerTest {
         // Given
         val throwable = forge.aThrowable()
 
-        assumeTrue { throwable !is SocketTimeoutException }
+        assumeTrue { throwable !is IOException }
 
         // When
         testableListener.onError(fakeHost, throwable)
@@ -59,7 +59,7 @@ internal class LoggingSyncListenerTest {
         @StringForgery(regex = "https://[a-z]+\\.com") fakeHost: String
     ) {
         // Given
-        val throwable = SocketTimeoutException()
+        val throwable = IOException()
 
         // When
         testableListener.onError(fakeHost, throwable)


### PR DESCRIPTION
### What does this PR do?

This change widens the scope of the exceptions thrown by Kronos library to be reported with telemetry. Apparently it [can throw InvalidServerReplyException](https://github.com/lyft/Kronos-Android/blob/b2774ab9458ffd0202e2c4880e2a181134953beb/kronos-java/src/main/java/com/lyft/kronos/internal/ntp/SntpClient.java#L156) when server is not a valid state (like `leap` value is equal to `0b11`, meaning server is not synchronized, check [NTP RFC](https://datatracker.ietf.org/doc/html/rfc5905#page-20)).

We cannot address such issues anyway and if NTP servers are not healthy it will be caught by infra monitoring.

To avoid spammy telemetry entries this PR adds all `IOException` instances to the ignore list.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

