### PR TITLE
Fix buttons overlap in the sample app

### DIFF
--- a/sample/kotlin/src/main/res/layout/fragment_home.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_home.xml
@@ -141,7 +141,7 @@
             android:drawableStart="@drawable/ic_compose_android_24dp"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/navigation_view_pager"/>
+            app:layout_constraintTop_toBottomOf="@id/navigation_picture"/>
 
         <androidx.appcompat.widget.AppCompatButton
                 android:id="@+id/navigation_about"
@@ -152,7 +152,7 @@
                 android:drawableStart="@drawable/ic_info_black_24"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/navigation_picture"/>
+                app:layout_constraintTop_toBottomOf="@id/navigation_compose"/>
 
 
     </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### What does this PR do?

This change fixes a minor UI glitch on the Home screen of the sample app: `Jetpack Compose` button was overlaying `Picture Loading` button.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

