### PR TITLE
RUMM-2165: Add trace sampling for instrumented network requests

### DIFF
--- a/dd-sdk-android-glide/README.md
+++ b/dd-sdk-android-glide/README.md
@@ -48,9 +48,11 @@ Doing so will automatically track Glide's network requests (creating both APM Tr
 @GlideModule
 class CustomGlideModule : 
     DatadogGlideModule(
-        listOf("example.com", "example.eu")
+        listOf("example.com", "example.eu"), traceSamplingRate = 20f
     )
 ```
+
+Network requests are sampled with an adjustable sampling rate. A sampling of 20% is applied by default.
 
 
 ## Contributing

--- a/dd-sdk-android-glide/apiSurface
+++ b/dd-sdk-android-glide/apiSurface
@@ -1,5 +1,5 @@
 open class com.datadog.android.glide.DatadogGlideModule : com.bumptech.glide.module.AppGlideModule
-  constructor(List<String> = emptyList())
+  constructor(List<String> = emptyList(), Float = DEFAULT_SAMPLING_RATE)
   override fun registerComponents(android.content.Context, com.bumptech.glide.Glide, com.bumptech.glide.Registry)
   override fun applyOptions(android.content.Context, com.bumptech.glide.GlideBuilder)
   open fun getClientBuilder(): okhttp3.OkHttpClient.Builder

--- a/dd-sdk-android/README.md
+++ b/dd-sdk-android/README.md
@@ -29,7 +29,7 @@ class SampleApplication : Application() {
 
 ### Setup for Europe
 
-If you're targetting our [Europe servers](https://datadoghq.eu), you can
+If you're targeting our [Europe servers](https://datadoghq.eu), you can
 initialize the library like this: 
 
 ```kotlin
@@ -139,12 +139,12 @@ do so by providing a map alongside the message, each entry being added as an att
 
 In Java you can do so as follows:
 ```java
-    mLogger.d(
+    Map<String, Object> attributes = new HashMap<>();
+    attributes.put("http.url", url);
+    logger.d(
             "onPageStarted",
             null, 
-            new HashMap<String, Object>() {{
-                put("http.url", url);
-            }}
+            attributes
     );
 ```
 

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -52,8 +52,8 @@ class com.datadog.android.DatadogEventListener : okhttp3.EventListener
   class Factory : okhttp3.EventListener.Factory
     override fun create(okhttp3.Call): okhttp3.EventListener
 open class com.datadog.android.DatadogInterceptor : com.datadog.android.tracing.TracingInterceptor
