### PR TITLE
RUMM-2295, RUMM-2296, RUMM-2297: Improvement to the reading batch logic

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnable.kt
@@ -45,7 +45,10 @@ internal class DataUploadRunnable(
     override fun run() {
         if (isNetworkAvailable() && isSystemReady()) {
             val context = contextProvider.context
-            storage.readNextBatch(context) { batchId, reader ->
+            storage.readNextBatch(
+                context,
+                noBatchCallback = { increaseInterval() }
+            ) { batchId, reader ->
                 val batch = reader.read()
                 val batchMeta = reader.currentMetadata()
 
@@ -56,8 +59,6 @@ internal class DataUploadRunnable(
                     batchMeta
                 )
             }
-
-            // TODO RUMM-2297 decrease interval if there is no batch available?
         }
 
         scheduleNextUpload()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/Storage.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/Storage.kt
@@ -27,11 +27,16 @@ internal interface Storage {
     /**
      * Utility to read a batch, asynchronously.
      * @param datadogContext the current [DatadogContext]
-     * @param callback an operation to perform with a [BatchId] and [BatchReader] that will target
+     * @param noBatchCallback an optional callback which is called when there is no batch available to read.
+     * @param batchCallback an operation to perform with a [BatchId] and [BatchReader] that will target
      * the next readable Batch
      */
     @WorkerThread
-    fun readNextBatch(datadogContext: DatadogContext, callback: (BatchId, BatchReader) -> Unit)
+    fun readNextBatch(
+        datadogContext: DatadogContext,
+        noBatchCallback: () -> Unit = {},
+        batchCallback: (BatchId, BatchReader) -> Unit
+    )
 
     /**
      * Utility to update the state of a batch, asynchronously.

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -41,7 +41,6 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.Ignore
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -163,11 +162,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
 
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
@@ -218,11 +217,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
 
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
@@ -272,11 +271,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
 
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
@@ -410,7 +409,7 @@ internal class DataUploadRunnableTest {
         testedRunnable.run()
 
         // Then
-        verify(mockStorage).readNextBatch(eq(fakeContext), any())
+        verify(mockStorage).readNextBatch(eq(fakeContext), any(), any())
         verifyNoMoreInteractions(mockStorage)
         verifyZeroInteractions(mockDataUploader)
         verify(mockThreadPoolExecutor).schedule(
@@ -436,11 +435,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
 
         whenever(
@@ -488,11 +487,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
 
         whenever(
@@ -541,11 +540,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(
@@ -594,11 +593,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(
@@ -639,11 +638,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(
@@ -685,11 +684,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(
@@ -745,11 +744,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(
@@ -782,12 +781,15 @@ internal class DataUploadRunnableTest {
         }
     }
 
-    @Ignore("Not supported functionality")
     @Test
     fun `𝕄 increase delay between runs 𝕎 no batch available`(
         @IntForgery(16, 64) runCount: Int
     ) {
         // When
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+            it.getArgument<() -> Unit>(1).invoke()
+        }
+
         repeat(runCount) {
             testedRunnable.run()
         }
@@ -827,11 +829,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorageTest.kt
@@ -955,14 +955,21 @@ internal class ConsentAwareStorageTest {
     }
 
     @Test
-    fun `𝕄 do nothing 𝕎 readNextBatch() {no file}`() {
+    fun `𝕄 notify no batch available 𝕎 readNextBatch() {no file}`() {
         // Given
         whenever(mockGrantedOrchestrator.getReadableFile(any())) doReturn null
+        val mockNoBatchCallback = mock<() -> Unit>()
 
         // When
-        testedStorage.readNextBatch(fakeDatadogContext) { _, _ ->
+        testedStorage.readNextBatch(
+            fakeDatadogContext,
+            noBatchCallback = mockNoBatchCallback
+        ) { _, _ ->
             fail { "Callback should not have been called here" }
         }
+
+        // Then
+        verify(mockNoBatchCallback).invoke()
     }
 
     // endregion

--- a/detekt.yml
+++ b/detekt.yml
@@ -648,6 +648,8 @@ datadog:
       - "java.util.concurrent.Callable.call():java.lang.Exception"
       - "java.util.concurrent.ConcurrentHashMap.remove(kotlin.String):java.lang.NullPointerException"
       - "java.util.concurrent.CopyOnWriteArraySet.removeAll(kotlin.collections.Collection):java.lang.NullPointerException,java.lang.ClassCastException"
+      - "java.util.concurrent.CountDownLatch.await(kotlin.Long, java.util.concurrent.TimeUnit):java.lang.InterruptedException"
+      - "java.util.concurrent.CountDownLatch.constructor(kotlin.Int):java.lang.IllegalArgumentException"
       - "java.util.concurrent.ExecutorService.awaitTermination(kotlin.Long, java.util.concurrent.TimeUnit):java.lang.InterruptedException"
       - "java.util.concurrent.ExecutorService.execute(java.lang.Runnable):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
       - "java.util.concurrent.ExecutorService.submit(java.lang.Runnable):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
@@ -672,6 +674,8 @@ datadog:
       # endregion
       # region Java Collections
       - "java.util.LinkedList.removeFirst():java.util.NoSuchElementException"
+      - "java.util.LinkedList.offer(com.datadog.android.core.internal.data.upload.UploadWorker.UploadNextBatchTask):java.lang.ClassCastException,java.lang.NullPointerException,java.lang.IllegalArgumentException"
+      - "java.util.Queue.offer(com.datadog.android.core.internal.data.upload.UploadWorker.UploadNextBatchTask):java.lang.ClassCastException,java.lang.NullPointerException,java.lang.IllegalArgumentException"
       # endregion
       # region Kotlin primitives
       - "kotlin.String.get(kotlin.Int):java.lang.IndexOutOfBoundsException"
@@ -877,6 +881,7 @@ datadog:
       - "java.util.LinkedList.forEach(kotlin.Function1)"
       - "java.util.LinkedList.isEmpty()"
       - "java.util.LinkedList.isNotEmpty()"
+      - "java.util.LinkedList.poll()"
       - "java.util.LinkedHashMap.remove(kotlin.String)"
       # endregion
       # region Java Concurrency
@@ -890,6 +895,7 @@ datadog:
       - "java.util.concurrent.CopyOnWriteArraySet.constructor()"
       - "java.util.concurrent.CopyOnWriteArraySet.remove(kotlin.String)"
       - "java.util.concurrent.CopyOnWriteArraySet.toTypedArray()"
+      - "java.util.concurrent.CountDownLatch.countDown()"
       - "java.util.concurrent.ExecutorService.shutdown()"
       - "java.util.concurrent.ExecutorService.shutdownNow()"
       - "java.util.concurrent.Executors.newSingleThreadExecutor()"
@@ -1007,6 +1013,7 @@ datadog:
       - "kotlin.collections.List.mapNotNull(kotlin.Function1)"
       - "kotlin.collections.List.orEmpty()"
       - "kotlin.collections.List.reversed()"
+      - "kotlin.collections.List.shuffled()"
       - "kotlin.collections.List.sumOf(kotlin.Function1)"
       - "kotlin.collections.List.take(kotlin.Int)"
       - "kotlin.collections.List.toCharArray()"


### PR DESCRIPTION
### What does this PR do?

This changes does the following:

* RUMM-2297: Callback is added to notify if batch is not available. This allows to control the upload scheduling mechanism.
* RUMM-2295: Removed the possibility of stack overflow in `UploadWorker` by converting recursive batch read to the usage of the queue with tasks.
* RUMM-2296: Removed the bottleneck in `UploadWorker`: now if some feature has long upload which fails (and hence needs to retried), other features are going to have a chance to perform upload before retry happens. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

