### PR TITLE
RUMM-2231 Fix the session management rules

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumContext.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumContext.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.domain
 
+import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import java.util.UUID
 
@@ -16,6 +17,7 @@ internal data class RumContext(
     val viewName: String? = null,
     val viewUrl: String? = null,
     val actionId: String? = null,
+    val sessionState: RumSessionScope.State = RumSessionScope.State.NOT_TRACKED,
     val viewType: RumViewScope.RumViewType = RumViewScope.RumViewType.NONE
 ) {
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -6,13 +6,6 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import android.annotation.SuppressLint
-import android.app.ActivityManager.RunningAppProcessInfo
-import android.os.Build
-import android.os.Process
-import android.os.SystemClock
-import com.datadog.android.Datadog
-import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.NoOpDataWriter
@@ -20,12 +13,10 @@ import com.datadog.android.core.internal.system.AndroidInfoProvider
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
 import com.datadog.android.core.internal.time.TimeProvider
-import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.event.RumEventSourceProvider
-import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import java.security.SecureRandom
 import java.util.UUID
@@ -49,22 +40,36 @@ internal class RumSessionScope(
     private val androidInfoProvider: AndroidInfoProvider
 ) : RumScope {
 
-    internal val childrenScopes = mutableListOf<RumScope>()
-
-    internal var keepSession: Boolean = false
     internal var sessionId = RumContext.NULL_UUID
-    internal val sessionStartNs = AtomicLong(System.nanoTime())
-    internal val lastUserInteractionNs = AtomicLong(0L)
-
-    private var resetSessionTime: Long? = null
-
-    internal var applicationDisplayed: Boolean = false
+    internal var sessionState: State = State.NOT_TRACKED
+    private val sessionStartNs = AtomicLong(System.nanoTime())
+    private val lastUserInteractionNs = AtomicLong(0L)
 
     private val random = SecureRandom()
+
     private val noOpWriter = NoOpDataWriter<Any>()
+
+    internal var childScope: RumScope = RumViewManagerScope(
+        this,
+        backgroundTrackingEnabled,
+        firstPartyHostDetector,
+        cpuVitalMonitor,
+        memoryVitalMonitor,
+        frameRateVitalMonitor,
+        timeProvider,
+        rumEventSourceProvider,
+        buildSdkVersionProvider,
+        androidInfoProvider
+    )
 
     init {
         GlobalRum.updateRumContext(getRumContext())
+    }
+
+    enum class State {
+        NOT_TRACKED,
+        TRACKED,
+        EXPIRED
     }
 
     // region RumScope
@@ -74,51 +79,24 @@ internal class RumSessionScope(
         writer: DataWriter<Any>
     ): RumScope {
         if (event is RumRawEvent.ResetSession) {
-            sessionId = RumContext.NULL_UUID
-            resetSessionTime = System.nanoTime()
-            applicationDisplayed = false
-        }
-        updateSessionIdIfNeeded()
-
-        val actualWriter = if (keepSession) writer else noOpWriter
-
-        val iterator = childrenScopes.iterator()
-        @Suppress("UnsafeThirdPartyFunctionCall") // next/remove can't fail: we checked hasNext
-        while (iterator.hasNext()) {
-            val scope = iterator.next().handleEvent(event, actualWriter)
-            if (scope == null) {
-                iterator.remove()
-            }
+            renewSession(System.nanoTime())
         }
 
-        if (event is RumRawEvent.StartView) {
-            val viewScope = RumViewScope.fromEvent(
-                this,
-                event,
-                firstPartyHostDetector,
-                cpuVitalMonitor,
-                memoryVitalMonitor,
-                frameRateVitalMonitor,
-                timeProvider,
-                rumEventSourceProvider,
-                androidInfoProvider
-            )
-            onViewDisplayed(event, viewScope, actualWriter)
-            childrenScopes.add(viewScope)
-        } else if (childrenScopes.count { it.isActive() } == 0) {
-            handleOrphanEvent(event, actualWriter)
-        }
+        updateSession(event)
+
+        val actualWriter = if (sessionState == State.TRACKED) writer else noOpWriter
+
+        childScope.handleEvent(event, actualWriter)
 
         return this
     }
 
     override fun getRumContext(): RumContext {
-        updateSessionIdIfNeeded()
-        return if (keepSession) {
-            parentScope.getRumContext().copy(sessionId = sessionId)
-        } else {
-            RumContext()
-        }
+        val parentContext = parentScope.getRumContext()
+        return parentContext.copy(
+            sessionId = sessionId,
+            sessionState = sessionState
+        )
     }
 
     override fun isActive(): Boolean {
@@ -129,186 +107,44 @@ internal class RumSessionScope(
 
     // region Internal
 
-    private fun handleOrphanEvent(
-        event: RumRawEvent,
-        writer: DataWriter<Any>
-    ) {
-        val isForegroundProcess =
-            CoreFeature.processImportance == RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-        if (applicationDisplayed || !isForegroundProcess) {
-            handleBackgroundEvent(event, writer)
-        } else {
-            handleAppLaunchEvent(event, writer)
-        }
-    }
-
-    private fun handleAppLaunchEvent(
-        event: RumRawEvent,
-        actualWriter: DataWriter<Any>
-    ) {
-        val isValidAppLaunchEvent = event.javaClass in validAppLaunchEventTypes
-        val isSilentOrphanEvent = event.javaClass in silentOrphanEventTypes
-
-        if (isValidAppLaunchEvent) {
-            val viewScope = createAppLaunchViewScope(event)
-            viewScope.handleEvent(event, actualWriter)
-            childrenScopes.add(viewScope)
-        } else if (!isSilentOrphanEvent) {
-            devLogger.w(MESSAGE_MISSING_VIEW)
-        }
-    }
-
-    private fun handleBackgroundEvent(
-        event: RumRawEvent,
-        writer: DataWriter<Any>
-    ) {
-        val isValidBackgroundEvent = event.javaClass in validBackgroundEventTypes
-        val isSilentOrphanEvent = event.javaClass in silentOrphanEventTypes
-
-        if (isValidBackgroundEvent && backgroundTrackingEnabled) {
-            // there is no active ViewScope to handle this event. We will assume the application
-            // is in background and we will create a special ViewScope (background)
-            // to handle all the events.
-            val viewScope = createBackgroundViewScope(event)
-            viewScope.handleEvent(event, writer)
-            childrenScopes.add(viewScope)
-        } else if (!isSilentOrphanEvent) {
-            devLogger.w(MESSAGE_MISSING_VIEW)
-        }
-    }
-
-    private fun createBackgroundViewScope(event: RumRawEvent): RumViewScope {
-        return RumViewScope(
-            this,
-            RUM_BACKGROUND_VIEW_URL,
-            RUM_BACKGROUND_VIEW_NAME,
-            event.eventTime,
-            emptyMap(),
-            firstPartyHostDetector,
-            NoOpVitalMonitor(),
-            NoOpVitalMonitor(),
-            NoOpVitalMonitor(),
-            timeProvider,
-            rumEventSourceProvider,
-            type = RumViewScope.RumViewType.BACKGROUND,
-            androidInfoProvider = androidInfoProvider
-        )
-    }
-
-    private fun createAppLaunchViewScope(event: RumRawEvent): RumViewScope {
-        return RumViewScope(
-            this,
-            RUM_APP_LAUNCH_VIEW_URL,
-            RUM_APP_LAUNCH_VIEW_NAME,
-            event.eventTime,
-            emptyMap(),
-            firstPartyHostDetector,
-            NoOpVitalMonitor(),
-            NoOpVitalMonitor(),
-            NoOpVitalMonitor(),
-            timeProvider,
-            rumEventSourceProvider,
-            type = RumViewScope.RumViewType.APPLICATION_LAUNCH,
-            androidInfoProvider = androidInfoProvider
-        )
-    }
-
-    internal fun onViewDisplayed(
-        event: RumRawEvent.StartView,
-        viewScope: RumViewScope,
-        writer: DataWriter<Any>
-    ) {
-        if (!applicationDisplayed) {
-            applicationDisplayed = true
-            val isForegroundProcess =
-                CoreFeature.processImportance == RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-            if (isForegroundProcess) {
-                val applicationStartTime = resolveStartupTimeNs()
-                viewScope.handleEvent(
-                    RumRawEvent.ApplicationStarted(event.eventTime, applicationStartTime),
-                    writer
-                )
-            }
-        }
-    }
-
-    @SuppressLint("NewApi")
-    private fun resolveStartupTimeNs(): Long {
-        val resetTimeNs = resetSessionTime
-        return when {
-            resetTimeNs != null -> resetTimeNs
-            buildSdkVersionProvider.version() >= Build.VERSION_CODES.N -> {
-                val diffMs = SystemClock.elapsedRealtime() - Process.getStartElapsedRealtime()
-                System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(diffMs)
-            }
-            else -> Datadog.startupTimeNs
-        }
-    }
-
-    @Synchronized
-    private fun updateSessionIdIfNeeded() {
+    private fun updateSession(event: RumRawEvent) {
         val nanoTime = System.nanoTime()
         val isNewSession = sessionId == RumContext.NULL_UUID
-        val sessionLength = nanoTime - sessionStartNs.get()
-        val duration = nanoTime - lastUserInteractionNs.get()
-        val isInactiveSession = duration >= sessionInactivityNanos
-        val isLongSession = sessionLength >= sessionMaxDurationNanos
 
-        if (isNewSession || isInactiveSession || isLongSession) {
-            keepSession = (random.nextFloat() * 100f) < samplingRate
-            sessionStartNs.set(nanoTime)
-            sessionId = UUID.randomUUID().toString()
-            sessionListener?.onSessionStarted(sessionId, !keepSession)
+        val timeSinceLastInteractionNs = nanoTime - lastUserInteractionNs.get()
+        val isExpired = timeSinceLastInteractionNs >= sessionInactivityNanos
+        val timeSinceSessionStartNs = nanoTime - sessionStartNs.get()
+        val isTimedOut = timeSinceSessionStartNs >= sessionMaxDurationNanos
+
+        val isInteraction = (event is RumRawEvent.StartView) || (event is RumRawEvent.StartAction)
+
+        if (isInteraction) {
+            if (isNewSession || isExpired || isTimedOut) {
+                renewSession(nanoTime)
+            }
+            lastUserInteractionNs.set(nanoTime)
+        } else {
+            if (isExpired) {
+                sessionState = State.EXPIRED
+            } else if (isTimedOut) {
+                renewSession(nanoTime)
+            }
         }
+    }
 
-        lastUserInteractionNs.set(nanoTime)
+    private fun renewSession(nanoTime: Long) {
+        val keepSession = (random.nextFloat() * 100f) < samplingRate
+        sessionState = if (keepSession) State.TRACKED else State.NOT_TRACKED
+        sessionId = UUID.randomUUID().toString()
+        sessionStartNs.set(nanoTime)
+        sessionListener?.onSessionStarted(sessionId, !keepSession)
     }
 
     // endregion
 
     companion object {
 
-        internal val validBackgroundEventTypes = arrayOf<Class<*>>(
-            RumRawEvent.AddError::class.java,
-            RumRawEvent.StartAction::class.java,
-            RumRawEvent.StartResource::class.java
-        )
-        internal val validAppLaunchEventTypes = arrayOf<Class<*>>(
-            RumRawEvent.AddError::class.java,
-            RumRawEvent.AddLongTask::class.java,
-            RumRawEvent.StartAction::class.java,
-            RumRawEvent.StartResource::class.java
-        )
-
-        internal val silentOrphanEventTypes = arrayOf<Class<*>>(
-            RumRawEvent.ApplicationStarted::class.java,
-            RumRawEvent.KeepAlive::class.java,
-            RumRawEvent.ResetSession::class.java,
-            RumRawEvent.StopView::class.java,
-            RumRawEvent.ActionDropped::class.java,
-            RumRawEvent.ActionSent::class.java,
-            RumRawEvent.ErrorDropped::class.java,
-            RumRawEvent.ErrorSent::class.java,
-            RumRawEvent.LongTaskDropped::class.java,
-            RumRawEvent.LongTaskSent::class.java,
-            RumRawEvent.ResourceDropped::class.java,
-            RumRawEvent.ResourceSent::class.java
-        )
-
         internal val DEFAULT_SESSION_INACTIVITY_NS = TimeUnit.MINUTES.toNanos(15)
         internal val DEFAULT_SESSION_MAX_DURATION_NS = TimeUnit.HOURS.toNanos(4)
-
-        internal const val RUM_BACKGROUND_VIEW_URL = "com/datadog/background/view"
-        internal const val RUM_BACKGROUND_VIEW_NAME = "Background"
-
-        internal const val RUM_APP_LAUNCH_VIEW_URL = "com/datadog/application-launch/view"
-        internal const val RUM_APP_LAUNCH_VIEW_NAME = "ApplicationLaunch"
-
-        internal const val MESSAGE_MISSING_VIEW =
-            "A RUM event was detected, but no view is active. " +
-                "To track views automatically, try calling the " +
-                "Configuration.Builder.useViewTrackingStrategy() method.\n" +
-                "You can also track views manually using the RumMonitor.startView() and " +
-                "RumMonitor.stopView() methods."
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -1,0 +1,260 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.scope
+
+import android.annotation.SuppressLint
+import android.app.ActivityManager
+import android.os.Build
+import android.os.Process
+import android.os.SystemClock
+import androidx.annotation.VisibleForTesting
+import com.datadog.android.Datadog
+import com.datadog.android.core.internal.CoreFeature
+import com.datadog.android.core.internal.net.FirstPartyHostDetector
+import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.system.AndroidInfoProvider
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
+import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.core.internal.utils.devLogger
+import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.rum.internal.domain.event.RumEventSourceProvider
+import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
+import com.datadog.android.rum.internal.vitals.VitalMonitor
+import java.util.concurrent.TimeUnit
+
+internal class RumViewManagerScope(
+    private val parentScope: RumScope,
+    private val backgroundTrackingEnabled: Boolean,
+    internal val firstPartyHostDetector: FirstPartyHostDetector,
+    private val cpuVitalMonitor: VitalMonitor,
+    private val memoryVitalMonitor: VitalMonitor,
+    private val frameRateVitalMonitor: VitalMonitor,
+    private val timeProvider: TimeProvider,
+    private val rumEventSourceProvider: RumEventSourceProvider,
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider(),
+    private val androidInfoProvider: AndroidInfoProvider
+) : RumScope {
+
+    internal val childrenScopes = mutableListOf<RumScope>()
+    internal var applicationDisplayed = false
+
+    // region RumScope
+
+    override fun handleEvent(event: RumRawEvent, writer: DataWriter<Any>): RumScope {
+        delegateToChildren(event, writer)
+
+        if (event is RumRawEvent.StartView) {
+            startForegroundView(event, writer)
+        } else if (childrenScopes.count { it.isActive() } == 0) {
+            handleOrphanEvent(event, writer)
+        }
+
+        return this
+    }
+
+    override fun getRumContext(): RumContext {
+        return parentScope.getRumContext()
+    }
+
+    override fun isActive(): Boolean {
+        return true
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun delegateToChildren(
+        event: RumRawEvent,
+        writer: DataWriter<Any>
+    ) {
+        val iterator = childrenScopes.iterator()
+        @Suppress("UnsafeThirdPartyFunctionCall") // next/remove can't fail: we checked hasNext
+        while (iterator.hasNext()) {
+            val result = iterator.next().handleEvent(event, writer)
+            if (result == null) {
+                iterator.remove()
+            }
+        }
+    }
+
+    private fun handleOrphanEvent(event: RumRawEvent, writer: DataWriter<Any>) {
+        val processFlag = CoreFeature.processImportance
+        val importanceForeground = ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+        val isForegroundProcess = processFlag == importanceForeground
+
+        if (applicationDisplayed || !isForegroundProcess) {
+            handleBackgroundEvent(event, writer)
+        } else {
+            handleAppLaunchEvent(event, writer)
+        }
+    }
+
+    private fun startForegroundView(event: RumRawEvent.StartView, writer: DataWriter<Any>) {
+        val viewScope = RumViewScope.fromEvent(
+            this,
+            event,
+            firstPartyHostDetector,
+            cpuVitalMonitor,
+            memoryVitalMonitor,
+            frameRateVitalMonitor,
+            timeProvider,
+            rumEventSourceProvider,
+            androidInfoProvider
+        )
+        onViewDisplayed(event, viewScope, writer)
+        childrenScopes.add(viewScope)
+    }
+
+    private fun handleBackgroundEvent(
+        event: RumRawEvent,
+        writer: DataWriter<Any>
+    ) {
+        val isValidBackgroundEvent = event.javaClass in validBackgroundEventTypes
+        val isSilentOrphanEvent = event.javaClass in silentOrphanEventTypes
+
+        if (isValidBackgroundEvent && backgroundTrackingEnabled) {
+            // there is no active ViewScope to handle this event. We will assume the application
+            // is in background and we will create a special ViewScope (background)
+            // to handle all the events.
+            val viewScope = createBackgroundViewScope(event)
+            viewScope.handleEvent(event, writer)
+            childrenScopes.add(viewScope)
+        } else if (!isSilentOrphanEvent) {
+            devLogger.w(MESSAGE_MISSING_VIEW)
+        }
+    }
+
+    private fun handleAppLaunchEvent(
+        event: RumRawEvent,
+        actualWriter: DataWriter<Any>
+    ) {
+        val isValidAppLaunchEvent = event.javaClass in validAppLaunchEventTypes
+        val isSilentOrphanEvent = event.javaClass in silentOrphanEventTypes
+
+        if (isValidAppLaunchEvent) {
+            val viewScope = createAppLaunchViewScope(event)
+            viewScope.handleEvent(event, actualWriter)
+            childrenScopes.add(viewScope)
+        } else if (!isSilentOrphanEvent) {
+            devLogger.w(MESSAGE_MISSING_VIEW)
+        }
+    }
+
+    private fun createBackgroundViewScope(event: RumRawEvent): RumViewScope {
+        return RumViewScope(
+            this,
+            RUM_BACKGROUND_VIEW_URL,
+            RUM_BACKGROUND_VIEW_NAME,
+            event.eventTime,
+            emptyMap(),
+            firstPartyHostDetector,
+            NoOpVitalMonitor(),
+            NoOpVitalMonitor(),
+            NoOpVitalMonitor(),
+            timeProvider,
+            rumEventSourceProvider,
+            type = RumViewScope.RumViewType.BACKGROUND,
+            androidInfoProvider = androidInfoProvider
+        )
+    }
+
+    private fun createAppLaunchViewScope(event: RumRawEvent): RumViewScope {
+        return RumViewScope(
+            this,
+            RUM_APP_LAUNCH_VIEW_URL,
+            RUM_APP_LAUNCH_VIEW_NAME,
+            event.eventTime,
+            emptyMap(),
+            firstPartyHostDetector,
+            NoOpVitalMonitor(),
+            NoOpVitalMonitor(),
+            NoOpVitalMonitor(),
+            timeProvider,
+            rumEventSourceProvider,
+            type = RumViewScope.RumViewType.APPLICATION_LAUNCH,
+            androidInfoProvider = androidInfoProvider
+        )
+    }
+
+    @VisibleForTesting
+    internal fun onViewDisplayed(
+        event: RumRawEvent.StartView,
+        viewScope: RumViewScope,
+        writer: DataWriter<Any>
+    ) {
+        if (!applicationDisplayed) {
+            applicationDisplayed = true
+            val isForegroundProcess = CoreFeature.processImportance ==
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+            if (isForegroundProcess) {
+                val applicationStartTime = resolveStartupTimeNs()
+                viewScope.handleEvent(
+                    RumRawEvent.ApplicationStarted(event.eventTime, applicationStartTime),
+                    writer
+                )
+            }
+        }
+    }
+
+    @SuppressLint("NewApi")
+    private fun resolveStartupTimeNs(): Long {
+        return when {
+            buildSdkVersionProvider.version() >= Build.VERSION_CODES.N -> {
+                val diffMs = SystemClock.elapsedRealtime() - Process.getStartElapsedRealtime()
+                System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(diffMs)
+            }
+            else -> Datadog.startupTimeNs
+        }
+    }
+
+    // endregion
+
+    companion object {
+
+        internal val validBackgroundEventTypes = arrayOf<Class<*>>(
+            RumRawEvent.AddError::class.java,
+            RumRawEvent.StartAction::class.java,
+            RumRawEvent.StartResource::class.java
+        )
+        internal val validAppLaunchEventTypes = arrayOf<Class<*>>(
+            RumRawEvent.AddError::class.java,
+            RumRawEvent.AddLongTask::class.java,
+            RumRawEvent.StartAction::class.java,
+            RumRawEvent.StartResource::class.java
+        )
+
+        internal val silentOrphanEventTypes = arrayOf<Class<*>>(
+            RumRawEvent.ApplicationStarted::class.java,
+            RumRawEvent.KeepAlive::class.java,
+            RumRawEvent.ResetSession::class.java,
+            RumRawEvent.StopView::class.java,
+            RumRawEvent.ActionDropped::class.java,
+            RumRawEvent.ActionSent::class.java,
+            RumRawEvent.ErrorDropped::class.java,
+            RumRawEvent.ErrorSent::class.java,
+            RumRawEvent.LongTaskDropped::class.java,
+            RumRawEvent.LongTaskSent::class.java,
+            RumRawEvent.ResourceDropped::class.java,
+            RumRawEvent.ResourceSent::class.java
+        )
+
+        internal const val RUM_BACKGROUND_VIEW_URL = "com/datadog/background/view"
+        internal const val RUM_BACKGROUND_VIEW_NAME = "Background"
+
+        internal const val RUM_APP_LAUNCH_VIEW_URL = "com/datadog/application-launch/view"
+        internal const val RUM_APP_LAUNCH_VIEW_NAME = "ApplicationLaunch"
+
+        internal const val MESSAGE_MISSING_VIEW =
+            "A RUM event was detected, but no view is active. " +
+                "To track views automatically, try calling the " +
+                "Configuration.Builder.useViewTrackingStrategy() method.\n" +
+                "You can also track views manually using the RumMonitor.startView() and " +
+                "RumMonitor.stopView() methods."
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -28,6 +28,7 @@ import com.datadog.android.rum.internal.domain.scope.RumApplicationScope
 import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.domain.scope.RumScope
 import com.datadog.android.rum.internal.domain.scope.RumSessionScope
+import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.model.ViewEvent
@@ -388,9 +389,10 @@ internal class DatadogRumMonitor(
         debugListener?.let {
             val applicationScope = rootScope as? RumApplicationScope
             val sessionScope = applicationScope?.childScope as? RumSessionScope
-            if (sessionScope != null) {
+            val viewManagerScope = sessionScope?.childScope as? RumViewManagerScope
+            if (viewManagerScope != null) {
                 it.onReceiveRumActiveViews(
-                    sessionScope.childrenScopes
+                    viewManagerScope.childrenScopes
                         .filterIsInstance<RumViewScope>()
                         .filter { viewScope -> viewScope.isActive() }
                         .mapNotNull { viewScope -> viewScope.getRumContext().viewName }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -1,0 +1,174 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.scope
+
+import com.datadog.android.rum.RumActionType
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.utils.forge.exhaustiveAttributes
+import com.datadog.tools.unit.forge.aThrowable
+import fr.xgouchet.elmyr.Forge
+import java.net.URL
+import java.util.UUID
+
+internal fun Forge.interactiveRumRawEvent(): RumRawEvent {
+    return anElementFrom(
+        startViewEvent(),
+        startActionEvent()
+    )
+}
+
+internal fun Forge.startViewEvent(): RumRawEvent.StartView {
+    return RumRawEvent.StartView(
+        key = anHexadecimalString(),
+        name = anAlphabeticalString(),
+        attributes = exhaustiveAttributes()
+    )
+}
+
+internal fun Forge.startActionEvent(continuous: Boolean? = null): RumRawEvent.StartAction {
+    return RumRawEvent.StartAction(
+        type = aValueFrom(RumActionType::class.java),
+        name = anAlphabeticalString(),
+        waitForStop = continuous ?: aBool(),
+        attributes = exhaustiveAttributes()
+    )
+}
+
+internal fun Forge.stopActionEvent(): RumRawEvent.StopAction {
+    return RumRawEvent.StopAction(
+        type = aValueFrom(RumActionType::class.java),
+        name = anAlphabeticalString(),
+        attributes = exhaustiveAttributes()
+    )
+}
+
+internal fun Forge.startResourceEvent(): RumRawEvent.StartResource {
+    return RumRawEvent.StartResource(
+        key = anAlphabeticalString(),
+        url = getForgery<URL>().toString(),
+        method = anElementFrom("POST", "GET", "PUT", "DELETE", "HEAD"),
+        attributes = exhaustiveAttributes()
+    )
+}
+
+internal fun Forge.stopResourceEvent(): RumRawEvent.StopResource {
+    return RumRawEvent.StopResource(
+        key = anAlphabeticalString(),
+        statusCode = aNullable { aLong(100, 600) },
+        size = aNullable { aPositiveLong() },
+        kind = aValueFrom(RumResourceKind::class.java),
+        attributes = exhaustiveAttributes()
+    )
+}
+
+internal fun Forge.stopResourceWithErrorEvent(): RumRawEvent.StopResourceWithError {
+    return RumRawEvent.StopResourceWithError(
+        key = anAlphabeticalString(),
+        statusCode = aNullable { aLong(100, 600) },
+        source = aValueFrom(RumErrorSource::class.java),
+        message = anAlphabeticalString(),
+        throwable = aThrowable(),
+        attributes = exhaustiveAttributes()
+    )
+}
+
+internal fun Forge.stopResourceWithStacktraceEvent(): RumRawEvent.StopResourceWithStackTrace {
+    return RumRawEvent.StopResourceWithStackTrace(
+        key = anAlphabeticalString(),
+        statusCode = aNullable { aLong(100, 600) },
+        source = aValueFrom(RumErrorSource::class.java),
+        message = anAlphabeticalString(),
+        stackTrace = anAlphabeticalString(),
+        errorType = aNullable { anAlphabeticalString() },
+        attributes = exhaustiveAttributes()
+    )
+}
+
+internal fun Forge.addErrorEvent(): RumRawEvent.AddError {
+    return RumRawEvent.AddError(
+        message = anAlphabeticalString(),
+        source = aValueFrom(RumErrorSource::class.java),
+        stacktrace = null,
+        throwable = null,
+        isFatal = this.aBool(),
+        attributes = exhaustiveAttributes()
+    )
+}
+
+internal fun Forge.addLongTaskEvent(): RumRawEvent.AddLongTask {
+    return RumRawEvent.AddLongTask(
+        durationNs = aLong(min = 1),
+        target = anAlphabeticalString()
+    )
+}
+
+internal fun Forge.validBackgroundEvent(): RumRawEvent {
+    return this.anElementFrom(
+        listOf(
+            startActionEvent(),
+            addErrorEvent(),
+            startResourceEvent()
+        )
+    )
+}
+
+internal fun Forge.invalidBackgroundEvent(): RumRawEvent {
+    return this.anElementFrom(
+        listOf(
+            addLongTaskEvent(),
+            stopActionEvent(),
+            stopResourceEvent(),
+            stopResourceWithErrorEvent(),
+            stopResourceWithStacktraceEvent()
+        )
+    )
+}
+
+internal fun Forge.validAppLaunchEvent(): RumRawEvent {
+    return this.anElementFrom(
+        listOf(
+            startActionEvent(),
+            addLongTaskEvent(),
+            addErrorEvent(),
+            startResourceEvent()
+        )
+    )
+}
+
+internal fun Forge.invalidAppLaunchEvent(): RumRawEvent {
+    return this.anElementFrom(
+        listOf(
+            stopActionEvent(),
+            stopResourceEvent(),
+            stopResourceWithErrorEvent(),
+            stopResourceWithStacktraceEvent()
+        )
+    )
+}
+
+internal fun Forge.silentOrphanEvent(): RumRawEvent {
+    val fakeId = getForgery<UUID>().toString()
+
+    return this.anElementFrom(
+        listOf(
+            RumRawEvent.ApplicationStarted(Time(), aLong()),
+            RumRawEvent.ResetSession(),
+            RumRawEvent.KeepAlive(),
+            RumRawEvent.StopView(anAlphabeticalString(), emptyMap()),
+            RumRawEvent.ActionSent(fakeId),
+            RumRawEvent.ErrorSent(fakeId),
+            RumRawEvent.LongTaskSent(fakeId),
+            RumRawEvent.ResourceSent(fakeId),
+            RumRawEvent.ActionDropped(fakeId),
+            RumRawEvent.ErrorDropped(fakeId),
+            RumRawEvent.LongTaskDropped(fakeId),
+            RumRawEvent.ResourceDropped(fakeId)
+        )
+    )
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -273,7 +273,7 @@ internal class RumSessionScopeTest {
     }
 
     @Test
-    fun `𝕄 keep session context 𝕎 handleEvent(non interactive) {before expiration threshold}`(
+    fun `𝕄 keep session context 𝕎 handleEvent(non interactive) {before expiration}`(
         forge: Forge
     ) {
         // Given
@@ -291,7 +291,7 @@ internal class RumSessionScopeTest {
     }
 
     @Test
-    fun `𝕄 keep session context 𝕎 handleEvent(action) {before expiration threshold}`(
+    fun `𝕄 keep session context 𝕎 handleEvent(action) {before expiration}`(
         forge: Forge
     ) {
         // Given
@@ -309,7 +309,7 @@ internal class RumSessionScopeTest {
     }
 
     @Test
-    fun `𝕄 keep session context 𝕎 handleEvent(view) {before expiration threshold}`(
+    fun `𝕄 keep session context 𝕎 handleEvent(view) {before expiration}`(
         forge: Forge
     ) {
         // Given
@@ -327,10 +327,11 @@ internal class RumSessionScopeTest {
     }
 
     @Test
-    fun `𝕄 update session context 𝕎 handleEvent(non interactive) {after expiration threshold}`(
+    fun `𝕄 update context 𝕎 handleEvent(non interactive) {after expiration, background enabled}`(
         forge: Forge
     ) {
         // Given
+        initializeTestedScope(backgroundTrackingEnabled = true)
         testedScope.handleEvent(forge.startViewEvent(), mockWriter)
         val initialContext = testedScope.getRumContext()
 
@@ -346,7 +347,27 @@ internal class RumSessionScopeTest {
     }
 
     @Test
-    fun `𝕄 update session context 𝕎 handleEvent(action) {after expiration threshold}`(
+    fun `𝕄 update context 𝕎 handleEvent(non interactive) {after expiration, background disabled}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(backgroundTrackingEnabled = false)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        Thread.sleep(TEST_INACTIVITY_MS)
+        val result = testedScope.handleEvent(mock(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId).isEqualTo(initialContext.sessionId)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.EXPIRED)
+    }
+
+    @Test
+    fun `𝕄 update context 𝕎 handleEvent(action) {after expiration}`(
         forge: Forge
     ) {
         // Given
@@ -367,7 +388,7 @@ internal class RumSessionScopeTest {
     }
 
     @Test
-    fun `𝕄 update session context 𝕎 handleEvent(view) {after expiration threshold}`(
+    fun `𝕄 update context 𝕎 handleEvent(view) {after expiration}`(
         forge: Forge
     ) {
         // Given
@@ -388,7 +409,91 @@ internal class RumSessionScopeTest {
     }
 
     @Test
-    fun `𝕄 update session context 𝕎 handleEvent(non interactive) {after timeout threshold}`(
+    fun `𝕄 update context 𝕎 handleEvent(resource) {after expiration, background enabled}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(backgroundTrackingEnabled = true)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        Thread.sleep(TEST_INACTIVITY_MS)
+        val result = testedScope.handleEvent(forge.startResourceEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(initialContext.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+    }
+
+    @Test
+    fun `𝕄 update context 𝕎 handleEvent(error) {after expiration, background enabled}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(backgroundTrackingEnabled = true)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        Thread.sleep(TEST_INACTIVITY_MS)
+        val result = testedScope.handleEvent(forge.addErrorEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(initialContext.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+    }
+
+    @Test
+    fun `𝕄 update context 𝕎 handleEvent(resource) {after expiration, background disabled}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(backgroundTrackingEnabled = false)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        Thread.sleep(TEST_INACTIVITY_MS)
+        val result = testedScope.handleEvent(forge.startResourceEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId).isEqualTo(initialContext.sessionId)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.EXPIRED)
+    }
+
+    @Test
+    fun `𝕄 update context 𝕎 handleEvent(error) {after expiration, background disabled}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(backgroundTrackingEnabled = false)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        Thread.sleep(TEST_INACTIVITY_MS)
+        val result = testedScope.handleEvent(forge.addErrorEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId).isEqualTo(initialContext.sessionId)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.EXPIRED)
+    }
+
+    @Test
+    fun `𝕄 update context 𝕎 handleEvent(non interactive) {after timeout threshold}`(
         forge: Forge
     ) {
         // Given
@@ -414,7 +519,7 @@ internal class RumSessionScopeTest {
     }
 
     @Test
-    fun `𝕄 update session context 𝕎 handleEvent(action) {after timeout threshold}`(
+    fun `𝕄 update context 𝕎 handleEvent(action) {after timeout threshold}`(
         forge: Forge
     ) {
         // Given
@@ -440,7 +545,7 @@ internal class RumSessionScopeTest {
     }
 
     @Test
-    fun `𝕄 update session context 𝕎 handleEvent(view) {after timeout threshold}`(
+    fun `𝕄 update context 𝕎 handleEvent(view) {after timeout threshold}`(
         forge: Forge
     ) {
         // Given
@@ -642,12 +747,13 @@ internal class RumSessionScopeTest {
 
     private fun initializeTestedScope(
         samplingRate: Float = 100f,
-        withMockChildScope: Boolean = true
+        withMockChildScope: Boolean = true,
+        backgroundTrackingEnabled: Boolean? = null
     ) {
         testedScope = RumSessionScope(
             mockParentScope,
             samplingRate,
-            fakeBackgroundTrackingEnabled,
+            backgroundTrackingEnabled ?: fakeBackgroundTrackingEnabled,
             mockDetector,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -6,61 +6,41 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import android.app.ActivityManager.RunningAppProcessInfo
 import android.content.Context
-import android.os.Build
-import android.util.Log
-import com.datadog.android.Datadog
-import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.NoOpDataWriter
 import com.datadog.android.core.internal.system.AndroidInfoProvider
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.time.TimeProvider
-import com.datadog.android.core.model.NetworkInfo
-import com.datadog.android.core.model.UserInfo
-import com.datadog.android.rum.GlobalRum
-import com.datadog.android.rum.RumActionType
-import com.datadog.android.rum.RumErrorSource
-import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
-import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.RumEventSourceProvider
-import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.any
-import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.isA
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.same
-import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
-import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
-import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.net.URL
-import java.util.UUID
 import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.data.Offset
+import org.assertj.core.api.Assertions.offset
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -79,16 +59,13 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(Configurator::class)
 internal class RumSessionScopeTest {
 
-    lateinit var testedScope: RumSessionScope
+    lateinit var testedScope: RumScope
 
     @Mock
     lateinit var mockParentScope: RumScope
 
     @Mock
     lateinit var mockChildScope: RumScope
-
-    @Mock
-    lateinit var fakeEvent: RumRawEvent
 
     @Mock
     lateinit var mockWriter: DataWriter<Any>
@@ -112,19 +89,13 @@ internal class RumSessionScopeTest {
     lateinit var mockSessionListener: RumSessionListener
 
     @Mock
-    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+    lateinit var mockRumEventSourceProvider: RumEventSourceProvider
 
     @Mock
-    lateinit var mockRumEventSourceProvider: RumEventSourceProvider
+    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
 
     @Forgery
     lateinit var fakeParentContext: RumContext
-
-    @Forgery
-    lateinit var fakeUserInfo: UserInfo
-
-    @Forgery
-    lateinit var fakeNetworkInfo: NetworkInfo
 
     @Forgery
     lateinit var fakeAndroidInfoProvider: AndroidInfoProvider
@@ -135,255 +106,547 @@ internal class RumSessionScopeTest {
     @BoolForgery
     var fakeBackgroundTrackingEnabled: Boolean = false
 
+    lateinit var fakeInitialViewEvent: RumRawEvent
+
     @BeforeEach
-    fun `set up`() {
-        whenever(coreFeature.mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
-        whenever(coreFeature.mockNetworkInfoProvider.getLatestNetworkInfo())
-            .thenReturn(fakeNetworkInfo)
+    fun `set up`(forge: Forge) {
+        fakeInitialViewEvent = forge.startViewEvent()
+
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
-        whenever(mockChildScope.isActive()) doReturn true
-        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.BASE
 
-        CoreFeature.processImportance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-
-        testedScope = RumSessionScope(
-            mockParentScope,
-            100f,
-            fakeBackgroundTrackingEnabled,
-            mockDetector,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockTimeProvider,
-            mockSessionListener,
-            mockRumEventSourceProvider,
-            mockBuildSdkVersionProvider,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS,
-            fakeAndroidInfoProvider
-        )
-        val originalRumContext = testedScope.getRumContext()
-        assertThat(GlobalRum.getRumContext()).isEqualTo(originalRumContext)
+        initializeTestedScope()
     }
 
-    // region Session management
+    @AfterEach
+    fun `tear down`() {
+        // whatever happens
+        assertThat(testedScope.isActive()).isTrue()
+    }
+
+    // region childScope
 
     @Test
-    fun `updates sessionId if first call`() {
+    fun `𝕄 have a ViewManager child scope 𝕎 init()`() {
+        // Given
+        initializeTestedScope(fakeSamplingRate, false)
+
+        // When
+        val childScope = (testedScope as RumSessionScope).childScope
+
+        // Then
+        assertThat(childScope).isInstanceOf(RumViewManagerScope::class.java)
+    }
+
+    @Test
+    fun `𝕄 delegate events to child scope 𝕎 handleViewEvent() {TRACKED}`(
+        forge: Forge
+    ) {
+        // Given
+        (testedScope as RumSessionScope).sessionState = RumSessionScope.State.TRACKED
+        val event = forge.interactiveRumRawEvent()
+
+        // When
+        val result = testedScope.handleEvent(event, mockWriter)
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        verify(mockChildScope).handleEvent(event, mockWriter)
+    }
+
+    @Test
+    fun `𝕄 delegate events to child scope 𝕎 handleViewEvent() {NOT TRACKED}`() {
+        // Given
+        (testedScope as RumSessionScope).sessionState = RumSessionScope.State.NOT_TRACKED
+        val mockEvent: RumRawEvent = mock()
+
+        // When
+        val result = testedScope.handleEvent(mockEvent, mockWriter)
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        verify(mockChildScope).handleEvent(same(mockEvent), isA<NoOpDataWriter<Any>>())
+    }
+
+    @Test
+    fun `𝕄 delegate events to child scope 𝕎 handleViewEvent() {EXPIRED}`() {
+        // Given
+        (testedScope as RumSessionScope).sessionState = RumSessionScope.State.EXPIRED
+        val mockEvent: RumRawEvent = mock()
+
+        // When
+        val result = testedScope.handleEvent(mockEvent, mockWriter)
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        verify(mockChildScope).handleEvent(same(mockEvent), isA<NoOpDataWriter<Any>>())
+    }
+
+    // endregion
+
+    // region getRumContext()
+
+    @Test
+    fun `𝕄 have empty session context 𝕎 init()+getRumContext()`() {
+        // Given
+
+        // When
         val context = testedScope.getRumContext()
 
+        // Then
+        assertThat(context.sessionId).isEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.NOT_TRACKED)
+        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
+        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
+    }
+
+    @Test
+    fun `𝕄 create new session context 𝕎 handleEvent(view)+getRumContext() {sampling = 100}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(100f)
+
+        // When
+        val result = testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId).isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
+        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
+    }
+
+    @Test
+    fun `𝕄 create new untracked context 𝕎 handleEvent(view)+getRumContext() {sampling = 0}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(0f)
+
+        // When
+        val result = testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId).isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.NOT_TRACKED)
+        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
+        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
+    }
+
+    @Test
+    fun `𝕄 create new context 𝕎 handleEvent(view)+getRumContext() {sampling = x}`(
+        forge: Forge
+    ) {
+        var tracked = 0
+        var untracked = 0
+        var other = 0
+        val knownSessionId = mutableSetOf<String>()
+
+        repeat(1000) {
+            // Given
+            initializeTestedScope(fakeSamplingRate)
+
+            // When
+            testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+            val context = testedScope.getRumContext()
+
+            // Then
+            assertThat(context.sessionId).isNotEqualTo(RumContext.NULL_UUID)
+            assertThat(knownSessionId).doesNotContain(context.sessionId)
+            knownSessionId.add(context.sessionId)
+            when (context.sessionState) {
+                RumSessionScope.State.NOT_TRACKED -> untracked++
+                RumSessionScope.State.TRACKED -> tracked++
+                RumSessionScope.State.EXPIRED -> other++
+            }
+        }
+
+        assertThat(other).isZero()
+        val sampledRate = tracked.toFloat() * 100f / (tracked + untracked).toFloat()
+        // because sampling is random based we can't guarantee exactly 75%
+        assertThat(sampledRate).isCloseTo(fakeSamplingRate, offset(5f))
+    }
+
+    @Test
+    fun `𝕄 keep session context 𝕎 handleEvent(non interactive) {before expiration threshold}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        val result = testedScope.handleEvent(mock(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId).isEqualTo(initialContext.sessionId)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+    }
+
+    @Test
+    fun `𝕄 keep session context 𝕎 handleEvent(action) {before expiration threshold}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        val result = testedScope.handleEvent(forge.startActionEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId).isEqualTo(initialContext.sessionId)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+    }
+
+    @Test
+    fun `𝕄 keep session context 𝕎 handleEvent(view) {before expiration threshold}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        val result = testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId).isEqualTo(initialContext.sessionId)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+    }
+
+    @Test
+    fun `𝕄 update session context 𝕎 handleEvent(non interactive) {after expiration threshold}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        Thread.sleep(TEST_INACTIVITY_MS)
+        val result = testedScope.handleEvent(mock(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId).isEqualTo(initialContext.sessionId)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.EXPIRED)
+    }
+
+    @Test
+    fun `𝕄 update session context 𝕎 handleEvent(action) {after expiration threshold}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        Thread.sleep(TEST_INACTIVITY_MS)
+        val result = testedScope.handleEvent(forge.startActionEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(initialContext.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+    }
+
+    @Test
+    fun `𝕄 update session context 𝕎 handleEvent(view) {after expiration threshold}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        Thread.sleep(TEST_INACTIVITY_MS)
+        val result = testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(initialContext.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+    }
+
+    @Test
+    fun `𝕄 update session context 𝕎 handleEvent(non interactive) {after timeout threshold}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+        val repeatCount = (TEST_MAX_DURATION_MS / TEST_SLEEP_MS) + 1
+        for (i in 0..repeatCount) {
+            Thread.sleep(TEST_SLEEP_MS)
+            testedScope.handleEvent(forge.startActionEvent(false), mockWriter)
+        }
+
+        // When
+        Thread.sleep(TEST_SLEEP_MS)
+        val result = testedScope.handleEvent(mock(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(initialContext.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+    }
+
+    @Test
+    fun `𝕄 update session context 𝕎 handleEvent(action) {after timeout threshold}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+        val repeatCount = (TEST_MAX_DURATION_MS / TEST_SLEEP_MS) + 1
+        for (i in 0..repeatCount) {
+            Thread.sleep(TEST_SLEEP_MS)
+            testedScope.handleEvent(forge.startActionEvent(), mockWriter)
+        }
+
+        // When
+        Thread.sleep(TEST_SLEEP_MS)
+        val result = testedScope.handleEvent(forge.startActionEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(initialContext.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+    }
+
+    @Test
+    fun `𝕄 update session context 𝕎 handleEvent(view) {after timeout threshold}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+        val repeatCount = (TEST_MAX_DURATION_MS / TEST_SLEEP_MS) + 1
+        for (i in 0..repeatCount) {
+            Thread.sleep(TEST_SLEEP_MS)
+            testedScope.handleEvent(forge.startActionEvent(), mockWriter)
+        }
+
+        // When
+        Thread.sleep(TEST_SLEEP_MS)
+        val result = testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(initialContext.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+    }
+
+    @Test
+    fun `𝕄 create new context 𝕎 handleEvent(ResetSession)+getRumContext()`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        val result = testedScope.handleEvent(RumRawEvent.ResetSession(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(initialContext.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
+        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
+    }
+
+    // endregion
+
+    // region Session Listener
+
+    @Test
+    fun `𝕄 notify listener 𝕎 session is updated {tracked, timed out}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+        val repeatCount = (TEST_MAX_DURATION_MS / TEST_SLEEP_MS) + 1
+        for (i in 0..repeatCount) {
+            Thread.sleep(TEST_SLEEP_MS)
+            testedScope.handleEvent(forge.startActionEvent(false), mockWriter)
+        }
+
+        // When
+        Thread.sleep(TEST_MAX_DURATION_MS)
+        val result = testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
         assertThat(context.sessionId)
             .isNotEqualTo(RumContext.NULL_UUID)
-            .isEqualTo(testedScope.sessionId)
-        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
-        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
+            .isNotEqualTo(initialContext.sessionId)
+        verify(mockSessionListener).onSessionStarted(initialContext.sessionId, false)
+        verify(mockSessionListener).onSessionStarted(context.sessionId, false)
     }
 
     @Test
-    fun `returns context with null IDs if session not kept`() {
-        testedScope = RumSessionScope(
-            mockParentScope,
-            0f,
-            fakeBackgroundTrackingEnabled,
-            mockDetector,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockTimeProvider,
-            mockSessionListener,
-            mockRumEventSourceProvider,
-            mockBuildSdkVersionProvider,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS,
-            fakeAndroidInfoProvider
-        )
-        val context = testedScope.getRumContext()
+    fun `𝕄 notify listener 𝕎 session is updated {tracked, expired}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
 
-        assertThat(context.sessionId).isEqualTo(RumContext.NULL_UUID)
-        assertThat(context.applicationId).isEqualTo(RumContext.NULL_UUID)
-    }
-
-    @Test
-    fun `updates sessionId if last interaction too old`() {
-        val firstSessionId = testedScope.getRumContext().sessionId
-
+        // When
         Thread.sleep(TEST_INACTIVITY_MS)
+        val result = testedScope.handleEvent(forge.startViewEvent(), mockWriter)
         val context = testedScope.getRumContext()
 
+        // Then
+        assertThat(result).isSameAs(testedScope)
         assertThat(context.sessionId)
-            .isNotEqualTo(UUID(0, 0))
-            .isNotEqualTo(firstSessionId)
-        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
-        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+            .isNotEqualTo(initialContext.sessionId)
+        verify(mockSessionListener).onSessionStarted(initialContext.sessionId, false)
+        verify(mockSessionListener).onSessionStarted(context.sessionId, false)
     }
 
     @Test
-    fun `updates sessionId if duration is too long`() {
-        val firstSessionId = testedScope.getRumContext().sessionId
+    fun `𝕄 notify listener 𝕎 session is updated {tracked, manual reset}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
 
-        Thread.sleep(TEST_MAX_DURATION_MS)
+        // When
+        val result = testedScope.handleEvent(RumRawEvent.ResetSession(), mockWriter)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
         val context = testedScope.getRumContext()
 
+        // Then
+        assertThat(result).isSameAs(testedScope)
         assertThat(context.sessionId)
-            .isNotEqualTo(UUID(0, 0))
-            .isNotEqualTo(firstSessionId)
-        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
-        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+            .isNotEqualTo(initialContext.sessionId)
+        verify(mockSessionListener).onSessionStarted(initialContext.sessionId, false)
+        verify(mockSessionListener).onSessionStarted(context.sessionId, false)
     }
 
     @Test
-    fun `updates sessionId if duration is too long with updates`() {
+    fun `𝕄 notify listener 𝕎 session is updated {not tracked, timed out}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(0f)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
         val repeatCount = (TEST_MAX_DURATION_MS / TEST_SLEEP_MS) + 1
-        val firstSessionId = testedScope.getRumContext().sessionId
-
         for (i in 0..repeatCount) {
             Thread.sleep(TEST_SLEEP_MS)
-            testedScope.handleEvent(fakeEvent, mockWriter)
+            testedScope.handleEvent(forge.startActionEvent(false), mockWriter)
         }
-        Thread.sleep(TEST_SLEEP_MS)
+
+        // When
+        Thread.sleep(TEST_MAX_DURATION_MS)
+        val result = testedScope.handleEvent(forge.startViewEvent(), mockWriter)
         val context = testedScope.getRumContext()
 
+        // Then
+        assertThat(result).isSameAs(testedScope)
         assertThat(context.sessionId)
-            .isNotEqualTo(UUID(0, 0))
-            .isNotEqualTo(firstSessionId)
-        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
-        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+            .isNotEqualTo(initialContext.sessionId)
+        verify(mockSessionListener).onSessionStarted(initialContext.sessionId, true)
+        verify(mockSessionListener).onSessionStarted(context.sessionId, true)
     }
 
     @Test
-    fun `updates sessionId on ResetSession event `() {
-        val firstSessionId = testedScope.getRumContext().sessionId
-        fakeEvent = RumRawEvent.ResetSession()
-
-        testedScope.handleEvent(fakeEvent, mockWriter)
-        val context = testedScope.getRumContext()
-
-        assertThat(context.sessionId)
-            .isNotEqualTo(UUID(0, 0))
-            .isNotEqualTo(firstSessionId)
-        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
-        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
-    }
-
-    @Test
-    fun `keeps sessionId if last interaction is recent`() {
-        val repeatCount = (TEST_INACTIVITY_MS / TEST_SLEEP_MS) + 1
-        val firstSessionId = testedScope.getRumContext().sessionId
-
-        for (i in 0..repeatCount) {
-            Thread.sleep(TEST_SLEEP_MS)
-            testedScope.handleEvent(fakeEvent, mockWriter)
-        }
-        val context = testedScope.getRumContext()
-
-        assertThat(context.sessionId).isEqualTo(firstSessionId)
-        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
-        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
-    }
-
-    @Test
-    fun `updates keepSession state based on sampling rate`() {
-        testedScope = RumSessionScope(
-            mockParentScope,
-            fakeSamplingRate,
-            fakeBackgroundTrackingEnabled,
-            mockDetector,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockTimeProvider,
-            mockSessionListener,
-            mockRumEventSourceProvider,
-            mockBuildSdkVersionProvider,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS,
-            fakeAndroidInfoProvider
-        )
-        var sessions = 0
-        var sessionsKept = 0
-
-        repeat(1024) {
-            testedScope.handleEvent(RumRawEvent.ResetSession(), mockWriter)
-            val context = testedScope.getRumContext()
-            if (testedScope.keepSession) {
-                assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
-                assertThat(context.sessionId).isEqualTo(testedScope.sessionId)
-            } else {
-                assertThat(context.applicationId).isEqualTo(RumContext.NULL_UUID)
-                assertThat(context.sessionId).isEqualTo(RumContext.NULL_UUID)
-            }
-            sessions++
-            if (testedScope.keepSession) sessionsKept++
-        }
-
-        val actualRate = (sessionsKept.toFloat() * 100f) / sessions
-        assertThat(actualRate).isCloseTo(fakeSamplingRate, Offset.offset(5f))
-    }
-
-    // endregion
-
-    // region Listener
-
-    @Test
-    fun `𝕄 notify listener 𝕎 session is updated`() {
+    fun `𝕄 notify listener 𝕎 session is updated {not tracked, expired}`(
+        forge: Forge
+    ) {
         // Given
-        val firstSessionId = testedScope.getRumContext().sessionId
-        val isFirstSessionDiscarded = !testedScope.keepSession
+        initializeTestedScope(0f)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
 
         // When
         Thread.sleep(TEST_INACTIVITY_MS)
+        val result = testedScope.handleEvent(forge.startViewEvent(), mockWriter)
         val context = testedScope.getRumContext()
 
         // Then
+        assertThat(result).isSameAs(testedScope)
         assertThat(context.sessionId)
-            .isNotEqualTo(UUID(0, 0))
-            .isNotEqualTo(firstSessionId)
-        verify(mockSessionListener).onSessionStarted(firstSessionId, isFirstSessionDiscarded)
-        verify(mockSessionListener).onSessionStarted(context.sessionId, !testedScope.keepSession)
+            .isNotEqualTo(RumContext.NULL_UUID)
+            .isNotEqualTo(initialContext.sessionId)
+        verify(mockSessionListener).onSessionStarted(initialContext.sessionId, true)
+        verify(mockSessionListener).onSessionStarted(context.sessionId, true)
+    }
+
+    @Test
+    fun `𝕄 notify listener 𝕎 session is updated {not tracked, manual reset}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(0f)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val initialContext = testedScope.getRumContext()
+
+        // When
+        val result = testedScope.handleEvent(RumRawEvent.ResetSession(), mockWriter)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId)
+            .isNotEqualTo(RumContext.NULL_UUID)
+            .isNotEqualTo(initialContext.sessionId)
+        verify(mockSessionListener).onSessionStarted(initialContext.sessionId, true)
+        verify(mockSessionListener).onSessionStarted(context.sessionId, true)
     }
 
     // endregion
 
-    @Test
-    fun `M return true W isActive()`() {
-        val isActive = testedScope.isActive()
+    // region Internal
 
-        assertThat(isActive).isTrue()
-    }
-
-    @Test
-    fun `M log warning W handleEvent() without child scope`() {
-        // Given
-        Datadog.setVerbosity(Log.VERBOSE)
-
-        // When
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        assertThat(testedScope.childrenScopes).isEmpty()
-        assertThat(result).isSameAs(testedScope)
-        verify(logger.mockDevLogHandler).handleLog(Log.WARN, RumSessionScope.MESSAGE_MISSING_VIEW)
-        verifyNoMoreInteractions(logger.mockDevLogHandler, mockWriter)
-    }
-
-    @Test
-    fun `M delegate to child scope W handleEvent()`() {
-        testedScope.childrenScopes.add(mockChildScope)
-
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        verify(mockChildScope).handleEvent(fakeEvent, mockWriter)
-        assertThat(testedScope.childrenScopes).containsExactly(mockChildScope)
-        assertThat(result).isSameAs(testedScope)
-        verifyZeroInteractions(mockWriter, logger.mockDevLogHandler)
-    }
-
-    @Test
-    fun `M delegate to child scope with noop writer W handleEvent() and session not kept`() {
+    private fun initializeTestedScope(
+        samplingRate: Float = 100f,
+        withMockChildScope: Boolean = true
+    ) {
         testedScope = RumSessionScope(
             mockParentScope,
-            0f,
+            samplingRate,
             fakeBackgroundTrackingEnabled,
             mockDetector,
             mockCpuVitalMonitor,
@@ -397,851 +660,13 @@ internal class RumSessionScopeTest {
             TEST_MAX_DURATION_NS,
             fakeAndroidInfoProvider
         )
-        testedScope.childrenScopes.add(mockChildScope)
 
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        argumentCaptor<DataWriter<Any>> {
-            verify(mockChildScope).handleEvent(same(fakeEvent), capture())
-
-            assertThat(firstValue)
-                .isNotSameAs(mockWriter)
-                .isInstanceOf(NoOpDataWriter::class.java)
+        if (withMockChildScope) {
+            (testedScope as RumSessionScope).childScope = mockChildScope
         }
-        assertThat(testedScope.childrenScopes).containsExactly(mockChildScope)
-        assertThat(result).isSameAs(testedScope)
-        verifyZeroInteractions(mockWriter, logger.mockDevLogHandler)
     }
 
-    @Test
-    fun `M start a foreground ViewScope W handleEvent(StartView) { app displayed }`(
-        @StringForgery key: String,
-        @StringForgery name: String,
-        forge: Forge
-    ) {
-        // GIVEN
-        val fakeAttributes = forge.exhaustiveAttributes()
-        testedScope = RumSessionScope(
-            mockParentScope,
-            100f,
-            true,
-            mockDetector,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockTimeProvider,
-            mockSessionListener,
-            mockRumEventSourceProvider,
-            mockBuildSdkVersionProvider,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS,
-            fakeAndroidInfoProvider
-        )
-        testedScope.applicationDisplayed = true
-
-        fakeEvent = RumRawEvent.StartView(key, name, fakeAttributes)
-
-        // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        assertThat(testedScope.childrenScopes).hasSize(1)
-        assertThat(testedScope.childrenScopes[0])
-            .isInstanceOfSatisfying(RumViewScope::class.java) {
-                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
-                assertThat(it.keyRef.get()).isEqualTo(key)
-                assertThat(it.name).isEqualTo(name)
-                assertThat(it.type).isEqualTo(RumViewScope.RumViewType.FOREGROUND)
-            }
-    }
-
-    @Test
-    fun `M update child scope W handleEvent(StartView)`(
-        @StringForgery key: String,
-        @StringForgery name: String,
-        forge: Forge
-    ) {
-        val attributes = forge.exhaustiveAttributes()
-        fakeEvent = RumRawEvent.StartView(key, name, attributes)
-
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        assertThat(testedScope.childrenScopes).hasSize(1)
-        val viewScope = testedScope.childrenScopes.first() as RumViewScope
-        assertThat(viewScope.keyRef.get()).isEqualTo(key)
-        assertThat(viewScope.name).isEqualTo(name)
-        assertThat(viewScope.attributes).isEqualTo(attributes)
-        assertThat(viewScope.firstPartyHostDetector).isSameAs(mockDetector)
-        assertThat(result).isSameAs(testedScope)
-    }
-
-    @Test
-    fun `M update child scope W handleEvent(StartView) event with existing children`(
-        @StringForgery key: String,
-        @StringForgery name: String,
-        forge: Forge
-    ) {
-        testedScope.childrenScopes.add(mockChildScope)
-        val attributes = forge.exhaustiveAttributes()
-        fakeEvent = RumRawEvent.StartView(key, name, attributes)
-
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        verify(mockChildScope).handleEvent(fakeEvent, mockWriter)
-        assertThat(testedScope.childrenScopes).hasSize(2)
-        val viewScope = testedScope.childrenScopes.last() as RumViewScope
-        assertThat(viewScope.keyRef.get()).isEqualTo(key)
-        assertThat(viewScope.name).isEqualTo(name)
-        assertThat(viewScope.attributes).containsAllEntriesOf(attributes)
-        assertThat(viewScope.firstPartyHostDetector).isSameAs(mockDetector)
-        assertThat(result).isSameAs(testedScope)
-    }
-
-    @Test
-    fun `M keep children scope W handleEvent child returns non null`() {
-        testedScope.childrenScopes.add(mockChildScope)
-        whenever(mockChildScope.handleEvent(fakeEvent, mockWriter)) doReturn mockChildScope
-
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        assertThat(testedScope.childrenScopes).containsExactly(mockChildScope)
-        assertThat(result).isSameAs(testedScope)
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `M remove children scope W handleEvent child returns null`() {
-        testedScope.childrenScopes.add(mockChildScope)
-        whenever(mockChildScope.handleEvent(fakeEvent, mockWriter)) doReturn null
-
-        val result = testedScope.handleEvent(fakeEvent, mockWriter)
-
-        assertThat(testedScope.childrenScopes).isEmpty()
-        assertThat(result).isSameAs(testedScope)
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `M send ApplicationStarted event W applicationDisplayed`(
-        @StringForgery key: String,
-        @StringForgery name: String
-    ) {
-        // Given
-        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.KITKAT
-        val childView: RumViewScope = mock()
-        val startViewEvent = RumRawEvent.StartView(key, name, emptyMap())
-
-        // When
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
-
-        // Then
-        argumentCaptor<RumRawEvent> {
-            verify(childView).handleEvent(capture(), same(mockWriter))
-
-            val event = firstValue as RumRawEvent.ApplicationStarted
-            assertThat(event.applicationStartupNanos).isEqualTo(Datadog.startupTimeNs)
-        }
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `M send ApplicationStarted event W applicationDisplayed {API 24+}`(
-        @StringForgery key: String,
-        @StringForgery name: String
-    ) {
-        // Given
-        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.N
-        val childView: RumViewScope = mock()
-        val startViewEvent = RumRawEvent.StartView(key, name, emptyMap())
-
-        // When
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
-
-        // Then
-        argumentCaptor<RumRawEvent> {
-            verify(childView).handleEvent(capture(), same(mockWriter))
-
-            val event = firstValue as RumRawEvent.ApplicationStarted
-            assertThat(event.applicationStartupNanos)
-                .isCloseTo(System.nanoTime(), Offset.offset(TimeUnit.MILLISECONDS.toNanos(100)))
-        }
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `M send ApplicationStarted event only once W applicationDisplayed`(
-        @StringForgery key: String,
-        @StringForgery name: String
-    ) {
-        val childView: RumViewScope = mock()
-        val startViewEvent = RumRawEvent.StartView(key, name, emptyMap())
-
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
-
-        argumentCaptor<RumRawEvent> {
-            verify(childView).handleEvent(capture(), same(mockWriter))
-
-            val event = firstValue as RumRawEvent.ApplicationStarted
-            assertThat(event.applicationStartupNanos).isEqualTo(Datadog.startupTimeNs)
-        }
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `M send ApplicationStarted event W applicationDisplayed after ResetSession`(
-        @StringForgery key: String,
-        @StringForgery name: String
-    ) {
-        val childView: RumViewScope = mock()
-        val startViewEvent = RumRawEvent.StartView(key, name, emptyMap())
-
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
-        val resetNanos = System.nanoTime()
-        testedScope.handleEvent(RumRawEvent.ResetSession(), mockWriter)
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
-
-        argumentCaptor<RumRawEvent> {
-            verify(childView, times(2)).handleEvent(capture(), same(mockWriter))
-
-            val event = firstValue as RumRawEvent.ApplicationStarted
-            assertThat(event.applicationStartupNanos).isEqualTo(Datadog.startupTimeNs)
-            val event2 = lastValue as RumRawEvent.ApplicationStarted
-            assertThat(event2.applicationStartupNanos).isGreaterThanOrEqualTo(resetNanos)
-        }
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `M not send ApplicationStarted event W applicationDisplayed {not a foreground process}`(
-        @StringForgery key: String,
-        @StringForgery name: String,
-        forge: Forge
-    ) {
-        CoreFeature.processImportance = forge.anElementFrom(
-            RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE,
-            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING,
-            @Suppress("DEPRECATION")
-            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING_PRE_28,
-            RunningAppProcessInfo.IMPORTANCE_VISIBLE,
-            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE,
-            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE_PRE_26,
-            RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE,
-            RunningAppProcessInfo.IMPORTANCE_SERVICE,
-            RunningAppProcessInfo.IMPORTANCE_CACHED,
-            RunningAppProcessInfo.IMPORTANCE_GONE
-        )
-        val childView: RumViewScope = mock()
-        val startViewEvent = RumRawEvent.StartView(key, name, emptyMap())
-
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
-
-        verify(childView, never()).handleEvent(any(), same(mockWriter))
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `M do nothing W applicationDisplayed if session not kept`(
-        @StringForgery key: String,
-        @StringForgery name: String
-    ) {
-        testedScope = RumSessionScope(
-            mockParentScope,
-            0f,
-            fakeBackgroundTrackingEnabled,
-            mockDetector,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockTimeProvider,
-            mockSessionListener,
-            mockRumEventSourceProvider,
-            mockBuildSdkVersionProvider,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS,
-            fakeAndroidInfoProvider
-        )
-        val startViewEvent = RumRawEvent.StartView(key, name, emptyMap())
-
-        val result = testedScope.handleEvent(startViewEvent, mockWriter)
-
-        assertThat(testedScope.childrenScopes).isNotEmpty()
-        assertThat(result).isSameAs(testedScope)
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `M start a background ViewScope W handleEvent { app displayed, event is relevant }`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope = RumSessionScope(
-            mockParentScope,
-            100f,
-            true,
-            mockDetector,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockTimeProvider,
-            mockSessionListener,
-            mockRumEventSourceProvider,
-            mockBuildSdkVersionProvider,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS,
-            fakeAndroidInfoProvider
-        )
-        testedScope.applicationDisplayed = true
-        val fakeEvent = forge.forgeValidBackgroundEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        assertThat(testedScope.childrenScopes).hasSize(1)
-        assertThat(testedScope.childrenScopes[0])
-            .isInstanceOfSatisfying(RumViewScope::class.java) {
-                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
-                assertThat(it.keyRef.get()).isEqualTo(RumSessionScope.RUM_BACKGROUND_VIEW_URL)
-                assertThat(it.name).isEqualTo(RumSessionScope.RUM_BACKGROUND_VIEW_NAME)
-                assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.memoryVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.frameRateVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-            }
-    }
-
-    @Test
-    fun `M start a background ViewScope W handleEvent { stopped view, event is relevant }`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope = RumSessionScope(
-            mockParentScope,
-            100f,
-            true,
-            mockDetector,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockTimeProvider,
-            mockSessionListener,
-            mockRumEventSourceProvider,
-            mockBuildSdkVersionProvider,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS,
-            fakeAndroidInfoProvider
-        )
-        testedScope.applicationDisplayed = true
-        testedScope.childrenScopes.add(mockChildScope)
-        whenever(mockChildScope.isActive()) doReturn false
-        whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
-        val fakeEvent = forge.forgeValidBackgroundEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        assertThat(testedScope.childrenScopes).hasSize(2)
-        assertThat(testedScope.childrenScopes[0]).isSameAs(mockChildScope)
-        assertThat(testedScope.childrenScopes[1])
-            .isInstanceOfSatisfying(RumViewScope::class.java) {
-                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
-                assertThat(it.keyRef.get()).isEqualTo(RumSessionScope.RUM_BACKGROUND_VIEW_URL)
-                assertThat(it.name).isEqualTo(RumSessionScope.RUM_BACKGROUND_VIEW_NAME)
-                assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.memoryVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.frameRateVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.type).isEqualTo(RumViewScope.RumViewType.BACKGROUND)
-            }
-    }
-
-    @Test
-    fun `M start a Background ViewScope W handleEvent { event is relevant, not foreground }`(
-        forge: Forge
-    ) {
-        // GIVEN
-        CoreFeature.processImportance = forge.anElementFrom(
-            RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE,
-            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING,
-            @Suppress("DEPRECATION")
-            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING_PRE_28,
-            RunningAppProcessInfo.IMPORTANCE_VISIBLE,
-            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE,
-            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE_PRE_26,
-            RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE,
-            RunningAppProcessInfo.IMPORTANCE_SERVICE,
-            RunningAppProcessInfo.IMPORTANCE_CACHED,
-            RunningAppProcessInfo.IMPORTANCE_GONE
-        )
-        testedScope = RumSessionScope(
-            parentScope = mockParentScope,
-            samplingRate = 100f,
-            backgroundTrackingEnabled = true,
-            firstPartyHostDetector = mockDetector,
-            cpuVitalMonitor = mockCpuVitalMonitor,
-            memoryVitalMonitor = mockMemoryVitalMonitor,
-            frameRateVitalMonitor = mockFrameRateVitalMonitor,
-            timeProvider = mockTimeProvider,
-            sessionListener = mockSessionListener,
-            rumEventSourceProvider = mockRumEventSourceProvider,
-            sessionInactivityNanos = TEST_INACTIVITY_NS,
-            sessionMaxDurationNanos = TEST_MAX_DURATION_NS,
-            androidInfoProvider = fakeAndroidInfoProvider
-        )
-        testedScope.applicationDisplayed = false
-        val fakeEvent = forge.forgeValidBackgroundEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        assertThat(testedScope.childrenScopes).hasSize(1)
-        assertThat(testedScope.childrenScopes[0])
-            .isInstanceOfSatisfying(RumViewScope::class.java) {
-                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
-                assertThat(it.keyRef.get()).isEqualTo(RumSessionScope.RUM_BACKGROUND_VIEW_URL)
-                assertThat(it.name).isEqualTo(RumSessionScope.RUM_BACKGROUND_VIEW_NAME)
-                assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.memoryVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.frameRateVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.type).isEqualTo(RumViewScope.RumViewType.BACKGROUND)
-            }
-    }
-
-    @Test
-    fun `M start an AppLaunch ViewScope W handleEvent { app not displayed, event is relevant }`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope.applicationDisplayed = false
-        val fakeEvent = forge.forgeValidAppLaunchEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        assertThat(testedScope.childrenScopes).hasSize(1)
-        assertThat(testedScope.childrenScopes[0])
-            .isInstanceOfSatisfying(RumViewScope::class.java) {
-                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
-                assertThat(it.keyRef.get()).isEqualTo(RumSessionScope.RUM_APP_LAUNCH_VIEW_URL)
-                assertThat(it.name).isEqualTo(RumSessionScope.RUM_APP_LAUNCH_VIEW_NAME)
-                assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.memoryVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.frameRateVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
-                assertThat(it.type).isEqualTo(RumViewScope.RumViewType.APPLICATION_LAUNCH)
-            }
-    }
-
-    @Test
-    fun `M not start an AppLaunch ViewScope W handleEvent { event is relevant, not foreground }`(
-        forge: Forge
-    ) {
-        // GIVEN
-        CoreFeature.processImportance = forge.anElementFrom(
-            RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE,
-            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING,
-            @Suppress("DEPRECATION")
-            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING_PRE_28,
-            RunningAppProcessInfo.IMPORTANCE_VISIBLE,
-            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE,
-            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE_PRE_26,
-            RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE,
-            RunningAppProcessInfo.IMPORTANCE_SERVICE,
-            RunningAppProcessInfo.IMPORTANCE_CACHED,
-            RunningAppProcessInfo.IMPORTANCE_GONE
-        )
-        testedScope = RumSessionScope(
-            parentScope = mockParentScope,
-            samplingRate = 100f,
-            backgroundTrackingEnabled = false,
-            firstPartyHostDetector = mockDetector,
-            cpuVitalMonitor = mockCpuVitalMonitor,
-            memoryVitalMonitor = mockMemoryVitalMonitor,
-            frameRateVitalMonitor = mockFrameRateVitalMonitor,
-            timeProvider = mockTimeProvider,
-            rumEventSourceProvider = mockRumEventSourceProvider,
-            sessionListener = mockSessionListener,
-            sessionInactivityNanos = TEST_INACTIVITY_NS,
-            sessionMaxDurationNanos = TEST_MAX_DURATION_NS,
-            androidInfoProvider = fakeAndroidInfoProvider
-        )
-        testedScope.applicationDisplayed = false
-        val fakeEvent = forge.forgeValidAppLaunchEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        assertThat(testedScope.childrenScopes).hasSize(0)
-    }
-
-    @Test
-    fun `M ignore event W handleEvent { app displayed, event is relevant, background disabled }`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope = RumSessionScope(
-            mockParentScope,
-            100f,
-            false,
-            mockDetector,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockTimeProvider,
-            mockSessionListener,
-            mockRumEventSourceProvider,
-            mockBuildSdkVersionProvider,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS,
-            fakeAndroidInfoProvider
-        )
-        val fakeEvent = forge.forgeInvalidAppLaunchEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        assertThat(testedScope.childrenScopes).hasSize(0)
-    }
-
-    @Test
-    fun `M ignore event W handleEvent { app displayed, event is relevant, active view }`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope = RumSessionScope(
-            mockParentScope,
-            100f,
-            false,
-            mockDetector,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockTimeProvider,
-            mockSessionListener,
-            mockRumEventSourceProvider,
-            mockBuildSdkVersionProvider,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS,
-            fakeAndroidInfoProvider
-        )
-        testedScope.childrenScopes.add(mockChildScope)
-        whenever(mockChildScope.isActive()) doReturn true
-        whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
-        val fakeEvent = forge.forgeInvalidAppLaunchEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        assertThat(testedScope.childrenScopes).hasSize(1)
-        assertThat(testedScope.childrenScopes[0]).isSameAs(mockChildScope)
-    }
-
-    @Test
-    fun `M send warn dev log W handleEvent { app displayed, event is relevant, bg disabled }`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope = RumSessionScope(
-            mockParentScope,
-            100f,
-            false,
-            mockDetector,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockTimeProvider,
-            mockSessionListener,
-            mockRumEventSourceProvider,
-            mockBuildSdkVersionProvider,
-            TEST_INACTIVITY_NS,
-            TEST_MAX_DURATION_NS,
-            fakeAndroidInfoProvider
-        )
-        testedScope.applicationDisplayed = true
-        val fakeEvent = forge.forgeValidBackgroundEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        verify(logger.mockDevLogHandler).handleLog(Log.WARN, RumSessionScope.MESSAGE_MISSING_VIEW)
-    }
-
-    @Test
-    fun `M not start a background ViewScope W handleEvent { app displayed, event not relevant}`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope.applicationDisplayed = true
-        val fakeEvent = forge.forgeInvalidBackgroundEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        assertThat(testedScope.childrenScopes).hasSize(0)
-    }
-
-    @Test
-    fun `M not start an appLaunch ViewScope W handleEvent { app not displayed, event not relevant}`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope.applicationDisplayed = false
-        val fakeEvent = forge.forgeInvalidAppLaunchEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        assertThat(testedScope.childrenScopes).hasSize(0)
-    }
-
-    @Test
-    fun `M send warn dev log W handleEvent { app displayed, bg event not relevant}`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope.applicationDisplayed = true
-        val fakeEvent = forge.forgeInvalidBackgroundEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        verify(logger.mockDevLogHandler).handleLog(Log.WARN, RumSessionScope.MESSAGE_MISSING_VIEW)
-    }
-
-    @Test
-    fun `M not send warn dev log W handleEvent { app displayed, bg event silent}`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope.applicationDisplayed = true
-        val fakeEvent = forge.forgeSilentOrphanEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        verifyZeroInteractions(logger.mockDevLogHandler)
-    }
-
-    @Test
-    fun `M send warn dev log W handleEvent { app not displayed, app launch event not relevant}`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope.applicationDisplayed = false
-        val fakeEvent = forge.forgeInvalidAppLaunchEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        verify(logger.mockDevLogHandler).handleLog(Log.WARN, RumSessionScope.MESSAGE_MISSING_VIEW)
-    }
-
-    @Test
-    fun `M not send warn dev log W handleEvent { app not displayed, bg event silent}`(
-        forge: Forge
-    ) {
-        // GIVEN
-        testedScope.applicationDisplayed = false
-        val fakeEvent = forge.forgeSilentOrphanEvent()
-
-        // WHEN
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // THEN
-        verifyZeroInteractions(logger.mockDevLogHandler)
-    }
-
-    private fun Forge.forgeValidBackgroundEvent(): RumRawEvent {
-        val fakeEventTime = Time()
-        val fakeName = this.anAlphabeticalString()
-
-        return this.anElementFrom(
-            listOf(
-                RumRawEvent.StartAction(
-                    this.aValueFrom(RumActionType::class.java),
-                    fakeName,
-                    this.aBool(),
-                    emptyMap(),
-                    fakeEventTime
-                ),
-                RumRawEvent.AddError(
-                    fakeName,
-                    this.aValueFrom(RumErrorSource::class.java),
-                    stacktrace = null,
-                    throwable = null,
-                    isFatal = this.aBool(),
-                    attributes = emptyMap(),
-                    eventTime = fakeEventTime
-                ),
-                RumRawEvent.StartResource(
-                    fakeName,
-                    getForgery<URL>().toString(),
-                    anElementFrom("POST", "GET", "PUT", "DELETE", "HEAD"),
-                    emptyMap(),
-                    fakeEventTime
-                )
-            )
-        )
-    }
-
-    private fun Forge.forgeValidAppLaunchEvent(): RumRawEvent {
-        val fakeEventTime = Time()
-        val fakeName = this.anAlphabeticalString()
-
-        return this.anElementFrom(
-            listOf(
-                RumRawEvent.StartAction(
-                    this.aValueFrom(RumActionType::class.java),
-                    fakeName,
-                    this.aBool(),
-                    emptyMap(),
-                    fakeEventTime
-                ),
-                RumRawEvent.AddLongTask(System.nanoTime(), fakeName, fakeEventTime),
-                RumRawEvent.AddError(
-                    fakeName,
-                    this.aValueFrom(RumErrorSource::class.java),
-                    stacktrace = null,
-                    throwable = null,
-                    isFatal = this.aBool(),
-                    attributes = emptyMap(),
-                    eventTime = fakeEventTime
-                ),
-                RumRawEvent.StartResource(
-                    fakeName,
-                    getForgery<URL>().toString(),
-                    anElementFrom("POST", "GET", "PUT", "DELETE", "HEAD"),
-                    emptyMap(),
-                    fakeEventTime
-                )
-            )
-        )
-    }
-
-    private fun Forge.forgeInvalidBackgroundEvent(): RumRawEvent {
-        val fakeEventTime = Time()
-        val fakeKey = anAlphabeticalString()
-        val fakeName = anAlphabeticalString()
-
-        return this.anElementFrom(
-            listOf(
-                RumRawEvent.AddLongTask(System.nanoTime(), fakeName, fakeEventTime),
-                RumRawEvent.StopAction(
-                    this.aValueFrom(RumActionType::class.java),
-                    fakeKey,
-                    emptyMap(),
-                    fakeEventTime
-                ),
-                RumRawEvent.StopResource(
-                    fakeKey,
-                    statusCode = null,
-                    size = null,
-                    kind = this.aValueFrom(RumResourceKind::class.java),
-                    attributes = emptyMap(),
-                    eventTime = fakeEventTime
-                ),
-                RumRawEvent.StopResourceWithError(
-                    fakeKey,
-                    message = this.aString(),
-                    statusCode = null,
-                    source = this.aValueFrom(RumErrorSource::class.java),
-                    throwable = this.getForgery(),
-                    attributes = emptyMap(),
-                    eventTime = fakeEventTime
-                ),
-                RumRawEvent.StopResourceWithStackTrace(
-                    fakeKey,
-                    message = this.aString(),
-                    statusCode = null,
-                    source = this.aValueFrom(RumErrorSource::class.java),
-                    stackTrace = this.anAlphaNumericalString(),
-                    errorType = aNullable { anAlphabeticalString() },
-                    attributes = emptyMap(),
-                    eventTime = fakeEventTime
-                )
-            )
-        )
-    }
-
-    private fun Forge.forgeInvalidAppLaunchEvent(): RumRawEvent {
-        val fakeEventTime = Time()
-        val fakeKey = this.anAlphabeticalString()
-
-        return this.anElementFrom(
-            listOf(
-                RumRawEvent.StopAction(
-                    this.aValueFrom(RumActionType::class.java),
-                    fakeKey,
-                    emptyMap(),
-                    fakeEventTime
-                ),
-                RumRawEvent.StopResource(
-                    fakeKey,
-                    statusCode = null,
-                    size = null,
-                    kind = this.aValueFrom(RumResourceKind::class.java),
-                    attributes = emptyMap(),
-                    eventTime = fakeEventTime
-                ),
-                RumRawEvent.StopResourceWithError(
-                    fakeKey,
-                    message = this.aString(),
-                    statusCode = null,
-                    source = this.aValueFrom(RumErrorSource::class.java),
-                    throwable = this.getForgery(),
-                    attributes = emptyMap(),
-                    eventTime = fakeEventTime
-                ),
-                RumRawEvent.StopResourceWithStackTrace(
-                    fakeKey,
-                    message = this.aString(),
-                    statusCode = null,
-                    source = this.aValueFrom(RumErrorSource::class.java),
-                    stackTrace = this.anAlphaNumericalString(),
-                    errorType = aNullable { anAlphabeticalString() },
-                    attributes = emptyMap(),
-                    eventTime = fakeEventTime
-                )
-            )
-        )
-    }
-
-    private fun Forge.forgeSilentOrphanEvent(): RumRawEvent {
-        val fakeEventTime = Time()
-        val fakeKey = anAlphabeticalString()
-        val fakeId = getForgery<UUID>().toString()
-
-        return this.anElementFrom(
-            listOf(
-                RumRawEvent.ApplicationStarted(fakeEventTime, aLong()),
-                RumRawEvent.ResetSession(),
-                RumRawEvent.KeepAlive(),
-                RumRawEvent.StopView(
-                    fakeKey,
-                    emptyMap(),
-                    fakeEventTime
-                ),
-                RumRawEvent.ActionSent(fakeId),
-                RumRawEvent.ErrorSent(fakeId),
-                RumRawEvent.LongTaskSent(fakeId),
-                RumRawEvent.ResourceSent(fakeId),
-                RumRawEvent.ActionDropped(fakeId),
-                RumRawEvent.ErrorDropped(fakeId),
-                RumRawEvent.LongTaskDropped(fakeId),
-                RumRawEvent.ResourceDropped(fakeId)
-            )
-        )
-    }
+    // endregion
 
     companion object {
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -1,0 +1,715 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain.scope
+
+import android.app.ActivityManager.RunningAppProcessInfo
+import android.content.Context
+import android.os.Build
+import android.util.Log
+import com.datadog.android.Datadog
+import com.datadog.android.core.internal.CoreFeature
+import com.datadog.android.core.internal.net.FirstPartyHostDetector
+import com.datadog.android.core.internal.persistence.DataWriter
+import com.datadog.android.core.internal.system.AndroidInfoProvider
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.core.model.NetworkInfo
+import com.datadog.android.core.model.UserInfo
+import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.rum.internal.domain.event.RumEventSourceProvider
+import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
+import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.utils.config.ApplicationContextTestConfiguration
+import com.datadog.android.utils.config.CoreFeatureTestConfiguration
+import com.datadog.android.utils.config.LoggerTestConfiguration
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.same
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.concurrent.TimeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RumViewManagerScopeTest {
+
+    lateinit var testedScope: RumViewManagerScope
+
+    @Mock
+    lateinit var mockParentScope: RumScope
+
+    @Mock
+    lateinit var mockChildScope: RumScope
+
+    @Mock
+    lateinit var mockWriter: DataWriter<Any>
+
+    @Mock
+    lateinit var mockDetector: FirstPartyHostDetector
+
+    @Mock
+    lateinit var mockCpuVitalMonitor: VitalMonitor
+
+    @Mock
+    lateinit var mockMemoryVitalMonitor: VitalMonitor
+
+    @Mock
+    lateinit var mockFrameRateVitalMonitor: VitalMonitor
+
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
+    @Mock
+    lateinit var mockRumEventSourceProvider: RumEventSourceProvider
+
+    @Mock
+    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+
+    @Forgery
+    lateinit var fakeParentContext: RumContext
+
+    @Forgery
+    lateinit var fakeUserInfo: UserInfo
+
+    @Forgery
+    lateinit var fakeNetworkInfo: NetworkInfo
+
+    @Forgery
+    lateinit var fakeAndroidInfoProvider: AndroidInfoProvider
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(coreFeature.mockUserInfoProvider.getUserInfo()) doReturn fakeUserInfo
+        whenever(coreFeature.mockNetworkInfoProvider.getLatestNetworkInfo())
+            .thenReturn(fakeNetworkInfo)
+
+        whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
+        whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
+        whenever(mockChildScope.isActive()) doReturn true
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.BASE
+
+        testedScope = RumViewManagerScope(
+            mockParentScope,
+            true,
+            mockDetector,
+            mockCpuVitalMonitor,
+            mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
+            mockTimeProvider,
+            mockRumEventSourceProvider,
+            mockBuildSdkVersionProvider,
+            fakeAndroidInfoProvider
+        )
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        // whatever happens
+        assertThat(testedScope.isActive()).isTrue()
+        assertThat(testedScope.getRumContext()).isEqualTo(fakeParentContext)
+    }
+
+    // region Children scopes
+
+    @Test
+    fun `𝕄 delegate to child scope 𝕎 handleEvent()`() {
+        // Given
+        val fakeEvent: RumRawEvent = mock()
+        testedScope.childrenScopes.add(mockChildScope)
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        verify(mockChildScope).handleEvent(fakeEvent, mockWriter)
+        assertThat(result).isSameAs(testedScope)
+        verifyZeroInteractions(mockWriter, logger.mockDevLogHandler)
+    }
+
+    @Test
+    fun `𝕄 keep children scope 𝕎 handleEvent child returns non null`() {
+        // Given
+        val fakeEvent: RumRawEvent = mock()
+        testedScope.childrenScopes.add(mockChildScope)
+        whenever(mockChildScope.handleEvent(fakeEvent, mockWriter)) doReturn mockChildScope
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).containsExactly(mockChildScope)
+        assertThat(result).isSameAs(testedScope)
+        verifyZeroInteractions(mockWriter)
+    }
+
+    @Test
+    fun `𝕄 remove children scope 𝕎 handleEvent child returns null`() {
+        // Given
+        val fakeEvent: RumRawEvent = mock()
+        testedScope.childrenScopes.add(mockChildScope)
+        whenever(mockChildScope.handleEvent(fakeEvent, mockWriter)) doReturn null
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).isEmpty()
+        assertThat(result).isSameAs(testedScope)
+        verifyZeroInteractions(mockWriter)
+    }
+
+    // endregion
+
+    // region Foreground View
+
+    @Test
+    fun `𝕄 start a foreground ViewScope 𝕎 handleEvent(StartView) { app displayed }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeEvent = forge.startViewEvent()
+        testedScope.applicationDisplayed = true
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(1)
+        assertThat(testedScope.childrenScopes[0])
+            .isInstanceOfSatisfying(RumViewScope::class.java) {
+                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
+                assertThat(it.keyRef.get()).isEqualTo(fakeEvent.key)
+                assertThat(it.name).isEqualTo(fakeEvent.name)
+                assertThat(it.type).isEqualTo(RumViewScope.RumViewType.FOREGROUND)
+                assertThat(it.attributes).containsAllEntriesOf(fakeEvent.attributes)
+                assertThat(it.firstPartyHostDetector).isSameAs(mockDetector)
+            }
+        assertThat(testedScope.applicationDisplayed).isTrue()
+    }
+
+    @Test
+    fun `𝕄 start a foreground ViewScope 𝕎 handleEvent(StartView) { app not displayed }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeEvent = forge.startViewEvent()
+        testedScope.applicationDisplayed = false
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(1)
+        assertThat(testedScope.childrenScopes[0])
+            .isInstanceOfSatisfying(RumViewScope::class.java) {
+                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
+                assertThat(it.keyRef.get()).isEqualTo(fakeEvent.key)
+                assertThat(it.name).isEqualTo(fakeEvent.name)
+                assertThat(it.type).isEqualTo(RumViewScope.RumViewType.FOREGROUND)
+                assertThat(it.attributes).containsAllEntriesOf(fakeEvent.attributes)
+                assertThat(it.firstPartyHostDetector).isSameAs(mockDetector)
+            }
+        assertThat(testedScope.applicationDisplayed).isTrue()
+    }
+
+    // endregion
+
+    // region Background View
+
+    @Test
+    fun `𝕄 start a bg ViewScope 𝕎 handleEvent { app displayed, event is relevant }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.applicationDisplayed = true
+        val fakeEvent = forge.validBackgroundEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(1)
+        assertThat(testedScope.childrenScopes[0])
+            .isInstanceOfSatisfying(RumViewScope::class.java) {
+                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
+                assertThat(it.keyRef.get()).isEqualTo(RumViewManagerScope.RUM_BACKGROUND_VIEW_URL)
+                assertThat(it.name).isEqualTo(RumViewManagerScope.RUM_BACKGROUND_VIEW_NAME)
+                assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.memoryVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.frameRateVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+            }
+    }
+
+    @Test
+    fun `𝕄 start a bg ViewScope 𝕎 handleEvent { stopped view, event is relevant }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.applicationDisplayed = true
+        testedScope.childrenScopes.add(mockChildScope)
+        whenever(mockChildScope.isActive()) doReturn false
+        whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
+        val fakeEvent = forge.validBackgroundEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(2)
+        assertThat(testedScope.childrenScopes[0]).isSameAs(mockChildScope)
+        assertThat(testedScope.childrenScopes[1])
+            .isInstanceOfSatisfying(RumViewScope::class.java) {
+                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
+                assertThat(it.keyRef.get()).isEqualTo(RumViewManagerScope.RUM_BACKGROUND_VIEW_URL)
+                assertThat(it.name).isEqualTo(RumViewManagerScope.RUM_BACKGROUND_VIEW_NAME)
+                assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.memoryVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.frameRateVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.type).isEqualTo(RumViewScope.RumViewType.BACKGROUND)
+            }
+    }
+
+    @Test
+    fun `𝕄 start a bg ViewScope 𝕎 handleEvent { event is relevant, not foreground }`(
+        forge: Forge
+    ) {
+        // Given
+        CoreFeature.processImportance = forge.anElementFrom(
+            RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE,
+            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING,
+            @Suppress("DEPRECATION")
+            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING_PRE_28,
+            RunningAppProcessInfo.IMPORTANCE_VISIBLE,
+            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE,
+            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE_PRE_26,
+            RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE,
+            RunningAppProcessInfo.IMPORTANCE_SERVICE,
+            RunningAppProcessInfo.IMPORTANCE_CACHED,
+            RunningAppProcessInfo.IMPORTANCE_GONE
+        )
+        testedScope.applicationDisplayed = false
+        val fakeEvent = forge.validBackgroundEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(1)
+        assertThat(testedScope.childrenScopes[0])
+            .isInstanceOfSatisfying(RumViewScope::class.java) {
+                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
+                assertThat(it.keyRef.get()).isEqualTo(RumViewManagerScope.RUM_BACKGROUND_VIEW_URL)
+                assertThat(it.name).isEqualTo(RumViewManagerScope.RUM_BACKGROUND_VIEW_NAME)
+                assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.memoryVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.frameRateVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.type).isEqualTo(RumViewScope.RumViewType.BACKGROUND)
+            }
+    }
+
+    @Test
+    fun `𝕄 not start a bg ViewScope 𝕎 handleEvent { app displayed, event not relevant}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.applicationDisplayed = true
+        val fakeEvent = forge.invalidBackgroundEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(0)
+    }
+
+    @Test
+    fun `𝕄 not start a bg ViewScope 𝕎 handleEvent { bg disabled, event is relevant }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope = RumViewManagerScope(
+            parentScope = mockParentScope,
+            backgroundTrackingEnabled = false,
+            firstPartyHostDetector = mockDetector,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            timeProvider = mockTimeProvider,
+            rumEventSourceProvider = mockRumEventSourceProvider,
+            androidInfoProvider = fakeAndroidInfoProvider
+        )
+        testedScope.applicationDisplayed = true
+        val fakeEvent = forge.validBackgroundEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(0)
+    }
+
+    @Test
+    fun `𝕄 not start a bg ViewScope 𝕎 handleEvent { app displayed, event relevant, active view }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope = RumViewManagerScope(
+            parentScope = mockParentScope,
+            backgroundTrackingEnabled = false,
+            firstPartyHostDetector = mockDetector,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            timeProvider = mockTimeProvider,
+            rumEventSourceProvider = mockRumEventSourceProvider,
+            buildSdkVersionProvider = mockBuildSdkVersionProvider,
+            androidInfoProvider = fakeAndroidInfoProvider
+        )
+        testedScope.childrenScopes.add(mockChildScope)
+        whenever(mockChildScope.isActive()) doReturn true
+        whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
+        val fakeEvent = forge.validBackgroundEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(1)
+        assertThat(testedScope.childrenScopes[0]).isSameAs(mockChildScope)
+    }
+
+    @Test
+    fun `𝕄 send warn dev log 𝕎 handleEvent { app displayed, event is relevant, bg disabled }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope = RumViewManagerScope(
+            parentScope = mockParentScope,
+            backgroundTrackingEnabled = false,
+            firstPartyHostDetector = mockDetector,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            timeProvider = mockTimeProvider,
+            rumEventSourceProvider = mockRumEventSourceProvider,
+            buildSdkVersionProvider = mockBuildSdkVersionProvider,
+            androidInfoProvider = fakeAndroidInfoProvider
+        )
+        testedScope.applicationDisplayed = true
+        val fakeEvent = forge.validBackgroundEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        verify(logger.mockDevLogHandler)
+            .handleLog(Log.WARN, RumViewManagerScope.MESSAGE_MISSING_VIEW)
+    }
+
+    @Test
+    fun `𝕄 not send warn dev log 𝕎 handleEvent { app not displayed, bg event silent}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.applicationDisplayed = false
+        val fakeEvent = forge.silentOrphanEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        verifyZeroInteractions(logger.mockDevLogHandler)
+    }
+
+    // endregion
+
+    // region AppLaunch View
+
+    @Test
+    fun `𝕄 start an AppLaunch ViewScope 𝕎 handleEvent { app not displayed, event is relevant }`(
+        forge: Forge
+    ) {
+        // Given
+        CoreFeature.processImportance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+        testedScope.applicationDisplayed = false
+        val fakeEvent = forge.validAppLaunchEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(1)
+        assertThat(testedScope.childrenScopes[0])
+            .isInstanceOfSatisfying(RumViewScope::class.java) {
+                assertThat(it.eventTimestamp).isEqualTo(fakeEvent.eventTime.timestamp)
+                assertThat(it.keyRef.get()).isEqualTo(RumViewManagerScope.RUM_APP_LAUNCH_VIEW_URL)
+                assertThat(it.name).isEqualTo(RumViewManagerScope.RUM_APP_LAUNCH_VIEW_NAME)
+                assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.memoryVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.frameRateVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
+                assertThat(it.type).isEqualTo(RumViewScope.RumViewType.APPLICATION_LAUNCH)
+            }
+    }
+
+    @Test
+    fun `𝕄 not start an AppLaunch ViewScope 𝕎 handleEvent { event is relevant, not foreground }`(
+        forge: Forge
+    ) {
+        // Given
+        CoreFeature.processImportance = forge.anElementFrom(
+            RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE,
+            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING,
+            @Suppress("DEPRECATION")
+            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING_PRE_28,
+            RunningAppProcessInfo.IMPORTANCE_VISIBLE,
+            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE,
+            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE_PRE_26,
+            RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE,
+            RunningAppProcessInfo.IMPORTANCE_SERVICE,
+            RunningAppProcessInfo.IMPORTANCE_CACHED,
+            RunningAppProcessInfo.IMPORTANCE_GONE
+        )
+        testedScope = RumViewManagerScope(
+            parentScope = mockParentScope,
+            backgroundTrackingEnabled = false,
+            firstPartyHostDetector = mockDetector,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            timeProvider = mockTimeProvider,
+            rumEventSourceProvider = mockRumEventSourceProvider,
+            androidInfoProvider = fakeAndroidInfoProvider
+        )
+        testedScope.applicationDisplayed = false
+        val fakeEvent = forge.validAppLaunchEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(0)
+    }
+
+    @Test
+    fun `𝕄 not start an AppLaunch ViewScope 𝕎 handleEvent { app not displayed, evt not relevant}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.applicationDisplayed = false
+        val fakeEvent = forge.invalidAppLaunchEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(0)
+    }
+
+    @Test
+    fun `𝕄 not start an AppLaunch ViewScope 𝕎 handleEvent { app displ, evt relev, active view}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope = RumViewManagerScope(
+            parentScope = mockParentScope,
+            backgroundTrackingEnabled = false,
+            firstPartyHostDetector = mockDetector,
+            cpuVitalMonitor = mockCpuVitalMonitor,
+            memoryVitalMonitor = mockMemoryVitalMonitor,
+            frameRateVitalMonitor = mockFrameRateVitalMonitor,
+            timeProvider = mockTimeProvider,
+            rumEventSourceProvider = mockRumEventSourceProvider,
+            buildSdkVersionProvider = mockBuildSdkVersionProvider,
+            androidInfoProvider = fakeAndroidInfoProvider
+        )
+        testedScope.childrenScopes.add(mockChildScope)
+        whenever(mockChildScope.isActive()) doReturn true
+        whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
+        val fakeEvent = forge.validAppLaunchEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(1)
+        assertThat(testedScope.childrenScopes[0]).isSameAs(mockChildScope)
+    }
+
+    @Test
+    fun `𝕄 send warn dev log 𝕎 handleEvent { app not displayed, app launch event not relevant}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.applicationDisplayed = false
+        val fakeEvent = forge.invalidAppLaunchEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        verify(logger.mockDevLogHandler).handleLog(
+            Log.WARN,
+            RumViewManagerScope.MESSAGE_MISSING_VIEW
+        )
+    }
+
+    @Test
+    fun `𝕄 not send warn dev log 𝕎 handleEvent { app not displayed, app launch event silent}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.applicationDisplayed = false
+        val fakeEvent = forge.silentOrphanEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        verifyZeroInteractions(logger.mockDevLogHandler)
+    }
+
+    // endregion
+
+    // region ApplicationStarted
+
+    @Test
+    fun `𝕄 send ApplicationStarted event 𝕎 onViewDisplayed() {Legacy}`(
+        forge: Forge,
+        @IntForgery(min = Build.VERSION_CODES.KITKAT, max = Build.VERSION_CODES.N) apiVersion: Int
+    ) {
+        // Given
+        CoreFeature.processImportance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+        whenever(mockBuildSdkVersionProvider.version()) doReturn apiVersion
+        val childView: RumViewScope = mock()
+        val startViewEvent = forge.startViewEvent()
+
+        // When
+        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
+
+        // Then
+        argumentCaptor<RumRawEvent> {
+            verify(childView).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.ApplicationStarted
+            assertThat(event.applicationStartupNanos).isEqualTo(Datadog.startupTimeNs)
+        }
+        verifyZeroInteractions(mockWriter)
+    }
+
+    @Test
+    fun `𝕄 send ApplicationStarted event 𝕎 onViewDisplayed() {Nougat+}`(
+        forge: Forge,
+        @IntForgery(min = Build.VERSION_CODES.N) apiVersion: Int
+    ) {
+        // Given
+        CoreFeature.processImportance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+        whenever(mockBuildSdkVersionProvider.version()) doReturn apiVersion
+        val childView: RumViewScope = mock()
+        val startViewEvent = forge.startViewEvent()
+
+        // When
+        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
+
+        // Then
+        argumentCaptor<RumRawEvent> {
+            verify(childView).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.ApplicationStarted
+            assertThat(event.applicationStartupNanos)
+                .isCloseTo(System.nanoTime(), Offset.offset(TimeUnit.MILLISECONDS.toNanos(100)))
+        }
+        verifyZeroInteractions(mockWriter)
+    }
+
+    @Test
+    fun `𝕄 not send ApplicationStarted event 𝕎 onViewDisplayed() {app already started}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.applicationDisplayed = true
+        val childView: RumViewScope = mock()
+        val startViewEvent = forge.startViewEvent()
+
+        // When
+        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
+
+        // Then
+        verifyZeroInteractions(childView, mockWriter)
+    }
+
+    @Test
+    fun `𝕄 not send ApplicationStarted event 𝕎 onViewDisplayed() {not foreground process}`(
+        forge: Forge
+    ) {
+        // Given
+        CoreFeature.processImportance = forge.anElementFrom(
+            RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE,
+            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING,
+            @Suppress("DEPRECATION")
+            RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING_PRE_28,
+            RunningAppProcessInfo.IMPORTANCE_VISIBLE,
+            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE,
+            RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE_PRE_26,
+            RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE,
+            RunningAppProcessInfo.IMPORTANCE_SERVICE,
+            RunningAppProcessInfo.IMPORTANCE_CACHED,
+            RunningAppProcessInfo.IMPORTANCE_GONE
+        )
+        testedScope.applicationDisplayed = false
+        val childView: RumViewScope = mock()
+        val startViewEvent = forge.startViewEvent()
+
+        // When
+        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
+
+        // Then
+        verifyZeroInteractions(childView, mockWriter)
+    }
+
+    // endregion
+
+    companion object {
+
+        val appContext = ApplicationContextTestConfiguration(Context::class.java)
+        val coreFeature = CoreFeatureTestConfiguration(appContext)
+        val logger = LoggerTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(logger, appContext, coreFeature)
+        }
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -26,6 +26,7 @@ import com.datadog.android.rum.internal.domain.scope.RumRawEvent
 import com.datadog.android.rum.internal.domain.scope.RumResourceScope
 import com.datadog.android.rum.internal.domain.scope.RumScope
 import com.datadog.android.rum.internal.domain.scope.RumSessionScope
+import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.model.ViewEvent
@@ -1286,8 +1287,8 @@ internal class DatadogRumMonitorTest {
         // Given
         val mockRumApplicationScope = mock<RumApplicationScope>()
         testedMonitor.rootScope = mockRumApplicationScope
-
         val mockSessionScope = mock<RumSessionScope>()
+        val mockViewManagerScope = mock<RumViewManagerScope>()
 
         val listener = mock<RumDebugListener>()
         testedMonitor.debugListener = listener
@@ -1300,16 +1301,14 @@ internal class DatadogRumMonitorTest {
                 whenever(isActive()) doReturn true
             }
         }
-
         val expectedViewNames = viewScopes.mapNotNull { it.getRumContext().viewName }
-
         val otherScopes = forge.aList {
             forge.anElementFrom(mock(), mock<RumActionScope>(), mock<RumResourceScope>())
         }
-
         whenever(mockRumApplicationScope.childScope) doReturn mockSessionScope
-        whenever(mockSessionScope.childrenScopes) doReturn
-            (viewScopes + otherScopes).toMutableList()
+        whenever(mockSessionScope.childScope) doReturn mockViewManagerScope
+        whenever(mockViewManagerScope.childrenScopes)
+            .thenReturn((viewScopes + otherScopes).toMutableList())
 
         // When
         testedMonitor.notifyDebugListenerWithState()
@@ -1325,12 +1324,11 @@ internal class DatadogRumMonitorTest {
         // Given
         val mockRumApplicationScope = mock<RumApplicationScope>()
         testedMonitor.rootScope = mockRumApplicationScope
-
         val mockSessionScope = mock<RumSessionScope>()
+        val mockViewManagerScope = mock<RumViewManagerScope>()
 
         val listener = mock<RumDebugListener>()
         testedMonitor.debugListener = listener
-
         val viewScopes = forge.aList {
             mock<RumViewScope>().apply {
                 whenever(getRumContext()) doReturn
@@ -1339,16 +1337,14 @@ internal class DatadogRumMonitorTest {
                 whenever(isActive()) doReturn false
             }
         }
-
         val expectedViewNames = emptyList<String>()
-
         val otherScopes = forge.aList {
             forge.anElementFrom(mock(), mock<RumActionScope>(), mock<RumResourceScope>())
         }
-
         whenever(mockRumApplicationScope.childScope) doReturn mockSessionScope
-        whenever(mockSessionScope.childrenScopes) doReturn
-            (viewScopes + otherScopes).toMutableList()
+        whenever(mockSessionScope.childScope) doReturn mockViewManagerScope
+        whenever(mockViewManagerScope.childrenScopes)
+            .thenReturn((viewScopes + otherScopes).toMutableList())
 
         // When
         testedMonitor.notifyDebugListenerWithState()


### PR DESCRIPTION
### What does this PR do?

This PR improves the way we track session, and ensure the logic follows the expectation from our billing guidelines

We separate the `RumSessionScope` into two classes: 
- `RumSessionScope` which manages the session lifecycle (extending the life of a session, renewing or reseting a session)
- `RumViewManagerScope` which handles the different views and creates Background/AppLaunch views when necessary