-  constructor(List<String>, com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
-  constructor(com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
+  constructor(List<String>, com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+  constructor(com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
   override fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
   override fun canSendSpan(): Boolean
@@ -357,7 +357,7 @@ enum com.datadog.android.rum.RumErrorSource
   - AGENT
   - WEBVIEW
 class com.datadog.android.rum.RumInterceptor : com.datadog.android.DatadogInterceptor
-  constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
+  constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
 interface com.datadog.android.rum.RumMonitor
   fun startView(Any, String, Map<String, Any?> = emptyMap())
   fun stopView(Any, Map<String, Any?> = emptyMap())
@@ -1439,8 +1439,8 @@ class com.datadog.android.tracing.AndroidTracer : com.datadog.opentracing.DDTrac
 interface com.datadog.android.tracing.TracedRequestListener
   fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span, okhttp3.Response?, Throwable?)
 open class com.datadog.android.tracing.TracingInterceptor : okhttp3.Interceptor
-  constructor(List<String>, TracedRequestListener = NoOpTracedRequestListener())
-  constructor(TracedRequestListener = NoOpTracedRequestListener())
+  constructor(List<String>, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+  constructor(TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
   protected open fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
   companion object 

--- a/dd-sdk-android/src/main/java/com/datadog/opentracing/propagation/DatadogHttpCodec.java
+++ b/dd-sdk-android/src/main/java/com/datadog/opentracing/propagation/DatadogHttpCodec.java
@@ -26,7 +26,6 @@ class DatadogHttpCodec {
   private static final String TRACE_ID_KEY = "x-datadog-trace-id";
   private static final String SPAN_ID_KEY = "x-datadog-parent-id";
   private static final String SAMPLING_PRIORITY_KEY = "x-datadog-sampling-priority";
-  private static final String SELECTED_FOR_SAMPLE_KEY = "x-datadog-sampled";
   private static final String ORIGIN_KEY = "x-datadog-origin";
 
   private DatadogHttpCodec() {
@@ -50,8 +49,6 @@ class DatadogHttpCodec {
 
       // always use max sampling priority for Android traces
       carrier.put(SAMPLING_PRIORITY_KEY, "1");
-      // makes this request trace selected for sampling
-      carrier.put(SELECTED_FOR_SAMPLE_KEY, "1");
     }
   }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
@@ -6,10 +6,13 @@
 
 package com.datadog.android
 
+import androidx.annotation.FloatRange
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.net.identifyRequest
+import com.datadog.android.core.internal.sampling.RateBasedSampler
+import com.datadog.android.core.internal.sampling.Sampler
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.rum.GlobalRum
@@ -65,8 +68,9 @@ import okhttp3.Response
  * ```
  *
  * @param tracedHosts a list of all the hosts that you want to be automatically tracked
- * by our APM [TracingInterceptor]. If no host provided the interceptor won't trace
- * any OkHttpRequest, nor propagate tracing information to the backend.
+ * by our APM [TracingInterceptor]. If no host provided (via this argument or global
+ * configuration [Configuration.Builder.setFirstPartyHosts]) the interceptor won't trace
+ * any [okhttp3.Request], nor propagate tracing information to the backend.
  * Please note that the host constraint will only be applied on the [TracingInterceptor] and we will
  * continue to dispatch RUM Resource events for each request without applying any host filtering.
  * @param tracedRequestListener which listens on the intercepted [okhttp3.Request] and offers
@@ -80,12 +84,14 @@ internal constructor(
     tracedRequestListener: TracedRequestListener,
     firstPartyHostDetector: FirstPartyHostDetector,
     internal val rumResourceAttributesProvider: RumResourceAttributesProvider,
+    traceSampler: Sampler,
     localTracerFactory: () -> Tracer
 ) : TracingInterceptor(
     tracedHosts,
     tracedRequestListener,
     firstPartyHostDetector,
     ORIGIN_RUM,
+    traceSampler,
     localTracerFactory
 ) {
 
@@ -97,24 +103,30 @@ internal constructor(
      * Requests made to a URL with any one of these hosts (or any subdomain) will:
      * - be considered a first party RUM Resource and categorised as such in your RUM dashboard;
      * - be wrapped in a Span and have trace id injected to get a full flame-graph in APM.
-     * If no host provided the interceptor won't trace any OkHttp [Request], nor propagate tracing
+     * If no host provided (via this argument or global configuration [Configuration.Builder.setFirstPartyHosts])
+     * the interceptor won't trace any OkHttp [Request], nor propagate tracing
      * information to the backend, but RUM Resource events will still be sent for each request.
      * @param tracedRequestListener which listens on the intercepted [okhttp3.Request] and offers
      * the possibility to modify the created [io.opentracing.Span].
      * @param rumResourceAttributesProvider which listens on the intercepted [okhttp3.Request]
      * and offers the possibility to add custom attributes to the RUM resource events.
+     * @param traceSamplingRate the sampling rate for APM traces created for auto-instrumented
+     * requests. It must be a value between `0.0` and `100.0`. A value of `0.0` means no trace will
+     * be kept, `100.0` means all traces will be kept (default value is `20.0`).
      */
     @JvmOverloads
     constructor(
         firstPartyHosts: List<String>,
         tracedRequestListener: TracedRequestListener = NoOpTracedRequestListener(),
         rumResourceAttributesProvider: RumResourceAttributesProvider =
-            NoOpRumResourceAttributesProvider()
+            NoOpRumResourceAttributesProvider(),
+        @FloatRange(from = 0.0, to = 100.0) traceSamplingRate: Float = DEFAULT_TRACE_SAMPLING_RATE
     ) : this(
         tracedHosts = firstPartyHosts,
         tracedRequestListener = tracedRequestListener,
         firstPartyHostDetector = CoreFeature.firstPartyHostDetector,
         rumResourceAttributesProvider = rumResourceAttributesProvider,
+        traceSampler = RateBasedSampler(traceSamplingRate / 100),
         localTracerFactory = { AndroidTracer.Builder().build() }
     )
 
@@ -126,17 +138,22 @@ internal constructor(
      * the possibility to modify the created [io.opentracing.Span].
      * @param rumResourceAttributesProvider which listens on the intercepted [okhttp3.Request]
      * and offers the possibility to add custom attributes to the RUM resource events.
+     * @param traceSamplingRate the sampling rate for APM traces created for auto-instrumented
+     * requests. It must be a value between `0.0` and `100.0`. A value of `0.0` means no trace will
+     * be kept, `100.0` means all traces will be kept (default value is `20.0`).
      */
     @JvmOverloads
     constructor(
         tracedRequestListener: TracedRequestListener = NoOpTracedRequestListener(),
         rumResourceAttributesProvider: RumResourceAttributesProvider =
-            NoOpRumResourceAttributesProvider()
+            NoOpRumResourceAttributesProvider(),
+        @FloatRange(from = 0.0, to = 100.0) traceSamplingRate: Float = DEFAULT_TRACE_SAMPLING_RATE
     ) : this(
         tracedHosts = emptyList(),
         tracedRequestListener = tracedRequestListener,
         firstPartyHostDetector = CoreFeature.firstPartyHostDetector,
         rumResourceAttributesProvider = rumResourceAttributesProvider,
+        traceSampler = RateBasedSampler(traceSamplingRate / 100),
         localTracerFactory = { AndroidTracer.Builder().build() }
     )
 
@@ -169,7 +186,6 @@ internal constructor(
         throwable: Throwable?
     ) {
         super.onRequestIntercepted(request, span, response, throwable)
-
         if (RumFeature.isInitialized()) {
             if (response != null) {
                 handleResponse(request, response, span)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumInterceptor.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum
 
+import androidx.annotation.FloatRange
 import com.datadog.android.DatadogInterceptor
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
@@ -36,16 +37,22 @@ import okhttp3.Request
  * Requests made to a URL with any one of these hosts (or any subdomain) will:
  * - be considered a first party RUM Resource and categorised as such in your RUM dashboard;
  * - be wrapped in a Span and have trace id injected to get a full flame-graph in APM.
- * If no host provided the interceptor won't trace any OkHttp [Request], nor propagate tracing
+ * If no host provided (via this argument or global configuration [Configuration.Builder.setFirstPartyHosts])
+ * the interceptor won't trace any OkHttp [Request], nor propagate tracing
  * information to the backend, but RUM Resource events will still be sent for each request.
  * @param rumResourceAttributesProvider which listens on the intercepted [okhttp3.Request]
  * and offers the possibility to add custom attributes to the RUM resource events.
+ * @param traceSamplingRate the sampling rate for APM traces created for auto-instrumented
+ * requests. It must be a value between `0.0` and `100.0`. A value of `0.0` means no trace will
+ * be kept, `100.0` means all traces will be kept (default value is `20.0`).
  */
 class RumInterceptor(
     firstPartyHosts: List<String> = emptyList(),
     rumResourceAttributesProvider: RumResourceAttributesProvider =
-        NoOpRumResourceAttributesProvider()
+        NoOpRumResourceAttributesProvider(),
+    @FloatRange(from = 0.0, to = 100.0) traceSamplingRate: Float = DEFAULT_TRACE_SAMPLING_RATE
 ) : DatadogInterceptor(
     firstPartyHosts,
-    rumResourceAttributesProvider = rumResourceAttributesProvider
+    rumResourceAttributesProvider = rumResourceAttributesProvider,
+    traceSamplingRate = traceSamplingRate
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracedRequestListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracedRequestListener.kt
@@ -20,7 +20,8 @@ interface TracedRequestListener {
 
     /**
      * Notifies that a span was automatically created around an OkHttp [Request].
-     * You can update the given [Span] (e.g.: add custom tags / baggage items) before it is persisted.
+     * You can update the given [Span] (e.g.: add custom tags / baggage items) before it
+     * is persisted. Won't be called if [Request] wasn't sampled.
      * @param request the intercepted [Request]
      * @param span the [Span] created around the intercepted [Request]
      * @param response the [Request] response in case of any

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android
 
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.net.identifyRequest
+import com.datadog.android.core.internal.sampling.RateBasedSampler
 import com.datadog.android.rum.NoOpRumResourceAttributesProvider
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -85,6 +86,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             tracedRequestListener = mockRequestListener,
             firstPartyHostDetector = mockDetector,
             rumResourceAttributesProvider = mockRumAttributesProvider,
+            traceSampler = mockTraceSampler,
             localTracerFactory = factory
         )
     }
@@ -113,7 +115,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     }
 
     @Test
-    fun `M instantiate with default callbacks W init()`() {
+    fun `M instantiate with default values W init() { no tracing hosts specified }`() {
         // When
         val interceptor = DatadogInterceptor()
 
@@ -123,10 +125,16 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             .isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener)
             .isInstanceOf(NoOpTracedRequestListener::class.java)
+        assertThat(interceptor.traceSampler)
+            .isInstanceOf(RateBasedSampler::class.java)
+        val traceSampler = interceptor.traceSampler as RateBasedSampler
+        assertThat(traceSampler.sampleRate).isEqualTo(
+            TracingInterceptor.DEFAULT_TRACE_SAMPLING_RATE / 100
+        )
     }
 
     @Test
-    fun `M instantiate with default callbacks W init()`(
+    fun `M instantiate with default values W init() { traced hosts specified }`(
         @StringForgery(regex = "[a-z]+\\.[a-z]{3}") hosts: List<String>
     ) {
         // When
@@ -138,6 +146,12 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             .isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
         assertThat(interceptor.tracedRequestListener)
             .isInstanceOf(NoOpTracedRequestListener::class.java)
+        assertThat(interceptor.traceSampler)
+            .isInstanceOf(RateBasedSampler::class.java)
+        val traceSampler = interceptor.traceSampler as RateBasedSampler
+        assertThat(traceSampler.sampleRate).isEqualTo(
+            TracingInterceptor.DEFAULT_TRACE_SAMPLING_RATE / 100
+        )
     }
 
     @Test
@@ -151,6 +165,44 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.TRACE_ID to fakeTraceId,
             RumAttributes.SPAN_ID to fakeSpanId
         ) + fakeAttributes
+        val requestId = identifyRequest(fakeRequest)
+        val mimeType = fakeMediaType?.type()
+        val kind = when {
+            mimeType != null -> RumResourceKind.fromMimeType(mimeType)
+            else -> RumResourceKind.NATIVE
+        }
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        inOrder(rumMonitor.mockInstance) {
+            verify(rumMonitor.mockInstance).startResource(
+                requestId,
+                fakeMethod,
+                fakeUrl,
+                expectedStartAttrs
+            )
+            verify(rumMonitor.mockInstance).stopResource(
+                requestId,
+                statusCode,
+                fakeResponseBody.toByteArray().size.toLong(),
+                kind,
+                expectedStopAttrs
+            )
+        }
+    }
+
+    @Test
+    fun `𝕄 start and stop RUM Resource 𝕎 intercept() {successful request + not sampled}`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        stubChain(mockChain, statusCode)
+        val expectedStartAttrs = emptyMap<String, Any?>()
+        // no span -> shouldn't have trace/spans IDs
+        val expectedStopAttrs = fakeAttributes
         val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type()
         val kind = when {
@@ -198,6 +250,52 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.TRACE_ID to fakeTraceId,
             RumAttributes.SPAN_ID to fakeSpanId
         ) + fakeAttributes
+        val requestId = identifyRequest(fakeRequest)
+        val mimeType = fakeMediaType?.type()
+        val kind = when {
+            mimeType != null -> RumResourceKind.fromMimeType(mimeType)
+            else -> RumResourceKind.NATIVE
+        }
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        inOrder(rumMonitor.mockInstance) {
+            verify(rumMonitor.mockInstance).startResource(
+                requestId,
+                fakeMethod,
+                fakeUrl,
+                emptyMap()
+            )
+            verify(rumMonitor.mockInstance).stopResource(
+                requestId,
+                statusCode,
+                null,
+                kind,
+                expectedStopAttrs
+            )
+        }
+    }
+
+    @Test
+    fun `𝕄 start and stop RUM Resource 𝕎 intercept() {successful request empty response + !smp}`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        stubChain(mockChain) {
+            Response.Builder()
+                .request(fakeRequest)
+                .protocol(Protocol.HTTP_2)
+                .code(statusCode)
+                .message("HTTP $statusCode")
+                .body(ResponseBody.create(fakeMediaType, ""))
+                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
+                .build()
+        }
+        // no span -> shouldn't have trace/spans IDs
+        val expectedStopAttrs = fakeAttributes
         val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type()
         val kind = when {
@@ -285,6 +383,63 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     }
 
     @Test
+    fun `𝕄 start and stop RUM Resource 𝕎 intercept() {success request throwing response + !smp}`(
+        @IntForgery(min = 200, max = 300) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        stubChain(mockChain) {
+            Response.Builder()
+                .request(fakeRequest)
+                .protocol(Protocol.HTTP_2)
+                .code(statusCode)
+                .message("HTTP $statusCode")
+                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
+                .body(object : ResponseBody() {
+                    override fun contentType(): MediaType? = fakeMediaType
+
+                    override fun contentLength(): Long = fakeResponseBody.length.toLong()
+
+                    override fun source(): BufferedSource {
+                        return mock<BufferedSource>().apply {
+                            whenever(this.request(any())) doThrow IOException()
+                        }
+                    }
+                })
+                .build()
+        }
+        val expectedStartAttrs = emptyMap<String, Any?>()
+        // no span -> shouldn't have trace/spans IDs
+        val expectedStopAttrs = fakeAttributes
+        val requestId = identifyRequest(fakeRequest)
+        val mimeType = fakeMediaType?.type()
+        val kind = when {
+            mimeType != null -> RumResourceKind.fromMimeType(mimeType)
+            else -> RumResourceKind.NATIVE
+        }
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        inOrder(rumMonitor.mockInstance) {
+            verify(rumMonitor.mockInstance).startResource(
+                requestId,
+                fakeMethod,
+                fakeUrl,
+                expectedStartAttrs
+            )
+            verify(rumMonitor.mockInstance).stopResource(
+                requestId,
+                statusCode,
+                null,
+                kind,
+                expectedStopAttrs
+            )
+        }
+    }
+
+    @Test
     fun `𝕄 start and stop RUM Resource 𝕎 intercept() {failing request}`(
         @IntForgery(min = 400, max = 500) statusCode: Int
     ) {
@@ -295,6 +450,44 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.TRACE_ID to fakeTraceId,
             RumAttributes.SPAN_ID to fakeSpanId
         ) + fakeAttributes
+        val requestId = identifyRequest(fakeRequest)
+        val mimeType = fakeMediaType?.type()
+        val kind = when {
+            mimeType != null -> RumResourceKind.fromMimeType(mimeType)
+            else -> RumResourceKind.NATIVE
+        }
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        inOrder(rumMonitor.mockInstance) {
+            verify(rumMonitor.mockInstance).startResource(
+                requestId,
+                fakeMethod,
+                fakeUrl,
+                expectedStartAttrs
+            )
+            verify(rumMonitor.mockInstance).stopResource(
+                requestId,
+                statusCode,
+                fakeResponseBody.toByteArray().size.toLong(),
+                kind,
+                expectedStopAttrs
+            )
+        }
+    }
+
+    @Test
+    fun `𝕄 start and stop RUM Resource 𝕎 intercept() {failing request + not sampled}`(
+        @IntForgery(min = 400, max = 500) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        stubChain(mockChain, statusCode)
+        val expectedStartAttrs = emptyMap<String, Any?>()
+        // no span -> shouldn't have trace/spans IDs
+        val expectedStopAttrs = fakeAttributes
         val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type()
         val kind = when {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutRumTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutRumTest.kt
@@ -56,6 +56,7 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
             tracedRequestListener = mockRequestListener,
             firstPartyHostDetector = mockDetector,
             rumResourceAttributesProvider = mockRumAttributesProvider,
+            traceSampler = mockTraceSampler,
             localTracerFactory = factory
         )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumInterceptorTest.kt
@@ -1,0 +1,64 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum
+
+import com.datadog.android.core.internal.sampling.RateBasedSampler
+import com.datadog.android.tracing.NoOpTracedRequestListener
+import com.datadog.android.tracing.TracingInterceptor
+import com.datadog.android.tracing.TracingInterceptorNotSendingSpanTest
+import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RumInterceptorTest : TracingInterceptorNotSendingSpanTest() {
+
+    @Test
+    fun `M instantiate with default values W init()`() {
+        // When
+        val interceptor = RumInterceptor()
+
+        // Then
+        assertThat(interceptor.tracedHosts).isEmpty()
+        assertThat(interceptor.rumResourceAttributesProvider)
+            .isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
+        assertThat(interceptor.tracedRequestListener)
+            .isInstanceOf(NoOpTracedRequestListener::class.java)
+        assertThat(interceptor.traceSampler)
+            .isInstanceOf(RateBasedSampler::class.java)
+        val traceSampler = interceptor.traceSampler as RateBasedSampler
+        assertThat(traceSampler.sampleRate)
+            .isEqualTo(TracingInterceptor.DEFAULT_TRACE_SAMPLING_RATE / 100)
+    }
+
+    companion object {
+        val rumMonitor = GlobalRumMonitorTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(logger, appContext, coreFeature, rumMonitor)
+        }
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -11,16 +11,19 @@ import android.util.Log
 import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
+import com.datadog.android.core.internal.sampling.Sampler
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.opentracing.DDTracer
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.setStaticValue
+import com.datadog.trace.api.interceptor.MutableSpan
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
@@ -109,6 +112,9 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     @Mock
     lateinit var mockDetector: FirstPartyHostDetector
 
+    @Mock
+    lateinit var mockTraceSampler: Sampler
+
     // endregion
 
     // region Fakes
@@ -158,6 +164,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         whenever(mockSpan.context()) doReturn mockSpanContext
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
+        whenever(mockTraceSampler.sample()) doReturn true
 
         fakeMediaType = if (forge.aBool()) {
             val mediaType = forge.anElementFrom("application", "image", "text", "model") +
@@ -195,16 +202,13 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
                 mockRequestListener,
                 mockDetector,
                 fakeOrigin,
+                mockTraceSampler,
                 factory
             ) {
             override fun canSendSpan(): Boolean {
                 return false
             }
         }
-    }
-
-    open fun getExpectedOrigin(): String {
-        return fakeOrigin
     }
 
     @Test
@@ -230,6 +234,30 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
+    fun `𝕄 inject non-tracing header 𝕎 intercept() {global known host + not sampled}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        verifyZeroInteractions(mockTracer, mockLocalTracer)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(TracingInterceptor.SAMPLING_PRIORITY_HEADER))
+                .isEqualTo("0")
+            assertThat(lastValue.header(TracingInterceptor.TRACE_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.SPAN_ID_HEADER)).isNull()
+        }
+    }
+
+    @Test
     fun `𝕄 inject tracing header 𝕎 intercept() {local known host}`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
@@ -251,6 +279,33 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
             assertThat(lastValue.header(key)).isEqualTo(value)
+        }
+    }
+
+    @Test
+    fun `𝕄 inject non-tracing header 𝕎 intercept() {local known host + not sampled}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts))
+        fakeRequest = forgeRequest(forge)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        verifyZeroInteractions(mockTracer, mockLocalTracer)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(TracingInterceptor.SAMPLING_PRIORITY_HEADER))
+                .isEqualTo("0")
+            assertThat(lastValue.header(TracingInterceptor.TRACE_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.SPAN_ID_HEADER)).isNull()
         }
     }
 
@@ -314,9 +369,27 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
+    fun `𝕄 not create a span 𝕎 intercept() { not sampled }`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        verifyZeroInteractions(mockTracer, mockSpan, mockSpanBuilder, mockLocalTracer)
+    }
+
+    @Test
     fun `𝕄 create a span with info 𝕎 intercept() for successful request`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -536,6 +609,23 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     }
 
     @Test
+    fun `𝕄 not call the listener 𝕎 intercept() for completed request { not sampled }`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        verifyZeroInteractions(mockRequestListener)
+        assertThat(response).isSameAs(fakeResponse)
+    }
+
+    @Test
     fun `𝕄 call the listener 𝕎 intercept() for throwing request`(
         @Forgery throwable: Throwable,
         @StringForgery tagKey: String,
@@ -563,6 +653,23 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         verify(mockSpan).setTag("error.stack", throwable.loggableStackTrace())
         verify(mockSpan).setTag(tagKey, tagValue)
         verify(mockSpan, never()).finish()
+    }
+
+    @Test
+    fun `𝕄 not call the listener 𝕎 intercept() for throwing request { not sampled }`(
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockChain.request()) doReturn fakeRequest
+        whenever(mockChain.proceed(any())) doThrow throwable
+
+        assertThrows<Throwable>(throwable.message.orEmpty()) {
+            testedInterceptor.intercept(mockChain)
+        }
+
+        verifyZeroInteractions(mockRequestListener)
     }
 
     @Test
@@ -610,6 +717,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     fun `𝕄 create only one local tracer 𝕎 intercept() called from multiple threads`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
+        // Given
         var called = 0
         val tracedHosts = listOf(fakeHostIp, fakeHostName)
         whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
@@ -620,6 +728,17 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
         stubChain(mockChain, statusCode)
 
+        // need this setup, otherwise #intercept actually throws NPE, which pollutes the log
+        val localSpanBuilder: DDTracer.DDSpanBuilder = mock()
+        val localSpan: Span = mock(extraInterfaces = arrayOf(MutableSpan::class))
+        whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
+        whenever(localSpanBuilder.start()) doReturn localSpan
+        whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
+        whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
+        whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
+
+        // When
         val countDownLatch = CountDownLatch(2)
         Thread {
             testedInterceptor.intercept(mockChain)
@@ -638,11 +757,11 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     // region Internal
 
-    internal fun stubChain(chain: Interceptor.Chain, statusCode: Int) {
+    private fun stubChain(chain: Interceptor.Chain, statusCode: Int) {
         return stubChain(chain) { forgeResponse(statusCode) }
     }
 
-    internal fun stubChain(
+    private fun stubChain(
         chain: Interceptor.Chain,
         responseBuilder: () -> Response
     ) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -24,6 +24,7 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.setStaticValue
 import com.datadog.trace.api.interceptor.MutableSpan
+import com.datadog.trace.api.sampling.PrioritySampling
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
@@ -366,6 +367,76 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             assertThat(lastValue.header(key)).isEqualTo(value)
         }
         verify(mockSpanBuilder).asChildOf(parentSpanContext)
+    }
+
+    @Test
+    fun `𝕄 respect sampling decision 𝕎 intercept() {sampled in upstream interceptor}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int,
+        @StringForgery key: String,
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        fakeRequest = forgeRequest(forge) {
+            it.addHeader(
+                TracingInterceptor.SAMPLING_PRIORITY_HEADER,
+                forge.anElementFrom(
+                    PrioritySampling.SAMPLER_KEEP.toString(),
+                    PrioritySampling.USER_KEEP.toString()
+                )
+            )
+        }
+        stubChain(mockChain, statusCode)
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        doAnswer { invocation ->
+            val carrier = invocation.arguments[2] as TextMapInject
+            carrier.put(key, value)
+        }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(key)).isEqualTo(value)
+        }
+    }
+
+    @Test
+    fun `𝕄 respect sampling decision 𝕎 intercept() {sampled out in upstream interceptor}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        fakeRequest = forgeRequest(forge) {
+            it.addHeader(
+                TracingInterceptor.SAMPLING_PRIORITY_HEADER,
+                forge.anElementFrom(
+                    PrioritySampling.SAMPLER_DROP.toString(),
+                    PrioritySampling.USER_DROP.toString()
+                )
+            )
+        }
+        stubChain(mockChain, statusCode)
+        whenever(mockTraceSampler.sample()).thenReturn(true)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(TracingInterceptor.SAMPLING_PRIORITY_HEADER))
+                .isEqualTo("0")
+            assertThat(lastValue.header(TracingInterceptor.TRACE_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.SPAN_ID_HEADER)).isNull()
+        }
+        verifyZeroInteractions(mockTracer, mockLocalTracer, mockSpanBuilder, mockSpan)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerTest.kt
@@ -25,6 +25,7 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.setStaticValue
 import com.datadog.trace.api.interceptor.MutableSpan
+import com.datadog.trace.api.sampling.PrioritySampling
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
@@ -459,6 +460,76 @@ internal open class TracingInterceptorNonDdTracerTest {
             assertThat(firstValue.headers(key)).containsOnly(value)
         }
         verify(mockSpanBuilder).asChildOf(parentSpanContext)
+    }
+
+    @Test
+    fun `𝕄 respect sampling decision 𝕎 intercept() {sampled in upstream interceptor}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int,
+        @StringForgery key: String,
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        fakeRequest = forgeRequest(forge) {
+            it.addHeader(
+                TracingInterceptor.SAMPLING_PRIORITY_HEADER,
+                forge.anElementFrom(
+                    PrioritySampling.SAMPLER_KEEP.toString(),
+                    PrioritySampling.USER_KEEP.toString()
+                )
+            )
+        }
+        stubChain(mockChain, statusCode)
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        doAnswer { invocation ->
+            val carrier = invocation.arguments[2] as TextMapInject
+            carrier.put(key, value)
+        }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(key)).isEqualTo(value)
+        }
+    }
+
+    @Test
+    fun `𝕄 respect sampling decision 𝕎 intercept() {sampled out in upstream interceptor}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        fakeRequest = forgeRequest(forge) {
+            it.addHeader(
+                TracingInterceptor.SAMPLING_PRIORITY_HEADER,
+                forge.anElementFrom(
+                    PrioritySampling.SAMPLER_DROP.toString(),
+                    PrioritySampling.USER_DROP.toString()
+                )
+            )
+        }
+        stubChain(mockChain, statusCode)
+        whenever(mockTraceSampler.sample()).thenReturn(true)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(TracingInterceptor.SAMPLING_PRIORITY_HEADER))
+                .isEqualTo("0")
+            assertThat(lastValue.header(TracingInterceptor.TRACE_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.SPAN_ID_HEADER)).isNull()
+        }
+        verifyZeroInteractions(mockTracer, mockLocalTracer, mockSpanBuilder, mockSpan)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
@@ -11,6 +11,7 @@ import android.util.Log
 import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
+import com.datadog.android.core.internal.sampling.Sampler
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
@@ -108,6 +109,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
     @Mock
     lateinit var mockDetector: FirstPartyHostDetector
 
+    @Mock
+    lateinit var mockTraceSampler: Sampler
+
     // endregion
 
     // region Fakes
@@ -157,6 +161,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         whenever(mockSpan.context()) doReturn mockSpanContext
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
+        whenever(mockTraceSampler.sample()) doReturn true
 
         fakeMediaType = if (forge.aBool()) {
             val mediaType = forge.anElementFrom("application", "image", "text", "model") +
@@ -194,6 +199,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
                 mockRequestListener,
                 mockDetector,
                 fakeOrigin,
+                mockTraceSampler,
                 factory
             ) {
             override fun canSendSpan(): Boolean {
@@ -229,6 +235,30 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
+    fun `𝕄 inject non-tracing header 𝕎 intercept() {global known host + not sampled}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        verifyZeroInteractions(mockTracer, mockLocalTracer)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(TracingInterceptor.SAMPLING_PRIORITY_HEADER))
+                .isEqualTo("0")
+            assertThat(lastValue.header(TracingInterceptor.TRACE_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.SPAN_ID_HEADER)).isNull()
+        }
+    }
+
+    @Test
     fun `𝕄 inject tracing header 𝕎 intercept() {local known host}`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
