### PR TITLE
RUMM-2076 Add the Configuration#setVitalsMonitorUpdateFrequency API

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -106,6 +106,7 @@ data class com.datadog.android.core.configuration.Configuration
     DEPRECATED fun setInternalLogsEnabled(String, String): Builder
     fun setAdditionalConfiguration(Map<String, Any>): Builder
     fun setProxy(java.net.Proxy, okhttp3.Authenticator?): Builder
+    fun setVitalsUpdateFrequency(VitalsUpdateFrequency): Builder
   companion object 
 data class com.datadog.android.core.configuration.Credentials
   constructor(String, String, String, String?, String? = null)
@@ -118,6 +119,12 @@ enum com.datadog.android.core.configuration.UploadFrequency
   - FREQUENT
   - AVERAGE
   - RARE
+enum com.datadog.android.core.configuration.VitalsUpdateFrequency
+  constructor(Long)
+  - FREQUENT
+  - AVERAGE
+  - RARE
+  - NEVER
 data class com.datadog.android.core.model.NetworkInfo
   constructor(Connectivity = Connectivity.NETWORK_NOT_CONNECTED, kotlin.String? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.String? = null)
   fun toJson(): com.google.gson.JsonElement

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -103,7 +103,8 @@ internal constructor(
             val viewTrackingStrategy: ViewTrackingStrategy?,
             val longTaskTrackingStrategy: TrackingStrategy?,
             val rumEventMapper: EventMapper<Any>,
-            val backgroundEventTracking: Boolean
+            val backgroundEventTracking: Boolean,
+            val vitalsMonitorUpdateFrequency: VitalsUpdateFrequency
         ) : Feature()
     }
 
@@ -691,6 +692,17 @@ internal constructor(
                 devLogger.e(ERROR_FEATURE_DISABLED.format(Locale.US, feature.featureName, method))
             }
         }
+
+        /**
+         * Allows to specify the frequency at which to update the mobile vitals
+         * data provided in the RUM [ViewEvent].
+         * @param frequency as [VitalsUpdateFrequency]
+         * @see [VitalsUpdateFrequency]
+         */
+        fun setVitalsUpdateFrequency(frequency: VitalsUpdateFrequency): Builder {
+            rumConfig = rumConfig.copy(vitalsMonitorUpdateFrequency = frequency)
+            return this
+        }
     }
 
     // endregion
