### PR TITLE
RUMM-2477: Update Cmake to 3.22.1

### DIFF
--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -29,7 +29,10 @@ ENV ANDROID_COMPILE_SDK 31
 ENV ANDROID_BUILD_TOOLS 31.0.0
 ENV ANDROID_SDK_TOOLS 7583922
 ENV NDK_VERSION 22.1.7171670
-ENV CMAKE_VERSION 3.10.2.4988404
+ENV CMAKE_VERSION 3.22.1
+# Docker image is shared between branches and some older versions (1.14 and below) need to have CMAKE 3.10
+# Can be removed at some point
+ENV CMAKE_VERSION_LEGACY 3.10.2.4988404
 
 
 
@@ -70,6 +73,7 @@ RUN \
     echo y | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS}" >/dev/null && \
     echo y | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --install "ndk;${NDK_VERSION}" >/dev/null && \
     echo y | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --install "cmake;${CMAKE_VERSION}" >/dev/null && \
+    echo y | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --install "cmake;${CMAKE_VERSION_LEGACY}" >/dev/null && \
     yes | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --licenses
 
 RUN set -x \

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -12,9 +12,7 @@ object Dependencies {
 
         // NDK
         const val Ndk = "22.1.7171670"
-        // TODO RUMM-1660. Check if Cmake >= 3.20.4 is available when doing AGP 7 migration
-        // Cannot use 3.18.1 here, because it has a bug in the File API.
-        const val CMake = "3.10.2"
+        const val CMake = "3.22.1"
     }
 
     object Repositories {

--- a/dd-sdk-android-ndk/CMakeLists.txt
+++ b/dd-sdk-android-ndk/CMakeLists.txt
@@ -1,5 +1,5 @@
 project("dd-sdk-android-ndk")
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.22.1)
 # use the C++ 17 compiler
 set(CMAKE_CXX_STANDARD 17)
 add_subdirectory(src/main/cpp)

--- a/instrumented/nightly-tests/src/main/cpp/CMakeLists.txt
+++ b/instrumented/nightly-tests/src/main/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 project("datadog-nightly-tests")
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.22.1)
 
 add_library( # Sets the name of the library.
         datadog-nightly-lib

--- a/sample/kotlin/src/main/cpp/CMakeLists.txt
+++ b/sample/kotlin/src/main/cpp/CMakeLists.txt
@@ -1,5 +1,5 @@
 project("datadog-native-sample")
-cmake_minimum_required(VERSION 3.10.2)
+cmake_minimum_required(VERSION 3.22.1)
 
 add_library( # Sets the name of the library.
         datadog-native-sample-lib

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/crash/CrashFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/crash/CrashFragment.kt
@@ -62,11 +62,6 @@ class CrashFragment :
         viewModel = ViewModelProviders.of(this).get(CrashViewModel::class.java)
     }
 
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        triggerCrash()
-    }
-
     // endregion
 
     // region View.OnClickListener


### PR DESCRIPTION
### What does this PR do?

This change updates Cmake to `3.22.1` to address the previous rollback done in https://github.com/DataDog/dd-sdk-android/pull/716.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