@@ -250,6 +280,33 @@ internal open class TracingInterceptorNotSendingSpanTest {
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
             assertThat(lastValue.header(key)).isEqualTo(value)
+        }
+    }
+
+    @Test
+    fun `𝕄 inject non-tracing header 𝕎 intercept() {local known host + not sampled}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts))
+        fakeRequest = forgeRequest(forge)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        verifyZeroInteractions(mockTracer, mockLocalTracer)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(TracingInterceptor.SAMPLING_PRIORITY_HEADER))
+                .isEqualTo("0")
+            assertThat(lastValue.header(TracingInterceptor.TRACE_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.SPAN_ID_HEADER)).isNull()
         }
     }
 
@@ -312,6 +369,23 @@ internal open class TracingInterceptorNotSendingSpanTest {
         }
         verify(mockSpanBuilder).asChildOf(parentSpanContext)
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
+    }
+
+    @Test
+    fun `𝕄 not create a span 𝕎 intercept() { not sampled }`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        verifyZeroInteractions(mockTracer, mockSpan, mockSpanBuilder, mockLocalTracer)
     }
 
     @Test
@@ -563,6 +637,23 @@ internal open class TracingInterceptorNotSendingSpanTest {
     }
 
     @Test
+    fun `𝕄 not call the listener 𝕎 intercept() for completed request { not sampled }`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        verifyZeroInteractions(mockRequestListener)
+        assertThat(response).isSameAs(fakeResponse)
+    }
+
+    @Test
     fun `𝕄 call the listener 𝕎 intercept() for throwing request`(
         @Forgery throwable: Throwable,
         @StringForgery tagKey: String,
@@ -592,6 +683,23 @@ internal open class TracingInterceptorNotSendingSpanTest {
         verify(mockSpan).setTag(tagKey, tagValue)
         verify(mockSpan, never()).finish()
         verify(mockSpan as MutableSpan).drop()
+    }
+
+    @Test
+    fun `𝕄 not call the listener 𝕎 intercept() for throwing request { not sampled }`(
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockChain.request()) doReturn fakeRequest
+        whenever(mockChain.proceed(any())) doThrow throwable
+
+        assertThrows<Throwable>(throwable.message.orEmpty()) {
+            testedInterceptor.intercept(mockChain)
+        }
+
+        verifyZeroInteractions(mockRequestListener)
     }
 
     @Test
@@ -639,6 +747,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     fun `𝕄 create only one local tracer 𝕎 intercept() called from multiple threads`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
+        // Given
         var called = 0
         val tracedHosts = listOf(fakeHostIp, fakeHostName)
         whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
@@ -649,6 +758,17 @@ internal open class TracingInterceptorNotSendingSpanTest {
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
         stubChain(mockChain, statusCode)
 
+        // need this setup, otherwise #intercept actually throws NPE, which pollutes the log
+        val localSpanBuilder: DDTracer.DDSpanBuilder = mock()
+        val localSpan: Span = mock(extraInterfaces = arrayOf(MutableSpan::class))
+        whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
+        whenever(localSpanBuilder.start()) doReturn localSpan
+        whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
+        whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
+        whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
+
+        // When
         val countDownLatch = CountDownLatch(2)
         Thread {
             testedInterceptor.intercept(mockChain)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
@@ -26,6 +26,7 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.setStaticValue
 import com.datadog.trace.api.interceptor.MutableSpan
+import com.datadog.trace.api.sampling.PrioritySampling
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.argumentCaptor
@@ -463,6 +464,76 @@ internal open class TracingInterceptorTest {
         }
         verify(mockSpanBuilder).asChildOf(parentSpanContext)
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
+    }
+
+    @Test
+    fun `𝕄 respect sampling decision 𝕎 intercept() {sampled in upstream interceptor}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int,
+        @StringForgery key: String,
+        @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        fakeRequest = forgeRequest(forge) {
+            it.addHeader(
+                TracingInterceptor.SAMPLING_PRIORITY_HEADER,
+                forge.anElementFrom(
+                    PrioritySampling.SAMPLER_KEEP.toString(),
+                    PrioritySampling.USER_KEEP.toString()
+                )
+            )
+        }
+        stubChain(mockChain, statusCode)
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        doAnswer { invocation ->
+            val carrier = invocation.arguments[2] as TextMapInject
+            carrier.put(key, value)
+        }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(key)).isEqualTo(value)
+        }
+    }
+
+    @Test
+    fun `𝕄 respect sampling decision 𝕎 intercept() {sampled out in upstream interceptor}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        fakeRequest = forgeRequest(forge) {
+            it.addHeader(
+                TracingInterceptor.SAMPLING_PRIORITY_HEADER,
+                forge.anElementFrom(
+                    PrioritySampling.SAMPLER_DROP.toString(),
+                    PrioritySampling.USER_DROP.toString()
+                )
+            )
+        }
+        stubChain(mockChain, statusCode)
+        whenever(mockTraceSampler.sample()).thenReturn(true)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(TracingInterceptor.SAMPLING_PRIORITY_HEADER))
+                .isEqualTo("0")
+            assertThat(lastValue.header(TracingInterceptor.TRACE_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.SPAN_ID_HEADER)).isNull()
+        }
+        verifyZeroInteractions(mockTracer, mockLocalTracer, mockSpanBuilder, mockSpan)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
@@ -11,6 +11,8 @@ import android.util.Log
 import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
+import com.datadog.android.core.internal.sampling.RateBasedSampler
+import com.datadog.android.core.internal.sampling.Sampler
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
@@ -108,6 +110,9 @@ internal open class TracingInterceptorTest {
     @Mock
     lateinit var mockDetector: FirstPartyHostDetector
 
+    @Mock
+    lateinit var mockTraceSampler: Sampler
+
     // endregion
 
     // region Fakes
@@ -155,6 +160,7 @@ internal open class TracingInterceptorTest {
         whenever(mockSpan.context()) doReturn mockSpanContext
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
+        whenever(mockTraceSampler.sample()) doReturn true
 
         val mediaType = forge.anElementFrom("application", "image", "text", "model") +
             "/" + forge.anAlphabeticalString()
@@ -181,6 +187,7 @@ internal open class TracingInterceptorTest {
             mockRequestListener,
             mockDetector,
             fakeOrigin,
+            mockTraceSampler,
             factory
         )
     }
@@ -196,7 +203,7 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
-    fun `M instantiate with default callbacks W init()`() {
+    fun `M instantiate with default values W init()`() {
         // When
         val interceptor = TracingInterceptor()
 
@@ -204,10 +211,16 @@ internal open class TracingInterceptorTest {
         assertThat(interceptor.tracedHosts).isEmpty()
         assertThat(interceptor.tracedRequestListener)
             .isInstanceOf(NoOpTracedRequestListener::class.java)
+        assertThat(interceptor.traceSampler)
+            .isInstanceOf(RateBasedSampler::class.java)
+        val traceSampler = interceptor.traceSampler as RateBasedSampler
+        assertThat(traceSampler.sampleRate).isEqualTo(
+            TracingInterceptor.DEFAULT_TRACE_SAMPLING_RATE / 100
+        )
     }
 
     @Test
-    fun `M instantiate with default callbacks W init()`(
+    fun `M instantiate with default values W init()`(
         @StringForgery(regex = "[a-z]+\\.[a-z]{3}") hosts: List<String>
     ) {
         // When
@@ -217,6 +230,12 @@ internal open class TracingInterceptorTest {
         assertThat(interceptor.tracedHosts).containsAll(hosts)
         assertThat(interceptor.tracedRequestListener)
             .isInstanceOf(NoOpTracedRequestListener::class.java)
+        assertThat(interceptor.traceSampler)
+            .isInstanceOf(RateBasedSampler::class.java)
+        val traceSampler = interceptor.traceSampler as RateBasedSampler
+        assertThat(traceSampler.sampleRate).isEqualTo(
+            TracingInterceptor.DEFAULT_TRACE_SAMPLING_RATE / 100
+        )
     }
 
     @Test
@@ -242,6 +261,30 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
+    fun `𝕄 inject non-tracing header 𝕎 intercept() {global known host + not sampled}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        verifyZeroInteractions(mockTracer, mockLocalTracer)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(TracingInterceptor.SAMPLING_PRIORITY_HEADER))
+                .isEqualTo("0")
+            assertThat(lastValue.header(TracingInterceptor.TRACE_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.SPAN_ID_HEADER)).isNull()
+        }
+    }
+
+    @Test
     fun `𝕄 inject tracing header 𝕎 intercept() {local known host}`(
         @StringForgery key: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
@@ -263,6 +306,33 @@ internal open class TracingInterceptorTest {
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
             assertThat(firstValue.headers(key)).containsOnly(value)
+        }
+    }
+
+    @Test
+    fun `𝕄 inject non-tracing header 𝕎 intercept() {local known host + not sampled}`(
+        @IntForgery(min = 200, max = 600) statusCode: Int,
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts))
+        fakeRequest = forgeRequest(forge)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        verifyZeroInteractions(mockTracer, mockLocalTracer)
+        argumentCaptor<Request> {
+            verify(mockChain).proceed(capture())
+            assertThat(lastValue.header(TracingInterceptor.SAMPLING_PRIORITY_HEADER))
+                .isEqualTo("0")
+            assertThat(lastValue.header(TracingInterceptor.TRACE_ID_HEADER)).isNull()
+            assertThat(lastValue.header(TracingInterceptor.SPAN_ID_HEADER)).isNull()
         }
     }
 
