### PR TITLE
RUMM-2095: Support new AGP publishing model

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,4 +5,5 @@
 #
 org.gradle.jvmargs=-Xmx2560m -XX:MaxPermSize=512m
 android.useAndroidX=true
+android.disableAutomaticComponentCreation=true
 # Leave the next line blank for CI


### PR DESCRIPTION
### What does this PR do?

This change brings support of the new publishing model by explicitly specifying components for publishing (`release` in our case).

This new model landed [originally in AGP 7.1](https://developer.android.com/studio/releases/gradle-plugin#disable-component-creation) and automatic components creation for publishing will be disabled in AGP 8.0.

Docs for the new approach can be found [here](https://developer.android.com/studio/publish-library/configure-pub-variants).

Since new model can also attach `sources` and `javadoc` (by `Dokka`) artifacts to the published component, explicit tasks for the sources and docs are removed.

Change is verified by publishing to the local Maven, everything is fine and file set is complete (`aar` + `sources` + `javadoc` + `pom` + `module`) and has an expected content. 

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

