### PR TITLE
RUMM-2501: Use SDK v2 components in the upload pipeline

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1729,6 +1729,15 @@ data class com.datadog.android.v2.api.Request
   constructor(String, String, String, Map<String, String>, ByteArray, String? = null)
 interface com.datadog.android.v2.api.RequestFactory
   fun create(com.datadog.android.v2.api.context.DatadogContext, List<ByteArray>, ByteArray?): Request
+  companion object 
+    const val CONTENT_TYPE_JSON: String
+    const val CONTENT_TYPE_TEXT_UTF8: String
+    const val HEADER_API_KEY: String
+    const val HEADER_EVP_ORIGIN: String
+    const val HEADER_EVP_ORIGIN_VERSION: String
+    const val HEADER_REQUEST_ID: String
+    const val QUERY_PARAM_SOURCE: String
+    const val QUERY_PARAM_TAGS: String
 interface com.datadog.android.v2.api.SDKCore
   fun registerFeature(String, FeatureStorageConfiguration, FeatureUploadConfiguration)
   fun getFeature(String): FeatureScope?
@@ -1750,7 +1759,7 @@ enum com.datadog.android.v2.api.SDKEndpoint
 data class com.datadog.android.v2.api.context.CarrierInfo
   constructor(String?, String?)
 data class com.datadog.android.v2.api.context.DatadogContext
-  constructor(com.datadog.android.DatadogSite, String, String, String, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, com.datadog.android.privacy.TrackingConsent, Map<String, Map<String, Any?>>)
+  constructor(com.datadog.android.DatadogSite, String, String, String, String, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, com.datadog.android.privacy.TrackingConsent, Map<String, Map<String, Any?>>)
 data class com.datadog.android.v2.api.context.DeviceInfo
   constructor(String, String, String, DeviceType, String, String, String, String, String)
 enum com.datadog.android.v2.api.context.DeviceType

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -65,6 +65,9 @@ import com.datadog.android.rum.internal.ndk.NdkNetworkInfoDataWriter
 import com.datadog.android.rum.internal.ndk.NdkUserInfoDataWriter
 import com.datadog.android.rum.internal.ndk.NoOpNdkCrashHandler
 import com.datadog.android.security.Encryption
+import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.DatadogContextProvider
+import com.datadog.android.v2.core.internal.NoOpContextProvider
 import com.lyft.kronos.AndroidClockFactory
 import com.lyft.kronos.KronosClock
 import java.io.File
