### PR TITLE
RUMM-2568: Remove DataReader v1 usages

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -71,7 +71,7 @@ internal abstract class SdkFeature<T : Any, C : Configuration.Feature>(
 
     fun clearAllData() {
         @Suppress("ThreadSafety") // TODO RUMM-1503 delegate to another thread
-        persistenceStrategy.getReader().dropAll()
+        storage.dropAll()
     }
 
     fun stop() {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/PersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/PersistenceStrategy.kt
@@ -19,8 +19,6 @@ internal interface PersistenceStrategy<T : Any> {
 
     fun getWriter(): DataWriter<T>
 
-    fun getReader(): DataReader
-
     fun getFlusher(): Flusher
 
     fun getStorage(): Storage

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategy.kt
@@ -6,9 +6,7 @@
 
 package com.datadog.android.core.internal.persistence.file.batch
 
-import com.datadog.android.core.internal.persistence.DataReader
 import com.datadog.android.core.internal.persistence.DataWriter
-import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.persistence.Serializer
 import com.datadog.android.core.internal.persistence.file.FileMover
@@ -28,7 +26,6 @@ internal open class BatchFilePersistenceStrategy<T : Any>(
     private val fileOrchestrator: ConsentAwareFileOrchestrator,
     private val executorService: ExecutorService,
     serializer: Serializer<T>,
-    payloadDecoration: PayloadDecoration,
     internal val internalLogger: Logger,
     internal val fileReaderWriter: BatchFileReaderWriter,
     internal val metadataFileReaderWriter: FileReaderWriter,
@@ -45,22 +42,10 @@ internal open class BatchFilePersistenceStrategy<T : Any>(
         )
     }
 
-    private val dataReader = BatchFileDataReader(
-        fileOrchestrator,
-        payloadDecoration,
-        fileReaderWriter,
-        fileMover,
-        internalLogger
-    )
-
     // region PersistenceStrategy
 
     override fun getWriter(): DataWriter<T> {
         return dataWriter
-    }
-
-    override fun getReader(): DataReader {
-        return dataReader
     }
 
     override fun getStorage(): Storage {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportFilePersistenceStrategy.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.error.internal
 
-import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
@@ -44,7 +43,6 @@ internal class CrashReportFilePersistenceStrategy(
     ),
     executorService,
     LogEventSerializer(),
-    PayloadDecoration.JSON_ARRAY_DECORATION,
     sdkLogger,
     BatchFileReaderWriter.create(sdkLogger, localDataEncryption),
     FileReaderWriter.create(sdkLogger, localDataEncryption),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/LogFilePersistenceStrategy.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.log.internal.domain
 
-import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
@@ -49,7 +48,6 @@ internal class LogFilePersistenceStrategy(
     ),
     executorService,
     MapperSerializer(LogEventMapperWrapper(logEventMapper), LogEventSerializer()),
-    PayloadDecoration.JSON_ARRAY_DECORATION,
     sdkLogger,
     BatchFileReaderWriter.create(sdkLogger, localDataEncryption),
     FileReaderWriter.create(sdkLogger, localDataEncryption),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumFilePersistenceStrategy.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.rum.internal.domain
 
 import com.datadog.android.core.internal.persistence.DataWriter
-import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.Serializer
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
@@ -53,7 +52,6 @@ internal class RumFilePersistenceStrategy(
         eventMapper,
         RumEventSerializer()
     ),
-    PayloadDecoration.NEW_LINE_DECORATION,
     internalLogger,
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
     FileReaderWriter.create(internalLogger, localDataEncryption),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracesFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/domain/TracesFilePersistenceStrategy.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.tracing.internal.domain
 
 import com.datadog.android.core.internal.CoreFeature
-import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
@@ -58,7 +57,6 @@ internal class TracesFilePersistenceStrategy(
         SpanEventMapperWrapper(spanEventMapper),
         SpanEventSerializer(envName)
     ),
-    PayloadDecoration.NEW_LINE_DECORATION,
     internalLogger,
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
     FileReaderWriter.create(internalLogger, localDataEncryption),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/Storage.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/Storage.kt
@@ -43,4 +43,10 @@ internal interface Storage {
      */
     @WorkerThread
     fun confirmBatchRead(batchId: BatchId, callback: (BatchConfirmation) -> Unit)
+
+    /**
+     * Removes all the files backed by this storage, synchronously.
+     */
+    @WorkerThread
+    fun dropAll()
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogFilePersistenceStrategy.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.webview.internal.log
 
-import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
@@ -44,7 +43,6 @@ internal class WebViewLogFilePersistenceStrategy(
     ),
     executorService,
     WebViewLogEventSerializer(),
-    PayloadDecoration.JSON_ARRAY_DECORATION,
     sdkLogger,
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
     FileReaderWriter.create(internalLogger, localDataEncryption),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFilePersistenceStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFilePersistenceStrategy.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.webview.internal.rum
 
 import com.datadog.android.core.internal.persistence.DataWriter
-import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.Serializer
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
@@ -47,7 +46,6 @@ internal class WebViewRumFilePersistenceStrategy(
     ),
     executorService,
     RumEventSerializer(),
-    PayloadDecoration.NEW_LINE_DECORATION,
     internalLogger,
     BatchFileReaderWriter.create(internalLogger, localDataEncryption),
     FileReaderWriter.create(internalLogger, localDataEncryption),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -10,7 +10,6 @@ import android.app.Application
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
 import com.datadog.android.core.internal.data.upload.UploadScheduler
-import com.datadog.android.core.internal.persistence.DataReader
 import com.datadog.android.core.internal.persistence.NoOpPersistenceStrategy
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.error.internal.CrashReportsFeature
@@ -82,9 +81,6 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
     lateinit var mockPersistenceStrategy: PersistenceStrategy<T>
 
     @Mock
-    lateinit var mockReader: DataReader
-
-    @Mock
     lateinit var mockUploader: DataUploader
 
     @Mock
@@ -97,7 +93,6 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        whenever(mockPersistenceStrategy.getReader()) doReturn mockReader
         whenever(coreFeature.mockTrackingConsentProvider.getConsent()) doReturn fakeConsent
 
         fakeConfigurationFeature = forgeConfiguration(forge)
@@ -268,14 +263,11 @@ internal abstract class SdkFeatureTest<T : Any, C : Configuration.Feature, F : S
 
     @Test
     fun `𝕄 clear local storage 𝕎 clearAllData()`() {
-        // Given
-        testedFeature.persistenceStrategy = mockPersistenceStrategy
-
         // When
         testedFeature.clearAllData()
 
         // Then
-        verify(mockReader).dropAll()
+        verify(mockStorage).dropAll()
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -650,6 +650,10 @@ internal class UploadWorkerTest {
         override fun confirmBatchRead(batchId: BatchId, callback: (BatchConfirmation) -> Unit) {
             executor.execute { delegate.confirmBatchRead(batchId, callback) }
         }
+
+        override fun dropAll() {
+            fail("we don't expect this one to be called")
+        }
     }
 
     // endregion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFilePersistenceStrategyTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.core.internal.persistence.file.batch
 
-import com.datadog.android.core.internal.persistence.PayloadDecoration
 import com.datadog.android.core.internal.persistence.PersistenceStrategy
 import com.datadog.android.core.internal.persistence.Serializer
 import com.datadog.android.core.internal.persistence.file.FileMover
@@ -77,9 +76,6 @@ internal class BatchFilePersistenceStrategyTest {
     lateinit var mockStorage: Storage
 
     @Forgery
-    lateinit var fakePayloadDecoration: PayloadDecoration
-
-    @Forgery
     lateinit var fakeFilePersistenceConfig: FilePersistenceConfig
 
     @BeforeEach
@@ -96,7 +92,6 @@ internal class BatchFilePersistenceStrategyTest {
             mockFileOrchestrator,
             mockExecutorService,
             mockSerializer,
-            fakePayloadDecoration,
             Logger(mockLogHandler),
             mockFileReaderWriter,
             mockMetaFileReaderWriter,
@@ -129,15 +124,6 @@ internal class BatchFilePersistenceStrategyTest {
     }
 
     @Test
-    fun `𝕄 return batch file reader 𝕎 getReader()`() {
-        // When
-        val reader = testedStrategy.getReader()
-
-        // Then
-        assertThat(reader).isInstanceOf(BatchFileDataReader::class.java)
-    }
-
-    @Test
     fun `𝕄 return same storage 𝕎 getStorage()`() {
         // When
         val storage = testedStrategy.getStorage()
@@ -155,15 +141,5 @@ internal class BatchFilePersistenceStrategyTest {
         check(flusher is DataFlusher)
         assertThat(flusher.fileOrchestrator).isSameAs(mockFileOrchestrator)
         assertThat(flusher.fileReader).isSameAs(mockFileReaderWriter)
-    }
-
-    @Test
-    fun `𝕄 return same batch file reader 𝕎 getReader() twice`() {
-        // When
-        val reader1 = testedStrategy.getReader()
-        val reader2 = testedStrategy.getReader()
-
-        // Then
-        assertThat(reader1).isSameAs(reader2)
     }
 }


### PR DESCRIPTION
### What does this PR do?

Remove the remaining usages of `DataReader` used in v1, because we are now using `Storage` for reading raw data and de-serialization is not needed anyway.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

