### PR TITLE
Don't report telemetry for unknown web events

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/MixedWebViewEventConsumer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/MixedWebViewEventConsumer.kt
@@ -41,7 +41,7 @@ internal class MixedWebViewEventConsumer(
                     rumEventConsumer.consume(wrappedEvent)
                 }
                 else -> {
-                    sdkLogger.errorWithTelemetry(
+                    sdkLogger.e(
                         WRONG_EVENT_TYPE_ERROR_MESSAGE.format(US, eventType)
                     )
                 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/MixedWebViewEventConsumerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/MixedWebViewEventConsumerTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.webview
 
+import android.util.Log
 import com.datadog.android.log.internal.utils.ERROR_WITH_TELEMETRY_LEVEL
 import com.datadog.android.utils.assertj.JsonElementAssert.Companion.assertThat
 import com.datadog.android.utils.config.LoggerTestConfiguration
@@ -138,7 +139,7 @@ internal class MixedWebViewEventConsumerTest {
 
         // Then
         verify(logger.mockSdkLogHandler).handleLog(
-            ERROR_WITH_TELEMETRY_LEVEL,
+            Log.ERROR,
             MixedWebViewEventConsumer.WRONG_EVENT_TYPE_ERROR_MESSAGE.format(
                 US,
                 fakeUnknownEventType


### PR DESCRIPTION
### What does this PR do?

Remove telemetry reporting for unknown web events, because Browser SDK can be way ahead of Android SDK.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

