### PR TITLE
RUMM-2324: Let user to disable RUM view tracking strategy

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -78,7 +78,7 @@ data class com.datadog.android.core.configuration.Configuration
     fun useCustomRumEndpoint(String): Builder
     fun trackInteractions(Array<com.datadog.android.rum.tracking.ViewAttributesProvider> = emptyArray(), com.datadog.android.rum.tracking.InteractionPredicate = NoOpInteractionPredicate()): Builder
     fun trackLongTasks(Long = DEFAULT_LONG_TASK_THRESHOLD_MS): Builder
-    fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy): Builder
+    fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
     fun addPlugin(com.datadog.android.plugin.DatadogPlugin, com.datadog.android.plugin.Feature): Builder
     fun setBatchSize(BatchSize): Builder
     fun setUploadFrequency(UploadFrequency): Builder

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -299,9 +299,9 @@ internal constructor(
 
         /**
          * Sets the automatic view tracking strategy used by the SDK.
-         * By default no view will be tracked.
+         * By default [ActivityViewTrackingStrategy] will be used.
          * @param strategy as the [ViewTrackingStrategy]
-         * Note: By default, the RUM Monitor will let you handle View events manually.
+         * Note: If [null] is passed, the RUM Monitor will let you handle View events manually.
          * This means that you should call [RumMonitor.startView] and [RumMonitor.stopView]
          * yourself. A view should be started when it becomes visible and interactive
          * (equivalent to `onResume`) and be stopped when it's paused (equivalent to `onPause`).
@@ -310,7 +310,7 @@ internal constructor(
          * @see [com.datadog.android.rum.tracking.MixedViewTrackingStrategy]
          * @see [com.datadog.android.rum.tracking.NavigationViewTrackingStrategy]
          */
-        fun useViewTrackingStrategy(strategy: ViewTrackingStrategy): Builder {
+        fun useViewTrackingStrategy(strategy: ViewTrackingStrategy?): Builder {
             applyIfFeatureEnabled(PluginFeature.RUM, "useViewTrackingStrategy") {
                 rumConfig = rumConfig.copy(viewTrackingStrategy = strategy)
             }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -511,6 +511,26 @@ internal class ConfigurationBuilderTest {
     }
 
     @Test
+    fun `𝕄 build config without view strategy 𝕎 useViewTrackingStrategy(null) and build()`() {
+        // When
+        val config = testedBuilder
+            .useViewTrackingStrategy(null)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(
+                viewTrackingStrategy = null
+            )
+        )
+        assertThat(config.additionalConfig).isEmpty()
+    }
+
+    @Test
     fun `𝕄 build config with sampling rate 𝕎 sampleRumSessions() and build()`(
         @FloatForgery(min = 0f, max = 100f) sampling: Float
     ) {


### PR DESCRIPTION
### What does this PR do?

This change allows user to disable the default view tracking strategy if there is a need/wish to do view tracking manually by using `RumMonitor` on the user side.

This is achieved by letting call `Configuration#useViewTrackingStrategy` with `null` argument, which will make SDK use `NoOpViewTrackingStrategy`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