@@ -393,6 +463,23 @@ internal open class TracingInterceptorTest {
         }
         verify(mockSpanBuilder).asChildOf(parentSpanContext)
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
+    }
+
+    @Test
+    fun `𝕄 not create a span 𝕎 intercept() { not sampled }`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        assertThat(response).isSameAs(fakeResponse)
+        verifyZeroInteractions(mockTracer, mockSpan, mockSpanBuilder, mockLocalTracer)
     }
 
     @Test
@@ -666,6 +753,23 @@ internal open class TracingInterceptorTest {
     }
 
     @Test
+    fun `𝕄 not call the listener 𝕎 intercept() for completed request { not sampled }`(
+        @IntForgery(min = 200, max = 600) statusCode: Int
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        stubChain(mockChain, statusCode)
+
+        // When
+        val response = testedInterceptor.intercept(mockChain)
+
+        // Then
+        verifyZeroInteractions(mockRequestListener)
+        assertThat(response).isSameAs(fakeResponse)
+    }
+
+    @Test
     fun `𝕄 call the listener 𝕎 intercept() for throwing request`(
         @Forgery throwable: Throwable,
         @StringForgery tagKey: String,
@@ -694,6 +798,23 @@ internal open class TracingInterceptorTest {
         verify(mockSpan).setTag("error.stack", throwable.loggableStackTrace())
         verify(mockSpan).setTag(tagKey, tagValue)
         verify(mockSpan).finish()
+    }
+
+    @Test
+    fun `𝕄 not call the listener 𝕎 intercept() for throwing request { not sampled }`(
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockChain.request()) doReturn fakeRequest
+        whenever(mockChain.proceed(any())) doThrow throwable
+
+        assertThrows<Throwable>(throwable.message.orEmpty()) {
+            testedInterceptor.intercept(mockChain)
+        }
+
+        verifyZeroInteractions(mockRequestListener)
     }
 
     @Test
