### PR TITLE
RUMM-2333: Features can store their context in SDK context

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1740,6 +1740,7 @@ interface com.datadog.android.v2.api.SDKCore
   fun stop()
   fun clearAllData()
   fun flushStoredData()
+  fun setFeatureContext(String, Map<String, Any?>)
 enum com.datadog.android.v2.api.SDKEndpoint
   - US1
   - US3
@@ -1749,7 +1750,7 @@ enum com.datadog.android.v2.api.SDKEndpoint
 data class com.datadog.android.v2.api.context.CarrierInfo
   constructor(String?, String?)
 data class com.datadog.android.v2.api.context.DatadogContext
-  constructor(com.datadog.android.DatadogSite, String, String, String, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, com.datadog.android.privacy.TrackingConsent, Map<String, Any>)
+  constructor(com.datadog.android.DatadogSite, String, String, String, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, com.datadog.android.privacy.TrackingConsent, Map<String, Map<String, Any?>>)
 data class com.datadog.android.v2.api.context.DeviceInfo
   constructor(String, String, String, DeviceType, String, String, String, String, String)
 enum com.datadog.android.v2.api.context.DeviceType

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -70,6 +70,7 @@ import com.lyft.kronos.KronosClock
 import java.io.File
 import java.lang.ref.WeakReference
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingDeque
 import java.util.concurrent.ScheduledThreadPoolExecutor
