### PR TITLE
RUMM-2504: Switch to the SDK v2 storage component

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1699,9 +1699,12 @@ data class com.datadog.android.tracing.model.SpanEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): SimCarrier
+interface com.datadog.android.v2.api.BatchWriterListener
+  fun onDataWritten(String)
+  fun onDataWriteFailed(String)
 interface com.datadog.android.v2.api.EventBatchWriter
   fun currentMetadata(): ByteArray?
-  fun write(ByteArray, String, ByteArray?)
+  fun write(ByteArray, String, ByteArray?, BatchWriterListener)
 interface com.datadog.android.v2.api.FeatureConfiguration
   fun register(SDKCore)
 interface com.datadog.android.v2.api.FeatureScope

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -8,7 +8,6 @@ package com.datadog.android.rum.internal.domain
 
 import androidx.annotation.WorkerThread
 import com.datadog.android.core.internal.persistence.Serializer
-import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FileWriter
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileDataWriter
 import com.datadog.android.core.internal.persistence.file.existsSafe
@@ -22,19 +21,22 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.storage.Storage
 import java.io.File
 import java.util.Locale
 
 internal class RumDataWriter(
-    fileOrchestrator: FileOrchestrator,
+    storage: Storage,
+    contextProvider: ContextProvider,
     serializer: Serializer<Any>,
-    fileWriter: FileWriter,
+    private val fileWriter: FileWriter,
     internalLogger: Logger,
     private val lastViewEventFile: File
 ) : BatchFileDataWriter<Any>(
-    fileOrchestrator,
+    storage,
+    contextProvider,
     serializer,
-    fileWriter,
     internalLogger
 ) {
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumFilePersistenceStrategy.kt
@@ -10,7 +10,6 @@ import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.Serializer
 import com.datadog.android.core.internal.persistence.file.FileMover
-import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.advanced.ScheduledWriter
@@ -28,7 +27,7 @@ import java.io.File
 import java.util.concurrent.ExecutorService
 
 internal class RumFilePersistenceStrategy(
-    contextProvider: ContextProvider,
+    private val contextProvider: ContextProvider,
     consentProvider: ConsentProvider,
     storageDir: File,
     eventMapper: EventMapper<Any>,
@@ -58,14 +57,14 @@ internal class RumFilePersistenceStrategy(
 ) {
 
     override fun createWriter(
-        fileOrchestrator: FileOrchestrator,
         executorService: ExecutorService,
         serializer: Serializer<Any>,
         internalLogger: Logger
     ): DataWriter<Any> {
         return ScheduledWriter(
             RumDataWriter(
-                fileOrchestrator,
+                getStorage(),
+                contextProvider,
                 serializer,
                 fileReaderWriter,
                 internalLogger,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/BatchWriterListener.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/BatchWriterListener.kt
@@ -14,7 +14,7 @@ import com.datadog.tools.annotation.NoOpImplementation
  * @see [EventBatchWriter]
  */
 @NoOpImplementation
-internal interface BatchWriterListener {
+interface BatchWriterListener {
     /**
      * Called whenever data is written successfully.
      * @param eventId the id of the written event

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/EventBatchWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/EventBatchWriter.kt
@@ -25,11 +25,13 @@ interface EventBatchWriter {
      * @param eventId a unique identifier for the event (used to identify events in
      * the [BatchWriterListener] callbacks).
      * @param newMetadata the optional updated metadata
+     * @param listener to notify about write operation outcome
      */
     @WorkerThread
     fun write(
         event: ByteArray,
         eventId: String,
-        newMetadata: ByteArray?
+        newMetadata: ByteArray?,
+        listener: BatchWriterListener
     )
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/ContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/ContextProvider.kt
@@ -13,6 +13,7 @@ internal interface ContextProvider {
     // TODO RUMM-0000 lifecycle checks may be needed for the cases when context is requested
     //  when datadog is not initialized yet/anymore (case of UploadWorker, other calls site
     //  should be in sync with lifecycle)
+    // TODO RUMM-0000 can be accessed from different threads
     val context: DatadogContext
 
     fun setFeatureContext(feature: String, context: Map<String, Any?>)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorage.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorage.kt
@@ -26,7 +26,6 @@ internal class ConsentAwareStorage(
     private val batchEventsReaderWriter: BatchFileReaderWriter,
     private val batchMetadataReaderWriter: FileReaderWriter,
     private val fileMover: FileMover,
-    private val listener: BatchWriterListener,
     private val internalLogger: InternalLogger,
     private val filePersistenceConfig: FilePersistenceConfig
 ) : Storage {
@@ -60,7 +59,12 @@ internal class ConsentAwareStorage(
             }
 
             @WorkerThread
-            override fun write(event: ByteArray, eventId: String, newMetadata: ByteArray?) {
+            override fun write(
+                event: ByteArray,
+                eventId: String,
+                newMetadata: ByteArray?,
+                listener: BatchWriterListener
+            ) {
                 // prevent useless operation for empty event / null orchestrator
                 if (event.isEmpty() || orchestrator == null) {
                     listener.onDataWritten(eventId)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFilePersistenceStrategy.kt
@@ -10,7 +10,6 @@ import com.datadog.android.core.internal.persistence.DataWriter
 import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.Serializer
 import com.datadog.android.core.internal.persistence.file.FileMover
-import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.advanced.ScheduledWriter
@@ -26,7 +25,7 @@ import java.io.File
 import java.util.concurrent.ExecutorService
 
 internal class WebViewRumFilePersistenceStrategy(
-    contextProvider: ContextProvider,
+    private val contextProvider: ContextProvider,
     consentProvider: ConsentProvider,
     storageDir: File,
     executorService: ExecutorService,
@@ -52,14 +51,14 @@ internal class WebViewRumFilePersistenceStrategy(
 ) {
 
     override fun createWriter(
-        fileOrchestrator: FileOrchestrator,
         executorService: ExecutorService,
         serializer: Serializer<Any>,
         internalLogger: Logger
     ): DataWriter<Any> {
         return ScheduledWriter(
             RumDataWriter(
-                fileOrchestrator,
+                getStorage(),
+                contextProvider,
                 serializer,
                 fileReaderWriter,
                 internalLogger,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategyTest.kt
@@ -129,6 +129,25 @@ internal class BatchFilePersistenceStrategyTest {
     }
 
     @Test
+    fun `𝕄 return consent aware storage 𝕎 getStorage()`() {
+        // When
+        val storage = testedStrategy.getStorage()
+
+        // Then
+        assertThat(storage).isInstanceOf(ConsentAwareStorage::class.java)
+    }
+
+    @Test
+    fun `𝕄 return consent aware storage 𝕎 getStorage() twice`() {
+        // When
+        val storage1 = testedStrategy.getStorage()
+        val storage2 = testedStrategy.getStorage()
+
+        // Then
+        assertThat(storage1).isSameAs(storage2)
+    }
+
+    @Test
     fun `𝕄 return batch file flusher 𝕎 getFlusher()`() {
         // When
         val flusher = testedStrategy.getFlusher()
@@ -147,46 +166,5 @@ internal class BatchFilePersistenceStrategyTest {
 
         // Then
         assertThat(reader1).isSameAs(reader2)
-    }
-
-    @Test
-    fun `𝕄 share orchestrator 𝕎 getWriter() + getReader()`() {
-        // Given
-
-        // When
-        val writer = testedStrategy.getWriter()
-        val reader = testedStrategy.getReader()
-
-        // Then
-        check(writer is ScheduledWriter)
-        check(reader is BatchFileDataReader)
-        val delegateWriter = writer.delegateWriter
-        check(delegateWriter is BatchFileDataWriter)
-        assertThat(delegateWriter.fileOrchestrator).isSameAs(reader.fileOrchestrator)
-    }
-
-    @Test
-    fun `𝕄 share handler 𝕎 getWriter() + getReader()`() {
-        // Given
-
-        // When
-        val writer = testedStrategy.getWriter()
-        val reader = testedStrategy.getReader()
-
-        // Then
-        check(writer is ScheduledWriter)
-        check(reader is BatchFileDataReader)
-        val delegateWriter = writer.delegateWriter
-        check(delegateWriter is BatchFileDataWriter)
-        assertThat(delegateWriter.fileWriter).isSameAs(reader.fileReader)
-    }
-
-    @Test
-    fun `𝕄 return consent aware storage 𝕎 getStorage()`() {
-        // When
-        val storage = testedStrategy.getStorage()
-
-        // Then
-        assertThat(storage).isInstanceOf(ConsentAwareStorage::class.java)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.rum.internal.domain
 
 import android.util.Log
 import com.datadog.android.core.internal.persistence.Serializer
-import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FileWriter
 import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.logger.LogHandler
@@ -21,6 +20,8 @@ import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.storage.Storage
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
@@ -62,13 +63,16 @@ internal class RumDataWriterTest {
     lateinit var mockSerializer: Serializer<Any>
 
     @Mock
-    lateinit var mockOrchestrator: FileOrchestrator
-
-    @Mock
     lateinit var mockFileWriter: FileWriter
 
     @Mock
     lateinit var mockLogHandler: LogHandler
+
+    @Mock
+    lateinit var mockStorage: Storage
+
+    @Mock
+    lateinit var mockContextProvider: ContextProvider
 
     @StringForgery
     lateinit var fakeSerializedEvent: String
@@ -82,7 +86,8 @@ internal class RumDataWriterTest {
         fakeSerializedData = fakeSerializedEvent.toByteArray(Charsets.UTF_8)
 
         testedWriter = RumDataWriter(
-            mockOrchestrator,
+            mockStorage,
+            mockContextProvider,
             mockSerializer,
             mockFileWriter,
             Logger(mockLogHandler),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorageTest.kt
@@ -91,7 +91,6 @@ internal class ConsentAwareStorageTest {
             mockBatchReaderWriter,
             mockMetaReaderWriter,
             mockFileMover,
-            mockListener,
             mockInternalLogger,
             mockFilePersistenceConfig
         )
@@ -121,7 +120,7 @@ internal class ConsentAwareStorageTest {
         testedStorage.writeCurrentBatch(sdkContext) {
             val meta = it.currentMetadata()
             val updatedMeta = meta?.reversedArray()
-            it.write(serializedData, eventId, updatedMeta)
+            it.write(serializedData, eventId, updatedMeta, mockListener)
         }
 
         // Then
@@ -163,7 +162,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -194,7 +193,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -214,7 +213,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -236,7 +235,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -261,7 +260,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -296,7 +295,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -335,7 +334,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -358,7 +357,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, forge.aNullable { ByteArray(0) })
+            it.write(serializedData, eventId, forge.aNullable { ByteArray(0) }, mockListener)
         }
 
         // Then
@@ -390,7 +389,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -415,7 +414,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -444,7 +443,7 @@ internal class ConsentAwareStorageTest {
         testedStorage.writeCurrentBatch(sdkContext) {
             val meta = it.currentMetadata()
             val updatedMeta = meta?.reversedArray()
-            it.write(serializedData, eventId, updatedMeta)
+            it.write(serializedData, eventId, updatedMeta, mockListener)
         }
 
         // Then
@@ -481,7 +480,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -508,7 +507,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -528,7 +527,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -550,7 +549,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -575,7 +574,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -610,7 +609,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -649,7 +648,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -672,7 +671,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, forge.aNullable { ByteArray(0) })
+            it.write(serializedData, eventId, forge.aNullable { ByteArray(0) }, mockListener)
         }
 
         // Then
@@ -704,7 +703,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -729,7 +728,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -749,7 +748,7 @@ internal class ConsentAwareStorageTest {
         testedStorage.writeCurrentBatch(sdkContext) {
             val meta = it.currentMetadata()
             val updatedMeta = meta?.reversedArray()
-            it.write(serializedData, eventId, updatedMeta)
+            it.write(serializedData, eventId, updatedMeta, mockListener)
         }
 
         // Then
@@ -773,7 +772,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -798,7 +797,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -818,7 +817,7 @@ internal class ConsentAwareStorageTest {
 
         // When
         testedStorage.writeCurrentBatch(sdkContext) {
-            it.write(serializedData, eventId, serializedBatchMetadata)
+            it.write(serializedData, eventId, serializedBatchMetadata, mockListener)
         }
 
         // Then
@@ -987,7 +986,6 @@ internal class ConsentAwareStorageTest {
             mockBatchReaderWriter,
             mockMetaReaderWriter,
             mockFileMover,
-            mockListener,
             mockInternalLogger,
             mockFilePersistenceConfig
         )

--- a/detekt.yml
+++ b/detekt.yml
@@ -1097,6 +1097,7 @@ datadog:
       # endregion
       # region Kotlin Primitives
       - "kotlin.Any.constructor()"
+      - "kotlin.Any.hashCode()"
       - "kotlin.Any.toString()"
       - "kotlin.Boolean.hashCode()"
       - "kotlin.Byte.toInt()"


### PR DESCRIPTION
### What does this PR do?

This change does a switch to the `Storage` implementation written earlier. While it is not used as it should be in the feature configuration per SDK v2 plan, this change helps to minimize the diff of the transition and makes a proof that new component works.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

