### PR TITLE
RUMM-2229 Prepare release version 1.13.0-no-name

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -17,7 +17,7 @@ object AndroidConfig {
     const val MIN_SDK_FOR_COMPOSE = 21
     const val BUILD_TOOLS_VERSION = "31.0.0"
 
-    val VERSION = Version(1, 13, 0, Version.Type.ReleaseCandidate(1))
+    val VERSION = Version(1, 13, 0, Version.Type.Custom("no-nav"))
 }
 
 @Suppress("UnstableApiUsage")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/utils/Version.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/utils/Version.kt
@@ -38,6 +38,10 @@ data class Version(
         object Dev : Type() {
             override val suffix: String = "-dev"
         }
+
+        class Custom(val name: String) : Type() {
+            override val suffix: String = "-$name"
+        }
     }
 
     // endregion

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/utils/VersionTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/utils/VersionTest.kt
@@ -88,4 +88,11 @@ class VersionTest {
         val expected = "3.12.7-dev"
         assert(name == expected) { " expected name to be $expected but was $name" }
     }
+
+    @Test
+    fun addSuffixForCustom() {
+        val name = Version(3, 12, 7, Version.Type.Custom("foo")).name
+        val expected = "3.12.7-foo"
+        assert(name == expected) { " expected name to be $expected but was $name" }
+    }
 }


### PR DESCRIPTION
### What does this PR do?

Prepare the release version name for artefacts without navigation components

### Motivation

See #941