@@ -737,7 +749,8 @@ internal constructor(
             viewTrackingStrategy = ActivityViewTrackingStrategy(false),
             longTaskTrackingStrategy = MainLooperLongTaskStrategy(DEFAULT_LONG_TASK_THRESHOLD_MS),
             rumEventMapper = NoOpEventMapper(),
-            backgroundEventTracking = false
+            backgroundEventTracking = false,
+            vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE
         )
 
         internal const val ERROR_FEATURE_DISABLED = "The %s feature has been disabled in your " +

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/VitalsUpdateFrequency.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/VitalsUpdateFrequency.kt
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.configuration
+
+/**
+ * Defines the frequency at which mobile vitals monitor updates the data.
+ */
+enum class VitalsUpdateFrequency(
+    internal val periodInMs: Long
+) {
+
+    /** Every 100 milliseconds. */
+    FREQUENT(100L),
+
+    /** Every 500 milliseconds. This is the default frequency. */
+    AVERAGE(500L),
+
+    /** Every 1000 milliseconds. */
+    RARE(1000L),
+
+    /** No data will be sent for mobile vitals. */
+    NEVER(0)
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/thread/NoOpScheduledExecutorService.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/thread/NoOpScheduledExecutorService.kt
@@ -1,0 +1,106 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.thread
+
+import java.util.concurrent.Callable
+import java.util.concurrent.Future
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.ScheduledFuture
+import java.util.concurrent.TimeUnit
+
+internal class NoOpScheduledExecutorService : ScheduledExecutorService {
+    override fun execute(command: Runnable?) {
+        // No-op
+    }
+
+    override fun shutdown() {
+        // No-op
+    }
+
+    override fun shutdownNow(): MutableList<Runnable>? {
+        return null
+    }
+
+    override fun isShutdown(): Boolean {
+        return false
+    }
+
+    override fun isTerminated(): Boolean {
+        return false
+    }
+
+    override fun awaitTermination(timeout: Long, unit: TimeUnit?): Boolean {
+        return false
+    }
+
+    override fun <T : Any?> submit(task: Callable<T>?): Future<T>? {
+        return null
+    }
+
+    override fun <T : Any?> submit(task: Runnable?, result: T): Future<T>? {
+        return null
+    }
+
+    override fun submit(task: Runnable?): Future<*>? {
+        return null
+    }
+
+    override fun <T : Any?> invokeAll(tasks: MutableCollection<out Callable<T>>?):
+        MutableList<Future<T>>? {
+        return null
+    }
+
+    override fun <T : Any?> invokeAll(
+        tasks: MutableCollection<out Callable<T>>?,
+        timeout: Long,
+        unit: TimeUnit?
+    ): MutableList<Future<T>>? {
+        return null
+    }
+
+    override fun <T : Any?> invokeAny(tasks: MutableCollection<out Callable<T>>?): T? {
+        return null
+    }
+
+    override fun <T : Any?> invokeAny(
+        tasks: MutableCollection<out Callable<T>>?,
+        timeout: Long,
+        unit: TimeUnit?
+    ): T? {
+        return null
+    }
+
+    override fun schedule(command: Runnable?, delay: Long, unit: TimeUnit?): ScheduledFuture<*>? {
+        return null
+    }
+
+    override fun <V : Any?> schedule(
+        callable: Callable<V>?,
+        delay: Long,
+        unit: TimeUnit?
+    ): ScheduledFuture<V>? {
+        return null
+    }
+
+    override fun scheduleAtFixedRate(
+        command: Runnable?,
+        initialDelay: Long,
+        period: Long,
+        unit: TimeUnit?
+    ): ScheduledFuture<*>? {
+        return null
+    }
+
+    override fun scheduleWithFixedDelay(
+        command: Runnable?,
+        initialDelay: Long,
+        delay: Long,
+        unit: TimeUnit?
+    ): ScheduledFuture<*>? {
+        return null
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -148,7 +148,8 @@ internal class ConfigurationBuilderTest {
                 viewTrackingStrategy = ActivityViewTrackingStrategy(false),
                 rumEventMapper = NoOpEventMapper(),
                 longTaskTrackingStrategy = MainLooperLongTaskStrategy(100L),
-                backgroundEventTracking = false
+                backgroundEventTracking = false,
+                vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE
             )
         )
         assertThat(config.additionalConfig).isEmpty()
@@ -1641,6 +1642,21 @@ internal class ConfigurationBuilderTest {
         assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+    }
+
+    @Test
+    fun `M use the given frequency W setVitalsMonitorUpdateFrequency`(
+        @Forgery fakeFrequency: VitalsUpdateFrequency
+    ) {
+        // When
+        val config = testedBuilder
+            .setVitalsUpdateFrequency(fakeFrequency)
+            .build()
+
+        // Then
+        assertThat(config.rumConfig).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(vitalsMonitorUpdateFrequency = fakeFrequency)
+        )
     }
 
     private fun Configuration.Builder.setSecurityConfig(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -9,9 +9,11 @@ package com.datadog.android.rum.internal
 import android.app.Application
 import android.view.Choreographer
 import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.configuration.VitalsUpdateFrequency
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.SdkFeatureTest
 import com.datadog.android.core.internal.event.NoOpEventMapper
+import com.datadog.android.core.internal.thread.NoOpScheduledExecutorService
 import com.datadog.android.rum.internal.domain.RumFilePersistenceStrategy
 import com.datadog.android.rum.internal.net.RumOkHttpUploaderV2
 import com.datadog.android.rum.internal.tracking.NoOpUserActionTrackingStrategy
@@ -32,6 +34,7 @@ import com.nhaarman.mockitokotlin2.doNothing
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -44,6 +47,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -216,10 +221,16 @@ internal class RumFeatureTest : SdkFeatureTest<Any, Configuration.Feature.RUM, R
         assertThat(testedFeature.rumEventMapper).isSameAs(fakeConfigurationFeature.rumEventMapper)
     }
 
-    @Test
-    fun `𝕄 setup vital monitors 𝕎 initialize()`() {
+    @ParameterizedTest
+    @EnumSource(VitalsUpdateFrequency::class, names = ["NEVER"], mode = EnumSource.Mode.EXCLUDE)
+    fun `𝕄 setup vital monitors 𝕎 initialize { frequency != NEVER }`(
+        fakeFrequency: VitalsUpdateFrequency
+    ) {
         // When
-        testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeConfigurationFeature.copy(vitalsMonitorUpdateFrequency = fakeFrequency)
+        )
 
         // Then
         assertThat(testedFeature.cpuVitalMonitor)
@@ -235,20 +246,65 @@ internal class RumFeatureTest : SdkFeatureTest<Any, Configuration.Feature.RUM, R
     }
 
     @Test
-    fun `𝕄 register choreographer callback safely 𝕎 initialize()`(
+    fun `M not initialize the vital monitors W initialize { frequency = NEVER }`() {
+        // When
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeConfigurationFeature.copy(
+                vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.NEVER
+            )
+        )
+
+        // Then
+        assertThat(testedFeature.cpuVitalMonitor)
+            .isInstanceOf(NoOpVitalMonitor::class.java)
+        assertThat(testedFeature.memoryVitalMonitor)
+            .isInstanceOf(NoOpVitalMonitor::class.java)
+        assertThat(testedFeature.frameRateVitalMonitor)
+            .isInstanceOf(NoOpVitalMonitor::class.java)
+        assertThat(RumFeature.vitalExecutorService)
+            .isInstanceOf(NoOpScheduledExecutorService::class.java)
+    }
+
+    @ParameterizedTest
+    @EnumSource(VitalsUpdateFrequency::class, names = ["NEVER"], mode = EnumSource.Mode.EXCLUDE)
+    fun `𝕄 register choreographer callback safely 𝕎 initialize { frequency != NEVER }()`(
+        fakeFrequency: VitalsUpdateFrequency,
         @StringForgery message: String
     ) {
         // Given
         doThrow(IllegalStateException(message)).whenever(mockChoreographer).postFrameCallback(any())
 
         // When
-        testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeConfigurationFeature.copy(vitalsMonitorUpdateFrequency = fakeFrequency)
+        )
 
         // Then
         argumentCaptor<Choreographer.FrameCallback> {
             verify(mockChoreographer).postFrameCallback(capture())
             assertThat(firstValue).isInstanceOf(VitalFrameCallback::class.java)
         }
+    }
+
+    @Test
+    fun `𝕄 not register choreographer callback 𝕎 initialize { frequency = NEVER }()`(
+        @StringForgery message: String
+    ) {
+        // Given
+        doThrow(IllegalStateException(message)).whenever(mockChoreographer).postFrameCallback(any())
+
+        // When
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeConfigurationFeature.copy(
+                vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.NEVER
+            )
+        )
+
+        // Then
+        verifyZeroInteractions(mockChoreographer)
     }
 
     @Test
