### PR TITLE
RUMM-2208: SDK v2 upload pipeline

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1505,7 +1505,7 @@ interface com.datadog.android.v2.api.FeatureScope
 data class com.datadog.android.v2.api.FeatureStorageConfiguration
   constructor(Int, Int, Int, Long)
 data class com.datadog.android.v2.api.FeatureUploadConfiguration
-  constructor(String, PayloadFormat)
+  constructor(RequestFactory)
 interface com.datadog.android.v2.api.InternalLogger
   enum Level
     - DEBUG
@@ -1521,6 +1521,10 @@ interface com.datadog.android.v2.api.PayloadFormat
   fun prefixBytes(): ByteArray
   fun suffixBytes(): ByteArray
   fun separatorBytes(): ByteArray
+data class com.datadog.android.v2.api.Request
+  constructor(String, String, String, Map<String, String>, ByteArray, String? = null)
+interface com.datadog.android.v2.api.RequestFactory
+  fun create(com.datadog.android.v2.api.context.DatadogContext, List<ByteArray>, ByteArray?): Request
 interface com.datadog.android.v2.api.SDKCore
   fun registerFeature(String, FeatureStorageConfiguration, FeatureUploadConfiguration)
   fun getFeature(String): FeatureScope?
@@ -1575,6 +1579,7 @@ class com.datadog.android.v2.core.DatadogCore : com.datadog.android.v2.api.SDKCo
   override fun clearAllData()
   override fun stop()
   override fun flushStoredData()
+  fun getAllFeatures(): List<com.datadog.android.v2.api.FeatureScope>
   companion object 
 class com.datadog.android.webview.DatadogEventBridge
   constructor()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/FeatureUploadConfiguration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/FeatureUploadConfiguration.kt
