### PR TITLE
RUMM-2182: Prevent crash of ProhibitLeavingStaticMocks check on a class with synthetic members

### DIFF
--- a/tools/unit/src/main/kotlin/com/datadog/tools/unit/extensions/ProhibitLeavingStaticMocksExtension.kt
+++ b/tools/unit/src/main/kotlin/com/datadog/tools/unit/extensions/ProhibitLeavingStaticMocksExtension.kt
@@ -102,7 +102,9 @@ class ProhibitLeavingStaticMocksExtension : AfterEachCallback {
     }
 
     private fun findFieldsToWatch(visitedClass: KClass<*>): List<FieldCallSpec> {
-        val kotlinObjectFields = if (visitedClass.objectInstance != null) {
+        val kotlinObjectFields = if (visitedClass.simpleName != null &&
+            visitedClass.objectInstance != null
+        ) {
             findTargetFieldsInKotlin(
                 visitedClass,
                 visitedClass.objectInstance
@@ -111,7 +113,9 @@ class ProhibitLeavingStaticMocksExtension : AfterEachCallback {
             emptyList()
         }
 
-        val kotlinCompanionObjectFields = if (visitedClass.companionObjectInstance != null) {
+        val kotlinCompanionObjectFields = if (visitedClass.simpleName != null &&
+            visitedClass.companionObjectInstance != null
+        ) {
             findTargetFieldsInKotlin(
                 visitedClass.companionObject!!,
                 visitedClass.companionObjectInstance

--- a/tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/ProhibitLeavingStaticMocksExtensionTest.kt
+++ b/tools/unit/src/test/kotlin/com/datadog/tools/unit/extensions/ProhibitLeavingStaticMocksExtensionTest.kt
@@ -148,6 +148,12 @@ class ProhibitLeavingStaticMocksExtensionTest {
         assertDoesNotThrow { testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES) }
     }
 
+    @Test
+    fun `M not throw error W object with synthetic field`() {
+        val roots = listOf(ObjectWithLambdaMember::class)
+        assertDoesNotThrow { testedExtension.scanForStaticMocksLeft(roots, PACKAGE_PREFIXES) }
+    }
+
     // region fake classes for test
 
     @Suppress("unused")
@@ -238,6 +244,11 @@ class ProhibitLeavingStaticMocksExtensionTest {
     class MockInNonObjectClass(
         @Suppress("unused") val mock: Any = mock()
     )
+
+    object ObjectWithLambdaMember {
+        @Suppress("unused")
+        val lambda = { println("foobar") }
+    }
 
     companion object {
         val PACKAGE_PREFIXES = listOf("com.datadog")


### PR DESCRIPTION
### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

