### PR TITLE
Fix the logic of joining byte arrays when there is no items

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ByteArrayExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ByteArrayExt.kt
@@ -40,10 +40,11 @@ internal fun Collection<ByteArray>.join(
     prefix: ByteArray = ByteArray(0),
     suffix: ByteArray = ByteArray(0)
 ): ByteArray {
-    val result = ByteArray(
-        this.sumOf { it.size } +
-            prefix.size + suffix.size + separator.size * (this.size - 1)
-    )
+    val dataSize = this.sumOf { it.size }
+    val separatorsSize = if (this.isNotEmpty()) separator.size * (this.size - 1) else 0
+    val resultSize = prefix.size + dataSize + separatorsSize + suffix.size
+
+    val result = ByteArray(resultSize)
 
     var offset = 0
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/ByteArrayExtTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/ByteArrayExtTest.kt
@@ -270,5 +270,66 @@ internal class ByteArrayExtTest {
         assertThat(joined).isEqualTo(expected)
     }
 
+    @Test
+    fun `𝕄 join items 𝕎 join() { no items }`(
+        @StringForgery separator: String,
+        @StringForgery prefix: String,
+        @StringForgery suffix: String
+    ) {
+        // Given
+        val dataBytes = emptyList<ByteArray>()
+
+        val separatorBytes = separator.toByteArray()
+        val prefixBytes = prefix.toByteArray()
+        val suffixBytes = suffix.toByteArray()
+
+        val expected = prefixBytes + suffixBytes
+
+        // When
+        val joined =
+            dataBytes.join(separator = separatorBytes, prefix = prefixBytes, suffix = suffixBytes)
+
+        // Then
+        assertThat(joined).isEqualTo(expected)
+    }
+
+    @Test
+    fun `𝕄 join items 𝕎 join() { single item }`(
+        @StringForgery separator: String,
+        @StringForgery prefix: String,
+        @StringForgery suffix: String,
+        forge: Forge
+    ) {
+        // Given
+        val dataBytes = listOf(forge.aString().toByteArray())
+
+        val separatorBytes = separator.toByteArray()
+        val prefixBytes = prefix.toByteArray()
+        val suffixBytes = suffix.toByteArray()
+
+        val expected = prefixBytes + dataBytes[0] + suffixBytes
+
+        // When
+        val joined =
+            dataBytes.join(separator = separatorBytes, prefix = prefixBytes, suffix = suffixBytes)
+
+        // Then
+        assertThat(joined).isEqualTo(expected)
+    }
+
+    @Test
+    fun `𝕄 join items 𝕎 join() { no prefix, no suffix, no data }`(
+        @StringForgery separator: String
+    ) {
+        // Given
+        val dataBytes = emptyList<ByteArray>()
+
+        // When
+        val joined = dataBytes.join(separator = separator.toByteArray())
+
+        // Then
+        assertThat(joined).isEmpty()
+    }
+
     // endregion
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -942,6 +942,7 @@ datadog:
       - "kotlin.ByteArray.any(kotlin.Function1)"
       - "kotlin.ByteArray.isEmpty()"
       - "kotlin.ByteArray.isNotEmpty()"
+      - "kotlin.collections.Collection.isNotEmpty()"
       - "kotlin.collections.Collection.sumOf(kotlin.Function1)"
       - "kotlin.collections.Collection.withIndex()"
       - "kotlin.collections.Iterable.any(kotlin.Function1)"


### PR DESCRIPTION
### What does this PR do?

Fixes a silly bug: size taken by separators could be negative in case of empty collection (doesn't impact any data upload though).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

