### PR TITLE
Use RumFeature#context instead of CoreFeature#contextRef in RumFeature

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -98,7 +98,7 @@ internal class RumFeature(
     }
 
     override fun onStop() {
-        unregisterTrackingStrategies(coreFeature.contextRef.get())
+        unregisterTrackingStrategies(appContext)
 
         viewTrackingStrategy = NoOpViewTrackingStrategy()
         actionTrackingStrategy = NoOpUserActionTrackingStrategy()


### PR DESCRIPTION
### What does this PR do?

Tiny change to use `RumFeature#context` which is set during the initialization instead of `CoreFeature#contextRef: WeakReference`(which may disappear).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

