### PR TITLE
RUMM-2651 SR - skip new lines and spaces when obfuscating texts

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -663,6 +663,7 @@ datadog:
       # region Java misc
       - "java.text.SimpleDateFormat.format(java.util.Date):java.lang.NullPointerException"
       - "java.util.TimeZone.getTimeZone(kotlin.String):java.lang.NullPointerException"
+      - "java.lang.Character.toChars(kotlin.Int):java.lang.IllegalArgumentException"
       - "java.lang.Runtime.addShutdownHook(java.lang.Thread):java.lang.IllegalArgumentException,java.lang.IllegalStateException,java.lang.SecurityException"
       - "java.lang.System.arraycopy(kotlin.Any, kotlin.Int, kotlin.Any, kotlin.Int, kotlin.Int):java.lang.IndexOutOfBoundsException,java.lang.ArrayStoreException,java.lang.NullPointerException"
       - "java.lang.System.loadLibrary(kotlin.String):java.lang.SecurityException,java.lang.UnsatisfiedLinkError,java.lang.NullPointerException"
@@ -914,6 +915,7 @@ datadog:
       - "java.util.Stack.isNotEmpty()"
       - "java.util.Stack.pop()"
       - "java.util.Stack.push(com.datadog.android.sessionreplay.recorder.Node)"
+      - "java.util.stream.IntStream.forEach(java.util.function.IntConsumer)"
       # endregion
       # region Java Concurrency
       - "java.lang.Thread.UncaughtExceptionHandler.uncaughtException(java.lang.Thread, kotlin.Throwable)"
@@ -976,6 +978,7 @@ datadog:
       - "java.io.StringWriter.constructor()"
       # endregion
       # region Java misc
+      - "java.lang.Character.isWhitespace(kotlin.Int)"
       - "java.lang.Class.hashCode()"
       - "java.lang.Class.isAssignableFrom(java.lang.Class)"
       - "java.lang.IllegalArgumentException.constructor(kotlin.String)"
@@ -996,6 +999,7 @@ datadog:
       - "java.lang.ref.WeakReference.constructor(kotlin.Any)"
       - "java.lang.ref.WeakReference.get()"
       - "java.lang.StringBuilder.append(kotlin.Char)"
+      - "java.lang.StringBuilder.append(kotlin.CharArray)"
       - "java.lang.StringBuilder.append(kotlin.String)"
       - "java.math.BigInteger.toLong()"
       - "java.nio.charset.Charset.defaultCharset()"
@@ -1199,6 +1203,7 @@ datadog:
       # endregion
       # region Kotlin String
       - "kotlin.String.all(kotlin.Function1)"
