### PR TITLE
RUMM-2448: Add variant tag to logs

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -199,6 +199,7 @@ object com.datadog.android.log.LogAttributes
   const val USR_EMAIL: String
   const val USR_ID: String
   const val USR_NAME: String
+  const val VARIANT: String
 class com.datadog.android.log.Logger
   fun v(String, Throwable? = null, Map<String, Any?> = emptyMap())
   fun d(String, Throwable? = null, Map<String, Any?> = emptyMap())

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -258,7 +258,8 @@ internal object CoreFeature {
                     timeProvider,
                     sdkVersion,
                     envName,
-                    packageVersion
+                    packageVersion,
+                    variant
                 ),
                 NdkCrashLogDeserializer(sdkLogger),
                 RumEventDeserializer(),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -79,7 +79,8 @@ internal object CrashReportsFeature : SdkFeature<LogEvent, Configuration.Feature
                 CoreFeature.timeProvider,
                 CoreFeature.sdkVersion,
                 CoreFeature.envName,
-                CoreFeature.packageVersion
+                CoreFeature.packageVersion,
+                CoreFeature.variant
             ),
             writer = persistenceStrategy.getWriter(),
             appContext = appContext

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
@@ -305,4 +305,10 @@ object LogAttributes {
      * @see [Datadog.setUserInfo]
      */
     const val USR_NAME: String = "$USR_ATTRIBUTES_GROUP.name"
+
+    /**
+     * The application variant. (String)
+     * This value is filled automatically by the [Logger].
+     */
+    const val VARIANT: String = "variant"
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -344,7 +344,8 @@ internal constructor(internal var handler: LogHandler) {
                 CoreFeature.timeProvider,
                 CoreFeature.sdkVersion,
                 CoreFeature.envName,
-                CoreFeature.packageVersion
+                CoreFeature.packageVersion,
+                CoreFeature.variant
             )
         }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogGenerator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogGenerator.kt
