### PR TITLE
RUMM-2042: Filter Datadog logs per level

### DIFF
--- a/dd-sdk-android-timber/apiSurface
+++ b/dd-sdk-android-timber/apiSurface
@@ -1,3 +1,4 @@
 class com.datadog.android.timber.DatadogTree : timber.log.Timber.Tree
   constructor(com.datadog.android.log.Logger)
+  constructor(Int)
   override fun log(Int, String?, String, Throwable?)

--- a/dd-sdk-android-timber/src/main/kotlin/com/datadog/android/timber/DatadogTree.kt
+++ b/dd-sdk-android-timber/src/main/kotlin/com/datadog/android/timber/DatadogTree.kt
@@ -19,6 +19,21 @@ class DatadogTree(
 ) :
     Timber.Tree() {
 
+    /**
+     * Creates a [Timber.Tree] with a default [Logger] having a minimum log priority
+     * for Datadog logs set to specified value.
+     *
+     * See [Logger.Builder.setDatadogLogsMinPriority] for details.
+     *
+     * @param minLogPriority Minimum log priority to be sent to the Datadog servers.
+     */
+    constructor(minLogPriority: Int) :
+        this(
+            Logger.Builder()
+                .setDatadogLogsMinPriority(minLogPriority)
+                .build()
+        )
+
     init {
         logger.addTag("android:timber")
     }

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -209,6 +209,7 @@ class com.datadog.android.log.Logger
     fun build(): Logger
     fun setServiceName(String): Builder
     fun setDatadogLogsEnabled(Boolean): Builder
+    fun setDatadogLogsMinPriority(Int): Builder
     fun setLogcatLogsEnabled(Boolean): Builder
     fun setNetworkInfoEnabled(Boolean): Builder
     fun setLoggerName(String): Builder

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -33,8 +33,8 @@ import org.json.JSONObject
 /**
  * A class enabling Datadog logging features.
  *
- * It allows you to create a specific context (automatic information, custom attributes, tags) that will be embedded in all
- * logs sent through this logger.
+ * It allows you to create a specific context (automatic information, custom attributes, tags) that
+ * will be embedded in all logs sent through this logger.
  *
  * You can have multiple loggers configured in your application, each with their own settings.
  */
@@ -186,6 +186,7 @@ internal constructor(internal var handler: LogHandler) {
         private var bundleWithRumEnabled: Boolean = true
         private var loggerName: String = CoreFeature.packageName
         private var sampleRate: Float = 1.0f
+        private var minDatadogLogsPriority: Int = -1
 
         /**
          * Builds a [Logger] based on the current state of this Builder.
@@ -217,11 +218,22 @@ internal constructor(internal var handler: LogHandler) {
 
         /**
          * Enables your logs to be sent to the Datadog servers.
-         * You can use this feature to disable Datadog logs based on a configuration or an application flavor.
+         * You can use this feature to disable Datadog logs based on a configuration or an
+         * application flavor.
          * @param enabled true by default
          */
         fun setDatadogLogsEnabled(enabled: Boolean): Builder {
             datadogLogsEnabled = enabled
+            return this
+        }
+
+        /**
+         * Sets a minimum priority for the log to be sent to the Datadog servers. If log priority
+         * is below this one, then it won't be sent. Default value is -1 (allow all).
+         * @param minLogPriority Minimum log priority to be sent to the Datadog servers.
+         */
+        fun setDatadogLogsMinPriority(minLogPriority: Int): Builder {
+            minDatadogLogsPriority = minLogPriority
             return this
         }
 
@@ -299,6 +311,7 @@ internal constructor(internal var handler: LogHandler) {
             return DatadogLogHandler(
                 logGenerator = logGenerator,
                 writer = writer,
+                minLogPriority = minDatadogLogsPriority,
                 bundleWithTraces = bundleWithTraceEnabled,
                 bundleWithRum = bundleWithRumEnabled,
                 sampler = RateBasedSampler(sampleRate)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -20,7 +20,8 @@ internal class DatadogLogHandler(
     internal val writer: DataWriter<LogEvent>,
     internal val bundleWithTraces: Boolean = true,
     internal val bundleWithRum: Boolean = true,
-    internal val sampler: Sampler = RateBasedSampler(1.0f)
+    internal val sampler: Sampler = RateBasedSampler(1.0f),
+    internal val minLogPriority: Int = -1
 ) : LogHandler {
 
     // region LogHandler
@@ -33,6 +34,10 @@ internal class DatadogLogHandler(
         tags: Set<String>,
         timestamp: Long?
     ) {
+        if (level < minLogPriority) {
+            return
+        }
+
         val resolvedTimeStamp = timestamp ?: System.currentTimeMillis()
         if (sampler.sample()) {
             val log = createLog(level, message, throwable, attributes, tags, resolvedTimeStamp)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -27,6 +27,7 @@ import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -89,6 +90,7 @@ internal class LoggerBuilderTest {
         assertThat(handler.bundleWithTraces).isTrue()
         assertThat(handler.sampler).isInstanceOf(RateBasedSampler::class.java)
         assertThat((handler.sampler as RateBasedSampler).sampleRate).isEqualTo(1.0f)
+        assertThat(handler.minLogPriority).isEqualTo(-1)
     }
 
     @Test
@@ -113,6 +115,18 @@ internal class LoggerBuilderTest {
 
         val handler: LogHandler = logger.handler
         assertThat(handler).isInstanceOf(NoOpLogHandler::class.java)
+    }
+
+    @Test
+    fun `builder can set min datadog logs priority`(
+        @IntForgery minLogPriority: Int
+    ) {
+        val logger: Logger = Logger.Builder()
+            .setDatadogLogsMinPriority(minLogPriority)
+            .build()
+
+        val handler: DatadogLogHandler = logger.handler as DatadogLogHandler
+        assertThat(handler.minLogPriority).isEqualTo(minLogPriority)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -205,6 +205,39 @@ internal class DatadogLogHandlerTest {
     }
 
     @Test
+    fun `M not forward log to LogWriter W level is below the min supported`(
+        forge: Forge
+    ) {
+        // Given
+        testedHandler = DatadogLogHandler(
+            LogGenerator(
+                fakeServiceName,
+                fakeLoggerName,
+                mockNetworkInfoProvider,
+                mockUserInfoProvider,
+                mockTimeProvider,
+                fakeSdkVersion,
+                fakeEnvName,
+                fakeAppVersion
+            ),
+            mockWriter,
+            minLogPriority = forge.anInt(min = fakeLevel + 1)
+        )
+
+        // When
+        testedHandler.handleLog(
+            fakeLevel,
+            fakeMessage,
+            forge.aNullable { fakeThrowable },
+            fakeAttributes,
+            fakeTags
+        )
+
+        // Then
+        verifyZeroInteractions(mockWriter, mockSampler)
+    }
+
+    @Test
     fun `forward log to LogWriter with throwable`() {
         val now = System.currentTimeMillis()
 

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerBuilderE2ETests.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.nightly.logs
 
+import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -106,6 +107,35 @@ class LoggerBuilderE2ETests {
             logger = Logger.Builder().setDatadogLogsEnabled(false).build()
         }
         logger.sendRandomLog(testMethodName, forge)
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setDatadogLogsMinPriority(Int): Builder
+     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun build(): Logger
+     */
+    @Test
+    fun logs_logger_builder_datadog_min_log_priority() {
+        val testMethodName = "logs_logger_builder_datadog_min_log_priority"
+
+        val minLogLevel = forge.anElementFrom(
+            Log.ERROR,
+            Log.WARN,
+            Log.INFO,
+            Log.DEBUG
+        )
+
+        measureLoggerInitialize {
+            logger = Logger.Builder()
+                .setDatadogLogsEnabled(true)
+                .setDatadogLogsMinPriority(minLogLevel)
+                .build()
+        }
+        logger.sendRandomLog(
+            testMethodName,
+            forge,
+            minLogLevel = Log.VERBOSE,
+            maxLogLevel = minLogLevel
+        )
     }
 
     /**

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsUtils.kt
@@ -17,12 +17,14 @@ fun initializeLogger() = Logger.Builder()
 
 fun Logger.sendRandomLog(
     testMethodName: String,
-    forge: Forge
+    forge: Forge,
+    minLogLevel: Int = 1,
+    maxLogLevel: Int = 6
 ) {
     val message = forge.anAlphabeticalString()
     val throwable = forge.aNullable { forge.aThrowable() }
     val attributes = defaultTestAttributes(testMethodName)
-    when (forge.anInt(min = 1, max = 7)) {
+    when (forge.anInt(min = minLogLevel, max = maxLogLevel + 1)) {
         1 -> v(message, throwable, attributes)
         2 -> d(message, throwable, attributes)
         3 -> w(message, throwable, attributes)


### PR DESCRIPTION
### What does this PR do?

Closes #847. This PR includes the following:

* Adds a possibility to set up default `logger` with min priority log level set in the `DatadogTree` (Timber integration module).
* Adds a possibility to define minimum log level sent to the Datadog servers in the `Logger.Builder` configuration (main SDK module). Note: `logcat` logs are not affected by this parameter.

### Motivation

This feature is useful when Datadog logger is used in the collaboration with other loggers and there is need for more granular control for Datadog logger to avoid sending unwanted log levels to avoid exploding log volume usage (can be the case of verbose or debug logs).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