+      - "kotlin.String.codePoints()"
       - "kotlin.String.contains(kotlin.Char, kotlin.Boolean)"
       - "kotlin.String.contains(kotlin.CharSequence, kotlin.Boolean)"
       - "kotlin.String.count(kotlin.Function1)"

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/MaskAllTextWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/MaskAllTextWireframeMapper.kt
@@ -9,14 +9,11 @@ package com.datadog.android.sessionreplay.recorder.mapper
 import android.widget.TextView
 
 internal class MaskAllTextWireframeMapper(
-    viewWireframeMapper: ViewWireframeMapper = ViewWireframeMapper()
+    viewWireframeMapper: ViewWireframeMapper = ViewWireframeMapper(),
+    private val stringObfuscator: StringObfuscator = StringObfuscator()
 ) : TextWireframeMapper(viewWireframeMapper) {
 
     override fun resolveTextValue(textView: TextView): String {
-        return String(CharArray(textView.text.length) { CHARACTER_MASK })
-    }
-
-    companion object {
-        private const val CHARACTER_MASK = 'x'
+        return stringObfuscator.obfuscate(textView.text.toString())
     }
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/StringObfuscator.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/StringObfuscator.kt
@@ -1,0 +1,65 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+
+internal class StringObfuscator {
+
+    fun obfuscate(stringValue: String): String {
+        return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            obfuscateUsingCodeStream(stringValue)
+        } else {
+            obfuscateUsingCharacterCode(stringValue)
+        }
+    }
+
+    private fun obfuscateUsingCharacterCode(stringValue: String): String {
+        return String(
+            CharArray(stringValue.length) {
+                val character = stringValue[it]
+                // Given that we replace each printable character with `x` for 2 chars expressions
+                // as emojis we will have 2 `x` instead of 1 but this will not be a problem as the
+                // obfuscation will still be applied.
+                if (Character.isWhitespace(character.code)) {
+                    character
+                } else {
+                    CHARACTER_MASK
+                }
+            }
+        )
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    private fun obfuscateUsingCodeStream(stringValue: String): String {
+        // Because we are using the CharSequence.codePoints() stream we are going to correctly
+        // handle the cases where the text contains 2 chars expression. In this case one single
+        // codePoint will be returned for those 2 chars and the obfuscation char will be `x`.
+        val stringBuilder = StringBuilder()
+        stringValue.codePoints().forEach {
+            if (Character.isWhitespace(it)) {
+                // I don't think we should log this case here. I could not even reproduce it
+                // in my tests. As long as there is a valid string there there should not be
+                // any problem.
+                @Suppress("SwallowedException")
+                try {
+                    stringBuilder.append(Character.toChars(it))
+                } catch (e: IllegalArgumentException) {
+                    stringBuilder.append(CHARACTER_MASK)
+                }
+            } else {
+                stringBuilder.append(CHARACTER_MASK)
+            }
+        }
+        return stringBuilder.toString()
+    }
+
+    companion object {
+        private const val CHARACTER_MASK = 'x'
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseTextViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseTextViewWireframeMapperTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.sessionreplay.recorder.densityNormalized
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -24,6 +25,9 @@ import org.junit.jupiter.params.provider.MethodSource
 internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTest() {
 
     lateinit var testedTextWireframeMapper: TextWireframeMapper
+
+    @StringForgery
+    lateinit var fakeText: String
 
     @BeforeEach
     fun `set up`() {
@@ -44,7 +48,6 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
         // Given
         val fakeFontSize = forge.aFloat(min = 0f)
         val fakeStyleColor = forge.aStringMatching("#[0-9a-f]{6}ff")
-        val fakeText = forge.aString()
         val fakeFontColor = fakeStyleColor
             .substring(1)
             .toLong(16)
@@ -81,7 +84,7 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
     ) {
         // Given
         val mockTextView: TextView = forge.aMockView<TextView>().apply {
-            whenever(this.text).thenReturn(forge.aString())
+            whenever(this.text).thenReturn(fakeText)
             whenever(this.typeface).thenReturn(mock())
             whenever(this.textAlignment).thenReturn(fakeTextAlignment)
         }
@@ -108,7 +111,6 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
         forge: Forge
     ) {
         // Given
-        val fakeText = forge.aString()
         val mockTextView: TextView = forge.aMockView<TextView>().apply {
             whenever(this.text).thenReturn(fakeText)
             whenever(this.typeface).thenReturn(mock())
@@ -133,7 +135,6 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
     @Test
     fun `M resolve a TextWireframe W map() { TextView with textPadding }`(forge: Forge) {
         // Given
-        val fakeText = forge.aString()
         val fakeTextPaddingTop = forge.anInt()
         val fakeTextPaddingBottom = forge.anInt()
         val fakeTextPaddingStart = forge.anInt()
@@ -192,7 +193,7 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
         }
         val mockTextView = forge.aMockView<TextView>().apply {
             whenever(this.background).thenReturn(mockDrawable)
-            whenever(this.text).thenReturn(forge.aString())
+            whenever(this.text).thenReturn(fakeText)
             whenever(this.typeface).thenReturn(mock())
         }
 

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/StringObfuscatorTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/StringObfuscatorTest.kt
@@ -1,0 +1,310 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder.mapper
+
+import android.os.Build
+import com.datadog.android.sessionreplay.utils.ForgeConfigurator
+import com.datadog.tools.unit.annotations.TestTargetApi
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.util.LinkedList
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class StringObfuscatorTest {
+
+    lateinit var testedObfuscator: StringObfuscator
+
+    @BeforeEach
+    fun `set up`() {
+        testedObfuscator = StringObfuscator()
+    }
+
+    // region Android N and above
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.N)
+    fun `M mask String W obfuscate(){string with newline, Android N}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedChunk1 = forge.aString(size = forge.anInt(1, max = 10)) { '\n' }
+        val fakeExpectedChunk2 = forge.aString { 'x' }
+        val fakeExpectedChunk3 = forge.aString(size = forge.anInt(1, max = 10)) { '\n' }
+        val fakeExpectedChunk4 = forge.aString { 'x' }
+        val fakeExpectedChunk5 = forge.aString(size = forge.anInt(1, max = 10)) { '\n' }
+        val fakeExpectedText = (
+            fakeExpectedChunk1 +
+                fakeExpectedChunk2 +
+                fakeExpectedChunk3 +
+                fakeExpectedChunk4 +
+                fakeExpectedChunk5
+            )
+        val fakeText = (
+            fakeExpectedChunk1 +
+                forge.aString(fakeExpectedChunk2.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk3 +
+                forge.aString(fakeExpectedChunk4.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk5
+            )
+
+        // When
+        val obfuscatedText = testedObfuscator.obfuscate(fakeText)
+
+        // Then
+        assertThat(obfuscatedText).isEqualTo(fakeExpectedText)
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.N)
+    fun `M mask String W obfuscate(){string with carriage return character, Android N}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedChunk1 = forge.aString(size = forge.anInt(1, max = 10)) { '\r' }
+        val fakeExpectedChunk2 = forge.aString { 'x' }
+        val fakeExpectedChunk3 = forge.aString(size = forge.anInt(1, max = 10)) { '\r' }
+        val fakeExpectedChunk4 = forge.aString { 'x' }
+        val fakeExpectedChunk5 = forge.aString(size = forge.anInt(1, max = 10)) { '\r' }
+        val fakeExpectedText = (
+            fakeExpectedChunk1 +
+                fakeExpectedChunk2 +
+                fakeExpectedChunk3 +
+                fakeExpectedChunk4 +
+                fakeExpectedChunk5
+            )
+        val fakeText = (
+            fakeExpectedChunk1 +
+                forge.aString(fakeExpectedChunk2.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk3 +
+                forge.aString(fakeExpectedChunk4.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk5
+            )
+
+        // When
+        val obfuscatedText = testedObfuscator.obfuscate(fakeText)
+
+        // Then
+        assertThat(obfuscatedText).isEqualTo(fakeExpectedText)
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.N)
+    fun `M mask String W obfuscate(){string with whitespace character, Android N}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedChunk1 = forge.aWhitespaceString()
+        val fakeExpectedChunk2 = forge.aString { 'x' }
+        val fakeExpectedChunk3 = forge.aWhitespaceString()
+        val fakeExpectedChunk4 = forge.aString { 'x' }
+        val fakeExpectedChunk5 = forge.aWhitespaceString()
+        val fakeExpectedText = (
+            fakeExpectedChunk1 +
+                fakeExpectedChunk2 +
+                fakeExpectedChunk3 +
+                fakeExpectedChunk4 +
+                fakeExpectedChunk5
+            )
+        val fakeText = (
+            fakeExpectedChunk1 +
+                forge.aString(fakeExpectedChunk2.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk3 +
+                forge.aString(fakeExpectedChunk4.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk5
+            )
+
+        // When
+        val obfuscatedText = testedObfuscator.obfuscate(fakeText)
+
+        // Then
+        assertThat(obfuscatedText).isEqualTo(fakeExpectedText)
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.N)
+    fun `M mask String W obfuscate(){string with whitespace character and emoji, Android N}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeChunk1 = forge.aStringWithEmoji()
+        val fakeChunk2 = forge.aWhitespaceString()
+        val fakeChunk3 = forge.aStringWithEmoji()
+        val fakeChunk4 = forge.aWhitespaceString()
+        val fakeText = fakeChunk1 + fakeChunk2 + fakeChunk3 + fakeChunk4
+
+        // the real size of an emoji chunk is chunk.length/2 as one emoji contains 2 chars.
+        // In our current code for >= Android N we are treating this case correctly so expected
+        // obfuscated string length is chunk.length/2
+        val fakeExpectedChunk1 = String(CharArray(fakeChunk1.length / 2) { 'x' })
+        val fakeExpectedChunk3 = String(CharArray(fakeChunk3.length / 2) { 'x' })
+        val fakeExpectedText = fakeExpectedChunk1 + fakeChunk2 + fakeExpectedChunk3 + fakeChunk4
+
+        // When
+        val obfuscatedText = testedObfuscator.obfuscate(fakeText)
+
+        // Then
+        assertThat(obfuscatedText).isEqualTo(fakeExpectedText)
+    }
+
+    // endregion
+
+    // region below Android N
+
+    @Test
+    fun `M mask String W obfuscate(){string with newline}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedChunk1 = forge.aString(size = forge.anInt(1, max = 10)) { '\n' }
+        val fakeExpectedChunk2 = forge.aString { 'x' }
+        val fakeExpectedChunk3 = forge.aString(size = forge.anInt(1, max = 10)) { '\n' }
+        val fakeExpectedChunk4 = forge.aString { 'x' }
+        val fakeExpectedChunk5 = forge.aString(size = forge.anInt(1, max = 10)) { '\n' }
+        val fakeExpectedText = (
+            fakeExpectedChunk1 +
+                fakeExpectedChunk2 +
+                fakeExpectedChunk3 +
+                fakeExpectedChunk4 +
+                fakeExpectedChunk5
+            )
+        val fakeText = (
+            fakeExpectedChunk1 +
+                forge.aString(fakeExpectedChunk2.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk3 +
+                forge.aString(fakeExpectedChunk4.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk5
+            )
+
+        // When
+        val obfuscatedText = testedObfuscator.obfuscate(fakeText)
+
+        // Then
+        assertThat(obfuscatedText).isEqualTo(fakeExpectedText)
+    }
+
+    @Test
+    fun `M mask String W obfuscate(){string with carriage return character}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedChunk1 = forge.aString(size = forge.anInt(1, max = 10)) { '\r' }
+        val fakeExpectedChunk2 = forge.aString { 'x' }
+        val fakeExpectedChunk3 = forge.aString(size = forge.anInt(1, max = 10)) { '\r' }
+        val fakeExpectedChunk4 = forge.aString { 'x' }
+        val fakeExpectedChunk5 = forge.aString(size = forge.anInt(1, max = 10)) { '\r' }
+        val fakeExpectedText = (
+            fakeExpectedChunk1 +
+                fakeExpectedChunk2 +
+                fakeExpectedChunk3 +
+                fakeExpectedChunk4 +
+                fakeExpectedChunk5
+            )
+        val fakeText = (
+            fakeExpectedChunk1 +
+                forge.aString(fakeExpectedChunk2.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk3 +
+                forge.aString(fakeExpectedChunk4.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk5
+            )
+
+        // When
+        val obfuscatedText = testedObfuscator.obfuscate(fakeText)
+
+        // Then
+        assertThat(obfuscatedText).isEqualTo(fakeExpectedText)
+    }
+
+    @Test
+    fun `M mask String W obfuscate(){string with whitespace character}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedChunk1 = forge.aWhitespaceString()
+        val fakeExpectedChunk2 = forge.aString { 'x' }
+        val fakeExpectedChunk3 = forge.aWhitespaceString()
+        val fakeExpectedChunk4 = forge.aString { 'x' }
+        val fakeExpectedChunk5 = forge.aWhitespaceString()
+        val fakeExpectedText = (
+            fakeExpectedChunk1 +
+                fakeExpectedChunk2 +
+                fakeExpectedChunk3 +
+                fakeExpectedChunk4 +
+                fakeExpectedChunk5
+            )
+        val fakeText = (
+            fakeExpectedChunk1 +
+                forge.aString(fakeExpectedChunk2.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk3 +
+                forge.aString(fakeExpectedChunk4.length) { forge.anAlphaNumericalChar() } +
+                fakeExpectedChunk5
+            )
+
+        // When
+        val obfuscatedText = testedObfuscator.obfuscate(fakeText)
+
+        // Then
+        assertThat(obfuscatedText).isEqualTo(fakeExpectedText)
+    }
+
+    @Test
+    fun `M mask String W obfuscate(){string with whitespace character and emoji}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeChunk1 = forge.aStringWithEmoji()
+        val fakeChunk2 = forge.aWhitespaceString()
+        val fakeChunk3 = forge.aStringWithEmoji()
+        val fakeChunk4 = forge.aWhitespaceString()
+        val fakeText = fakeChunk1 + fakeChunk2 + fakeChunk3 + fakeChunk4
+
+        // the real size of an emoji chunk is chunk.length/2 as one emoji contains 2 chars.
+        // In our current code for < Android N we do not treat this case correctly so the
+        // expected obfuscated string size will be chunk.length
+        val fakeExpectedChunk1 = String(CharArray(fakeChunk1.length) { 'x' })
+        val fakeExpectedChunk3 = String(CharArray(fakeChunk3.length) { 'x' })
+        val fakeExpectedText = fakeExpectedChunk1 + fakeChunk2 + fakeExpectedChunk3 + fakeChunk4
+
+        // When
+        val obfuscatedText = testedObfuscator.obfuscate(fakeText)
+
+        // Then
+        assertThat(obfuscatedText).isEqualTo(fakeExpectedText)
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun Forge.aStringWithEmoji(): String {
+        val charsList = LinkedList<Char>()
+        val stringSize = anInt(min = 10, max = 100)
+        repeat(stringSize) {
+            val emojiCodePoint = anInt(min = 0x1f600, max = 0x1f60A)
+            val chars = Character.toChars(emojiCodePoint).toList()
+            charsList.addAll(chars)
+        }
+        return String(charsList.toCharArray())
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

We need to skip the new lines and spaces characters when applying the obfuscation on the text values to keep the aspect ratio of the replicated text view element in the Web Player.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