@@ -9,10 +9,8 @@ package com.datadog.android.v2.api
 /**
  * Contains the upload configuration for an [FeatureScope] instance.
  *
- * @property endpointUrl the url endpoint data should be uploaded to
- * @property payloadFormat the expected format of the payload
+ * @property requestFactory creates a request from a given batch and its metadata
  */
 data class FeatureUploadConfiguration(
-    val endpointUrl: String,
-    val payloadFormat: PayloadFormat
+    val requestFactory: RequestFactory
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/Request.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/Request.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.api
+
+/**
+ * Request object holding the data to be sent.
+ *
+ * @property id Unique identifier of the request.
+ * @property context Description of the request (ex. "RUM request", "Logs request", etc.).
+ * @property url URL to call.
+ * @property headers Request headers. Note that User Agent header will be ignored.
+ * @property body Request payload.
+ * @property contentType Content type of the request, if needed.
+ */
+data class Request(
+    val id: String,
+    val context: String,
+    val url: String,
+    val headers: Map<String, String>,
+    // won't generate custom equals/hashcode, because ID field is enough to identify the request
+    // and we don't want to have array content comparison
+    @Suppress("ArrayInDataClass") val body: ByteArray,
+    val contentType: String? = null
+)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/RequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/RequestFactory.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.api
+
+import com.datadog.android.v2.api.context.DatadogContext
+
+/**
+ * Factory used to build requests from the batches stored.
+ */
+fun interface RequestFactory {
+
+    // TODO RUMM-2298 Support 1:many relationship between batch and requests
+    /**
+     * Creates a request for the given batch.
+     * @param context Datadog SDK context.
+     * @param batchData Raw data of the batch.
+     * @param batchMetadata Raw metadata of the batch.
+     */
+    fun create(
+        context: DatadogContext,
+        batchData: List<ByteArray>,
+        batchMetadata: ByteArray?
+    ): Request
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -33,6 +33,7 @@ import com.datadog.android.v2.api.FeatureScope
 import com.datadog.android.v2.api.FeatureStorageConfiguration
 import com.datadog.android.v2.api.FeatureUploadConfiguration
 import com.datadog.android.v2.api.SDKCore
+import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.webview.internal.log.WebViewLogsFeature
 import com.datadog.android.webview.internal.rum.WebViewRumFeature
 import com.datadog.opentracing.DDSpan
@@ -60,6 +61,9 @@ class DatadogCore(
         null
     internal var webViewLogsFeature: SdkFeature<JsonObject, Configuration.Feature.Logs>? = null
     internal var webViewRumFeature: SdkFeature<Any, Configuration.Feature.RUM>? = null
+
+    // TODO RUMM-0000 handle context
+    internal var context: DatadogContext? = null
 
     init {
         val isDebug = isAppDebuggable(context)
@@ -141,6 +145,15 @@ class DatadogCore(
         crashReportsFeature?.flushStoredData()
         webViewLogsFeature?.flushStoredData()
         webViewRumFeature?.flushStoredData()
+    }
+
+    /**
+     * Returns all registered features.
+     */
+    fun getAllFeatures(): List<FeatureScope> {
+        // TODO-2138
+        // should it be a part of SDKCore?
+        return emptyList()
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogFeature.kt
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core
+
+import com.datadog.android.v2.api.FeatureScope
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.Storage
+
+internal abstract class DatadogFeature(
+    val storage: Storage,
+    val uploader: DataUploader
+) : FeatureScope

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/ContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/ContextProvider.kt
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal
+
+import com.datadog.android.v2.api.context.DatadogContext
+
+internal interface ContextProvider {
+    val context: DatadogContext?
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/NoOpContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/NoOpContextProvider.kt
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal
+
+import com.datadog.android.v2.api.context.DatadogContext
+
+internal class NoOpContextProvider : ContextProvider {
+    override val context: DatadogContext? = null
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataFlusher.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataFlusher.kt
@@ -1,0 +1,44 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal.data.upload
+
+import androidx.annotation.WorkerThread
+import com.datadog.android.core.internal.persistence.file.FileMover
+import com.datadog.android.core.internal.persistence.file.FileOrchestrator
+import com.datadog.android.core.internal.persistence.file.FileReader
+import com.datadog.android.core.internal.persistence.file.batch.BatchFileReader
+import com.datadog.android.core.internal.persistence.file.existsSafe
+import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.net.DataUploader
+
+// TODO RUMM-0000 Should replace com.datadog.android.core.internal.net.DataFlusher once
+//  features are configured as V2
+internal class DataFlusher(
+    internal val contextProvider: ContextProvider,
+    internal val fileOrchestrator: FileOrchestrator,
+    internal val fileReader: BatchFileReader,
+    internal val metadataFileReader: FileReader,
+    internal val fileMover: FileMover
+) : Flusher {
+
+    @WorkerThread
+    override fun flush(uploader: DataUploader) {
+        val context = contextProvider.context ?: return
+
+        val toUploadFiles = fileOrchestrator.getFlushableFiles()
+        toUploadFiles.forEach {
+            val batch = fileReader.readData(it)
+            val metaFile = fileOrchestrator.getMetadataFile(it)
+            val meta = if (metaFile != null) metadataFileReader.readData(metaFile) else null
+            uploader.upload(context, batch, meta)
+            fileMover.delete(it)
+            if (metaFile?.existsSafe() == true) {
+                fileMover.delete(metaFile)
+            }
+        }
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnable.kt
@@ -1,0 +1,135 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal.data.upload
+
+import androidx.annotation.WorkerThread
+import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.internal.data.upload.UploadRunnable
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
+import com.datadog.android.core.internal.system.SystemInfoProvider
+import com.datadog.android.core.internal.utils.scheduleSafe
+import com.datadog.android.core.model.NetworkInfo
+import com.datadog.android.v2.api.context.DatadogContext
+import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.BatchId
+import com.datadog.android.v2.core.internal.storage.Storage
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
+import kotlin.math.min
+
+// TODO RUMM-0000 Should replace com.datadog.android.core.internal.net.DataUploadRunnable once
+//  features are configured as V2
+internal class DataUploadRunnable(
+    private val threadPoolExecutor: ScheduledThreadPoolExecutor,
+    private val storage: Storage,
+    private val dataUploader: DataUploader,
+    private val contextProvider: ContextProvider,
+    private val networkInfoProvider: NetworkInfoProvider,
+    private val systemInfoProvider: SystemInfoProvider,
+    uploadFrequency: UploadFrequency
+) : UploadRunnable {
+
+    internal var currentDelayIntervalMs = DEFAULT_DELAY_FACTOR * uploadFrequency.baseStepMs
+    internal var minDelayMs = MIN_DELAY_FACTOR * uploadFrequency.baseStepMs
+    internal var maxDelayMs = MAX_DELAY_FACTOR * uploadFrequency.baseStepMs
+
+    //  region Runnable
+
+    @WorkerThread
+    override fun run() {
+        if (isNetworkAvailable() && isSystemReady()) {
+            val context = contextProvider.context
+            if (context != null) {
+                storage.readNextBatch(context) { batchId, reader ->
+                    val batch = reader.read()
+                    val batchMeta = reader.currentMetadata()
+
+                    consumeBatch(
+                        context,
+                        batchId,
+                        batch,
+                        batchMeta
+                    )
+                }
+            }
+
+            // TODO RUMM-2297 decrease interval if there is no batch available?
+        }
+
+        scheduleNextUpload()
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun isNetworkAvailable(): Boolean {
+        val networkInfo = networkInfoProvider.getLatestNetworkInfo()
+        return networkInfo.connectivity != NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
+    }
+
+    private fun isSystemReady(): Boolean {
+        val systemInfo = systemInfoProvider.getLatestSystemInfo()
+        val hasEnoughPower = systemInfo.batteryFullOrCharging ||
+            systemInfo.onExternalPowerSource ||
+            systemInfo.batteryLevel > LOW_BATTERY_THRESHOLD
+        return hasEnoughPower && !systemInfo.powerSaveMode
+    }
+
+    private fun scheduleNextUpload() {
+        threadPoolExecutor.remove(this)
+        threadPoolExecutor.scheduleSafe(
+            "Data upload",
+            currentDelayIntervalMs,
+            TimeUnit.MILLISECONDS,
+            this
+        )
+    }
+
+    @WorkerThread
+    private fun consumeBatch(
+        context: DatadogContext,
+        batchId: BatchId,
+        batch: List<ByteArray>,
+        batchMeta: ByteArray?
+    ) {
+        val status = dataUploader.upload(context, batch, batchMeta)
+
+        storage.confirmBatchRead(batchId) {
+            if (status.shouldRetry) {
+                it.markAsRead(false)
+                increaseInterval()
+            } else {
+                it.markAsRead(true)
+                decreaseInterval()
+            }
+        }
+    }
+
+    private fun decreaseInterval() {
+        currentDelayIntervalMs = max(minDelayMs, currentDelayIntervalMs * DECREASE_PERCENT / 100)
+    }
+
+    private fun increaseInterval() {
+        currentDelayIntervalMs = min(maxDelayMs, currentDelayIntervalMs * INCREASE_PERCENT / 100)
+    }
+
+    // endregion
+
+    companion object {
+        internal const val LOW_BATTERY_THRESHOLD = 10
+
+        internal const val MIN_DELAY_FACTOR = 1
+        internal const val DEFAULT_DELAY_FACTOR = 5
+        internal const val MAX_DELAY_FACTOR = 10
+
+        const val DECREASE_PERCENT = 90
+        const val INCREASE_PERCENT = 110
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadScheduler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadScheduler.kt
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal.data.upload
+
+import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.internal.data.upload.UploadScheduler
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
+import com.datadog.android.core.internal.system.SystemInfoProvider
+import com.datadog.android.core.internal.utils.scheduleSafe
+import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.Storage
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+internal class DataUploadScheduler(
+    storage: Storage,
+    dataUploader: DataUploader,
+    contextProvider: ContextProvider,
+    networkInfoProvider: NetworkInfoProvider,
+    systemInfoProvider: SystemInfoProvider,
+    uploadFrequency: UploadFrequency,
+    private val scheduledThreadPoolExecutor: ScheduledThreadPoolExecutor
+) : UploadScheduler {
+
+    private val runnable = DataUploadRunnable(
+        scheduledThreadPoolExecutor,
+        storage,
+        dataUploader,
+        contextProvider,
+        networkInfoProvider,
+        systemInfoProvider,
+        uploadFrequency
+    )
+
+    override fun startScheduling() {
+        scheduledThreadPoolExecutor.scheduleSafe(
+            "Data upload",
+            runnable.currentDelayIntervalMs,
+            TimeUnit.MILLISECONDS,
+            runnable
+        )
+    }
+
+    override fun stopScheduling() {
+        scheduledThreadPoolExecutor.remove(runnable)
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/Flusher.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/Flusher.kt
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal.data.upload
+
+import androidx.annotation.WorkerThread
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.tools.annotation.NoOpImplementation
+
+// TODO RUMM-0000 Should replace com.datadog.android.core.internal.net.Flusher once
+//  features are configured as V2
+@NoOpImplementation
+internal interface Flusher {
+
+    @WorkerThread
+    fun flush(uploader: DataUploader)
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploader.kt
@@ -1,0 +1,156 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal.net
+
+import com.datadog.android.core.internal.net.UploadStatus
+import com.datadog.android.core.internal.system.AndroidInfoProvider
+import com.datadog.android.core.internal.utils.devLogger
+import com.datadog.android.log.Logger
+import com.datadog.android.v2.api.Request as DatadogRequest
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.api.context.DatadogContext
+import java.util.Locale
+import okhttp3.Call
+import okhttp3.MediaType
+import okhttp3.Request
+import okhttp3.RequestBody
+
+// TODO RUMM-0000 Should replace com.datadog.android.core.internal.net.DataOkHttpUploaderV2 once
+//  features are configured as V2
+internal class DataOkHttpUploader(
+    val requestFactory: RequestFactory,
+    val internalLogger: Logger,
+    val callFactory: Call.Factory,
+    val sdkVersion: String,
+    val androidInfoProvider: AndroidInfoProvider
+) : DataUploader {
+
+    // region DataUploader
+
+    @Suppress("TooGenericExceptionCaught")
+    override fun upload(
+        context: DatadogContext,
+        batch: List<ByteArray>,
+        batchMeta: ByteArray?
+    ): UploadStatus {
+        val request = requestFactory.create(context, batch, batchMeta)
+
+        val uploadStatus = try {
+            executeUploadRequest(request)
+        } catch (e: Throwable) {
+            internalLogger.e("Unable to upload batch data.", e)
+            UploadStatus.NETWORK_ERROR
+        }
+
+        uploadStatus.logStatus(
+            request.context,
+            request.body.size,
+            devLogger,
+            ignoreInfo = false,
+            sendToTelemetry = false,
+            requestId = request.id
+        )
+        uploadStatus.logStatus(
+            request.context,
+            request.body.size,
+            internalLogger,
+            ignoreInfo = true,
+            sendToTelemetry = true,
+            requestId = request.id
+        )
+
+        return uploadStatus
+    }
+
+    // endregion
+
+    private val userAgent by lazy {
+        System.getProperty(SYSTEM_UA).let {
+            if (it.isNullOrBlank()) {
+                "Datadog/$sdkVersion " +
+                    "(Linux; U; Android ${androidInfoProvider.getDeviceVersion()}; " +
+                    "${androidInfoProvider.getDeviceModel()} " +
+                    "Build/${androidInfoProvider.getDeviceBuildId()})"
+            } else {
+                it
+            }
+        }
+    }
+
+    // region Internal
+
+    @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
+    private fun executeUploadRequest(
+        request: DatadogRequest
+    ): UploadStatus {
+        val okHttpRequest = buildOkHttpRequest(request)
+        val call = callFactory.newCall(okHttpRequest)
+        val response = call.execute()
+        response.close()
+        return responseCodeToUploadStatus(response.code())
+    }
+
+    @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
+    private fun buildOkHttpRequest(request: DatadogRequest): Request {
+        val mediaType = if (request.contentType == null) {
+            null
+        } else {
+            MediaType.parse(request.contentType)
+        }
+        val builder = Request.Builder()
+            .url(request.url)
+            .post(RequestBody.create(mediaType, request.body))
+
+        for ((header, value) in request.headers) {
+            if (header.lowercase(Locale.US) == "user-agent") {
+                internalLogger.w(WARNING_USER_AGENT_HEADER_RESERVED)
+                continue
+            }
+            builder.addHeader(header, value)
+        }
+
+        builder.addHeader(HEADER_USER_AGENT, userAgent)
+
+        return builder.build()
+    }
+
+    private fun responseCodeToUploadStatus(code: Int): UploadStatus {
+        return when (code) {
+            HTTP_ACCEPTED -> UploadStatus.SUCCESS
+            HTTP_BAD_REQUEST -> UploadStatus.HTTP_CLIENT_ERROR
+            HTTP_UNAUTHORIZED -> UploadStatus.INVALID_TOKEN_ERROR
+            HTTP_FORBIDDEN -> UploadStatus.INVALID_TOKEN_ERROR
+            HTTP_CLIENT_TIMEOUT -> UploadStatus.HTTP_CLIENT_RATE_LIMITING
+            HTTP_ENTITY_TOO_LARGE -> UploadStatus.HTTP_CLIENT_ERROR
+            HTTP_TOO_MANY_REQUESTS -> UploadStatus.HTTP_CLIENT_RATE_LIMITING
+            HTTP_INTERNAL_ERROR -> UploadStatus.HTTP_SERVER_ERROR
+            HTTP_UNAVAILABLE -> UploadStatus.HTTP_SERVER_ERROR
+            else -> UploadStatus.UNKNOWN_ERROR
+        }
+    }
+
+    companion object {
+
+        const val HTTP_ACCEPTED = 202
+
+        const val HTTP_BAD_REQUEST = 400
+        const val HTTP_UNAUTHORIZED = 401
+        const val HTTP_FORBIDDEN = 403
+        const val HTTP_CLIENT_TIMEOUT = 408
+        const val HTTP_ENTITY_TOO_LARGE = 413
+        const val HTTP_TOO_MANY_REQUESTS = 429
+
+        const val HTTP_INTERNAL_ERROR = 500
+        const val HTTP_UNAVAILABLE = 503
+
+        const val SYSTEM_UA = "http.agent"
+
+        const val WARNING_USER_AGENT_HEADER_RESERVED =
+            "Ignoring provided User-Agent header, because it is reserved."
+        const val HEADER_USER_AGENT = "User-Agent"
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataUploader.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal.net
+
+import com.datadog.android.core.internal.net.UploadStatus
+import com.datadog.android.v2.api.context.DatadogContext
+import com.datadog.tools.annotation.NoOpImplementation
+
+@NoOpImplementation
+internal interface DataUploader {
+    // TODO RUMM-2298 Support 1:many relationship between batch and requests
+    fun upload(
+        context: DatadogContext,
+        batch: List<ByteArray>,
+        batchMeta: ByteArray?
+    ): UploadStatus
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/BatchReader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/BatchReader.kt
@@ -9,6 +9,13 @@ package com.datadog.android.v2.core.internal.storage
 import androidx.annotation.WorkerThread
 
 internal interface BatchReader {
+
+    /**
+     * @return the metadata of the current readable file
+     */
+    @WorkerThread
+    fun currentMetadata(): ByteArray?
+
     @WorkerThread
     fun read(): List<ByteArray>
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/Storage.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/Storage.kt
@@ -8,10 +8,12 @@ package com.datadog.android.v2.core.internal.storage
 
 import androidx.annotation.WorkerThread
 import com.datadog.android.v2.api.context.DatadogContext
+import com.datadog.tools.annotation.NoOpImplementation
 
 /**
  * Main core api to interact with the local storage of events.
  */
+@NoOpImplementation
 internal interface Storage {
 
     /**

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataFlusherTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataFlusherTest.kt
@@ -1,0 +1,169 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal.data.upload
+
+import com.datadog.android.core.internal.persistence.file.FileMover
+import com.datadog.android.core.internal.persistence.file.FileOrchestrator
+import com.datadog.android.core.internal.persistence.file.FileReader
+import com.datadog.android.core.internal.persistence.file.batch.BatchFileReader
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.context.DatadogContext
+import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.io.File
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DataFlusherTest {
+    lateinit var testedFlusher: DataFlusher
+
+    @Mock
+    lateinit var mockDataUploader: DataUploader
+
+    @Mock
+    lateinit var mockFileOrchestrator: FileOrchestrator
+
+    @Mock
+    lateinit var mockFileReader: BatchFileReader
+
+    @Mock
+    lateinit var mockMetaFileReader: FileReader
+
+    @Mock
+    lateinit var mockFileMover: FileMover
+
+    @Mock
+    lateinit var mockContextProvider: ContextProvider
+
+    @Forgery
+    lateinit var fakeContext: DatadogContext
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockContextProvider.context) doReturn fakeContext
+
+        testedFlusher = DataFlusher(
+            mockContextProvider,
+            mockFileOrchestrator,
+            mockFileReader,
+            mockMetaFileReader,
+            mockFileMover
+        )
+    }
+
+    @Test
+    fun `M upload all the batches W flush`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeFiles = forge.aList { mock<File>() }
+        val fakeMetaFiles = forge.aList(fakeFiles.size) { forge.aNullable { mock<File>() } }
+        val fakeBatches = forge
+            .aList(fakeFiles.size) {
+                forge
+                    .aList {
+                        forge.aString()
+                    }
+                    .map { it.toByteArray() }
+            }
+        val fakeMeta = fakeMetaFiles.map { if (it != null) forge.aString().toByteArray() else null }
+        whenever(mockFileOrchestrator.getFlushableFiles()).thenReturn(fakeFiles)
+        fakeFiles.forEachIndexed { index, file ->
+            whenever(
+                mockFileReader.readData(file)
+            ).thenReturn(fakeBatches[index])
+            val fakeMetaFile = fakeMetaFiles[index]
+            whenever(
+                mockFileOrchestrator.getMetadataFile(file)
+            ).thenReturn(fakeMetaFile)
+            if (fakeMetaFile != null) {
+                whenever(mockMetaFileReader.readData(fakeMetaFile)).thenReturn(fakeMeta[index])
+            }
+        }
+
+        // When
+        testedFlusher.flush(mockDataUploader)
+
+        // Then
+        fakeBatches.forEachIndexed { index, batch ->
+            verify(mockDataUploader).upload(fakeContext, batch, fakeMeta[index])
+        }
+    }
+
+    @Test
+    fun `M delete all the batches W flush`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeFiles = forge.aList { mock<File>() }
+        val fakeMetaFiles =
+            forge.aList(fakeFiles.size) { mock<File>().apply { whenever(exists()) doReturn true } }
+
+        val fakeBatches = forge
+            .aList(fakeFiles.size) {
+                forge
+                    .aList {
+                        forge.aString()
+                    }
+                    .map { it.toByteArray() }
+            }
+        whenever(mockFileOrchestrator.getFlushableFiles()).thenReturn(fakeFiles)
+        fakeFiles.forEachIndexed { index, file ->
+            whenever(
+                mockFileReader.readData(file)
+            ).thenReturn(fakeBatches[index])
+            whenever(
+                mockFileOrchestrator.getMetadataFile(file)
+            ).thenReturn(fakeMetaFiles[index])
+        }
+
+        // When
+        testedFlusher.flush(mockDataUploader)
+
+        // Then
+        fakeFiles.forEach {
+            verify(mockFileMover).delete(it)
+        }
+        fakeMetaFiles.forEach {
+            verify(mockFileMover).delete(it)
+        }
+    }
+
+    @Test
+    fun `M do nothing W flush { no data available }`() {
+        // Given
+        whenever(mockFileOrchestrator.getFlushableFiles()).thenReturn(emptyList())
+
+        // When
+        testedFlusher.flush(mockDataUploader)
+
+        // Then
+        verifyZeroInteractions(mockFileReader)
+        verifyZeroInteractions(mockDataUploader)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -1,0 +1,896 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal.data.upload
+
+import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.internal.net.UploadStatus
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
+import com.datadog.android.core.internal.system.SystemInfo
+import com.datadog.android.core.internal.system.SystemInfoProvider
+import com.datadog.android.core.model.NetworkInfo
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.context.DatadogContext
+import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.BatchConfirmation
+import com.datadog.android.v2.core.internal.storage.BatchId
+import com.datadog.android.v2.core.internal.storage.BatchReader
+import com.datadog.android.v2.core.internal.storage.Storage
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.same
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Ignore
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DataUploadRunnableTest {
+
+    @Mock
+    lateinit var mockThreadPoolExecutor: ScheduledThreadPoolExecutor
+
+    @Mock
+    lateinit var mockStorage: Storage
+
+    @Mock
+    lateinit var mockDataUploader: DataUploader
+
+    @Mock
+    lateinit var mockNetworkInfoProvider: NetworkInfoProvider
+
+    @Mock
+    lateinit var mockSystemInfoProvider: SystemInfoProvider
+
+    @Mock
+    lateinit var mockContextProvider: ContextProvider
+
+    @Forgery
+    lateinit var fakeContext: DatadogContext
+
+    @Forgery
+    lateinit var fakeUploadFrequency: UploadFrequency
+
+    private lateinit var testedRunnable: DataUploadRunnable
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        val fakeNetworkInfo =
+            NetworkInfo(
+                forge.aValueFrom(
+                    enumClass = NetworkInfo.Connectivity::class.java,
+                    exclude = listOf(NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED)
+                )
+            )
+        whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
+        val fakeSystemInfo = SystemInfo(
+            batteryFullOrCharging = true,
+            batteryLevel = forge.anInt(min = 20, max = 100),
+            powerSaveMode = false,
+            onExternalPowerSource = true
+        )
+        whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
+
+        whenever(mockContextProvider.context) doReturn fakeContext
+
+        testedRunnable = DataUploadRunnable(
+            mockThreadPoolExecutor,
+            mockStorage,
+            mockDataUploader,
+            mockContextProvider,
+            mockNetworkInfoProvider,
+            mockSystemInfoProvider,
+            fakeUploadFrequency
+        )
+    }
+
+    @Test
+    fun `doesn't send batch when offline`() {
+        // Given
+        val networkInfo =
+            NetworkInfo(
+                NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
+            )
+        whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn networkInfo
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verifyZeroInteractions(mockDataUploader, mockStorage)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `M send batch W run() { batteryFullOrCharging }`(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @IntForgery(min = 0, max = DataUploadRunnable.LOW_BATTERY_THRESHOLD) batteryLevel: Int,
+        forge: Forge
+    ) {
+        // Given
+        val fakeSystemInfo = SystemInfo(
+            batteryFullOrCharging = true,
+            batteryLevel = batteryLevel,
+            onExternalPowerSource = false,
+            powerSaveMode = false
+        )
+
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+
+        whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
+
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doReturn UploadStatus.SUCCESS
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verify(batchConfirmation).markAsRead(true)
+        verifyNoMoreInteractions(batchConfirmation)
+        verify(batchReader).read()
+        verify(mockDataUploader).upload(fakeContext, batchData, batchMetadata)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `M send batch W run() { battery level high }`(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @IntForgery(min = DataUploadRunnable.LOW_BATTERY_THRESHOLD + 1) batteryLevel: Int,
+        forge: Forge
+    ) {
+        // Given
+        val fakeSystemInfo = SystemInfo(
+            batteryLevel = batteryLevel,
+            batteryFullOrCharging = false,
+            onExternalPowerSource = false,
+            powerSaveMode = false
+        )
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+
+        whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
+
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doReturn UploadStatus.SUCCESS
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verify(batchConfirmation).markAsRead(true)
+        verifyNoMoreInteractions(batchConfirmation)
+        verify(batchReader).read()
+        verify(mockDataUploader).upload(fakeContext, batchData, batchMetadata)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `M send batch W run() { onExternalPower }`(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @IntForgery(min = 0, max = DataUploadRunnable.LOW_BATTERY_THRESHOLD) batteryLevel: Int,
+        forge: Forge
+    ) {
+        val fakeSystemInfo = SystemInfo(
+            onExternalPowerSource = true,
+            batteryLevel = batteryLevel,
+            batteryFullOrCharging = false,
+            powerSaveMode = false
+        )
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+
+        whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
+
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doReturn UploadStatus.SUCCESS
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verify(batchConfirmation).markAsRead(true)
+        verifyNoMoreInteractions(batchConfirmation)
+        verify(batchReader).read()
+        verify(mockDataUploader).upload(fakeContext, batchData, batchMetadata)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `M not send batch W run() { no datadog context }`(
+        @IntForgery(min = 0, max = DataUploadRunnable.LOW_BATTERY_THRESHOLD) batteryLevel: Int
+    ) {
+        // Given
+        whenever(mockContextProvider.context) doReturn null
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verifyZeroInteractions(mockStorage, mockDataUploader)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `M not send batch W run() { not enough battery }`(
+        @IntForgery(min = 0, max = DataUploadRunnable.LOW_BATTERY_THRESHOLD) batteryLevel: Int
+    ) {
+        // Given
+        val fakeSystemInfo = SystemInfo(
+            batteryLevel = batteryLevel,
+            batteryFullOrCharging = false,
+            onExternalPowerSource = false,
+            powerSaveMode = false
+        )
+        whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verifyZeroInteractions(mockStorage, mockDataUploader)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `M not send batch W run() { batteryFullOrCharging, powerSaveMode}`(
+        @IntForgery(min = 0, max = 100) batteryLevel: Int
+    ) {
+        // Given
+        val fakeSystemInfo = SystemInfo(
+            batteryFullOrCharging = true,
+            powerSaveMode = true,
+            batteryLevel = batteryLevel,
+            onExternalPowerSource = false
+        )
+        whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verifyZeroInteractions(mockStorage, mockDataUploader)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `M not send batch W run() { batteryLeveHigh, powerSaveMode}`(
+        @IntForgery(min = DataUploadRunnable.LOW_BATTERY_THRESHOLD + 1) batteryLevel: Int
+    ) {
+        // Given
+        val fakeSystemInfo = SystemInfo(
+            batteryLevel = batteryLevel,
+            powerSaveMode = true,
+            batteryFullOrCharging = false,
+            onExternalPowerSource = false
+        )
+        whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verifyZeroInteractions(mockStorage, mockDataUploader)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `M not send batch W run() { onExternalPower, powerSaveMode}`(
+        @IntForgery(min = 0, max = DataUploadRunnable.LOW_BATTERY_THRESHOLD) batteryLevel: Int
+    ) {
+        // Given
+        val fakeSystemInfo = SystemInfo(
+            onExternalPowerSource = true,
+            powerSaveMode = true,
+            batteryLevel = batteryLevel,
+            batteryFullOrCharging = false
+        )
+        whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verifyZeroInteractions(mockStorage, mockDataUploader)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 no batch to send`() {
+        // When
+        testedRunnable.run()
+
+        // Then
+        verify(mockStorage).readNextBatch(eq(fakeContext), any())
+        verifyNoMoreInteractions(mockStorage)
+        verifyZeroInteractions(mockDataUploader)
+        verify(mockThreadPoolExecutor).schedule(
+            eq(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `batch sent successfully`(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        forge: Forge
+    ) {
+        // Given
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doReturn UploadStatus.SUCCESS
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verify(batchConfirmation).markAsRead(true)
+        verifyNoMoreInteractions(batchConfirmation)
+        verify(batchReader).read()
+        verify(mockDataUploader).upload(fakeContext, batchData, batchMetadata)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        UploadStatus::class,
+        names = ["NETWORK_ERROR", "HTTP_SERVER_ERROR", "HTTP_CLIENT_RATE_LIMITING"],
+        mode = EnumSource.Mode.INCLUDE
+    )
+    fun `batch kept on error`(
+        uploadStatus: UploadStatus,
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        forge: Forge
+    ) {
+        // Given
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doReturn uploadStatus
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verify(batchConfirmation).markAsRead(false)
+        verifyNoMoreInteractions(batchConfirmation)
+        verify(batchReader).read()
+        verify(mockDataUploader).upload(fakeContext, batchData, batchMetadata)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        UploadStatus::class,
+        names = ["NETWORK_ERROR", "HTTP_SERVER_ERROR", "HTTP_CLIENT_RATE_LIMITING"],
+        mode = EnumSource.Mode.INCLUDE
+    )
+    fun `batch kept after n errors`(
+        uploadStatus: UploadStatus,
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @IntForgery(min = 3, max = 42) runCount: Int,
+        forge: Forge
+    ) {
+        // Given
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doReturn uploadStatus
+
+        // WHen
+        for (i in 0 until runCount) {
+            testedRunnable.run()
+        }
+
+        // Then
+        verify(batchConfirmation, times(runCount)).markAsRead(false)
+        verifyNoMoreInteractions(batchConfirmation)
+        verify(batchReader, times(runCount)).read()
+        verify(mockDataUploader, times(runCount)).upload(fakeContext, batchData, batchMetadata)
+        verify(mockThreadPoolExecutor, times(runCount)).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        UploadStatus::class,
+        names = ["INVALID_TOKEN_ERROR", "HTTP_REDIRECTION", "HTTP_CLIENT_ERROR", "UNKNOWN_ERROR"],
+        mode = EnumSource.Mode.INCLUDE
+    )
+    fun `batch dropped on error`(
+        uploadStatus: UploadStatus,
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        forge: Forge
+    ) {
+        // Given
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doReturn uploadStatus
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verify(batchConfirmation).markAsRead(true)
+        verifyNoMoreInteractions(batchConfirmation)
+        verify(batchReader).read()
+        verify(mockDataUploader).upload(fakeContext, batchData, batchMetadata)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `when has batches the upload frequency will increase`(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        forge: Forge
+    ) {
+        // Given
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doReturn UploadStatus.SUCCESS
+
+        // When
+        repeat(5) {
+            testedRunnable.run()
+        }
+
+        // Then
+        val captor = argumentCaptor<Long>()
+        verify(mockThreadPoolExecutor, times(5))
+            .schedule(same(testedRunnable), captor.capture(), eq(TimeUnit.MILLISECONDS))
+        captor.allValues.reduce { previous, next ->
+            assertThat(next).isLessThan(previous)
+            next
+        }
+    }
+
+    @Test
+    fun `𝕄 reduce delay between runs 𝕎 upload is successful`(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @IntForgery(16, 64) runCount: Int,
+        forge: Forge
+    ) {
+        // Given
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doReturn UploadStatus.SUCCESS
+
+        // When
+        repeat(runCount) {
+            testedRunnable.run()
+        }
+
+        // Then
+        argumentCaptor<Long> {
+            verify(mockThreadPoolExecutor, times(runCount))
+                .schedule(
+                    same(testedRunnable),
+                    capture(),
+                    eq(TimeUnit.MILLISECONDS)
+                )
+
+            allValues.reduce { previous, next ->
+                assertThat(next)
+                    .isLessThanOrEqualTo(previous)
+                    .isBetween(testedRunnable.minDelayMs, testedRunnable.maxDelayMs)
+                next
+            }
+        }
+    }
+
+    @ParameterizedTest
+    @EnumSource(
+        UploadStatus::class,
+        names = ["HTTP_REDIRECTION", "HTTP_CLIENT_ERROR", "UNKNOWN_ERROR", "INVALID_TOKEN_ERROR"],
+        mode = EnumSource.Mode.INCLUDE
+    )
+    fun `𝕄 reduce delay between runs 𝕎 batch fails and should be dropped`(
+        uploadStatus: UploadStatus,
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @IntForgery(16, 64) runCount: Int,
+        forge: Forge
+    ) {
+        // Given
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doReturn uploadStatus
+
+        // When
+        repeat(runCount) {
+            testedRunnable.run()
+        }
+
+        // Then
+        argumentCaptor<Long> {
+            verify(mockThreadPoolExecutor, times(runCount))
+                .schedule(
+                    same(testedRunnable),
+                    capture(),
+                    eq(TimeUnit.MILLISECONDS)
+                )
+
+            allValues.reduce { previous, next ->
+                assertThat(next)
+                    .isLessThanOrEqualTo(previous)
+                    .isBetween(testedRunnable.minDelayMs, testedRunnable.maxDelayMs)
+                next
+            }
+        }
+    }
+
+    @Ignore("Not supported functionality")
+    @Test
+    fun `𝕄 increase delay between runs 𝕎 no batch available`(
+        @IntForgery(16, 64) runCount: Int
+    ) {
+        // When
+        repeat(runCount) {
+            testedRunnable.run()
+        }
+
+        // Then
+        argumentCaptor<Long> {
+            verify(mockThreadPoolExecutor, times(runCount))
+                .schedule(
+                    same(testedRunnable),
+                    capture(),
+                    eq(TimeUnit.MILLISECONDS)
+                )
+
+            allValues.reduce { previous, next ->
+                assertThat(next)
+                    .isGreaterThanOrEqualTo(previous)
+                    .isBetween(testedRunnable.minDelayMs, testedRunnable.maxDelayMs)
+                next
+            }
+        }
+    }
+
+    @Test
+    fun `𝕄 increase delay between runs 𝕎 batch fails and should be retried`(
+        @IntForgery(16, 64) runCount: Int,
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        forge: Forge
+    ) {
+        // Given
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            }
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        }
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doAnswer {
+            forge.aValueFrom(
+                UploadStatus::class.java,
+                exclude = listOf(
+                    UploadStatus.HTTP_REDIRECTION,
+                    UploadStatus.HTTP_CLIENT_ERROR,
+                    UploadStatus.UNKNOWN_ERROR,
+                    UploadStatus.INVALID_TOKEN_ERROR,
+                    UploadStatus.SUCCESS
+                )
+            )
+        }
+
+        // When
+        repeat(runCount) {
+            testedRunnable.run()
+        }
+
+        // Then
+        argumentCaptor<Long> {
+            verify(mockThreadPoolExecutor, times(runCount))
+                .schedule(
+                    same(testedRunnable),
+                    capture(),
+                    eq(TimeUnit.MILLISECONDS)
+                )
+
+            allValues.reduce { previous, next ->
+                assertThat(next)
+                    .isGreaterThanOrEqualTo(previous)
+                    .isBetween(testedRunnable.minDelayMs, testedRunnable.maxDelayMs)
+                next
+            }
+        }
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadSchedulerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadSchedulerTest.kt
@@ -1,0 +1,86 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal.data.upload
+
+import com.datadog.android.core.configuration.UploadFrequency
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class DataUploadSchedulerTest {
+
+    lateinit var testedScheduler: DataUploadScheduler
+
+    @Mock
+    lateinit var mockExecutor: ScheduledThreadPoolExecutor
+
+    @Forgery
+    lateinit var fakeUploadFrequency: UploadFrequency
+
+    @BeforeEach
+    fun `set up`() {
+        testedScheduler = DataUploadScheduler(
+            mock(),
+            mock(),
+            mock(),
+            mock(),
+            mock(),
+            fakeUploadFrequency,
+            mockExecutor
+        )
+    }
+
+    @Test
+    fun `when start it will schedule a runnable`() {
+        // When
+        testedScheduler.startScheduling()
+
+        // Then
+        verify(mockExecutor).schedule(
+            any(),
+            eq(fakeUploadFrequency.baseStepMs * DataUploadRunnable.DEFAULT_DELAY_FACTOR),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `when stop it will try to remove the scheduled runnable`() {
+        // Given
+        testedScheduler.startScheduling()
+
+        // When
+        testedScheduler.stopScheduling()
+
+        // Then
+        val argumentCaptor = argumentCaptor<Runnable>()
+        verify(mockExecutor).schedule(
+            argumentCaptor.capture(),
+            eq(fakeUploadFrequency.baseStepMs * DataUploadRunnable.DEFAULT_DELAY_FACTOR),
+            eq(TimeUnit.MILLISECONDS)
+        )
+        verify(mockExecutor).remove(argumentCaptor.firstValue)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploaderTest.kt
@@ -1,0 +1,541 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal.net
+
+import com.datadog.android.core.internal.net.UploadStatus
+import com.datadog.android.core.internal.system.AndroidInfoProvider
+import com.datadog.android.log.Logger
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.Request as DatadogRequest
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.api.context.DatadogContext
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.doThrow
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.AdvancedForgery
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.MapForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.io.IOException
+import java.util.Locale
+import okhttp3.Call
+import okhttp3.Headers
+import okhttp3.HttpUrl
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody
+import okhttp3.Response
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DataOkHttpUploaderTest {
+
+    private lateinit var testedUploader: DataOkHttpUploader
+
+    @Mock
+    lateinit var mockRequestFactory: RequestFactory
+
+    @Mock
+    lateinit var mockLogger: Logger
+
+    @Mock
+    lateinit var mockCallFactory: Call.Factory
+
+    @Mock
+    lateinit var mockCall: Call
+
+    @Mock
+    lateinit var mockAndroidInfoProvider: AndroidInfoProvider
+
+    @StringForgery
+    lateinit var fakeSdkVersion: String
+
+    @StringForgery
+    lateinit var fakeDeviceModel: String
+
+    @StringForgery
+    lateinit var fakeDeviceBuildId: String
+
+    @StringForgery
+    lateinit var fakeDeviceVersion: String
+
+    @Forgery
+    lateinit var fakeContext: DatadogContext
+
+    @StringForgery(regex = "https://[a-z]+\\.com/api")
+    lateinit var fakeEndpoint: String
+
+    @StringForgery
+    lateinit var fakeRequestId: String
+
+    @MapForgery(
+        key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+        value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
+    )
+    lateinit var fakeHeaders: Map<String, String>
+
+    @MapForgery(
+        key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+        value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
+    )
+    lateinit var fakeQueryParams: Map<String, String>
+
+    @StringForgery
+    lateinit var fakeRequestContext: String
+
+    @StringForgery
+    lateinit var fakeRequestBody: String
+
+    lateinit var fakeResponse: Response
+
+    lateinit var fakeDatadogRequest: DatadogRequest
+
+    private lateinit var fakeUserAgent: String
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        whenever(mockCallFactory.newCall(any())) doReturn mockCall
+
+        whenever(mockAndroidInfoProvider.getDeviceVersion()) doReturn fakeDeviceVersion
+        whenever(mockAndroidInfoProvider.getDeviceModel()) doReturn fakeDeviceModel
+        whenever(mockAndroidInfoProvider.getDeviceBuildId()) doReturn fakeDeviceBuildId
+
+        val fakeContentType = forge.anElementFrom(
+            "multipart/form-data",
+            "application/json",
+            "application/x-www-form-urlencoded"
+        )
+        val url = if (forge.aBool()) {
+            fakeEndpoint
+        } else {
+            fakeEndpoint.plus("?" + fakeQueryParams.map { "${it.key}=${it.value}" })
+        }
+        fakeDatadogRequest = DatadogRequest(
+            id = fakeRequestId,
+            context = fakeRequestContext,
+            headers = fakeHeaders,
+            url = url,
+            body = fakeRequestBody.toByteArray(),
+            contentType = forge.aNullable { fakeContentType }
+        )
+        whenever(mockRequestFactory.create(eq(fakeContext), any(), any())) doReturn
+            fakeDatadogRequest
+
+        fakeUserAgent = if (forge.aBool()) forge.anAlphaNumericalString() else ""
+        System.setProperty("http.agent", fakeUserAgent)
+
+        testedUploader = DataOkHttpUploader(
+            mockRequestFactory,
+            mockLogger,
+            mockCallFactory,
+            fakeSdkVersion,
+            mockAndroidInfoProvider
+        )
+    }
+
+    // region Expected status codes
+
+    @Test
+    fun `𝕄 return success 𝕎 upload() {202 accepted status} `(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(202, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.SUCCESS)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return client error 𝕎 upload() {400 bad request status} `(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(400, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.HTTP_CLIENT_ERROR)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return client token error 𝕎 upload() {401 unauthorized status} `(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(401, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.INVALID_TOKEN_ERROR)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return client error 𝕎 upload() {403 forbidden status} `(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(403, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.INVALID_TOKEN_ERROR)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return client error with retry 𝕎 upload() {408 timeout status} `(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(408, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.HTTP_CLIENT_RATE_LIMITING)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return client error 𝕎 upload() {413 too large status} `(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(413, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.HTTP_CLIENT_ERROR)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return client error with retry 𝕎 upload() {429 too many requests status} `(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(429, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.HTTP_CLIENT_RATE_LIMITING)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return server error 𝕎 upload() {500 internal error status} `(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(500, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.HTTP_SERVER_ERROR)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return server error 𝕎 upload() {503 unavailable status} `(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(503, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.HTTP_SERVER_ERROR)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    // endregion
+
+    // region Unknown cases
+
+    @RepeatedTest(32)
+    fun `𝕄 return unknown error 𝕎 upload() {xxx status} `(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        forge: Forge,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+
+        var statusCode: Int
+        do {
+            statusCode = forge.anInt(200, 600)
+        } while (statusCode in arrayOf(202, 400, 401, 403, 408, 413, 429, 500, 503))
+        whenever(mockCall.execute()) doReturn mockResponse(statusCode, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.UNKNOWN_ERROR)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return error 𝕎 upload() {IOException}`(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doThrow IOException(message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.NETWORK_ERROR)
+        verifyRequest(fakeDatadogRequest)
+    }
+
+    @Test
+    fun `𝕄 return error 𝕎 upload() {any Throwable}`(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doThrow throwable
+
+        // When
+        val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(result).isEqualTo(UploadStatus.NETWORK_ERROR)
+        verifyRequest(fakeDatadogRequest)
+    }
+
+    // endregion
+
+    @Test
+    fun `𝕄 log warning 𝕎 upload() { feature request has user-agent header }`(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String,
+        @StringForgery userAgentValue: String,
+        forge: Forge
+    ) {
+        // Given
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(202, message)
+
+        fakeDatadogRequest = fakeDatadogRequest.copy(
+            headers = fakeDatadogRequest.headers.toMutableMap().apply {
+                put(forge.anElementFrom("User-Agent", "user-agent", "UsEr-AgEnT"), userAgentValue)
+            }
+        )
+
+        whenever(mockRequestFactory.create(fakeContext, batchData, batchMetadata)) doReturn
+            fakeDatadogRequest
+
+        // When
+        testedUploader.upload(fakeContext, batchData, batchMetadata)
+
+        // Then
+        verify(mockLogger).w(
+            DataOkHttpUploader.WARNING_USER_AGENT_HEADER_RESERVED
+        )
+    }
+
+    // region Internal
+
+    private fun mockResponse(statusCode: Int, message: String): Response {
+        fakeResponse = Response.Builder()
+            .request(Request.Builder().url(fakeEndpoint).get().build())
+            .code(statusCode)
+            .message(message)
+            .protocol(Protocol.HTTP_2)
+            .body(mock())
+            .build()
+        return fakeResponse
+    }
+
+    private fun verifyRequest(expectedRequest: DatadogRequest) {
+        argumentCaptor<Request> {
+            verify(mockCallFactory).newCall(capture())
+
+            verifyRequestUrl(firstValue.url(), HttpUrl.get(expectedRequest.url))
+            verifyRequestHeaders(
+                firstValue.headers(),
+                expectedRequest.headers
+            )
+            verifyRequestBody(firstValue.body(), expectedRequest.body, expectedRequest.contentType)
+        }
+    }
+
+    private fun verifyRequestUrl(url: HttpUrl, expectedUrl: HttpUrl) {
+        assertThat(url.scheme()).isEqualTo(expectedUrl.scheme())
+        assertThat(url.host()).isEqualTo(expectedUrl.host())
+        assertThat(url.encodedPath()).isEqualTo(expectedUrl.encodedPath())
+
+        val expectedQueryParams = expectedUrl.queryParameterNames()
+
+        assertThat(url.queryParameterNames().size).isEqualTo(expectedQueryParams.size)
+
+        if (expectedQueryParams.isEmpty()) {
+            assertThat(url.query()).isNullOrEmpty()
+        } else {
+            expectedQueryParams.forEach {
+                val actualValue = url.queryParameter(it)
+                val expectedValue = expectedUrl.queryParameter(it)
+                assertThat(actualValue)
+                    .overridingErrorMessage(
+                        "Expected query parameter $it to be equal to [$expectedValue] " +
+                            "but was [$actualValue]"
+                    )
+                    .isEqualTo(expectedValue)
+            }
+        }
+    }
+
+    private fun verifyRequestBody(
+        body: RequestBody?,
+        expectedBody: ByteArray,
+        contentType: String?
+    ) {
+        checkNotNull(body)
+        if (contentType == null) {
+            assertThat(body.contentType()).isNull()
+        } else {
+            assertThat(body.contentType().toString()).isEqualTo(contentType)
+        }
+        assertThat(body.contentLength()).isEqualTo(expectedBody.size.toLong())
+    }
+
+    private fun verifyRequestHeaders(
+        headers: Headers,
+        expectedHeaders: Map<String, String>
+    ) {
+        val actualHeaders = headers.toMultimap()
+
+        assertThat(actualHeaders.values).allMatch { it.size == 1 }
+
+        assertThat(
+            actualHeaders
+                .mapValues { it.value.first() }
+                .filter { !"User-Agent".equals(it.key, ignoreCase = true) }
+        )
+            .isEqualTo(expectedHeaders.mapKeys { it.key.lowercase(Locale.US) })
+
+        val expectedUserAgent = if (fakeUserAgent.isBlank()) {
+            "Datadog/$fakeSdkVersion " +
+                "(Linux; U; Android $fakeDeviceVersion; " +
+                "$fakeDeviceModel Build/$fakeDeviceBuildId)"
+        } else {
+            fakeUserAgent
+        }
+        assertThat(headers.get("User-Agent")).isEqualTo(expectedUserAgent)
+    }
+
+    private fun verifyResponseIsClosed() {
+        verify(fakeResponse.body())!!.close()
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

This change brings the foundation of the upload pipeline for SDK v2 which is using a single `Storage` concept introduced before (meaning pipeline also leverages batch metadata).

In the nutshell upload job will read the batch available for the upload via `Storage#readNextBatch` call and will pass the batch and its metadata (if exists) to the uploader, which knows a) how to create a request (responsibility of the feature); b) how to execute it (responsibility of the SDK).

Most of the changes are done in the `UploadWorker`, `DataOkHttpUploader`, `DataUploadRunnable` classes (the last 2 are the copies of the v1 classes residing in the v2 package, this is done in order to avoid big changes in the `SdkFeature`, which will be done later).

Note, that this change doesn't yet support `1:many` relationship between batch and requests created, this will be done in another task(s).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