@@ -118,6 +119,8 @@ internal class CoreFeature {
     internal lateinit var webViewTrackingHosts: List<String>
     internal lateinit var storageDir: File
     internal lateinit var androidInfoProvider: AndroidInfoProvider
+
+    internal val featuresContext: MutableMap<String, Map<String, Any?>> = ConcurrentHashMap()
 
     // TESTS ONLY, to prevent Kronos spinning sync threads in unit-tests
     internal var disableKronosBackgroundSync = false
@@ -179,6 +182,7 @@ internal class CoreFeature {
             cleanupApplicationInfo()
             cleanupProviders()
             shutDownExecutors()
+            featuresContext.clear()
             initialized.set(false)
             ndkCrashHandler = NoOpNdkCrashHandler()
             trackingConsentProvider = NoOpConsentProvider()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/SDKCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/SDKCore.kt
@@ -14,7 +14,7 @@ import com.datadog.tools.annotation.NoOpImplementation
 /**
  * SDKCore is the entry point to register Datadog features to the core registry.
  */
-@Suppress("ComplexInterface")
+@Suppress("ComplexInterface", "TooManyFunctions")
 @NoOpImplementation
 interface SDKCore {
 
@@ -101,4 +101,12 @@ interface SDKCore {
      * Flushes all stored data (send everything right now).
      */
     fun flushStoredData()
+
+    /**
+     * Sets the context for the particular feature.
+     *
+     * @param feature Feature name.
+     * @param context Context to set.
+     */
+    fun setFeatureContext(feature: String, context: Map<String, Any?>)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/context/DatadogContext.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/context/DatadogContext.kt
@@ -46,5 +46,5 @@ data class DatadogContext(
     val deviceInfo: DeviceInfo,
     val userInfo: UserInfo,
     val trackingConsent: TrackingConsent,
-    val featuresContext: Map<String, Any>
+    val featuresContext: Map<String, Map<String, Any?>>
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -162,6 +162,11 @@ internal class DatadogCore(
         webViewRumFeature?.flushStoredData()
     }
 
+    /** @inheritDoc */
+    override fun setFeatureContext(feature: String, context: Map<String, Any?>) {
+        contextProvider?.setFeatureContext(feature, context)
+    }
+
     /**
      * Returns all registered features.
      */

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/ContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/ContextProvider.kt
@@ -14,4 +14,6 @@ internal interface ContextProvider {
     //  when datadog is not initialized yet/anymore (case of UploadWorker, other calls site
     //  should be in sync with lifecycle)
     val context: DatadogContext
+
+    fun setFeatureContext(feature: String, context: Map<String, Any?>)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/DatadogContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/DatadogContextProvider.kt
@@ -74,9 +74,13 @@ internal class DatadogContextProvider(val coreFeature: CoreFeature) : ContextPro
                     )
                 },
                 trackingConsent = coreFeature.trackingConsentProvider.getConsent(),
-                featuresContext = emptyMap()
+                featuresContext = coreFeature.featuresContext
             )
         }
+
+    override fun setFeatureContext(feature: String, context: Map<String, Any?>) {
+        coreFeature.featuresContext[feature] = context
+    }
 
     private fun NetworkInfoV1.Connectivity.asV2(): NetworkInfo.Connectivity {
         return when (this) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -51,8 +51,10 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.AdvancedForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.MapForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -919,6 +921,31 @@ internal class CoreFeatureTest {
 
         // Then
         verify(mockConsentProvider).unregisterAllCallbacks()
+    }
+
+    @Test
+    fun `𝕄 clean up feature context 𝕎 stop()`(
+        @StringForgery feature: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
+        ) context: Map<String, String>
+    ) {
+        // Given
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeSdkInstanceId,
+            fakeCredentials,
+            fakeConfig,
+            fakeConsent
+        )
+        testedFeature.featuresContext[feature] = context
+
+        // When
+        testedFeature.stop()
+
+        // Then
+        assertThat(testedFeature.featuresContext).isEmpty()
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
@@ -20,6 +20,7 @@ import com.datadog.android.core.internal.system.SystemInfoProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.log.internal.user.MutableUserInfoProvider
 import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.tools.unit.extensions.config.MockTestConfiguration
 import com.lyft.kronos.KronosClock
 import com.nhaarman.mockitokotlin2.doReturn
@@ -49,6 +50,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
     lateinit var fakeUploadFrequency: UploadFrequency
     lateinit var fakeSite: DatadogSite
     var fakeProcessImportance: Int = 0
+    lateinit var fakeFeaturesContext: MutableMap<String, Map<String, Any?>>
 
     lateinit var mockUploadExecutor: ScheduledThreadPoolExecutor
     lateinit var mockOkHttpClient: OkHttpClient
@@ -94,6 +96,11 @@ internal class CoreFeatureTestConfiguration<T : Context>(
         fakeUploadFrequency = forge.aValueFrom(UploadFrequency::class.java)
         fakeSite = forge.aValueFrom(DatadogSite::class.java)
         fakeProcessImportance = forge.anInt()
+        // building nested maps with default size slows down tests quite a lot, so will use
+        // an explicit small size
+        fakeFeaturesContext = forge.aMap(size = 2) {
+            forge.anAlphabeticalString() to forge.exhaustiveAttributes()
+        }.toMutableMap()
     }
 
     private fun createMocks() {
@@ -129,6 +136,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
         whenever(mockInstance.storageDir) doReturn fakeStorageDir
         whenever(mockInstance.uploadFrequency) doReturn fakeUploadFrequency
         whenever(mockInstance.site) doReturn fakeSite
+        whenever(mockInstance.featuresContext) doReturn fakeFeaturesContext
         CoreFeature.processImportance = fakeProcessImportance
 
         whenever(mockInstance.persistenceExecutorService) doReturn mockPersistenceExecutor

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
@@ -30,7 +30,11 @@ class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
             deviceInfo = forge.getForgery(),
             userInfo = forge.getForgery(),
             trackingConsent = forge.aValueFrom(TrackingConsent::class.java),
-            featuresContext = emptyMap()
+            // building nested maps with default size slows down tests quite a lot, so will use
+            // an explicit small size
+            featuresContext = forge.aMap(size = 2) {
+                forge.anAlphabeticalString() to forge.exhaustiveAttributes()
+            }
         )
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
@@ -18,6 +18,7 @@ import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
 import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.core.internal.ContextProvider
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.ProhibitLeavingStaticMocksExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -26,8 +27,10 @@ import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.annotation.AdvancedForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.MapForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -164,6 +167,25 @@ internal class DatadogCoreTest {
                 "key2" to "one"
             )
         )
+    }
+
+    @Test
+    fun `𝕄 set feature context 𝕎 setFeatureContext() is called`(
+        @StringForgery feature: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
+        ) context: Map<String, String>
+    ) {
+        // Given
+        val mockContextProvider = mock<ContextProvider>()
+        testedCore.contextProvider = mockContextProvider
+
+        // When
+        testedCore.setFeatureContext(feature, context)
+
+        // Then
+        verify(mockContextProvider).setFeatureContext(feature, context)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/DatadogContextProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/DatadogContextProviderTest.kt
@@ -20,8 +20,12 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.annotation.AdvancedForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.MapForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import java.util.concurrent.TimeUnit
@@ -142,7 +146,22 @@ internal class DatadogContextProviderTest {
 
         assertThat(context.trackingConsent).isEqualTo(fakeTrackingConsent)
 
-        assertThat(context.featuresContext).isEmpty()
+        assertThat(context.featuresContext).isEqualTo(coreFeature.mockInstance.featuresContext)
+    }
+
+    @Test
+    fun `𝕄 set feature context 𝕎 setFeatureContext()`(
+        @StringForgery feature: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
+        ) context: Map<String, String>
+    ) {
+        // When
+        testedProvider.setFeatureContext(feature, context)
+
+        // Then
+        assertThat(coreFeature.mockInstance.featuresContext[feature]).isEqualTo(context)
     }
 
     companion object {

--- a/detekt.yml
+++ b/detekt.yml
@@ -1067,6 +1067,7 @@ datadog:
       - "kotlin.collections.MutableList.toMutableList()"
       - "kotlin.collections.MutableList.withIndex()"
       - "kotlin.collections.MutableList?.firstOrNull(kotlin.Function1)"
+      - "kotlin.collections.MutableMap.clear()"
       - "kotlin.collections.MutableMap.forEach(kotlin.Function1)"
       - "kotlin.collections.MutableMap.isEmpty()"
       - "kotlin.collections.MutableMap.isNotEmpty()"


### PR DESCRIPTION
### What does this PR do?

A small change allowing features to store their context in the SDK context. The actual usage and (maybe) subscription model for the changes will come later.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