@@ -310,14 +366,37 @@ internal class RumFeatureTest : SdkFeatureTest<Any, Configuration.Feature.RUM, R
         assertThat(testedFeature.rumEventMapper).isInstanceOf(NoOpEventMapper::class.java)
     }
 
-    @Test
-    fun `𝕄 initialize vital executor 𝕎 initialize()`() {
+    @ParameterizedTest
+    @EnumSource(VitalsUpdateFrequency::class, names = ["NEVER"], mode = EnumSource.Mode.EXCLUDE)
+    fun `𝕄 initialize vital executor 𝕎 initialize { frequency != NEVER }()`(
+        fakeFrequency: VitalsUpdateFrequency
+    ) {
         // When
-        testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeConfigurationFeature.copy(
+                vitalsMonitorUpdateFrequency = fakeFrequency
+            )
+        )
 
         // Then
         val scheduledRunnables = testedFeature.vitalExecutorService.shutdownNow()
         assertThat(scheduledRunnables).isNotEmpty
+    }
+
+    @Test
+    fun `𝕄 not initialize vital executor 𝕎 initialize { frequency = NEVER }()`() {
+        // When
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeConfigurationFeature.copy(
+                vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.NEVER
+            )
+        )
+
+        // Then
+        assertThat(RumFeature.vitalExecutorService)
+            .isInstanceOf(NoOpScheduledExecutorService::class.java)
     }
 
     @Test
@@ -332,6 +411,19 @@ internal class RumFeatureTest : SdkFeatureTest<Any, Configuration.Feature.RUM, R
 
         // Then
         verify(mockVitalExecutorService).shutdownNow()
+    }
+
+    @Test
+    fun `𝕄 reset vital executor 𝕎 stop()`() {
+        // Given
+        testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
+
+        // When
+        testedFeature.stop()
+
+        // Then
+        assertThat(RumFeature.vitalExecutorService)
+            .isInstanceOf(NoOpScheduledExecutorService::class.java)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.configuration.VitalsUpdateFrequency
 import com.nhaarman.mockitokotlin2.mock
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
@@ -23,7 +24,8 @@ internal class ConfigurationRumForgeryFactory :
             viewTrackingStrategy = mock(),
             rumEventMapper = mock(),
             longTaskTrackingStrategy = mock(),
-            backgroundEventTracking = forge.aBool()
+            backgroundEventTracking = forge.aBool(),
+            vitalsMonitorUpdateFrequency = forge.aValueFrom(VitalsUpdateFrequency::class.java)
         )
     }
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -860,6 +860,7 @@ datadog:
       - "java.util.concurrent.ExecutorService.shutdownNow()"
       - "java.util.concurrent.Executors.newSingleThreadExecutor()"
       - "java.util.concurrent.LinkedBlockingDeque.constructor()"
+      - "java.util.concurrent.ScheduledExecutorService.shutdownNow()"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.remove(java.lang.Runnable)"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.shutdown()"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.shutdownNow()"


### PR DESCRIPTION
### What does this PR do?

In this PR we are introduce a new API : `ConfigurationBuilder.setVitalsUpdateFrequency(frequency)` where the frequency is an enum :

```
/** Every 100 milliseconds. */
FREQUENT(100L),

/** Every 500 milliseconds. This is the default frequency. */
AVERAGE(500L),

/** Every 1000 milliseconds. */
RARE(1000L),

/** No data will be sent for mobile vitals. */
NEVER(0)
```
This will allow the client to customise the update frequency for mobile vitals reader or disable this feature.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

