### PR TITLE
Expose Telemetry and addLongTask for internal use

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -7,6 +7,7 @@ object com.datadog.android.Datadog
   fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
   fun addUserExtraInfo(Map<String, Any?> = emptyMap())
   fun enableRumDebugging(Boolean)
+  val _internal: _InternalProxy
 object com.datadog.android.DatadogEndpoint
   const val LOGS_US1: String
   const val LOGS_US3: String
@@ -59,6 +60,14 @@ enum com.datadog.android.DatadogSite
   fun logsEndpoint(): String
   fun tracesEndpoint(): String
   fun rumEndpoint(): String
+class com.datadog.android._InternalProxy
+  class _TelemetryProxy
+    fun debug(String)
+    fun error(String, String?, String?)
+  class _RumProxy
+    fun addLongTask(Long, String)
+  val _telemetry: _TelemetryProxy
+  val _rumProxy: _RumProxy?
 enum com.datadog.android.core.configuration.BatchSize
   constructor(Long)
   - SMALL

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -7,7 +7,7 @@ object com.datadog.android.Datadog
   fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
   fun addUserExtraInfo(Map<String, Any?> = emptyMap())
   fun enableRumDebugging(Boolean)
-  val _internal: _InternalProxy
+  var _internal: _InternalProxy
 object com.datadog.android.DatadogEndpoint
   const val LOGS_US1: String
   const val LOGS_US3: String
@@ -63,11 +63,9 @@ enum com.datadog.android.DatadogSite
 class com.datadog.android._InternalProxy
   class _TelemetryProxy
     fun debug(String)
+    fun error(String, Throwable? = null)
     fun error(String, String?, String?)
-  class _RumProxy
-    fun addLongTask(Long, String)
   val _telemetry: _TelemetryProxy
-  val _rumProxy: _RumProxy?
 enum com.datadog.android.core.configuration.BatchSize
   constructor(Long)
   - SMALL
@@ -377,6 +375,7 @@ interface com.datadog.android.rum.RumMonitor
   fun addError(String, RumErrorSource, Throwable?, Map<String, Any?>)
   fun addErrorWithStacktrace(String, RumErrorSource, String?, Map<String, Any?>)
   fun addTiming(String)
+  fun _getInternal(): _RumInternalProxy?
   class Builder
     fun sampleRumSessions(Float): Builder
     fun setSessionListener(RumSessionListener): Builder
@@ -401,6 +400,8 @@ enum com.datadog.android.rum.RumResourceKind
   companion object 
 interface com.datadog.android.rum.RumSessionListener
   fun onSessionStarted(String, Boolean)
+class com.datadog.android.rum._RumInternalProxy
+  fun addLongTask(Long, String)
 data class com.datadog.android.rum.model.ActionEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, ActionEventSession, Source? = null, View, Usr? = null, Connectivity? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action)
   val type: kotlin.String

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -19,13 +19,13 @@ import com.datadog.android.core.internal.lifecycle.ProcessLifecycleCallback
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.sdkLogger
+import com.datadog.android.core.internal.utils.telemetry
 import com.datadog.android.core.model.UserInfo
 import com.datadog.android.error.internal.CrashReportsFeature
 import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.internal.RumFeature
-import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
 import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.webview.internal.log.WebViewLogsFeature