@@ -94,6 +97,7 @@ internal class CoreFeature {
     internal var timeProvider: TimeProvider = NoOpTimeProvider()
     internal var trackingConsentProvider: ConsentProvider = NoOpConsentProvider()
     internal var userInfoProvider: MutableUserInfoProvider = NoOpMutableUserInfoProvider()
+    internal var contextProvider: ContextProvider = NoOpContextProvider()
 
     internal lateinit var okHttpClient: OkHttpClient
     internal lateinit var kronosClock: KronosClock
@@ -160,6 +164,7 @@ internal class CoreFeature {
         prepareNdkCrashData()
         setupInfoProviders(appContext, consent)
         initialized.set(true)
+        contextProvider = DatadogContextProvider(this)
     }
 
     fun stop() {
@@ -186,6 +191,7 @@ internal class CoreFeature {
             initialized.set(false)
             ndkCrashHandler = NoOpNdkCrashHandler()
             trackingConsentProvider = NoOpConsentProvider()
+            contextProvider = NoOpContextProvider()
         }
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
@@ -88,7 +88,7 @@ internal class UploadWorker(
             @Suppress("UnsafeThirdPartyFunctionCall") // safe to create, argument is not negative
             val lock = CountDownLatch(1)
 
-            storage.readNextBatch(context, noBatchCallback = {
+            storage.readNextBatch(noBatchCallback = {
                 lock.countDown()
             }) { batchId, reader ->
                 val batch = reader.read()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/PersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/PersistenceStrategy.kt
@@ -6,7 +6,8 @@
 
 package com.datadog.android.core.internal.persistence
 
-import com.datadog.android.core.internal.data.upload.Flusher
+import com.datadog.android.v2.core.internal.data.upload.Flusher
+import com.datadog.android.v2.core.internal.storage.Storage
 import com.datadog.tools.annotation.NoOpImplementation
 
 /**
@@ -21,4 +22,6 @@ internal interface PersistenceStrategy<T : Any> {
     fun getReader(): DataReader
 
     fun getFlusher(): Flusher
+
+    fun getStorage(): Storage
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportFilePersistenceStrategy.kt
@@ -8,6 +8,7 @@ package com.datadog.android.error.internal
 
 import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.file.FileMover
+import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.batch.BatchFilePersistenceStrategy
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
@@ -17,16 +18,19 @@ import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.domain.event.LogEventSerializer
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.security.Encryption
+import com.datadog.android.v2.core.internal.ContextProvider
 import java.io.File
 import java.util.concurrent.ExecutorService
 
 internal class CrashReportFilePersistenceStrategy(
+    contextProvider: ContextProvider,
     consentProvider: ConsentProvider,
     storageDir: File,
     executorService: ExecutorService,
     internalLogger: Logger,
     localDataEncryption: Encryption?
 ) : BatchFilePersistenceStrategy<LogEvent>(
+    contextProvider,
     FeatureFileOrchestrator(
         consentProvider,
         storageDir,
@@ -39,5 +43,6 @@ internal class CrashReportFilePersistenceStrategy(
     PayloadDecoration.JSON_ARRAY_DECORATION,
     sdkLogger,
     BatchFileReaderWriter.create(sdkLogger, localDataEncryption),
+    FileReaderWriter.create(sdkLogger, localDataEncryption),
     FileMover(sdkLogger)
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -10,12 +10,12 @@ import android.content.Context
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.SdkFeature
-import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.internal.domain.DatadogLogGenerator
-import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
 import com.datadog.android.log.model.LogEvent
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.log.internal.net.LogsRequestFactory
 
 internal class CrashReportsFeature(
     coreFeature: CoreFeature
@@ -38,6 +38,7 @@ internal class CrashReportsFeature(
         configuration: Configuration.Feature.CrashReport
     ): PersistenceStrategy<LogEvent> {
         return CrashReportFilePersistenceStrategy(
+            coreFeature.contextProvider,
             coreFeature.trackingConsentProvider,
             coreFeature.storageDir,
             coreFeature.persistenceExecutorService,
@@ -46,19 +47,12 @@ internal class CrashReportsFeature(
         )
     }
 
-    override fun createUploader(configuration: Configuration.Feature.CrashReport): DataUploader {
-        return LogsOkHttpUploaderV2(
-            configuration.endpointUrl,
-            coreFeature.clientToken,
-            coreFeature.sourceName,
-            coreFeature.sdkVersion,
-            coreFeature.okHttpClient,
-            coreFeature.androidInfoProvider,
-            sdkLogger
-        )
+    override fun createRequestFactory(configuration: Configuration.Feature.CrashReport):
+        RequestFactory {
+        return LogsRequestFactory(configuration.endpointUrl)
     }
 
-    override fun onPostInitialized(context: Context) { }
+    override fun onPostInitialized(context: Context) {}
 
     // endregion
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -10,12 +10,12 @@ import android.content.Context
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.SdkFeature
-import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.internal.domain.LogFilePersistenceStrategy
-import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
 import com.datadog.android.log.model.LogEvent
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.log.internal.net.LogsRequestFactory
 
 internal class LogsFeature(
     coreFeature: CoreFeature
@@ -28,6 +28,7 @@ internal class LogsFeature(
         configuration: Configuration.Feature.Logs
     ): PersistenceStrategy<LogEvent> {
         return LogFilePersistenceStrategy(
+            coreFeature.contextProvider,
             coreFeature.trackingConsentProvider,
             coreFeature.storageDir,
             coreFeature.persistenceExecutorService,
@@ -37,19 +38,11 @@ internal class LogsFeature(
         )
     }
 
-    override fun createUploader(configuration: Configuration.Feature.Logs): DataUploader {
-        return LogsOkHttpUploaderV2(
-            configuration.endpointUrl,
-            coreFeature.clientToken,
-            coreFeature.sourceName,
-            coreFeature.sdkVersion,
-            coreFeature.okHttpClient,
-            coreFeature.androidInfoProvider,
-            sdkLogger
-        )
+    override fun createRequestFactory(configuration: Configuration.Feature.Logs): RequestFactory {
+        return LogsRequestFactory(configuration.endpointUrl)
     }
 
-    override fun onPostInitialized(context: Context) { }
+    override fun onPostInitialized(context: Context) {}
 
     // endregion
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumFilePersistenceStrategy.kt
@@ -11,6 +11,7 @@ import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.Serializer
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
+import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.advanced.ScheduledWriter
 import com.datadog.android.core.internal.persistence.file.batch.BatchFilePersistenceStrategy
@@ -22,10 +23,12 @@ import com.datadog.android.log.Logger
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.event.RumEventSerializer
 import com.datadog.android.security.Encryption
+import com.datadog.android.v2.core.internal.ContextProvider
 import java.io.File
 import java.util.concurrent.ExecutorService
 
 internal class RumFilePersistenceStrategy(
+    contextProvider: ContextProvider,
     consentProvider: ConsentProvider,
     storageDir: File,
     eventMapper: EventMapper<Any>,
@@ -34,6 +37,7 @@ internal class RumFilePersistenceStrategy(
     localDataEncryption: Encryption?,
     private val lastViewEventFile: File
 ) : BatchFilePersistenceStrategy<Any>(
+    contextProvider,
     FeatureFileOrchestrator(
         consentProvider,
         storageDir,
@@ -49,6 +53,7 @@ internal class RumFilePersistenceStrategy(
     PayloadDecoration.NEW_LINE_DECORATION,
     internalLogger,
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
+    FileReaderWriter.create(internalLogger, localDataEncryption),
     FileMover(internalLogger)
 ) {
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracingFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracingFeature.kt
@@ -10,11 +10,11 @@ import android.content.Context
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.SdkFeature
-import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.tracing.internal.domain.TracesFilePersistenceStrategy
-import com.datadog.android.tracing.internal.net.TracesOkHttpUploaderV2
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.tracing.internal.net.TracesRequestFactory
 import com.datadog.opentracing.DDSpan
 
 internal class TracingFeature(
@@ -28,6 +28,7 @@ internal class TracingFeature(
         configuration: Configuration.Feature.Tracing
     ): PersistenceStrategy<DDSpan> {
         return TracesFilePersistenceStrategy(
+            coreFeature.contextProvider,
             coreFeature.trackingConsentProvider,
             coreFeature.storageDir,
             coreFeature.persistenceExecutorService,
@@ -39,18 +40,12 @@ internal class TracingFeature(
         )
     }
 
-    override fun createUploader(configuration: Configuration.Feature.Tracing): DataUploader {
-        return TracesOkHttpUploaderV2(
-            configuration.endpointUrl,
-            coreFeature.clientToken,
-            coreFeature.sourceName,
-            coreFeature.sdkVersion,
-            coreFeature.okHttpClient,
-            coreFeature.androidInfoProvider
-        )
+    override fun createRequestFactory(configuration: Configuration.Feature.Tracing):
+        RequestFactory {
+        return TracesRequestFactory(configuration.endpointUrl)
     }
 
-    override fun onPostInitialized(context: Context) { }
+    override fun onPostInitialized(context: Context) {}
 
     // endregion
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracesFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracesFilePersistenceStrategy.kt
@@ -9,6 +9,7 @@ package com.datadog.android.tracing.internal.domain
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.file.FileMover
+import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.batch.BatchFilePersistenceStrategy
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
@@ -21,11 +22,13 @@ import com.datadog.android.tracing.internal.domain.event.DdSpanToSpanEventMapper
 import com.datadog.android.tracing.internal.domain.event.SpanEventMapperWrapper
 import com.datadog.android.tracing.internal.domain.event.SpanEventSerializer
 import com.datadog.android.tracing.internal.domain.event.SpanMapperSerializer
+import com.datadog.android.v2.core.internal.ContextProvider
 import com.datadog.opentracing.DDSpan
 import java.io.File
 import java.util.concurrent.ExecutorService
 
 internal class TracesFilePersistenceStrategy(
+    contextProvider: ContextProvider,
     consentProvider: ConsentProvider,
     storageDir: File,
     executorService: ExecutorService,
@@ -35,6 +38,7 @@ internal class TracesFilePersistenceStrategy(
     spanEventMapper: SpanEventMapper,
     localDataEncryption: Encryption?
 ) : BatchFilePersistenceStrategy<DDSpan>(
+    contextProvider,
     FeatureFileOrchestrator(
         consentProvider,
         storageDir,
@@ -53,5 +57,6 @@ internal class TracesFilePersistenceStrategy(
     PayloadDecoration.NEW_LINE_DECORATION,
     internalLogger,
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
+    FileReaderWriter.create(internalLogger, localDataEncryption),
     FileMover(internalLogger)
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/BatchWriterListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/BatchWriterListener.kt
@@ -6,11 +6,14 @@
 
 package com.datadog.android.v2.api
 
+import com.datadog.tools.annotation.NoOpImplementation
+
 /**
  * A Listener to be notified when an event is actually written in the storage,
  * or when a write operation failed.
  * @see [EventBatchWriter]
  */
+@NoOpImplementation
 internal interface BatchWriterListener {
     /**
      * Called whenever data is written successfully.

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/RequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/RequestFactory.kt
@@ -25,4 +25,46 @@ fun interface RequestFactory {
         batchData: List<ByteArray>,
         batchMetadata: ByteArray?
     ): Request
+
+    companion object {
+        /**
+         * application/json content type.
+         */
+        const val CONTENT_TYPE_JSON: String = "application/json"
+
+        /**
+         * text/plain;charset=UTF-8 content type.
+         */
+        const val CONTENT_TYPE_TEXT_UTF8: String = "text/plain;charset=UTF-8"
+
+        /**
+         * Datadog API key header.
+         */
+        const val HEADER_API_KEY: String = "DD-API-KEY"
+
+        /**
+         * Datadog Event Platform Origin header, e.g. android, flutter, etc.
+         */
+        const val HEADER_EVP_ORIGIN: String = "DD-EVP-ORIGIN"
+
+        /**
+         * Datadog Event Platform Origin version header, e.g. SDK version.
+         */
+        const val HEADER_EVP_ORIGIN_VERSION: String = "DD-EVP-ORIGIN-VERSION"
+
+        /**
+         * Datadog Request ID header, used for debugging purposes.
+         */
+        const val HEADER_REQUEST_ID: String = "DD-REQUEST-ID"
+
+        /**
+         * Datadog source query parameter name.
+         */
+        const val QUERY_PARAM_SOURCE: String = "ddsource"
+
+        /**
+         * Datadog tags query parameter name.
+         */
+        const val QUERY_PARAM_TAGS: String = "ddtags"
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/context/DatadogContext.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/context/DatadogContext.kt
@@ -20,6 +20,7 @@ import com.datadog.android.privacy.TrackingConsent
  * [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
  * @property version the version of the application that data is generated from. Used for
  * [Unified Service Tagging](https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging).
+ * @property variant the name of the application variant (if applies).
  * @property source denotes the mobile application's platform, such as "ios" or "flutter" that
  * data is generated from. See: Datadog [Reserved Attributes](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#reserved-attributes).
  * @property sdkVersion the version of SDK.
@@ -38,6 +39,7 @@ data class DatadogContext(
     val service: String,
     val env: String,
     val version: String,
+    val variant: String,
     val source: String,
     val sdkVersion: String,
     val time: TimeInfo,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -34,7 +34,6 @@ import com.datadog.android.v2.api.FeatureStorageConfiguration
 import com.datadog.android.v2.api.FeatureUploadConfiguration
 import com.datadog.android.v2.api.SDKCore
 import com.datadog.android.v2.core.internal.ContextProvider
-import com.datadog.android.v2.core.internal.DatadogContextProvider
 import com.datadog.android.webview.internal.log.WebViewLogsFeature
 import com.datadog.android.webview.internal.rum.WebViewRumFeature
 import com.datadog.opentracing.DDSpan
@@ -64,7 +63,14 @@ internal class DatadogCore(
     internal var webViewRumFeature: SdkFeature<Any, Configuration.Feature.RUM>? = null
 
     // TODO RUMM-0000 handle context
-    internal var contextProvider: ContextProvider? = null
+    internal val contextProvider: ContextProvider?
+        get() {
+            return if (coreFeature.initialized.get()) {
+                return coreFeature.contextProvider
+            } else {
+                null
+            }
+        }
 
     init {
         val isDebug = isAppDebuggable(context)
@@ -143,8 +149,6 @@ internal class DatadogCore(
         webViewRumFeature?.stop()
         webViewRumFeature = null
 
-        contextProvider = null
-
         coreFeature.stop()
     }
 
@@ -203,7 +207,6 @@ internal class DatadogCore(
             mutableConfig.coreConfig,
             TrackingConsent.PENDING
         )
-        contextProvider = DatadogContextProvider(coreFeature)
 
         applyAdditionalConfiguration(mutableConfig.additionalConfig)
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/DatadogContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/DatadogContextProvider.kt
@@ -26,6 +26,7 @@ internal class DatadogContextProvider(val coreFeature: CoreFeature) : ContextPro
                 service = coreFeature.serviceName,
                 env = coreFeature.envName,
                 version = coreFeature.packageVersionProvider.version,
+                variant = coreFeature.variant,
                 sdkVersion = coreFeature.sdkVersion,
                 source = coreFeature.sourceName,
                 time = with(coreFeature.timeProvider) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/NoOpContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/NoOpContextProvider.kt
@@ -1,0 +1,51 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core.internal
+
+import com.datadog.android.DatadogSite
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.v2.api.context.DatadogContext
+import com.datadog.android.v2.api.context.DeviceInfo
+import com.datadog.android.v2.api.context.DeviceType
+import com.datadog.android.v2.api.context.NetworkInfo
+import com.datadog.android.v2.api.context.ProcessInfo
+import com.datadog.android.v2.api.context.TimeInfo
+import com.datadog.android.v2.api.context.UserInfo
+
+internal class NoOpContextProvider : ContextProvider {
+    // TODO RUMM-0000 this one is quite ugly. Should return type be nullable?
+    override val context: DatadogContext
+        get() = DatadogContext(
+            site = DatadogSite.US1,
+            clientToken = "",
+            service = "",
+            env = "",
+            version = "",
+            variant = "",
+            source = "",
+            sdkVersion = "",
+            time = TimeInfo(
+                deviceTimeNs = 0L,
+                serverTimeNs = 0L,
+                serverTimeOffsetMs = 0L,
+                serverTimeOffsetNs = 0L
+            ),
+            processInfo = ProcessInfo(isMainProcess = true, processImportance = 0),
+            networkInfo = NetworkInfo(
+                connectivity = NetworkInfo.Connectivity.NETWORK_OTHER,
+                carrier = null
+            ),
+            deviceInfo = DeviceInfo("", "", "", DeviceType.OTHER, "", "", "", "", ""),
+            userInfo = UserInfo(null, null, null, emptyMap()),
+            trackingConsent = TrackingConsent.NOT_GRANTED,
+            featuresContext = emptyMap()
+        )
+
+    override fun setFeatureContext(feature: String, context: Map<String, Any?>) {
+        // no-op
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnable.kt
@@ -46,7 +46,6 @@ internal class DataUploadRunnable(
         if (isNetworkAvailable() && isSystemReady()) {
             val context = contextProvider.context
             storage.readNextBatch(
-                context,
                 noBatchCallback = { increaseInterval() }
             ) { batchId, reader ->
                 val batch = reader.read()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploader.kt
@@ -19,8 +19,6 @@ import okhttp3.MediaType
 import okhttp3.Request
 import okhttp3.RequestBody
 
-// TODO RUMM-0000 Should replace com.datadog.android.core.internal.net.DataOkHttpUploaderV2 once
-//  features are configured as V2
 internal class DataOkHttpUploader(
     val requestFactory: RequestFactory,
     val internalLogger: Logger,
@@ -84,6 +82,15 @@ internal class DataOkHttpUploader(
     private fun executeUploadRequest(
         request: DatadogRequest
     ): UploadStatus {
+        val apiKey = request.headers.entries
+            .firstOrNull {
+                it.key.equals(RequestFactory.HEADER_API_KEY, ignoreCase = true)
+            }
+            ?.value
+        if (apiKey != null && (apiKey.isEmpty() || !isValidHeaderValue(apiKey))) {
+            return UploadStatus.INVALID_TOKEN_ERROR
+        }
+
         val okHttpRequest = buildOkHttpRequest(request)
         val call = callFactory.newCall(okHttpRequest)
         val response = call.execute()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorage.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorage.kt
@@ -90,7 +90,6 @@ internal class ConsentAwareStorage(
     /** @inheritdoc */
     @WorkerThread
     override fun readNextBatch(
-        datadogContext: DatadogContext,
         noBatchCallback: () -> Unit,
         batchCallback: (BatchId, BatchReader) -> Unit
     ) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/Storage.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/Storage.kt
@@ -21,6 +21,7 @@ internal interface Storage {
      * @param callback an operation to perform with a [BatchWriter] that will target the current
      * writeable Batch
      */
+    @WorkerThread
     fun writeCurrentBatch(datadogContext: DatadogContext, callback: (BatchWriter) -> Unit)
 
     /**

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/Storage.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/Storage.kt
@@ -18,7 +18,6 @@ internal interface Storage {
 
     /**
      * Utility to write data, asynchronously.
-     * @param datadogContext the current [DatadogContext]
      * @param callback an operation to perform with a [BatchWriter] that will target the current
      * writeable Batch
      */
@@ -26,14 +25,12 @@ internal interface Storage {
 
     /**
      * Utility to read a batch, asynchronously.
-     * @param datadogContext the current [DatadogContext]
      * @param noBatchCallback an optional callback which is called when there is no batch available to read.
      * @param batchCallback an operation to perform with a [BatchId] and [BatchReader] that will target
      * the next readable Batch
      */
     @WorkerThread
     fun readNextBatch(
-        datadogContext: DatadogContext,
         noBatchCallback: () -> Unit = {},
         batchCallback: (BatchId, BatchReader) -> Unit
     )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/log/internal/net/LogsRequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/log/internal/net/LogsRequestFactory.kt
@@ -1,0 +1,70 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.log.internal.net
+
+import com.datadog.android.core.internal.utils.join
+import com.datadog.android.v2.api.Request
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.api.context.DatadogContext
+import java.util.Locale
+import java.util.UUID
+
+internal class LogsRequestFactory(
+    private val endpointUrl: String
+) : RequestFactory {
+
+    override fun create(
+        context: DatadogContext,
+        batchData: List<ByteArray>,
+        batchMetadata: ByteArray?
+    ): Request {
+        val requestId = UUID.randomUUID().toString()
+
+        return Request(
+            id = requestId,
+            description = "Logs Request",
+            url = buildUrl(context.source),
+            headers = buildHeaders(
+                requestId,
+                context.clientToken,
+                context.source,
+                context.sdkVersion
+            ),
+            body = batchData.join(
+                separator = PAYLOAD_SEPARATOR,
+                prefix = PAYLOAD_PREFIX,
+                suffix = PAYLOAD_SUFFIX
+            ),
+            contentType = RequestFactory.CONTENT_TYPE_JSON
+        )
+    }
+
+    private fun buildUrl(source: String): String {
+        return "%s/api/v2/logs?%s=%s"
+            .format(Locale.US, endpointUrl, RequestFactory.QUERY_PARAM_SOURCE, source)
+    }
+
+    private fun buildHeaders(
+        requestId: String,
+        clientToken: String,
+        source: String,
+        sdkVersion: String
+    ): Map<String, String> {
+        return mapOf(
+            RequestFactory.HEADER_API_KEY to clientToken,
+            RequestFactory.HEADER_EVP_ORIGIN to source,
+            RequestFactory.HEADER_EVP_ORIGIN_VERSION to sdkVersion,
+            RequestFactory.HEADER_REQUEST_ID to requestId
+        )
+    }
+
+    companion object {
+        private val PAYLOAD_SEPARATOR = ",".toByteArray(Charsets.UTF_8)
+        private val PAYLOAD_PREFIX = "[".toByteArray(Charsets.UTF_8)
+        private val PAYLOAD_SUFFIX = "]".toByteArray(Charsets.UTF_8)
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/rum/internal/net/RumRequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/rum/internal/net/RumRequestFactory.kt
@@ -1,0 +1,101 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.rum.internal.net
+
+import com.datadog.android.core.internal.utils.join
+import com.datadog.android.rum.RumAttributes
+import com.datadog.android.v2.api.Request
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.api.context.DatadogContext
+import java.util.Locale
+import java.util.UUID
+
+internal class RumRequestFactory(
+    private val endpointUrl: String
+) : RequestFactory {
+
+    override fun create(
+        context: DatadogContext,
+        batchData: List<ByteArray>,
+        batchMetadata: ByteArray?
+    ): Request {
+        val requestId = UUID.randomUUID().toString()
+
+        return Request(
+            id = requestId,
+            description = "RUM Request",
+            url = buildUrl(context),
+            headers = buildHeaders(
+                requestId,
+                context.clientToken,
+                context.source,
+                context.sdkVersion
+            ),
+            body = batchData.join(
+                separator = PAYLOAD_SEPARATOR
+            ),
+            contentType = RequestFactory.CONTENT_TYPE_TEXT_UTF8
+        )
+    }
+
+    private fun buildUrl(context: DatadogContext): String {
+        val queryParams = mapOf(
+            RequestFactory.QUERY_PARAM_SOURCE to context.source,
+            RequestFactory.QUERY_PARAM_TAGS to buildTags(
+                context.service,
+                context.version,
+                context.sdkVersion,
+                context.env,
+                context.variant
+            )
+        )
+
+        val intakeUrl = "%s/api/v2/rum".format(Locale.US, endpointUrl)
+
+        return intakeUrl + queryParams.map { "${it.key}=${it.value}" }
+            .joinToString("&", prefix = "?")
+    }
+
+    private fun buildHeaders(
+        requestId: String,
+        clientToken: String,
+        source: String,
+        sdkVersion: String
+    ): Map<String, String> {
+        return mapOf(
+            RequestFactory.HEADER_API_KEY to clientToken,
+            RequestFactory.HEADER_EVP_ORIGIN to source,
+            RequestFactory.HEADER_EVP_ORIGIN_VERSION to sdkVersion,
+            RequestFactory.HEADER_REQUEST_ID to requestId
+        )
+    }
+
+    private fun buildTags(
+        serviceName: String,
+        version: String,
+        sdkVersion: String,
+        env: String,
+        variant: String
+    ): String {
+        val elements = mutableListOf(
+            "${RumAttributes.SERVICE_NAME}:$serviceName",
+            "${RumAttributes.APPLICATION_VERSION}:$version",
+            "${RumAttributes.SDK_VERSION}:$sdkVersion",
+            "${RumAttributes.ENV}:$env"
+        )
+
+        if (variant.isNotEmpty()) {
+            elements.add("${RumAttributes.VARIANT}:$variant")
+        }
+
+        return elements.joinToString(",")
+    }
+
+    companion object {
+        private val PAYLOAD_SEPARATOR = "\n".toByteArray(Charsets.UTF_8)
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/tracing/internal/net/TracesRequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/tracing/internal/net/TracesRequestFactory.kt
@@ -1,0 +1,61 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.tracing.internal.net
+
+import com.datadog.android.core.internal.utils.join
+import com.datadog.android.v2.api.Request
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.api.context.DatadogContext
+import java.util.Locale
+import java.util.UUID
+
+internal class TracesRequestFactory(
+    private val endpointUrl: String
+) : RequestFactory {
+
+    override fun create(
+        context: DatadogContext,
+        batchData: List<ByteArray>,
+        batchMetadata: ByteArray?
+    ): Request {
+        val requestId = UUID.randomUUID().toString()
+
+        return Request(
+            id = requestId,
+            description = "Traces Request",
+            url = "%s/api/v2/spans".format(Locale.US, endpointUrl),
+            headers = buildHeaders(
+                requestId,
+                context.clientToken,
+                context.source,
+                context.sdkVersion
+            ),
+            body = batchData.join(
+                separator = PAYLOAD_SEPARATOR
+            ),
+            contentType = RequestFactory.CONTENT_TYPE_TEXT_UTF8
+        )
+    }
+
+    private fun buildHeaders(
+        requestId: String,
+        clientToken: String,
+        source: String,
+        sdkVersion: String
+    ): Map<String, String> {
+        return mapOf(
+            RequestFactory.HEADER_API_KEY to clientToken,
+            RequestFactory.HEADER_EVP_ORIGIN to source,
+            RequestFactory.HEADER_EVP_ORIGIN_VERSION to sdkVersion,
+            RequestFactory.HEADER_REQUEST_ID to requestId
+        )
+    }
+
+    companion object {
+        private val PAYLOAD_SEPARATOR = "\n".toByteArray(Charsets.UTF_8)
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogFilePersistenceStrategy.kt
@@ -8,6 +8,7 @@ package com.datadog.android.webview.internal.log
 
 import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.file.FileMover
+import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.batch.BatchFilePersistenceStrategy
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
@@ -16,29 +17,32 @@ import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.domain.event.WebViewLogEventSerializer
 import com.datadog.android.security.Encryption
+import com.datadog.android.v2.core.internal.ContextProvider
 import com.google.gson.JsonObject
 import java.io.File
 import java.util.concurrent.ExecutorService
 
 internal class WebViewLogFilePersistenceStrategy(
+    contextProvider: ContextProvider,
     consentProvider: ConsentProvider,
     storageDir: File,
     executorService: ExecutorService,
     internalLogger: Logger,
     localDataEncryption: Encryption?
-) :
-    BatchFilePersistenceStrategy<JsonObject>(
-        FeatureFileOrchestrator(
-            consentProvider,
-            storageDir,
-            WebViewLogsFeature.WEB_LOGS_FEATURE_NAME,
-            executorService,
-            internalLogger
-        ),
+) : BatchFilePersistenceStrategy<JsonObject>(
+    contextProvider,
+    FeatureFileOrchestrator(
+        consentProvider,
+        storageDir,
+        WebViewLogsFeature.WEB_LOGS_FEATURE_NAME,
         executorService,
-        WebViewLogEventSerializer(),
-        PayloadDecoration.JSON_ARRAY_DECORATION,
-        sdkLogger,
-        BatchFileReaderWriter.create(internalLogger, localDataEncryption),
-        FileMover(internalLogger)
-    )
+        internalLogger
+    ),
+    executorService,
+    WebViewLogEventSerializer(),
+    PayloadDecoration.JSON_ARRAY_DECORATION,
+    sdkLogger,
+    BatchFileReaderWriter.create(internalLogger, localDataEncryption),
+    FileReaderWriter.create(internalLogger, localDataEncryption),
+    FileMover(internalLogger)
+)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeature.kt
@@ -10,10 +10,10 @@ import android.content.Context
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.SdkFeature
-import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
-import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.log.internal.net.LogsRequestFactory
 import com.google.gson.JsonObject
 
 internal class WebViewLogsFeature(
@@ -27,6 +27,7 @@ internal class WebViewLogsFeature(
         configuration: Configuration.Feature.Logs
     ): PersistenceStrategy<JsonObject> {
         return WebViewLogFilePersistenceStrategy(
+            coreFeature.contextProvider,
             coreFeature.trackingConsentProvider,
             coreFeature.storageDir,
             coreFeature.persistenceExecutorService,
@@ -35,16 +36,8 @@ internal class WebViewLogsFeature(
         )
     }
 
-    override fun createUploader(configuration: Configuration.Feature.Logs): DataUploader {
-        return LogsOkHttpUploaderV2(
-            configuration.endpointUrl,
-            coreFeature.clientToken,
-            coreFeature.sourceName,
-            coreFeature.sdkVersion,
-            coreFeature.okHttpClient,
-            coreFeature.androidInfoProvider,
-            sdkLogger
-        )
+    override fun createRequestFactory(configuration: Configuration.Feature.Logs): RequestFactory {
+        return LogsRequestFactory(configuration.endpointUrl)
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
@@ -10,11 +10,11 @@ import android.content.Context
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.SdkFeature
-import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.rum.internal.ndk.DatadogNdkCrashHandler
-import com.datadog.android.rum.internal.net.RumOkHttpUploaderV2
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.rum.internal.net.RumRequestFactory
 
 internal class WebViewRumFeature(
     coreFeature: CoreFeature
@@ -27,6 +27,7 @@ internal class WebViewRumFeature(
         configuration: Configuration.Feature.RUM
     ): PersistenceStrategy<Any> {
         return WebViewRumFilePersistenceStrategy(
+            coreFeature.contextProvider,
             coreFeature.trackingConsentProvider,
             coreFeature.storageDir,
             coreFeature.persistenceExecutorService,
@@ -36,16 +37,8 @@ internal class WebViewRumFeature(
         )
     }
 
-    override fun createUploader(configuration: Configuration.Feature.RUM): DataUploader {
-        return RumOkHttpUploaderV2(
-            configuration.endpointUrl,
-            coreFeature.clientToken,
-            coreFeature.sourceName,
-            coreFeature.sdkVersion,
-            coreFeature.okHttpClient,
-            coreFeature.androidInfoProvider,
-            coreFeature
-        )
+    override fun createRequestFactory(configuration: Configuration.Feature.RUM): RequestFactory {
+        return RumRequestFactory(configuration.endpointUrl)
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFilePersistenceStrategy.kt
@@ -11,6 +11,7 @@ import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.Serializer
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
+import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.advanced.ScheduledWriter
 import com.datadog.android.core.internal.persistence.file.batch.BatchFilePersistenceStrategy
@@ -20,10 +21,12 @@ import com.datadog.android.log.Logger
 import com.datadog.android.rum.internal.domain.RumDataWriter
 import com.datadog.android.rum.internal.domain.event.RumEventSerializer
 import com.datadog.android.security.Encryption
+import com.datadog.android.v2.core.internal.ContextProvider
 import java.io.File
 import java.util.concurrent.ExecutorService
 
 internal class WebViewRumFilePersistenceStrategy(
+    contextProvider: ContextProvider,
     consentProvider: ConsentProvider,
     storageDir: File,
     executorService: ExecutorService,
@@ -31,6 +34,7 @@ internal class WebViewRumFilePersistenceStrategy(
     localDataEncryption: Encryption?,
     private val lastViewEventFile: File
 ) : BatchFilePersistenceStrategy<Any>(
+    contextProvider,
     FeatureFileOrchestrator(
         consentProvider,
         storageDir,
@@ -43,6 +47,7 @@ internal class WebViewRumFilePersistenceStrategy(
     PayloadDecoration.NEW_LINE_DECORATION,
     internalLogger,
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
+    FileReaderWriter.create(internalLogger, localDataEncryption),
     FileMover(internalLogger)
 ) {
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -34,6 +34,8 @@ import com.datadog.android.rum.internal.ndk.DatadogNdkCrashHandler
 import com.datadog.android.rum.internal.ndk.NoOpNdkCrashHandler
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.core.internal.DatadogContextProvider
+import com.datadog.android.v2.core.internal.NoOpContextProvider
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.annotations.TestTargetApi
 import com.datadog.tools.unit.assertj.containsInstanceOf
@@ -255,6 +257,22 @@ internal class CoreFeatureTest {
             .isInstanceOf(TrackingConsentProvider::class.java)
         assertThat(testedFeature.trackingConsentProvider.getConsent())
             .isEqualTo(fakeConsent)
+    }
+
+    @Test
+    fun `𝕄 initialise the datadog context provider 𝕎 initialize`() {
+        // When
+        testedFeature.initialize(
+            appContext.mockInstance,
+            fakeSdkInstanceId,
+            fakeCredentials,
+            fakeConfig,
+            fakeConsent
+        )
+
+        // Then
+        assertThat(testedFeature.contextProvider)
+            .isInstanceOf(DatadogContextProvider::class.java)
     }
 
     @Test
@@ -878,6 +896,8 @@ internal class CoreFeatureTest {
             .isInstanceOf(NoOpConsentProvider::class.java)
         assertThat(testedFeature.userInfoProvider)
             .isInstanceOf(NoOpMutableUserInfoProvider::class.java)
+        assertThat(testedFeature.contextProvider)
+            .isInstanceOf(NoOpContextProvider::class.java)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -8,8 +8,6 @@ package com.datadog.android.core.internal
 
 import android.app.Application
 import com.datadog.android.core.configuration.Configuration
-import com.datadog.android.core.internal.data.upload.DataFlusher
-import com.datadog.android.core.internal.data.upload.DataUploadScheduler
 import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
 import com.datadog.android.core.internal.data.upload.UploadScheduler
 import com.datadog.android.core.internal.net.DataUploader
@@ -25,6 +23,9 @@ import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.core.internal.data.upload.DataFlusher
+import com.datadog.android.v2.core.internal.data.upload.DataUploadScheduler
+import com.datadog.android.v2.core.internal.net.DataOkHttpUploader
 import com.datadog.android.webview.internal.log.WebViewLogsFeature
 import com.datadog.android.webview.internal.rum.WebViewRumFeature
 import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn
@@ -130,6 +131,12 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
                 eq(TimeUnit.MILLISECONDS)
             )
         }
+
+        assertThat(testedFeature.uploader)
+            .isInstanceOf(DataOkHttpUploader::class.java)
+
+        val uploader = testedFeature.uploader as DataOkHttpUploader
+        assertThat(uploader.callFactory).isSameAs(coreFeature.mockInstance.okHttpClient)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -8,9 +8,9 @@ package com.datadog.android.error.internal
 
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.SdkFeatureTest
-import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.log.internal.net.LogsRequestFactory
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.nhaarman.mockitokotlin2.mock
 import fr.xgouchet.elmyr.Forge
@@ -72,16 +72,12 @@ internal class CrashReportsFeatureTest :
     }
 
     @Test
-    fun `𝕄 create a crash reports uploader 𝕎 createUploader()`() {
+    fun `𝕄 create a crash request factory 𝕎 createRequestFactory()`() {
         // When
-        val uploader = testedFeature.createUploader(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
 
         // Then
-        assertThat(uploader).isInstanceOf(LogsOkHttpUploaderV2::class.java)
-        val crashReportsUploader = uploader as LogsOkHttpUploaderV2
-        assertThat(crashReportsUploader.intakeUrl).startsWith(fakeConfigurationFeature.endpointUrl)
-        assertThat(crashReportsUploader.intakeUrl).endsWith("/api/v2/logs")
-        assertThat(crashReportsUploader.callFactory).isSameAs(coreFeature.mockInstance.okHttpClient)
+        assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -13,9 +13,9 @@ import com.datadog.android.core.internal.persistence.file.batch.BatchFileDataWri
 import com.datadog.android.event.MapperSerializer
 import com.datadog.android.log.internal.domain.LogFilePersistenceStrategy
 import com.datadog.android.log.internal.domain.event.LogEventMapperWrapper
-import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.log.internal.net.LogsRequestFactory
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -61,16 +61,12 @@ internal class LogsFeatureTest :
     }
 
     @Test
-    fun `𝕄 create a logs uploader 𝕎 createUploader()`() {
+    fun `𝕄 create a logs request factory 𝕎 createRequestFactory()`() {
         // When
-        val uploader = testedFeature.createUploader(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
 
         // Then
-        assertThat(uploader).isInstanceOf(LogsOkHttpUploaderV2::class.java)
-        val logsUploader = uploader as LogsOkHttpUploaderV2
-        assertThat(logsUploader.intakeUrl).startsWith(fakeConfigurationFeature.endpointUrl)
-        assertThat(logsUploader.intakeUrl).endsWith("/api/v2/logs")
-        assertThat(logsUploader.callFactory).isSameAs(coreFeature.mockInstance.okHttpClient)
+        assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -14,7 +14,6 @@ import com.datadog.android.core.internal.SdkFeatureTest
 import com.datadog.android.core.internal.event.NoOpEventMapper
 import com.datadog.android.core.internal.thread.NoOpScheduledExecutorService
 import com.datadog.android.rum.internal.domain.RumFilePersistenceStrategy
-import com.datadog.android.rum.internal.net.RumOkHttpUploaderV2
 import com.datadog.android.rum.internal.tracking.NoOpUserActionTrackingStrategy
 import com.datadog.android.rum.internal.tracking.UserActionTrackingStrategy
 import com.datadog.android.rum.internal.vitals.AggregatingVitalMonitor
@@ -26,6 +25,7 @@ import com.datadog.android.rum.tracking.TrackingStrategy
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.rum.internal.net.RumRequestFactory
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
@@ -93,19 +93,15 @@ internal class RumFeatureTest : SdkFeatureTest<Any, Configuration.Feature.RUM, R
     }
 
     @Test
-    fun `𝕄 create a logs uploader 𝕎 createUploader()`() {
+    fun `𝕄 create a rum request factory 𝕎 createRequestFactory()`() {
         // Given
         testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
 
         // When
-        val uploader = testedFeature.createUploader(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
 
         // Then
-        assertThat(uploader).isInstanceOf(RumOkHttpUploaderV2::class.java)
-        val rumUploader = uploader as RumOkHttpUploaderV2
-        assertThat(rumUploader.intakeUrl).startsWith(fakeConfigurationFeature.endpointUrl)
-        assertThat(rumUploader.intakeUrl).endsWith("/api/v2/rum")
-        assertThat(rumUploader.callFactory).isSameAs(coreFeature.mockInstance.okHttpClient)
+        assertThat(requestFactory).isInstanceOf(RumRequestFactory::class.java)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracingFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracingFeatureTest.kt
@@ -13,8 +13,8 @@ import com.datadog.android.core.internal.persistence.file.batch.BatchFileDataWri
 import com.datadog.android.tracing.internal.domain.TracesFilePersistenceStrategy
 import com.datadog.android.tracing.internal.domain.event.SpanEventMapperWrapper
 import com.datadog.android.tracing.internal.domain.event.SpanMapperSerializer
-import com.datadog.android.tracing.internal.net.TracesOkHttpUploaderV2
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.tracing.internal.net.TracesRequestFactory
 import com.datadog.opentracing.DDSpan
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import fr.xgouchet.elmyr.Forge
@@ -76,15 +76,11 @@ internal class TracingFeatureTest :
     }
 
     @Test
-    fun `𝕄 create a tracing uploader 𝕎 createUploader()`() {
+    fun `𝕄 create a tracing request factory 𝕎 createRequestFactory()`() {
         // When
-        val uploader = testedFeature.createUploader(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
 
         // Then
-        assertThat(uploader).isInstanceOf(TracesOkHttpUploaderV2::class.java)
-        val tracesUploader = uploader as TracesOkHttpUploaderV2
-        assertThat(tracesUploader.intakeUrl).startsWith(fakeConfigurationFeature.endpointUrl)
-        assertThat(tracesUploader.intakeUrl).endsWith("/api/v2/spans")
-        assertThat(tracesUploader.callFactory).isSameAs(coreFeature.mockInstance.okHttpClient)
+        assertThat(requestFactory).isInstanceOf(TracesRequestFactory::class.java)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
@@ -21,6 +21,7 @@ import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.log.internal.user.MutableUserInfoProvider
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.utils.forge.exhaustiveAttributes
+import com.datadog.android.v2.core.internal.ContextProvider
 import com.datadog.tools.unit.extensions.config.MockTestConfiguration
 import com.lyft.kronos.KronosClock
 import com.nhaarman.mockitokotlin2.doReturn
@@ -66,6 +67,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
     lateinit var mockTrackingConsentProvider: ConsentProvider
     lateinit var mockAndroidInfoProvider: AndroidInfoProvider
     lateinit var mockAppVersionProvider: AppVersionProvider
+    lateinit var mockContextProvider: ContextProvider
 
     // region CoreFeatureTestConfiguration
 
@@ -119,6 +121,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
         mockAndroidInfoProvider = mock()
         mockTrackingConsentProvider = mock { on { getConsent() } doReturn TrackingConsent.PENDING }
         mockAppVersionProvider = mock { on { version } doReturn appContext.fakeVersionName }
+        mockContextProvider = mock()
     }
 
     private fun configureCoreFeature() {
@@ -152,6 +155,7 @@ internal class CoreFeatureTestConfiguration<T : Context>(
         whenever(mockInstance.userInfoProvider) doReturn mockUserInfoProvider
         whenever(mockInstance.trackingConsentProvider) doReturn mockTrackingConsentProvider
         whenever(mockInstance.androidInfoProvider) doReturn mockAndroidInfoProvider
+        whenever(mockInstance.contextProvider) doReturn mockContextProvider
     }
 
     // endregion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
@@ -21,6 +21,7 @@ class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
             clientToken = forge.anHexadecimalString().lowercase(Locale.US),
             service = forge.anAlphabeticalString(),
             version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),
+            variant = forge.anAlphabeticalString(),
             env = forge.anAlphabeticalString(),
             source = forge.anAlphabeticalString(),
             sdkVersion = forge.aStringMatching("[0-9](\\.[0-9]{1,2}){1,3}"),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
@@ -179,7 +179,7 @@ internal class DatadogCoreTest {
     ) {
         // Given
         val mockContextProvider = mock<ContextProvider>()
-        testedCore.contextProvider = mockContextProvider
+        testedCore.coreFeature.contextProvider = mockContextProvider
 
         // When
         testedCore.setFeatureContext(feature, context)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -120,10 +120,9 @@ internal class DataUploadRunnableTest {
     @Test
     fun `doesn't send batch when offline`() {
         // Given
-        val networkInfo =
-            NetworkInfo(
-                NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
-            )
+        val networkInfo = NetworkInfo(
+            NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
+        )
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn networkInfo
 
         // When
@@ -405,6 +404,11 @@ internal class DataUploadRunnableTest {
 
     @Test
     fun `𝕄 do nothing 𝕎 no batch to send`() {
+        // Given
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
+            it.getArgument<() -> Unit>(0)()
+        }
+
         // When
         testedRunnable.run()
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -162,11 +162,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
 
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
@@ -217,11 +217,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
 
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
@@ -271,11 +271,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
 
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
@@ -409,7 +409,7 @@ internal class DataUploadRunnableTest {
         testedRunnable.run()
 
         // Then
-        verify(mockStorage).readNextBatch(eq(fakeContext), any(), any())
+        verify(mockStorage).readNextBatch(any(), any())
         verifyNoMoreInteractions(mockStorage)
         verifyZeroInteractions(mockDataUploader)
         verify(mockThreadPoolExecutor).schedule(
@@ -435,11 +435,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
 
         whenever(
@@ -487,11 +487,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
 
         whenever(
@@ -540,11 +540,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(
@@ -593,11 +593,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(
@@ -638,11 +638,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(
@@ -684,11 +684,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(
@@ -744,11 +744,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(
@@ -786,8 +786,8 @@ internal class DataUploadRunnableTest {
         @IntForgery(16, 64) runCount: Int
     ) {
         // When
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
-            it.getArgument<() -> Unit>(1).invoke()
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
+            it.getArgument<() -> Unit>(0).invoke()
         }
 
         repeat(runCount) {
@@ -829,11 +829,11 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.read()) doReturn batchData
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
-        whenever(mockStorage.readNextBatch(eq(fakeContext), any(), any())) doAnswer {
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
             whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
                 it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
             }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(2).invoke(batchId, batchReader)
+            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
         whenever(
             mockDataUploader.upload(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorageTest.kt
@@ -868,7 +868,7 @@ internal class ConsentAwareStorageTest {
         // Whenever
         var readData: List<ByteArray>? = null
         var readMetadata: ByteArray? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { _, reader ->
+        testedStorage.readNextBatch { _, reader ->
             readMetadata = reader.currentMetadata()
             readData = reader.read()
         }
@@ -891,7 +891,7 @@ internal class ConsentAwareStorageTest {
         // Whenever
         var readData: List<ByteArray>? = null
         var readMetadata: ByteArray? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { _, reader ->
+        testedStorage.readNextBatch { _, reader ->
             readMetadata = reader.currentMetadata()
             readData = reader.read()
         }
@@ -920,7 +920,7 @@ internal class ConsentAwareStorageTest {
         // Whenever
         var readData: List<ByteArray>? = null
         var readMetadata: ByteArray? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { _, reader ->
+        testedStorage.readNextBatch { _, reader ->
             readMetadata = reader.currentMetadata()
             readData = reader.read()
         }
@@ -943,10 +943,10 @@ internal class ConsentAwareStorageTest {
 
         // When
         var readData: List<ByteArray>? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { _, reader ->
+        testedStorage.readNextBatch { _, reader ->
             readData = reader.read()
         }
-        testedStorage.readNextBatch(fakeDatadogContext) { _, _ ->
+        testedStorage.readNextBatch { _, _ ->
             fail { "Callback should not have been called again" }
         }
 
@@ -962,7 +962,6 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.readNextBatch(
-            fakeDatadogContext,
             noBatchCallback = mockNoBatchCallback
         ) { _, _ ->
             fail { "Callback should not have been called here" }
@@ -1003,7 +1002,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         var batchId: BatchId? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { id, _ ->
+        testedStorage.readNextBatch { id, _ ->
             batchId = id
         }
         testedStorage.confirmBatchRead(batchId!!) { confirm ->
@@ -1029,16 +1028,16 @@ internal class ConsentAwareStorageTest {
         // When
         var batchId1: BatchId? = null
         var batchId2: BatchId? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { id, _ ->
+        testedStorage.readNextBatch { id, _ ->
             batchId1 = id
         }
-        testedStorage.readNextBatch(fakeDatadogContext) { _, _ ->
+        testedStorage.readNextBatch { _, _ ->
             fail { "Callback should not have been called here" }
         }
         testedStorage.confirmBatchRead(batchId1!!) { confirm ->
             confirm.markAsRead(false)
         }
-        testedStorage.readNextBatch(fakeDatadogContext) { id, _ ->
+        testedStorage.readNextBatch { id, _ ->
             batchId2 = id
         }
 
@@ -1060,13 +1059,13 @@ internal class ConsentAwareStorageTest {
         whenever(mockGrantedOrchestrator.getMetadataFile(file)) doReturn mockMetaFile
 
         // When
-        testedStorage.readNextBatch(fakeDatadogContext) { _, _ ->
+        testedStorage.readNextBatch { _, _ ->
             // no-op
         }
         testedStorage.confirmBatchRead(BatchId.fromFile(anotherFile)) { confirm ->
             confirm.markAsRead(true)
         }
-        testedStorage.readNextBatch(fakeDatadogContext) { _, _ ->
+        testedStorage.readNextBatch { _, _ ->
             fail { "Callback should not have been called here" }
         }
 
@@ -1085,7 +1084,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         var batchId: BatchId? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { id, _ ->
+        testedStorage.readNextBatch { id, _ ->
             batchId = id
         }
         testedStorage.confirmBatchRead(batchId!!) { confirm ->
@@ -1120,7 +1119,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         var batchId: BatchId? = null
-        testedStorage.readNextBatch(fakeDatadogContext) { id, _ ->
+        testedStorage.readNextBatch { id, _ ->
             batchId = id
         }
         testedStorage.confirmBatchRead(batchId!!) { confirm ->

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/log/internal/net/LogsRequestFactoryTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/log/internal/net/LogsRequestFactoryTest.kt
@@ -1,0 +1,88 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.log.internal.net
+
+import com.datadog.android.core.internal.utils.join
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.api.context.DatadogContext
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class LogsRequestFactoryTest {
+
+    private lateinit var testedFactory: LogsRequestFactory
+
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
+    @StringForgery(regex = "https://[a-z]+\\.com")
+    lateinit var fakeEndpoint: String
+
+    @BeforeEach
+    fun `set up`() {
+        testedFactory = LogsRequestFactory(
+            endpointUrl = fakeEndpoint
+        )
+    }
+
+    @Suppress("NAME_SHADOWING")
+    @Test
+    fun `𝕄 create a proper request 𝕎 create()`(
+        @StringForgery batchData: List<String>,
+        @StringForgery batchMetadata: String,
+        forge: Forge
+    ) {
+        // Given
+        val batchData = batchData.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMetadata.toByteArray() }
+
+        // When
+        val request = testedFactory.create(fakeDatadogContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(request.url).isEqualTo(
+            "$fakeEndpoint/api/v2/logs?" +
+                "ddsource=${fakeDatadogContext.source}"
+        )
+        assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_JSON)
+        assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
+            mapOf(
+                RequestFactory.HEADER_API_KEY to fakeDatadogContext.clientToken,
+                RequestFactory.HEADER_EVP_ORIGIN to fakeDatadogContext.source,
+                RequestFactory.HEADER_EVP_ORIGIN_VERSION to fakeDatadogContext.sdkVersion
+            )
+        )
+        assertThat(request.headers[RequestFactory.HEADER_REQUEST_ID]).isNotEmpty()
+        assertThat(request.id).isEqualTo(request.headers[RequestFactory.HEADER_REQUEST_ID])
+        assertThat(request.description).isEqualTo("Logs Request")
+        assertThat(request.body).isEqualTo(
+            batchData.join(
+                separator = ",".toByteArray(),
+                prefix = "[".toByteArray(),
+                suffix = "]".toByteArray()
+            )
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/rum/internal/net/RumRequestFactoryTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/rum/internal/net/RumRequestFactoryTest.kt
@@ -1,0 +1,100 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.rum.internal.net
+
+import com.datadog.android.core.internal.utils.join
+import com.datadog.android.rum.RumAttributes
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.api.context.DatadogContext
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class RumRequestFactoryTest {
+
+    private lateinit var testedFactory: RumRequestFactory
+
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
+    @StringForgery(regex = "https://[a-z]+\\.com")
+    lateinit var fakeEndpoint: String
+
+    @BeforeEach
+    fun `set up`() {
+        testedFactory = RumRequestFactory(
+            endpointUrl = fakeEndpoint
+        )
+    }
+
+    @Suppress("NAME_SHADOWING")
+    @Test
+    fun `𝕄 create a proper request 𝕎 create()`(
+        @StringForgery batchData: List<String>,
+        @StringForgery batchMetadata: String,
+        forge: Forge
+    ) {
+        // Given
+        val batchData = batchData.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMetadata.toByteArray() }
+
+        // When
+        val request = testedFactory.create(fakeDatadogContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(request.url).isEqualTo(expectedUrl(fakeEndpoint))
+        assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_TEXT_UTF8)
+        assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
+            mapOf(
+                RequestFactory.HEADER_API_KEY to fakeDatadogContext.clientToken,
+                RequestFactory.HEADER_EVP_ORIGIN to fakeDatadogContext.source,
+                RequestFactory.HEADER_EVP_ORIGIN_VERSION to fakeDatadogContext.sdkVersion
+            )
+        )
+        assertThat(request.headers[RequestFactory.HEADER_REQUEST_ID]).isNotEmpty()
+        assertThat(request.id).isEqualTo(request.headers[RequestFactory.HEADER_REQUEST_ID])
+        assertThat(request.description).isEqualTo("RUM Request")
+        assertThat(request.body).isEqualTo(
+            batchData.join(
+                separator = "\n".toByteArray()
+            )
+        )
+    }
+
+    private fun expectedUrl(endpointUrl: String): String {
+        val queryTags = mutableListOf(
+            "${RumAttributes.SERVICE_NAME}:${fakeDatadogContext.service}",
+            "${RumAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
+            "${RumAttributes.SDK_VERSION}:${fakeDatadogContext.sdkVersion}",
+            "${RumAttributes.ENV}:${fakeDatadogContext.env}"
+        )
+
+        if (fakeDatadogContext.variant.isNotEmpty()) {
+            queryTags.add("${RumAttributes.VARIANT}:${fakeDatadogContext.variant}")
+        }
+
+        return "$endpointUrl/api/v2/rum?ddsource=${fakeDatadogContext.source}" +
+            "&ddtags=${queryTags.joinToString(",")}"
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/tracing/internal/net/TracesRequestFactoryTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/tracing/internal/net/TracesRequestFactoryTest.kt
@@ -1,0 +1,83 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.tracing.internal.net
+
+import com.datadog.android.core.internal.utils.join
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.RequestFactory
+import com.datadog.android.v2.api.context.DatadogContext
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class TracesRequestFactoryTest {
+
+    private lateinit var testedFactory: TracesRequestFactory
+
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
+    @StringForgery(regex = "https://[a-z]+\\.com")
+    lateinit var fakeEndpoint: String
+
+    @BeforeEach
+    fun `set up`() {
+        testedFactory = TracesRequestFactory(
+            endpointUrl = fakeEndpoint
+        )
+    }
+
+    @Suppress("NAME_SHADOWING")
+    @Test
+    fun `𝕄 create a proper request 𝕎 create()`(
+        @StringForgery batchData: List<String>,
+        @StringForgery batchMetadata: String,
+        forge: Forge
+    ) {
+        // Given
+        val batchData = batchData.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMetadata.toByteArray() }
+
+        // When
+        val request = testedFactory.create(fakeDatadogContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(request.url).isEqualTo("$fakeEndpoint/api/v2/spans")
+        assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_TEXT_UTF8)
+        assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
+            mapOf(
+                RequestFactory.HEADER_API_KEY to fakeDatadogContext.clientToken,
+                RequestFactory.HEADER_EVP_ORIGIN to fakeDatadogContext.source,
+                RequestFactory.HEADER_EVP_ORIGIN_VERSION to fakeDatadogContext.sdkVersion
+            )
+        )
+        assertThat(request.headers[RequestFactory.HEADER_REQUEST_ID]).isNotEmpty()
+        assertThat(request.id).isEqualTo(request.headers[RequestFactory.HEADER_REQUEST_ID])
+        assertThat(request.description).isEqualTo("Traces Request")
+        assertThat(request.body).isEqualTo(
+            batchData.join(
+                separator = "\n".toByteArray()
+            )
+        )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeatureTest.kt
@@ -8,8 +8,8 @@ package com.datadog.android.webview.internal.log
 
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.SdkFeatureTest
-import com.datadog.android.log.internal.net.LogsOkHttpUploaderV2
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.log.internal.net.LogsRequestFactory
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.google.gson.JsonObject
@@ -58,15 +58,11 @@ internal class WebViewLogsFeatureTest :
     }
 
     @Test
-    fun `𝕄 create a logs uploader 𝕎 createUploader()`() {
+    fun `𝕄 create a logs request factory 𝕎 createRequestFactory()`() {
         // When
-        val uploader = testedFeature.createUploader(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
 
         // Then
-        assertThat(uploader).isInstanceOf(LogsOkHttpUploaderV2::class.java)
-        val logsUploader = uploader as LogsOkHttpUploaderV2
-        assertThat(logsUploader.intakeUrl).startsWith(fakeConfigurationFeature.endpointUrl)
-        assertThat(logsUploader.intakeUrl).endsWith("/api/v2/logs")
-        assertThat(logsUploader.callFactory).isSameAs(coreFeature.mockInstance.okHttpClient)
+        assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
@@ -8,8 +8,8 @@ package com.datadog.android.webview.internal.rum
 
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.SdkFeatureTest
-import com.datadog.android.rum.internal.net.RumOkHttpUploaderV2
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.rum.internal.net.RumRequestFactory
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import fr.xgouchet.elmyr.Forge
@@ -57,15 +57,11 @@ internal class WebViewRumFeatureTest : SdkFeatureTest<Any,
     }
 
     @Test
-    fun `𝕄 create a rum uploader 𝕎 createUploader()`() {
+    fun `𝕄 create a rum request factory 𝕎 createRequestFactory()`() {
         // When
-        val uploader = testedFeature.createUploader(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
 
         // Then
-        assertThat(uploader).isInstanceOf(RumOkHttpUploaderV2::class.java)
-        val rumUploader = uploader as RumOkHttpUploaderV2
-        assertThat(rumUploader.intakeUrl).startsWith(fakeConfigurationFeature.endpointUrl)
-        assertThat(rumUploader.intakeUrl).endsWith("/api/v2/rum")
-        assertThat(rumUploader.callFactory).isSameAs(coreFeature.mockInstance.okHttpClient)
+        assertThat(requestFactory).isInstanceOf(RumRequestFactory::class.java)
     }
 }


### PR DESCRIPTION
### What does this PR do?

This is a transitional PR (some things are not final) which makes the usage of SDK v2 components in the upload pipeline.

Namely we now are using `Storage` for the batch reads and `RequestFactory` as well.

Some content inside the implementations of `RequestFactory` for RUM, Logs and Traces is duplicated, but this is on purpose, because later on these classes will be split into different modules.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

