### PR TITLE
RUMM-2528 prevent crash on peekBody

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
@@ -256,7 +256,13 @@ internal constructor(
             val contentLength = body.contentLength()
             if (contentLength == 0L) null else contentLength
         } catch (e: IOException) {
-            sdkLogger.e("Unable to peek response body", e)
+            sdkLogger.e(ERROR_PEEK_BODY, e)
+            null
+        } catch (e: IllegalStateException) {
+            sdkLogger.e(ERROR_PEEK_BODY, e)
+            null
+        } catch (e: IllegalArgumentException) {
+            sdkLogger.e(ERROR_PEEK_BODY, e)
             null
         }
     }
@@ -272,6 +278,8 @@ internal constructor(
 
         internal const val ERROR_NO_RESPONSE =
             "The request ended with no response nor any exception."
+
+        internal const val ERROR_PEEK_BODY = "Unable to peek response body."
 
         internal const val ERROR_MSG_FORMAT = "OkHttp request error %s %s"
 

--- a/detekt.yml
+++ b/detekt.yml
@@ -690,7 +690,7 @@ datadog:
       # region OkHttp
       - "okhttp3.Call.execute():java.io.IOException"
       - "okhttp3.Dns.lookup(kotlin.String):java.net.UnknownHostException"
-      - "okhttp3.Response.peekBody(kotlin.Long):java.io.IOException"
+      - "okhttp3.Response.peekBody(kotlin.Long):java.io.IOException,java.lang.IllegalArgumentException,java.lang.IllegalStateException"
       - "okhttp3.RequestBody.writeTo(okio.BufferedSink):java.io.IOException"
       - "okhttp3.Response.close():java.lang.IllegalStateException"
       - "okhttp3.Request.Builder.build():java.lang.IllegalStateException"


### PR DESCRIPTION
### What does this PR do?

Prevent crashes from calling `peekBody` in DatadogInterceptor. Some implementations had some unchecked exceptions we missed. 

### Motivation

Fixes #1049 