@@ -289,13 +289,9 @@ object Datadog {
      *
      * @see _InternalProxy
      */
-    @JvmStatic
     @Suppress("ObjectPropertyNaming")
-    val _internal: _InternalProxy by lazy {
-        _InternalProxy(
-            GlobalRum.get() as? AdvancedRumMonitor
-        )
-    }
+    var _internal: _InternalProxy = _InternalProxy(telemetry)
+        private set
 
     // endregion
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -290,6 +290,7 @@ object Datadog {
      * @see _InternalProxy
      */
     @JvmStatic
+    @Suppress("ObjectPropertyNaming")
     val _internal: _InternalProxy by lazy {
         _InternalProxy(
             GlobalRum.get() as? AdvancedRumMonitor

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -25,6 +25,7 @@ import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
 import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.webview.internal.log.WebViewLogsFeature
@@ -281,6 +282,18 @@ object Datadog {
         } else {
             RumFeature.disableDebugging()
         }
+    }
+
+    /**
+     * For Datadog internal use only.
+     *
+     * @see _InternalProxy
+     */
+    @JvmStatic
+    val _internal: _InternalProxy by lazy {
+        _InternalProxy(
+            GlobalRum.get() as? AdvancedRumMonitor
+        )
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/_InternalProxy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/_InternalProxy.kt
@@ -19,6 +19,13 @@ import com.datadog.android.telemetry.internal.Telemetry
  * Methods, members, and functionality of this class  are subject to change without notice, as they
  * are not considered part of the public interface of the Datadog SDK.
  */
+@Suppress(
+    "UndocumentedPublicClass",
+    "UndocumentedPublicFunction",
+    "UndocumentedPublicProperty",
+    "ClassNaming",
+    "VariableNaming"
+)
 class _InternalProxy {
     class _TelemetryProxy {
         private val telemetry: Telemetry = Telemetry()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/_InternalProxy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/_InternalProxy.kt
@@ -1,0 +1,53 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android
+
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
+import com.datadog.android.telemetry.internal.Telemetry
+
+/**
+ * This class exposes internal methods that are used by other Datadog modules and cross platform
+ * frameworks. It is not meant for public use.
+ *
+ * DO NOT USE this class or its methods if you are not working on the internals of the Datadog SDK
+ * or one of the cross platform frameworks.
+ *
+ * Methods, members, and functionality of this class  are subject to change without notice, as they
+ * are not considered part of the public interface of the Datadog SDK.
+ */
+class _InternalProxy {
+    class _TelemetryProxy {
+        private val telemetry: Telemetry = Telemetry()
+
+        fun debug(message: String) {
+            telemetry.debug(message)
+        }
+
+        fun error(message: String, stack: String?, kind: String?) {
+            telemetry.error(message, stack, kind)
+        }
+    }
+
+    class _RumProxy {
+        private val rumMonitor: AdvancedRumMonitor
+
+        internal constructor(rumMonitor: AdvancedRumMonitor) {
+            this.rumMonitor = rumMonitor
+        }
+
+        fun addLongTask(durationNs: Long, target: String) {
+            rumMonitor.addLongTask(durationNs, target)
+        }
+    }
+
+    val _telemetry: _TelemetryProxy = _TelemetryProxy()
+    val _rumProxy: _RumProxy?
+
+    internal constructor(rumMonitor: AdvancedRumMonitor?) {
+        _rumProxy = rumMonitor?.let { _RumProxy(rumMonitor) }
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -238,6 +238,14 @@ interface RumMonitor {
         name: String
     )
 
+    /**
+     * For Datadog internal use only.
+     *
+     * @see _RumInternalProxy
+     */
+    @Suppress("FunctionNaming")
+    fun _getInternal(): _RumInternalProxy?
+
     // region Builder
 
     /**

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -4,9 +4,9 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android
+package com.datadog.android.rum
 
-import com.datadog.android.telemetry.internal.Telemetry
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 
 /**
  * This class exposes internal methods that are used by other Datadog modules and cross platform
@@ -25,30 +25,14 @@ import com.datadog.android.telemetry.internal.Telemetry
     "ClassNaming",
     "VariableNaming"
 )
-class _InternalProxy {
-    class _TelemetryProxy {
-        private val telemetry: Telemetry
+class _RumInternalProxy {
+    private val rumMonitor: AdvancedRumMonitor
 
-        internal constructor(telemetry: Telemetry) {
-            this.telemetry = telemetry
-        }
-
-        fun debug(message: String) {
-            telemetry.debug(message)
-        }
-
-        fun error(message: String, throwable: Throwable? = null) {
-            telemetry.error(message, throwable)
-        }
-
-        fun error(message: String, stack: String?, kind: String?) {
-            telemetry.error(message, stack, kind)
-        }
+    internal constructor(rumMonitor: AdvancedRumMonitor) {
+        this.rumMonitor = rumMonitor
     }
 
-    val _telemetry: _TelemetryProxy
-
-    internal constructor(telemetry: Telemetry) {
-        _telemetry = _TelemetryProxy(telemetry)
+    fun addLongTask(durationNs: Long, target: String) {
+        rumMonitor.addLongTask(durationNs, target)
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -190,7 +190,8 @@ internal sealed class RumRawEvent {
     internal data class SendTelemetry(
         val type: TelemetryType,
         val message: String,
-        val throwable: Throwable?,
+        val stack: String?,
+        val kind: String?,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -44,4 +44,6 @@ internal interface AdvancedRumMonitor : RumMonitor {
     fun sendDebugTelemetryEvent(message: String)
 
     fun sendErrorTelemetryEvent(message: String, throwable: Throwable?)
+
+    fun sendErrorTelemetryEvent(message: String, stack: String?, kind: String?)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -19,6 +19,7 @@ import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum._RumInternalProxy
 import com.datadog.android.rum.internal.CombinedRumSessionListener
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.debug.RumDebugListener
@@ -82,6 +83,8 @@ internal class DatadogRumMonitor(
     }
 
     internal var debugListener: RumDebugListener? = null
+
+    private val internalProxy = _RumInternalProxy(this)
 
     init {
         handler.postDelayed(keepAliveRunnable, KEEP_ALIVE_MS)
@@ -330,17 +333,17 @@ internal class DatadogRumMonitor(
     }
 
     override fun sendErrorTelemetryEvent(message: String, throwable: Throwable?) {
-        var stack: String? = null
-        var kind: String? = null
-        throwable?.let {
-            stack = it.loggableStackTrace()
-            kind = it.javaClass.canonicalName ?: it.javaClass.simpleName
-        }
+        var stack: String? = throwable?.loggableStackTrace()
+        var kind: String? = throwable?.javaClass?.canonicalName ?: throwable?.javaClass?.simpleName
         handleEvent(RumRawEvent.SendTelemetry(TelemetryType.ERROR, message, stack, kind))
     }
 
     override fun sendErrorTelemetryEvent(message: String, stack: String?, kind: String?) {
         handleEvent(RumRawEvent.SendTelemetry(TelemetryType.ERROR, message, stack, kind))
+    }
+
+    override fun _getInternal(): _RumInternalProxy? {
+        return internalProxy
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -12,6 +12,7 @@ import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.system.AndroidInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.devLogger
+import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -325,11 +326,21 @@ internal class DatadogRumMonitor(
     }
 
     override fun sendDebugTelemetryEvent(message: String) {
-        handleEvent(RumRawEvent.SendTelemetry(TelemetryType.DEBUG, message, null))
+        handleEvent(RumRawEvent.SendTelemetry(TelemetryType.DEBUG, message, null, null))
     }
 
     override fun sendErrorTelemetryEvent(message: String, throwable: Throwable?) {
-        handleEvent(RumRawEvent.SendTelemetry(TelemetryType.ERROR, message, throwable))
+        var stack: String? = null
+        var kind: String? = null
+        throwable?.let {
+            stack = it.loggableStackTrace()
+            kind = it.javaClass.canonicalName ?: it.javaClass.simpleName
+        }
+        handleEvent(RumRawEvent.SendTelemetry(TelemetryType.ERROR, message, stack, kind))
+    }
+
+    override fun sendErrorTelemetryEvent(message: String, stack: String?, kind: String?) {
+        handleEvent(RumRawEvent.SendTelemetry(TelemetryType.ERROR, message, stack, kind))
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/Telemetry.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/Telemetry.kt
@@ -21,6 +21,10 @@ internal class Telemetry {
         rumMonitor.sendErrorTelemetryEvent(message, throwable)
     }
 
+    fun error(message: String, stack: String?, kind: String?) {
+        rumMonitor.sendErrorTelemetryEvent(message, stack, kind)
+    }
+
     fun debug(message: String) {
         rumMonitor.sendDebugTelemetryEvent(message)
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -9,7 +9,6 @@ package com.datadog.android.telemetry.internal
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.sampling.Sampler
 import com.datadog.android.core.internal.time.TimeProvider
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumSessionListener
@@ -48,7 +47,7 @@ internal class TelemetryEventHandler(
                     rumContext,
                     event.message,
                     event.stack,
-                    event.kind,
+                    event.kind
                 )
             }
         }
@@ -107,7 +106,7 @@ internal class TelemetryEventHandler(
         rumContext: RumContext,
         message: String,
         stack: String?,
-        kind: String?,
+        kind: String?
     ): TelemetryErrorEvent {
         return TelemetryErrorEvent(
             dd = TelemetryErrorEvent.Dd(),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -47,7 +47,8 @@ internal class TelemetryEventHandler(
                     timestamp,
                     rumContext,
                     event.message,
-                    event.throwable
+                    event.stack,
+                    event.kind,
                 )
             }
         }
@@ -105,7 +106,8 @@ internal class TelemetryEventHandler(
         timestamp: Long,
         rumContext: RumContext,
         message: String,
-        throwable: Throwable?
+        stack: String?,
+        kind: String?,
     ): TelemetryErrorEvent {
         return TelemetryErrorEvent(
             dd = TelemetryErrorEvent.Dd(),
@@ -120,23 +122,20 @@ internal class TelemetryEventHandler(
             action = rumContext.actionId?.let { TelemetryErrorEvent.Action(it) },
             telemetry = TelemetryErrorEvent.Telemetry(
                 message = message,
-                error = throwable?.let {
-                    TelemetryErrorEvent.Error(
-                        stack = it.loggableStackTrace(),
-                        kind = it.javaClass.canonicalName ?: it.javaClass.simpleName
-                    )
-                }
+                error = TelemetryErrorEvent.Error(
+                    stack = stack,
+                    kind = kind
+                )
             )
         )
     }
 
     private val RumRawEvent.SendTelemetry.identity: EventIdentity
         get() {
-            val throwableClass = if (throwable != null) throwable::class.java else null
-            return EventIdentity(message, throwableClass)
+            return EventIdentity(message, kind)
         }
 
-    internal data class EventIdentity(val message: String, val throwableClass: Class<*>?)
+    internal data class EventIdentity(val message: String, val kind: String?)
 
     // endregion
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -121,10 +121,10 @@ internal class TelemetryEventHandler(
             action = rumContext.actionId?.let { TelemetryErrorEvent.Action(it) },
             telemetry = TelemetryErrorEvent.Telemetry(
                 message = message,
-                error = TelemetryErrorEvent.Error(
+                error = if (stack != null || kind != null) TelemetryErrorEvent.Error(
                     stack = stack,
                     kind = kind
-                )
+                ) else null
             )
         )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/InternalProxyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/InternalProxyTest.kt
@@ -9,13 +9,14 @@ package com.datadog.android
 import com.datadog.android.telemetry.internal.Telemetry
 import com.datadog.android.utils.forge.Configurator
 import com.nhaarman.mockitokotlin2.verify
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.mockito.Mockito
+import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
@@ -33,7 +34,7 @@ internal class InternalProxyTest {
         @StringForgery message: String
     ) {
         // Given
-        val mockTelemetry = Mockito.mock(Telemetry::class.java)
+        val mockTelemetry = mock(Telemetry::class.java)
         val proxy = _InternalProxy(mockTelemetry)
 
         // When
@@ -50,7 +51,7 @@ internal class InternalProxyTest {
         @StringForgery kind: String
     ) {
         // Given
-        val mockTelemetry = Mockito.mock(Telemetry::class.java)
+        val mockTelemetry = mock(Telemetry::class.java)
         val proxy = _InternalProxy(mockTelemetry)
 
         // When
@@ -58,5 +59,21 @@ internal class InternalProxyTest {
 
         // Then
         verify(mockTelemetry).error(message, stack, kind)
+    }
+
+    @Test
+    fun `M proxy telemetry to RumMonitor W error({message, throwable})`(
+        @StringForgery message: String,
+        @Forgery throwable: Throwable
+    ) {
+        // Given
+        val mockTelemetry = mock(Telemetry::class.java)
+        val proxy = _InternalProxy(mockTelemetry)
+
+        // When
+        proxy._telemetry.error(message, throwable)
+
+        // Then
+        verify(mockTelemetry).error(message, throwable)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/InternalProxyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/InternalProxyTest.kt
@@ -1,0 +1,91 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android
+
+import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
+import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.nhaarman.mockitokotlin2.verify
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class InternalProxyTest {
+
+    @Test
+    fun `M proxy addLongTask to RumMonitor W addLongTask()`(
+        @LongForgery time: Long,
+        @StringForgery target: String,
+    ) {
+        // Given
+        val proxy = _InternalProxy(GlobalRum.get() as? AdvancedRumMonitor)
+
+        // When
+        proxy._rumProxy?.addLongTask(time, target)
+
+        // Then
+        verify(rumMonitor.mockInstance).addLongTask(time, target)
+    }
+
+    @Test
+    fun `M proxy telemetry to RumMonitor W debug()`(
+        @StringForgery message: String
+    ) {
+        // Given
+        val proxy = _InternalProxy(GlobalRum.get() as? AdvancedRumMonitor)
+
+        // When
+        proxy._telemetry.debug(message)
+
+        // Then
+        verify(rumMonitor.mockInstance).sendDebugTelemetryEvent(message)
+    }
+
+    @Test
+    fun `M proxy telemetry to RumMonitor W error()`(
+        @StringForgery message: String,
+        @StringForgery stack: String,
+        @StringForgery kind: String
+    ) {
+        // Given
+        val proxy = _InternalProxy(GlobalRum.get() as? AdvancedRumMonitor)
+
+        // When
+        proxy._telemetry.error(message, stack, kind)
+
+        // Then
+        verify(rumMonitor.mockInstance).sendErrorTelemetryEvent(message, stack, kind)
+    }
+
+    companion object {
+        val rumMonitor = GlobalRumMonitorTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(rumMonitor)
+        }
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/InternalProxyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/InternalProxyTest.kt
@@ -37,7 +37,7 @@ internal class InternalProxyTest {
     @Test
     fun `M proxy addLongTask to RumMonitor W addLongTask()`(
         @LongForgery time: Long,
-        @StringForgery target: String,
+        @StringForgery target: String
     ) {
         // Given
         val proxy = _InternalProxy(GlobalRum.get() as? AdvancedRumMonitor)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
@@ -6,11 +6,8 @@
 
 package com.datadog.android.rum
 
-import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.tools.unit.annotations.TestConfigurationsProvider
-import com.datadog.tools.unit.extensions.TestConfigurationExtension
-import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -19,13 +16,13 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mockito.mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(TestConfigurationExtension::class),
     ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -38,22 +35,13 @@ internal class RumInternalProxyTest {
         @StringForgery target: String
     ) {
         // Given
-        val proxy = _RumInternalProxy(rumMonitor.mockInstance)
+        val mockRumMonitor = mock(AdvancedRumMonitor::class.java)
+        val proxy = _RumInternalProxy(mockRumMonitor)
 
         // When
         proxy.addLongTask(time, target)
 
         // Then
-        verify(rumMonitor.mockInstance).addLongTask(time, target)
-    }
-
-    companion object {
-        val rumMonitor = GlobalRumMonitorTestConfiguration()
-
-        @TestConfigurationsProvider
-        @JvmStatic
-        fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(rumMonitor)
-        }
+        verify(mockRumMonitor).addLongTask(time, target)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
@@ -4,59 +4,56 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android
+package com.datadog.android.rum
 
-import com.datadog.android.telemetry.internal.Telemetry
+import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.verify
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.mockito.Mockito
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
+    ExtendWith(TestConfigurationExtension::class),
     ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class InternalProxyTest {
+internal class RumInternalProxyTest {
 
     @Test
-    fun `M proxy telemetry to RumMonitor W debug()`(
-        @StringForgery message: String
+    fun `M proxy addLongTask to RumMonitor W addLongTask()`(
+        @LongForgery time: Long,
+        @StringForgery target: String
     ) {
         // Given
-        val mockTelemetry = Mockito.mock(Telemetry::class.java)
-        val proxy = _InternalProxy(mockTelemetry)
+        val proxy = _RumInternalProxy(rumMonitor.mockInstance)
 
         // When
-        proxy._telemetry.debug(message)
+        proxy.addLongTask(time, target)
 
         // Then
-        verify(mockTelemetry).debug(message)
+        verify(rumMonitor.mockInstance).addLongTask(time, target)
     }
 
-    @Test
-    fun `M proxy telemetry to RumMonitor W error()`(
-        @StringForgery message: String,
-        @StringForgery stack: String,
-        @StringForgery kind: String
-    ) {
-        // Given
-        val mockTelemetry = Mockito.mock(Telemetry::class.java)
-        val proxy = _InternalProxy(mockTelemetry)
+    companion object {
+        val rumMonitor = GlobalRumMonitorTestConfiguration()
 
-        // When
-        proxy._telemetry.error(message, stack, kind)
-
-        // Then
-        verify(mockTelemetry).error(message, stack, kind)
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(rumMonitor)
+        }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -11,6 +11,7 @@ import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.system.AndroidInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -1399,7 +1400,8 @@ internal class DatadogRumMonitorTest {
             )
             assertThat(lastValue.message).isEqualTo(message)
             assertThat(lastValue.type).isEqualTo(TelemetryType.DEBUG)
-            assertThat(lastValue.throwable).isNull()
+            assertThat(lastValue.stack).isNull()
+            assertThat(lastValue.kind).isNull()
         }
     }
 
@@ -1420,7 +1422,8 @@ internal class DatadogRumMonitorTest {
             )
             assertThat(lastValue.message).isEqualTo(message)
             assertThat(lastValue.type).isEqualTo(TelemetryType.ERROR)
-            assertThat(lastValue.throwable).isEqualTo(throwable)
+            assertThat(lastValue.stack).isEqualTo(throwable?.loggableStackTrace())
+            assertThat(lastValue.kind).isEqualTo(throwable?.javaClass?.canonicalName)
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -151,8 +151,8 @@ internal class TelemetryEventHandlerTest {
                 hasSessionId(rumContext.sessionId)
                 hasViewId(rumContext.viewId)
                 hasActionId(rumContext.actionId)
-                hasErrorStack(errorRawEvent.throwable?.loggableStackTrace())
-                hasErrorKind(errorRawEvent.throwable?.javaClass?.canonicalName)
+                hasErrorStack(errorRawEvent.stack)
+                hasErrorKind(errorRawEvent.kind)
             }
         }
     }
@@ -190,7 +190,7 @@ internal class TelemetryEventHandlerTest {
                     Locale.US,
                     TelemetryEventHandler.EventIdentity(
                         rawEvent.message,
-                        if (rawEvent.throwable != null) rawEvent.throwable::class.java else null
+                        rawEvent.kind
                     )
                 )
             )
@@ -223,8 +223,8 @@ internal class TelemetryEventHandlerTest {
                         hasSessionId(rumContext.sessionId)
                         hasViewId(rumContext.viewId)
                         hasActionId(rumContext.actionId)
-                        hasErrorStack(rawEvent.throwable?.loggableStackTrace())
-                        hasErrorKind(rawEvent.throwable?.javaClass?.canonicalName)
+                        hasErrorStack(rawEvent.stack)
+                        hasErrorKind(rawEvent.kind)
                     }
                 }
                 else -> throw IllegalArgumentException(
@@ -290,8 +290,8 @@ internal class TelemetryEventHandlerTest {
                             hasSessionId(rumContext.sessionId)
                             hasViewId(rumContext.viewId)
                             hasActionId(rumContext.actionId)
-                            hasErrorStack(events[it.index].throwable?.loggableStackTrace())
-                            hasErrorKind(events[it.index].throwable?.javaClass?.canonicalName)
+                            hasErrorStack(events[it.index].stack)
+                            hasErrorKind(events[it.index].kind)
                         }
                     }
                     else -> throw IllegalArgumentException(
@@ -373,9 +373,9 @@ internal class TelemetryEventHandlerTest {
                             hasSessionId(rumContext.sessionId)
                             hasViewId(rumContext.viewId)
                             hasActionId(rumContext.actionId)
-                            hasErrorStack(expectedEvents[it.index].throwable?.loggableStackTrace())
+                            hasErrorStack(expectedEvents[it.index].stack)
                             hasErrorKind(
-                                expectedEvents[it.index].throwable?.javaClass?.canonicalName
+                                expectedEvents[it.index].kind
                             )
                         }
                     }
@@ -429,15 +429,18 @@ internal class TelemetryEventHandlerTest {
         return RumRawEvent.SendTelemetry(
             TelemetryType.DEBUG,
             aString(),
+            null,
             null
         )
     }
 
     private fun Forge.createRumRawTelemetryErrorEvent(): RumRawEvent.SendTelemetry {
+        val throwable = aNullable { aThrowable() }
         return RumRawEvent.SendTelemetry(
             TelemetryType.ERROR,
             aString(),
-            aNullable { aThrowable() }
+            throwable?.loggableStackTrace(),
+            throwable?.javaClass?.canonicalName
         )
     }
 

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/telemetry/TelemetryPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/telemetry/TelemetryPlaygroundActivity.kt
@@ -66,24 +66,9 @@ internal class TelemetryPlaygroundActivity : AppCompatActivity(R.layout.main_act
         val errorMessage = intent.getStringExtra(TELEMETRY_ERROR_MESSAGE_KEY)
             ?: throw IllegalArgumentException("Telemetry error message should be provided")
 
-        GlobalRum.get().sendDebugTelemetry(debugMessage)
-        GlobalRum.get().sendErrorTelemetry(errorMessage)
-        GlobalRum.get()
-            .sendErrorTelemetry(errorMessage, forge.aThrowable())
-    }
-
-    private fun RumMonitor.sendDebugTelemetry(message: String) {
-        this.invokeMethod("sendDebugTelemetryEvent", message)
-    }
-
-    private fun RumMonitor.sendErrorTelemetry(message: String, throwable: Throwable? = null) {
-        this.invokeMethod("sendErrorTelemetryEvent", message, throwable)
-    }
-
-    private fun RumMonitor.invokeMethod(methodName: String, vararg args: Any?) {
-        val method = this::class.java.declaredMethods.first { it.name == methodName }
-        method.isAccessible = true
-        method.invoke(this, *args)
+        Datadog._internal._telemetry.debug(debugMessage)
+        Datadog._internal._telemetry.error(errorMessage)
+        Datadog._internal._telemetry.error(errorMessage, forge.aThrowable())
     }
 
     private fun Forge.aThrowable() = anElementFrom(anError(), anException())

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -26,5 +26,8 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.log.Logger#fun log(Int, String, Throwable? = null, Map<String, Any?> = emptyMap())
  * apiMethodSignature: com.datadog.android.plugin.DatadogPluginConfig#constructor(android.content.Context, String, String, com.datadog.android.privacy.TrackingConsent)
  * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setLogcatLogsEnabled(Boolean): Builder
- *
+ * apiMethodSignature: com.datadog.android._InternalProxy$_TelemetryProxy#fun debug(String)
+ * apiMethodSignature: com.datadog.android._InternalProxy$_TelemetryProxy#fun error(String, String?, String?)
+ * apiMethodSignature: com.datadog.android._InternalProxy$_TelemetryProxy#fun error(String, Throwable? = null)
+ * apiMethodSignature: com.datadog.android.rum._RumInternalProxy#fun addLongTask(Long, String)
  */


### PR DESCRIPTION
### What does this PR do?

This exposes some internal Datadog classes and methods for use by cross platform frameworks.

We expose internal methods through the _InternalProxy class, which is documented for internal use, and the `_internal` static member on the Datadog object. We keep Telemetry and RUM as separate proxies, in case we have to split them as v2 takes shape.

As part of exposing telemetry I also needed a way to report errors that are not Throwable, so I modified the event to replace the `throwable` member with `stack` and `kind`, and moved the creation of those strings farther up the chain (they were created on event write prior).

### Additional Notes

Please double check all my logic on the switch from `throwable` to `stack` and `kind`

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

