### PR TITLE
RUMM-2177: Use TLV format for data storage

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/EventMeta.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/EventMeta.kt
@@ -11,32 +11,28 @@ import com.google.gson.JsonParseException
 import com.google.gson.JsonParser
 import kotlin.jvm.Throws
 
-internal data class EventMeta(val eventSize: Int) {
+// TODO RUMM-2172 use meta.
+//  For now it has nothing (fake property just because data class requires it)
+internal data class EventMeta(private val fake: String = "") {
 
     val asBytes: ByteArray
         get() {
             return JsonObject()
-                .apply {
-                    addProperty(EVENT_SIZE_KEY, eventSize)
-                }
                 .toString()
                 .toByteArray(Charsets.UTF_8)
         }
 
     companion object {
 
-        private const val EVENT_SIZE_KEY = "ev_size"
-
         @Throws(JsonParseException::class)
         @Suppress("ThrowingInternalException", "TooGenericExceptionCaught")
         fun fromBytes(metaBytes: ByteArray): EventMeta {
             return try {
-                @Suppress("UnsafeThirdPartyFunctionCall") // there is Throws annotation
+                // there is Throws annotation
+                @Suppress("UnsafeThirdPartyFunctionCall", "UNUSED_VARIABLE")
                 val json = JsonParser.parseString(String(metaBytes, Charsets.UTF_8))
                     .asJsonObject
-                EventMeta(
-                    eventSize = json.get(EVENT_SIZE_KEY).asInt
-                )
+                EventMeta()
             } catch (e: IllegalStateException) {
                 throw JsonParseException(e)
             } catch (e: ClassCastException) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/EventMetaTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/EventMetaTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.core.internal.persistence.file
 
 import com.google.gson.JsonParseException
 import fr.xgouchet.elmyr.Forge
-import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -23,11 +22,9 @@ import org.junit.jupiter.api.extension.Extensions
 internal class EventMetaTest {
 
     @Test
-    fun `𝕄 return original value 𝕎 asBytes + fromBytes()`(
-        @IntForgery(min = 0) eventSize: Int
-    ) {
+    fun `𝕄 return original value 𝕎 asBytes + fromBytes()`() {
         // Given
-        val originalMeta = EventMeta(eventSize)
+        val originalMeta = EventMeta()
 
         // When
         val restoredMeta = EventMeta.fromBytes(originalMeta.asBytes)
@@ -49,9 +46,7 @@ internal class EventMetaTest {
     ) {
         // Given
         val metaBytes = forge.anElementFrom(
-            "[]",
-            "{}",
-            "{\"ev_size\": \"string\"}"
+            "[]"
         ).toByteArray()
 
         // When + Then

--- a/detekt.yml
+++ b/detekt.yml
@@ -618,7 +618,13 @@ datadog:
       - "java.io.FileOutputStream.use(kotlin.Function1):java.io.IOException"
       - "java.io.FileOutputStream.write(kotlin.ByteArray):java.io.IOException"
       - "java.io.InputStream.read():java.io.IOException"
+      - "java.io.InputStream.read(kotlin.ByteArray):java.io.IOException"
       - "java.io.InputStream.read(kotlin.ByteArray, kotlin.Int, kotlin.Int):java.io.IOException"
+      - "java.nio.ByteBuffer.allocate(kotlin.Int):java.lang.IllegalArgumentException"
+      - "java.nio.ByteBuffer.array():java.nio.ReadOnlyBufferException,java.lang.UnsupportedOperationException"
+      - "java.nio.ByteBuffer.put(kotlin.ByteArray):java.nio.BufferOverflowException,java.nio.ReadOnlyBufferException"
+      - "java.nio.ByteBuffer.putInt(kotlin.Int):java.nio.BufferOverflowException,java.nio.ReadOnlyBufferException"
+      - "java.nio.ByteBuffer.putShort(kotlin.Short):java.nio.BufferOverflowException,java.nio.ReadOnlyBufferException"
       - "java.nio.channels.FileChannel.lock():java.io.IOException,java.lang.IllegalStateException"
       - "java.nio.channels.FileLock.release():java.io.IOException"
       # endregion


### PR DESCRIPTION
### What does this PR do?

This change aligns the binary format used to write data to the disk with format implemented in https://github.com/DataDog/dd-sdk-ios/pull/841.

For every event received we are going to write `meta` + `event` in the TLV (Type-Length-Value) format, where the format itself for each block (`meta` or `event`) has the following structure:

```
    +-  2 bytes -+-   4 bytes  -+- n bytes  -|
   |  block type | data size (n) |    data   |
    +------------+---------------+-----------+
```

It is safe to merge it without cleaning existing data, because this PR targets SDK v2 branch, where the change later will be done to use SDK instance ID in the feature folder naming, so data in the SDK v2 read/write paths won't overlap with data from existing SDK (but during the current development existing data should be erased from emulator).

Tests are verified against the latest testable commit.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

