### PR TITLE
RUMM-2356 Add session replay recorder basic logic

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/AndroidXFragmentLifecycleCallbacks.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/tracking/AndroidXFragmentLifecycleCallbacks.kt
@@ -57,6 +57,8 @@ internal open class AndroidXFragmentLifecycleCallbacks(
         }
     }
 
+    // TODO: RUMM-0000 Update Androidx packages and handle deprecated APIs
+    @Suppress("DEPRECATION")
     override fun onFragmentActivityCreated(
         fm: FragmentManager,
         f: Fragment,

--- a/detekt.yml
+++ b/detekt.yml
@@ -788,6 +788,8 @@ datadog:
       - "android.view.Window.Callback.dispatchKeyEvent(android.view.KeyEvent)"
       - "android.view.Window.Callback.dispatchTouchEvent(android.view.MotionEvent)"
       - "android.view.Window.Callback.onMenuItemSelected(kotlin.Int, android.view.MenuItem)"
+      - "android.view.View.getChildAt(kotlin.Int)"
+      - "android.view.View.hashCode()"
       # endregion
       # region Android Webview APIs
       - "android.webkit.ConsoleMessage.MessageLevel.toLogLevel()"
@@ -813,6 +815,9 @@ datadog:
       - "android.widget.TextView.setBackgroundColor(kotlin.Int)"
       - "android.widget.TextView.setPadding(kotlin.Int)"
       - "android.widget.TextView.setTextColor(kotlin.Int)"
+      # endregion
+      # region Android Graphics
+      - "android.graphics.drawable.Drawable.getDrawable(kotlin.Int)"
       # endregion
       # region Androidx APIs
       - "androidx.compose.foundation.interaction.DragInteraction.Start.constructor()"
@@ -880,6 +885,7 @@ datadog:
       - "java.util.LinkedList.add(android.view.View)"
       - "java.util.LinkedList.add(com.datadog.android.privacy.TrackingConsentProviderCallback)"
       - "java.util.LinkedList.addFirst(android.view.View)"
+      - "java.util.LinkedList.add(com.datadog.android.sessionreplay.recorder.Node)"
       - "java.util.LinkedList.clear()"
       - "java.util.LinkedList.constructor()"
       - "java.util.LinkedList.forEach(kotlin.Function1)"
@@ -1103,15 +1109,19 @@ datadog:
       - "kotlin.Double.toInt()"
       - "kotlin.Double.toLong()"
       - "kotlin.Float.toInt()"
+      - "kotlin.Float.toLong()"
       - "kotlin.Int.inv()"
       - "kotlin.Int.toChar()"
       - "kotlin.Int.toLong()"
+      - "kotlin.Int.and(kotlin.Int)"
       - "kotlin.IntArray.constructor(kotlin.Int)"
       - "kotlin.Long.asTime()"
       - "kotlin.Long.coerceIn(kotlin.Long, kotlin.Long)"
       - "kotlin.Long.hashCode()"
       - "kotlin.Long.toDouble()"
       - "kotlin.Long.toInt()"
+      - "kotlin.Long.shl(kotlin.Int)"
+      - "kotlin.Long.or(kotlin.Long)"
       - "kotlin.Number.toLong()"
       # endregion
       # region Kotlin String

--- a/library/dd-sdk-android-session-replay/apiSurface
+++ b/library/dd-sdk-android-session-replay/apiSurface
@@ -168,7 +168,7 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
     companion object 
       fun fromJson(kotlin.String): ShapeBorder
   data class TextStyle
-    constructor(kotlin.String, kotlin.Long, Type, kotlin.String)
+    constructor(kotlin.String, kotlin.Long, kotlin.String)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): TextStyle
@@ -196,16 +196,6 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Source
-  enum Type
-    constructor(kotlin.String)
-    - SERIF
-    - SANS_SERIF
-    - SCRIPT
-    - MONOSPACED
-    - DYNAMIC
-    fun toJson(): com.google.gson.JsonElement
-    companion object 
-      fun fromJson(kotlin.String): Type
   enum Horizontal
     constructor(kotlin.String)
     - LEFT

