### PR TITLE
RUMM-2329: Remove deprecated APIs

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -13,25 +13,16 @@ object com.datadog.android.DatadogEndpoint
   const val LOGS_US5: String
   const val LOGS_US1_FED: String
   const val LOGS_EU1: String
-  DEPRECATED const val LOGS_US: String
-  DEPRECATED const val LOGS_EU: String
-  DEPRECATED const val LOGS_GOV: String
   const val TRACES_US1: String
   const val TRACES_US3: String
   const val TRACES_US5: String
   const val TRACES_US1_FED: String
   const val TRACES_EU1: String
-  DEPRECATED const val TRACES_US: String
-  DEPRECATED const val TRACES_EU: String
-  DEPRECATED const val TRACES_GOV: String
   const val RUM_US1: String
   const val RUM_US3: String
   const val RUM_US5: String
   const val RUM_US1_FED: String
   const val RUM_EU1: String
-  DEPRECATED const val RUM_US: String
-  DEPRECATED const val RUM_EU: String
-  DEPRECATED const val RUM_GOV: String
   const val NTP_0: String
   const val NTP_1: String
   const val NTP_2: String
@@ -81,9 +72,6 @@ data class com.datadog.android.core.configuration.Configuration
     fun setFirstPartyHosts(List<String>): Builder
     fun setWebViewTrackingHosts(List<String>): Builder
     fun useSite(com.datadog.android.DatadogSite): Builder
-    DEPRECATED fun useEUEndpoints(): Builder
-    DEPRECATED fun useUSEndpoints(): Builder
-    DEPRECATED fun useGovEndpoints(): Builder
     fun useCustomLogsEndpoint(String): Builder
     fun useCustomTracesEndpoint(String): Builder
     fun useCustomCrashReportsEndpoint(String): Builder
@@ -104,7 +92,6 @@ data class com.datadog.android.core.configuration.Configuration
     fun setRumLongTaskEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.LongTaskEvent>): Builder
     fun setSpanEventMapper(com.datadog.android.event.SpanEventMapper): Builder
     fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
-    DEPRECATED fun setInternalLogsEnabled(String, String): Builder
     fun setAdditionalConfiguration(Map<String, Any>): Builder
     fun setProxy(java.net.Proxy, okhttp3.Authenticator?): Builder
     fun setVitalsUpdateFrequency(VitalsUpdateFrequency): Builder
@@ -372,7 +359,6 @@ interface com.datadog.android.rum.RumMonitor
   fun stopView(Any, Map<String, Any?> = emptyMap())
   fun addUserAction(RumActionType, String, Map<String, Any?>)
   fun startUserAction(RumActionType, String, Map<String, Any?>)
-  DEPRECATED fun stopUserAction(Map<String, Any?> = emptyMap())
   fun stopUserAction(RumActionType, String, Map<String, Any?> = emptyMap())
   fun startResource(String, String, String, Map<String, Any?> = emptyMap())
   fun stopResource(String, Int?, Long?, RumResourceKind, Map<String, Any?>)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogEndpoint.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogEndpoint.kt
