### PR TITLE
RUMM-2330 Generate Session Replay modes based on the JSON schemas

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KtLintConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/KtLintConfig.kt
@@ -26,6 +26,7 @@ fun Project.ktLintConfig() {
             exclude("**/com/datadog/android/core/model/**")
             exclude("**/com/datadog/android/tracing/model/**")
             exclude("**/com/datadog/android/log/model/**")
+            exclude("**/com/datadog/android/sessionreplay/model/**")
             include("**/kotlin/**")
         }
     }

--- a/library/dd-sdk-android-session-replay/.gitignore
+++ b/library/dd-sdk-android-session-replay/.gitignore
@@ -16,3 +16,6 @@ out/
 
 # Gradle files
 build/
+
+# Generated Poko
+src/main/kotlin/com/datadog/android/sessionreplay/model/

--- a/library/dd-sdk-android-session-replay/apiSurface
+++ b/library/dd-sdk-android-session-replay/apiSurface
@@ -1,0 +1,928 @@
+data class com.datadog.android.sessionreplay.model.FullSnapshotRecord
+  constructor(kotlin.Long, Data)
+  val type: kotlin.Long
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): FullSnapshotRecord
+  data class Data
+    constructor(kotlin.collections.List<Wireframe>)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Data
+  sealed class Wireframe
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class ShapeWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ShapeWireframe
+    data class TextWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null, kotlin.String, TextStyle, TextPosition? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TextWireframe
+    companion object 
+      fun fromJson(kotlin.String): Wireframe
+  data class ShapeStyle
+    constructor(kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeStyle
+  data class ShapeBorder
+    constructor(kotlin.String, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeBorder
+  data class TextStyle
+    constructor(kotlin.String, kotlin.Long, Type, kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextStyle
+  data class TextPosition
+    constructor(Padding? = null, Alignment? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextPosition
+  data class Padding
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Padding
+  data class Alignment
+    constructor(Horizontal? = null, Vertical? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Alignment
+  enum Type
+    constructor(kotlin.String)
+    - SERIF
+    - SANS_SERIF
+    - SCRIPT
+    - MONOSPACED
+    - DYNAMIC
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type
+  enum Horizontal
+    constructor(kotlin.String)
+    - LEFT
+    - RIGHT
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Horizontal
+  enum Vertical
+    constructor(kotlin.String)
+    - TOP
+    - BOTTOM
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Vertical
+sealed class com.datadog.android.sessionreplay.model.IncrementalData
+  abstract fun toJson(): com.google.gson.JsonElement
+  data class MutationData : IncrementalData
+    constructor(kotlin.collections.List<Add>? = null, kotlin.collections.List<Remove>? = null, kotlin.collections.List<WireframeUpdateMutation>? = null)
+    val source: kotlin.Long
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): MutationData
+  data class ViewportResizeData : IncrementalData
+    constructor(kotlin.Long? = null, kotlin.Long? = null)
+    val source: kotlin.Long
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ViewportResizeData
+  data class TouchData : IncrementalData
+    constructor(kotlin.collections.List<Position>? = null)
+    val source: kotlin.Long
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TouchData
+  companion object 
+    fun fromJson(kotlin.String): IncrementalData
+  data class Add
+    constructor(kotlin.Long? = null, Wireframe)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Add
+  data class Remove
+    constructor(kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Remove
+  sealed class WireframeUpdateMutation
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class TextWireframeUpdate : WireframeUpdateMutation
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, TextStyle? = null, TextPosition? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TextWireframeUpdate
+    data class ShapeWireframeUpdate : WireframeUpdateMutation
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ShapeWireframeUpdate
+    companion object 
+      fun fromJson(kotlin.String): WireframeUpdateMutation
+  data class Position
+    constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Position
+  sealed class Wireframe
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class ShapeWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ShapeWireframe
+    data class TextWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null, kotlin.String, TextStyle, TextPosition? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TextWireframe
+    companion object 
+      fun fromJson(kotlin.String): Wireframe
+  data class ShapeStyle
+    constructor(kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeStyle
+  data class ShapeBorder
+    constructor(kotlin.String, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeBorder
+  data class TextStyle
+    constructor(kotlin.String, kotlin.Long, Type, kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextStyle
+  data class TextPosition
+    constructor(Padding? = null, Alignment? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextPosition
+  data class Padding
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Padding
+  data class Alignment
+    constructor(Horizontal? = null, Vertical? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Alignment
+  enum Type
+    constructor(kotlin.String)
+    - SERIF
+    - SANS_SERIF
+    - SCRIPT
+    - MONOSPACED
+    - DYNAMIC
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type
+  enum Horizontal
+    constructor(kotlin.String)
+    - LEFT
+    - RIGHT
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Horizontal
+  enum Vertical
+    constructor(kotlin.String)
+    - TOP
+    - BOTTOM
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Vertical
+data class com.datadog.android.sessionreplay.model.IncrementalSnapshotRecord
+  constructor(kotlin.Long, IncrementalData)
+  val type: kotlin.Long
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): IncrementalSnapshotRecord
+  sealed class IncrementalData
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class MutationData : IncrementalData
+      constructor(kotlin.collections.List<Add>? = null, kotlin.collections.List<Remove>? = null, kotlin.collections.List<WireframeUpdateMutation>? = null)
+      val source: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): MutationData
+    data class ViewportResizeData : IncrementalData
+      constructor(kotlin.Long? = null, kotlin.Long? = null)
+      val source: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ViewportResizeData
+    data class TouchData : IncrementalData
+      constructor(kotlin.collections.List<Position>? = null)
+      val source: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TouchData
+    companion object 
+      fun fromJson(kotlin.String): IncrementalData
+  data class Add
+    constructor(kotlin.Long? = null, Wireframe)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Add
+  data class Remove
+    constructor(kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Remove
+  sealed class WireframeUpdateMutation
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class TextWireframeUpdate : WireframeUpdateMutation
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, TextStyle? = null, TextPosition? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TextWireframeUpdate
+    data class ShapeWireframeUpdate : WireframeUpdateMutation
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ShapeWireframeUpdate
+    companion object 
+      fun fromJson(kotlin.String): WireframeUpdateMutation
+  data class Position
+    constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Position
+  sealed class Wireframe
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class ShapeWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ShapeWireframe
+    data class TextWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null, kotlin.String, TextStyle, TextPosition? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TextWireframe
+    companion object 
+      fun fromJson(kotlin.String): Wireframe
+  data class ShapeStyle
+    constructor(kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeStyle
+  data class ShapeBorder
+    constructor(kotlin.String, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeBorder
+  data class TextStyle
+    constructor(kotlin.String, kotlin.Long, Type, kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextStyle
+  data class TextPosition
+    constructor(Padding? = null, Alignment? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextPosition
+  data class Padding
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Padding
+  data class Alignment
+    constructor(Horizontal? = null, Vertical? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Alignment
+  enum Type
+    constructor(kotlin.String)
+    - SERIF
+    - SANS_SERIF
+    - SCRIPT
+    - MONOSPACED
+    - DYNAMIC
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type
+  enum Horizontal
+    constructor(kotlin.String)
+    - LEFT
+    - RIGHT
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Horizontal
+  enum Vertical
+    constructor(kotlin.String)
+    - TOP
+    - BOTTOM
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Vertical
+sealed class com.datadog.android.sessionreplay.model.Record
+  abstract fun toJson(): com.google.gson.JsonElement
+  data class FullSnapshotRecord : Record
+    constructor(kotlin.Long, Data)
+    val type: kotlin.Long
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): FullSnapshotRecord
+  data class IncrementalSnapshotRecord : Record
+    constructor(kotlin.Long, IncrementalData)
+    val type: kotlin.Long
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): IncrementalSnapshotRecord
+  data class MetadataRecord : Record
+    constructor(kotlin.Long, Data1)
+    val type: kotlin.Long
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): MetadataRecord
+  data class FocusRecord : Record
+    constructor(kotlin.Long, Data2)
+    val type: kotlin.Long
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): FocusRecord
+  data class ViewEndRecord : Record
+    constructor(kotlin.Long)
+    val type: kotlin.Long
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ViewEndRecord
+  companion object 
+    fun fromJson(kotlin.String): Record
+  data class Data
+    constructor(kotlin.collections.List<Wireframe>)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Data
+  sealed class IncrementalData
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class MutationData : IncrementalData
+      constructor(kotlin.collections.List<Add>? = null, kotlin.collections.List<Remove>? = null, kotlin.collections.List<WireframeUpdateMutation>? = null)
+      val source: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): MutationData
+    data class ViewportResizeData : IncrementalData
+      constructor(kotlin.Long? = null, kotlin.Long? = null)
+      val source: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ViewportResizeData
+    data class TouchData : IncrementalData
+      constructor(kotlin.collections.List<Position>? = null)
+      val source: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TouchData
+    companion object 
+      fun fromJson(kotlin.String): IncrementalData
+  data class Data1
+    constructor(kotlin.Long, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Data1
+  data class Data2
+    constructor(kotlin.Boolean)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Data2
+  sealed class Wireframe
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class ShapeWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ShapeWireframe
+    data class TextWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null, kotlin.String, TextStyle, TextPosition? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TextWireframe
+    companion object 
+      fun fromJson(kotlin.String): Wireframe
+  data class Add
+    constructor(kotlin.Long? = null, Wireframe)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Add
+  data class Remove
+    constructor(kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Remove
+  sealed class WireframeUpdateMutation
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class TextWireframeUpdate : WireframeUpdateMutation
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, TextStyle? = null, TextPosition? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TextWireframeUpdate
+    data class ShapeWireframeUpdate : WireframeUpdateMutation
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ShapeWireframeUpdate
+    companion object 
+      fun fromJson(kotlin.String): WireframeUpdateMutation
+  data class Position
+    constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Position
+  data class ShapeStyle
+    constructor(kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeStyle
+  data class ShapeBorder
+    constructor(kotlin.String, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeBorder
+  data class TextStyle
+    constructor(kotlin.String, kotlin.Long, Type, kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextStyle
+  data class TextPosition
+    constructor(Padding? = null, Alignment? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextPosition
+  data class Padding
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Padding
+  data class Alignment
+    constructor(Horizontal? = null, Vertical? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Alignment
+  enum Type
+    constructor(kotlin.String)
+    - SERIF
+    - SANS_SERIF
+    - SCRIPT
+    - MONOSPACED
+    - DYNAMIC
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type
+  enum Horizontal
+    constructor(kotlin.String)
+    - LEFT
+    - RIGHT
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Horizontal
+  enum Vertical
+    constructor(kotlin.String)
+    - TOP
+    - BOTTOM
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Vertical
+data class com.datadog.android.sessionreplay.model.Segment
+  constructor(Application, Session, View, Source, kotlin.Long, kotlin.Long, kotlin.Boolean, kotlin.Long, CreationReason = CreationReason.INIT, kotlin.Long, kotlin.collections.List<Record>)
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): Segment
+  data class Application
+    constructor(kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Application
+  data class Session
+    constructor(kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Session
+  data class View
+    constructor(kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): View
+  sealed class Record
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class FullSnapshotRecord : Record
+      constructor(kotlin.Long, Data)
+      val type: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): FullSnapshotRecord
+    data class IncrementalSnapshotRecord : Record
+      constructor(kotlin.Long, IncrementalData)
+      val type: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): IncrementalSnapshotRecord
+    data class MetadataRecord : Record
+      constructor(kotlin.Long, Data1)
+      val type: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): MetadataRecord
+    data class FocusRecord : Record
+      constructor(kotlin.Long, Data2)
+      val type: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): FocusRecord
+    data class ViewEndRecord : Record
+      constructor(kotlin.Long)
+      val type: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ViewEndRecord
+    companion object 
+      fun fromJson(kotlin.String): Record
+  data class Data
+    constructor(kotlin.collections.List<Wireframe>)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Data
+  sealed class IncrementalData
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class MutationData : IncrementalData
+      constructor(kotlin.collections.List<Add>? = null, kotlin.collections.List<Remove>? = null, kotlin.collections.List<WireframeUpdateMutation>? = null)
+      val source: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): MutationData
+    data class ViewportResizeData : IncrementalData
+      constructor(kotlin.Long? = null, kotlin.Long? = null)
+      val source: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ViewportResizeData
+    data class TouchData : IncrementalData
+      constructor(kotlin.collections.List<Position>? = null)
+      val source: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TouchData
+    companion object 
+      fun fromJson(kotlin.String): IncrementalData
+  data class Data1
+    constructor(kotlin.Long, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Data1
+  data class Data2
+    constructor(kotlin.Boolean)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Data2
+  sealed class Wireframe
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class ShapeWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ShapeWireframe
+    data class TextWireframe : Wireframe
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null, kotlin.String, TextStyle, TextPosition? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TextWireframe
+    companion object 
+      fun fromJson(kotlin.String): Wireframe
+  data class Add
+    constructor(kotlin.Long? = null, Wireframe)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Add
+  data class Remove
+    constructor(kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Remove
+  sealed class WireframeUpdateMutation
+    abstract fun toJson(): com.google.gson.JsonElement
+    data class TextWireframeUpdate : WireframeUpdateMutation
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, TextStyle? = null, TextPosition? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): TextWireframeUpdate
+    data class ShapeWireframeUpdate : WireframeUpdateMutation
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null)
+      val type: kotlin.String
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): ShapeWireframeUpdate
+    companion object 
+      fun fromJson(kotlin.String): WireframeUpdateMutation
+  data class Position
+    constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Position
+  data class ShapeStyle
+    constructor(kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeStyle
+  data class ShapeBorder
+    constructor(kotlin.String, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeBorder
+  data class TextStyle
+    constructor(kotlin.String, kotlin.Long, Type, kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextStyle
+  data class TextPosition
+    constructor(Padding? = null, Alignment? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextPosition
+  data class Padding
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Padding
+  data class Alignment
+    constructor(Horizontal? = null, Vertical? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Alignment
+  enum Source
+    constructor(kotlin.String)
+    - ANDROID
+    - IOS
+    - BROWSER
+    - FLUTTER
+    - REACT_NATIVE
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Source
+  enum CreationReason
+    constructor(kotlin.String)
+    - INIT
+    - SEGMENT_DURATION_LIMIT
+    - SEGMENT_BYTES_LIMIT
+    - VIEW_CHANGE
+    - BEFORE_UNLOAD
+    - VISIBILITY_HIDDEN
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): CreationReason
+  enum Type
+    constructor(kotlin.String)
+    - SERIF
+    - SANS_SERIF
+    - SCRIPT
+    - MONOSPACED
+    - DYNAMIC
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type
+  enum Horizontal
+    constructor(kotlin.String)
+    - LEFT
+    - RIGHT
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Horizontal
+  enum Vertical
+    constructor(kotlin.String)
+    - TOP
+    - BOTTOM
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Vertical
+data class com.datadog.android.sessionreplay.model.ShapeBorder
+  constructor(kotlin.String, kotlin.Long)
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): ShapeBorder
+data class com.datadog.android.sessionreplay.model.ShapeStyle
+  constructor(kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null)
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): ShapeStyle
+data class com.datadog.android.sessionreplay.model.TextPosition
+  constructor(Padding? = null, Alignment? = null)
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): TextPosition
+  data class Padding
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Padding
+  data class Alignment
+    constructor(Horizontal? = null, Vertical? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Alignment
+  enum Horizontal
+    constructor(kotlin.String)
+    - LEFT
+    - RIGHT
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Horizontal
+  enum Vertical
+    constructor(kotlin.String)
+    - TOP
+    - BOTTOM
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Vertical
+data class com.datadog.android.sessionreplay.model.TextStyle
+  constructor(kotlin.String, kotlin.Long, Type, kotlin.String)
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): TextStyle
+  enum Type
+    constructor(kotlin.String)
+    - SERIF
+    - SANS_SERIF
+    - SCRIPT
+    - MONOSPACED
+    - DYNAMIC
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type
+sealed class com.datadog.android.sessionreplay.model.Wireframe
+  abstract fun toJson(): com.google.gson.JsonElement
+  data class ShapeWireframe : Wireframe
+    constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null)
+    val type: kotlin.String
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeWireframe
+  data class TextWireframe : Wireframe
+    constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null, kotlin.String, TextStyle, TextPosition? = null)
+    val type: kotlin.String
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextWireframe
+  companion object 
+    fun fromJson(kotlin.String): Wireframe
+  data class ShapeStyle
+    constructor(kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeStyle
+  data class ShapeBorder
+    constructor(kotlin.String, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeBorder
+  data class TextStyle
+    constructor(kotlin.String, kotlin.Long, Type, kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextStyle
+  data class TextPosition
+    constructor(Padding? = null, Alignment? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextPosition
+  data class Padding
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Padding
+  data class Alignment
+    constructor(Horizontal? = null, Vertical? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Alignment
+  enum Type
+    constructor(kotlin.String)
+    - SERIF
+    - SANS_SERIF
+    - SCRIPT
+    - MONOSPACED
+    - DYNAMIC
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type
+  enum Horizontal
+    constructor(kotlin.String)
+    - LEFT
+    - RIGHT
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Horizontal
+  enum Vertical
+    constructor(kotlin.String)
+    - TOP
+    - BOTTOM
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Vertical
+sealed class com.datadog.android.sessionreplay.model.WireframeUpdateMutation
+  abstract fun toJson(): com.google.gson.JsonElement
+  data class TextWireframeUpdate : WireframeUpdateMutation
+    constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, TextStyle? = null, TextPosition? = null)
+    val type: kotlin.String
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextWireframeUpdate
+  data class ShapeWireframeUpdate : WireframeUpdateMutation
+    constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null)
+    val type: kotlin.String
+    override fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeWireframeUpdate
+  companion object 
+    fun fromJson(kotlin.String): WireframeUpdateMutation
+  data class ShapeStyle
+    constructor(kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeStyle
+  data class ShapeBorder
+    constructor(kotlin.String, kotlin.Long)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): ShapeBorder
+  data class TextStyle
+    constructor(kotlin.String, kotlin.Long, Type, kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextStyle
+  data class TextPosition
+    constructor(Padding? = null, Alignment? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TextPosition
+  data class Padding
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Padding
+  data class Alignment
+    constructor(Horizontal? = null, Vertical? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Alignment
+  enum Type
+    constructor(kotlin.String)
+    - SERIF
+    - SANS_SERIF
+    - SCRIPT
+    - MONOSPACED
+    - DYNAMIC
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type
+  enum Horizontal
+    constructor(kotlin.String)
+    - LEFT
+    - RIGHT
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Horizontal
+  enum Vertical
+    constructor(kotlin.String)
+    - TOP
+    - BOTTOM
+    - CENTER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Vertical

--- a/library/dd-sdk-android-session-replay/build.gradle.kts
+++ b/library/dd-sdk-android-session-replay/build.gradle.kts
@@ -75,6 +75,7 @@ android {
 
 dependencies {
     implementation(libs.kotlin)
+    implementation(libs.gson)
 
     testImplementation(project(":tools:unit"))
     testImplementation(libs.bundles.jUnit5)
@@ -84,8 +85,15 @@ dependencies {
     detekt(libs.detektCli)
 }
 
+apply(from = "clone_session_replay_schema.gradle.kts")
+apply(from = "generate_session_replay_models.gradle.kts")
+
 kotlinConfig()
-detektConfig()
+detektConfig(
+    excludes = listOf(
+        "**/com/datadog/android/sessionreplay/model/**"
+    )
+)
 ktLintConfig()
 junitConfig()
 javadocConfig()

--- a/library/dd-sdk-android-session-replay/clone_session_replay_schema.gradle.kts
+++ b/library/dd-sdk-android-session-replay/clone_session_replay_schema.gradle.kts
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+import com.datadog.gradle.plugin.gitclone.GitCloneDependenciesTask
+
+tasks.register<GitCloneDependenciesTask>("cloneSessionReplaySchema") {
+    extension.apply {
+        clone(
+            "https://github.com/DataDog/rum-events-format.git",
+            "schemas/session-replay/",
+            destinationFolder = "src/main/json/session-replay",
+            ref = "master"
+        )
+    }
+}

--- a/library/dd-sdk-android-session-replay/generate_session_replay_models.gradle.kts
+++ b/library/dd-sdk-android-session-replay/generate_session_replay_models.gradle.kts
@@ -1,0 +1,55 @@
+import com.datadog.gradle.plugin.apisurface.ApiSurfacePlugin
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+
+val generateSessionReplayModelsTaskName = "generateSessionReplayModels"
+val generateSessionReplayMobileModelsTaskName = "generateSessionReplayMobileModels"
+
+tasks.register(
+    "generateSessionReplayModels",
+    com.datadog.gradle.plugin.jsonschema.GenerateJsonSchemaTask::class.java
+) {
+    inputDirPath = "src/main/json/session-replay"
+    targetPackageName = "com.datadog.android.sessionreplay.model"
+    ignoredFiles = arrayOf(
+        "_common-record-schema.json",
+        "focus-record-schema.json",
+        "metadata-record-schema.json",
+        "view-end-record-schema.json"
+    )
+}
+
+tasks.register(
+    "generateSessionReplayMobileModels",
+    com.datadog.gradle.plugin.jsonschema.GenerateJsonSchemaTask::class.java
+) {
+    inputDirPath = "src/main/json/session-replay/mobile"
+    targetPackageName = "com.datadog.android.sessionreplay.model"
+    ignoredFiles = arrayOf(
+        "_common-wireframe-schema.json",
+        "_common-shape-wireframe-schema.json",
+        "_common-shape-wireframe-update-schema.json",
+        "_common-wireframe-schema.json",
+        "_common-wireframe-update-schema.json",
+        "mutation-data-schema.json",
+        "viewport-resize-data-schema.json",
+        "touch-data-schema.json",
+        "shape-wireframe-schema.json",
+        "text-wireframe-schema.json",
+        "shape-wireframe-update-schema.json",
+        "text-wireframe-update-schema.json"
+    )
+}
+
+afterEvaluate {
+    tasks.findByName(ApiSurfacePlugin.TASK_GEN_API_SURFACE)
+        ?.dependsOn(
+            generateSessionReplayModelsTaskName,
+            generateSessionReplayMobileModelsTaskName
+        )
+    tasks.withType(KotlinCompile::class.java) {
+        dependsOn(
+            generateSessionReplayModelsTaskName,
+            generateSessionReplayMobileModelsTaskName
+        )
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/_common-record-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/_common-record-schema.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "_common-record-schema.json",
+    "title": "CommonRecordSchema",
+    "type": "object",
+    "description": "Schema of common properties for a Record event type.",
+    "required": [
+        "timestamp"
+    ],
+    "properties": {
+        "timestamp": {
+            "type": "integer",
+            "description": "Defines the UTC time in milliseconds when this Record was performed.",
+            "readOnly": true
+        }
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/focus-record-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/focus-record-schema.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "focus-record-schema.json",
+    "title": "FocusRecord",
+    "type": "object",
+    "description": "Schema of a Record type which contains focus information.",
+    "allOf": [
+        {
+            "$ref": "_common-record-schema.json"
+        },
+        {
+            "required": [
+                "type",
+                "data"
+            ],
+            "properties": {
+                "type": {
+                    "type": "integer",
+                    "description": "The type of this Record.",
+                    "const": 6,
+                    "readOnly": true
+                },
+                "data": {
+                    "type": "object",
+                    "readOnly": true,
+                    "required": [
+                        "has_focus"
+                    ],
+                    "properties": {
+                        "has_focus": {
+                            "type": "boolean",
+                            "description": "Whether this screen has a focus or not. For now it will always be true for mobile.",
+                            "readOnly": true
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/metadata-record-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/metadata-record-schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "metadata-record-schema.json",
+    "title": "MetadataRecord",
+    "type": "object",
+    "description": "Schema of a Record which contains the screen properties.",
+    "allOf": [
+        {
+            "$ref": "_common-record-schema.json"
+        },
+        {
+            "required": [
+                "type",
+                "data"
+            ],
+            "properties": {
+                "type": {
+                    "type": "integer",
+                    "description": "The type of this Record.",
+                    "const": 4,
+                    "readOnly": true
+                },
+                "data": {
+                    "type": "object",
+                    "description": "The data contained by this record.",
+                    "readOnly": true,
+                    "required": [
+                        "width",
+                        "height"
+                    ],
+                    "properties": {
+                        "width": {
+                            "type": "integer",
+                            "description": "The width of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the normalized width is the current width divided by 2.",
+                            "readOnly": true
+                        },
+                        "height": {
+                            "type": "integer",
+                            "description": "The height of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the normalized height is the current height divided by 2.",
+                            "readOnly": true
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/_common-shape-wireframe-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/_common-shape-wireframe-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "_common-shape-wireframe-schema.json",
+  "title": "CommonShapeWireframe",
+  "type": "object",
+  "description": "Schema of common properties for ShapeWireframe events type and all its sub - types.",
+  "allOf": [
+    {
+      "$ref": "_common-wireframe-schema.json"
+    },
+    {
+      "properties": {
+        "shapeStyle": {
+          "type": "object",
+          "description": "The style of this wireframe.",
+          "$ref": "shape-style-schema.json",
+          "readOnly": true
+        },
+        "border": {
+          "type": "object",
+          "description": "The border properties of this wireframe. The default value is null (no-border).",
+          "$ref": "shape-border-schema.json",
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/_common-shape-wireframe-update-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/_common-shape-wireframe-update-schema.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "_common-shape-wireframe-update-schema.json",
+  "title": "CommonShapeWireframeUpdate",
+  "type": "object",
+  "description": "Schema of common properties for ShapeWireframeUpdate events type and all its sub - types.",
+  "allOf": [
+    {
+      "$ref": "_common-wireframe-update-schema.json"
+    },
+    {
+      "properties": {
+        "shapeStyle": {
+          "type": "object",
+          "description": "The style of this wireframe.",
+          "$ref": "shape-style-schema.json",
+          "readOnly": true
+        },
+        "border": {
+          "type": "object",
+          "description": "The border properties of this wireframe. The default value is null (no-border).",
+          "$ref": "shape-border-schema.json",
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/_common-wireframe-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/_common-wireframe-schema.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "_common-wireframe-schema.json",
+  "title": "CommonWireframe",
+  "type": "object",
+  "description": "Schema of common properties for Wireframe events type.",
+  "required": [
+    "id",
+    "x",
+    "y",
+    "width",
+    "height"
+  ],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.",
+      "readOnly": true
+    },
+    "x": {
+      "type": "integer",
+      "description": "The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.",
+      "readOnly": true
+    },
+    "y": {
+      "type": "integer",
+      "description": "The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.",
+      "readOnly": true
+    },
+    "width": {
+      "type": "integer",
+      "description": "The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.",
+      "readOnly": true
+    },
+    "height": {
+      "type": "integer",
+      "description": "The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.",
+      "readOnly": true
+    }
+  }
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/_common-wireframe-update-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/_common-wireframe-update-schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "_common-wireframe-update-schema.json",
+  "title": "CommonWireframeUpdate",
+  "type": "object",
+  "description": "Schema of common properties for WireframeUpdate events type.",
+  "required": [
+    "id"
+  ],
+  "properties": {
+    "id": {
+      "type": "integer",
+      "description": "Defines the unique ID of the wireframe. This is persistent throughout the view lifetime.",
+      "readOnly": true
+    },
+    "x": {
+      "type": "integer",
+      "description": "The position in pixels on X axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.",
+      "readOnly": true
+    },
+    "y": {
+      "type": "integer",
+      "description": "The position in pixels on Y axis of the UI element in absolute coordinates. The anchor point is always the top-left corner of the wireframe.",
+      "readOnly": true
+    },
+    "width": {
+      "type": "integer",
+      "description": "The width in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width of all UI elements is divided by 2 to get a normalized width.",
+      "readOnly": true
+    },
+    "height": {
+      "type": "integer",
+      "description": "The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.",
+      "readOnly": true
+    }
+  }
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/full-snapshot-record-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/full-snapshot-record-schema.json
@@ -1,0 +1,43 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "full-snapshot-record-schema.json",
+    "title": "FullSnapshotRecord",
+    "type": "object",
+    "description": "Schema of a Record type which contains the full snapshot of a screen.",
+    "allOf": [
+        {
+            "$ref": "../_common-record-schema.json"
+        },
+        {
+            "required": [
+                "type",
+                "data"
+            ],
+            "properties": {
+                "type": {
+                    "type": "integer",
+                    "description": "The type of this Record.",
+                    "const": 2,
+                    "readOnly": true
+                },
+                "data": {
+                    "type": "object",
+                    "readOnly": true,
+                    "required": [
+                        "wireframes"
+                    ],
+                    "properties": {
+                        "wireframes": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "wireframe-schema.json"
+                            },
+                            "description": "The Wireframes contained by this Record.",
+                            "readOnly": true
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/incremental-data-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/incremental-data-schema.json
@@ -1,0 +1,18 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "incremental-data-schema.json",
+    "title": "IncrementalData",
+    "type": "object",
+    "description": "Schema of a Session Replay IncrementalData type.",
+    "oneOf": [
+        {
+            "$ref": "mutation-data-schema.json"
+        },
+        {
+            "$ref": "viewport-resize-data-schema.json"
+        },
+        {
+            "$ref": "touch-data-schema.json"
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/incremental-snapshot-record-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/incremental-snapshot-record-schema.json
@@ -1,0 +1,31 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "incremental-snapshot-record-schema.json",
+    "title": "IncrementalSnapshotRecord",
+    "type": "object",
+    "description": "Schema of a Record type which contains mutations of a screen.",
+    "allOf": [
+        {
+            "$ref": "../_common-record-schema.json"
+        },
+        {
+            "required": [
+                "type",
+                "data"
+            ],
+            "properties": {
+                "type": {
+                    "type": "integer",
+                    "description": "The type of this Record.",
+                    "const": 3,
+                    "readOnly": true
+                },
+                "data": {
+                    "$ref": "incremental-data-schema.json",
+                    "description": "The IncrementalData contained by this Record.",
+                    "readOnly": true
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/mutation-data-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/mutation-data-schema.json
@@ -1,0 +1,67 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "mutation-data-schema.json",
+    "title": "MutationData",
+    "type": "object",
+    "description": "Schema of a MutationData.",
+    "allOf": [
+        {
+            "properties": {
+                "source": {
+                    "type": "integer",
+                    "const": 1,
+                    "description": "The source of this type of incremental data.",
+                    "readOnly": true
+                },
+                "adds": {
+                    "type": "array",
+                    "readOnly": true,
+                    "items": {
+                        "required": [
+                            "wireframe"
+                        ],
+                        "properties": {
+                            "previousId": {
+                                "type": "integer",
+                                "description": "The previous wireframe id next or after which this new wireframe is drawn or attached to, respectively.",
+                                "readOnly": true
+                            },
+                            "wireframe": {
+                                "$ref": "wireframe-schema.json",
+                                "description": "The new wireframe that needs to be added to the screen.",
+                                "readOnly": true
+                            }
+                        }
+                    },
+                    "description": "Contains the newly added wireframes."
+                },
+                "removes": {
+                    "type": "array",
+                    "readOnly": true,
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "id"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "description": "The id of the wireframe that needs to be removed.",
+                                "readOnly": true
+                            }
+                        }
+                    },
+                    "description": "Contains the removed wireframes as an array of ids."
+                },
+                "updates": {
+                    "type": "array",
+                    "readOnly": true,
+                    "items": {
+                        "$ref": "wireframe-update-mutation-schema.json"
+                    },
+                    "description": "Contains the updated wireframes mutations."
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/shape-border-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/shape-border-schema.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "shape-border-schema.json",
+    "title": "ShapeBorder",
+    "type": "object",
+    "description": "Schema of all properties of a ShapeBorder.",
+    "allOf": [
+        {
+            "required": [
+                "color",
+                "width"
+            ],
+            "properties": {
+                "color": {
+                    "type": "string",
+                    "pattern": "(?i)^#[a-f0-9]{6}([a-f0-9]{2})?$",
+                    "description": "The border color as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.",
+                    "readOnly": true
+                },
+                "width": {
+                    "type": "integer",
+                    "description": "The width of the border in pixels.",
+                    "readOnly": true
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/shape-style-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/shape-style-schema.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "shape-style-schema.json",
+    "title": "ShapeStyle",
+    "type": "object",
+    "description": "Schema of all properties of a ShapeStyle.",
+    "allOf": [
+        {
+            "properties": {
+                "backgroundColor": {
+                    "type": "string",
+                    "pattern": "(?i)^#[a-f0-9]{6}([a-f0-9]{2})?$",
+                    "description": "The background color for this wireframe as a String hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional. The default value is #FFFFFF00.",
+                    "readOnly": true
+                },
+                "opacity": {
+                    "type": "number",
+                    "description": "The opacity of this wireframe. Takes values from 0 to 1, default value is 1.",
+                    "readOnly": true
+                },
+                "cornerRadius": {
+                    "type": "number",
+                    "description": "The corner(border) radius of this wireframe in pixels. The default value is 0.",
+                    "readOnly": true
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/shape-wireframe-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/shape-wireframe-schema.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "shape-wireframe-schema.json",
+  "title": "ShapeWireframe",
+  "type": "object",
+  "description": "Schema of all properties of a ShapeWireframe.",
+  "allOf": [
+    {
+      "$ref": "_common-shape-wireframe-schema.json"
+    },
+    {
+      "required": [
+        "type"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the wireframe.",
+          "const": "shape",
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/shape-wireframe-update-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/shape-wireframe-update-schema.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "shape-wireframe-update-schema.json",
+    "title": "ShapeWireframeUpdate",
+    "type": "object",
+    "description": "Schema of a ShapeWireframeUpdate.",
+    "allOf": [
+        {
+            "$ref": "_common-shape-wireframe-update-schema.json"
+        },
+        {
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the wireframe.",
+                    "const": "shape",
+                    "readOnly": true
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/text-position-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/text-position-schema.json
@@ -1,0 +1,65 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "text-position-schema.json",
+    "title": "TextPosition",
+    "type": "object",
+    "description": "Schema of all properties of a TextPosition.",
+    "allOf": [
+        {
+            "properties": {
+                "padding": {
+                    "type": "object",
+                    "properties": {
+                        "top": {
+                            "type": "integer",
+                            "description": "The top padding in pixels. The default value is 0.",
+                            "readOnly": true
+                        },
+                        "bottom": {
+                            "type": "integer",
+                            "description": "The bottom padding in pixels. The default value is 0.",
+                            "readOnly": true
+                        },
+                        "left": {
+                            "type": "integer",
+                            "description": "The left padding in pixels. The default value is 0.",
+                            "readOnly": true
+                        },
+                        "right": {
+                            "type": "integer",
+                            "description": "The right padding in pixels. The default value is 0.",
+                            "readOnly": true
+                        }
+                    },
+                    "readOnly": true
+                },
+                "alignment": {
+                    "type": "object",
+                    "properties": {
+                        "horizontal": {
+                            "type": "string",
+                            "description": "The horizontal text alignment. The default value is `left`.",
+                            "enum": [
+                                "left",
+                                "right",
+                                "center"
+                            ],
+                            "readOnly": true
+                        },
+                        "vertical": {
+                            "type": "string",
+                            "description": "The vertical text alignment. The default value is `top`.",
+                            "enum": [
+                                "top",
+                                "bottom",
+                                "center"
+                            ],
+                            "readOnly": true
+                        }
+                    },
+                    "readOnly": true
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/text-style-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/text-style-schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "text-style-schema.json",
+    "title": "TextStyle",
+    "type": "object",
+    "description": "Schema of all properties of a TextStyle.",
+    "allOf": [
+        {
+            "required": [
+                "color",
+                "family",
+                "size",
+                "type"
+            ],
+            "properties": {
+                "family": {
+                    "type": "string",
+                    "description": "The font family.",
+                    "readOnly": true
+                },
+                "size": {
+                    "type": "integer",
+                    "description": "The font size in pixels.",
+                    "readOnly": true
+                },
+                "type": {
+                    "type": "string",
+                    "enum": [
+                        "serif",
+                        "sans-serif",
+                        "script",
+                        "monospaced",
+                        "dynamic"
+                    ],
+                    "description": "The font type.",
+                    "readOnly": true
+                },
+                "color": {
+                    "type": "string",
+                    "pattern": "(?i)^#[a-f0-9]{6}([a-f0-9]{2})?$",
+                    "description": "The font color as a string hexadecimal. Follows the #RRGGBBAA color format with the alpha value as optional.",
+                    "readOnly": true
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/text-wireframe-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/text-wireframe-schema.json
@@ -1,0 +1,44 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "text-wireframe-schema.json",
+  "title": "TextWireframe",
+  "type": "object",
+  "description": "Schema of all properties of a TextWireframe.",
+  "allOf": [
+    {
+      "$ref": "_common-shape-wireframe-schema.json"
+    },
+    {
+      "required": [
+        "text",
+        "type",
+        "textStyle"
+      ],
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The type of the wireframe.",
+          "const": "text",
+          "readOnly": true
+        },
+        "text": {
+          "type": "string",
+          "description": "The text value of the wireframe.",
+          "readOnly": false
+        },
+        "textStyle": {
+          "type": "object",
+          "description": "The style of this text.",
+          "$ref": "text-style-schema.json",
+          "readOnly": true
+        },
+        "textPosition": {
+          "type": "object",
+          "description": "The position of the text in the wireframe.",
+          "$ref": "text-position-schema.json",
+          "readOnly": true
+        }
+      }
+    }
+  ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/text-wireframe-update-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/text-wireframe-update-schema.json
@@ -1,0 +1,42 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "text-wireframe-update-schema.json",
+    "title": "TextWireframeUpdate",
+    "type": "object",
+    "description": "Schema of all properties of a TextWireframeUpdate.",
+    "allOf": [
+        {
+            "$ref": "_common-shape-wireframe-update-schema.json"
+        },
+        {
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "string",
+                    "description": "The type of the wireframe.",
+                    "const": "text",
+                    "readOnly": true
+                },
+                "text": {
+                    "type": "string",
+                    "description": "The text value of the wireframe.",
+                    "readOnly": false
+                },
+                "textStyle": {
+                    "type": "object",
+                    "description": "The style of this text.",
+                    "$ref": "text-style-schema.json",
+                    "readOnly": true
+                },
+                "textPosition": {
+                    "type": "object",
+                    "description": "The position of the text in the wireframe.",
+                    "$ref": "text-position-schema.json",
+                    "readOnly": true
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/touch-data-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/touch-data-schema.json
@@ -1,0 +1,55 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "touch-data-schema.json",
+    "title": "TouchData",
+    "type": "object",
+    "description": "Schema of a TouchData.",
+    "allOf": [
+        {
+            "properties": {
+                "source": {
+                    "type": "integer",
+                    "const": 2,
+                    "description": "The source of this type of incremental data.",
+                    "readOnly": true
+                },
+                "positions": {
+                    "type": "array",
+                    "readOnly": true,
+                    "items": {
+                        "type": "object",
+                        "required": [
+                            "id",
+                            "x",
+                            "y",
+                            "timestamp"
+                        ],
+                        "properties": {
+                            "id": {
+                                "type": "integer",
+                                "description": "The touch id of the touch event this position corresponds to. In mobile it is possible to have multiple touch events (fingers touching the screen) happening at the same time.",
+                                "readOnly": true
+                            },
+                            "x": {
+                                "type": "integer",
+                                "description": "The x coordinate value of the position.",
+                                "readOnly": true
+                            },
+                            "y": {
+                                "type": "integer",
+                                "description": "The y coordinate value of the position.",
+                                "readOnly": true
+                            },
+                            "timestamp": {
+                                "type": "integer",
+                                "description": "The UTC timestamp in milliseconds corresponding to the moment the position change was recorded. Each timestamp is computed as the UTC interval since 00:00:00.000 01.01.1970.",
+                                "readOnly": true
+                            }
+                        }
+                    },
+                    "description": "Contains the positions of the finger on the screen during the touchDown/touchUp event lifecycle."
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/viewport-resize-data-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/viewport-resize-data-schema.json
@@ -1,0 +1,29 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "viewport-resize-data-schema.json",
+    "title": "ViewportResizeData",
+    "type": "object",
+    "description": "Schema of a ViewportResizeData.",
+    "allOf": [
+        {
+            "properties": {
+                "source": {
+                    "type": "integer",
+                    "const": 3,
+                    "description": "The source of this type of incremental data.",
+                    "readOnly": true
+                },
+                "width": {
+                    "type": "integer",
+                    "description": "The new width of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the width is divided by 2 to get a normalized width.",
+                    "readOnly": true
+                },
+                "height": {
+                    "type": "integer",
+                    "description": "The new height of the screen in pixels, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height is divided by 2 to get a normalized height.",
+                    "readOnly": true
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/wireframe-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/wireframe-schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "wireframe-schema.json",
+    "title": "Wireframe",
+    "type": "object",
+    "description": "Schema of a Wireframe type.",
+    "oneOf": [
+        {
+            "$ref": "shape-wireframe-schema.json"
+        },
+        {
+            "$ref": "text-wireframe-schema.json"
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/wireframe-update-mutation-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/mobile/wireframe-update-mutation-schema.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "wireframe-update-mutation-schema.json",
+    "title": "WireframeUpdateMutation",
+    "type": "object",
+    "description": "Schema of a WireframeUpdateMutation type.",
+    "oneOf": [
+        {
+            "$ref": "text-wireframe-update-schema.json"
+        },
+        {
+            "$ref": "shape-wireframe-update-schema.json"
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/record-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/record-schema.json
@@ -1,0 +1,24 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "record-schema.json",
+    "title": "Record",
+    "type": "object",
+    "description": "Schema of a Session Replay Record.",
+    "oneOf": [
+        {
+            "$ref": "mobile/full-snapshot-record-schema.json"
+        },
+        {
+            "$ref": "mobile/incremental-snapshot-record-schema.json"
+        },
+        {
+            "$ref": "metadata-record-schema.json"
+        },
+        {
+            "$ref": "focus-record-schema.json"
+        },
+        {
+            "$ref": "view-end-record-schema.json"
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/segment-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/segment-schema.json
@@ -1,0 +1,133 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "segment-schema.json",
+    "title": "Segment",
+    "type": "object",
+    "description": "Schema of a Session Replay data Segment.",
+    "allOf": [
+        {
+            "required": [
+                "application",
+                "session",
+                "view",
+                "source",
+                "start",
+                "end",
+                "has_full_snapshot_record",
+                "records_count",
+                "creation_reason",
+                "index_in_view",
+                "records"
+            ],
+            "properties": {
+                "application": {
+                    "type": "object",
+                    "description": "Application properties",
+                    "required": [
+                        "id"
+                    ],
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "UUID of the application",
+                            "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+                            "readOnly": true
+                        }
+                    },
+                    "readOnly": true
+                },
+                "session": {
+                    "type": "object",
+                    "description": "Session properties",
+                    "required": [
+                        "id"
+                    ],
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "UUID of the session",
+                            "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+                            "readOnly": true
+                        }
+                    },
+                    "readOnly": true
+                },
+                "view": {
+                    "type": "object",
+                    "description": "View properties",
+                    "required": [
+                        "id"
+                    ],
+                    "properties": {
+                        "id": {
+                            "type": "string",
+                            "description": "UUID of the view",
+                            "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$",
+                            "readOnly": true
+                        }
+                    },
+                    "readOnly": true
+                },
+                "source": {
+                    "type": "string",
+                    "description": "The source of this record",
+                    "enum": [
+                        "android",
+                        "ios",
+                        "browser",
+                        "flutter",
+                        "react-native"
+                    ],
+                    "readOnly": true
+                },
+                "start": {
+                    "type": "integer",
+                    "description": "The start UTC timestamp in milliseconds corresponding to the first record in the Segment data. Each timestamp is computed as the UTC interval since 00:00:00.000 01.01.1970.",
+                    "readOnly": true
+                },
+                "end": {
+                    "type": "integer",
+                    "description": "The end UTC timestamp in milliseconds corresponding to the last record in the Segment data. Each timestamp is computed as the UTC interval since 00:00:00.000 01.01.1970.",
+                    "readOnly": true
+                },
+                "has_full_snapshot_record": {
+                    "type": "boolean",
+                    "description": "Whether this Segment contains a full snapshot record or not.",
+                    "readOnly": true
+                },
+                "records_count": {
+                    "type": "integer",
+                    "description": "The number of records in this Segment.",
+                    "readOnly": true
+                },
+                "creation_reason": {
+                    "type": "string",
+                    "description": "The reason this Segment was created. For mobile there is only one possible value for this, which is always the default value.",
+                    "enum": [
+                        "init",
+                        "segment_duration_limit",
+                        "segment_bytes_limit",
+                        "view_change",
+                        "before_unload",
+                        "visibility_hidden"
+                    ],
+                    "default": "init",
+                    "readOnly": true
+                },
+                "index_in_view": {
+                    "type": "integer",
+                    "description": "The index of this Segment in the segments list that was recorded for this view ID. Starts from 0.",
+                    "readOnly": true
+                },
+                "records": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "record-schema.json"
+                    },
+                    "description": "The records contained by this Segment.",
+                    "readOnly": true
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/session-replay/view-end-record-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/session-replay/view-end-record-schema.json
@@ -1,0 +1,25 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "$id": "view-end-record-schema.json",
+    "title": "ViewEndRecord",
+    "type": "object",
+    "description": "Schema of a Record which signifies that view lifecycle ended.",
+    "allOf": [
+        {
+            "$ref": "_common-record-schema.json"
+        },
+        {
+            "required": [
+                "type"
+            ],
+            "properties": {
+                "type": {
+                    "type": "integer",
+                    "description": "The type of this Record.",
+                    "const": 7,
+                    "readOnly": true
+                }
+            }
+        }
+    ]
+}

--- a/library/dd-sdk-android-session-replay/transitiveDependencies
+++ b/library/dd-sdk-android-session-replay/transitiveDependencies
@@ -1,8 +1,9 @@
 Dependencies List
 
+com.google.code.gson:gson:2.8.8                                 :  236 Kb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.6.10                :  195 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.6.10                       : 1472 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              : 1685 Kb
+Total transitive dependencies size                              : 1922 Kb
 


### PR DESCRIPTION
### What does this PR do?

In this PR we are adding the necessary gradle tasks to the `library:dd-sdk-android-session-replay` module to be able to generate the required Session Replay Pokos based on the JSON schemas defined in the : [Rum Events Format Repository](https://github.com/DataDog/rum-events-format).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

