### PR TITLE
Add configuration method to disable action tracking.

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -85,6 +85,7 @@ data class com.datadog.android.core.configuration.Configuration
     fun useCustomCrashReportsEndpoint(String): Builder
     fun useCustomRumEndpoint(String): Builder
     fun trackInteractions(Array<com.datadog.android.rum.tracking.ViewAttributesProvider> = emptyArray(), com.datadog.android.rum.tracking.InteractionPredicate = NoOpInteractionPredicate()): Builder
+    fun disableInteractionTracking(): Builder
     fun trackLongTasks(Long = DEFAULT_LONG_TASK_THRESHOLD_MS): Builder
     fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
     fun addPlugin(com.datadog.android.plugin.DatadogPlugin, com.datadog.android.plugin.Feature): Builder

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -29,6 +29,7 @@ import com.datadog.android.rum.internal.instrumentation.UserActionTrackingStrate
 import com.datadog.android.rum.internal.instrumentation.UserActionTrackingStrategyLegacy
 import com.datadog.android.rum.internal.instrumentation.gestures.DatadogGesturesTracker
 import com.datadog.android.rum.internal.tracking.JetpackViewAttributesProvider
+import com.datadog.android.rum.internal.tracking.NoOpUserActionTrackingStrategy
 import com.datadog.android.rum.internal.tracking.UserActionTrackingStrategy
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
@@ -276,6 +277,18 @@ internal constructor(
             )
             applyIfFeatureEnabled(PluginFeature.RUM, "trackInteractions") {
                 rumConfig = rumConfig.copy(userActionTrackingStrategy = strategy)
+            }
+            return this
+        }
+
+        /**
+         * Disable the user interaction automatic tracker.
+         */
+        fun disableInteractionTracking(): Builder {
+            applyIfFeatureEnabled(PluginFeature.RUM, "disableInteractionTracking") {
+                rumConfig = rumConfig.copy(
+                    userActionTrackingStrategy = NoOpUserActionTrackingStrategy()
+                )
             }
             return this
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -335,6 +335,27 @@ internal class ConfigurationBuilderTest {
     }
 
     @Test
+    fun `M set the NoOpUserActionTrackingStrategy W disableInteractionTracking()`() {
+        // Given
+
+        // When
+        val config = testedBuilder
+            .disableInteractionTracking()
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        assertThat(config.rumConfig!!)
+            .hasNoOpUserActionTrackingStrategy()
+            .hasViewTrackingStrategy(Configuration.DEFAULT_RUM_CONFIG.viewTrackingStrategy!!)
+            .hasLongTaskTrackingEnabled(Configuration.DEFAULT_LONG_TASK_THRESHOLD_MS)
+        assertThat(config.additionalConfig).isEmpty()
+    }
+
+    @Test
     fun `𝕄 bundle the custom attributes providers W trackInteractions()`(
         @IntForgery(0, 10) attributesCount: Int
     ) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ConfigurationRumAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ConfigurationRumAssert.kt
@@ -11,6 +11,7 @@ import com.datadog.android.rum.internal.instrumentation.MainLooperLongTaskStrate
 import com.datadog.android.rum.internal.instrumentation.UserActionTrackingStrategyApi29
 import com.datadog.android.rum.internal.instrumentation.UserActionTrackingStrategyLegacy
 import com.datadog.android.rum.internal.instrumentation.gestures.DatadogGesturesTracker
+import com.datadog.android.rum.internal.tracking.NoOpUserActionTrackingStrategy
 import com.datadog.android.rum.internal.tracking.UserActionTrackingStrategy
 import com.datadog.android.rum.tracking.InteractionPredicate
 import com.datadog.android.rum.tracking.TrackingStrategy
@@ -31,6 +32,12 @@ internal class ConfigurationRumAssert(actual: Configuration.Feature.RUM) :
     ): ConfigurationRumAssert {
         assertThat(actual.userActionTrackingStrategy)
             .isEqualTo(userActionTrackingStrategy)
+        return this
+    }
+
+    fun hasNoOpUserActionTrackingStrategy(): ConfigurationRumAssert {
+        assertThat(actual.userActionTrackingStrategy)
+            .isInstanceOf(NoOpUserActionTrackingStrategy::class.java)
         return this
     }
 

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -30,4 +30,5 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android._InternalProxy$_TelemetryProxy#fun error(String, String?, String?)
  * apiMethodSignature: com.datadog.android._InternalProxy$_TelemetryProxy#fun error(String, Throwable? = null)
  * apiMethodSignature: com.datadog.android.rum._RumInternalProxy#fun addLongTask(Long, String)
+ * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun disableInteractionTracking(): Builder
  */


### PR DESCRIPTION
### What does this PR do?

This allows users to replace the current UserAcitonTrackingStategy with a NoOpUserActionTrackingStrategy.

### Motivation

This is mostly for Flutter, since the initialization of the UserActionTrackingStrategy happens after the MainActivity is live, so the initial creation misses hooking into the Activity anyway, and subsequent attempts to listen to the Activity result in logcat spam, as there are no views that the tracking strategy can see.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