--- a/library/dd-sdk-android-session-replay/build.gradle.kts
+++ b/library/dd-sdk-android-session-replay/build.gradle.kts
@@ -76,6 +76,7 @@ android {
 dependencies {
     implementation(libs.kotlin)
     implementation(libs.gson)
+    implementation(libs.androidXAppCompat)
 
     testImplementation(project(":tools:unit"))
     testImplementation(libs.bundles.jUnit5)

--- a/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/full-snapshot-record-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/full-snapshot-record-schema.json
@@ -14,7 +14,7 @@
         "type": {
           "type": "integer",
           "description": "The type of this Record.",
-          "const": 2,
+          "const": 10,
           "readOnly": true
         },
         "data": {

--- a/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/incremental-snapshot-record-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/incremental-snapshot-record-schema.json
@@ -14,7 +14,7 @@
         "type": {
           "type": "integer",
           "description": "The type of this Record.",
-          "const": 3,
+          "const": 11,
           "readOnly": true
         },
         "data": {

--- a/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/text-style-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/text-style-schema.json
@@ -6,22 +6,20 @@
   "description": "Schema of all properties of a TextStyle.",
   "allOf": [
     {
-      "required": ["color", "family", "size", "type"],
+      "required": [
+        "color",
+        "family",
+        "size"
+      ],
       "properties": {
         "family": {
           "type": "string",
-          "description": "The font family.",
+          "description": "The preferred font family collection, ordered by preference and formatted as a String list: e.g. Century Gothic, Verdana, sans-serif",
           "readOnly": true
         },
         "size": {
           "type": "integer",
           "description": "The font size in pixels.",
-          "readOnly": true
-        },
-        "type": {
-          "type": "string",
-          "enum": ["serif", "sans-serif", "script", "monospaced", "dynamic"],
-          "description": "The font type.",
           "readOnly": true
         },
         "color": {

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/LongExt.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/LongExt.kt
@@ -7,15 +7,15 @@
 package com.datadog.android.sessionreplay.recorder
 
 /**
- * Normalizes an Int value (font size, view dimension, view position, etc.) according with the
+ * Normalizes a Long value (font size, view dimension, view position, etc.) according with the
  * device pixels density.
  * Example: if a device has a DPI = 2, the normalized height of a view will be
  * view.height/2.
  * @param density
  */
-internal fun Int.densityNormalized(density: Float): Int {
+internal fun Long.densityNormalized(density: Float): Long {
     if (density == 0f) {
         return this
     }
-    return (this / density).toInt()
+    return (this / density).toLong()
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapper.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.view.View
+import com.datadog.android.sessionreplay.model.MobileSegment
+import java.util.Locale
+
+internal abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wireframe> :
+    WireframeMapper<T, S> {
+
+    protected fun resolveViewId(view: View): Long {
+        return if (view.id != View.NO_ID) view.id.toLong() else view.hashCode().toLong()
+    }
+
+    protected fun colorAndAlphaAsStringHexa(color: Int, alphaAsHexa: Long): String {
+        // we shift left 8 bits to make room for alpha
+        val colorAndAlphaAsHexa = (color.toLong().shl(8)).or(alphaAsHexa)
+        return String.format(Locale.US, "#%08X", 0xFFFFFFFF and colorAndAlphaAsHexa)
+    }
+
+    companion object {
+        internal const val OPAQUE_AS_HEXA: Long = 255
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonWireframeMapper.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.widget.Button
+import com.datadog.android.sessionreplay.model.MobileSegment
+
+internal class ButtonWireframeMapper(
+    private val textWireframeMapper: TextWireframeMapper = TextWireframeMapper()
+) :
+    WireframeMapper<Button, MobileSegment.Wireframe.TextWireframe> {
+    override fun map(view: Button, pixelsDensity: Float): MobileSegment.Wireframe.TextWireframe {
+        return textWireframeMapper.map(view, pixelsDensity)
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/GenericWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/GenericWireframeMapper.kt
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.view.View
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import com.datadog.android.sessionreplay.model.MobileSegment
+
+internal class GenericWireframeMapper(
+    private val viewWireframeMapper: ViewWireframeMapper = ViewWireframeMapper(),
+    private val imageMapper: ViewScreenshotWireframeMapper =
+        ViewScreenshotWireframeMapper(viewWireframeMapper),
+    private val textMapper: TextWireframeMapper = TextWireframeMapper(viewWireframeMapper),
+    private val buttonMapper: ButtonWireframeMapper = ButtonWireframeMapper(textMapper)
+) : WireframeMapper<View, MobileSegment.Wireframe> {
+
+    override fun map(view: View, pixelsDensity: Float): MobileSegment.Wireframe {
+        return when {
+            Button::class.java.isAssignableFrom(view::class.java) -> {
+                buttonMapper.map(view as Button, pixelsDensity)
+            }
+            TextView::class.java.isAssignableFrom(view::class.java) -> {
+                textMapper.map(view as TextView, pixelsDensity)
+            }
+            ImageView::class.java.isAssignableFrom(view::class.java) -> {
+                imageMapper.map(view as ImageView, pixelsDensity)
+            }
+            else -> {
+                viewWireframeMapper.map(view, pixelsDensity)
+            }
+        }
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextWireframeMapper.kt
@@ -1,0 +1,119 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.graphics.Typeface
+import android.view.Gravity
+import android.widget.TextView
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.densityNormalized
+
+internal class TextWireframeMapper(
+    private val viewWireframeMapper: ViewWireframeMapper = ViewWireframeMapper()
+) : BaseWireframeMapper<TextView, MobileSegment.Wireframe.TextWireframe>() {
+
+    override fun map(view: TextView, pixelsDensity: Float): MobileSegment.Wireframe.TextWireframe {
+        val shapeWireframe = viewWireframeMapper.map(view, pixelsDensity)
+        return MobileSegment.Wireframe.TextWireframe(
+            shapeWireframe.id,
+            shapeWireframe.x,
+            shapeWireframe.y,
+            shapeWireframe.width,
+            shapeWireframe.height,
+            shapeStyle = shapeWireframe.shapeStyle,
+            border = shapeWireframe.border,
+            text = view.text.toString(),
+            textStyle = view.resolveTextStyle(pixelsDensity),
+            textPosition = view.resolveTextPosition(pixelsDensity)
+        )
+    }
+
+    // region Internal
+
+    private fun TextView.resolveTextStyle(pixelsDensity: Float): MobileSegment.TextStyle {
+        return MobileSegment.TextStyle(
+            this.typeface.resolveFontFamily(),
+            this.textSize.toLong().densityNormalized(pixelsDensity),
+            colorAndAlphaAsStringHexa(currentTextColor, OPAQUE_AS_HEXA)
+        )
+    }
+
+    private fun Typeface.resolveFontFamily(): String {
+        return when {
+            this === Typeface.SANS_SERIF -> SANS_SERIF_FAMILY_NAME
+            this === Typeface.MONOSPACE -> MONOSPACE_FAMILY_NAME
+            this === Typeface.SERIF -> SERIF_FAMILY_NAME
+            else -> SANS_SERIF_FAMILY_NAME
+        }
+    }
+
+    private fun TextView.resolveTextPosition(pixelsDensity: Float): MobileSegment.TextPosition {
+        return MobileSegment.TextPosition(resolvePadding(pixelsDensity), resolveAlignment())
+    }
+
+    private fun TextView.resolvePadding(pixelsDensity: Float): MobileSegment.Padding {
+        return MobileSegment.Padding(
+            top = this.totalPaddingTop.densityNormalized(pixelsDensity).toLong(),
+            bottom = this.totalPaddingBottom.densityNormalized(pixelsDensity).toLong(),
+            left = this.totalPaddingStart.densityNormalized(pixelsDensity).toLong(),
+            right = this.totalPaddingEnd.densityNormalized(pixelsDensity).toLong()
+        )
+    }
+
+    private fun TextView.resolveAlignment(): MobileSegment.Alignment {
+        return when (this.textAlignment) {
+            TextView.TEXT_ALIGNMENT_CENTER -> MobileSegment.Alignment(
+                horizontal = MobileSegment.Horizontal.CENTER,
+                vertical = MobileSegment.Vertical.CENTER
+            )
+            TextView.TEXT_ALIGNMENT_TEXT_END,
+            TextView.TEXT_ALIGNMENT_VIEW_END -> MobileSegment.Alignment(
+                horizontal = MobileSegment.Horizontal.RIGHT,
+                vertical = MobileSegment.Vertical.CENTER
+            )
+            TextView.TEXT_ALIGNMENT_TEXT_START,
+            TextView.TEXT_ALIGNMENT_VIEW_START -> MobileSegment.Alignment(
+                horizontal = MobileSegment.Horizontal.LEFT,
+                vertical = MobileSegment.Vertical.CENTER
+            )
+            TextView.TEXT_ALIGNMENT_GRAVITY -> resolveAlignmentFromGravity()
+            else -> MobileSegment.Alignment(
+                horizontal = MobileSegment.Horizontal.LEFT,
+                vertical = MobileSegment.Vertical.CENTER
+            )
+        }
+    }
+
+    private fun TextView.resolveAlignmentFromGravity(): MobileSegment.Alignment {
+        val horizontalAlignment = when (this.gravity.and(Gravity.HORIZONTAL_GRAVITY_MASK)) {
+            Gravity.START,
+            Gravity.LEFT -> MobileSegment.Horizontal.LEFT
+            Gravity.END,
+            Gravity.RIGHT -> MobileSegment.Horizontal.RIGHT
+            Gravity.CENTER -> MobileSegment.Horizontal.CENTER
+            Gravity.CENTER_HORIZONTAL -> MobileSegment.Horizontal.CENTER
+            else -> MobileSegment.Horizontal.LEFT
+        }
+        val verticalAlignment = when (this.gravity.and(Gravity.VERTICAL_GRAVITY_MASK)) {
+            Gravity.TOP -> MobileSegment.Vertical.TOP
+            Gravity.BOTTOM -> MobileSegment.Vertical.BOTTOM
+            Gravity.CENTER_VERTICAL -> MobileSegment.Vertical.CENTER
+            Gravity.CENTER -> MobileSegment.Vertical.CENTER
+            else -> MobileSegment.Vertical.CENTER
+        }
+
+        return MobileSegment.Alignment(horizontalAlignment, verticalAlignment)
+    }
+
+    // endregion
+
+    companion object {
+        internal const val SANS_SERIF_FAMILY_NAME = "sans-serif"
+        internal const val SERIF_FAMILY_NAME = "serif"
+        internal const val MONOSPACE_FAMILY_NAME = "monospace"
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewScreenshotWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewScreenshotWireframeMapper.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.view.View
+import com.datadog.android.sessionreplay.model.MobileSegment
+
+// TODO: RUMM-0000 This should take a screenshot of the current view and return it as
+// and ImageWireframe. It will be handled in the Session Replay v1.
+internal class ViewScreenshotWireframeMapper(
+    private val viewWireframeMapper: ViewWireframeMapper = ViewWireframeMapper()
+) :
+    BaseWireframeMapper<View, MobileSegment.Wireframe.ShapeWireframe>() {
+
+    override fun map(view: View, pixelsDensity: Float):
+        MobileSegment.Wireframe.ShapeWireframe {
+        return viewWireframeMapper.map(view, pixelsDensity)
+            .copy(border = MobileSegment.ShapeBorder("#000000FF", 1))
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapper.kt
@@ -1,0 +1,62 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.InsetDrawable
+import android.graphics.drawable.RippleDrawable
+import android.os.Build
+import android.view.View
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.densityNormalized
+
+internal class ViewWireframeMapper :
+    BaseWireframeMapper<View, MobileSegment.Wireframe.ShapeWireframe>() {
+
+    override fun map(view: View, pixelsDensity: Float): MobileSegment.Wireframe.ShapeWireframe {
+        val scaledHeight = view.height.densityNormalized(pixelsDensity).toLong()
+        val scaledWidth = view.width.densityNormalized(pixelsDensity).toLong()
+        val coordinates = IntArray(2)
+        // this will always have size >= 2
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        view.getLocationInWindow(coordinates)
+        val x = coordinates[0].densityNormalized(pixelsDensity).toLong()
+        val y = coordinates[1].densityNormalized(pixelsDensity).toLong()
+        val styleBorderPair = view.background?.resolveShapeStyleAndBorder()
+        return MobileSegment.Wireframe.ShapeWireframe(
+            resolveViewId(view),
+            x,
+            y,
+            scaledWidth,
+            scaledHeight,
+            shapeStyle = styleBorderPair?.first,
+            border = styleBorderPair?.second
+        )
+    }
+
+    private fun Drawable.resolveShapeStyleAndBorder():
+        Pair<MobileSegment.ShapeStyle?, MobileSegment.ShapeBorder?>? {
+        return if (this is ColorDrawable) {
+            val color = colorAndAlphaAsStringHexa(color, alpha.toLong())
+            MobileSegment.ShapeStyle(color, alpha) to null
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+            this is RippleDrawable &&
+            numberOfLayers >= 1
+        ) {
+            getDrawable(0).resolveShapeStyleAndBorder()
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && this is InsetDrawable) {
+            drawable?.resolveShapeStyleAndBorder()
+        } else {
+            // We cannot handle this drawable so we will use a border to delimit its container
+            // bounds.
+            // TODO: RUMM-0000 In case the background drawable could not be handled we should
+            // instead resolve it as an ImageWireframe.
+            null to MobileSegment.ShapeBorder("#000000FF", 1)
+        }
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/WireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/WireframeMapper.kt
@@ -4,11 +4,11 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.sessionreplay.recorder
+package com.datadog.android.sessionreplay.recorder.mapper
 
+import android.view.View
 import com.datadog.android.sessionreplay.model.MobileSegment
 
-internal data class Node(
-    val wireframes: List<MobileSegment.Wireframe>,
-    val children: List<Node> = emptyList()
-)
+internal interface WireframeMapper<T : View, S : MobileSegment.Wireframe> {
+    fun map(view: T, pixelsDensity: Float): S
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/ForgeExt.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/ForgeExt.kt
@@ -1,0 +1,59 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder
+
+import android.view.View
+import android.view.ViewGroup
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+
+internal fun Forge.aViewWithChildren(
+    numberOfChildren: Int,
+    currentLevel: Int,
+    maxLevel: Int = 10
+): View {
+    if (currentLevel >= maxLevel) {
+        return aMockView()
+    }
+    val level = currentLevel + 1
+    val mockViewGroup: ViewGroup = aMockView()
+    whenever(mockViewGroup.childCount).thenReturn(numberOfChildren)
+    for (i in 0 until numberOfChildren) {
+        val mockChildGroup = aViewWithChildren(
+            numberOfChildren,
+            level,
+            maxLevel
+        )
+        whenever(mockViewGroup.id).thenReturn(currentLevel * 10 + i)
+        whenever(mockViewGroup.getChildAt(i)).thenReturn(mockChildGroup)
+    }
+    return mockViewGroup
+}
+
+internal inline fun <reified T : View> Forge.aMockView(): T {
+    return mock {
+        val absX = anInt(min = 0)
+        val absY = anInt(min = 0)
+        val locationInWindow = intArrayOf(absX, absY)
+        whenever(it.getLocationInWindow(locationInWindow)).then {
+            val location = (
+                it.arguments[0]
+                    as IntArray
+                )
+            location[0] = absX
+            location[1] = absY
+            null
+        }
+        whenever(it.x).thenReturn(aFloat(min = 0f))
+        whenever(it.y).thenReturn(aFloat(min = 0f))
+        whenever(it.width).thenReturn(anInt(min = 1))
+        whenever(it.height).thenReturn(anInt(min = 1))
+        whenever(it.isShown).thenReturn(true)
+        whenever(it.alpha).thenReturn(1f)
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/LongExtTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/LongExtTest.kt
@@ -1,0 +1,47 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder
+
+import com.datadog.android.sessionreplay.utils.ForgeConfigurator
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class LongExtTest {
+
+    @RepeatedTest(100)
+    fun `M correctly normalize an Int W densityNormalized()`(
+        @LongForgery fakeLong: Long,
+        @FloatForgery(min = 1.0f, max = 100.0f)
+        fakeDensity: Float
+    ) {
+        assertThat(fakeLong.densityNormalized(fakeDensity))
+            .isEqualTo((fakeLong / fakeDensity).toLong())
+    }
+
+    @Test
+    fun `M correctly handle division by 0 W densityNormalized() {density is 0}`(
+        @LongForgery fakeLong: Long
+    ) {
+        assertThat(fakeLong.densityNormalized(0f)).isEqualTo(fakeLong)
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/SnapshotProducerTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/SnapshotProducerTest.kt
@@ -1,0 +1,253 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder
+
+import android.os.Build
+import android.view.View
+import android.view.ViewGroup
+import android.view.ViewStub
+import androidx.annotation.RequiresApi
+import androidx.appcompat.widget.ActionBarContextView
+import androidx.appcompat.widget.Toolbar
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.mapper.GenericWireframeMapper
+import com.datadog.android.sessionreplay.recorder.mapper.ViewScreenshotWireframeMapper
+import com.datadog.android.sessionreplay.utils.ForgeConfigurator
+import com.datadog.tools.unit.annotations.TestTargetApi
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class SnapshotProducerTest {
+
+    lateinit var testedSnapshotProducer: SnapshotProducer
+
+    @FloatForgery(min = 1f, max = 10f)
+    var fakePixelDensity: Float = 1f
+
+    @Mock
+    lateinit var mockViewScreenshotWireframeMapper: ViewScreenshotWireframeMapper
+
+    @Mock
+    lateinit var mockGenericWireframeMapper: GenericWireframeMapper
+
+    @Mock
+    lateinit var mockViewWireframe: MobileSegment.Wireframe
+
+    @Mock
+    lateinit var mockShapeScreenshotWireframe: MobileSegment.Wireframe.ShapeWireframe
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockViewScreenshotWireframeMapper.map(any(), eq(fakePixelDensity)))
+            .thenReturn(mockShapeScreenshotWireframe)
+        whenever(mockGenericWireframeMapper.map(any(), eq(fakePixelDensity)))
+            .thenReturn(mockViewWireframe)
+        testedSnapshotProducer = SnapshotProducer(
+            mockViewScreenshotWireframeMapper,
+            mockGenericWireframeMapper
+        )
+    }
+
+    // region Default Tests
+
+    @Test
+    fun `M produce a tree of Nodes W produce() { single view }`(forge: Forge) {
+        // Given
+        val fakeRoot = forge.aMockView<View>()
+
+        // When
+        val snapshot = testedSnapshotProducer.produce(fakeRoot, fakePixelDensity)
+
+        // Then
+        val expectedSnapshot = fakeRoot.toNode()
+        assertThat(snapshot).isEqualTo(expectedSnapshot).usingRecursiveComparison()
+    }
+
+    @Test
+    fun `M produce a tree of Nodes W produce() { view tree }`(forge: Forge) {
+        // Given
+        val fakeRoot = forge.aViewWithChildren(2, 0, 2)
+
+        // When
+        val snapshot = testedSnapshotProducer.produce(fakeRoot, fakePixelDensity)
+
+        // Then
+        val expectedSnapshot = fakeRoot.toNode()
+        assertThat(snapshot).isEqualTo(expectedSnapshot).usingRecursiveComparison()
+    }
+
+    // endregion
+
+    // region validity tests
+
+    @Test
+    fun `M return null W produce() { root is invisible }`(forge: Forge) {
+        // Given
+        val fakeRoot = forge
+            .aViewWithChildren(2, 0, 2)
+            .apply { whenever(this.isShown).thenReturn(false) }
+
+        // Then
+        assertThat(testedSnapshotProducer.produce(fakeRoot, fakePixelDensity)).isNull()
+    }
+
+    @Test
+    fun `M return null W produce() { root width is 0 or less }`(forge: Forge) {
+        // Given
+        val fakeRoot = forge
+            .aViewWithChildren(2, 0, 2)
+            .apply {
+                whenever(this.width).thenReturn(forge.anInt(max = 1))
+            }
+
+        // Then
+        assertThat(testedSnapshotProducer.produce(fakeRoot, fakePixelDensity)).isNull()
+    }
+
+    @Test
+    fun `M return null W produce() { root height is 0 or less }`(forge: Forge) {
+        // Given
+        val fakeRoot = forge
+            .aViewWithChildren(2, 0, 2)
+            .apply {
+                whenever(this.height).thenReturn(forge.anInt(max = 1))
+            }
+
+        // Then
+        assertThat(testedSnapshotProducer.produce(fakeRoot, fakePixelDensity)).isNull()
+    }
+
+    // endregion
+
+    // region System Noise
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    fun `M exclude the navigationBarBackground W produce()`(forge: Forge) {
+        // Given
+        val fakeRoot = forge
+            .aViewWithChildren(2, 0, 2)
+            .apply {
+                whenever(this.id).thenReturn(android.R.id.navigationBarBackground)
+            }
+
+        // Then
+        assertThat(testedSnapshotProducer.produce(fakeRoot, fakePixelDensity)).isNull()
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    fun `M exclude the statusBarBackground W produce()`(forge: Forge) {
+        // Given
+        val fakeRoot = forge
+            .aViewWithChildren(2, 0, 2)
+            .apply {
+                whenever(this.id).thenReturn(android.R.id.statusBarBackground)
+            }
+
+        // Then
+        assertThat(testedSnapshotProducer.produce(fakeRoot, fakePixelDensity)).isNull()
+    }
+
+    @Test
+    fun `M exclude the ViewStub W produce()`() {
+        // Given
+        val fakeRoot: ViewStub = mock()
+
+        // Then
+        assertThat(testedSnapshotProducer.produce(fakeRoot, fakePixelDensity)).isNull()
+    }
+
+    @Test
+    fun `M exclude the ActionBarContextView W produce()`() {
+        // Given
+        val fakeRoot: ActionBarContextView = mock()
+
+        // Then
+        assertThat(testedSnapshotProducer.produce(fakeRoot, fakePixelDensity)).isNull()
+    }
+
+    // endregion
+
+    // region Toolbar
+
+    @Test
+    fun `M resolve a Node with screenshot with border W produce() { androidx Toolbar }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockToolBar: Toolbar = forge.aMockView<Toolbar>().apply {
+            whenever(this.id).thenReturn(androidx.appcompat.R.id.action_bar)
+        }
+
+        // When
+        val snapshot = testedSnapshotProducer.produce(mockToolBar, fakePixelDensity)
+
+        // Then
+        val shapeWireframe = snapshot?.wireframes?.get(0) as MobileSegment.Wireframe.ShapeWireframe
+        assertThat(shapeWireframe).isEqualTo(mockShapeScreenshotWireframe)
+    }
+
+    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    @Test
+    fun `M resolve a Node with screenshot with border W produce() { android Toolbar }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockToolBar: android.widget.Toolbar = forge.aMockView()
+
+        // When
+        val snapshot = testedSnapshotProducer.produce(mockToolBar, fakePixelDensity)
+
+        // Then
+        val shapeWireframe = snapshot?.wireframes?.get(0) as MobileSegment.Wireframe.ShapeWireframe
+        assertThat(shapeWireframe).isEqualTo(mockShapeScreenshotWireframe)
+    }
+
+    // endregion
+
+    // region Internals
+
+    private fun View.toNode(): Node {
+        val children = if (this is ViewGroup) {
+            val nodes = mutableListOf<Node>()
+            for (i in 0 until childCount) {
+                nodes.add(this.getChildAt(i).toNode())
+            }
+            nodes
+        } else emptyList()
+        return Node(wireframes = listOf(mockViewWireframe), children = children)
+    }
+
+    // endregion
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapperTest.kt
@@ -1,0 +1,332 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.graphics.Typeface
+import android.view.Gravity
+import android.view.View
+import android.widget.TextView
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.densityNormalized
+import com.datadog.tools.unit.setStaticValue
+import com.nhaarman.mockitokotlin2.mock
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import java.util.stream.Stream
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.params.provider.Arguments
+
+internal abstract class BaseWireframeMapperTest {
+
+    @FloatForgery(min = 1f, max = 10f)
+    var fakePixelDensity: Float = 1f
+
+    protected fun View.toShapeWireframe(): MobileSegment.Wireframe.ShapeWireframe {
+        val coordinates = IntArray(2)
+        this.getLocationInWindow(coordinates)
+        val x = coordinates[0].densityNormalized(fakePixelDensity).toLong()
+        val y = coordinates[1].densityNormalized(fakePixelDensity).toLong()
+        return MobileSegment.Wireframe.ShapeWireframe(
+            id.toLong(),
+            x = x,
+            y = y,
+            width = width.toLong().densityNormalized(fakePixelDensity),
+            height = height.toLong().densityNormalized(fakePixelDensity)
+        )
+    }
+
+    protected fun TextView.toTextWireframe(): MobileSegment.Wireframe.TextWireframe {
+        val coordinates = IntArray(2)
+        this.getLocationInWindow(coordinates)
+        val x = coordinates[0].densityNormalized(fakePixelDensity).toLong()
+        val y = coordinates[1].densityNormalized(fakePixelDensity).toLong()
+        return MobileSegment.Wireframe.TextWireframe(
+            id.toLong(),
+            x = x,
+            y = y,
+            text = text.toString(),
+            width = width.toLong().densityNormalized(fakePixelDensity),
+            height = height.toLong().densityNormalized(fakePixelDensity),
+            textStyle = MobileSegment.TextStyle(
+                "sans-serif",
+                0,
+                "#000000FF"
+            ),
+            textPosition = MobileSegment.TextPosition(
+                MobileSegment.Padding(0, 0, 0, 0),
+                alignment =
+                MobileSegment.Alignment(
+                    MobileSegment.Horizontal.LEFT,
+                    MobileSegment.Vertical
+                        .CENTER
+                )
+            )
+        )
+    }
+
+    companion object {
+        const val ALPHA_MASK: Long = 0x000000FF
+
+        @JvmStatic
+        fun textTypefaces(): Stream<Arguments> {
+            // we initialize the TYPEFACES
+            Typeface::class.java.setStaticValue("DEFAULT", mock<Typeface>())
+            Typeface::class.java.setStaticValue("MONOSPACE", mock<Typeface>())
+            Typeface::class.java.setStaticValue("DEFAULT_BOLD", mock<Typeface>())
+            Typeface::class.java.setStaticValue("SERIF", mock<Typeface>())
+            Typeface::class.java.setStaticValue("SANS_SERIF", mock<Typeface>())
+            return listOf(
+                Arguments.of(Typeface.DEFAULT, TextWireframeMapper.SANS_SERIF_FAMILY_NAME),
+                Arguments.of(Typeface.DEFAULT_BOLD, TextWireframeMapper.SANS_SERIF_FAMILY_NAME),
+                Arguments.of(Typeface.MONOSPACE, TextWireframeMapper.MONOSPACE_FAMILY_NAME),
+                Arguments.of(Typeface.SERIF, TextWireframeMapper.SERIF_FAMILY_NAME),
+                Arguments.of(mock<Typeface>(), TextWireframeMapper.SANS_SERIF_FAMILY_NAME)
+            )
+                .stream()
+        }
+
+        @JvmStatic
+        fun textAlignments(): Stream<Arguments> {
+            return listOf(
+                Arguments.of(
+                    TextView.TEXT_ALIGNMENT_CENTER,
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.CENTER,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    TextView.TEXT_ALIGNMENT_TEXT_END,
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.RIGHT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    TextView.TEXT_ALIGNMENT_VIEW_END,
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.RIGHT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    TextView.TEXT_ALIGNMENT_TEXT_START,
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    TextView.TEXT_ALIGNMENT_VIEW_START,
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Int.MAX_VALUE,
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                )
+            ).stream()
+        }
+
+        @JvmStatic
+        fun textAlignmentsFromGravity(): Stream<Arguments> {
+            return listOf(
+                Arguments.of(
+                    Gravity.START.or(Gravity.TOP),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.TOP
+                    )
+                ),
+                Arguments.of(
+                    Gravity.LEFT.or(Gravity.TOP),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.TOP
+                    )
+                ),
+                Arguments.of(
+                    Gravity.RIGHT.or(Gravity.TOP),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.RIGHT,
+                        vertical = MobileSegment.Vertical.TOP
+                    )
+                ),
+                Arguments.of(
+                    Gravity.END.or(Gravity.TOP),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.RIGHT,
+                        vertical = MobileSegment.Vertical.TOP
+                    )
+                ),
+                Arguments.of(
+                    Gravity.CENTER.or(Gravity.TOP),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.CENTER,
+                        vertical = MobileSegment.Vertical.TOP
+                    )
+                ),
+                Arguments.of(
+                    Gravity.CENTER_HORIZONTAL.or(Gravity.TOP),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.CENTER,
+                        vertical = MobileSegment.Vertical.TOP
+                    )
+                ),
+                Arguments.of(
+                    Gravity.START.or(Gravity.BOTTOM),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.BOTTOM
+                    )
+                ),
+                Arguments.of(
+                    Gravity.LEFT.or(Gravity.BOTTOM),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.BOTTOM
+                    )
+                ),
+                Arguments.of(
+                    Gravity.RIGHT.or(Gravity.BOTTOM),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.RIGHT,
+                        vertical = MobileSegment.Vertical.BOTTOM
+                    )
+                ),
+                Arguments.of(
+                    Gravity.END.or(Gravity.BOTTOM),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.RIGHT,
+                        vertical = MobileSegment.Vertical.BOTTOM
+                    )
+                ),
+                Arguments.of(
+                    Gravity.CENTER.or(Gravity.BOTTOM),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.CENTER,
+                        vertical = MobileSegment.Vertical.BOTTOM
+                    )
+                ),
+                Arguments.of(
+                    Gravity.CENTER_HORIZONTAL.or(Gravity.BOTTOM),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.CENTER,
+                        vertical = MobileSegment.Vertical.BOTTOM
+                    )
+                ),
+                Arguments.of(
+                    Gravity.START.or(Gravity.CENTER),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.LEFT.or(Gravity.CENTER),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.RIGHT.or(Gravity.CENTER),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.RIGHT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.END.or(Gravity.CENTER),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.RIGHT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.CENTER.or(Gravity.CENTER),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.CENTER,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.CENTER_HORIZONTAL.or(Gravity.CENTER),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.CENTER,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.START.or(Gravity.CENTER_VERTICAL),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.LEFT.or(Gravity.CENTER_VERTICAL),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.RIGHT.or(Gravity.CENTER_VERTICAL),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.RIGHT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.END.or(Gravity.CENTER_VERTICAL),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.RIGHT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.CENTER.or(Gravity.CENTER_VERTICAL),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.CENTER,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Gravity.CENTER_HORIZONTAL.or(Gravity.CENTER_VERTICAL),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.CENTER,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                ),
+                Arguments.of(
+                    Int.MAX_VALUE.or(Int.MIN_VALUE),
+                    MobileSegment.Alignment(
+                        horizontal = MobileSegment.Horizontal.LEFT,
+                        vertical = MobileSegment.Vertical.CENTER
+                    )
+                )
+
+            ).stream()
+        }
+
+        @AfterAll
+        @JvmStatic
+        fun `tear down all`() {
+            // we reset the TYPEFACES
+            Typeface::class.java.setStaticValue("DEFAULT", null)
+            Typeface::class.java.setStaticValue("MONOSPACE", null)
+            Typeface::class.java.setStaticValue("DEFAULT_BOLD", null)
+            Typeface::class.java.setStaticValue("SERIF", null)
+            Typeface::class.java.setStaticValue("SANS_SERIF", null)
+        }
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonWireframeMapperTest.kt
@@ -1,0 +1,176 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.graphics.Typeface
+import android.widget.Button
+import android.widget.TextView
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.aMockView
+import com.datadog.android.sessionreplay.recorder.densityNormalized
+import com.datadog.android.sessionreplay.utils.ForgeConfigurator
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class ButtonWireframeMapperTest : BaseWireframeMapperTest() {
+
+    lateinit var testedButtonWireframeMapper: ButtonWireframeMapper
+
+    @BeforeEach
+    fun `set up`() {
+        testedButtonWireframeMapper = ButtonWireframeMapper()
+    }
+
+    @ParameterizedTest
+    @MethodSource("textTypefaces")
+    fun `M resolve a TextWireframe W map() { Button with fontStyle }`(
+        typeface: Typeface,
+        expectedFontFamily: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeFontSize = forge.aFloat(min = 0f)
+        val fakeStyleColor = forge.aStringMatching("#[0-9A-F]{6}FF")
+        val fakeText = forge.aString()
+        val fakeFontColor = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .shr(8)
+            .toInt()
+        val mockButton: Button = forge.aMockView<Button>().apply {
+            whenever(this.typeface).thenReturn(typeface)
+            whenever(this.textSize).thenReturn(fakeFontSize)
+            whenever(this.currentTextColor).thenReturn(fakeFontColor)
+            whenever(this.text).thenReturn(fakeText)
+        }
+
+        // When
+        val buttonWireframe = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockButton.toTextWireframe()
+            .copy(
+                textStyle = MobileSegment.TextStyle(
+                    expectedFontFamily,
+                    fakeFontSize.toLong().densityNormalized(fakePixelDensity),
+                    fakeStyleColor
+                )
+            )
+        assertThat(buttonWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M resolve a TextWireframe W map() { Button with text }`(forge: Forge) {
+        // Given
+        val fakeText = forge.aString()
+        val mockButton: Button = forge.aMockView<Button>().apply {
+            whenever(this.text).thenReturn(fakeText)
+            whenever(this.typeface).thenReturn(mock())
+        }
+
+        // When
+        val buttonWireframe = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockButton.toTextWireframe().copy(text = fakeText)
+        assertThat(buttonWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @ParameterizedTest
+    @MethodSource("textAlignments")
+    fun `M resolve a TextWireframe W map() { Button with textAlignment }`(
+        textAlignment: Int,
+        expectedTextAlignment: MobileSegment.Alignment,
+        forge: Forge
+    ) {
+        // Given
+        val mockButton: Button = forge.aMockView<Button>().apply {
+            whenever(this.text).thenReturn(forge.aString())
+            whenever(this.typeface).thenReturn(mock())
+            whenever(this.textAlignment).thenReturn(textAlignment)
+        }
+
+        // When
+        val buttonWireframe = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockButton.toTextWireframe().copy(
+            textPosition = MobileSegment
+                .TextPosition(
+                    padding = MobileSegment.Padding(0, 0, 0, 0),
+                    alignment = expectedTextAlignment
+                )
+        )
+        assertThat(buttonWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @ParameterizedTest
+    @MethodSource("textAlignmentsFromGravity")
+    fun `M resolve a TextWireframe W map() { Button with textAlignment from gravity }`(
+        gravity: Int,
+        expectedTextAlignment: MobileSegment.Alignment,
+        forge: Forge
+    ) {
+        // Given
+        val fakeText = forge.aString()
+        val mockButton: Button = forge.aMockView<Button>().apply {
+            whenever(this.text).thenReturn(fakeText)
+            whenever(this.typeface).thenReturn(mock())
+            whenever(this.textAlignment).thenReturn(TextView.TEXT_ALIGNMENT_GRAVITY)
+            whenever(this.gravity).thenReturn(gravity)
+        }
+
+        // When
+        val buttonWireframe = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockButton.toTextWireframe().copy(
+            textPosition = MobileSegment
+                .TextPosition(
+                    padding = MobileSegment.Padding(0, 0, 0, 0),
+                    alignment = expectedTextAlignment
+                )
+        )
+        assertThat(buttonWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M resolve a TextWireframe W map() { Button with textPadding }`(forge: Forge) {
+        // Given
+        val fakeText = forge.aString()
+        val mockButton: Button = forge.aMockView<Button>().apply {
+            whenever(this.text).thenReturn(fakeText)
+            whenever(this.typeface).thenReturn(mock())
+        }
+
+        // When
+        val buttonWireframe = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockButton.toTextWireframe().copy(text = fakeText)
+        assertThat(buttonWireframe).isEqualTo(expectedWireframe)
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/GenericWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/GenericWireframeMapperTest.kt
@@ -1,0 +1,126 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.view.View
+import android.widget.Button
+import android.widget.ImageView
+import android.widget.TextView
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class GenericWireframeMapperTest {
+    @FloatForgery
+    var fakePixelDensity: Float = 1f
+
+    @Mock
+    lateinit var mockViewWireframeMapper: ViewWireframeMapper
+
+    @Mock
+    lateinit var mockImageWireframeMapper: ViewScreenshotWireframeMapper
+
+    @Mock
+    lateinit var mockTextWireframeMapper: TextWireframeMapper
+
+    @Mock
+    lateinit var mockButtonWireframeMapper: ButtonWireframeMapper
+
+    @Mock
+    lateinit var mockShapeWireframe: MobileSegment.Wireframe.ShapeWireframe
+
+    @Mock
+    lateinit var mockImageWireframe: MobileSegment.Wireframe.ShapeWireframe
+
+    @Mock
+    lateinit var mockTextWireframe: MobileSegment.Wireframe.TextWireframe
+
+    @Mock
+    lateinit var mockButtonWireframe: MobileSegment.Wireframe.TextWireframe
+
+    lateinit var testedGenericWireframeMapper: GenericWireframeMapper
+
+    @BeforeEach
+    fun `set up`() {
+        testedGenericWireframeMapper = GenericWireframeMapper(
+            mockViewWireframeMapper,
+            mockImageWireframeMapper,
+            mockTextWireframeMapper,
+            mockButtonWireframeMapper
+        )
+    }
+
+    @Test
+    fun `M resolve a ShapeWireframe W map { View }`() {
+        // Given
+        val mockView: View = mock()
+        whenever(mockViewWireframeMapper.map(mockView, fakePixelDensity))
+            .thenReturn(mockShapeWireframe)
+
+        // When
+        val wireframe = testedGenericWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        assertThat(wireframe).isEqualTo(mockShapeWireframe)
+    }
+
+    @Test
+    fun `M resolve a ShapeWireframe W map { ImageView }`() {
+        // Given
+        val mockView: ImageView = mock()
+        whenever(mockImageWireframeMapper.map(mockView, fakePixelDensity))
+            .thenReturn(mockImageWireframe)
+
+        // When
+        val wireframe = testedGenericWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        assertThat(wireframe).isEqualTo(mockImageWireframe)
+    }
+
+    @Test
+    fun `M resolve a TextWireframe W map { TextView }`() {
+        // Given
+        val mockView: TextView = mock()
+        whenever(mockTextWireframeMapper.map(mockView, fakePixelDensity))
+            .thenReturn(mockTextWireframe)
+
+        // When
+        val wireframe = testedGenericWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        assertThat(wireframe).isEqualTo(mockTextWireframe)
+    }
+
+    @Test
+    fun `M resolve a ButtonWireframe W map { Button }`() {
+        // Given
+        val mockView: Button = mock()
+        whenever(mockButtonWireframeMapper.map(mockView, fakePixelDensity))
+            .thenReturn(mockButtonWireframe)
+
+        // When
+        val wireframe = testedGenericWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        assertThat(wireframe).isEqualTo(mockButtonWireframe)
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewWireframeMapperTest.kt
@@ -1,0 +1,220 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.graphics.Typeface
+import android.graphics.drawable.ColorDrawable
+import android.widget.Button
+import android.widget.TextView
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.aMockView
+import com.datadog.android.sessionreplay.recorder.densityNormalized
+import com.datadog.android.sessionreplay.utils.ForgeConfigurator
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class TextViewWireframeMapperTest : BaseWireframeMapperTest() {
+
+    lateinit var testedTextWireframeMapper: TextWireframeMapper
+
+    @BeforeEach
+    fun `set up`() {
+        testedTextWireframeMapper = TextWireframeMapper()
+    }
+
+    @ParameterizedTest
+    @MethodSource("textTypefaces")
+    fun `M resolve a TextWireframe W map() { TextView with fontStyle }`(
+        typeface: Typeface,
+        expectedFontFamily: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeFontSize = forge.aFloat(min = 0f)
+        val fakeStyleColor = forge.aStringMatching("#[0-9A-F]{6}FF")
+        val fakeText = forge.aString()
+        val fakeFontColor = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .shr(8)
+            .toInt()
+        val mockTextView: TextView = forge.aMockView<TextView>().apply {
+            whenever(this.typeface).thenReturn(typeface)
+            whenever(this.textSize).thenReturn(fakeFontSize)
+            whenever(this.currentTextColor).thenReturn(fakeFontColor)
+            whenever(this.text).thenReturn(fakeText)
+        }
+
+        // When
+        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockTextView.toTextWireframe()
+            .copy(
+                textStyle = MobileSegment.TextStyle(
+                    expectedFontFamily,
+                    fakeFontSize.toLong().densityNormalized(fakePixelDensity),
+                    fakeStyleColor
+                )
+            )
+        assertThat(textWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M resolve a TextWireframe W map() { TextView with text }`(forge: Forge) {
+        // Given
+        val fakeText = forge.aString()
+        val mockButton: TextView = forge.aMockView<Button>().apply {
+            whenever(this.text).thenReturn(fakeText)
+            whenever(this.typeface).thenReturn(mock())
+        }
+
+        // When
+        val textWireframe = testedTextWireframeMapper.map(mockButton, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockButton.toTextWireframe().copy(text = fakeText)
+        assertThat(textWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @ParameterizedTest
+    @MethodSource("textAlignments")
+    fun `M resolve a TextWireframe W map() { TextView with textAlignment }`(
+        textAlignment: Int,
+        expectedTextAlignment: MobileSegment.Alignment,
+        forge: Forge
+    ) {
+        // Given
+        val mockTextView: TextView = forge.aMockView<TextView>().apply {
+            whenever(this.text).thenReturn(forge.aString())
+            whenever(this.typeface).thenReturn(mock())
+            whenever(this.textAlignment).thenReturn(textAlignment)
+        }
+
+        // When
+        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockTextView.toTextWireframe().copy(
+            textPosition = MobileSegment
+                .TextPosition(
+                    padding = MobileSegment.Padding(0, 0, 0, 0),
+                    alignment = expectedTextAlignment
+                )
+        )
+        assertThat(textWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @ParameterizedTest
+    @MethodSource("textAlignmentsFromGravity")
+    fun `M resolve a TextWireframe W map() { TextView with textAlignment from gravity }`(
+        gravity: Int,
+        expectedTextAlignment: MobileSegment.Alignment,
+        forge: Forge
+    ) {
+        // Given
+        val fakeText = forge.aString()
+        val mockTextView: TextView = forge.aMockView<TextView>().apply {
+            whenever(this.text).thenReturn(fakeText)
+            whenever(this.typeface).thenReturn(mock())
+            whenever(this.textAlignment).thenReturn(TextView.TEXT_ALIGNMENT_GRAVITY)
+            whenever(this.gravity).thenReturn(gravity)
+        }
+
+        // When
+        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockTextView.toTextWireframe().copy(
+            textPosition = MobileSegment
+                .TextPosition(
+                    padding = MobileSegment.Padding(0, 0, 0, 0),
+                    alignment = expectedTextAlignment
+                )
+        )
+        assertThat(textWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M resolve a TextWireframe W map() { TextView with textPadding }`(forge: Forge) {
+        // Given
+        val fakeText = forge.aString()
+        val mockTextView: TextView = forge.aMockView<TextView>().apply {
+            whenever(this.text).thenReturn(fakeText)
+            whenever(this.typeface).thenReturn(mock())
+        }
+
+        // When
+        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockTextView.toTextWireframe().copy(text = fakeText)
+        assertThat(textWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M resolve a TextWireframe with shapeStyle W map { TextView with ColorDrawable }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeStyleColor = forge.aStringMatching("#[0-9A-F]{8}")
+        val fakeDrawableColor = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .shr(8)
+            .toInt()
+        val fakeDrawableAlpha = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .and(ALPHA_MASK)
+            .toInt()
+        val mockDrawable = mock<ColorDrawable> {
+            whenever(it.color).thenReturn(fakeDrawableColor)
+            whenever(it.alpha).thenReturn(fakeDrawableAlpha)
+        }
+        val mockTextView = forge.aMockView<TextView>().apply {
+            whenever(this.background).thenReturn(mockDrawable)
+            whenever(this.text).thenReturn(forge.aString())
+            whenever(this.typeface).thenReturn(mock())
+        }
+
+        // When
+        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockTextView.toTextWireframe().copy(
+            shapeStyle = MobileSegment
+                .ShapeStyle(
+                    backgroundColor = fakeStyleColor,
+                    opacity = fakeDrawableAlpha,
+                    cornerRadius = null
+                )
+        )
+        assertThat(textWireframe).isEqualTo(expectedWireframe)
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewScreenshotWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewScreenshotWireframeMapperTest.kt
@@ -1,0 +1,52 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.view.View
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.aMockView
+import com.datadog.android.sessionreplay.utils.ForgeConfigurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class ViewScreenshotWireframeMapperTest : BaseWireframeMapperTest() {
+
+    lateinit var testedWireframeMapper: ViewScreenshotWireframeMapper
+
+    @BeforeEach
+    fun `set up`() {
+        testedWireframeMapper = ViewScreenshotWireframeMapper()
+    }
+
+    @Test
+    fun `M resolve a ShapeWireframe with border W map()`(forge: Forge) {
+        // Given
+        val mockView: View = forge.aMockView()
+        // When
+        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockView.toShapeWireframe()
+            .copy(border = MobileSegment.ShapeBorder("#000000FF", 1))
+        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapperTest.kt
@@ -1,0 +1,332 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.InsetDrawable
+import android.graphics.drawable.RippleDrawable
+import android.os.Build
+import android.view.View
+import androidx.annotation.RequiresApi
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.aMockView
+import com.datadog.android.sessionreplay.utils.ForgeConfigurator
+import com.datadog.tools.unit.annotations.TestTargetApi
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
+
+    lateinit var testedWireframeMapper: ViewWireframeMapper
+
+    @BeforeEach
+    fun `set up`() {
+        testedWireframeMapper = ViewWireframeMapper()
+    }
+
+    @Test
+    fun `M resolve a ShapeWireframe W map()`(forge: Forge) {
+        // Given
+        val mockView: View = forge.aMockView()
+        val expectedWireframe = mockView.toShapeWireframe()
+
+        // When
+        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M default to View hashcode W map() { View and id = NO_ID}`(forge: Forge) {
+        // Given
+        val mockView: View = forge.aMockView<View>().apply {
+            whenever(id).thenReturn(View.NO_ID)
+            // we cannot mock the hashcode method as it is final
+        }
+
+        // When
+        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockView.toShapeWireframe().copy(id = mockView.hashCode().toLong())
+        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M use the View hashcode for Wireframe id W produce() { id is not valid }`(forge: Forge) {
+        // Given
+        val mockViews = forge.aList(size = forge.anInt(min = 10, max = 20)) {
+            val mockRoot = aMockView<View>()
+            whenever(mockRoot.id).thenReturn(View.NO_ID)
+            mockRoot
+        }
+
+        // When
+        val shapeWireframes = mockViews.map {
+            testedWireframeMapper.map(
+                it,
+                fakePixelDensity
+            )
+        }
+
+        // Then
+        val idsSet: MutableSet<Long> = mutableSetOf()
+        shapeWireframes.forEach {
+            assertThat(idsSet).doesNotContain(it.id)
+            idsSet.add(it.id)
+        }
+    }
+
+    @Test
+    fun `M resolve a ShapeWireframe with shapeStyle W map { ColorDrawable }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeStyleColor = forge.aStringMatching("#[0-9A-F]{8}")
+        val fakeDrawableColor = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .shr(8)
+            .toInt()
+        val fakeDrawableAlpha = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .and(ALPHA_MASK)
+            .toInt()
+        val mockDrawable = mock<ColorDrawable> {
+            whenever(it.color).thenReturn(fakeDrawableColor)
+            whenever(it.alpha).thenReturn(fakeDrawableAlpha)
+        }
+        val mockView = forge.aMockView<View>().apply {
+            whenever(this.background).thenReturn(mockDrawable)
+        }
+
+        // When
+        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockView.toShapeWireframe().copy(
+            shapeStyle = MobileSegment
+                .ShapeStyle(
+                    backgroundColor = fakeStyleColor,
+                    opacity = fakeDrawableAlpha,
+                    cornerRadius = null
+                )
+        )
+        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.M)
+    @TestTargetApi(Build.VERSION_CODES.M)
+    @Test
+    fun `M resolve a ShapeWireframe with shapeStyle W map {InsetDrawable, M}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeStyleColor = forge.aStringMatching("#[0-9A-F]{8}")
+        val fakeDrawableColor = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .shr(8)
+            .toInt()
+        val fakeDrawableAlpha = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .and(ALPHA_MASK)
+            .toInt()
+        val mockDrawable = mock<ColorDrawable> {
+            whenever(it.color).thenReturn(fakeDrawableColor)
+            whenever(it.alpha).thenReturn(fakeDrawableAlpha)
+        }
+        val mockInsetDrawable: InsetDrawable = mock<InsetDrawable> {
+            whenever(it.drawable).thenReturn(mockDrawable)
+        }
+        val mockView = forge.aMockView<View>().apply {
+            whenever(this.background).thenReturn(mockInsetDrawable)
+        }
+
+        // When
+        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockView.toShapeWireframe().copy(
+            shapeStyle = MobileSegment
+                .ShapeStyle(
+                    backgroundColor = fakeStyleColor,
+                    opacity = fakeDrawableAlpha,
+                    cornerRadius = null
+                )
+        )
+        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M resolve a ShapeWireframe no shapeStyle W map { InsetDrawable, lower than M }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeStyleColor = forge.aStringMatching("#[0-9A-F]{8}")
+        val fakeDrawableColor = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .shr(8)
+            .toInt()
+        val fakeDrawableAlpha = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .and(ALPHA_MASK)
+            .toInt()
+        val mockDrawable = mock<ColorDrawable> {
+            whenever(it.color).thenReturn(fakeDrawableColor)
+            whenever(it.alpha).thenReturn(fakeDrawableAlpha)
+        }
+        val mockInsetDrawable: InsetDrawable = mock<InsetDrawable> {
+            whenever(it.drawable).thenReturn(mockDrawable)
+        }
+        val mockView = forge.aMockView<View>().apply {
+            whenever(this.background).thenReturn(mockInsetDrawable)
+        }
+
+        // When
+        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockView.toShapeWireframe()
+            .copy(border = MobileSegment.ShapeBorder("#000000FF", 1))
+        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Test
+    fun `M resolve a ShapeWireframe with shapeStyle W map {RippleDrawable, ColorDrawable, L}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeStyleColor = forge.aStringMatching("#[0-9A-F]{8}")
+        val fakeDrawableColor = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .shr(8)
+            .toInt()
+        val fakeDrawableAlpha = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .and(ALPHA_MASK)
+            .toInt()
+        val mockDrawable = mock<ColorDrawable> {
+            whenever(it.color).thenReturn(fakeDrawableColor)
+            whenever(it.alpha).thenReturn(fakeDrawableAlpha)
+        }
+        val mockRipple: RippleDrawable = mock<RippleDrawable> {
+            whenever(it.numberOfLayers).thenReturn(forge.anInt(min = 1))
+            whenever(it.getDrawable(0)).thenReturn(mockDrawable)
+        }
+        val mockView = forge.aMockView<View>().apply {
+            whenever(this.background).thenReturn(mockRipple)
+        }
+
+        // When
+        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockView.toShapeWireframe().copy(
+            shapeStyle = MobileSegment
+                .ShapeStyle(
+                    backgroundColor = fakeStyleColor,
+                    opacity = fakeDrawableAlpha,
+                    cornerRadius = null
+                )
+        )
+        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M resolve a ShapeWireframe no shapeStyle W map {RippleDrawable, ColorDrawable, lowL}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeStyleColor = forge.aStringMatching("#[0-9A-F]{8}")
+        val fakeDrawableColor = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .shr(8)
+            .toInt()
+        val fakeDrawableAlpha = fakeStyleColor
+            .substring(1)
+            .toLong(16)
+            .and(ALPHA_MASK)
+            .toInt()
+        val mockDrawable = mock<ColorDrawable> {
+            whenever(it.color).thenReturn(fakeDrawableColor)
+            whenever(it.alpha).thenReturn(fakeDrawableAlpha)
+        }
+        val mockRipple: RippleDrawable = mock<RippleDrawable> {
+            whenever(it.numberOfLayers).thenReturn(forge.anInt(min = 1))
+            whenever(it.getDrawable(0)).thenReturn(mockDrawable)
+        }
+        val mockView = forge.aMockView<View>().apply {
+            whenever(this.background).thenReturn(mockRipple)
+        }
+
+        // When
+        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockView.toShapeWireframe().copy(
+            border = MobileSegment.ShapeBorder
+            ("#000000FF", 1)
+        )
+        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+    }
+
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @Test
+    fun `M resolve a ShapeWireframe no shapeStyle W produce {RippleDrawable, NonColorDrawable, L}`(
+        forge: Forge
+    ) {
+        // Given
+        val mockDrawable = mock<Drawable>()
+        val mockRipple: RippleDrawable = mock {
+            whenever(it.numberOfLayers).thenReturn(forge.anInt(min = 1))
+            whenever(it.getDrawable(0)).thenReturn(mockDrawable)
+        }
+        val mockView = forge.aMockView<View>().apply {
+            whenever(this.background).thenReturn(mockRipple)
+        }
+
+        // When
+        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+
+        // Then
+        val expectedWireframe = mockView.toShapeWireframe()
+            .copy(border = MobileSegment.ShapeBorder("#000000FF", 1))
+        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/NodeForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/NodeForgeryFactory.kt
@@ -14,10 +14,7 @@ internal class NodeForgeryFactory : ForgeryFactory<Node> {
 
     override fun getForgery(forge: Forge): Node {
         return Node(
-            forge.anInt(min = 0),
-            parent = forge.aNullable {
-                forge.getForgery()
-            }
+            wireframes = emptyList()
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR introduces the basic logic in our `SnapshotProducer` as a part of the `ScreenRecorder` component where we are actually going to capture the application screens and resolve them as `Node` tree equivalents. 

Please note that for now the `SnapshotProducer` is quite dummy and can only handle basic application screens mostly from our Android Sample App. The way we will work on this component is through multiple iterations by running it with different sample applications and improving the output.
 
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

