### PR TITLE
Remove internal monitoring token references

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/FlavorBuildConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/FlavorBuildConfig.kt
@@ -62,11 +62,6 @@ fun configureFlavorForSampleApp(flavor: ApplicationProductFlavor, rootDir: File)
         "\"${config.applicationKey}\""
     )
     flavor.buildConfigField(
-        "String",
-        "DD_INTERNAL_MONITORING_CLIENT_TOKEN",
-        "\"${config.internalMonitoringToken}\""
-    )
-    flavor.buildConfigField(
             "String",
             "DD_SITE_NAME",
             "\"${flavor.name.toUpperCase(Locale.US)}\""

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/SampleAppConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/SampleAppConfig.kt
@@ -13,6 +13,5 @@ data class SampleAppConfig(
     val token: String = "",
     val rumApplicationId: String = "",
     val apiKey: String = "",
-    val applicationKey: String = "",
-    val internalMonitoringToken: String = ""
+    val applicationKey: String = ""
 )

--- a/sample/README.md
+++ b/sample/README.md
@@ -38,13 +38,3 @@ If you need to target a site that is not part of the `DatadogSite` enum, configu
     "rumEndpoint": "http://api.example.com/rum"
 }
 ```
-
-### Internal Monitoring
-
-If you want to enable the internal monitoring, you need to add the relevant `clientToken` in the following attribute: 
-
-```json
-{
-    "internalMonitoringToken": "INTERNAL TOKEN"
-}
-```


### PR DESCRIPTION
### What does this PR do?

This change removes the references to the internal monitoring token, which is not used anymore since we introduced the SDK telemetry.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

