### PR TITLE
RUMM-2186: Write batch metadata

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1497,7 +1497,7 @@ data class com.datadog.android.tracing.model.SpanEvent
       fun fromJson(kotlin.String): SimCarrier
 interface com.datadog.android.v2.api.EventBatchWriter
   fun currentMetadata(): ByteArray?
-  fun write(ByteArray, String, ByteArray)
+  fun write(ByteArray, String, ByteArray?)
 interface com.datadog.android.v2.api.FeatureConfiguration
   fun register(SDKCore)
 interface com.datadog.android.v2.api.FeatureScope

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataFlusher.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataFlusher.kt
@@ -9,14 +9,14 @@ package com.datadog.android.core.internal.data.upload
 import androidx.annotation.WorkerThread
 import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.persistence.PayloadDecoration
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.utils.join
 
 internal class DataFlusher(
     internal val fileOrchestrator: FileOrchestrator,
     internal val decoration: PayloadDecoration,
-    internal val handler: FileHandler
+    internal val handler: ChunkedFileHandler
 ) : Flusher {
 
     @WorkerThread

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/ChunkedFileHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/ChunkedFileHandler.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence.file
+
+import androidx.annotation.WorkerThread
+import java.io.File
+
+// TODO RUMM-2235 Rework file persistence classes/interfaces
+/**
+ * A sub-class of [FileHandler] dedicated to the reading files in a format which assumes file
+ * contains multiple data chunks.
+ */
+internal interface ChunkedFileHandler : FileHandler {
+
+    /**
+     * Reads data from the given file.
+     *  @param file the file to read from
+     *  @return the list of events as [ByteArray] data stored in a file.
+     */
+    @WorkerThread
+    fun readData(
+        file: File
+    ): List<ByteArray>
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileHandler.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.persistence.file
 import androidx.annotation.WorkerThread
 import java.io.File
 
+// TODO RUMM-2235 Rework file persistence classes/interfaces
 /**
  * A class used for direct file manipulation on disk.
  */
@@ -27,16 +28,6 @@ internal interface FileHandler {
         data: ByteArray,
         append: Boolean
     ): Boolean
-
-    /**
-     * Reads data from the given file.
-     *  @param file the file to read from
-     *  @return the list of events as [ByteArray] data stored in a file.
-     */
-    @WorkerThread
-    fun readData(
-        file: File
-    ): List<ByteArray>
 
     /**
      * Deletes the file or directory (recursively if needed).

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileOrchestrator.kt
@@ -21,12 +21,11 @@ import java.io.File
 internal interface FileOrchestrator {
 
     /**
-     * @param dataSize the size of the data to write (in bytes)
-     * @return a File with enough space to write `dataSize` bytes, or null if no space is available
+     * @return a File with enough space to write data, or null if no space is available
      * or the disk can't be written to.
      */
     @WorkerThread
-    fun getWritableFile(dataSize: Int): File?
+    fun getWritableFile(): File?
 
     /**
      * @param excludeFiles a set of files to exclude from the readable files

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/SingleItemFileHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/SingleItemFileHandler.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence.file
+
+import androidx.annotation.WorkerThread
+import java.io.File
+
+// TODO RUMM-2235 Rework file persistence classes/interfaces
+/**
+ * A sub-class of [FileHandler] dedicated to the reading files in a format which assumes file
+ * contains single data chunk.
+ */
+internal interface SingleItemFileHandler : FileHandler {
+
+    /**
+     * Reads data from the given file.
+     *  @param file the file to read from
+     *  @return the data
+     */
+    @WorkerThread
+    fun readData(
+        file: File
+    ): ByteArray
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/CacheFileMigrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/CacheFileMigrator.kt
@@ -7,14 +7,14 @@
 package com.datadog.android.core.internal.persistence.file.advanced
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.log.Logger
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.RejectedExecutionException
 
 internal class CacheFileMigrator(
-    private val fileHandler: FileHandler,
+    private val fileHandler: ChunkedFileHandler,
     private val executorService: ExecutorService,
     private val internalLogger: Logger
 ) : DataMigrator<Boolean> {
@@ -39,7 +39,11 @@ internal class CacheFileMigrator(
             fileHandler,
             internalLogger
         )
-        val deleteOperation = WipeDataMigrationOperation(sourceDir, fileHandler, internalLogger)
+        val deleteOperation = WipeDataMigrationOperation(
+            sourceDir,
+            fileHandler,
+            internalLogger
+        )
 
         try {
             @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileMigrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileMigrator.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.core.internal.persistence.file.advanced
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.Logger
@@ -17,7 +17,7 @@ import java.util.concurrent.ExecutorService
 import java.util.concurrent.RejectedExecutionException
 
 internal class ConsentAwareFileMigrator(
-    private val fileHandler: FileHandler,
+    private val fileHandler: ChunkedFileHandler,
     private val executorService: ExecutorService,
     private val internalLogger: Logger
 ) : DataMigrator<TrackingConsent> {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
@@ -33,8 +33,8 @@ internal open class ConsentAwareFileOrchestrator(
     // region FileOrchestrator
 
     @WorkerThread
-    override fun getWritableFile(dataSize: Int): File? {
-        return delegateOrchestrator.getWritableFile(dataSize)
+    override fun getWritableFile(): File? {
+        return delegateOrchestrator.getWritableFile()
     }
 
     @WorkerThread

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/MoveDataMigrationOperation.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/MoveDataMigrationOperation.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.core.internal.persistence.file.advanced
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.utils.retryWithDelay
 import com.datadog.android.log.Logger
 import java.io.File
@@ -20,7 +20,7 @@ import java.util.concurrent.TimeUnit
 internal class MoveDataMigrationOperation(
     internal val fromDir: File?,
     internal val toDir: File?,
-    internal val fileHandler: FileHandler,
+    internal val fileHandler: ChunkedFileHandler,
     internal val internalLogger: Logger
 ) : DataMigrationOperation {
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/WipeDataMigrationOperation.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/WipeDataMigrationOperation.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.core.internal.persistence.file.advanced
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.utils.retryWithDelay
 import com.datadog.android.log.Logger
 import java.io.File
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeUnit
  */
 internal class WipeDataMigrationOperation(
     internal val targetDir: File?,
-    internal val fileHandler: FileHandler,
+    internal val fileHandler: ChunkedFileHandler,
     internal val internalLogger: Logger
 ) : DataMigrationOperation {
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileDataReader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileDataReader.kt
@@ -10,7 +10,7 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.core.internal.persistence.Batch
 import com.datadog.android.core.internal.persistence.DataReader
 import com.datadog.android.core.internal.persistence.PayloadDecoration
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.utils.join
 import com.datadog.android.log.Logger
@@ -23,7 +23,7 @@ import java.util.Locale
 internal class BatchFileDataReader(
     internal val fileOrchestrator: FileOrchestrator,
     internal val decoration: PayloadDecoration,
-    internal val handler: FileHandler,
+    internal val handler: ChunkedFileHandler,
     internal val internalLogger: Logger
 ) : DataReader {
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileHandler.kt
@@ -7,9 +7,8 @@
 package com.datadog.android.core.internal.persistence.file.batch
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.core.internal.persistence.file.EncryptedFileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.EventMeta
-import com.datadog.android.core.internal.persistence.file.FileHandler
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.isDirectorySafe
 import com.datadog.android.core.internal.persistence.file.lengthSafe
@@ -39,7 +38,7 @@ internal class BatchFileHandler(
     private val metaParser: (metaBytes: ByteArray) -> EventMeta = {
         EventMeta.fromBytes(it)
     }
-) : FileHandler {
+) : ChunkedFileHandler {
 
     // region FileHandler
 
@@ -310,13 +309,13 @@ internal class BatchFileHandler(
 
         /**
          * Creates either plain [BatchFileHandler] or [BatchFileHandler] wrapped in
-         * [EncryptedFileHandler] if encryption is provided.
+         * [EncryptedBatchFileHandler] if encryption is provided.
          */
-        fun create(internalLogger: Logger, encryption: Encryption?): FileHandler {
+        fun create(internalLogger: Logger, encryption: Encryption?): ChunkedFileHandler {
             return if (encryption == null) {
                 BatchFileHandler(internalLogger)
             } else {
-                EncryptedFileHandler(encryption, BatchFileHandler(internalLogger))
+                EncryptedBatchFileHandler(encryption, BatchFileHandler(internalLogger))
             }
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategy.kt
@@ -13,7 +13,7 @@ import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.persistence.Serializer
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.advanced.ScheduledWriter
 import com.datadog.android.log.Logger
@@ -25,7 +25,7 @@ internal open class BatchFilePersistenceStrategy<T : Any>(
     serializer: Serializer<T>,
     private val payloadDecoration: PayloadDecoration,
     internalLogger: Logger,
-    internal val fileHandler: FileHandler
+    internal val fileHandler: ChunkedFileHandler
 ) : PersistenceStrategy<T> {
 
     private val fileWriter: DataWriter<T> by lazy {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchFileHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchFileHandler.kt
@@ -4,17 +4,19 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.core.internal.persistence.file
+package com.datadog.android.core.internal.persistence.file.batch
 
 import androidx.annotation.WorkerThread
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.security.Encryption
 import java.io.File
 
-internal class EncryptedFileHandler(
+// TODO RUMM-2235 Rework file persistence classes/interfaces
+internal class EncryptedBatchFileHandler(
     internal val encryption: Encryption,
-    internal val delegate: FileHandler
-) : FileHandler by delegate {
+    internal val delegate: ChunkedFileHandler
+) : ChunkedFileHandler by delegate {
 
     @WorkerThread
     override fun writeData(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/EncryptedSingleItemFileHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/EncryptedSingleItemFileHandler.kt
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence.file.single
+
+import androidx.annotation.WorkerThread
+import com.datadog.android.core.internal.persistence.file.SingleItemFileHandler
+import com.datadog.android.core.internal.utils.devLogger
+import com.datadog.android.security.Encryption
+import java.io.File
+
+// TODO RUMM-2235 Rework file persistence classes/interfaces
+internal class EncryptedSingleItemFileHandler(
+    internal val encryption: Encryption,
+    internal val delegate: SingleItemFileHandler
+) : SingleItemFileHandler by delegate {
+
+    @WorkerThread
+    override fun writeData(
+        file: File,
+        data: ByteArray,
+        append: Boolean
+    ): Boolean {
+        val encryptedData = encryption.encrypt(data)
+
+        if (data.isNotEmpty() && encryptedData.isEmpty()) {
+            devLogger.e(BAD_ENCRYPTION_RESULT_MESSAGE)
+            return false
+        }
+
+        return delegate.writeData(
+            file,
+            encryptedData,
+            append
+        )
+    }
+
+    @WorkerThread
+    override fun readData(
+        file: File
+    ): ByteArray {
+        return encryption.decrypt(delegate.readData(file))
+    }
+
+    companion object {
+        internal const val BAD_ENCRYPTION_RESULT_MESSAGE = "Encryption of non-empty data produced" +
+            " empty result, aborting write operation."
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/PlainFileHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/PlainFileHandler.kt
@@ -1,0 +1,148 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence.file.single
+
+import androidx.annotation.WorkerThread
+import com.datadog.android.core.internal.persistence.file.SingleItemFileHandler
+import com.datadog.android.core.internal.persistence.file.existsSafe
+import com.datadog.android.core.internal.persistence.file.isDirectorySafe
+import com.datadog.android.core.internal.persistence.file.listFilesSafe
+import com.datadog.android.core.internal.persistence.file.mkdirsSafe
+import com.datadog.android.core.internal.persistence.file.readBytesSafe
+import com.datadog.android.core.internal.persistence.file.renameToSafe
+import com.datadog.android.core.internal.utils.use
+import com.datadog.android.log.Logger
+import com.datadog.android.log.internal.utils.errorWithTelemetry
+import com.datadog.android.security.Encryption
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.FileOutputStream
+import java.io.IOException
+import java.util.Locale
+
+// TODO RUMM-2235 Rework file persistence classes/interfaces
+// This file may go away after rework, not adding tests for now (it is a simplified copy of
+// BatchFileHandler)
+@Suppress("unused")
+internal class PlainFileHandler(
+    private val internalLogger: Logger
+) : SingleItemFileHandler {
+
+    // region FileHandler
+
+    @WorkerThread
+    override fun writeData(
+        file: File,
+        data: ByteArray,
+        append: Boolean
+    ): Boolean {
+        return try {
+            lockFileAndWriteData(file, append, data)
+            true
+        } catch (e: IOException) {
+            internalLogger.errorWithTelemetry(ERROR_WRITE.format(Locale.US, file.path), e)
+            false
+        } catch (e: SecurityException) {
+            internalLogger.errorWithTelemetry(ERROR_WRITE.format(Locale.US, file.path), e)
+            false
+        }
+    }
+
+    @WorkerThread
+    override fun readData(
+        file: File
+    ): ByteArray {
+        return file.readBytesSafe() ?: ByteArray(0)
+    }
+
+    @WorkerThread
+    override fun delete(target: File): Boolean {
+        return try {
+            target.deleteRecursively()
+        } catch (e: FileNotFoundException) {
+            internalLogger.errorWithTelemetry(ERROR_DELETE.format(Locale.US, target.path), e)
+            false
+        } catch (e: SecurityException) {
+            internalLogger.errorWithTelemetry(ERROR_DELETE.format(Locale.US, target.path), e)
+            false
+        }
+    }
+
+    @WorkerThread
+    override fun moveFiles(srcDir: File, destDir: File): Boolean {
+        if (!srcDir.existsSafe()) {
+            internalLogger.i(INFO_MOVE_NO_SRC.format(Locale.US, srcDir.path))
+            return true
+        }
+        if (!srcDir.isDirectorySafe()) {
+            internalLogger.errorWithTelemetry(ERROR_MOVE_NOT_DIR.format(Locale.US, srcDir.path))
+            return false
+        }
+        if (!destDir.existsSafe()) {
+            if (!destDir.mkdirsSafe()) {
+                internalLogger.errorWithTelemetry(ERROR_MOVE_NO_DST.format(Locale.US, srcDir.path))
+                return false
+            }
+        } else if (!destDir.isDirectorySafe()) {
+            internalLogger.errorWithTelemetry(ERROR_MOVE_NOT_DIR.format(Locale.US, destDir.path))
+            return false
+        }
+
+        val srcFiles = srcDir.listFilesSafe().orEmpty()
+        return srcFiles.all { file -> moveFile(file, destDir) }
+    }
+
+    // endregion
+
+    // region Internal
+
+    @Throws(IOException::class)
+    @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
+    private fun lockFileAndWriteData(
+        file: File,
+        append: Boolean,
+        data: ByteArray
+    ) {
+        FileOutputStream(file, append).use { outputStream ->
+            outputStream.channel.lock().use {
+                outputStream.write(data)
+            }
+        }
+    }
+
+    private fun moveFile(file: File, destDir: File): Boolean {
+        val destFile = File(destDir, file.name)
+        return file.renameToSafe(destFile)
+    }
+
+    // endregion
+
+    @Suppress("StringLiteralDuplication")
+    companion object {
+
+        internal const val ERROR_WRITE = "Unable to write data to file: %s"
+        internal const val ERROR_DELETE = "Unable to delete file: %s"
+        internal const val INFO_MOVE_NO_SRC = "Unable to move files; " +
+            "source directory does not exist: %s"
+        internal const val ERROR_MOVE_NOT_DIR = "Unable to move files; " +
+            "file is not a directory: %s"
+        internal const val ERROR_MOVE_NO_DST = "Unable to move files; " +
+            "could not create directory: %s"
+
+        /**
+         * Creates either plain [PlainFileHandler] or [PlainFileHandler] wrapped in
+         * [EncryptedSingleItemFileHandler] if encryption is provided.
+         */
+        fun create(internalLogger: Logger, encryption: Encryption?): SingleItemFileHandler {
+            return if (encryption == null) {
+                PlainFileHandler(internalLogger)
+            } else {
+                EncryptedSingleItemFileHandler(encryption, PlainFileHandler(internalLogger))
+            }
+        }
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleFileOrchestrator.kt
@@ -18,7 +18,7 @@ internal class SingleFileOrchestrator(
     // region FileOrchestrator
 
     @WorkerThread
-    override fun getWritableFile(dataSize: Int): File? {
+    override fun getWritableFile(): File? {
         file.parentFile?.mkdirsSafe()
         return file
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleItemDataWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/single/SingleItemDataWriter.kt
@@ -9,16 +9,21 @@ package com.datadog.android.core.internal.persistence.file.single
 import androidx.annotation.WorkerThread
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.Serializer
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
+import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.serializeToByteArray
 import com.datadog.android.log.Logger
+import com.datadog.android.log.internal.utils.errorWithTelemetry
+import java.util.Locale
 
 internal open class SingleItemDataWriter<T : Any>(
     internal val fileOrchestrator: FileOrchestrator,
     internal val serializer: Serializer<T>,
-    internal val handler: FileHandler,
-    internal val internalLogger: Logger
+    internal val handler: ChunkedFileHandler,
+    internal val internalLogger: Logger,
+    // TODO RUMM-0000 don't use default value
+    internal val filePersistenceConfig: FilePersistenceConfig = FilePersistenceConfig()
 ) : DataWriter<T> {
 
     // region DataWriter
@@ -49,9 +54,29 @@ internal open class SingleItemDataWriter<T : Any>(
 
     @WorkerThread
     private fun writeData(byteArray: ByteArray): Boolean {
-        val file = fileOrchestrator.getWritableFile(byteArray.size) ?: return false
+        if (!checkEventSize(byteArray.size)) return false
+
+        val file = fileOrchestrator.getWritableFile() ?: return false
         return handler.writeData(file, byteArray, false)
     }
 
+    private fun checkEventSize(eventSize: Int): Boolean {
+        if (eventSize > filePersistenceConfig.maxItemSize) {
+            internalLogger.errorWithTelemetry(
+                ERROR_LARGE_DATA.format(
+                    Locale.US,
+                    eventSize,
+                    filePersistenceConfig.maxItemSize
+                )
+            )
+            return false
+        }
+        return true
+    }
+
     // endregion
+
+    companion object {
+        internal const val ERROR_LARGE_DATA = "Can't write data with size %d (max item size is %d)"
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -9,7 +9,7 @@ package com.datadog.android.rum.internal.domain
 import androidx.annotation.WorkerThread
 import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.Serializer
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileDataWriter
 import com.datadog.android.core.internal.persistence.file.existsSafe
@@ -30,7 +30,7 @@ internal class RumDataWriter(
     fileOrchestrator: FileOrchestrator,
     serializer: Serializer<Any>,
     decoration: PayloadDecoration,
-    handler: FileHandler,
+    handler: ChunkedFileHandler,
     internalLogger: Logger,
     private val lastViewEventFile: File
 ) : BatchFileDataWriter<Any>(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
@@ -10,7 +10,7 @@ import android.content.Context
 import androidx.annotation.WorkerThread
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.Deserializer
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.listFilesSafe
 import com.datadog.android.core.internal.persistence.file.readTextSafe
@@ -43,7 +43,7 @@ internal class DatadogNdkCrashHandler(
     private val userInfoDeserializer: Deserializer<UserInfo>,
     private val internalLogger: Logger,
     private val timeProvider: TimeProvider,
-    private val fileHandler: FileHandler,
+    private val fileHandler: ChunkedFileHandler,
     private val rumEventSourceProvider: RumEventSourceProvider
 ) : NdkCrashHandler {
 
@@ -116,7 +116,7 @@ internal class DatadogNdkCrashHandler(
     }
 
     @WorkerThread
-    private fun readFileContent(file: File, fileHandler: FileHandler): String? {
+    private fun readFileContent(file: File, fileHandler: ChunkedFileHandler): String? {
         val content = fileHandler.readData(file)
         return if (content.isEmpty()) {
             null

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkNetworkInfoDataWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkNetworkInfoDataWriter.kt
@@ -8,7 +8,7 @@ package com.datadog.android.rum.internal.ndk
 
 import android.content.Context
 import com.datadog.android.core.internal.net.info.NetworkInfoSerializer
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.advanced.ConsentAwareFileMigrator
 import com.datadog.android.core.internal.persistence.file.advanced.ConsentAwareFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.single.SingleFileOrchestrator
@@ -22,7 +22,7 @@ internal class NdkNetworkInfoDataWriter(
     context: Context,
     consentProvider: ConsentProvider,
     executorService: ExecutorService,
-    fileHandler: FileHandler,
+    fileHandler: ChunkedFileHandler,
     internalLogger: Logger
 ) : SingleItemDataWriter<NetworkInfo>(
     ConsentAwareFileOrchestrator(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkUserInfoDataWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkUserInfoDataWriter.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.rum.internal.ndk
 
 import android.content.Context
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.advanced.ConsentAwareFileMigrator
 import com.datadog.android.core.internal.persistence.file.advanced.ConsentAwareFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.single.SingleFileOrchestrator
@@ -22,7 +22,7 @@ internal class NdkUserInfoDataWriter(
     context: Context,
     consentProvider: ConsentProvider,
     executorService: ExecutorService,
-    fileHandler: FileHandler,
+    fileHandler: ChunkedFileHandler,
     internalLogger: Logger
 ) : SingleItemDataWriter<UserInfo>(
     ConsentAwareFileOrchestrator(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/EventBatchWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/EventBatchWriter.kt
@@ -24,12 +24,12 @@ interface EventBatchWriter {
      * @param event the event to write
      * @param eventId a unique identifier for the event (used to identify events in
      * the [BatchWriterListener] callbacks).
-     * @param newMetadata the updated metadata
+     * @param newMetadata the optional updated metadata
      */
     @WorkerThread
     fun write(
         event: ByteArray,
         eventId: String,
-        newMetadata: ByteArray
+        newMetadata: ByteArray?
     )
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/BatchReader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/BatchReader.kt
@@ -10,5 +10,5 @@ import androidx.annotation.WorkerThread
 
 internal interface BatchReader {
     @WorkerThread
-    fun read(batchId: BatchId): List<ByteArray>
+    fun read(): List<ByteArray>
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorage.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorage.kt
@@ -7,8 +7,11 @@
 package com.datadog.android.v2.core.internal.storage
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
+import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
+import com.datadog.android.core.internal.persistence.file.SingleItemFileHandler
+import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.BatchWriterListener
 import com.datadog.android.v2.api.InternalLogger
@@ -19,15 +22,20 @@ import java.util.Locale
 internal class ConsentAwareStorage(
     private val grantedOrchestrator: FileOrchestrator,
     private val pendingOrchestrator: FileOrchestrator,
-    private val handler: FileHandler,
+    private val batchEventsFileHandler: ChunkedFileHandler,
+    private val batchMetadataFileHandler: SingleItemFileHandler,
     private val listener: BatchWriterListener,
-    private val internalLogger: InternalLogger
+    private val internalLogger: InternalLogger,
+    private val filePersistenceConfig: FilePersistenceConfig,
+    // only for the test
+    private val batchMetadataFileProvider: (batchFile: File) -> File =
+        { File("${it.path}_metadata") }
 ) : Storage {
 
     /**
      * Keeps track of files currently being read.
      */
-    private val lockedFiles: MutableSet<File> = mutableSetOf()
+    private val lockedBatches: MutableSet<Batch> = mutableSetOf()
 
     /** @inheritdoc */
     @WorkerThread
@@ -41,24 +49,34 @@ internal class ConsentAwareStorage(
             TrackingConsent.NOT_GRANTED -> null
         }
 
+        val batchFile = orchestrator?.getWritableFile()
+        val metadataFile = if (batchFile != null) batchMetadataFileProvider(batchFile) else null
+
         val writer = object : BatchWriter {
             @WorkerThread
             override fun currentMetadata(): ByteArray? {
-                // TODO RUMM-2186 handle writing/updating batch metadata in separate file
-                return null
+                if (orchestrator == null || metadataFile == null) return null
+
+                return batchMetadataFileHandler.readData(metadataFile)
             }
 
             @WorkerThread
-            override fun write(event: ByteArray, eventId: String, newMetadata: ByteArray) {
+            override fun write(event: ByteArray, eventId: String, newMetadata: ByteArray?) {
                 // prevent useless operation for empty event / null orchestrator
                 if (event.isEmpty() || orchestrator == null) {
                     listener.onDataWritten(eventId)
                     return
                 }
 
-                val file = orchestrator.getWritableFile(event.size)
+                if (!checkEventSize(event.size)) {
+                    listener.onDataWriteFailed(eventId)
+                    return
+                }
 
-                if (file != null && handler.writeData(file, event, true)) {
+                if (batchFile != null && batchEventsFileHandler.writeData(batchFile, event, true)) {
+                    if (newMetadata?.isNotEmpty() == true && metadataFile != null) {
+                        writeBatchMetadata(metadataFile, newMetadata)
+                    }
                     listener.onDataWritten(eventId)
                 } else {
                     listener.onDataWriteFailed(eventId)
@@ -74,18 +92,17 @@ internal class ConsentAwareStorage(
         datadogContext: DatadogContext,
         callback: (BatchId, BatchReader) -> Unit
     ) {
-        val batchFile = synchronized(lockedFiles) {
-            grantedOrchestrator.getReadableFile(lockedFiles)?.also {
-                lockedFiles.add(it)
+        val batchFile = synchronized(lockedBatches) {
+            grantedOrchestrator.getReadableFile(lockedBatches.map { it.file }.toSet())?.also {
+                lockedBatches.add(Batch(it, batchMetadataFileProvider(it)))
             } ?: return
         }
 
         val batchId = BatchId.fromFile(batchFile)
         val reader = object : BatchReader {
             @WorkerThread
-            override fun read(batchId: BatchId): List<ByteArray> {
-                // TODO RUMM-2186 check the batch id match this reader
-                return handler.readData(batchFile)
+            override fun read(): List<ByteArray> {
+                return batchEventsFileHandler.readData(batchFile)
             }
         }
         callback(batchId, reader)
@@ -94,33 +111,92 @@ internal class ConsentAwareStorage(
     /** @inheritdoc */
     @WorkerThread
     override fun confirmBatchRead(batchId: BatchId, callback: (BatchConfirmation) -> Unit) {
-        val batchFile = synchronized(lockedFiles) {
-            lockedFiles.firstOrNull { batchId.matchesFile(it) }
+        val batch = synchronized(lockedBatches) {
+            lockedBatches.firstOrNull { batchId.matchesFile(it.file) }
         } ?: return
         val confirmation = object : BatchConfirmation {
             @WorkerThread
             override fun markAsRead(deleteBatch: Boolean) {
                 if (deleteBatch) {
-                    val result = handler.delete(batchFile)
-                    if (!result) {
-                        internalLogger.log(
-                            InternalLogger.Level.WARN,
-                            InternalLogger.Target.MAINTAINER,
-                            WARNING_DELETE_FAILED.format(Locale.US, batchFile.path),
-                            null,
-                            emptyMap()
-                        )
+                    deleteBatchFile(batch.file)
+                    if (batch.metaFile.existsSafe()) {
+                        deleteBatchMetadataFile(batch.metaFile)
                     }
                 }
-                synchronized(lockedFiles) {
-                    lockedFiles.remove(batchFile)
+                synchronized(lockedBatches) {
+                    lockedBatches.remove(batch)
                 }
             }
         }
         callback(confirmation)
     }
 
+    private fun checkEventSize(eventSize: Int): Boolean {
+        if (eventSize > filePersistenceConfig.maxItemSize) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.USER,
+                ERROR_LARGE_DATA.format(
+                    Locale.US,
+                    eventSize,
+                    filePersistenceConfig.maxItemSize
+                ),
+                null,
+                emptyMap()
+            )
+            return false
+        }
+        return true
+    }
+
+    @WorkerThread
+    private fun writeBatchMetadata(metadataFile: File, metadata: ByteArray) {
+        val result =
+            batchMetadataFileHandler.writeData(metadataFile, metadata, false)
+        if (!result) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                WARNING_METADATA_WRITE_FAILED.format(Locale.US, metadataFile.path),
+                null,
+                emptyMap()
+            )
+        }
+    }
+
+    @WorkerThread
+    private fun deleteBatchFile(batchFile: File) {
+        val result = batchEventsFileHandler.delete(batchFile)
+        if (!result) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                WARNING_DELETE_FAILED.format(Locale.US, batchFile.path),
+                null,
+                emptyMap()
+            )
+        }
+    }
+
+    @WorkerThread
+    private fun deleteBatchMetadataFile(metadataFile: File) {
+        val result = batchMetadataFileHandler.delete(metadataFile)
+        if (!result) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                WARNING_DELETE_FAILED.format(Locale.US, metadataFile.path),
+                null,
+                emptyMap()
+            )
+        }
+    }
+
+    private data class Batch(val file: File, val metaFile: File)
+
     companion object {
         internal const val WARNING_DELETE_FAILED = "Unable to delete file: %s"
+        internal const val ERROR_LARGE_DATA = "Can't write data with size %d (max item size is %d)"
+        internal const val WARNING_METADATA_WRITE_FAILED = "Unable to write metadata file: %s"
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataFlusherTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataFlusherTest.kt
@@ -8,7 +8,7 @@ package com.datadog.android.core.internal.data.upload
 
 import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.persistence.PayloadDecoration
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.utils.forge.Configurator
 import com.nhaarman.mockitokotlin2.mock
@@ -47,7 +47,7 @@ internal class DataFlusherTest {
     lateinit var payloadDecoration: PayloadDecoration
 
     @Mock
-    lateinit var mockFileHandler: FileHandler
+    lateinit var mockFileHandler: ChunkedFileHandler
 
     @StringForgery
     lateinit var fakePrefix: String

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/CacheFileMigratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/CacheFileMigratorTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.core.internal.persistence.file.advanced
 
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.logger.LogHandler
@@ -50,7 +50,7 @@ internal class CacheFileMigratorTest {
     lateinit var mockNewOrchestrator: FileOrchestrator
 
     @Mock
-    lateinit var mockFileHandler: FileHandler
+    lateinit var mockFileHandler: ChunkedFileHandler
 
     @Mock
     lateinit var mockExecutorService: ExecutorService

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileMigratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileMigratorTest.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.core.internal.persistence.file.advanced
 
 import android.util.Log
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.logger.LogHandler
@@ -54,7 +54,7 @@ internal class ConsentAwareFileMigratorTest {
     lateinit var mockNewOrchestrator: FileOrchestrator
 
     @Mock
-    lateinit var mockFileHandler: FileHandler
+    lateinit var mockFileHandler: ChunkedFileHandler
 
     @Mock
     lateinit var mockExecutorService: ExecutorService

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
@@ -18,7 +18,6 @@ import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
-import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.File
@@ -122,14 +121,13 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `𝕄 return pending writable file 𝕎 getWritableFile() {consent=PENDING}`(
-        @Forgery file: File,
-        @IntForgery(min = 1) dataSize: Int
+        @Forgery file: File
     ) {
         // Given
-        whenever(mockPendingOrchestrator.getWritableFile(dataSize)) doReturn file
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
 
         // When
-        val result = testedOrchestrator.getWritableFile(dataSize)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -138,16 +136,15 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `𝕄 return pending writable file 𝕎 getWritableFile() {consent=GRANTED then PENDING}`(
-        @Forgery file: File,
-        @IntForgery(min = 1) dataSize: Int
+        @Forgery file: File
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.GRANTED)
-        whenever(mockPendingOrchestrator.getWritableFile(dataSize)) doReturn file
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.GRANTED, TrackingConsent.PENDING)
-        val result = testedOrchestrator.getWritableFile(dataSize)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -156,16 +153,15 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `𝕄 return pending writable file 𝕎 getWritableFile() {consent=NOT_GRANTED then PENDING}`(
-        @Forgery file: File,
-        @IntForgery(min = 1) dataSize: Int
+        @Forgery file: File
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.NOT_GRANTED)
-        whenever(mockPendingOrchestrator.getWritableFile(dataSize)) doReturn file
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.NOT_GRANTED, TrackingConsent.PENDING)
-        val result = testedOrchestrator.getWritableFile(dataSize)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -174,15 +170,14 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `𝕄 return granted writable file 𝕎 getWritableFile() {consent=GRANTED}`(
-        @Forgery file: File,
-        @IntForgery(min = 1) dataSize: Int
+        @Forgery file: File
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.GRANTED)
-        whenever(mockGrantedOrchestrator.getWritableFile(dataSize)) doReturn file
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
 
         // When
-        val result = testedOrchestrator.getWritableFile(dataSize)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -191,16 +186,15 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `𝕄 return granted writable file 𝕎 getWritableFile() {consent=NOT_GRANTED then GRANTED}`(
-        @Forgery file: File,
-        @IntForgery(min = 1) dataSize: Int
+        @Forgery file: File
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.NOT_GRANTED)
-        whenever(mockGrantedOrchestrator.getWritableFile(dataSize)) doReturn file
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.NOT_GRANTED, TrackingConsent.GRANTED)
-        val result = testedOrchestrator.getWritableFile(dataSize)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -209,16 +203,15 @@ internal class ConsentAwareFileOrchestratorTest {
 
     @Test
     fun `𝕄 return granted writable file 𝕎 getWritableFile() {consent=PENDING then GRANTED}`(
-        @Forgery file: File,
-        @IntForgery(min = 1) dataSize: Int
+        @Forgery file: File
     ) {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.PENDING)
-        whenever(mockGrantedOrchestrator.getWritableFile(dataSize)) doReturn file
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.PENDING, TrackingConsent.GRANTED)
-        val result = testedOrchestrator.getWritableFile(dataSize)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(file)
@@ -226,14 +219,12 @@ internal class ConsentAwareFileOrchestratorTest {
     }
 
     @Test
-    fun `𝕄 return null file 𝕎 getWritableFile() {consent=NOT_GRANTED}`(
-        @IntForgery(min = 1) dataSize: Int
-    ) {
+    fun `𝕄 return null file 𝕎 getWritableFile() {consent=NOT_GRANTED}`() {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.NOT_GRANTED)
 
         // When
-        val result = testedOrchestrator.getWritableFile(dataSize)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isNull()
@@ -241,15 +232,13 @@ internal class ConsentAwareFileOrchestratorTest {
     }
 
     @Test
-    fun `𝕄 return null file 𝕎 getWritableFile() {consent=GRANTED then NOT_GRANTED}`(
-        @IntForgery(min = 1) dataSize: Int
-    ) {
+    fun `𝕄 return null file 𝕎 getWritableFile() {consent=GRANTED then NOT_GRANTED}`() {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.GRANTED)
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.GRANTED, TrackingConsent.NOT_GRANTED)
-        val result = testedOrchestrator.getWritableFile(dataSize)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isNull()
@@ -257,15 +246,13 @@ internal class ConsentAwareFileOrchestratorTest {
     }
 
     @Test
-    fun `𝕄 return null file 𝕎 getWritableFile() {consent=PENDING then NOT_GRANTED}`(
-        @IntForgery(min = 1) dataSize: Int
-    ) {
+    fun `𝕄 return null file 𝕎 getWritableFile() {consent=PENDING then NOT_GRANTED}`() {
         // Given
         instantiateTestedOrchestrator(TrackingConsent.PENDING)
 
         // When
         testedOrchestrator.onConsentUpdated(TrackingConsent.PENDING, TrackingConsent.NOT_GRANTED)
-        val result = testedOrchestrator.getWritableFile(dataSize)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isNull()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/MoveDataMigrationOperationTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/MoveDataMigrationOperationTest.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.core.internal.persistence.file.advanced
 
 import android.util.Log
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.utils.forge.Configurator
@@ -47,7 +47,7 @@ internal class MoveDataMigrationOperationTest {
     lateinit var fakeToDirectory: File
 
     @Mock
-    lateinit var mockFileHandler: FileHandler
+    lateinit var mockFileHandler: ChunkedFileHandler
 
     @Mock
     lateinit var mockLogHander: LogHandler

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/SingleFileOrchestratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/SingleFileOrchestratorTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.core.internal.persistence.file.advanced
 
 import com.datadog.android.core.internal.persistence.file.single.SingleFileOrchestrator
 import com.datadog.android.utils.forge.Configurator
-import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -53,22 +52,18 @@ internal class SingleFileOrchestratorTest {
     // region getWritableFile
 
     @Test
-    fun `𝕄 create parent dir 𝕎 getWritableFile()`(
-        @IntForgery(min = 1) dataSize: Int
-    ) {
+    fun `𝕄 create parent dir 𝕎 getWritableFile()`() {
         // When
-        testedOrchestrator.getWritableFile(dataSize)
+        testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(fakeFile.parentFile).exists()
     }
 
     @Test
-    fun `𝕄 return file 𝕎 getWritableFile()`(
-        @IntForgery(min = 1) dataSize: Int
-    ) {
+    fun `𝕄 return file 𝕎 getWritableFile()`() {
         // When
-        val result = testedOrchestrator.getWritableFile(dataSize)
+        val result = testedOrchestrator.getWritableFile()
 
         // Then
         assertThat(result).isSameAs(fakeFile)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/WipeDataMigrationOperationTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/WipeDataMigrationOperationTest.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.core.internal.persistence.file.advanced
 
 import android.util.Log
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.utils.forge.Configurator
@@ -45,7 +45,7 @@ internal class WipeDataMigrationOperationTest {
     lateinit var fakeTargetDirectory: File
 
     @Mock
-    lateinit var mockFileHandler: FileHandler
+    lateinit var mockFileHandler: ChunkedFileHandler
 
     @Mock
     lateinit var mockLogHander: LogHandler

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileDataReaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileDataReaderTest.kt
@@ -10,7 +10,7 @@ import android.util.Log
 import com.datadog.android.core.internal.persistence.Batch
 import com.datadog.android.core.internal.persistence.DataReader
 import com.datadog.android.core.internal.persistence.PayloadDecoration
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.logger.LogHandler
@@ -54,7 +54,7 @@ internal class BatchFileDataReaderTest {
     lateinit var mockOrchestrator: FileOrchestrator
 
     @Mock
-    lateinit var mockFileHandler: FileHandler
+    lateinit var mockFileHandler: ChunkedFileHandler
 
     @Mock
     lateinit var mockLogHandler: LogHandler

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileHandlerTest.kt
@@ -7,9 +7,8 @@
 package com.datadog.android.core.internal.persistence.file.batch
 
 import android.util.Log
-import com.datadog.android.core.internal.persistence.file.EncryptedFileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.EventMeta
-import com.datadog.android.core.internal.persistence.file.FileHandler
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.utils.ERROR_WITH_TELEMETRY_LEVEL
 import com.datadog.android.security.Encryption
@@ -54,7 +53,7 @@ import org.mockito.quality.Strictness
 @MockitoSettings(strictness = Strictness.LENIENT)
 internal class BatchFileHandlerTest {
 
-    lateinit var testedFileHandler: FileHandler
+    lateinit var testedFileHandler: ChunkedFileHandler
 
     @StringForgery(regex = "([a-z]+)-([a-z]+)")
     lateinit var fakeSrcDirName: String
@@ -513,7 +512,13 @@ internal class BatchFileHandlerTest {
 
         // When
         var writeResult = true
-        data.forEach { writeResult = writeResult && testedFileHandler.writeData(file, it, true) }
+        data.forEach {
+            writeResult = writeResult && testedFileHandler.writeData(
+                file,
+                it,
+                true
+            )
+        }
         val readResult = testedFileHandler.readData(file)
 
         // Then
@@ -734,9 +739,9 @@ internal class BatchFileHandlerTest {
 
         // Then
         assertThat(fileHandler)
-            .isInstanceOf(EncryptedFileHandler::class.java)
+            .isInstanceOf(EncryptedBatchFileHandler::class.java)
 
-        (fileHandler as EncryptedFileHandler).let {
+        (fileHandler as EncryptedBatchFileHandler).let {
             assertThat(it.delegate).isInstanceOf(BatchFileHandler::class.java)
             assertThat(it.encryption).isEqualTo(mockEncryption)
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategyTest.kt
@@ -10,7 +10,7 @@ import com.datadog.android.core.internal.data.upload.DataFlusher
 import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.persistence.Serializer
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.advanced.ScheduledWriter
 import com.datadog.android.log.Logger
@@ -56,7 +56,7 @@ internal class BatchFilePersistenceStrategyTest {
     lateinit var mockExecutorService: ExecutorService
 
     @Mock
-    lateinit var mockFileHandler: FileHandler
+    lateinit var mockFileHandler: ChunkedFileHandler
 
     @Forgery
     lateinit var fakePayloadDecoration: PayloadDecoration

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchFileHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/EncryptedBatchFileHandlerTest.kt
@@ -1,0 +1,228 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence.file.batch
+
+import android.util.Log
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
+import com.datadog.android.log.Logger
+import com.datadog.android.security.Encryption
+import com.datadog.android.utils.config.LoggerTestConfiguration
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.io.File
+import kotlin.experimental.inv
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@ForgeConfiguration(Configurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class EncryptedBatchFileHandlerTest {
+
+    @Mock
+    lateinit var mockEncryption: Encryption
+
+    @Mock
+    lateinit var mockFileHandlerDelegate: ChunkedFileHandler
+
+    @Mock
+    lateinit var mockFile: File
+
+    @Mock
+    lateinit var mockInternalLogger: Logger
+
+    private lateinit var testedFileHandler: EncryptedBatchFileHandler
+
+    @BeforeEach
+    fun setUp() {
+        whenever(mockFileHandlerDelegate.writeData(any(), any(), any())) doReturn true
+
+        whenever(mockEncryption.encrypt(any())) doAnswer {
+            val bytes = it.getArgument<ByteArray>(0)
+            encrypt(bytes)
+        }
+        whenever(mockEncryption.decrypt(any())) doAnswer {
+            val bytes = it.getArgument<ByteArray>(0)
+            decrypt(bytes)
+        }
+
+        testedFileHandler =
+            EncryptedBatchFileHandler(mockEncryption, mockFileHandlerDelegate)
+    }
+
+    // region FileHandler#writeData tests
+
+    @Test
+    fun `𝕄 encrypt data and return true 𝕎 writeData()`(
+        @StringForgery data: String,
+        @BoolForgery append: Boolean
+    ) {
+        // When
+        val result = testedFileHandler.writeData(
+            mockFile,
+            data.toByteArray(),
+            append = append
+        )
+        val encryptedData = encrypt(data.toByteArray())
+
+        // Then
+        assertThat(result).isTrue()
+        verify(mockFileHandlerDelegate)
+            .writeData(
+                mockFile,
+                encryptedData,
+                append
+            )
+
+        verifyZeroInteractions(mockInternalLogger)
+        verifyZeroInteractions(logger.mockDevLogHandler)
+    }
+
+    @Test
+    fun `𝕄 log internal error and return false 𝕎 writeData() { bad encryption result }`(
+        @StringForgery data: String,
+        @BoolForgery append: Boolean
+    ) {
+        // Given
+        whenever(mockEncryption.encrypt(data.toByteArray())) doReturn ByteArray(0)
+
+        // When
+        val result = testedFileHandler.writeData(
+            mockFile,
+            data.toByteArray(),
+            append = append
+        )
+
+        // Then
+        assertThat(result).isFalse()
+
+        verify(logger.mockDevLogHandler).handleLog(
+            Log.ERROR,
+            EncryptedBatchFileHandler.BAD_ENCRYPTION_RESULT_MESSAGE
+        )
+        verifyZeroInteractions(mockInternalLogger)
+        verifyZeroInteractions(mockFileHandlerDelegate)
+    }
+
+    // endregion
+
+    // region FileHandler#readData tests
+
+    @Test
+    fun `𝕄 decrypt data 𝕎 readData()`(
+        forge: Forge
+    ) {
+        // Given
+        val events = forge.aList {
+            forge.aString().toByteArray()
+        }
+
+        whenever(
+            mockFileHandlerDelegate.readData(mockFile)
+        ) doReturn events.map { encrypt(it) }
+
+        // When
+        val result = testedFileHandler.readData(mockFile)
+
+        // Then
+        assertThat(result).containsExactlyElementsOf(events)
+    }
+
+    // endregion
+
+    // region writeData + readData
+
+    @Test
+    fun `𝕄 return valid data 𝕎 writeData() + readData()`(
+        forge: Forge
+    ) {
+        // Given
+        val events = forge.aList { forge.aString().toByteArray() }
+
+        val storage = mutableListOf<ByteArray>()
+
+        whenever(
+            mockFileHandlerDelegate.writeData(
+                eq(mockFile),
+                any(),
+                eq(true)
+            )
+        ) doAnswer {
+            storage.add(it.getArgument(1))
+            true
+        }
+
+        whenever(
+            mockFileHandlerDelegate.readData(mockFile)
+        ) doAnswer { storage }
+
+        // When
+        var writeResult = true
+        events.forEach {
+            writeResult = writeResult && testedFileHandler.writeData(mockFile, it, true)
+        }
+        val readResult = testedFileHandler.readData(mockFile)
+
+        // Then
+        assertThat(writeResult).isTrue()
+        assertThat(readResult).containsExactlyElementsOf(events)
+
+        verifyZeroInteractions(mockInternalLogger)
+        verifyZeroInteractions(logger.mockDevLogHandler)
+    }
+
+    // endregion
+
+    // region private
+
+    // this is valid encryption-decryption pair, after the round we will get the original data
+    private fun encrypt(data: ByteArray): ByteArray {
+        return data.map { it.inv() }.toByteArray()
+    }
+
+    private fun decrypt(data: ByteArray): ByteArray {
+        return data.map { it.inv() }.toByteArray()
+    }
+
+    // endregion
+
+    companion object {
+
+        val logger = LoggerTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(logger)
+        }
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
@@ -9,7 +9,7 @@ package com.datadog.android.rum.internal.domain
 import android.util.Log
 import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.Serializer
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.logger.LogHandler
@@ -66,7 +66,7 @@ internal class RumDataWriterTest {
     lateinit var mockOrchestrator: FileOrchestrator
 
     @Mock
-    lateinit var mockFileHandler: FileHandler
+    lateinit var mockFileHandler: ChunkedFileHandler
 
     @Mock
     lateinit var mockLogHandler: LogHandler

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandlerTest.kt
@@ -9,7 +9,7 @@ package com.datadog.android.rum.internal.ndk
 import android.content.Context
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.Deserializer
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.model.NetworkInfo
 import com.datadog.android.core.model.UserInfo
@@ -99,7 +99,7 @@ internal class DatadogNdkCrashHandlerTest {
     lateinit var mockLogHandler: LogHandler
 
     @Mock
-    lateinit var mockFileHandler: FileHandler
+    lateinit var mockFileHandler: ChunkedFileHandler
 
     lateinit var fakeNdkCacheDir: File
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -71,7 +71,7 @@ internal class Configurator :
         forge.addFactory(OrgJSONArrayForgeryFactory())
 
         // Datadog SDK v2
-        forge.addFactory(SDKContextForgeryFactory())
+        forge.addFactory(DatadogContextForgeryFactory())
 
         forge.useJvmFactories()
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
@@ -8,20 +8,20 @@ package com.datadog.android.utils.forge
 
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.context.ApplicationInfo
+import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.NetworkInfo
 import com.datadog.android.v2.api.context.ProcessInfo
-import com.datadog.android.v2.api.context.SDKContext
 import com.datadog.android.v2.api.context.TimeInfo
 import com.datadog.android.v2.api.context.UserInfo
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-class SDKContextForgeryFactory : ForgeryFactory<SDKContext> {
+class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
     /**
      * TODO RUMM-000 implement all nested class factories
      */
-    override fun getForgery(forge: Forge): SDKContext {
-        return SDKContext(
+    override fun getForgery(forge: Forge): DatadogContext {
+        return DatadogContext(
             TimeInfo(forge.aLong(), forge.aLong()),
             ApplicationInfo(
                 forge.anAlphabeticalString(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorageTest.kt
@@ -6,9 +6,10 @@
 
 package com.datadog.android.v2.core.internal.storage
 
-import com.datadog.android.core.internal.persistence.file.FileHandler
+import com.datadog.android.core.internal.persistence.file.ChunkedFileHandler
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
-import com.datadog.android.core.internal.persistence.file.batch.BatchFileDataReader
+import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
+import com.datadog.android.core.internal.persistence.file.SingleItemFileHandler
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.BatchWriterListener
@@ -17,12 +18,16 @@ import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.tools.unit.extensions.ProhibitLeavingStaticMocksExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argThat
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -30,12 +35,12 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.io.File
 import java.util.Locale
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.api.fail
+import org.mockito.ArgumentMatcher
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -51,7 +56,7 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(Configurator::class)
 internal class ConsentAwareStorageTest {
 
-    lateinit var testedStorage: Storage
+    private lateinit var testedStorage: Storage
 
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
@@ -63,7 +68,10 @@ internal class ConsentAwareStorageTest {
     lateinit var mockGrantedOrchestrator: FileOrchestrator
 
     @Mock
-    lateinit var mockFileHandler: FileHandler
+    lateinit var mockBatchFileHandler: ChunkedFileHandler
+
+    @Mock
+    lateinit var mockBatchMetadataFileHandler: SingleItemFileHandler
 
     @Mock
     lateinit var mockListener: BatchWriterListener
@@ -71,86 +79,115 @@ internal class ConsentAwareStorageTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @Mock
+    lateinit var mockFilePersistenceConfig: FilePersistenceConfig
+
     @BeforeEach
     fun `set up`() {
         testedStorage = ConsentAwareStorage(
             mockGrantedOrchestrator,
             mockPendingOrchestrator,
-            mockFileHandler,
+            mockBatchFileHandler,
+            mockBatchMetadataFileHandler,
             mockListener,
-            mockInternalLogger
+            mockInternalLogger,
+            mockFilePersistenceConfig
         )
-    }
-
-    @AfterEach
-    fun `tear down`() {
+        whenever(mockFilePersistenceConfig.maxItemSize) doReturn Long.MAX_VALUE
     }
 
     // region writeCurrentBatch
-    // TODO RUMM-2186 handle writing/updating batch metadata in separate file
 
     @Test
     fun `𝕄 provide writer 𝕎 writeCurrentBatch() {consent=granted}`(
         @StringForgery data: String,
+        @StringForgery batchMetadata: String,
         @StringForgery eventId: String,
         @Forgery file: File
     ) {
         // Given
-        val serialized = data.toByteArray(Charsets.UTF_8)
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
-        whenever(mockGrantedOrchestrator.getWritableFile(serialized.size)) doReturn file
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
+        whenever(mockBatchMetadataFileHandler.readData(argThatIsMetaOf(file))) doReturn
+            serializedMetadata
+        whenever(mockBatchFileHandler.writeData(file, serializedData, true)) doReturn true
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            val meta = it.currentMetadata()
+            val updatedMeta = meta?.reversedArray()
+            it.write(serializedData, eventId, updatedMeta)
         }
 
         // Then
-        verify(mockGrantedOrchestrator).getWritableFile(serialized.size)
-        verify(mockFileHandler).writeData(
+        verify(mockGrantedOrchestrator).getWritableFile()
+        verify(mockBatchFileHandler).writeData(
             file,
-            serialized,
+            serializedData,
             append = true
         )
+        verify(mockBatchMetadataFileHandler).writeData(
+            argThatIsMetaOf(file),
+            eq(serializedMetadata.reversedArray()),
+            append = eq(false)
+        )
+        verify(mockBatchMetadataFileHandler).readData(argThatIsMetaOf(file))
+
         verifyNoMoreInteractions(
             mockGrantedOrchestrator,
             mockPendingOrchestrator,
-            mockFileHandler
+            mockBatchFileHandler,
+            mockBatchMetadataFileHandler
         )
     }
 
     @Test
     fun `𝕄 do nothing 𝕎 write() {consent=granted, empty array}`(
-        @StringForgery eventId: String
+        @StringForgery eventId: String,
+        @StringForgery batchMetadata: String,
+        @Forgery file: File
     ) {
         // Given
-        val serialized = ByteArray(0)
+        val serializedData = ByteArray(0)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
-        verifyZeroInteractions(mockFileHandler, mockGrantedOrchestrator, mockPendingOrchestrator)
+        verify(mockGrantedOrchestrator).getWritableFile()
+
+        verifyZeroInteractions(
+            mockBatchFileHandler,
+            mockBatchMetadataFileHandler,
+            mockPendingOrchestrator
+        )
+        verifyNoMoreInteractions(mockGrantedOrchestrator)
     }
 
     @Test
     fun `𝕄 notify success 𝕎 write() {consent = granted}`(
         @StringForgery data: String,
+        @StringForgery batchMetadata: String,
         @StringForgery eventId: String,
         @Forgery file: File
     ) {
         // Given
-        val serialized = data.toByteArray(Charsets.UTF_8)
+        val serializedData = data.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
-        whenever(mockGrantedOrchestrator.getWritableFile(any())) doReturn file
-        whenever(mockFileHandler.writeData(file, serialized, true)) doReturn true
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
+        whenever(mockBatchFileHandler.writeData(file, serializedData, true)) doReturn true
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
@@ -160,15 +197,17 @@ internal class ConsentAwareStorageTest {
 
     @Test
     fun `𝕄 notify success 𝕎 write() {consent = granted, empty array}`(
+        @StringForgery batchMetadata: String,
         @StringForgery eventId: String
     ) {
         // Given
-        val serialized = ByteArray(0)
+        val serializedData = ByteArray(0)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
@@ -179,39 +218,78 @@ internal class ConsentAwareStorageTest {
     @Test
     fun `𝕄 notify failure 𝕎 write() {consent = granted, no available file}`(
         @StringForgery data: String,
-        @StringForgery eventId: String,
-        @Forgery file: File
+        @StringForgery batchMetadata: String,
+        @StringForgery eventId: String
     ) {
         // Given
-        val serialized = data.toByteArray(Charsets.UTF_8)
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
-        whenever(mockGrantedOrchestrator.getWritableFile(any())) doReturn null
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn null
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
         verify(mockListener).onDataWriteFailed(eventId)
         verifyNoMoreInteractions(mockListener)
+    }
+
+    @Test
+    fun `𝕄 notify failure 𝕎 write() {consent = granted, item is too big}`(
+        @StringForgery data: String,
+        @StringForgery batchMetadata: String,
+        @StringForgery eventId: String,
+        @Forgery file: File
+    ) {
+        // Given
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
+        val maxItemSize = serializedData.size - 1
+        whenever(mockFilePersistenceConfig.maxItemSize) doReturn maxItemSize.toLong()
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext) {
+            it.write(serializedData, eventId, serializedBatchMetadata)
+        }
+
+        // Then
+        verify(mockListener).onDataWriteFailed(eventId)
+        verifyNoMoreInteractions(mockListener)
+        verify(mockInternalLogger).log(
+            InternalLogger.Level.ERROR,
+            InternalLogger.Target.USER,
+            ConsentAwareStorage.ERROR_LARGE_DATA.format(
+                Locale.US,
+                serializedData.size,
+                maxItemSize
+            ),
+            null,
+            emptyMap()
+        )
     }
 
     @Test
     fun `𝕄 notify failure 𝕎 write() {consent = granted, write operation failed}`(
         @StringForgery data: String,
+        @StringForgery batchMetadata: String,
         @StringForgery eventId: String,
-        @Forgery file: File
+        @Forgery batchFile: File
     ) {
         // Given
-        val serialized = data.toByteArray(Charsets.UTF_8)
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
-        whenever(mockGrantedOrchestrator.getWritableFile(any())) doReturn file
-        whenever(mockFileHandler.writeData(file, serialized, true)) doReturn false
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn batchFile
+        whenever(mockBatchFileHandler.writeData(batchFile, serializedData, true)) doReturn false
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
@@ -220,67 +298,202 @@ internal class ConsentAwareStorageTest {
     }
 
     @Test
-    fun `𝕄 provide writer 𝕎 writeCurrentBatch() {consent=pending}`(
+    fun `𝕄 not read metadata 𝕎 currentMetadata() {consent = granted, no available file}`() {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn null
+
+        // When
+        var meta: ByteArray? = null
+        testedStorage.writeCurrentBatch(sdkContext) {
+            meta = it.currentMetadata()
+        }
+
+        // Then
+        assertThat(meta).isNull()
+        verifyZeroInteractions(mockBatchFileHandler, mockBatchMetadataFileHandler)
+    }
+
+    @Test
+    fun `𝕄 not write metadata 𝕎 write() {consent = granted, no available file}`(
         @StringForgery data: String,
+        @StringForgery batchMetadata: String,
+        @StringForgery eventId: String
+    ) {
+        // Given
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn null
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext) {
+            it.write(serializedData, eventId, serializedBatchMetadata)
+        }
+
+        // Then
+        verifyZeroInteractions(mockBatchFileHandler, mockBatchMetadataFileHandler)
+    }
+
+    @Test
+    fun `𝕄 not write metadata 𝕎 write() {consent = granted, null or empty metadata}`(
+        @StringForgery data: String,
+        @Forgery file: File,
+        @StringForgery eventId: String,
+        forge: Forge
+    ) {
+        // Given
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext) {
+            it.write(serializedData, eventId, forge.aNullable { ByteArray(0) })
+        }
+
+        // Then
+        verify(mockBatchFileHandler).writeData(
+            file,
+            serializedData,
+            true
+        )
+        verifyNoMoreInteractions(mockBatchFileHandler)
+        verifyZeroInteractions(mockBatchMetadataFileHandler)
+    }
+
+    @Test
+    fun `𝕄 not write metadata 𝕎 write() {consent = granted, item is too big}`(
+        @StringForgery data: String,
+        @StringForgery batchMetadata: String,
         @StringForgery eventId: String,
         @Forgery file: File
     ) {
         // Given
-        val serialized = data.toByteArray(Charsets.UTF_8)
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
-        whenever(mockPendingOrchestrator.getWritableFile(serialized.size)) doReturn file
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
+        val maxItemSize = serializedData.size - 1
+        whenever(mockFilePersistenceConfig.maxItemSize) doReturn maxItemSize.toLong()
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
-        verify(mockPendingOrchestrator).getWritableFile(serialized.size)
-        verify(mockFileHandler).writeData(
+        verifyZeroInteractions(mockBatchMetadataFileHandler)
+    }
+
+    @Test
+    fun `𝕄 not write metadata 𝕎 write() {consent = granted, write operation failed}`(
+        @StringForgery data: String,
+        @StringForgery batchMetadata: String,
+        @StringForgery eventId: String,
+        @Forgery file: File
+    ) {
+        // Given
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
+        whenever(mockBatchFileHandler.writeData(file, serializedData, true)) doReturn false
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext) {
+            it.write(serializedData, eventId, serializedBatchMetadata)
+        }
+
+        // Then
+        verifyZeroInteractions(mockBatchMetadataFileHandler)
+    }
+
+    @Test
+    fun `𝕄 provide writer 𝕎 writeCurrentBatch() {consent=pending}`(
+        @StringForgery data: String,
+        @StringForgery batchMetadata: String,
+        @StringForgery eventId: String,
+        @Forgery file: File
+    ) {
+        // Given
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
+        whenever(mockBatchMetadataFileHandler.readData(argThatIsMetaOf(file))) doReturn
+            serializedBatchMetadata
+        whenever(mockBatchFileHandler.writeData(file, serializedData, true)) doReturn true
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext) {
+            val meta = it.currentMetadata()
+            val updatedMeta = meta?.reversedArray()
+            it.write(serializedData, eventId, updatedMeta)
+        }
+
+        // Then
+        verify(mockPendingOrchestrator).getWritableFile()
+        verify(mockBatchMetadataFileHandler).readData(argThatIsMetaOf(file))
+        verify(mockBatchFileHandler).writeData(
             file,
-            serialized,
+            serializedData,
             append = true
+        )
+        verify(mockBatchMetadataFileHandler).writeData(
+            argThatIsMetaOf(file),
+            eq(serializedBatchMetadata.reversedArray()),
+            append = eq(false)
         )
         verifyNoMoreInteractions(
             mockGrantedOrchestrator,
             mockPendingOrchestrator,
-            mockFileHandler
+            mockBatchFileHandler,
+            mockBatchMetadataFileHandler
         )
     }
 
     @Test
     fun `𝕄 do nothing 𝕎 write() {consent=pending, empty array}`(
-        @StringForgery eventId: String
+        @StringForgery eventId: String,
+        @StringForgery batchMetadata: String
     ) {
         // Given
-        val serialized = ByteArray(0)
+        val serializedData = ByteArray(0)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
-        verifyZeroInteractions(mockFileHandler, mockGrantedOrchestrator, mockPendingOrchestrator)
+        verifyZeroInteractions(
+            mockBatchFileHandler,
+            mockBatchMetadataFileHandler,
+            mockGrantedOrchestrator
+        )
     }
 
     @Test
     fun `𝕄 notify success 𝕎 write() {consent = pending}`(
         @StringForgery data: String,
+        @StringForgery batchMetadata: String,
         @StringForgery eventId: String,
         @Forgery file: File
     ) {
         // Given
-        val serialized = data.toByteArray(Charsets.UTF_8)
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
-        whenever(mockPendingOrchestrator.getWritableFile(any())) doReturn file
-        whenever(mockFileHandler.writeData(file, serialized, true)) doReturn true
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
+        whenever(mockBatchFileHandler.writeData(file, serializedData, true)) doReturn true
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
@@ -290,15 +503,17 @@ internal class ConsentAwareStorageTest {
 
     @Test
     fun `𝕄 notify success 𝕎 write() {consent = pending, empty array}`(
-        @StringForgery eventId: String
+        @StringForgery eventId: String,
+        @StringForgery batchMetadata: String
     ) {
         // Given
-        val serialized = ByteArray(0)
+        val serializedData = ByteArray(0)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
@@ -309,39 +524,78 @@ internal class ConsentAwareStorageTest {
     @Test
     fun `𝕄 notify failure 𝕎 write() {consent = pending, no available file}`(
         @StringForgery data: String,
-        @StringForgery eventId: String,
-        @Forgery file: File
+        @StringForgery batchMetadata: String,
+        @StringForgery eventId: String
     ) {
         // Given
-        val serialized = data.toByteArray(Charsets.UTF_8)
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
-        whenever(mockPendingOrchestrator.getWritableFile(any())) doReturn null
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn null
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
         verify(mockListener).onDataWriteFailed(eventId)
         verifyNoMoreInteractions(mockListener)
+    }
+
+    @Test
+    fun `𝕄 notify failure 𝕎 write() {consent = pending, item is too big}`(
+        @StringForgery data: String,
+        @StringForgery batchMetadata: String,
+        @StringForgery eventId: String,
+        @Forgery file: File
+    ) {
+        // Given
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
+        val maxItemSize = serializedData.size - 1
+        whenever(mockFilePersistenceConfig.maxItemSize) doReturn maxItemSize.toLong()
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext) {
+            it.write(serializedData, eventId, serializedBatchMetadata)
+        }
+
+        // Then
+        verify(mockListener).onDataWriteFailed(eventId)
+        verifyNoMoreInteractions(mockListener)
+        verify(mockInternalLogger).log(
+            InternalLogger.Level.ERROR,
+            InternalLogger.Target.USER,
+            ConsentAwareStorage.ERROR_LARGE_DATA.format(
+                Locale.US,
+                serializedData.size,
+                maxItemSize
+            ),
+            null,
+            emptyMap()
+        )
     }
 
     @Test
     fun `𝕄 notify failure 𝕎 write() {consent = pending, write operation failed}`(
         @StringForgery data: String,
+        @StringForgery batchMetadata: String,
         @StringForgery eventId: String,
         @Forgery file: File
     ) {
         // Given
-        val serialized = data.toByteArray(Charsets.UTF_8)
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
-        whenever(mockPendingOrchestrator.getWritableFile(any())) doReturn file
-        whenever(mockFileHandler.writeData(file, serialized, true)) doReturn false
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
+        whenever(mockBatchFileHandler.writeData(file, serializedData, true)) doReturn false
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
@@ -350,56 +604,180 @@ internal class ConsentAwareStorageTest {
     }
 
     @Test
-    fun `𝕄 provide no op writer 𝕎 writeCurrentBatch() {consent=not_granted}`(
+    fun `𝕄 not read metadata 𝕎 currentMetadata() {consent = pending, no available file}`() {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn null
+
+        // When
+        var meta: ByteArray? = null
+        testedStorage.writeCurrentBatch(sdkContext) {
+            meta = it.currentMetadata()
+        }
+
+        // Then
+        assertThat(meta).isNull()
+        verifyZeroInteractions(mockBatchFileHandler, mockBatchMetadataFileHandler)
+    }
+
+    @Test
+    fun `𝕄 not write metadata 𝕎 write() {consent = pending, no available file}`(
         @StringForgery data: String,
+        @StringForgery batchMetadata: String,
+        @StringForgery eventId: String
+    ) {
+        // Given
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn null
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext) {
+            it.write(serializedData, eventId, serializedBatchMetadata)
+        }
+
+        // Then
+        verifyZeroInteractions(mockBatchFileHandler, mockBatchMetadataFileHandler)
+    }
+
+    @Test
+    fun `𝕄 not write metadata 𝕎 write() {consent = pending, null or empty metadata}`(
+        @StringForgery data: String,
+        @StringForgery eventId: String,
+        @Forgery file: File,
+        forge: Forge
+    ) {
+        // Given
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext) {
+            it.write(serializedData, eventId, forge.aNullable { ByteArray(0) })
+        }
+
+        // Then
+        verify(mockBatchFileHandler).writeData(
+            file,
+            serializedData,
+            true
+        )
+        verifyNoMoreInteractions(mockBatchFileHandler)
+        verifyZeroInteractions(mockBatchMetadataFileHandler)
+    }
+
+    @Test
+    fun `𝕄 not write metadata 𝕎 write() {consent = pending, item is too big}`(
+        @StringForgery data: String,
+        @StringForgery batchMetadata: String,
         @StringForgery eventId: String,
         @Forgery file: File
     ) {
         // Given
-        val serialized = data.toByteArray(Charsets.UTF_8)
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        whenever(mockPendingOrchestrator.getWritableFile()) doReturn file
+        val maxItemSize = serializedData.size - 1
+        whenever(mockFilePersistenceConfig.maxItemSize) doReturn maxItemSize.toLong()
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext) {
+            it.write(serializedData, eventId, serializedBatchMetadata)
+        }
+
+        // Then
+        verifyZeroInteractions(mockBatchMetadataFileHandler)
+    }
+
+    @Test
+    fun `𝕄 not write metadata 𝕎 write() {consent = pending, write operation failed}`(
+        @StringForgery data: String,
+        @StringForgery batchMetadata: String,
+        @StringForgery eventId: String,
+        @Forgery file: File
+    ) {
+        // Given
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        whenever(mockGrantedOrchestrator.getWritableFile()) doReturn file
+        whenever(mockBatchFileHandler.writeData(file, serializedData, true)) doReturn false
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext) {
+            it.write(serializedData, eventId, serializedBatchMetadata)
+        }
+
+        // Then
+        verifyZeroInteractions(mockBatchMetadataFileHandler)
+    }
+
+    @Test
+    fun `𝕄 provide no op writer 𝕎 writeCurrentBatch() {consent=not_granted}`(
+        @StringForgery data: String,
+        @StringForgery eventId: String
+    ) {
+        // Given
+        val serializedData = data.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            val meta = it.currentMetadata()
+            val updatedMeta = meta?.reversedArray()
+            it.write(serializedData, eventId, updatedMeta)
         }
 
         // Then
-        verifyZeroInteractions(mockFileHandler, mockGrantedOrchestrator, mockPendingOrchestrator)
+        verifyZeroInteractions(
+            mockBatchFileHandler,
+            mockBatchMetadataFileHandler,
+            mockGrantedOrchestrator,
+            mockPendingOrchestrator
+        )
     }
 
     @Test
     fun `𝕄 do nothing 𝕎 write() {consent=not_granted, empty array}`(
+        @StringForgery batchMetadata: String,
         @StringForgery eventId: String
     ) {
         // Given
-        val serialized = ByteArray(0)
+        val serializedData = ByteArray(0)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
-        verifyZeroInteractions(mockFileHandler, mockGrantedOrchestrator, mockPendingOrchestrator)
+        verifyZeroInteractions(
+            mockBatchFileHandler,
+            mockBatchMetadataFileHandler,
+            mockGrantedOrchestrator,
+            mockPendingOrchestrator
+        )
     }
 
     @Test
     fun `𝕄 notify success 𝕎 write() {consent = not_granted}`(
         @StringForgery data: String,
-        @StringForgery eventId: String,
-        @Forgery file: File
+        @StringForgery batchMetadata: String,
+        @StringForgery eventId: String
     ) {
         // Given
-        val serialized = data.toByteArray(Charsets.UTF_8)
+        val serializedData = data.toByteArray(Charsets.UTF_8)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
-        whenever(mockGrantedOrchestrator.getWritableFile(any())) doReturn file
-        whenever(mockFileHandler.writeData(file, serialized, true)) doReturn true
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
@@ -409,20 +787,38 @@ internal class ConsentAwareStorageTest {
 
     @Test
     fun `𝕄 notify success 𝕎 write() {consent = not_granted, empty array}`(
+        @StringForgery batchMetadata: String,
         @StringForgery eventId: String
     ) {
         // Given
-        val serialized = ByteArray(0)
+        val serializedData = ByteArray(0)
+        val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serialized, eventId, ByteArray(0))
+            it.write(serializedData, eventId, serializedBatchMetadata)
         }
 
         // Then
         verify(mockListener).onDataWritten(eventId)
         verifyNoMoreInteractions(mockListener)
+    }
+
+    @Test
+    fun `𝕄 not read metadata 𝕎 currentMetadata() {consent = not_granted}`() {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
+
+        // When
+        var meta: ByteArray? = null
+        testedStorage.writeCurrentBatch(sdkContext) {
+            meta = it.currentMetadata()
+        }
+
+        // Then
+        assertThat(meta).isNull()
+        verifyZeroInteractions(mockBatchFileHandler, mockBatchMetadataFileHandler)
     }
 
     // endregion
@@ -437,12 +833,12 @@ internal class ConsentAwareStorageTest {
         // Given
         val mockData = data.map { it.toByteArray() }
         whenever(mockGrantedOrchestrator.getReadableFile(any())) doReturn file
-        whenever(mockFileHandler.readData(file)) doReturn mockData
+        whenever(mockBatchFileHandler.readData(file)) doReturn mockData
 
         // Whenever
         var readData: List<ByteArray>? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { id, reader ->
-            readData = reader.read(id)
+        testedStorage.readNextBatch(fakeDatadogContext) { _, reader ->
+            readData = reader.read()
         }
 
         // Then
@@ -458,12 +854,12 @@ internal class ConsentAwareStorageTest {
         val mockData = data.map { it.toByteArray() }
         whenever(mockGrantedOrchestrator.getReadableFile(emptySet())) doReturn file
         whenever(mockGrantedOrchestrator.getReadableFile(setOf(file))) doReturn null
-        whenever(mockFileHandler.readData(file)) doReturn mockData
+        whenever(mockBatchFileHandler.readData(file)) doReturn mockData
 
         // Whenever
         var readData: List<ByteArray>? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { id, reader ->
-            readData = reader.read(id)
+        testedStorage.readNextBatch(fakeDatadogContext) { _, reader ->
+            readData = reader.read()
         }
         testedStorage.readNextBatch(fakeDatadogContext) { _, _ ->
             fail { "Callback should not have been called again" }
@@ -489,12 +885,29 @@ internal class ConsentAwareStorageTest {
     // region confirmBatchRead
 
     @Test
-    fun `𝕄 delete batch file 𝕎 readNextBatch()+confirmBatchRead() {delete=true}`(
+    fun `𝕄 delete batch files 𝕎 readNextBatch()+confirmBatchRead() {delete=true}`(
         @Forgery file: File
     ) {
         // Given
+        testedStorage = ConsentAwareStorage(
+            mockGrantedOrchestrator,
+            mockPendingOrchestrator,
+            mockBatchFileHandler,
+            mockBatchMetadataFileHandler,
+            mockListener,
+            mockInternalLogger,
+            mockFilePersistenceConfig,
+            batchMetadataFileProvider = {
+                val batchMetadataFileMock = mock<File>()
+                whenever(batchMetadataFileMock.path) doReturn "${file.path}_metadata"
+                whenever(batchMetadataFileMock.exists()) doReturn true
+                batchMetadataFileMock
+            }
+        )
+
         whenever(mockGrantedOrchestrator.getReadableFile(emptySet())) doReturn file
-        whenever(mockFileHandler.delete(file)) doReturn true
+        whenever(mockBatchFileHandler.delete(file)) doReturn true
+        whenever(mockBatchMetadataFileHandler.delete(argThatIsMetaOf(file))) doReturn true
 
         // When
         var batchId: BatchId? = null
@@ -506,7 +919,8 @@ internal class ConsentAwareStorageTest {
         }
 
         // Then
-        verify(mockFileHandler).delete(file)
+        verify(mockBatchFileHandler).delete(file)
+        verify(mockBatchMetadataFileHandler).delete(argThatIsMetaOf(file))
     }
 
     @Test
@@ -534,7 +948,8 @@ internal class ConsentAwareStorageTest {
         }
 
         // Then
-        verify(mockFileHandler, never()).delete(file)
+        verify(mockBatchFileHandler, never()).delete(file)
+        verify(mockBatchMetadataFileHandler, never()).delete(argThatIsMetaOf(file))
         assertThat(batchId1).isEqualTo(batchId2)
     }
 
@@ -547,9 +962,8 @@ internal class ConsentAwareStorageTest {
         whenever(mockGrantedOrchestrator.getReadableFile(emptySet())) doReturn file
 
         // When
-        var batchId: BatchId? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { id, _ ->
-            batchId = id
+        testedStorage.readNextBatch(fakeDatadogContext) { _, _ ->
+            // no-op
         }
         testedStorage.confirmBatchRead(BatchId.fromFile(anotherFile)) { confirm ->
             confirm.markAsRead(true)
@@ -559,16 +973,17 @@ internal class ConsentAwareStorageTest {
         }
 
         // Then
-        verify(mockFileHandler, never()).delete(file)
+        verify(mockBatchFileHandler, never()).delete(file)
+        verify(mockBatchMetadataFileHandler, never()).delete(argThatIsMetaOf(file))
     }
 
     @Test
-    fun `𝕄 warn 𝕎 readNextBatch() + confirmBatchRead() {delete fails}`(
+    fun `𝕄 warn 𝕎 readNextBatch() + confirmBatchRead() {delete batch fails}`(
         @Forgery file: File
     ) {
         // Given
         whenever(mockGrantedOrchestrator.getReadableFile(emptySet())) doReturn file
-        whenever(mockFileHandler.delete(file)) doReturn false
+        whenever(mockBatchFileHandler.delete(file)) doReturn false
 
         // When
         var batchId: BatchId? = null
@@ -580,14 +995,85 @@ internal class ConsentAwareStorageTest {
         }
 
         // Then
-        verify(mockFileHandler).delete(file)
+        verify(mockBatchFileHandler).delete(file)
         verify(mockInternalLogger).log(
             InternalLogger.Level.WARN,
             InternalLogger.Target.MAINTAINER,
-            BatchFileDataReader.WARNING_DELETE_FAILED.format(Locale.US, file.path),
+            ConsentAwareStorage.WARNING_DELETE_FAILED.format(Locale.US, file.path),
             null,
             emptyMap()
         )
+        verifyNoMoreInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `𝕄 warn 𝕎 readNextBatch() + confirmBatchRead() {delete batch meta fails}`(
+        @Forgery file: File
+    ) {
+        // Given
+        testedStorage = ConsentAwareStorage(
+            mockGrantedOrchestrator,
+            mockPendingOrchestrator,
+            mockBatchFileHandler,
+            mockBatchMetadataFileHandler,
+            mockListener,
+            mockInternalLogger,
+            mockFilePersistenceConfig,
+            batchMetadataFileProvider = {
+                val batchMetadataFileMock = mock<File>()
+                whenever(batchMetadataFileMock.path) doReturn "${file.path}_metadata"
+                whenever(batchMetadataFileMock.exists()) doReturn true
+                batchMetadataFileMock
+            }
+        )
+
+        whenever(mockGrantedOrchestrator.getReadableFile(emptySet())) doReturn file
+        whenever(mockBatchFileHandler.delete(file)) doReturn true
+        whenever(mockBatchMetadataFileHandler.delete(argThatIsMetaOf(file))) doReturn false
+
+        // When
+        var batchId: BatchId? = null
+        testedStorage.readNextBatch(fakeDatadogContext) { id, _ ->
+            batchId = id
+        }
+        testedStorage.confirmBatchRead(batchId!!) { confirm ->
+            confirm.markAsRead(true)
+        }
+
+        // Then
+        verify(mockBatchFileHandler).delete(file)
+        verify(mockInternalLogger).log(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.MAINTAINER,
+            ConsentAwareStorage.WARNING_DELETE_FAILED.format(Locale.US, "${file.path}_metadata"),
+            null,
+            emptyMap()
+        )
+        verifyNoMoreInteractions(mockInternalLogger)
+    }
+
+    // endregion
+
+    // region private
+
+    private fun argThatIsMetaOf(file: File): File {
+        val wantedPath = "${file.path}_metadata"
+        return argThat(object : ArgumentMatcher<File> {
+            lateinit var capture: File
+
+            override fun matches(argument: File): Boolean {
+                capture = argument
+                return wantedPath == argument.path
+            }
+
+            override fun toString(): String {
+                return if (this::capture.isInitialized) {
+                    "Wanted $wantedPath, but got ${capture.path}"
+                } else {
+                    wantedPath
+                }
+            }
+        })
     }
 
     // endregion

--- a/detekt.yml
+++ b/detekt.yml
@@ -1023,6 +1023,7 @@ datadog:
       - "kotlin.collections.MutableMap.remove(com.datadog.android.rum.internal.vitals.VitalListener)"
       - "kotlin.collections.MutableMap.remove(kotlin.String)"
       - "kotlin.collections.MutableSet.add(com.datadog.android.telemetry.internal.TelemetryEventHandler.EventIdentity)"
+      - "kotlin.collections.MutableSet.add(com.datadog.android.v2.core.internal.storage.ConsentAwareStorage.Batch)"
       - "kotlin.collections.MutableSet.add(kotlin.String)"
       - "kotlin.collections.MutableSet.add(java.io.File)"
       - "kotlin.collections.MutableSet.clear()"
@@ -1031,7 +1032,9 @@ datadog:
       - "kotlin.collections.MutableSet.firstOrNull(kotlin.Function1)"
       - "kotlin.collections.MutableSet.forEach(kotlin.Function1)"
       - "kotlin.collections.MutableSet.joinToString(kotlin.CharSequence, kotlin.CharSequence, kotlin.CharSequence, kotlin.Int, kotlin.CharSequence, kotlin.Function1?)"
+      - "kotlin.collections.MutableSet.map(kotlin.Function1)"
       - "kotlin.collections.MutableSet.remove(java.io.File)"
+      - "kotlin.collections.MutableSet.remove(com.datadog.android.v2.core.internal.storage.ConsentAwareStorage.Batch)"
       - "kotlin.sequences.Sequence.filter(kotlin.Function1)"
       - "kotlin.sequences.Sequence.forEach(kotlin.Function1)"
       # endregion


### PR DESCRIPTION
### What does this PR do?

This change adds support for reading/writing optional batch metadata (in a non-typed format, currently as `ByteArray`).

Batch metadata file will be written to the batch data file and will be associated with it by the name (metadata file will have the same name as batch file, just with `_metadata` suffix).

This change also does the following:

* Removes the dependency on the event size in the `FileOrchestrator` to prevent the possibility of the switching to the next batch file if current batch size + event size exceeds the limit (we can do this, because the limit set in the SDK is still less than the actual limit of the intake(s) and the margin we have is still bigger than maximum event size). This makes us to keep batch metadata file and batch file in sync for the particular `BatchWriter` (otherwise we could have a metadata file from another batch). Responsibility of checking event size is now shifted to the `Writer` layer.
* Temporarily separates classes/interfaces for writing/reading batch files and simple files (with only 1 item, or without the need of metadata included), because return type of the read and file format are different now. This is not a final state (set of classes, content, names) and better rework will be done in RUMM-2235.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