@@ -741,6 +862,7 @@ internal open class TracingInterceptorTest {
     fun `𝕄 create only one local tracer 𝕎 intercept() called from multiple threads`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
+        // Given
         var called = 0
         testedInterceptor = instantiateTestedInterceptor {
             called++
@@ -750,6 +872,17 @@ internal open class TracingInterceptorTest {
         whenever(mockDetector.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
         stubChain(mockChain, statusCode)
 
+        // need this setup, otherwise #intercept actually throws NPE, which pollutes the log
+        val localSpanBuilder: DDTracer.DDSpanBuilder = mock()
+        val localSpan: Span = mock(extraInterfaces = arrayOf(MutableSpan::class))
+        whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
+        whenever(localSpanBuilder.start()) doReturn localSpan
+        whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
+        whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
+        whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
+
+        // When
         val countDownLatch = CountDownLatch(2)
         Thread {
             testedInterceptor.intercept(mockChain)

--- a/detekt.yml
+++ b/detekt.yml
@@ -1074,6 +1074,7 @@ datadog:
       - "kotlin.String.substringBefore(kotlin.Char, kotlin.String)"
       - "kotlin.String.toByteArray(java.nio.charset.Charset) "
       - "kotlin.String.toByteArray(java.nio.charset.Charset)"
+      - "kotlin.String.toIntOrNull()"
       - "kotlin.String.toDoubleOrNull()"
       - "kotlin.String.toLongOrNull()"
       - "kotlin.String.toMethod()"

--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -435,21 +435,28 @@ If you want to trace your OkHttp requests, you can add the provided [Interceptor
 {{< tabs >}}
 {{% tab "Kotlin" %}}
 ```kotlin
-val okHttpClient =  OkHttpClient.Builder() 
-        .addInterceptor(DatadogInterceptor(listOf("example.com", "example.eu")))
+val okHttpClient = OkHttpClient.Builder() 
+        .addInterceptor(
+            DatadogInterceptor(listOf("example.com", "example.eu"), traceSamplingRate = 20f)
+        )
         .build()
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
 ```java
+float traceSamplingRate = 20f;
 final OkHttpClient okHttpClient =  new OkHttpClient.Builder() 
-        .addInterceptor(new DatadogInterceptor(Arrays.asList("example.com", "example.eu")))
+        .addInterceptor(
+                new DatadogInterceptor(Arrays.asList("example.com", "example.eu"), traceSamplingRate)
+        )
         .build();
 ```
 {{% /tab %}}
 {{< /tabs >}}
 
 This creates a span around each request processed by the OkHttpClient (matching the provided hosts), with all the relevant information automatically filled (URL, method, status code, error), and propagates the tracing information to your backend to get a unified trace within Datadog.
+
+Network traces are sampled with an adjustable sampling rate. A sampling of 20% is applied by default.
 
 The interceptor tracks requests at the application level. You can also add a `TracingInterceptor` at the network level to get more details, for example when following redirections.
 
@@ -458,17 +465,18 @@ The interceptor tracks requests at the application level. You can also add a `Tr
 ```kotlin
 val tracedHosts = listOf("example.com", "example.eu") 
 val okHttpClient =  OkHttpClient.Builder()
-        .addInterceptor(DatadogInterceptor(tracedHosts))
-        .addNetworkInterceptor(TracingInterceptor(tracedHosts))
+        .addInterceptor(DatadogInterceptor(tracedHosts, traceSamplingRate = 20f))
+        .addNetworkInterceptor(TracingInterceptor(tracedHosts, traceSamplingRate = 20f))
         .build()
 ```
 {{% /tab %}}
 {{% tab "Java" %}}
 ```java
+float traceSamplingRate = 20f;
 final List<String> tracedHosts = Arrays.asList("example.com", "example.eu"); 
 final OkHttpClient okHttpClient =  new OkHttpClient.Builder()
-        .addInterceptor(new DatadogInterceptor(tracedHosts))
-        .addNetworkInterceptor(new TracingInterceptor(tracedHosts))
+        .addInterceptor(new DatadogInterceptor(tracedHosts, traceSamplingRate))
+        .addNetworkInterceptor(new TracingInterceptor(tracedHosts, traceSamplingRate))
         .build();
 ```
 {{% /tab %}}

--- a/docs/trace_collection.md
+++ b/docs/trace_collection.md
@@ -482,6 +482,8 @@ final OkHttpClient okHttpClient =  new OkHttpClient.Builder()
 {{% /tab %}}
 {{< /tabs >}}
 
+In this case trace sampling decision made by the upstream interceptor for a particular request will be respected by the downstream interceptor.
+
 Because the way the OkHttp Request is executed (using a Thread pool), the request span won't be automatically linked with the span that triggered the request. You can manually provide a parent span in the `OkHttp Request.Builder` as follows:
 
 {{< tabs >}}

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumResourceTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumResourceTrackingE2ETests.kt
@@ -15,6 +15,7 @@ import com.datadog.android.nightly.activities.ResourceTrackingCustomAttributesAc
 import com.datadog.android.nightly.activities.ResourceTrackingCustomSpanAttributesActivity
 import com.datadog.android.nightly.activities.ResourceTrackingFirstPartyHostsActivity
 import com.datadog.android.nightly.activities.ResourceTrackingNetworkInterceptorActivity
+import com.datadog.android.nightly.activities.ResourceTrackingTraceSamplingActivity
 import com.datadog.android.nightly.rules.NightlyTestRule
 import com.datadog.android.nightly.utils.defaultConfigurationBuilder
 import com.datadog.android.nightly.utils.initializeSdk
@@ -34,7 +35,7 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
+     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      */
     @Test
     fun rum_resource_tracking() {
@@ -58,8 +59,8 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
-     * apiMethodSignature: com.datadog.android.DatadogInterceptor#constructor(List<String>, com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
+     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.DatadogInterceptor#constructor(List<String>, com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      */
     @Test
     fun rum_resource_tracking_with_custom_attributes() {
@@ -83,9 +84,9 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.tracing.TracingInterceptor#constructor(TracedRequestListener = NoOpTracedRequestListener())
-     * apiMethodSignature: com.datadog.android.DatadogInterceptor#constructor(com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
-     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
+     * apiMethodSignature: com.datadog.android.tracing.TracingInterceptor#constructor(TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.DatadogInterceptor#constructor(com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setFirstPartyHosts(List<String>): Builder
      */
     @Test
@@ -115,8 +116,8 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
-     * apiMethodSignature: com.datadog.android.tracing.TracingInterceptor#constructor(List<String>, TracedRequestListener = NoOpTracedRequestListener())
+     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.tracing.TracingInterceptor#constructor(List<String>, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      */
     @Test
     fun rum_resource_tracking_with_network_interceptor() {
@@ -143,8 +144,8 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
-     * apiMethodSignature: com.datadog.android.DatadogInterceptor#constructor(List<String>, com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider())
+     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.DatadogInterceptor#constructor(List<String>, com.datadog.android.tracing.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setFirstPartyHosts(List<String>): Builder
      */
     @Test
@@ -167,5 +168,32 @@ internal class RumResourceTrackingE2ETests {
             )
         }
         launch(ResourceTrackingCustomSpanAttributesActivity::class.java)
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
+     * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
+     * apiMethodSignature: com.datadog.android.rum.RumInterceptor#constructor(List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     */
+    @Test
+    fun rum_resource_tracking_trace_sampling_75_percent() {
+        // this test is backed by 2 monitors:
+        // 1. RUM monitor - it should check that number of RUM resources is not affected by sampling
+        // 2. APM monitor - number of traces should be affected by sampling
+        measureSdkInitialize {
+            val config = defaultConfigurationBuilder(
+                logsEnabled = true,
+                tracesEnabled = true,
+                crashReportsEnabled = true,
+                rumEnabled = true
+            )
+                .useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
+                .build()
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                config = config
+            )
+        }
+        launch(ResourceTrackingTraceSamplingActivity::class.java)
     }
 }

--- a/instrumented/nightly-tests/src/main/AndroidManifest.xml
+++ b/instrumented/nightly-tests/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
         <activity android:name=".activities.ResourceTrackingCustomSpanAttributesActivity"/>
         <activity android:name=".activities.ResourceTrackingNetworkInterceptorActivity"/>
         <activity android:name=".activities.ResourceTrackingFirstPartyHostsActivity"/>
+        <activity android:name=".activities.ResourceTrackingTraceSamplingActivity"/>
         <activity android:name=".activities.WebViewTrackingActivity"/>
         <activity android:name=".activities.WebViewTrackingBridgeHostsActivity"/>
         <service

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingActivity.kt
@@ -23,7 +23,7 @@ internal open class ResourceTrackingActivity : AppCompatActivity() {
 
     open val okHttpClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
-            .addInterceptor(RumInterceptor())
+            .addInterceptor(RumInterceptor(traceSamplingRate = 100f))
             .build()
     }
     open val randomUrl: String = RANDOM_URL

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingCustomAttributesActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingCustomAttributesActivity.kt
@@ -34,7 +34,8 @@ internal class ResourceTrackingCustomAttributesActivity : ResourceTrackingActivi
                                 SPECIAL_NULL_ATTRIBUTE_NAME to null
                             )
                         }
-                    }
+                    },
+                    traceSamplingRate = 100f
                 )
             )
             .build()

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingCustomSpanAttributesActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingCustomSpanAttributesActivity.kt
@@ -17,7 +17,7 @@ import okhttp3.Response
 internal class ResourceTrackingCustomSpanAttributesActivity : ResourceTrackingActivity() {
     override val okHttpClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
-            .addInterceptor(RumInterceptor())
+            .addInterceptor(RumInterceptor(traceSamplingRate = 100f))
             .addNetworkInterceptor(
                 TracingInterceptor(
                     listOf(HOST),
@@ -30,7 +30,8 @@ internal class ResourceTrackingCustomSpanAttributesActivity : ResourceTrackingAc
                         ) {
                             span.setOperationName(TEST_METHOD_NAME)
                         }
-                    }
+                    },
+                    traceSamplingRate = 100f
                 )
             )
             .build()

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingNetworkInterceptorActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingNetworkInterceptorActivity.kt
@@ -17,13 +17,14 @@ internal class ResourceTrackingNetworkInterceptorActivity : ResourceTrackingActi
 
     override val okHttpClient: OkHttpClient by lazy {
         OkHttpClient.Builder()
-            .addInterceptor(RumInterceptor())
+            .addInterceptor(RumInterceptor(traceSamplingRate = 100f))
             .addNetworkInterceptor(
                 TracingInterceptor(
                     listOf(
                         HOST,
                         LocalServer.HOST
-                    )
+                    ),
+                    traceSamplingRate = 100f
                 )
             )
             .build()

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingTraceSamplingActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingTraceSamplingActivity.kt
@@ -1,0 +1,80 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.activities
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.datadog.android.nightly.R
+import com.datadog.android.nightly.server.LocalServer
+import com.datadog.android.rum.RumInterceptor
+import fr.xgouchet.elmyr.Forge
+import io.ktor.http.HttpStatusCode
+import io.ktor.response.respond
+import java.io.IOException
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import okhttp3.Call
+import okhttp3.Callback
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.Response
+
+internal class ResourceTrackingTraceSamplingActivity : AppCompatActivity() {
+
+    private val localServer: LocalServer by lazy { LocalServer() }
+
+    private val forge = Forge()
+
+    private val okHttpClient: OkHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor(
+                RumInterceptor(
+                    listOf(LocalServer.HOST),
+                    // 75% of the RUM resources sent should have traces included
+                    traceSamplingRate = 75f
+                )
+            )
+            .build()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.tracking_strategy_activity)
+    }
+
+    override fun onResume() {
+        super.onResume()
+        val callsNumber = 100
+        val countDownLatch = CountDownLatch(callsNumber)
+        localServer.start { it.respond(HttpStatusCode.OK, "{}") }
+        repeat(callsNumber) {
+            okHttpClient
+                .newCall(
+                    Request.Builder()
+                        .url(localServer.getUrl() + "#${forge.anAlphabeticalString()}")
+                        .build()
+                )
+                .enqueue(
+                    object : Callback {
+                        override fun onFailure(call: Call, e: IOException) {
+                            countDownLatch.countDown()
+                        }
+
+                        override fun onResponse(call: Call, response: Response) {
+                            countDownLatch.countDown()
+                        }
+                    }
+                )
+        }
+        countDownLatch.await(2, TimeUnit.MINUTES)
+    }
+
+    override fun onPause() {
+        localServer.stop()
+        super.onPause()
+    }
+}

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -56,8 +56,8 @@ class SampleApplication : Application() {
     )
 
     private val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(RumInterceptor())
