### PR TITLE
Custom battery intent handler

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -78,6 +78,7 @@ data class com.datadog.android.core.configuration.Configuration
     constructor(Boolean, Boolean, Boolean, Boolean)
     fun build(): Configuration
     fun setUseDeveloperModeWhenDebuggable(Boolean): Builder
+    fun setBatteryIntentHandler(com.datadog.android.plugin.BatteryIntentHandler)
     fun setFirstPartyHosts(List<String>): Builder
     fun setWebViewTrackingHosts(List<String>): Builder
     fun useSite(com.datadog.android.DatadogSite): Builder
@@ -287,6 +288,10 @@ data class com.datadog.android.log.model.LogEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Status
+data class com.datadog.android.plugin.BatteryIntentResults
+  constructor(Boolean, Int, Boolean)
+interface com.datadog.android.plugin.BatteryIntentHandler
+  fun handleBatteryIntent(android.content.Intent): BatteryIntentResults
 data class com.datadog.android.plugin.DatadogContext
   constructor(DatadogRumContext? = null)
 interface com.datadog.android.plugin.DatadogPlugin : com.datadog.android.privacy.TrackingConsentProviderCallback

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -21,6 +21,7 @@ import com.datadog.android.event.NoOpSpanEventMapper
 import com.datadog.android.event.SpanEventMapper
 import com.datadog.android.event.ViewEventMapper
 import com.datadog.android.log.model.LogEvent
+import com.datadog.android.plugin.BatteryIntentHandler
 import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.plugin.Feature as PluginFeature
 import com.datadog.android.rum.RumMonitor
