### PR TITLE
RUMM-2600 SR accept optional Typeface when resolving fontStyle

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextWireframeMapper.kt
@@ -47,7 +47,7 @@ internal open class TextWireframeMapper(
         )
     }
 
-    private fun resolveFontFamily(typeface: Typeface): String {
+    private fun resolveFontFamily(typeface: Typeface?): String {
         return when {
             typeface === Typeface.SANS_SERIF -> SANS_SERIF_FAMILY_NAME
             typeface === Typeface.MONOSPACE -> MONOSPACE_FAMILY_NAME

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseTextViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseTextViewWireframeMapperTest.kt
@@ -37,7 +37,7 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
     @ParameterizedTest
     @MethodSource("textTypefaces")
     fun `M resolve a TextWireframe W map() { TextView with fontStyle }`(
-        fakeTypeface: Typeface,
+        fakeTypeface: Typeface?,
         expectedFontFamily: String,
         forge: Forge
     ) {

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapperTest.kt
@@ -87,7 +87,8 @@ internal abstract class BaseWireframeMapperTest {
                 Arguments.of(Typeface.DEFAULT_BOLD, TextWireframeMapper.SANS_SERIF_FAMILY_NAME),
                 Arguments.of(Typeface.MONOSPACE, TextWireframeMapper.MONOSPACE_FAMILY_NAME),
                 Arguments.of(Typeface.SERIF, TextWireframeMapper.SERIF_FAMILY_NAME),
-                Arguments.of(mock<Typeface>(), TextWireframeMapper.SANS_SERIF_FAMILY_NAME)
+                Arguments.of(mock<Typeface>(), TextWireframeMapper.SANS_SERIF_FAMILY_NAME),
+                Arguments.of(null, TextWireframeMapper.SANS_SERIF_FAMILY_NAME)
             )
                 .stream()
         }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonWireframeMapperTest.kt
@@ -47,7 +47,7 @@ internal class ButtonWireframeMapperTest : BaseWireframeMapperTest() {
     @ParameterizedTest
     @MethodSource("textTypefaces")
     fun `M resolve a TextWireframe W map() { Button with fontStyle }`(
-        typeface: Typeface,
+        typeface: Typeface?,
         expectedFontFamily: String,
         forge: Forge
     ) {

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewWireframeMapperTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.sessionreplay.recorder.mapper
 
-import android.widget.Button
 import android.widget.TextView
 import com.datadog.android.sessionreplay.recorder.aMockView
 import com.datadog.android.sessionreplay.utils.ForgeConfigurator
@@ -37,16 +36,16 @@ internal class TextViewWireframeMapperTest : BaseTextViewWireframeMapperTest() {
     fun `M resolve a TextWireframe W map() { TextView with text }`(forge: Forge) {
         // Given
         val fakeText = forge.aString()
-        val mockButton: TextView = forge.aMockView<Button>().apply {
+        val mockTextView: TextView = forge.aMockView<TextView>().apply {
             whenever(this.text).thenReturn(fakeText)
             whenever(this.typeface).thenReturn(mock())
         }
 
         // When
-        val textWireframe = testedTextWireframeMapper.map(mockButton, fakePixelDensity)
+        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockButton.toTextWireframe().copy(text = fakeText)
+        val expectedWireframe = mockTextView.toTextWireframe().copy(text = fakeText)
         assertThat(textWireframe).isEqualTo(expectedWireframe)
     }
 }


### PR DESCRIPTION
### What does this PR do?

Sometimes the `TextView#typeface` property is `Null` and this was causing NPE when trying to resolve the `fontStyle` for the equivalent `TextWireframe`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

