### PR TITLE
RUMM-2494 Use View hashcode as unique identifier for mapped Wireframe

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapper.kt
@@ -14,7 +14,9 @@ internal abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wirefram
     WireframeMapper<T, S> {
 
     protected fun resolveViewId(view: View): Long {
-        return if (view.id != View.NO_ID) view.id.toLong() else view.hashCode().toLong()
+        // we will use the System.identityHashcode in here which always returns the default
+        // hashcode value whether or not a child class overrides this.
+        return System.identityHashCode(view).toLong()
     }
 
     protected fun colorAndAlphaAsStringHexa(color: Int, alphaAsHexa: Long): String {

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/ForgeExt.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/ForgeExt.kt
@@ -29,7 +29,6 @@ internal fun Forge.aMockViewWithChildren(
             level,
             maxLevel
         )
-        whenever(mockViewGroup.id).thenReturn(currentLevel * 10 + i)
         whenever(mockViewGroup.getChildAt(i)).thenReturn(mockChildGroup)
     }
     return mockViewGroup

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapperTest.kt
@@ -30,7 +30,7 @@ internal abstract class BaseWireframeMapperTest {
         val x = coordinates[0].densityNormalized(fakePixelDensity).toLong()
         val y = coordinates[1].densityNormalized(fakePixelDensity).toLong()
         return MobileSegment.Wireframe.ShapeWireframe(
-            id.toLong(),
+            System.identityHashCode(this).toLong(),
             x = x,
             y = y,
             width = width.toLong().densityNormalized(fakePixelDensity),
@@ -44,7 +44,7 @@ internal abstract class BaseWireframeMapperTest {
         val x = coordinates[0].densityNormalized(fakePixelDensity).toLong()
         val y = coordinates[1].densityNormalized(fakePixelDensity).toLong()
         return MobileSegment.Wireframe.TextWireframe(
-            id.toLong(),
+            System.identityHashCode(this).toLong(),
             x = x,
             y = y,
             text = resolveTextValue(this),

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapperTest.kt
@@ -62,28 +62,10 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
     }
 
     @Test
-    fun `M default to View hashcode W map() { View and id = NO_ID}`(forge: Forge) {
-        // Given
-        val mockView: View = forge.aMockView<View>().apply {
-            whenever(id).thenReturn(View.NO_ID)
-            // we cannot mock the hashcode method as it is final
-        }
-
-        // When
-        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
-
-        // Then
-        val expectedWireframe = mockView.toShapeWireframe().copy(id = mockView.hashCode().toLong())
-        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
-    }
-
-    @Test
-    fun `M use the View hashcode for Wireframe id W produce() { id is not valid }`(forge: Forge) {
+    fun `M use the View hashcode for Wireframe id W produce()`(forge: Forge) {
         // Given
         val mockViews = forge.aList(size = forge.anInt(min = 10, max = 20)) {
-            val mockRoot = aMockView<View>()
-            whenever(mockRoot.id).thenReturn(View.NO_ID)
-            mockRoot
+            aMockView<View>()
         }
 
         // When


### PR DESCRIPTION
### What does this PR do?

In this PR we are fixing the collision problem when taking the screen snapshot as a tree of wireframes. We were currently using the following approach:
```return if(view.id!=View.NO_ID) view.id else view.hashCode``` to resolve the view unique identifier to be used in the equivalent mapped `Wireframe`. Following our tests we cannot rely on the `view.id` property as this is not unique in a view tree and it can actually be the same for more views in a tree creating collisions. 
Instead we are going to use the `View` reference address returned by the `View.hashCode` function. In addition to this in order to avoid problems in case subclasses of the `View` class override the `hashCode` class we will use the `System.identityHashCode` function which will always return the default value from the default implementation of the `hashCode` function.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