@@ -50,36 +50,6 @@ object DatadogEndpoint {
      */
     const val LOGS_EU1: String = "https://mobile-http-intake.logs.datadoghq.eu"
 
-    /**
-     * The endpoint for Logs (US based servers), used by default by the SDK.
-     * @see [Configuration]
-     * @deprecated use [LOGS_US1] instead
-     */
-    @Deprecated("Use LOGS_US1 instead", ReplaceWith("DatadogEndpoint.LOGS_US1"))
-    const val LOGS_US: String = LOGS_US1
-
-    /**
-     * The endpoint for Logs (Europe based servers).
-     * Use this in your [Configuration] if you log on
-     * [app.datadoghq.eu](https://app.datadoghq.eu/) instead of
-     * [app.datadoghq.com](https://app.datadoghq.com/)
-     * @see [Configuration]
-     * @deprecated use [LOGS_EU1] instead
-     */
-    @Deprecated("Use LOGS_EU1 instead", ReplaceWith("DatadogEndpoint.LOGS_EU1"))
-    const val LOGS_EU: String = LOGS_EU1
-
-    /**
-     * The endpoint for Logs (GovCloud compatible servers).
-     * Use this in your [Configuration] if you log on
-     * [app.ddog-gov.com/](https://app.ddog-gov.com/) instead of
-     * [app.datadoghq.com](https://app.datadoghq.com/)
-     * @see [Configuration]
-     * @deprecated use [LOGS_US1_FED] instead
-     */
-    @Deprecated("Use LOGS_US1_FED instead", ReplaceWith("DatadogEndpoint.LOGS_US1_FED"))
-    const val LOGS_GOV: String = LOGS_US1_FED
-
     // endregion
 
     //  region Trace
@@ -119,36 +89,6 @@ object DatadogEndpoint {
      */
     const val TRACES_EU1: String = "https:/public-trace-http-intake.logs.datadoghq.eu"
 
-    /**
-     * The endpoint for Traces (US based servers), used by default by the SDK.
-     * @see [Configuration]
-     * @deprecated use [TRACES_US1] instead
-     */
-    @Deprecated("Use TRACES_US1 instead", ReplaceWith("DatadogEndpoint.TRACES_US1"))
-    const val TRACES_US: String = TRACES_US1
-
-    /**
-     * The endpoint for Traces (Europe based servers).
-     * Use this in your [Configuration] if you log on
-     * [app.datadoghq.eu](https://app.datadoghq.eu/) instead of
-     * [app.datadoghq.com](https://app.datadoghq.com/)
-     * @see [Configuration]
-     * @deprecated use [TRACES_EU1] instead
-     */
-    @Deprecated("Use TRACES_EU1 instead", ReplaceWith("DatadogEndpoint.TRACES_EU1"))
-    const val TRACES_EU: String = TRACES_EU1
-
-    /**
-     * The endpoint for Traces (GovCloud compatible servers).
-     * Use this in your [Configuration] if you log on
-     * [app.ddog-gov.com/](https://app.ddog-gov.com/) instead of
-     * [app.datadoghq.com](https://app.datadoghq.com/)
-     * @see [Configuration]
-     * @deprecated use [TRACES_US1_FED] instead
-     */
-    @Deprecated("Use TRACES_US1_FED instead", ReplaceWith("DatadogEndpoint.TRACES_US1_FED"))
-    const val TRACES_GOV: String = TRACES_US1_FED
-
     // endregion
 
     //  region RUM
@@ -187,34 +127,6 @@ object DatadogEndpoint {
      * @see [Configuration]
      */
     const val RUM_EU1: String = "https://rum-http-intake.logs.datadoghq.eu"
-
-    /**
-     * The endpoint for Real User Monitoring (US based servers), used by default by the SDK.
-     * @see [Configuration]
-     * @deprecated use [RUM_US1] instead
-     */
-    @Deprecated("Use RUM_US1 instead", ReplaceWith("DatadogEndpoint.RUM_US1"))
-    const val RUM_US: String = RUM_US1
-
-    /**
-     * The endpoint for Real User Monitoring (Europe based servers).
-     * Use this in your [Configuration] if you log on
-     * [app.datadoghq.eu](https://app.datadoghq.eu/) instead of
-     * [app.datadoghq.com](https://app.datadoghq.com/)
-     * @deprecated use [RUM_EU1] instead
-     */
-    @Deprecated("Use RUM_EU1 instead", ReplaceWith("DatadogEndpoint.RUM_EU1"))
-    const val RUM_EU: String = RUM_EU1
-
-    /**
-     * The endpoint for Real User Monitoring (GovCloud compatible servers).
-     * Use this in your [Configuration] if you log on
-     * [app.ddog-gov.com/](https://app.ddog-gov.com/) instead of
-     * [app.datadoghq.com](https://app.datadoghq.com/)
-     * @deprecated use [RUM_US1_FED] instead
-     */
-    @Deprecated("Use RUM_US1_FED instead", ReplaceWith("DatadogEndpoint.RUM_US1_FED"))
-    const val RUM_GOV: String = RUM_US1_FED
 
     // endregion
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -15,7 +15,6 @@ import com.datadog.android.DatadogInterceptor
 import com.datadog.android.DatadogSite
 import com.datadog.android.core.internal.event.NoOpEventMapper
 import com.datadog.android.core.internal.utils.devLogger
-import com.datadog.android.core.internal.utils.warnDeprecated
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.NoOpSpanEventMapper
 import com.datadog.android.event.SpanEventMapper
@@ -208,93 +207,6 @@ internal constructor(
             tracesConfig = tracesConfig.copy(endpointUrl = site.tracesEndpoint())
             crashReportConfig = crashReportConfig.copy(endpointUrl = site.logsEndpoint())
             rumConfig = rumConfig.copy(endpointUrl = site.rumEndpoint())
-            coreConfig = coreConfig.copy(needsClearTextHttp = false)
-            return this
-        }
-
-        /**
-         * Let the SDK target Datadog's Europe server.
-         *
-         * Call this if you log on [app.datadoghq.eu](https://app.datadoghq.eu/).
-         * @deprecated use the [useSite] method instead.
-         */
-        @Deprecated(
-            "Use the `useSite()` method instead.",
-            ReplaceWith(
-                "useSite(DatadogSite.EU1)",
-                "com.datadog.android.DatadogSite"
-            )
-        )
-        @Suppress("DEPRECATION", "StringLiteralDuplication")
-        fun useEUEndpoints(): Builder {
-            warnDeprecated(
-                target = "Configuration.Builder.useEUEndpoints()",
-                deprecatedSince = "1.10.0",
-                removedInVersion = "1.12.0",
-                alternative = "Configuration.Builder.useSite(DatadogSite.EU1)"
-            )
-            logsConfig = logsConfig.copy(endpointUrl = DatadogEndpoint.LOGS_EU)
-            tracesConfig = tracesConfig.copy(endpointUrl = DatadogEndpoint.TRACES_EU)
-            crashReportConfig = crashReportConfig.copy(endpointUrl = DatadogEndpoint.LOGS_EU)
-            rumConfig = rumConfig.copy(endpointUrl = DatadogEndpoint.RUM_EU)
-            coreConfig = coreConfig.copy(needsClearTextHttp = false)
-            return this
-        }
-
-        /**
-         * Let the SDK target Datadog's US server.
-         *
-         * Call this if you log on [app.datadoghq.com](https://app.datadoghq.com/).
-         * @deprecated use the [useSite] method instead.
-         */
-        @Deprecated(
-            "Use the `useSite()` method instead.",
-            ReplaceWith(
-                "useSite(DatadogSite.US1)",
-                "com.datadog.android.DatadogSite"
-            )
-        )
-        @Suppress("DEPRECATION", "StringLiteralDuplication")
-        fun useUSEndpoints(): Builder {
-            warnDeprecated(
-                target = "Configuration.Builder.useUSEndpoints()",
-                deprecatedSince = "1.10.0",
-                removedInVersion = "1.12.0",
-                alternative = "Configuration.Builder.useSite(DatadogSite.US1)"
-            )
-            logsConfig = logsConfig.copy(endpointUrl = DatadogEndpoint.LOGS_US)
-            tracesConfig = tracesConfig.copy(endpointUrl = DatadogEndpoint.TRACES_US)
-            crashReportConfig = crashReportConfig.copy(endpointUrl = DatadogEndpoint.LOGS_US)
-            rumConfig = rumConfig.copy(endpointUrl = DatadogEndpoint.RUM_US)
-            coreConfig = coreConfig.copy(needsClearTextHttp = false)
-            return this
-        }
-
-        /**
-         * Let the SDK target Datadog's Gov server.
-         *
-         * Call this if you log on [app.ddog-gov.com/](https://app.ddog-gov.com/).
-         * @deprecated use the [useSite] method instead.
-         */
-        @Deprecated(
-            "Use the `useSite()` method instead.",
-            ReplaceWith(
-                "useSite(DatadogSite.US1_FED)",
-                "com.datadog.android.DatadogSite"
-            )
-        )
-        @Suppress("DEPRECATION", "StringLiteralDuplication")
-        fun useGovEndpoints(): Builder {
-            warnDeprecated(
-                target = "Configuration.Builder.useGovEndpoints()",
-                deprecatedSince = "1.10.0",
-                removedInVersion = "1.12.0",
-                alternative = "Configuration.Builder.useSite(DatadogSite.US1_FED)"
-            )
-            logsConfig = logsConfig.copy(endpointUrl = DatadogEndpoint.LOGS_GOV)
-            tracesConfig = tracesConfig.copy(endpointUrl = DatadogEndpoint.TRACES_GOV)
-            crashReportConfig = crashReportConfig.copy(endpointUrl = DatadogEndpoint.LOGS_GOV)
-            rumConfig = rumConfig.copy(endpointUrl = DatadogEndpoint.RUM_GOV)
             coreConfig = coreConfig.copy(needsClearTextHttp = false)
             return this
         }
@@ -595,30 +507,6 @@ internal constructor(
             applyIfFeatureEnabled(PluginFeature.LOG, "setLogEventMapper") {
                 logsConfig = logsConfig.copy(logsEventMapper = eventMapper)
             }
-            return this
-        }
-
-        /**
-         * Enables the internal logs to be sent to a dedicated Datadog Org.
-         * @param clientToken the client token to use for internal logs
-         * @param endpointUrl the endpoint url to sent the internal logs to
-         * (one of [DatadogEndpoint.LOGS_US], [DatadogEndpoint.LOGS_EU], [DatadogEndpoint.LOGS_GOV])
-         *
-         * @deprecated This method has no effect and will be removed in the next version.
-         */
-        @Suppress("UNUSED_PARAMETER")
-        @Deprecated(
-            message = "This method has no effect and will be removed in the next version."
-        )
-        fun setInternalLogsEnabled(
-            clientToken: String,
-            endpointUrl: String
-        ): Builder {
-            warnDeprecated(
-                target = "Configuration.Builder.setInternalLogsEnabled()",
-                deprecatedSince = "1.13.0",
-                removedInVersion = "1.14.0"
-            )
             return this
         }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -95,23 +95,6 @@ interface RumMonitor {
     )
 
     /**
-     * Notifies that a User Action stopped.
-     * This is used to stop tracking long running user actions (e.g.: scroll), started
-     * with [startUserAction].
-     * @param attributes additional custom attributes to attach to the action
-     * @see [addUserAction]
-     * @see [startUserAction]
-     * @deprecated Use [stopUserAction] with name parameter instead.
-     */
-    @Deprecated(
-        "This method is deprecated. Please" +
-            " use RumMonitor#stopUserAction(type, name, attributes) instead"
-    )
-    fun stopUserAction(
-        attributes: Map<String, Any?> = emptyMap()
-    )
-
-    /**
      * Notifies that a User Action stopped, and update the action's type and name.
      * This is used to stop tracking long running user actions (e.g.: scroll), started
      * with [startUserAction].

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -116,12 +116,6 @@ internal class DatadogRumMonitor(
         )
     }
 
-    override fun stopUserAction(attributes: Map<String, Any?>) {
-        handleEvent(
-            RumRawEvent.StopAction(null, null, attributes)
-        )
-    }
-
     override fun stopUserAction(
         type: RumActionType,
         name: String,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -835,19 +835,14 @@ internal class DatadogTest {
         assertThat(RumFeature.debugActivityLifecycleListener).isNull()
     }
 
-    @Suppress("DEPRECATION")
     @Test
-    fun `𝕄 clear data in all features 𝕎 clearAllData()`(
-        @StringForgery internalLogsToken: String,
-        @StringForgery internalLogsUrl: String
-    ) {
+    fun `𝕄 clear data in all features 𝕎 clearAllData()`() {
         val config = Configuration.Builder(
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
             rumEnabled = true
         )
-            .setInternalLogsEnabled(internalLogsToken, internalLogsUrl)
             .build()
         val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
         val dataReaders: Array<DataReader> = Array(6) { mock() }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -49,7 +49,6 @@ import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
-import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.net.Proxy
@@ -259,75 +258,6 @@ internal class ConfigurationBuilderTest {
         )
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = site.rumEndpoint())
-        )
-        assertThat(config.additionalConfig).isEmpty()
-    }
-
-    @Suppress("DEPRECATION")
-    @Test
-    fun `𝕄 build config with US endpoints 𝕎 useUSEndpoints() and build()`() {
-        // When
-        val config = testedBuilder.useUSEndpoints().build()
-
-        // Then
-        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
-        assertThat(config.logsConfig).isEqualTo(
-            Configuration.DEFAULT_LOGS_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_US)
-        )
-        assertThat(config.tracesConfig).isEqualTo(
-            Configuration.DEFAULT_TRACING_CONFIG.copy(endpointUrl = DatadogEndpoint.TRACES_US)
-        )
-        assertThat(config.crashReportConfig).isEqualTo(
-            Configuration.DEFAULT_CRASH_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_US)
-        )
-        assertThat(config.rumConfig).isEqualTo(
-            Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = DatadogEndpoint.RUM_US)
-        )
-        assertThat(config.additionalConfig).isEmpty()
-    }
-
-    @Suppress("DEPRECATION")
-    @Test
-    fun `𝕄 build config with EU endpoints 𝕎 useEUEndpoints() and build()`() {
-        // When
-        val config = testedBuilder.useEUEndpoints().build()
-
-        // Then
-        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
-        assertThat(config.logsConfig).isEqualTo(
-            Configuration.DEFAULT_LOGS_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_EU)
-        )
-        assertThat(config.tracesConfig).isEqualTo(
-            Configuration.DEFAULT_TRACING_CONFIG.copy(endpointUrl = DatadogEndpoint.TRACES_EU)
-        )
-        assertThat(config.crashReportConfig).isEqualTo(
-            Configuration.DEFAULT_CRASH_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_EU)
-        )
-        assertThat(config.rumConfig).isEqualTo(
-            Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = DatadogEndpoint.RUM_EU)
-        )
-        assertThat(config.additionalConfig).isEmpty()
-    }
-
-    @Suppress("DEPRECATION")
-    @Test
-    fun `𝕄 build config with GOV endpoints 𝕎 useGOVEndpoints() and build()`() {
-        // When
-        val config = testedBuilder.useGovEndpoints().build()
-
-        // Then
-        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
-        assertThat(config.logsConfig).isEqualTo(
-            Configuration.DEFAULT_LOGS_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_GOV)
-        )
-        assertThat(config.tracesConfig).isEqualTo(
-            Configuration.DEFAULT_TRACING_CONFIG.copy(endpointUrl = DatadogEndpoint.TRACES_GOV)
-        )
-        assertThat(config.crashReportConfig).isEqualTo(
-            Configuration.DEFAULT_CRASH_CONFIG.copy(endpointUrl = DatadogEndpoint.LOGS_GOV)
-        )
-        assertThat(config.rumConfig).isEqualTo(
-            Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = DatadogEndpoint.RUM_GOV)
         )
         assertThat(config.additionalConfig).isEmpty()
     }
@@ -1487,26 +1417,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.coreConfig).isEqualTo(
             Configuration.DEFAULT_CORE_CONFIG.copy(uploadFrequency = uploadFrequency)
         )
-        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
-        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
-        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.rumConfig).isEqualTo(Configuration.DEFAULT_RUM_CONFIG)
-        assertThat(config.additionalConfig).isEmpty()
-    }
-
-    @Suppress("DEPRECATION")
-    @Test
-    fun `𝕄 not change anything 𝕎 setInternalLogsEnabled()`(
-        @StringForgery(StringForgeryType.HEXADECIMAL) clientToken: String,
-        @StringForgery(regex = "https://[a-z]+\\.com") url: String
-    ) {
-        // When
-        val config = testedBuilder
-            .setInternalLogsEnabled(clientToken, url)
-            .build()
-
-        // Then
-        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -254,23 +254,6 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `M delegate event to rootScope W stopUserAction()`() {
-        @Suppress("DEPRECATION")
-        testedMonitor.stopUserAction(fakeAttributes)
-        Thread.sleep(PROCESSING_DELAY)
-
-        argumentCaptor<RumRawEvent> {
-            verify(mockScope).handleEvent(capture(), same(mockWriter))
-
-            val event = firstValue as RumRawEvent.StopAction
-            assertThat(event.type).isNull()
-            assertThat(event.name).isNull()
-            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
-        }
-        verifyNoMoreInteractions(mockScope, mockWriter)
-    }
-
-    @Test
     fun `M delegate event to rootScope W stopUserAction()`(
         @Forgery type: RumActionType,
         @StringForgery name: String


### PR DESCRIPTION
### What does this PR do?

This change removes public APIs which were deprecated in the previous SDK version and now can be safely removed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