@@ -70,7 +71,8 @@ internal constructor(
         val proxy: Proxy?,
         val proxyAuth: Authenticator,
         val securityConfig: SecurityConfig,
-        val webViewTrackingHosts: List<String>
+        val webViewTrackingHosts: List<String>,
+        val batteryIntentHandler: BatteryIntentHandler? = null
     )
 
     internal sealed class Feature {
@@ -162,6 +164,16 @@ internal constructor(
         fun setUseDeveloperModeWhenDebuggable(developerModeEnabled: Boolean): Builder {
             coreConfig = coreConfig.copy(enableDeveloperModeWhenDebuggable = developerModeEnabled)
             return this
+        }
+
+        /**
+         * Sets the battery intent handler for interrogating battery state.
+         * Modifications of this intent processing could have negative effects on the users battery life and it is highly recommended to
+         * not provide your own BatteryIntentHandler unless there are very specific needs to override the default functionality.
+         * @param batteryIntentHandler processes battery state which is used to determine if logs are synced
+         */
+        fun setBatteryIntentHandler(batteryIntentHandler: BatteryIntentHandler){
+            coreConfig = coreConfig.copy(batteryIntentHandler = batteryIntentHandler)
         }
 
         /**
@@ -721,7 +733,8 @@ internal constructor(
             proxy = null,
             proxyAuth = Authenticator.NONE,
             securityConfig = SecurityConfig.DEFAULT,
-            webViewTrackingHosts = emptyList()
+            webViewTrackingHosts = emptyList(),
+            batteryIntentHandler = null
         )
         internal val DEFAULT_LOGS_CONFIG = Feature.Logs(
             endpointUrl = DatadogEndpoint.LOGS_US1,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -184,7 +184,7 @@ internal object CoreFeature {
         // having corrupted data (data from previous process over - written in this process into the
         // ndk crash folder before the crash was actually handled)
         prepareNdkCrashData(appContext)
-        setupInfoProviders(appContext, consent)
+        setupInfoProviders(appContext, consent, configuration)
         initialized.set(true)
     }
 
@@ -318,13 +318,17 @@ internal object CoreFeature {
 
     private fun setupInfoProviders(
         appContext: Context,
-        consent: TrackingConsent
+        consent: TrackingConsent,
+        configuration: Configuration.Core
     ) {
         // Tracking Consent Provider
         trackingConsentProvider = TrackingConsentProvider(consent)
 
         // System Info Provider
-        systemInfoProvider = BroadcastReceiverSystemInfoProvider()
+        systemInfoProvider = configuration.batteryIntentHandler?.let{ batteryIntentHandler ->
+            BroadcastReceiverSystemInfoProvider(batteryIntentHandler = batteryIntentHandler)
+        }?: BroadcastReceiverSystemInfoProvider()
+
         systemInfoProvider.register(appContext)
 
         // Network Info Provider

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/DefaultBatteryIntentHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/DefaultBatteryIntentHandler.kt
@@ -1,0 +1,45 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.system
+
+import android.content.Intent
+import android.os.BatteryManager
+import com.datadog.android.plugin.BatteryIntentHandler
+import com.datadog.android.plugin.BatteryIntentResults
+
+internal class DefaultBatteryIntentHandler: BatteryIntentHandler {
+    override fun handleBatteryIntent(intent: Intent): BatteryIntentResults {
+        val status = intent.getIntExtra(
+            BatteryManager.EXTRA_STATUS,
+            BatteryManager.BATTERY_STATUS_UNKNOWN
+        )
+        val level = intent.getIntExtra(BatteryManager.EXTRA_LEVEL, -1)
+        val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, 100)
+        val pluggedStatus = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, -1)
+        val batteryStatus = SystemInfo.BatteryStatus.fromAndroidStatus(status)
+        val batteryLevel = (level * 100) / scale
+        val onExternalPowerSource = pluggedStatus in PLUGGED_IN_STATUS_VALUES
+        val batteryFullOrCharging = batteryStatus in batteryFullOrChargingStatus
+
+
+        return BatteryIntentResults(batteryFullOrCharging, batteryLevel, onExternalPowerSource)
+    }
+
+    companion object {
+
+        private val batteryFullOrChargingStatus = setOf(
+            SystemInfo.BatteryStatus.CHARGING,
+            SystemInfo.BatteryStatus.FULL
+        )
+
+        private val PLUGGED_IN_STATUS_VALUES = setOf(
+            BatteryManager.BATTERY_PLUGGED_AC,
+            BatteryManager.BATTERY_PLUGGED_WIRELESS,
+            BatteryManager.BATTERY_PLUGGED_USB
+        )
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/BatteryIntentHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/BatteryIntentHandler.kt
@@ -1,0 +1,40 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.plugin
+
+import android.content.Intent
+
+/**
+ * Results based on values found in the battery intent.
+ */
+data class BatteryIntentResults(
+    /**
+     * Indicator of battery charge state.
+     */
+    val batteryFullOrCharging:Boolean,
+    /**
+     * Battery charge level.
+     */
+    val batteryLevel: Int,
+    /**
+     * Indicator of external power applied.
+     */
+    val onExternalPowerSource: Boolean
+    )
+
+/**
+ * The purpose behind the BatteryIntentHandler is to have the ability to modify how the system Battery intent is processed.
+ * Modifications of this intent processing could have negative effects on the users battery life and it is highly recommended to
+ * not provide your own BatteryIntentHandler unless there are very specific needs to override the default functionality.
+ */
+interface BatteryIntentHandler {
+    /**
+     * Process the system battery intent returning results based on intent values.
+     * @param intent - System battery intent
+     */
+    fun handleBatteryIntent(intent: Intent): BatteryIntentResults
+}


### PR DESCRIPTION
If a custom build of AOSP does not support or report the battery state for the device through the BatteryIntent broadcast logging is delayed or skipped.  When this scenario happens there is no work around.

For example when a battery status is dumped from the ADB shell that reports something similar to the following:

dumpsys battery >>>
Current Battery Service state:
  AC powered: false
  USB powered: false
  Wireless powered: false
  Max charging current: 0
  Max charging voltage: 0
  Charge counter: 0
  status: 1
  health: 1
  present: false
  level: 0
  scale: 100
  voltage: 0
  temperature: 0
  technology:

This will prevent the SDK from syncing the logs back to the server.  The only work around is to update the AOSP build which in some instances cannot be done in a timely manner.

To support custom builds that may not report battery stats there needs to be a way to provide a custom handler in BroadcastReceiverSystemInfoProvider for the BatteryIntent instead of only allowing the internal logic.  

To facilitate user logic I propose the following:

1. Create an interface BatteryIntentHandler with a method for processing and returning the results of the BatteryIntent.
2. Represent the results as BatterIntentHandlerResults that has values for full or charging (bool), charge level (int), and external power applied(bool).
3. Move the existing logic into a class called DefaultBatteryIntentHandler
4. Modify the BroadcastReceiverSystemInfoProvider constructor to accept the BatteryIntentHandler with a default value set to the DefaultBatteryIntentHandler.
5. In Configuration.Builder add new setter to pass in the BatteryIntentHandler: setBatteryIntentHandler(handler: BatteryIntentHandler)
6. In CoreFeature.setupInfoProviders use the BatteryIntentHandler if specified in the Configuration.Builder otherwise use the default constructor for BroadcastReceiverSystemInfoProvider.

The system can then be initialized like this:

``` 
var configuration = Configuration.Builder(
            logsEnabled = true,
            tracesEnabled = true,
            crashReportsEnabled = true,
            rumEnabled = true
        )
        if (NeedsCustomLogic) {
            configuration.setBatteryIntentHandler(object : BatteryIntentHandler {
                override fun handleBatteryIntent(intent: Intent): BatteryIntentResults {
                    return BatteryIntentResults(true, 100, true)
                }
            })
        }
        Datadog.initialize(
            context = this,
            credentials = Credentials(
                clientToken = "DD_CLIENT_TOKEN",
                envName = "environment",
                variant = "variant",
                rumApplicationId = "123",
                serviceName = "sample"
            ),
            configuration = configuration.build(),
            trackingConsent = TrackingConsent.GRANTED
        )
```



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

