### PR TITLE
Minor performance optimization during serialization into JSON format

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
@@ -60,10 +60,11 @@ internal fun Any?.toJsonElement(): JsonElement {
         is Double -> JsonPrimitive(this)
         is String -> JsonPrimitive(this)
         is Date -> JsonPrimitive(this.time)
+        // this line should come before Iterable, otherwise this branch is never executed
+        is JsonArray -> this
         is Iterable<*> -> this.toJsonArray()
         is Map<*, *> -> this.toJsonObject()
         is JsonObject -> this
-        is JsonArray -> this
         is JsonPrimitive -> this
         is JSONObject -> this.toJsonObject()
         is JSONArray -> this.toJsonArray()


### PR DESCRIPTION
### What does this PR do?

I noticed a small issue in the related code: since `JsonArray` actually implements `Iterable`, `is JsonArray` branch will never be executed, because it goes after `is Iterable` branch.

By moving `is JsonArray` up we skip useless `toJsonArray` call which will create new object and copy elements there from the old object.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

