### PR TITLE
RUMM-1876: Support calls with implicit receiver in UnsafeThirdPartyFunctionCall check

### DIFF
--- a/dd-sdk-android-ktx/src/main/kotlin/com/datadog/android/ktx/sqlite/SqliteDatabaseExt.kt
+++ b/dd-sdk-android-ktx/src/main/kotlin/com/datadog/android/ktx/sqlite/SqliteDatabaseExt.kt
@@ -28,16 +28,20 @@ inline fun <T> SQLiteDatabase.transactionTraced(
     val parentSpan = GlobalTracer.get().activeSpan()
     withinSpan(operationName, parentSpan, true) {
         if (exclusive) {
+            @Suppress("UnsafeThirdPartyFunctionCall") // we are in a valid state
             beginTransaction()
         } else {
+            @Suppress("UnsafeThirdPartyFunctionCall") // we are in a valid state
             beginTransactionNonExclusive()
         }
         try {
             @Suppress("UnsafeThirdPartyFunctionCall") // handled by caller
             val result = this.body(this@transactionTraced)
+            @Suppress("UnsafeThirdPartyFunctionCall") // we are in a valid state
             setTransactionSuccessful()
             return result
         } finally {
+            @Suppress("UnsafeThirdPartyFunctionCall") // we are in a valid state
             endTransaction()
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -285,7 +285,16 @@ internal object CoreFeature {
             cacheExpirationMs = TimeUnit.MINUTES.toMillis(30),
             minWaitTimeBetweenSyncMs = TimeUnit.MINUTES.toMillis(5),
             syncListener = LoggingSyncListener()
-        ).apply { if (!disableKronosBackgroundSync) { syncInBackground() } }
+        ).apply {
+            if (!disableKronosBackgroundSync) {
+                try {
+                    syncInBackground()
+                } catch (ise: IllegalStateException) {
+                    // should never happen
+                    sdkLogger.e("Cannot launch time sync", ise)
+                }
+            }
+        }
     }
 
     private fun readApplicationInformation(appContext: Context, credentials: Credentials) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileExt.kt
@@ -44,52 +44,52 @@ private fun <T> File.safeCall(
 }
 
 internal fun File.canWriteSafe(): Boolean {
-    return safeCall(default = false) { canWrite() }
+    return safeCall(default = false) { @Suppress("UnsafeThirdPartyFunctionCall") canWrite() }
 }
 
 internal fun File.canReadSafe(): Boolean {
-    return safeCall(default = false) { canRead() }
+    return safeCall(default = false) { @Suppress("UnsafeThirdPartyFunctionCall") canRead() }
 }
 
 internal fun File.deleteSafe(): Boolean {
-    return safeCall(default = false) { delete() }
+    return safeCall(default = false) { @Suppress("UnsafeThirdPartyFunctionCall") delete() }
 }
 
 internal fun File.existsSafe(): Boolean {
-    return safeCall(default = false) { exists() }
+    return safeCall(default = false) { @Suppress("UnsafeThirdPartyFunctionCall") exists() }
 }
 
 internal fun File.isFileSafe(): Boolean {
-    return safeCall(default = false) { isFile() }
+    return safeCall(default = false) { @Suppress("UnsafeThirdPartyFunctionCall") isFile() }
 }
 
 internal fun File.isDirectorySafe(): Boolean {
-    return safeCall(default = false) { isDirectory() }
+    return safeCall(default = false) { @Suppress("UnsafeThirdPartyFunctionCall") isDirectory() }
 }
 
 internal fun File.listFilesSafe(): Array<File>? {
-    return safeCall(default = null) { listFiles() }
+    return safeCall(default = null) { @Suppress("UnsafeThirdPartyFunctionCall") listFiles() }
 }
 
 internal fun File.listFilesSafe(filter: FileFilter): Array<File>? {
-    return safeCall(default = null) { listFiles(filter) }
+    return safeCall(default = null) { @Suppress("UnsafeThirdPartyFunctionCall") listFiles(filter) }
 }
 
 internal fun File.lengthSafe(): Long {
-    return safeCall(default = 0L) { length() }
+    return safeCall(default = 0L) { @Suppress("UnsafeThirdPartyFunctionCall") length() }
 }
 
 internal fun File.mkdirsSafe(): Boolean {
-    return safeCall(default = false) { mkdirs() }
+    return safeCall(default = false) { @Suppress("UnsafeThirdPartyFunctionCall") mkdirs() }
 }
 
 internal fun File.renameToSafe(dest: File): Boolean {
-    return safeCall(default = false) { renameTo(dest) }
+    return safeCall(default = false) { @Suppress("UnsafeThirdPartyFunctionCall") renameTo(dest) }
 }
 
 internal fun File.readTextSafe(charset: Charset = Charsets.UTF_8): String? {
     return if (existsSafe() && canReadSafe()) {
-        safeCall(default = null) { readText(charset) }
+        safeCall(default = null) { @Suppress("UnsafeThirdPartyFunctionCall") readText(charset) }
     } else {
         null
     }
@@ -97,7 +97,7 @@ internal fun File.readTextSafe(charset: Charset = Charsets.UTF_8): String? {
 
 internal fun File.readBytesSafe(): ByteArray? {
     return if (existsSafe() && canReadSafe()) {
-        safeCall(default = null) { readBytes() }
+        safeCall(default = null) { @Suppress("UnsafeThirdPartyFunctionCall") readBytes() }
     } else {
         null
     }
@@ -105,7 +105,7 @@ internal fun File.readBytesSafe(): ByteArray? {
 
 internal fun File.readLinesSafe(charset: Charset = Charsets.UTF_8): List<String>? {
     return if (existsSafe() && canReadSafe()) {
-        safeCall(default = null) { readLines(charset) }
+        safeCall(default = null) { @Suppress("UnsafeThirdPartyFunctionCall") readLines(charset) }
     } else {
         null
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ByteArrayExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/ByteArrayExt.kt
@@ -72,7 +72,10 @@ internal fun Collection<ByteArray>.join(
  * @return An index of the first occurrence of [b] or `-1` if none is found.
  */
 internal fun ByteArray.indexOf(b: Byte, startIndex: Int = 0): Int {
+    if (startIndex < 0) return -1
+
     for (i in startIndex until size) {
+        @Suppress("UnsafeThirdPartyFunctionCall") // iteration over indexes which exist
         if (get(i) == b) {
             return i
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
@@ -109,6 +109,7 @@ internal fun Map<*, *>.toJsonObject(): JsonElement {
 internal fun JSONObject.toJsonObject(): JsonElement {
     val obj = JsonObject()
     for (key in keys()) {
+        @Suppress("UnsafeThirdPartyFunctionCall") // iteration over keys which exist
         obj.add(key, get(key).toJsonElement())
     }
     return obj
@@ -117,6 +118,7 @@ internal fun JSONObject.toJsonObject(): JsonElement {
 internal fun JSONArray.toJsonArray(): JsonElement {
     val obj = JsonArray()
     for (index in 0 until length()) {
+        @Suppress("UnsafeThirdPartyFunctionCall") // iteration over indexes which exist
         obj.add(get(index).toJsonElement())
     }
     return obj

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/debug/UiRumDebugListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/debug/UiRumDebugListener.kt
@@ -76,6 +76,7 @@ internal class UiRumDebugListener :
             orientation = LinearLayout.VERTICAL
         }
 
+        @Suppress("UnsafeThirdPartyFunctionCall") // view added is not null
         contentView.addView(
             rumViewsContainer,
             FrameLayout.LayoutParams(
@@ -139,9 +140,11 @@ internal class UiRumDebugListener :
         rumViewsContainer?.run {
             removeAllViews()
             if (viewNames.isEmpty()) {
+                @Suppress("UnsafeThirdPartyFunctionCall") // view added is not null
                 addView(createDebugTextView(context, "No active RUM View", DEFAULT_ALPHA))
             } else {
                 for (viewName in viewNames.reversed().withIndex()) {
+                    @Suppress("UnsafeThirdPartyFunctionCall") // view added is not null
                     addView(
                         createDebugTextView(
                             context,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/resource/RumResourceInputStream.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/resource/RumResourceInputStream.kt
@@ -50,6 +50,7 @@ class RumResourceInputStream(
     override fun read(): Int {
         if (firstByte == 0L) firstByte = System.nanoTime()
         return callWithErrorTracking(ERROR_READ) {
+            @Suppress("UnsafeThirdPartyFunctionCall") // caller should handle the exception
             read().also {
                 if (it >= 0) size++
                 lastByte = System.nanoTime()
@@ -61,6 +62,7 @@ class RumResourceInputStream(
     override fun read(b: ByteArray): Int {
         if (firstByte == 0L) firstByte = System.nanoTime()
         return callWithErrorTracking(ERROR_READ) {
+            @Suppress("UnsafeThirdPartyFunctionCall") // caller should handle the exception
             read(b).also {
                 if (it >= 0) size += it
                 lastByte = System.nanoTime()
@@ -72,6 +74,7 @@ class RumResourceInputStream(
     override fun read(b: ByteArray, off: Int, len: Int): Int {
         if (firstByte == 0L) firstByte = System.nanoTime()
         return callWithErrorTracking(ERROR_READ) {
+            @Suppress("UnsafeThirdPartyFunctionCall") // caller should handle the exception
             read(b, off, len).also {
                 if (it >= 0) size += it
                 lastByte = System.nanoTime()
@@ -82,12 +85,14 @@ class RumResourceInputStream(
     /** @inheritdoc */
     override fun available(): Int {
         return callWithErrorTracking(ERROR_READ) {
+            @Suppress("UnsafeThirdPartyFunctionCall") // caller should handle the exception
             available()
         }
     }
 
     /** @inheritdoc */
     override fun skip(n: Long): Long {
+        @Suppress("UnsafeThirdPartyFunctionCall") // caller should handle the exception
         return callWithErrorTracking(ERROR_SKIP) {
             skip(n)
         }
@@ -109,6 +114,7 @@ class RumResourceInputStream(
 
     /** @inheritdoc */
     override fun reset() {
+        @Suppress("UnsafeThirdPartyFunctionCall") // caller should handle the exception
         return callWithErrorTracking(ERROR_RESET) {
             reset()
         }
@@ -117,6 +123,7 @@ class RumResourceInputStream(
     /** @inheritdoc */
     override fun close() {
         return callWithErrorTracking(ERROR_CLOSE) {
+            @Suppress("UnsafeThirdPartyFunctionCall") // caller should handle the exception
             close()
             val monitor = GlobalRum.get()
             (monitor as? AdvancedRumMonitor)?.addResourceTiming(

--- a/detekt.yml
+++ b/detekt.yml
@@ -587,14 +587,21 @@ datadog:
     treatUnknownConstructorAsThrowing: true
     knownThrowingCalls:
       # region Android
+      - "android.app.Activity.findNavController(kotlin.Int):java.lang.IllegalStateException"
       - "android.content.pm.PackageManager.getPackageInfo(kotlin.String, kotlin.Int):android.content.pm.PackageManager.NameNotFoundException"
       - "android.content.res.Resources.getResourceEntryName(kotlin.Int):android.content.res.Resources.NotFoundException"
+      - "android.database.sqlite.SQLiteDatabase.beginTransaction():java.lang.IllegalStateException"
+      - "android.database.sqlite.SQLiteDatabase.beginTransactionNonExclusive():java.lang.IllegalStateException"
+      - "android.database.sqlite.SQLiteDatabase.endTransaction():java.lang.IllegalStateException"
+      - "android.database.sqlite.SQLiteDatabase.setTransactionSuccessful():java.lang.IllegalStateException"
       - "android.net.ConnectivityManager.registerDefaultNetworkCallback(android.net.ConnectivityManager.NetworkCallback):java.lang.IllegalArgumentException,java.lang.SecurityException"
       - "android.net.ConnectivityManager.unregisterNetworkCallback(android.net.ConnectivityManager.NetworkCallback):java.lang.SecurityException"
       - "android.view.Choreographer.getInstance():java.lang.IllegalStateException"
       - "android.view.Choreographer.postFrameCallback():java.lang.IllegalArgumentException"
       - "android.view.MotionEvent.obtain(android.view.MotionEvent):java.lang.IllegalArgumentException"
       - "android.view.View.getLocationInWindow(kotlin.IntArray):java.lang.IllegalArgumentException"
+      - "android.widget.FrameLayout.addView(android.view.View, android.view.ViewGroup.LayoutParams):java.lang.IllegalArgumentException"
+      - "android.widget.LinearLayout.addView(android.view.View):java.lang.IllegalArgumentException"
       - "androidx.work.WorkManager.enqueueUniqueWork(kotlin.String, androidx.work.ExistingWorkPolicy, androidx.work.OneTimeWorkRequest):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
       - "android.content.res.Resources.getResourceName(kotlin.Int):android.content.res.Resources.NotFoundException"
       - "android.content.res.Resources.openRawResource(kotlin.Int):android.content.res.Resources.NotFoundException"
@@ -617,8 +624,13 @@ datadog:
       - "java.io.FileInputStream.use(kotlin.Function1):java.io.IOException"
       - "java.io.FileOutputStream.use(kotlin.Function1):java.io.IOException"
       - "java.io.FileOutputStream.write(kotlin.ByteArray):java.io.IOException"
+      - "java.io.InputStream.available():java.io.IOException"
+      - "java.io.InputStream.close():java.io.IOException"
       - "java.io.InputStream.read():java.io.IOException"
+      - "java.io.InputStream.read(kotlin.ByteArray):java.io.IOException"
       - "java.io.InputStream.read(kotlin.ByteArray, kotlin.Int, kotlin.Int):java.io.IOException"
+      - "java.io.InputStream.reset():java.io.IOException"
+      - "java.io.InputStream.skip(kotlin.Long):java.io.IOException"
       - "java.nio.channels.FileChannel.lock():java.io.IOException,java.lang.IllegalStateException"
       - "java.nio.channels.FileLock.release():java.io.IOException"
       # endregion
@@ -661,6 +673,7 @@ datadog:
       - "kotlin.String.toLong():java.lang.NumberFormatException"
       - "kotlin.ByteArray.copyOf(kotlin.Int):java.lang.NegativeArraySizeException"
       - "kotlin.ByteArray.copyOfRange(kotlin.Int, kotlin.Int):java.lang.IndexOutOfBoundsException,java.lang.IllegalArgumentException"
+      - "kotlin.ByteArray.get(kotlin.Int):java.lang.IndexOutOfBoundsException"
       - "kotlin.collections.MutableSet.first():java.util.NoSuchElementException"
       # endregion
       # region Kotlin Collections
@@ -690,11 +703,18 @@ datadog:
       - "okio.Okio.buffer(okio.Sink):java.lang.NullPointerException"
       - "okio.Buffer.readString(java.nio.charset.Charset):java.lang.IllegalArgumentException,java.io.IOException"
       # endregion
+      # region org.json
+      - "org.json.JSONArray.get(kotlin.Int):org.json.JSONException"
+      - "org.json.JSONObject.get(kotlin.String):org.json.JSONException"
+      # endregion
       # region OpenTracing
       - "io.opentracing.Scope.close():java.io.IOException"
       # endregion
       # region Gson
       - "com.google.gson.JsonParser.parseString(kotlin.String):com.google.gson.JsonParseException"
+      # endregion
+      # region Kronos
+      - "com.lyft.kronos.KronosClock.syncInBackground():java.lang.IllegalStateException"
       # endregion
     knownSafeCalls:
       # region Android APIs
@@ -770,14 +790,18 @@ datadog:
       # endregion
       # region Android View APIs
       - "android.widget.FrameLayout.LayoutParams.constructor(kotlin.Int, kotlin.Int)"
-      - "android.widget.FrameLayout.addView(android.view.View, android.view.ViewGroup.LayoutParams)"
       - "android.widget.FrameLayout.removeView(android.view.View)"
       - "android.widget.LinearLayout.constructor(android.content.Context)"
       - "android.widget.LinearLayout.post(java.lang.Runnable)"
+      - "android.widget.LinearLayout.removeAllViews()"
       - "android.widget.TextView.constructor(android.content.Context)"
+      - "android.widget.TextView.setBackgroundColor(kotlin.Int)"
+      - "android.widget.TextView.setPadding(kotlin.Int)"
+      - "android.widget.TextView.setTextColor(kotlin.Int)"
       # endregion
       # region Androidx APIs
       - "androidx.compose.foundation.interaction.DragInteraction.Start.constructor()"
+      - "androidx.compose.runtime.DisposableEffectScope.onDispose(kotlin.Function0)"
       - "androidx.core.view.GestureDetectorCompat.constructor(android.content.Context, android.view.GestureDetector.OnGestureListener)"
       - "androidx.core.view.GestureDetectorCompat.onTouchEvent(android.view.MotionEvent)"
       - "androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks.onFragmentActivityCreated(androidx.fragment.app.FragmentManager, androidx.fragment.app.Fragment, android.os.Bundle?)"
@@ -792,6 +816,7 @@ datadog:
       - "androidx.lifecycle.Lifecycle.removeObserver(androidx.lifecycle.LifecycleObserver)"
       - "androidx.navigation.NavController.addOnDestinationChangedListener(androidx.navigation.NavController.OnDestinationChangedListener)"
       - "androidx.navigation.NavController.removeOnDestinationChangedListener(androidx.navigation.NavController.OnDestinationChangedListener)"
+      - "androidx.recyclerview.widget.RecyclerView.findContainingViewHolder(android.view.View)"
       - "androidx.recyclerview.widget.RecyclerView.getChildAdapterPosition(android.view.View)"
       - "androidx.work.Constraints.Builder()"
       - "androidx.work.Constraints.Builder.build()"
@@ -897,6 +922,8 @@ datadog:
       # region Java I/O
       - "java.io.File.constructor(java.io.File, kotlin.String)"
       - "java.io.File.constructor(kotlin.String)"
+      - "java.io.InputStream.mark(kotlin.Int)"
+      - "java.io.InputStream.markSupported()"
       - "java.io.StringWriter.constructor()"
       # endregion
       # region Java misc
@@ -949,6 +976,7 @@ datadog:
       - "kotlin.collections.Collection.sumOf(kotlin.Function1)"
       - "kotlin.collections.Collection.withIndex()"
       - "kotlin.collections.Iterable.any(kotlin.Function1)"
+      - "kotlin.collections.Iterable.forEach(kotlin.Function1)"
       - "kotlin.collections.List.any(kotlin.Function1)"
       - "kotlin.collections.List.asSequence()"
       - "kotlin.collections.List.associateWith(kotlin.Function1)"
@@ -1019,6 +1047,7 @@ datadog:
       - "kotlin.collections.MutableMap.remove(kotlin.String)"
       - "kotlin.collections.MutableSet.add(com.datadog.android.telemetry.internal.TelemetryEventHandler.EventIdentity)"
       - "kotlin.collections.MutableSet.add(kotlin.String)"
+      - "kotlin.collections.MutableSet.addAll(kotlin.collections.Collection)"
       - "kotlin.collections.MutableSet.clear()"
       - "kotlin.collections.MutableSet.contains(com.datadog.android.telemetry.internal.TelemetryEventHandler.EventIdentity)"
       - "kotlin.collections.MutableSet.filter(kotlin.Function1)"
@@ -1093,6 +1122,11 @@ datadog:
       - "kotlin.Throwable.stackTraceToString()"
       - "kotlin.text.Regex.constructor(kotlin.String)"
       - "kotlin.text.Regex.matchEntire(kotlin.CharSequence)"
+      # region Kotlin Coroutines
+      - "kotlinx.coroutines.CoroutineScope.async(kotlin.coroutines.CoroutineContext, kotlinx.coroutines.CoroutineStart, kotlin.coroutines.SuspendFunction1)"
+      - "kotlinx.coroutines.CoroutineScope.launch(kotlin.coroutines.CoroutineContext, kotlinx.coroutines.CoroutineStart, kotlin.coroutines.SuspendFunction1)"
+      - "kotlinx.coroutines.flow.FlowCollector.emit(kotlin.Any?)"
+      # endregion
       # region Gson
       - "com.google.gson.JsonArray.add(kotlin.String)"
       - "com.google.gson.JsonParseException.constructor(kotlin.Throwable)"
@@ -1144,6 +1178,7 @@ datadog:
       - "okhttp3.Request.Builder.addHeader(kotlin.String, kotlin.String)"
       - "okhttp3.Request.Builder.header(kotlin.String, kotlin.String)"
       - "okhttp3.Request.Builder.removeHeader(kotlin.String)"
+      - "okhttp3.Request.Builder.tag(java.lang.Class, io.opentracing.Span)"
       - "okhttp3.Request.body()"
       - "okhttp3.Request.header(kotlin.String)"
       - "okhttp3.Request.headers()"
@@ -1158,6 +1193,10 @@ datadog:
       - "okhttp3.Response.header(kotlin.String)"
       - "okhttp3.ResponseBody.contentLength()"
       - "okio.Buffer.constructor()"
+      # endregion
+      # region org.json
+      - "org.json.JSONArray.length()"
+      - "org.json.JSONObject.keys()"
       # endregion
       # region OpenTracing
       - "io.opentracing.Span.context()"

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/ext/ReceiverExt.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/ext/ReceiverExt.kt
@@ -6,11 +6,13 @@
 
 package com.datadog.tools.detekt.ext
 
+import io.gitlab.arturbosch.detekt.rules.fqNameOrNull
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getType
 import org.jetbrains.kotlin.resolve.descriptorUtil.fqNameOrNull
 import org.jetbrains.kotlin.resolve.scopes.receivers.ClassQualifier
 import org.jetbrains.kotlin.resolve.scopes.receivers.ExpressionReceiver
+import org.jetbrains.kotlin.resolve.scopes.receivers.ImplicitReceiver
 import org.jetbrains.kotlin.resolve.scopes.receivers.Receiver
 import org.jetbrains.kotlin.types.FlexibleType
 import org.jetbrains.kotlin.types.lowerIfFlexible
@@ -30,6 +32,8 @@ internal fun Receiver?.type(bindingContext: BindingContext): String? {
         }
     } else if (this is ClassQualifier) {
         return descriptor.fqNameOrNull()?.toString()
+    } else if (this is ImplicitReceiver) {
+        return type.fqNameOrNull()?.toString()
     } else {
         println("DD: Unknown receiver type ${this.javaClass}")
         return null

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/UnsafeThirdPartyFunctionCall.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/UnsafeThirdPartyFunctionCall.kt
@@ -27,6 +27,7 @@ import org.jetbrains.kotlin.psi.KtTryExpression
 import org.jetbrains.kotlin.resolve.BindingContext
 import org.jetbrains.kotlin.resolve.calls.callUtil.getResolvedCall
 import org.jetbrains.kotlin.resolve.calls.callUtil.getType
+import org.jetbrains.kotlin.resolve.calls.resolvedCallUtil.getImplicitReceiverValue
 import org.jetbrains.kotlin.types.lowerIfFlexible
 
 /**
@@ -106,7 +107,10 @@ class UnsafeThirdPartyFunctionCall(
         val returnType = expression.getType(bindingContext)?.fullType() ?: return
 
         val explicitReceiverType = call.explicitReceiver?.type(bindingContext)
-        val receiverType = explicitReceiverType ?: call.dispatchReceiver?.type(bindingContext)
+        val receiverType = explicitReceiverType
+            ?: call.dispatchReceiver?.type(bindingContext)
+            ?: resolvedCall.getImplicitReceiverValue()?.type(bindingContext)
+
         val callDescriptor = resolvedCall.candidateDescriptor
 
         if (callDescriptor is ClassConstructorDescriptor) {

--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/UnsafeThirdPartyFunctionCallTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/UnsafeThirdPartyFunctionCallTest.kt
@@ -83,6 +83,67 @@ internal class UnsafeThirdPartyFunctionCallTest {
     }
 
     @Test
+    fun `detekt unsafe call on unknown third party function`() {
+        // Given
+        val code =
+            """
+                import java.io.File
+                
+                fun test(f: File): Any {
+                    return f.inputStream()
+                }
+            """.trimIndent()
+
+        // When
+        val findings = UnsafeThirdPartyFunctionCall(TestConfig())
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `detekt unsafe call on unknown third party function { implicit receiver }`() {
+        // Given
+        val code =
+            """
+                import java.io.File
+                
+                fun test(f: File): Any {
+                    return with(f) { inputStream() }
+                }
+            """.trimIndent()
+
+        // When
+        val findings = UnsafeThirdPartyFunctionCall(TestConfig())
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
+    fun `detekt unsafe call on unknown third party function { explicit it receiver }`() {
+        // Given
+        @Suppress("SimpleRedundantLet")
+        val code =
+            """
+                import java.io.File
+                
+                fun test(f: File): Any {
+                    return f.let { it.inputStream() }
+                }
+            """.trimIndent()
+
+        // When
+        val findings = UnsafeThirdPartyFunctionCall(TestConfig())
+            .compileAndLintWithContext(kotlinEnv.env, code)
+
+        // Then
+        assertThat(findings).hasSize(1)
+    }
+
+    @Test
     fun `detekt unsafe call on known third party function {disambiguate signatures}`() {
         // Given
         val knownThrowingCalls = listOf(


### PR DESCRIPTION
### What does this PR do?

This change brings support of the 3rd party calls with implicit receiver, such as:

```
fun test(f: File): Any {
    return with(f) { inputStream() }
}
```

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

