### PR TITLE
RUMM-2562 Correct the way we handle orientation change events in SR

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/Processor.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/Processor.kt
@@ -11,9 +11,7 @@ import com.datadog.android.sessionreplay.recorder.Node
 import com.datadog.android.sessionreplay.recorder.OrientationChanged
 
 internal interface Processor {
-    fun process(node: Node)
+    fun process(node: Node, orientationChanged: OrientationChanged? = null)
 
     fun process(touchData: MobileSegment.MobileIncrementalData.TouchData)
-
-    fun process(event: OrientationChanged)
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/RecorderOnDrawListener.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/RecorderOnDrawListener.kt
@@ -33,25 +33,26 @@ internal class RecorderOnDrawListener(
     private val takeSnapshotRunnable: Runnable = Runnable {
         trackedActivity.get()?.let { activity ->
             activity.window?.let {
-                checkForViewPortResize(activity, it.decorView)
                 snapshotProducer.produce(it.decorView, pixelsDensity)?.let { node ->
-                    processor.process(node)
+                    processor.process(node, resolveOrientationChange(activity, it.decorView))
                 }
             }
         }
     }
 
-    private fun checkForViewPortResize(activity: Activity, decorView: View) {
+    private fun resolveOrientationChange(activity: Activity, decorView: View): OrientationChanged? {
         val orientation = activity.resources.configuration.orientation
-        if (currentOrientation != orientation) {
-            processor.process(
+        val orientationChanged =
+            if (currentOrientation != orientation) {
                 OrientationChanged(
                     decorView.width.densityNormalized(pixelsDensity),
                     decorView.height.densityNormalized(pixelsDensity)
                 )
-            )
-        }
+            } else {
+                null
+            }
         currentOrientation = orientation
+        return orientationChanged
     }
 
     companion object {


### PR DESCRIPTION
### What does this PR do?

This PR fixes the way we are handling the orientation change for Session Replay. Previously we were handling this in a separated flow which introduced a new state into the `SnapshotProcessor` causing problems regarding the `new view` detection and the order of the records. With this new approach we are handling the `OrientationChanged` event in the same stack used for handling the screen snapshot and by doing this we eliminate the potential issues resulting from introducing a new state for the `SnapshotProcessor`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