-        .addNetworkInterceptor(TracingInterceptor())
+        .addInterceptor(RumInterceptor(traceSamplingRate = 100f))
+        .addNetworkInterceptor(TracingInterceptor(traceSamplingRate = 100f))
         .eventListenerFactory(DatadogEventListener.Factory())
         .build()
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/picture/SampleGlideModule.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/picture/SampleGlideModule.kt
@@ -19,8 +19,6 @@ class SampleGlideModule : DatadogGlideModule(listOf("shopist.io")) {
     override fun applyOptions(context: Context, builder: GlideBuilder) {
         super.applyOptions(context, builder)
 
-        val size10mb = 10485760L
-        val factory = InternalCacheDiskCacheFactory(context, "glide", size10mb)
         builder.setMemoryCache(LruResourceCache(1))
         builder.setLogLevel(Log.VERBOSE)
     }


### PR DESCRIPTION
### What does this PR do?

This change adds the trace sampling for auto-instrumented network requests (instrumentation via `TracingInterceptor`, `RumInterceptor` and `DatadogInterceptor`) by adding `x-datadog-sampling-priority` header to the outgoing requests which may have a value of `1` (keep) or `0` (drop). This header will later be parsed on the backend side and sampling decision will be respected for the services downstream.

Sampler will make a decision if request should be traced (by injecting tracing headers) or not. This will allow customer to control amount of traces created directly (via `TracingInterceptor`) or indirectly (via RUM2APM integration in case of `DatadogInterceptor` or `RumInterceptor`), which is necessary to align with a new billing model. Default trace sampling is set to 20%.

The sampling is applied **only** to the tracing part of the tracking, meaning that if, for example, trace sampling rate is 75% and 100 requests were made, in case of `DatadogInterceptor` or `RumInterceptor` it will be 100 RUM resources created, but only 75 spans roughly.

Also this change removes `x-datadog-sampled` header, which is not really used.

Generally, we can add the sampling priority information to the span in the following way:

* If span is `MutableSpan`, we can use `MutableSpan#setSamplingPriority`
* We can also use `Span#setTag` with values `Tags.MANUAL_KEEP` (or `MANUAL_DROP`)

The problem is that in the former case `MutableSpan` exists only for spans created by Datadog tracer, but we need also support non-Datadog tracers, so we cannot rely on this interface. In the latter case there is no way to read a tag from the span and it is also not available in the `SpanContext` interface.

So in this implementation we have to access `x-datadog-sampling-priority` header directly for reading/writing sampling decision instead of relying on the `Span` (and we need to add it explicitly anyway even if non-Datadog tracer is used, because in the end data is sent to the Datadog servers anyway).

Also this PR includes commit https://github.com/DataDog/dd-sdk-android/commit/2a08eaebd70e2b0b7159db0dd4c00ab4a4286c15 which is optional and can be discussed - it just makes chained interceptors respect sampling decision for the request which was made in the upstream interceptor.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

