### PR TITLE
RUMM-2492: Check if WorkManager is initialized before using it

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.lifecycle
 import android.content.Context
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.utils.cancelUploadWorker
+import com.datadog.android.core.internal.utils.isWorkManagerInitialized
 import com.datadog.android.core.internal.utils.triggerUploadWorker
 import com.datadog.android.core.model.NetworkInfo
 import java.lang.ref.Reference
@@ -24,7 +25,9 @@ internal class ProcessLifecycleCallback(
 
     override fun onStarted() {
         contextWeakRef.get()?.let {
-            cancelUploadWorker(it)
+            if (isWorkManagerInitialized(it)) {
+                cancelUploadWorker(it)
+            }
         }
     }
 
@@ -39,7 +42,9 @@ internal class ProcessLifecycleCallback(
             )
         if (isOffline) {
             contextWeakRef.get()?.let {
-                triggerUploadWorker(it)
+                if (isWorkManagerInitialized(it)) {
+                    triggerUploadWorker(it)
+                }
             }
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
@@ -56,3 +56,15 @@ internal fun triggerUploadWorker(context: Context) {
         sdkLogger.errorWithTelemetry(SETUP_ERROR_MESSAGE, e)
     }
 }
+
+@Suppress("TooGenericExceptionCaught", "SwallowedException")
+internal fun isWorkManagerInitialized(context: Context): Boolean {
+    return try {
+        // TODO RUMM-2511 Replace isWorkManagerInitialized
+        //  with WorkManager#isInitialized coming with version 2.8 once it is stable
+        WorkManager.getInstance(context)
+        true
+    } catch (e: Exception) {
+        false
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -11,6 +11,7 @@ import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.thread.waitToIdle
 import com.datadog.android.core.internal.utils.devLogger
+import com.datadog.android.core.internal.utils.isWorkManagerInitialized
 import com.datadog.android.core.internal.utils.triggerUploadWorker
 import com.datadog.android.log.internal.domain.LogGenerator
 import com.datadog.android.log.model.LogEvent
@@ -52,7 +53,9 @@ internal class DatadogExceptionHandler(
 
         // trigger a task to send the logs ASAP
         contextRef.get()?.let {
-            triggerUploadWorker(it)
+            if (isWorkManagerInitialized(it)) {
+                triggerUploadWorker(it)
+            }
         }
 
         // Always do this one last; this will shut down the VM

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
@@ -111,6 +111,9 @@ internal class ProcessLifecycleCallbackTest {
 
         // When
         testedCallback.onStopped()
+
+        // Then
+        verifyZeroInteractions(mockWorkManager)
     }
 
     @Test
@@ -144,6 +147,30 @@ internal class ProcessLifecycleCallbackTest {
 
         // When
         testedCallback.onStopped()
+
+        // Then
+        verifyZeroInteractions(mockWorkManager)
+    }
+
+    @Test
+    fun `when process started cancel existing workers`() {
+        // Given
+        WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
+
+        // When
+        testedCallback.onStarted()
+
+        // Then
+        verify(mockWorkManager).cancelAllWorkByTag(TAG_DATADOG_UPLOAD)
+    }
+
+    @Test
+    fun `when process started do nothing if no work manager`() {
+        // Given
+        WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", null)
+
+        // When
+        testedCallback.onStarted()
 
         // Then
         verifyZeroInteractions(mockWorkManager)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -34,6 +34,7 @@ import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -141,6 +142,30 @@ internal class WorkManagerUtilsTest {
 
         // Then
         verifyZeroInteractions(mockWorkManager)
+    }
+
+    @Test
+    fun `it will return false if WorkManager was not correctly instantiated`() {
+        // Given
+        WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", null)
+
+        // When
+        val result = isWorkManagerInitialized(appContext.mockInstance)
+
+        // Then
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `it will return true if WorkManager is correctly instantiated`() {
+        // Given
+        WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
+
+        // When
+        val result = isWorkManagerInitialized(appContext.mockInstance)
+
+        // Then
+        assertThat(result).isTrue
     }
 
     companion object {


### PR DESCRIPTION
### What does this PR do?

This PR adds a check to see if `WorkManager` is initialized before using it, because `WorkManager.getInstance` will throw `IllegalStateException` if `WorkManager` is not initialized and this add the noise to our telemetry.

Unfortunately, there is no `WorkManager#isInitialized` method yet (it will be added only in WorkManager 2.8, which is still in alpha), so had to write a hacky workaround.

Another option would be to check if we are in the main process before accessing `WorkManager`, but this won't work because:

* with `work-multiprocess` artifact execution/initialization of WorkManager may be shifted to any process
* User may do a custom initialization which happens after we are calling `WorkManager`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

