### PR TITLE
RUMM-2563: Create storage and uploader outside of the feature

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportFilePersistenceStrategy.kt
@@ -20,6 +20,7 @@ import com.datadog.android.log.internal.domain.event.LogEventSerializer
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.security.Encryption
 import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.storage.Storage
 import java.io.File
 import java.util.concurrent.ExecutorService
 
@@ -30,7 +31,8 @@ internal class CrashReportFilePersistenceStrategy(
     executorService: ExecutorService,
     internalLogger: Logger,
     localDataEncryption: Encryption?,
-    filePersistenceConfig: FilePersistenceConfig
+    filePersistenceConfig: FilePersistenceConfig,
+    storage: Storage
 ) : BatchFilePersistenceStrategy<LogEvent>(
     contextProvider,
     FeatureFileOrchestrator(
@@ -47,5 +49,6 @@ internal class CrashReportFilePersistenceStrategy(
     BatchFileReaderWriter.create(sdkLogger, localDataEncryption),
     FileReaderWriter.create(sdkLogger, localDataEncryption),
     FileMover(sdkLogger),
-    filePersistenceConfig
+    filePersistenceConfig,
+    storage
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -14,12 +14,14 @@ import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.internal.domain.DatadogLogGenerator
 import com.datadog.android.log.model.LogEvent
-import com.datadog.android.v2.api.RequestFactory
-import com.datadog.android.v2.log.internal.net.LogsRequestFactory
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.Storage
 
 internal class CrashReportsFeature(
-    coreFeature: CoreFeature
-) : SdkFeature<LogEvent, Configuration.Feature.CrashReport>(coreFeature) {
+    coreFeature: CoreFeature,
+    storage: Storage,
+    uploader: DataUploader
+) : SdkFeature<LogEvent, Configuration.Feature.CrashReport>(coreFeature, storage, uploader) {
 
     internal var originalUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
 
@@ -35,6 +37,7 @@ internal class CrashReportsFeature(
 
     override fun createPersistenceStrategy(
         context: Context,
+        storage: Storage,
         configuration: Configuration.Feature.CrashReport
     ): PersistenceStrategy<LogEvent> {
         return CrashReportFilePersistenceStrategy(
@@ -44,13 +47,9 @@ internal class CrashReportsFeature(
             coreFeature.persistenceExecutorService,
             sdkLogger,
             coreFeature.localDataEncryption,
-            coreFeature.buildFilePersistenceConfig()
+            coreFeature.buildFilePersistenceConfig(),
+            storage
         )
-    }
-
-    override fun createRequestFactory(configuration: Configuration.Feature.CrashReport):
-        RequestFactory {
-        return LogsRequestFactory(configuration.endpointUrl)
     }
 
     override fun onPostInitialized(context: Context) {}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -14,17 +14,20 @@ import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.internal.domain.LogFilePersistenceStrategy
 import com.datadog.android.log.model.LogEvent
-import com.datadog.android.v2.api.RequestFactory
-import com.datadog.android.v2.log.internal.net.LogsRequestFactory
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.Storage
 
 internal class LogsFeature(
-    coreFeature: CoreFeature
-) : SdkFeature<LogEvent, Configuration.Feature.Logs>(coreFeature) {
+    coreFeature: CoreFeature,
+    storage: Storage,
+    uploader: DataUploader
+) : SdkFeature<LogEvent, Configuration.Feature.Logs>(coreFeature, storage, uploader) {
 
     // region SdkFeature
 
     override fun createPersistenceStrategy(
         context: Context,
+        storage: Storage,
         configuration: Configuration.Feature.Logs
     ): PersistenceStrategy<LogEvent> {
         return LogFilePersistenceStrategy(
@@ -35,12 +38,9 @@ internal class LogsFeature(
             sdkLogger,
             configuration.logsEventMapper,
             coreFeature.localDataEncryption,
-            coreFeature.buildFilePersistenceConfig()
+            coreFeature.buildFilePersistenceConfig(),
+            storage
         )
-    }
-
-    override fun createRequestFactory(configuration: Configuration.Feature.Logs): RequestFactory {
-        return LogsRequestFactory(configuration.endpointUrl)
     }
 
     override fun onPostInitialized(context: Context) {}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFilePersistenceStrategy.kt
@@ -24,6 +24,7 @@ import com.datadog.android.log.internal.domain.event.LogEventSerializer
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.security.Encryption
 import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.storage.Storage
 import java.io.File
 import java.util.concurrent.ExecutorService
 
@@ -35,7 +36,8 @@ internal class LogFilePersistenceStrategy(
     internalLogger: Logger,
     logEventMapper: EventMapper<LogEvent>,
     localDataEncryption: Encryption?,
-    filePersistenceConfig: FilePersistenceConfig
+    filePersistenceConfig: FilePersistenceConfig,
+    storage: Storage
 ) : BatchFilePersistenceStrategy<LogEvent>(
     contextProvider,
     FeatureFileOrchestrator(
@@ -52,5 +54,6 @@ internal class LogFilePersistenceStrategy(
     BatchFileReaderWriter.create(sdkLogger, localDataEncryption),
     FileReaderWriter.create(sdkLogger, localDataEncryption),
     FileMover(internalLogger),
-    filePersistenceConfig
+    filePersistenceConfig,
+    storage
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -42,8 +42,8 @@ import com.datadog.android.rum.tracking.NoOpTrackingStrategy
 import com.datadog.android.rum.tracking.NoOpViewTrackingStrategy
 import com.datadog.android.rum.tracking.TrackingStrategy
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
-import com.datadog.android.v2.api.RequestFactory
-import com.datadog.android.v2.rum.internal.net.RumRequestFactory
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.Storage
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
@@ -51,8 +51,10 @@ import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
 internal class RumFeature(
-    coreFeature: CoreFeature
-) : SdkFeature<Any, Configuration.Feature.RUM>(coreFeature) {
+    coreFeature: CoreFeature,
+    storage: Storage,
+    uploader: DataUploader
+) : SdkFeature<Any, Configuration.Feature.RUM>(coreFeature, storage, uploader) {
 
     internal var samplingRate: Float = 0f
     internal var telemetrySamplingRate: Float = 0f
@@ -117,6 +119,7 @@ internal class RumFeature(
 
     override fun createPersistenceStrategy(
         context: Context,
+        storage: Storage,
         configuration: Configuration.Feature.RUM
     ): PersistenceStrategy<Any> {
         return RumFilePersistenceStrategy(
@@ -128,12 +131,9 @@ internal class RumFeature(
             sdkLogger,
             coreFeature.localDataEncryption,
             DatadogNdkCrashHandler.getLastViewEventFile(coreFeature.storageDir),
-            coreFeature.buildFilePersistenceConfig()
+            coreFeature.buildFilePersistenceConfig(),
+            storage
         )
-    }
-
-    override fun createRequestFactory(configuration: Configuration.Feature.RUM): RequestFactory {
-        return RumRequestFactory(configuration.endpointUrl)
     }
 
     override fun onPostInitialized(context: Context) {}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumFilePersistenceStrategy.kt
@@ -24,6 +24,7 @@ import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.event.RumEventSerializer
 import com.datadog.android.security.Encryption
 import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.storage.Storage
 import java.io.File
 import java.util.concurrent.ExecutorService
 
@@ -36,7 +37,8 @@ internal class RumFilePersistenceStrategy(
     internalLogger: Logger,
     localDataEncryption: Encryption?,
     private val lastViewEventFile: File,
-    filePersistenceConfig: FilePersistenceConfig
+    filePersistenceConfig: FilePersistenceConfig,
+    storage: Storage
 ) : BatchFilePersistenceStrategy<Any>(
     contextProvider,
     FeatureFileOrchestrator(
@@ -56,7 +58,8 @@ internal class RumFilePersistenceStrategy(
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
     FileReaderWriter.create(internalLogger, localDataEncryption),
     FileMover(internalLogger),
-    filePersistenceConfig
+    filePersistenceConfig,
+    storage
 ) {
 
     override fun createWriter(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracingFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracingFeature.kt
@@ -13,18 +13,21 @@ import com.datadog.android.core.internal.SdkFeature
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.tracing.internal.domain.TracesFilePersistenceStrategy
-import com.datadog.android.v2.api.RequestFactory
-import com.datadog.android.v2.tracing.internal.net.TracesRequestFactory
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.Storage
 import com.datadog.opentracing.DDSpan
 
 internal class TracingFeature(
-    coreFeature: CoreFeature
-) : SdkFeature<DDSpan, Configuration.Feature.Tracing>(coreFeature) {
+    coreFeature: CoreFeature,
+    storage: Storage,
+    uploader: DataUploader
+) : SdkFeature<DDSpan, Configuration.Feature.Tracing>(coreFeature, storage, uploader) {
 
     // region SdkFeature
 
     override fun createPersistenceStrategy(
         context: Context,
+        storage: Storage,
         configuration: Configuration.Feature.Tracing
     ): PersistenceStrategy<DDSpan> {
         return TracesFilePersistenceStrategy(
@@ -37,13 +40,9 @@ internal class TracingFeature(
             sdkLogger,
             configuration.spanEventMapper,
             coreFeature.localDataEncryption,
-            coreFeature.buildFilePersistenceConfig()
+            coreFeature.buildFilePersistenceConfig(),
+            storage
         )
-    }
-
-    override fun createRequestFactory(configuration: Configuration.Feature.Tracing):
-        RequestFactory {
-        return TracesRequestFactory(configuration.endpointUrl)
     }
 
     override fun onPostInitialized(context: Context) {}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracesFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracesFilePersistenceStrategy.kt
@@ -24,6 +24,7 @@ import com.datadog.android.tracing.internal.domain.event.SpanEventMapperWrapper
 import com.datadog.android.tracing.internal.domain.event.SpanEventSerializer
 import com.datadog.android.tracing.internal.domain.event.SpanMapperSerializer
 import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.storage.Storage
 import com.datadog.opentracing.DDSpan
 import java.io.File
 import java.util.concurrent.ExecutorService
@@ -38,7 +39,8 @@ internal class TracesFilePersistenceStrategy(
     internalLogger: Logger,
     spanEventMapper: SpanEventMapper,
     localDataEncryption: Encryption?,
-    filePersistenceConfig: FilePersistenceConfig
+    filePersistenceConfig: FilePersistenceConfig,
+    storage: Storage
 ) : BatchFilePersistenceStrategy<DDSpan>(
     contextProvider,
     FeatureFileOrchestrator(
@@ -61,5 +63,6 @@ internal class TracesFilePersistenceStrategy(
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
     FileReaderWriter.create(internalLogger, localDataEncryption),
     FileMover(internalLogger),
-    filePersistenceConfig
+    filePersistenceConfig,
+    storage
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogFilePersistenceStrategy.kt
@@ -19,6 +19,7 @@ import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.domain.event.WebViewLogEventSerializer
 import com.datadog.android.security.Encryption
 import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.storage.Storage
 import com.google.gson.JsonObject
 import java.io.File
 import java.util.concurrent.ExecutorService
@@ -30,7 +31,8 @@ internal class WebViewLogFilePersistenceStrategy(
     executorService: ExecutorService,
     internalLogger: Logger,
     localDataEncryption: Encryption?,
-    filePersistenceConfig: FilePersistenceConfig
+    filePersistenceConfig: FilePersistenceConfig,
+    storage: Storage
 ) : BatchFilePersistenceStrategy<JsonObject>(
     contextProvider,
     FeatureFileOrchestrator(
@@ -47,5 +49,6 @@ internal class WebViewLogFilePersistenceStrategy(
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
     FileReaderWriter.create(internalLogger, localDataEncryption),
     FileMover(internalLogger),
-    filePersistenceConfig
+    filePersistenceConfig,
+    storage
 )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeature.kt
@@ -12,18 +12,21 @@ import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.SdkFeature
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
-import com.datadog.android.v2.api.RequestFactory
-import com.datadog.android.v2.log.internal.net.LogsRequestFactory
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.Storage
 import com.google.gson.JsonObject
 
 internal class WebViewLogsFeature(
-    coreFeature: CoreFeature
-) : SdkFeature<JsonObject, Configuration.Feature.Logs>(coreFeature) {
+    coreFeature: CoreFeature,
+    storage: Storage,
+    uploader: DataUploader
+) : SdkFeature<JsonObject, Configuration.Feature.Logs>(coreFeature, storage, uploader) {
 
     // region SdkFeature
 
     override fun createPersistenceStrategy(
         context: Context,
+        storage: Storage,
         configuration: Configuration.Feature.Logs
     ): PersistenceStrategy<JsonObject> {
         return WebViewLogFilePersistenceStrategy(
@@ -33,12 +36,9 @@ internal class WebViewLogsFeature(
             coreFeature.persistenceExecutorService,
             sdkLogger,
             coreFeature.localDataEncryption,
-            coreFeature.buildFilePersistenceConfig()
+            coreFeature.buildFilePersistenceConfig(),
+            storage
         )
-    }
-
-    override fun createRequestFactory(configuration: Configuration.Feature.Logs): RequestFactory {
-        return LogsRequestFactory(configuration.endpointUrl)
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
@@ -13,17 +13,20 @@ import com.datadog.android.core.internal.SdkFeature
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.rum.internal.ndk.DatadogNdkCrashHandler
-import com.datadog.android.v2.api.RequestFactory
-import com.datadog.android.v2.rum.internal.net.RumRequestFactory
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.Storage
 
 internal class WebViewRumFeature(
-    coreFeature: CoreFeature
-) : SdkFeature<Any, Configuration.Feature.RUM>(coreFeature) {
+    coreFeature: CoreFeature,
+    storage: Storage,
+    uploader: DataUploader
+) : SdkFeature<Any, Configuration.Feature.RUM>(coreFeature, storage, uploader) {
 
     // region SdkFeature
 
     override fun createPersistenceStrategy(
         context: Context,
+        storage: Storage,
         configuration: Configuration.Feature.RUM
     ): PersistenceStrategy<Any> {
         return WebViewRumFilePersistenceStrategy(
@@ -34,12 +37,9 @@ internal class WebViewRumFeature(
             sdkLogger,
             coreFeature.localDataEncryption,
             DatadogNdkCrashHandler.getLastViewEventFile(coreFeature.storageDir),
-            coreFeature.buildFilePersistenceConfig()
+            coreFeature.buildFilePersistenceConfig(),
+            storage
         )
-    }
-
-    override fun createRequestFactory(configuration: Configuration.Feature.RUM): RequestFactory {
-        return RumRequestFactory(configuration.endpointUrl)
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFilePersistenceStrategy.kt
@@ -22,6 +22,7 @@ import com.datadog.android.rum.internal.domain.RumDataWriter
 import com.datadog.android.rum.internal.domain.event.RumEventSerializer
 import com.datadog.android.security.Encryption
 import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.internal.storage.Storage
 import java.io.File
 import java.util.concurrent.ExecutorService
 
@@ -33,7 +34,8 @@ internal class WebViewRumFilePersistenceStrategy(
     internalLogger: Logger,
     localDataEncryption: Encryption?,
     private val lastViewEventFile: File,
-    filePersistenceConfig: FilePersistenceConfig
+    filePersistenceConfig: FilePersistenceConfig,
+    storage: Storage
 ) : BatchFilePersistenceStrategy<Any>(
     contextProvider,
     FeatureFileOrchestrator(
@@ -50,7 +52,8 @@ internal class WebViewRumFilePersistenceStrategy(
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
     FileReaderWriter.create(internalLogger, localDataEncryption),
     FileMover(internalLogger),
-    filePersistenceConfig
+    filePersistenceConfig,
+    storage
 ) {
 
     override fun createWriter(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
@@ -22,6 +22,8 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.Storage
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
@@ -69,6 +71,12 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     @Mock
     lateinit var mockRumAttributesProvider: RumResourceAttributesProvider
 
+    @Mock
+    lateinit var mockStorage: Storage
+
+    @Mock
+    lateinit var mockUploader: DataUploader
+
     private lateinit var fakeAttributes: Map<String, Any?>
 
     override fun instantiateTestedInterceptor(
@@ -76,7 +84,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         factory: () -> Tracer
     ): TracingInterceptor {
         whenever((Datadog.globalSdkCore as DatadogCore).rumFeature) doReturn
-            RumFeature(coreFeature.mockInstance)
+            RumFeature(coreFeature.mockInstance, mockStorage, mockUploader)
         return DatadogInterceptor(
             tracedHosts = tracedHosts,
             tracedRequestListener = mockRequestListener,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutTracesTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutTracesTest.kt
@@ -171,9 +171,9 @@ internal class DatadogInterceptorWithoutTracesTest {
         ) { mockLocalTracer }
         Datadog.globalSdkCore = mock<DatadogCore>()
         whenever((Datadog.globalSdkCore as DatadogCore).tracingFeature) doReturn
-            TracingFeature(coreFeature.mockInstance)
+            TracingFeature(coreFeature.mockInstance, storage = mock(), uploader = mock())
         whenever((Datadog.globalSdkCore as DatadogCore).rumFeature) doReturn
-            RumFeature(coreFeature.mockInstance)
+            RumFeature(coreFeature.mockInstance, storage = mock(), uploader = mock())
 
         fakeResourceAttributes = forge.exhaustiveAttributes()
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -10,7 +10,6 @@ import android.app.Application
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
 import com.datadog.android.core.internal.data.upload.UploadScheduler
-import com.datadog.android.core.internal.net.DataUploader
 import com.datadog.android.core.internal.persistence.DataReader
 import com.datadog.android.core.internal.persistence.NoOpPersistenceStrategy
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
@@ -25,7 +24,8 @@ import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.core.internal.data.upload.DataFlusher
 import com.datadog.android.v2.core.internal.data.upload.DataUploadScheduler
-import com.datadog.android.v2.core.internal.net.DataOkHttpUploader
+import com.datadog.android.v2.core.internal.net.DataUploader
+import com.datadog.android.v2.core.internal.storage.Storage
 import com.datadog.android.webview.internal.log.WebViewLogsFeature
 import com.datadog.android.webview.internal.rum.WebViewRumFeature
 import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn
@@ -87,6 +87,9 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
     @Mock
     lateinit var mockUploader: DataUploader
 
+    @Mock
+    lateinit var mockStorage: Storage
+
     lateinit var fakeConfigurationFeature: C
 
     @Forgery
@@ -132,11 +135,7 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
             )
         }
 
-        assertThat(testedFeature.uploader)
-            .isInstanceOf(DataOkHttpUploader::class.java)
-
-        val uploader = testedFeature.uploader as DataOkHttpUploader
-        assertThat(uploader.callFactory).isSameAs(coreFeature.mockInstance.okHttpClient)
+        assertThat(testedFeature.uploader).isSameAs(mockUploader)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategyTest.kt
@@ -19,7 +19,7 @@ import com.datadog.android.log.internal.logger.LogHandler
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.core.internal.ContextProvider
 import com.datadog.android.v2.core.internal.data.upload.DataFlusher
-import com.datadog.android.v2.core.internal.storage.ConsentAwareStorage
+import com.datadog.android.v2.core.internal.storage.Storage
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
@@ -73,6 +73,9 @@ internal class BatchFilePersistenceStrategyTest {
     @Mock
     lateinit var mockContextProvider: ContextProvider
 
+    @Mock
+    lateinit var mockStorage: Storage
+
     @Forgery
     lateinit var fakePayloadDecoration: PayloadDecoration
 
@@ -98,7 +101,8 @@ internal class BatchFilePersistenceStrategyTest {
             mockFileReaderWriter,
             mockMetaFileReaderWriter,
             mockFileMover,
-            fakeFilePersistenceConfig
+            fakeFilePersistenceConfig,
+            mockStorage
         )
     }
 
@@ -134,22 +138,12 @@ internal class BatchFilePersistenceStrategyTest {
     }
 
     @Test
-    fun `𝕄 return consent aware storage 𝕎 getStorage()`() {
+    fun `𝕄 return same storage 𝕎 getStorage()`() {
         // When
         val storage = testedStrategy.getStorage()
 
         // Then
-        assertThat(storage).isInstanceOf(ConsentAwareStorage::class.java)
-    }
-
-    @Test
-    fun `𝕄 return consent aware storage 𝕎 getStorage() twice`() {
-        // When
-        val storage1 = testedStrategy.getStorage()
-        val storage2 = testedStrategy.getStorage()
-
-        // Then
-        assertThat(storage1).isSameAs(storage2)
+        assertThat(storage).isSameAs(mockStorage)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -10,7 +10,6 @@ import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.SdkFeatureTest
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.log.internal.net.LogsRequestFactory
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.nhaarman.mockitokotlin2.mock
 import fr.xgouchet.elmyr.Forge
@@ -50,7 +49,7 @@ internal class CrashReportsFeatureTest :
     }
 
     override fun createTestedFeature(): CrashReportsFeature {
-        return CrashReportsFeature(coreFeature.mockInstance)
+        return CrashReportsFeature(coreFeature.mockInstance, mockStorage, mockUploader)
     }
 
     override fun forgeConfiguration(forge: Forge): Configuration.Feature.CrashReport {
@@ -69,15 +68,6 @@ internal class CrashReportsFeatureTest :
         // Then
         assertThat(testedFeature.persistenceStrategy)
             .isInstanceOf(CrashReportFilePersistenceStrategy::class.java)
-    }
-
-    @Test
-    fun `𝕄 create a crash request factory 𝕎 createRequestFactory()`() {
-        // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
-
-        // Then
-        assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -62,7 +62,7 @@ internal class LoggerBuilderTest {
     fun `set up`() {
         val mockCore = mock<DatadogCore>()
         whenever(mockCore.coreFeature) doReturn coreFeature.mockInstance
-        val logsFeature = LogsFeature(coreFeature.mockInstance)
+        val logsFeature = LogsFeature(coreFeature.mockInstance, storage = mock(), uploader = mock())
         logsFeature.initialize(appContext.mockInstance, fakeConfig)
         whenever(mockCore.logsFeature) doReturn logsFeature
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -15,7 +15,6 @@ import com.datadog.android.log.internal.domain.LogFilePersistenceStrategy
 import com.datadog.android.log.internal.domain.event.LogEventMapperWrapper
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.log.internal.net.LogsRequestFactory
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -39,7 +38,7 @@ internal class LogsFeatureTest :
     SdkFeatureTest<LogEvent, Configuration.Feature.Logs, LogsFeature>() {
 
     override fun createTestedFeature(): LogsFeature {
-        return LogsFeature(coreFeature.mockInstance)
+        return LogsFeature(coreFeature.mockInstance, mockStorage, mockUploader)
     }
 
     override fun forgeConfiguration(forge: Forge): Configuration.Feature.Logs {
@@ -58,15 +57,6 @@ internal class LogsFeatureTest :
         // Then
         assertThat(testedFeature.persistenceStrategy)
             .isInstanceOf(LogFilePersistenceStrategy::class.java)
-    }
-
-    @Test
-    fun `𝕄 create a logs request factory 𝕎 createRequestFactory()`() {
-        // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
-
-        // Then
-        assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
@@ -66,7 +66,7 @@ internal class RumMonitorBuilderTest {
         whenever(mockCore.coreFeature) doReturn coreFeature.mockInstance
         whenever(mockCore.contextProvider) doReturn mock()
 
-        rumFeature = RumFeature(coreFeature.mockInstance)
+        rumFeature = RumFeature(coreFeature.mockInstance, storage = mock(), uploader = mock())
         rumFeature.initialize(appContext.mockInstance, fakeConfig)
         whenever(mockCore.rumFeature) doReturn rumFeature
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -25,7 +25,6 @@ import com.datadog.android.rum.tracking.TrackingStrategy
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.rum.internal.net.RumRequestFactory
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
@@ -65,7 +64,7 @@ internal class RumFeatureTest : SdkFeatureTest<Any, Configuration.Feature.RUM, R
     lateinit var mockChoreographer: Choreographer
 
     override fun createTestedFeature(): RumFeature {
-        return RumFeature(coreFeature.mockInstance)
+        return RumFeature(coreFeature.mockInstance, mockStorage, mockUploader)
     }
 
     override fun forgeConfiguration(forge: Forge): Configuration.Feature.RUM {
@@ -90,18 +89,6 @@ internal class RumFeatureTest : SdkFeatureTest<Any, Configuration.Feature.RUM, R
         // Then
         assertThat(testedFeature.persistenceStrategy)
             .isInstanceOf(RumFilePersistenceStrategy::class.java)
-    }
-
-    @Test
-    fun `𝕄 create a rum request factory 𝕎 createRequestFactory()`() {
-        // Given
-        testedFeature.initialize(appContext.mockInstance, fakeConfigurationFeature)
-
-        // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
-
-        // Then
-        assertThat(requestFactory).isInstanceOf(RumRequestFactory::class.java)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
@@ -173,7 +173,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         fakeRequest = forgeRequest(forge)
         Datadog.globalSdkCore = mock<DatadogCore>()
         whenever((Datadog.globalSdkCore as DatadogCore).tracingFeature) doReturn
-            TracingFeature(coreFeature.mockInstance)
+            TracingFeature(coreFeature.mockInstance, storage = mock(), uploader = mock())
         doAnswer { false }.whenever(mockDetector).isFirstPartyUrl(any<HttpUrl>())
         doAnswer { true }.whenever(mockDetector).isFirstPartyUrl(HttpUrl.get(fakeUrl))
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
@@ -95,8 +95,12 @@ internal class AndroidTracerTest {
         fakeToken = forge.anHexadecimalString()
 
         val mockCore = mock<DatadogCore>()
-        tracingFeature = TracingFeature(coreFeature.mockInstance)
-        rumFeature = RumFeature(coreFeature.mockInstance)
+        tracingFeature = TracingFeature(
+            coreFeature.mockInstance,
+            storage = mock(),
+            uploader = mock()
+        )
+        rumFeature = RumFeature(coreFeature.mockInstance, storage = mock(), uploader = mock())
 
         whenever(mockCore.tracingFeature) doReturn tracingFeature
         whenever(mockCore.rumFeature) doReturn rumFeature

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracingFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/TracingFeatureTest.kt
@@ -14,7 +14,6 @@ import com.datadog.android.tracing.internal.domain.TracesFilePersistenceStrategy
 import com.datadog.android.tracing.internal.domain.event.SpanEventMapperWrapper
 import com.datadog.android.tracing.internal.domain.event.SpanMapperSerializer
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.tracing.internal.net.TracesRequestFactory
 import com.datadog.opentracing.DDSpan
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import fr.xgouchet.elmyr.Forge
@@ -39,7 +38,7 @@ internal class TracingFeatureTest :
     SdkFeatureTest<DDSpan, Configuration.Feature.Tracing, TracingFeature>() {
 
     override fun createTestedFeature(): TracingFeature {
-        return TracingFeature(coreFeature.mockInstance)
+        return TracingFeature(coreFeature.mockInstance, mockStorage, mockUploader)
     }
 
     override fun forgeConfiguration(forge: Forge): Configuration.Feature.Tracing {
@@ -73,14 +72,5 @@ internal class TracingFeatureTest :
         val spanEventMapperWrapper = spanSerializer?.spanEventMapper as? SpanEventMapperWrapper
         val spanEventMapper = spanEventMapperWrapper?.wrappedEventMapper
         assertThat(spanEventMapper).isSameAs(fakeConfigurationFeature.spanEventMapper)
-    }
-
-    @Test
-    fun `𝕄 create a tracing request factory 𝕎 createRequestFactory()`() {
-        // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
-
-        // Then
-        assertThat(requestFactory).isInstanceOf(TracesRequestFactory::class.java)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeatureTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.webview.internal.log
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.SdkFeatureTest
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.log.internal.net.LogsRequestFactory
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.google.gson.JsonObject
@@ -36,7 +35,7 @@ internal class WebViewLogsFeatureTest :
     SdkFeatureTest<JsonObject, Configuration.Feature.Logs, WebViewLogsFeature>() {
 
     override fun createTestedFeature(): WebViewLogsFeature {
-        return WebViewLogsFeature(coreFeature.mockInstance)
+        return WebViewLogsFeature(coreFeature.mockInstance, mockStorage, mockUploader)
     }
 
     override fun forgeConfiguration(forge: Forge): Configuration.Feature.Logs {
@@ -55,14 +54,5 @@ internal class WebViewLogsFeatureTest :
         // Then
         assertThat(testedFeature.persistenceStrategy)
             .isInstanceOf(WebViewLogFilePersistenceStrategy::class.java)
-    }
-
-    @Test
-    fun `𝕄 create a logs request factory 𝕎 createRequestFactory()`() {
-        // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
-
-        // Then
-        assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.webview.internal.rum
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.SdkFeatureTest
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.rum.internal.net.RumRequestFactory
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import fr.xgouchet.elmyr.Forge
@@ -35,7 +34,7 @@ internal class WebViewRumFeatureTest : SdkFeatureTest<Any,
     Configuration.Feature.RUM, WebViewRumFeature>() {
 
     override fun createTestedFeature(): WebViewRumFeature {
-        return WebViewRumFeature(coreFeature.mockInstance)
+        return WebViewRumFeature(coreFeature.mockInstance, mockStorage, mockUploader)
     }
 
     override fun forgeConfiguration(forge: Forge): Configuration.Feature.RUM {
@@ -54,14 +53,5 @@ internal class WebViewRumFeatureTest : SdkFeatureTest<Any,
         // Then
         assertThat(testedFeature.persistenceStrategy)
             .isInstanceOf(WebViewRumFilePersistenceStrategy::class.java)
-    }
-
-    @Test
-    fun `𝕄 create a rum request factory 𝕎 createRequestFactory()`() {
-        // When
-        val requestFactory = testedFeature.createRequestFactory(fakeConfigurationFeature)
-
-        // Then
-        assertThat(requestFactory).isInstanceOf(RumRequestFactory::class.java)
     }
 }


### PR DESCRIPTION
### What does this PR do?

`Storage` and `DataUploader` are pulled outside of the feature-specific classes, because `core` module will be responsible for those two.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

