### PR TITLE
RUMM-2545: Feature-specific upload factory should have no-arg constructor

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -46,7 +46,7 @@ internal abstract class SdkFeature<T : Any, C : Configuration.Feature>(
 
         persistenceStrategy = createPersistenceStrategy(context, configuration)
 
-        setupUploader(configuration)
+        setupUploader()
 
         registerPlugins(
             configuration.plugins,
@@ -112,7 +112,7 @@ internal abstract class SdkFeature<T : Any, C : Configuration.Feature>(
         configuration: C
     ): PersistenceStrategy<T>
 
-    abstract fun createRequestFactory(configuration: C): RequestFactory
+    abstract fun createRequestFactory(): RequestFactory
 
     // endregion
 
@@ -137,9 +137,9 @@ internal abstract class SdkFeature<T : Any, C : Configuration.Feature>(
         featurePlugins.clear()
     }
 
-    private fun setupUploader(configuration: C) {
+    private fun setupUploader() {
         uploadScheduler = if (coreFeature.isMainProcess) {
-            val requestFactory = createRequestFactory(configuration)
+            val requestFactory = createRequestFactory()
             uploader = DataOkHttpUploader(
                 requestFactory,
                 internalLogger = sdkLogger,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -47,9 +47,8 @@ internal class CrashReportsFeature(
         )
     }
 
-    override fun createRequestFactory(configuration: Configuration.Feature.CrashReport):
-        RequestFactory {
-        return LogsRequestFactory(configuration.endpointUrl)
+    override fun createRequestFactory(): RequestFactory {
+        return LogsRequestFactory()
     }
 
     override fun onPostInitialized(context: Context) {}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -38,8 +38,8 @@ internal class LogsFeature(
         )
     }
 
-    override fun createRequestFactory(configuration: Configuration.Feature.Logs): RequestFactory {
-        return LogsRequestFactory(configuration.endpointUrl)
+    override fun createRequestFactory(): RequestFactory {
+        return LogsRequestFactory()
     }
 
     override fun onPostInitialized(context: Context) {}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -131,8 +131,8 @@ internal class RumFeature(
         )
     }
 
-    override fun createRequestFactory(configuration: Configuration.Feature.RUM): RequestFactory {
-        return RumRequestFactory(configuration.endpointUrl)
+    override fun createRequestFactory(): RequestFactory {
+        return RumRequestFactory()
     }
 
     override fun onPostInitialized(context: Context) {}
@@ -229,9 +229,6 @@ internal class RumFeature(
 
     companion object {
         internal val startupTimeNs: Long = System.nanoTime()
-
-        // Update Vitals every 500 millisecond
-        private const val VITAL_UPDATE_PERIOD_MS = 500L
 
         internal const val RUM_FEATURE_NAME = "rum"
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracingFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracingFeature.kt
@@ -40,9 +40,8 @@ internal class TracingFeature(
         )
     }
 
-    override fun createRequestFactory(configuration: Configuration.Feature.Tracing):
-        RequestFactory {
-        return TracesRequestFactory(configuration.endpointUrl)
+    override fun createRequestFactory(): RequestFactory {
+        return TracesRequestFactory()
     }
 
     override fun onPostInitialized(context: Context) {}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -66,7 +66,7 @@ internal class DatadogCore(
     internal val contextProvider: ContextProvider?
         get() {
             return if (coreFeature.initialized.get()) {
-                return coreFeature.contextProvider
+                coreFeature.contextProvider
             } else {
                 null
             }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/log/internal/net/LogsRequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/log/internal/net/LogsRequestFactory.kt
@@ -13,9 +13,7 @@ import com.datadog.android.v2.api.context.DatadogContext
 import java.util.Locale
 import java.util.UUID
 
-internal class LogsRequestFactory(
-    private val endpointUrl: String
-) : RequestFactory {
+internal class LogsRequestFactory : RequestFactory {
 
     override fun create(
         context: DatadogContext,
@@ -27,7 +25,7 @@ internal class LogsRequestFactory(
         return Request(
             id = requestId,
             description = "Logs Request",
-            url = buildUrl(context.source),
+            url = buildUrl(context.source, context.site.logsEndpoint()),
             headers = buildHeaders(
                 requestId,
                 context.clientToken,
@@ -43,7 +41,10 @@ internal class LogsRequestFactory(
         )
     }
 
-    private fun buildUrl(source: String): String {
+    private fun buildUrl(
+        source: String,
+        endpointUrl: String
+    ): String {
         return "%s/api/v2/logs?%s=%s"
             .format(Locale.US, endpointUrl, RequestFactory.QUERY_PARAM_SOURCE, source)
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/rum/internal/net/RumRequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/rum/internal/net/RumRequestFactory.kt
@@ -14,9 +14,7 @@ import com.datadog.android.v2.api.context.DatadogContext
 import java.util.Locale
 import java.util.UUID
 
-internal class RumRequestFactory(
-    private val endpointUrl: String
-) : RequestFactory {
+internal class RumRequestFactory : RequestFactory {
 
     override fun create(
         context: DatadogContext,
@@ -54,7 +52,7 @@ internal class RumRequestFactory(
             )
         )
 
-        val intakeUrl = "%s/api/v2/rum".format(Locale.US, endpointUrl)
+        val intakeUrl = "%s/api/v2/rum".format(Locale.US, context.site.rumEndpoint())
 
         return intakeUrl + queryParams.map { "${it.key}=${it.value}" }
             .joinToString("&", prefix = "?")

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/tracing/internal/net/TracesRequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/tracing/internal/net/TracesRequestFactory.kt
@@ -13,9 +13,7 @@ import com.datadog.android.v2.api.context.DatadogContext
 import java.util.Locale
 import java.util.UUID
 
-internal class TracesRequestFactory(
-    private val endpointUrl: String
-) : RequestFactory {
+internal class TracesRequestFactory : RequestFactory {
 
     override fun create(
         context: DatadogContext,
@@ -27,7 +25,7 @@ internal class TracesRequestFactory(
         return Request(
             id = requestId,
             description = "Traces Request",
-            url = "%s/api/v2/spans".format(Locale.US, endpointUrl),
+            url = "%s/api/v2/spans".format(Locale.US, context.site.tracesEndpoint()),
             headers = buildHeaders(
                 requestId,
                 context.clientToken,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeature.kt
@@ -36,8 +36,8 @@ internal class WebViewLogsFeature(
         )
     }
 
-    override fun createRequestFactory(configuration: Configuration.Feature.Logs): RequestFactory {
-        return LogsRequestFactory(configuration.endpointUrl)
+    override fun createRequestFactory(): RequestFactory {
+        return LogsRequestFactory()
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
@@ -37,8 +37,8 @@ internal class WebViewRumFeature(
         )
     }
 
-    override fun createRequestFactory(configuration: Configuration.Feature.RUM): RequestFactory {
-        return RumRequestFactory(configuration.endpointUrl)
+    override fun createRequestFactory(): RequestFactory {
+        return RumRequestFactory()
     }
 
     // endregion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -74,7 +74,7 @@ internal class CrashReportsFeatureTest :
     @Test
     fun `𝕄 create a crash request factory 𝕎 createRequestFactory()`() {
         // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory()
 
         // Then
         assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -63,7 +63,7 @@ internal class LogsFeatureTest :
     @Test
     fun `𝕄 create a logs request factory 𝕎 createRequestFactory()`() {
         // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory()
 
         // Then
         assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -98,7 +98,7 @@ internal class RumFeatureTest : SdkFeatureTest<Any, Configuration.Feature.RUM, R
         testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
 
         // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory()
 
         // Then
         assertThat(requestFactory).isInstanceOf(RumRequestFactory::class.java)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracingFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracingFeatureTest.kt
@@ -78,7 +78,7 @@ internal class TracingFeatureTest :
     @Test
     fun `𝕄 create a tracing request factory 𝕎 createRequestFactory()`() {
         // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory()
 
         // Then
         assertThat(requestFactory).isInstanceOf(TracesRequestFactory::class.java)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
@@ -9,8 +9,10 @@ package com.datadog.android.v2.core
 import android.app.Application
 import android.content.pm.ApplicationInfo
 import android.util.Log
+import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
@@ -18,11 +20,13 @@ import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
 import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.forge.CustomAttributes
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -30,6 +34,7 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import java.net.URL
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -55,8 +60,6 @@ import org.mockito.quality.Strictness
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
 internal class DatadogCoreInitializationTest {
-
-    // TODO RUMM-2206 handle all commented lines on this class
 
     lateinit var testedCore: DatadogCore
 
@@ -296,344 +299,256 @@ internal class DatadogCoreInitializationTest {
     }
 
     // region AdditionalConfig
-    //
-    // @Test
-    // fun `𝕄 apply source name 𝕎 applyAdditionalConfig(config) { with source name }`(
-    //     @StringForgery(type = StringForgeryType.ALPHABETICAL) source: String
-    // ) {
-    //     // Given
-    //     // CoreFeature.sourceName = CoreFeature.DEFAULT_SOURCE_NAME
-    //     val configuration = Configuration.Builder(
-    //         logsEnabled = true,
-    //         tracesEnabled = true,
-    //         crashReportsEnabled = true,
-    //         rumEnabled = true
-    //     )
-    //         .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to source))
-    //         .build()
-    //
-    //     // When
-    //     testedCore = DatadogCore(appContext.mockInstance, fakeCredentials, configuration)
-    //
-    //     // Then
-    //     assertThat(CoreFeature.sourceName).isEqualTo(source)
-    //     assertThat(
-    //         arrayOf(
-    //             LogsFeature.uploader,
-    //             RumFeature.uploader,
-    //             TracingFeature.uploader,
-    //             CrashReportsFeature.uploader,
-    //             WebViewRumFeature.uploader,
-    //             WebViewLogsFeature.uploader
-    //         )
-    //             .map { (it as DataOkHttpUploaderV2).source }
-    //     )
-    //         .containsOnly(source)
-    // }
-    //
-    // @Test
-    // fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { with empty source name }`(
-    //     @StringForgery(type = StringForgeryType.WHITESPACE) source: String
-    // ) {
-    //     // Given
-    //     CoreFeature.sourceName = CoreFeature.DEFAULT_SOURCE_NAME
-    //     val configuration = Configuration.Builder(
-    //         logsEnabled = true,
-    //         tracesEnabled = true,
-    //         crashReportsEnabled = true,
-    //         rumEnabled = true
-    //     )
-    //         .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to source))
-    //         .build()
-    //
-    //     // When
-    //     testedCore = DatadogCore(appContext.mockInstance, fakeCredentials, configuration)
-    //
-    //     // Then
-    //     assertThat(CoreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
-    //     assertThat(
-    //         arrayOf(
-    //             LogsFeature.uploader,
-    //             RumFeature.uploader,
-    //             TracingFeature.uploader,
-    //             CrashReportsFeature.uploader,
-    //             WebViewRumFeature.uploader,
-    //             WebViewLogsFeature.uploader
-    //         )
-    //             .map { (it as DataOkHttpUploaderV2).source }
-    //     )
-    //         .containsOnly(CoreFeature.DEFAULT_SOURCE_NAME)
-    // }
-    //
-    // @Test
-    // fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { with source name !string }`(
-    //     @IntForgery source: Int
-    // ) {
-    //     // Given
-    //     CoreFeature.sourceName = CoreFeature.DEFAULT_SOURCE_NAME
-    //     val configuration = Configuration.Builder(
-    //         logsEnabled = true,
-    //         tracesEnabled = true,
-    //         crashReportsEnabled = true,
-    //         rumEnabled = true
-    //     )
-    //         .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to source))
-    //         .build()
-    //
-    //     // When
-    //     testedCore = DatadogCore(appContext.mockInstance, fakeCredentials, configuration)
-    //
-    //     // Then
-    //     assertThat(CoreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
-    //     assertThat(
-    //         arrayOf(
-    //             LogsFeature.uploader,
-    //             RumFeature.uploader,
-    //             TracingFeature.uploader,
-    //             CrashReportsFeature.uploader,
-    //             WebViewRumFeature.uploader,
-    //             WebViewLogsFeature.uploader
-    //         )
-    //             .map { (it as DataOkHttpUploaderV2).source }
-    //     )
-    //         .containsOnly(CoreFeature.DEFAULT_SOURCE_NAME)
-    // }
-    //
-    // @Test
-    // fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { without source name }`(
-    //     @Forgery customAttributes: CustomAttributes
-    // ) {
-    //     // Given
-    //     CoreFeature.sourceName = CoreFeature.DEFAULT_SOURCE_NAME
-    //     val configuration = Configuration.Builder(
-    //         logsEnabled = true,
-    //         tracesEnabled = true,
-    //         crashReportsEnabled = true,
-    //         rumEnabled = true
-    //     )
-    //         .setAdditionalConfiguration(customAttributes.nonNullData)
-    //         .build()
-    //
-    //     // When
-    //     testedCore = DatadogCore(appContext.mockInstance, fakeCredentials, configuration)
-    //
-    //     // Then
-    //     assertThat(CoreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
-    //     assertThat(
-    //         arrayOf(
-    //             LogsFeature.uploader,
-    //             RumFeature.uploader,
-    //             TracingFeature.uploader,
-    //             CrashReportsFeature.uploader,
-    //             WebViewRumFeature.uploader,
-    //             WebViewLogsFeature.uploader
-    //         )
-    //             .map { (it as DataOkHttpUploaderV2).source }
-    //     )
-    //         .containsOnly(CoreFeature.DEFAULT_SOURCE_NAME)
-    // }
-    //
-    // @Test
-    // fun `𝕄 apply sdk version 𝕎 applyAdditionalConfig(config) { with sdk version }`(
-    //     @StringForgery(regex = "[0-9]+(\\.[0-9]+)+") sdkVersion: String
-    // ) {
-    //     // Given
-    //     val configuration = Configuration.Builder(
-    //         logsEnabled = true,
-    //         tracesEnabled = true,
-    //         crashReportsEnabled = true,
-    //         rumEnabled = true
-    //     )
-    //         .setAdditionalConfiguration(mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion))
-    //         .build()
-    //
-    //     // When
-    //     testedCore = DatadogCore(appContext.mockInstance, fakeCredentials, configuration)
-    //
-    //     // Then
-    //     assertThat(CoreFeature.sdkVersion).isEqualTo(sdkVersion)
-    //     assertThat(
-    //         arrayOf(
-    //             LogsFeature.uploader,
-    //             RumFeature.uploader,
-    //             TracingFeature.uploader,
-    //             CrashReportsFeature.uploader,
-    //             WebViewRumFeature.uploader,
-    //             WebViewLogsFeature.uploader
-    //         )
-    //             .map { (it as DataOkHttpUploaderV2).sdkVersion }
-    //     )
-    //         .containsOnly(sdkVersion)
-    // }
-    //
-    // @Test
-    // fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { with empty sdk version }`(
-    //     @StringForgery(type = StringForgeryType.WHITESPACE) sdkVersion: String
-    // ) {
-    //     // Given
-    //     val configuration = Configuration.Builder(
-    //         logsEnabled = true,
-    //         tracesEnabled = true,
-    //         crashReportsEnabled = true,
-    //         rumEnabled = true
-    //     )
-    //         .setAdditionalConfiguration(
-    //             mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion)
-    //         )
-    //         .build()
-    //
-    //     // When
-    //     testedCore = DatadogCore(appContext.mockInstance, fakeCredentials, configuration)
-    //
-    //     // Then
-    //     assertThat(CoreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
-    //     assertThat(
-    //         arrayOf(
-    //             LogsFeature.uploader,
-    //             RumFeature.uploader,
-    //             TracingFeature.uploader,
-    //             CrashReportsFeature.uploader,
-    //             WebViewRumFeature.uploader,
-    //             WebViewLogsFeature.uploader
-    //         )
-    //             .map { (it as DataOkHttpUploaderV2).sdkVersion }
-    //     )
-    //         .containsOnly(CoreFeature.DEFAULT_SDK_VERSION)
-    // }
-    //
-    // @Test
-    // fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { with sdk version !string }`(
-    //     @Forgery sdkVersion: URL
-    // ) {
-    //     // Given
-    //     val configuration = Configuration.Builder(
-    //         logsEnabled = true,
-    //         tracesEnabled = true,
-    //         crashReportsEnabled = true,
-    //         rumEnabled = true
-    //     )
-    //         .setAdditionalConfiguration(mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion))
-    //         .build()
-    //
-    //     // When
-    //     testedCore = DatadogCore(appContext.mockInstance, fakeCredentials, configuration)
-    //
-    //     // Then
-    //     assertThat(CoreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
-    //     assertThat(
-    //         arrayOf(
-    //             LogsFeature.uploader,
-    //             RumFeature.uploader,
-    //             TracingFeature.uploader,
-    //             CrashReportsFeature.uploader,
-    //             WebViewRumFeature.uploader,
-    //             WebViewLogsFeature.uploader
-    //         )
-    //             .map { (it as DataOkHttpUploaderV2).sdkVersion }
-    //     )
-    //         .containsOnly(CoreFeature.DEFAULT_SDK_VERSION)
-    // }
-    //
-    // @Test
-    // fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { without sdk version }`(
-    //     @Forgery customAttributes: CustomAttributes
-    // ) {
-    //     // Given
-    //     val configuration = Configuration.Builder(
-    //         logsEnabled = true,
-    //         tracesEnabled = true,
-    //         crashReportsEnabled = true,
-    //         rumEnabled = true
-    //     )
-    //         .setAdditionalConfiguration(customAttributes.nonNullData)
-    //         .build()
-    //
-    //     // When
-    //     testedCore = DatadogCore(appContext.mockInstance, fakeCredentials, configuration)
-    //
-    //     // Then
-    //     assertThat(CoreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
-    //     assertThat(
-    //         arrayOf(
-    //             LogsFeature.uploader,
-    //             RumFeature.uploader,
-    //             TracingFeature.uploader,
-    //             CrashReportsFeature.uploader,
-    //             WebViewLogsFeature.uploader,
-    //             WebViewRumFeature.uploader
-    //         )
-    //             .map { (it as DataOkHttpUploaderV2).sdkVersion }
-    //     )
-    //         .containsOnly(CoreFeature.DEFAULT_SDK_VERSION)
-    // }
-//
-//    @Test
-//    fun `𝕄 apply app version 𝕎 applyAdditionalConfig(config) { with app version }`(
-//        @StringForgery appVersion: String
-//    ) {
-//        // Given
-//        val config = Configuration.Builder(
-//            logsEnabled = true,
-//            tracesEnabled = true,
-//            crashReportsEnabled = true,
-//            rumEnabled = true
-//        )
-//            .setAdditionalConfiguration(mapOf(Datadog.DD_APP_VERSION_TAG to appVersion))
-//            .build()
-//        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
-//
-//        // When
-//        Datadog.initialize(DatadogTest.appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
-//
-//        // Then
-//        assertThat(CoreFeature.packageVersionProvider.version).isEqualTo(appVersion)
-//    }
-//
-//    @Test
-//    fun `𝕄 use default app version 𝕎 applyAdditionalConfig(config) { with empty app version }`(
-//        forge: Forge
-//    ) {
-//        // Given
-//        val config = Configuration.Builder(
-//            logsEnabled = true,
-//            tracesEnabled = true,
-//            crashReportsEnabled = true,
-//            rumEnabled = true
-//        )
-//            .setAdditionalConfiguration(
-//                mapOf(Datadog.DD_APP_VERSION_TAG to forge.aWhitespaceString())
-//            )
-//            .build()
-//        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
-//
-//        // When
-//        Datadog.initialize(DatadogTest.appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
-//
-//        // Then
-//        assertThat(CoreFeature.packageVersionProvider.version).isEqualTo(DatadogTest.appContext.fakeVersionName)
-//    }
-//
-//    @Test
-//    fun `𝕄 use default app version 𝕎 applyAdditionalConfig(config) { with app version !string }`(
-//        forge: Forge
-//    ) {
-//        // Given
-//        val config = Configuration.Builder(
-//            logsEnabled = true,
-//            tracesEnabled = true,
-//            crashReportsEnabled = true,
-//            rumEnabled = true
-//        )
-//            .setAdditionalConfiguration(mapOf(Datadog.DD_APP_VERSION_TAG to forge.anInt()))
-//            .build()
-//        val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
-//
-//        // When
-//        Datadog.initialize(DatadogTest.appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
-//
-//        // Then
-//        assertThat(CoreFeature.packageVersionProvider.version).isEqualTo(DatadogTest.appContext.fakeVersionName)
-//    }
+
+    @Test
+    fun `𝕄 apply source name 𝕎 applyAdditionalConfig(config) { with source name }`(
+        @StringForgery(type = StringForgeryType.ALPHABETICAL) source: String
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to source))
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.sourceName).isEqualTo(source)
+    }
+
+    @Test
+    fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { with empty source name }`(
+        @StringForgery(type = StringForgeryType.WHITESPACE) source: String
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to source))
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
+    }
+
+    @Test
+    fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { with source name !string }`(
+        @IntForgery source: Int
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to source))
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
+    }
+
+    @Test
+    fun `𝕄 use default source name 𝕎 applyAdditionalConfig(config) { without source name }`(
+        @Forgery customAttributes: CustomAttributes
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(customAttributes.nonNullData)
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.sourceName).isEqualTo(CoreFeature.DEFAULT_SOURCE_NAME)
+    }
+
+    @Test
+    fun `𝕄 apply sdk version 𝕎 applyAdditionalConfig(config) { with sdk version }`(
+        @StringForgery(regex = "[0-9]+(\\.[0-9]+)+") sdkVersion: String
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion))
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.sdkVersion).isEqualTo(sdkVersion)
+    }
+
+    @Test
+    fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { with empty sdk version }`(
+        @StringForgery(type = StringForgeryType.WHITESPACE) sdkVersion: String
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(
+                mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion)
+            )
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
+    }
+
+    @Test
+    fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { with sdk version !string }`(
+        @Forgery sdkVersion: URL
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion))
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
+    }
+
+    @Test
+    fun `𝕄 use default sdk version 𝕎 applyAdditionalConfig(config) { without sdk version }`(
+        @Forgery customAttributes: CustomAttributes
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(customAttributes.nonNullData)
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.sdkVersion).isEqualTo(CoreFeature.DEFAULT_SDK_VERSION)
+    }
+
+    @Test
+    fun `𝕄 apply app version 𝕎 applyAdditionalConfig(config) { with app version }`(
+        @StringForgery appVersion: String
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_APP_VERSION_TAG to appVersion))
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.packageVersionProvider.version).isEqualTo(appVersion)
+    }
+
+    @Test
+    fun `𝕄 use default app version 𝕎 applyAdditionalConfig(config) { with empty app version }`(
+        forge: Forge
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(
+                mapOf(Datadog.DD_APP_VERSION_TAG to forge.aWhitespaceString())
+            )
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.packageVersionProvider.version).isEqualTo(
+            appContext.fakeVersionName
+        )
+    }
+
+    @Test
+    fun `𝕄 use default app version 𝕎 applyAdditionalConfig(config) { with app version !string }`(
+        forge: Forge
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_APP_VERSION_TAG to forge.anInt()))
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.coreFeature.packageVersionProvider.version).isEqualTo(
+            appContext.fakeVersionName
+        )
+    }
 
     // endregion
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/log/internal/net/LogsRequestFactoryTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/log/internal/net/LogsRequestFactoryTest.kt
@@ -37,14 +37,9 @@ internal class LogsRequestFactoryTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
-    @StringForgery(regex = "https://[a-z]+\\.com")
-    lateinit var fakeEndpoint: String
-
     @BeforeEach
     fun `set up`() {
-        testedFactory = LogsRequestFactory(
-            endpointUrl = fakeEndpoint
-        )
+        testedFactory = LogsRequestFactory()
     }
 
     @Suppress("NAME_SHADOWING")
@@ -63,7 +58,7 @@ internal class LogsRequestFactoryTest {
 
         // Then
         assertThat(request.url).isEqualTo(
-            "$fakeEndpoint/api/v2/logs?" +
+            "${fakeDatadogContext.site.logsEndpoint()}/api/v2/logs?" +
                 "ddsource=${fakeDatadogContext.source}"
         )
         assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_JSON)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/rum/internal/net/RumRequestFactoryTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/rum/internal/net/RumRequestFactoryTest.kt
@@ -38,14 +38,9 @@ internal class RumRequestFactoryTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
-    @StringForgery(regex = "https://[a-z]+\\.com")
-    lateinit var fakeEndpoint: String
-
     @BeforeEach
     fun `set up`() {
-        testedFactory = RumRequestFactory(
-            endpointUrl = fakeEndpoint
-        )
+        testedFactory = RumRequestFactory()
     }
 
     @Suppress("NAME_SHADOWING")
@@ -63,7 +58,7 @@ internal class RumRequestFactoryTest {
         val request = testedFactory.create(fakeDatadogContext, batchData, batchMetadata)
 
         // Then
-        assertThat(request.url).isEqualTo(expectedUrl(fakeEndpoint))
+        assertThat(request.url).isEqualTo(expectedUrl(fakeDatadogContext.site.rumEndpoint()))
         assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_TEXT_UTF8)
         assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
             mapOf(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/tracing/internal/net/TracesRequestFactoryTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/tracing/internal/net/TracesRequestFactoryTest.kt
@@ -37,14 +37,9 @@ internal class TracesRequestFactoryTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
-    @StringForgery(regex = "https://[a-z]+\\.com")
-    lateinit var fakeEndpoint: String
-
     @BeforeEach
     fun `set up`() {
-        testedFactory = TracesRequestFactory(
-            endpointUrl = fakeEndpoint
-        )
+        testedFactory = TracesRequestFactory()
     }
 
     @Suppress("NAME_SHADOWING")
@@ -62,7 +57,9 @@ internal class TracesRequestFactoryTest {
         val request = testedFactory.create(fakeDatadogContext, batchData, batchMetadata)
 
         // Then
-        assertThat(request.url).isEqualTo("$fakeEndpoint/api/v2/spans")
+        assertThat(request.url).isEqualTo(
+            "${fakeDatadogContext.site.tracesEndpoint()}/api/v2/spans"
+        )
         assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_TEXT_UTF8)
         assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
             mapOf(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeatureTest.kt
@@ -60,7 +60,7 @@ internal class WebViewLogsFeatureTest :
     @Test
     fun `𝕄 create a logs request factory 𝕎 createRequestFactory()`() {
         // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory()
 
         // Then
         assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
@@ -59,7 +59,7 @@ internal class WebViewRumFeatureTest : SdkFeatureTest<Any,
     @Test
     fun `𝕄 create a rum request factory 𝕎 createRequestFactory()`() {
         // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
+        val requestFactory = testedFeature.createRequestFactory()
 
         // Then
         assertThat(requestFactory).isInstanceOf(RumRequestFactory::class.java)


### PR DESCRIPTION
### What does this PR do?

First PR in a series of PR whose goal is to align features configuration with SDK v2.

This change makes feature-specific request factories to have no-arg constructor, considering they should get everything they need from `DatadogContext`.

Also this change updates the tests of `DatadogCore` related to the additional configuration.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

