### PR TITLE
RUMM-2261: Handle WebView RUM and Logs data in the background upload worker

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
@@ -20,6 +20,8 @@ import com.datadog.android.error.internal.CrashReportsFeature
 import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.tracing.internal.TracingFeature
+import com.datadog.android.webview.internal.log.WebViewLogsFeature
+import com.datadog.android.webview.internal.rum.WebViewRumFeature
 
 internal class UploadWorker(
     appContext: Context,
@@ -56,6 +58,18 @@ internal class UploadWorker(
         uploadAllBatches(
             RumFeature.persistenceStrategy.getReader(),
             RumFeature.uploader
+        )
+
+        // Upload WebView RUM
+        uploadAllBatches(
+            WebViewRumFeature.persistenceStrategy.getReader(),
+            WebViewRumFeature.uploader
+        )
+
+        // Upload WebView Logs
+        uploadAllBatches(
+            WebViewLogsFeature.persistenceStrategy.getReader(),
+            WebViewLogsFeature.uploader
         )
 
         return Result.success()
@@ -110,8 +124,4 @@ internal class UploadWorker(
     }
 
     // endregion
-
-    companion object {
-        private const val TAG = "UploadWorker"
-    }
 }


### PR DESCRIPTION
### What does this PR do?

WebView RUM and Logs data upload was missing in the `UploadWorker`. Not a big issue, because we also do upload using another way as well while SDK is active, but this change adds the missing part for the consistency.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