@@ -26,7 +26,8 @@ internal class LogGenerator(
     internal val timeProvider: TimeProvider,
     internal val sdkVersion: String,
     envName: String,
-    appVersion: String
+    appVersion: String,
+    variant: String
 ) {
 
     private val simpleDateFormat = buildLogDateFormat()
@@ -39,6 +40,12 @@ internal class LogGenerator(
 
     private val appVersionTag = if (appVersion.isNotEmpty()) {
         "${LogAttributes.APPLICATION_VERSION}:$appVersion"
+    } else {
+        null
+    }
+
+    private val variantTag = if (variant.isNotEmpty()) {
+        "${LogAttributes.VARIANT}:$variant"
     } else {
         null
     }
@@ -122,6 +129,9 @@ internal class LogGenerator(
             combinedTags.add(it)
         }
         appVersionTag?.let {
+            combinedTags.add(it)
+        }
+        variantTag?.let {
             combinedTags.add(it)
         }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -123,6 +123,9 @@ internal class DatadogExceptionHandlerTest {
     @StringForgery(regex = "[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]")
     lateinit var fakeEnvName: String
 
+    @StringForgery
+    lateinit var fakeVariant: String
+
     @BeforeEach
     fun `set up`() {
         mockChoreographerInstance()
@@ -132,7 +135,7 @@ internal class DatadogExceptionHandlerTest {
 
         Datadog.initialize(
             appContext.mockInstance,
-            Credentials(fakeToken, fakeEnvName, Credentials.NO_VARIANT, null),
+            Credentials(fakeToken, fakeEnvName, fakeVariant, null),
             Configuration.Builder(
                 logsEnabled = true,
                 tracesEnabled = true,
@@ -153,7 +156,8 @@ internal class DatadogExceptionHandlerTest {
                 mockTimeProvider,
                 CoreFeature.sdkVersion,
                 CoreFeature.envName,
-                CoreFeature.packageVersion
+                CoreFeature.packageVersion,
+                CoreFeature.variant
             ),
             writer = mockLogWriter,
             appContext = appContext.mockInstance
@@ -191,7 +195,8 @@ internal class DatadogExceptionHandlerTest {
                 .hasExactlyTags(
                     listOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}"
+                        "${LogAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
                 .hasExactlyAttributes(
@@ -291,7 +296,8 @@ internal class DatadogExceptionHandlerTest {
                 .hasExactlyTags(
                     listOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}"
+                        "${LogAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
                 .hasExactlyAttributes(
@@ -327,7 +333,8 @@ internal class DatadogExceptionHandlerTest {
                 .hasExactlyTags(
                     listOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}"
+                        "${LogAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
                 .hasExactlyAttributes(
@@ -365,7 +372,8 @@ internal class DatadogExceptionHandlerTest {
                 .hasExactlyTags(
                     listOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}"
+                        "${LogAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
                 .hasExactlyAttributes(
@@ -409,7 +417,8 @@ internal class DatadogExceptionHandlerTest {
                 .hasExactlyTags(
                     listOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}"
+                        "${LogAttributes.APPLICATION_VERSION}:${appContext.fakeVersionName}",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
                 .hasExactlyAttributes(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/LogGeneratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/LogGeneratorTest.kt
@@ -82,6 +82,7 @@ internal class LogGeneratorTest {
     lateinit var fakeTags: Set<String>
     lateinit var fakeAppVersion: String
     lateinit var fakeEnvName: String
+    lateinit var fakeVariant: String
     lateinit var fakeLogMessage: String
     lateinit var fakeThrowable: Throwable
 
@@ -114,6 +115,7 @@ internal class LogGeneratorTest {
         fakeTags = forge.aList { anAlphabeticalString() }.toSet()
         fakeAppVersion = forge.aStringMatching("^[0-9]\\.[0-9]\\.[0-9]")
         fakeEnvName = forge.aStringMatching("[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]")
+        fakeVariant = forge.anAlphabeticalString()
         fakeThrowable = forge.aThrowable()
         fakeTimestamp = System.currentTimeMillis()
         fakeThreadName = forge.anAlphabeticalString()
@@ -138,7 +140,8 @@ internal class LogGeneratorTest {
             mockTimeProvider,
             fakeSdkVersion,
             fakeEnvName,
-            fakeAppVersion
+            fakeAppVersion,
+            fakeVariant
         )
     }
 
@@ -384,7 +387,8 @@ internal class LogGeneratorTest {
             mockTimeProvider,
             fakeSdkVersion,
             fakeEnvName,
-            fakeAppVersion
+            fakeAppVersion,
+            fakeVariant
         )
         // WHEN
         val log = testedLogGenerator.generateLog(
@@ -413,7 +417,8 @@ internal class LogGeneratorTest {
             mockTimeProvider,
             fakeSdkVersion,
             fakeEnvName,
-            fakeAppVersion
+            fakeAppVersion,
+            fakeVariant
         )
         // WHEN
         val log = testedLogGenerator.generateLog(
@@ -458,7 +463,8 @@ internal class LogGeneratorTest {
             mockTimeProvider,
             fakeSdkVersion,
             "",
-            fakeAppVersion
+            fakeAppVersion,
+            fakeVariant
         )
 
         // WHEN
@@ -472,7 +478,9 @@ internal class LogGeneratorTest {
         )
 
         // THEN
-        val expectedTags = fakeTags + "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"
+        val expectedTags = fakeTags +
+            "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion" +
+            "${LogAttributes.VARIANT}:$fakeVariant"
         assertThat(log).hasExactlyTags(expectedTags)
     }
 
@@ -495,7 +503,7 @@ internal class LogGeneratorTest {
     }
 
     @Test
-    fun `M not add the appVersionTag W not empty`() {
+    fun `M not add the appVersionTag W empty`() {
         // GIVEN
         testedLogGenerator = LogGenerator(
             fakeServiceName,
@@ -505,6 +513,57 @@ internal class LogGeneratorTest {
             mockTimeProvider,
             fakeSdkVersion,
             fakeEnvName,
+            "",
+            fakeVariant
+        )
+
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        val expectedTags = fakeTags +
+            "${LogAttributes.ENV}:$fakeEnvName" +
+            "${LogAttributes.VARIANT}:$fakeVariant"
+        assertThat(log).hasExactlyTags(expectedTags)
+    }
+
+    @Test
+    fun `M add the variantTag W not empty`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp
+        )
+
+        // THEN
+        val deserializedTags = log.ddtags.split(",")
+        Assertions.assertThat(deserializedTags)
+            .contains("${LogAttributes.VARIANT}:$fakeVariant")
+    }
+
+    @Test
+    fun `M not add the variantTag W empty`() {
+        // GIVEN
+        testedLogGenerator = LogGenerator(
+            fakeServiceName,
+            fakeLoggerName,
+            mockNetworkInfoProvider,
+            mockUserInfoProvider,
+            mockTimeProvider,
+            fakeSdkVersion,
+            fakeEnvName,
+            fakeAppVersion,
             ""
         )
 
@@ -519,7 +578,9 @@ internal class LogGeneratorTest {
         )
 
         // THEN
-        val expectedTags = fakeTags + "${LogAttributes.ENV}:$fakeEnvName"
+        val expectedTags = fakeTags +
+            "${LogAttributes.ENV}:$fakeEnvName" +
+            "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"
         assertThat(log).hasExactlyTags(expectedTags)
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -114,6 +114,8 @@ internal class DatadogLogHandlerTest {
 
     lateinit var fakeSdkVersion: String
 
+    lateinit var fakeVariant: String
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         // To avoid java.lang.NoClassDefFoundError: android/hardware/display/DisplayManagerGlobal.
@@ -128,6 +130,7 @@ internal class DatadogLogHandlerTest {
         )
         fakeAppVersion = forge.aStringMatching("^[0-9]\\.[0-9]\\.[0-9]")
         fakeEnvName = forge.aStringMatching("[a-zA-Z0-9_:./-]{0,195}[a-zA-Z0-9_./-]")
+        fakeVariant = forge.anAlphabeticalString()
         fakeServiceName = forge.anAlphabeticalString()
         fakeLoggerName = forge.anAlphabeticalString()
         fakeMessage = forge.anAlphabeticalString()
@@ -150,7 +153,8 @@ internal class DatadogLogHandlerTest {
                 mockTimeProvider,
                 fakeSdkVersion,
                 fakeEnvName,
-                fakeAppVersion
+                fakeAppVersion,
+                fakeVariant
             ),
             mockWriter
         )
@@ -197,7 +201,8 @@ internal class DatadogLogHandlerTest {
                 .hasExactlyTags(
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"
+                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
                 .doesNotHaveError()
@@ -218,7 +223,8 @@ internal class DatadogLogHandlerTest {
                 mockTimeProvider,
                 fakeSdkVersion,
                 fakeEnvName,
-                fakeAppVersion
+                fakeAppVersion,
+                fakeVariant
             ),
             mockWriter,
             minLogPriority = forge.anInt(min = fakeLevel + 1)
@@ -272,7 +278,8 @@ internal class DatadogLogHandlerTest {
                 .hasExactlyTags(
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"
+                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
                 .hasError(
@@ -374,7 +381,8 @@ internal class DatadogLogHandlerTest {
                 .hasExactlyTags(
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"
+                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
         }
@@ -425,7 +433,8 @@ internal class DatadogLogHandlerTest {
                 .hasExactlyTags(
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"
+                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
         }
@@ -443,7 +452,8 @@ internal class DatadogLogHandlerTest {
                 mockTimeProvider,
                 fakeSdkVersion,
                 fakeEnvName,
-                fakeAppVersion
+                fakeAppVersion,
+                fakeVariant
             ),
             mockWriter
         )
@@ -478,7 +488,8 @@ internal class DatadogLogHandlerTest {
                 .hasExactlyTags(
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"
+                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
         }
@@ -497,7 +508,8 @@ internal class DatadogLogHandlerTest {
                 mockTimeProvider,
                 fakeSdkVersion,
                 fakeEnvName,
-                fakeAppVersion
+                fakeAppVersion,
+                fakeVariant
             ),
             mockWriter
         )
@@ -525,7 +537,8 @@ internal class DatadogLogHandlerTest {
                 .hasExactlyTags(
                     setOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"
+                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
                 .doesNotHaveError()
@@ -654,7 +667,8 @@ internal class DatadogLogHandlerTest {
                 mockTimeProvider,
                 fakeSdkVersion,
                 fakeEnvName,
-                fakeAppVersion
+                fakeAppVersion,
+                fakeVariant
             ),
             mockWriter,
             bundleWithTraces = false
@@ -691,7 +705,8 @@ internal class DatadogLogHandlerTest {
                 mockTimeProvider,
                 fakeSdkVersion,
                 fakeEnvName,
-                fakeAppVersion
+                fakeAppVersion,
+                fakeVariant
             ),
             mockWriter,
             bundleWithTraces = false,
@@ -725,7 +740,8 @@ internal class DatadogLogHandlerTest {
                 mockTimeProvider,
                 fakeSdkVersion,
                 fakeEnvName,
-                fakeAppVersion
+                fakeAppVersion,
+                fakeVariant
             ),
             mockWriter,
             bundleWithTraces = false,
@@ -764,7 +780,8 @@ internal class DatadogLogHandlerTest {
                 .hasExactlyTags(
                     fakeTags + setOf(
                         "${LogAttributes.ENV}:$fakeEnvName",
-                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion"
+                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
                     )
                 )
         }


### PR DESCRIPTION
### What does this PR do?

**THIS PR TARGETS 1.14.0 RELEASE BRANCH**

This change adds `variant` to `ddTags` of Logs events to be able to support stacktraces de-obfuscation in Logs dashboard.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

