### PR TITLE
Telemetry adjustments

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/LoggingSyncListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/time/LoggingSyncListener.kt
@@ -7,9 +7,7 @@
 package com.datadog.android.core.internal.time
 
 import com.datadog.android.core.internal.utils.sdkLogger
-import com.datadog.android.log.internal.utils.errorWithTelemetry
 import com.lyft.kronos.SyncListener
-import java.io.IOException
 
 internal class LoggingSyncListener : SyncListener {
     override fun onStartSync(host: String) {
@@ -23,10 +21,6 @@ internal class LoggingSyncListener : SyncListener {
     override fun onError(host: String, throwable: Throwable) {
         val message = "Kronos onError @host:$host"
         val attributes = mapOf("kronos.sync.host" to host)
-        if (throwable is IOException) {
-            sdkLogger.e(message, throwable, attributes)
-        } else {
-            sdkLogger.errorWithTelemetry(message, throwable, attributes)
-        }
+        sdkLogger.e(message, throwable, attributes)
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -306,7 +306,6 @@ interface RumMonitor {
                     writer = RumFeature.persistenceStrategy.getWriter(),
                     handler = Handler(Looper.getMainLooper()),
                     telemetryEventHandler = TelemetryEventHandler(
-                        CoreFeature.serviceName,
                         CoreFeature.sdkVersion,
                         RumEventSourceProvider(CoreFeature.sourceName),
                         CoreFeature.timeProvider,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -21,7 +21,6 @@ import com.datadog.android.telemetry.model.TelemetryErrorEvent
 import java.util.Locale
 
 internal class TelemetryEventHandler(
-    internal val serviceName: String,
     internal val sdkVersion: String,
     private val sourceProvider: RumEventSourceProvider,
     private val timeProvider: TimeProvider,
@@ -90,7 +89,7 @@ internal class TelemetryEventHandler(
             date = timestamp,
             source = sourceProvider.telemetryDebugEventSource
                 ?: TelemetryDebugEvent.Source.ANDROID,
-            service = serviceName,
+            service = TELEMETRY_SERVICE_NAME,
             version = sdkVersion,
             application = TelemetryDebugEvent.Application(rumContext.applicationId),
             session = TelemetryDebugEvent.Session(rumContext.sessionId),
@@ -113,7 +112,7 @@ internal class TelemetryEventHandler(
             date = timestamp,
             source = sourceProvider.telemetryErrorEventSource
                 ?: TelemetryErrorEvent.Source.ANDROID,
-            service = serviceName,
+            service = TELEMETRY_SERVICE_NAME,
             version = sdkVersion,
             application = TelemetryErrorEvent.Application(rumContext.applicationId),
             session = TelemetryErrorEvent.Session(rumContext.sessionId),
@@ -147,5 +146,6 @@ internal class TelemetryEventHandler(
             "Already seen telemetry event with identity=%s, rejecting."
         const val MAX_EVENT_NUMBER_REACHED_MESSAGE =
             "Max number of telemetry events per session reached, rejecting."
+        const val TELEMETRY_SERVICE_NAME = "dd-sdk-android"
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/time/LoggingSyncListenerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/time/LoggingSyncListenerTest.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.core.internal.time
 
 import android.util.Log
-import com.datadog.android.log.internal.utils.ERROR_WITH_TELEMETRY_LEVEL
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -17,8 +16,6 @@ import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.io.IOException
-import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -32,34 +29,12 @@ internal class LoggingSyncListenerTest {
     private val testableListener = LoggingSyncListener()
 
     @Test
-    fun `𝕄 send error with telemetry 𝕎 onError() { non-network error }`(
+    fun `𝕄 log error 𝕎 onError()`(
         @StringForgery(regex = "https://[a-z]+\\.com") fakeHost: String,
         forge: Forge
     ) {
         // Given
         val throwable = forge.aThrowable()
-
-        assumeTrue { throwable !is IOException }
-
-        // When
-        testableListener.onError(fakeHost, throwable)
-
-        // Then
-        verify(logger.mockSdkLogHandler)
-            .handleLog(
-                ERROR_WITH_TELEMETRY_LEVEL,
-                "Kronos onError @host:$fakeHost",
-                throwable,
-                mapOf("kronos.sync.host" to fakeHost)
-            )
-    }
-
-    @Test
-    fun `𝕄 send error without telemetry 𝕎 onError() { network error }`(
-        @StringForgery(regex = "https://[a-z]+\\.com") fakeHost: String
-    ) {
-        // Given
-        val throwable = IOException()
 
         // When
         testableListener.onError(fakeHost, throwable)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
@@ -89,7 +89,6 @@ internal class RumMonitorBuilderTest {
         assertThat(monitor.backgroundTrackingEnabled).isEqualTo(fakeConfig.backgroundEventTracking)
 
         assertThat(monitor.telemetryEventHandler.sdkVersion).isEqualTo(CoreFeature.sdkVersion)
-        assertThat(monitor.telemetryEventHandler.serviceName).isEqualTo(CoreFeature.serviceName)
 
         val telemetrySampler = monitor.telemetryEventHandler.eventSampler
         check(telemetrySampler is RateBasedSampler)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -75,9 +75,6 @@ internal class TelemetryEventHandlerTest {
     lateinit var mockSampler: Sampler
 
     @StringForgery
-    lateinit var mockServiceName: String
-
-    @StringForgery
     lateinit var mockSdkVersion: String
 
     private var fakeServerOffset: Long = 0L
@@ -97,7 +94,6 @@ internal class TelemetryEventHandlerTest {
 
         testedTelemetryHandler =
             TelemetryEventHandler(
-                mockServiceName,
                 mockSdkVersion,
                 mockSourceProvider,
                 mockTimeProvider,
@@ -122,7 +118,7 @@ internal class TelemetryEventHandlerTest {
                 hasDate(debugRawEvent.eventTime.timestamp + fakeServerOffset)
                 hasSource(TelemetryDebugEvent.Source.ANDROID)
                 hasMessage(debugRawEvent.message)
-                hasService(mockServiceName)
+                hasService(TelemetryEventHandler.TELEMETRY_SERVICE_NAME)
                 hasVersion(mockSdkVersion)
                 hasApplicationId(rumContext.applicationId)
                 hasSessionId(rumContext.sessionId)
@@ -149,7 +145,7 @@ internal class TelemetryEventHandlerTest {
                 hasDate(errorRawEvent.eventTime.timestamp + fakeServerOffset)
                 hasSource(TelemetryErrorEvent.Source.ANDROID)
                 hasMessage(errorRawEvent.message)
-                hasService(mockServiceName)
+                hasService(TelemetryEventHandler.TELEMETRY_SERVICE_NAME)
                 hasVersion(mockSdkVersion)
                 hasApplicationId(rumContext.applicationId)
                 hasSessionId(rumContext.sessionId)
@@ -208,7 +204,7 @@ internal class TelemetryEventHandlerTest {
                         hasDate(rawEvent.eventTime.timestamp + fakeServerOffset)
                         hasSource(TelemetryDebugEvent.Source.ANDROID)
                         hasMessage(rawEvent.message)
-                        hasService(mockServiceName)
+                        hasService(TelemetryEventHandler.TELEMETRY_SERVICE_NAME)
                         hasVersion(mockSdkVersion)
                         hasApplicationId(rumContext.applicationId)
                         hasSessionId(rumContext.sessionId)
@@ -221,7 +217,7 @@ internal class TelemetryEventHandlerTest {
                         hasDate(rawEvent.eventTime.timestamp + fakeServerOffset)
                         hasSource(TelemetryErrorEvent.Source.ANDROID)
                         hasMessage(rawEvent.message)
-                        hasService(mockServiceName)
+                        hasService(TelemetryEventHandler.TELEMETRY_SERVICE_NAME)
                         hasVersion(mockSdkVersion)
                         hasApplicationId(rumContext.applicationId)
                         hasSessionId(rumContext.sessionId)
@@ -275,7 +271,7 @@ internal class TelemetryEventHandlerTest {
                             hasDate(events[it.index].eventTime.timestamp + fakeServerOffset)
                             hasSource(TelemetryDebugEvent.Source.ANDROID)
                             hasMessage(events[it.index].message)
-                            hasService(mockServiceName)
+                            hasService(TelemetryEventHandler.TELEMETRY_SERVICE_NAME)
                             hasVersion(mockSdkVersion)
                             hasApplicationId(rumContext.applicationId)
                             hasSessionId(rumContext.sessionId)
@@ -288,7 +284,7 @@ internal class TelemetryEventHandlerTest {
                             hasDate(events[it.index].eventTime.timestamp + fakeServerOffset)
                             hasSource(TelemetryErrorEvent.Source.ANDROID)
                             hasMessage(events[it.index].message)
-                            hasService(mockServiceName)
+                            hasService(TelemetryEventHandler.TELEMETRY_SERVICE_NAME)
                             hasVersion(mockSdkVersion)
                             hasApplicationId(rumContext.applicationId)
                             hasSessionId(rumContext.sessionId)
@@ -358,7 +354,7 @@ internal class TelemetryEventHandlerTest {
                             hasDate(expectedEvents[it.index].eventTime.timestamp + fakeServerOffset)
                             hasSource(TelemetryDebugEvent.Source.ANDROID)
                             hasMessage(expectedEvents[it.index].message)
-                            hasService(mockServiceName)
+                            hasService(TelemetryEventHandler.TELEMETRY_SERVICE_NAME)
                             hasVersion(mockSdkVersion)
                             hasApplicationId(rumContext.applicationId)
                             hasSessionId(rumContext.sessionId)
@@ -371,7 +367,7 @@ internal class TelemetryEventHandlerTest {
                             hasDate(expectedEvents[it.index].eventTime.timestamp + fakeServerOffset)
                             hasSource(TelemetryErrorEvent.Source.ANDROID)
                             hasMessage(expectedEvents[it.index].message)
-                            hasService(mockServiceName)
+                            hasService(TelemetryEventHandler.TELEMETRY_SERVICE_NAME)
                             hasVersion(mockSdkVersion)
                             hasApplicationId(rumContext.applicationId)
                             hasSessionId(rumContext.sessionId)


### PR DESCRIPTION
### What does this PR do?

This change does the following:

* Makes telemetry events use `dd-sdk-android` as a `service` name value.
* Removes telemetry from Kronos sync listener, because all the errors we get are not actionable and just add noise, and if there is any issue with NTP server or Kronos itself we will see it in the sample app anyway.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

