### PR TITLE
RUMM-2150: Fix race condition in the features folders creation logic

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
@@ -121,13 +121,21 @@ internal class BatchFileOrchestrator(
                 return false
             }
         } else {
-            if (rootDir.mkdirsSafe()) {
-                return true
-            } else {
-                internalLogger.errorWithTelemetry(
-                    ERROR_CANT_CREATE_ROOT.format(Locale.US, rootDir.path)
-                )
-                return false
+            synchronized(rootDir) {
+                // double check if directory was already created by some other thread
+                // entered this branch
+                if (rootDir.existsSafe()) {
+                    return true
+                }
+
+                if (rootDir.mkdirsSafe()) {
+                    return true
+                } else {
+                    internalLogger.errorWithTelemetry(
+                        ERROR_CANT_CREATE_ROOT.format(Locale.US, rootDir.path)
+                    )
+                    return false
+                }
             }
         }
     }


### PR DESCRIPTION
### What does this PR do?

This PR fixes a race condition in the features folders creation logic. It may occur when one thread checks for the existence of the root dit for the feature, gets that folder doesn't exist and goes in the folder creation logic branch, and another thread does the same. This may lead to a situation when both threads will call `File#mkdirs` but only one of them will get a successful result, because another one will get a failure since folder is already created.

Not sure if this situation can happen often in the client setup, but it happens in our nightly test runs when we do a call to change a consent (so to migrate files from one dir to another) right after SDK initialization step, which impacts test outcome.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

