### PR TITLE
Create internal API for sending technical performance metrics

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -384,6 +384,10 @@ interface com.datadog.android.rum.RumMonitor
     fun setSessionListener(RumSessionListener): Builder
     fun build(): RumMonitor
     companion object 
+enum com.datadog.android.rum.RumPerformanceMetric
+  - FLUTTER_BUILD_TIME
+  - FLUTTER_RASTER_TIME
+  - JS_REFRESH_RATE
 interface com.datadog.android.rum.RumResourceAttributesProvider
   fun onProvideAttributes(okhttp3.Request, okhttp3.Response?, Throwable?): Map<String, Any?>
 enum com.datadog.android.rum.RumResourceKind
@@ -405,6 +409,7 @@ interface com.datadog.android.rum.RumSessionListener
   fun onSessionStarted(String, Boolean)
 class com.datadog.android.rum._RumInternalProxy
   fun addLongTask(Long, String)
+  fun updatePerformanceMetric(RumPerformanceMetric, Double)
 data class com.datadog.android.rum.model.ActionEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, ActionEventSession, Source? = null, View, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, ActionEventAction)
   val type: kotlin.String
@@ -544,6 +549,7 @@ data class com.datadog.android.rum.model.ActionEvent
     - BROWSER
     - FLUTTER
     - REACT_NATIVE
+    - ROKU
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Source
@@ -727,6 +733,7 @@ data class com.datadog.android.rum.model.ErrorEvent
     - BROWSER
     - FLUTTER
     - REACT_NATIVE
+    - ROKU
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): ErrorEventSource
@@ -938,6 +945,7 @@ data class com.datadog.android.rum.model.LongTaskEvent
     - BROWSER
     - FLUTTER
     - REACT_NATIVE
+    - ROKU
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Source
@@ -1124,6 +1132,7 @@ data class com.datadog.android.rum.model.ResourceEvent
     - BROWSER
     - FLUTTER
     - REACT_NATIVE
+    - ROKU
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Source
@@ -1222,6 +1231,11 @@ data class com.datadog.android.rum.model.ResourceEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): ProviderType
+data class com.datadog.android.rum.model.RumPerfMetric
+  constructor(kotlin.Number, kotlin.Number, kotlin.Number, kotlin.Number? = null)
+  fun toJson(): com.google.gson.JsonElement
+  companion object 
+    fun fromJson(kotlin.String): RumPerfMetric
 data class com.datadog.android.rum.model.ViewEvent
   constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, ViewEventSession, Source? = null, View, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null)
   val type: kotlin.String
@@ -1239,7 +1253,7 @@ data class com.datadog.android.rum.model.ViewEvent
     companion object 
       fun fromJson(kotlin.String): ViewEventSession
   data class View
-    constructor(kotlin.String, kotlin.String? = null, kotlin.String, kotlin.String? = null, kotlin.Long? = null, LoadingType? = null, kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Number? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, CustomTimings? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, Action, Error, Crash? = null, LongTask? = null, FrozenFrame? = null, Resource, Frustration? = null, kotlin.collections.List<InForegroundPeriod>? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null)
+    constructor(kotlin.String, kotlin.String? = null, kotlin.String, kotlin.String? = null, kotlin.Long? = null, LoadingType? = null, kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Number? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, CustomTimings? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, Action, Error, Crash? = null, LongTask? = null, FrozenFrame? = null, Resource, Frustration? = null, kotlin.collections.List<InForegroundPeriod>? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, kotlin.Number? = null, FlutterBuildTime? = null, FlutterBuildTime? = null, FlutterBuildTime? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): View
@@ -1334,6 +1348,11 @@ data class com.datadog.android.rum.model.ViewEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): InForegroundPeriod
+  data class FlutterBuildTime
+    constructor(kotlin.Number, kotlin.Number, kotlin.Number, kotlin.Number? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): FlutterBuildTime
   data class Cellular
     constructor(kotlin.String? = null, kotlin.String? = null)
     fun toJson(): com.google.gson.JsonElement
@@ -1356,6 +1375,7 @@ data class com.datadog.android.rum.model.ViewEvent
     - BROWSER
     - FLUTTER
     - REACT_NATIVE
+    - ROKU
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Source

--- a/dd-sdk-android/src/main/json/rum/_common-schema.json
+++ b/dd-sdk-android/src/main/json/rum/_common-schema.json
@@ -64,7 +64,7 @@
     "source": {
       "type": "string",
       "description": "The source of this event",
-      "enum": ["android", "ios", "browser", "flutter", "react-native"],
+      "enum": ["android", "ios", "browser", "flutter", "react-native", "roku"],
       "readOnly": true
     },
     "view": {
@@ -135,17 +135,7 @@
           "description": "The list of available network interfaces",
           "items": {
             "type": "string",
-            "enum": [
-              "bluetooth",
-              "cellular",
-              "ethernet",
-              "wifi",
-              "wimax",
-              "mixed",
-              "other",
-              "unknown",
-              "none"
-            ]
+            "enum": ["bluetooth", "cellular", "ethernet", "wifi", "wimax", "mixed", "other", "unknown", "none"]
           },
           "readOnly": true
         },
@@ -231,11 +221,7 @@
     "os": {
       "type": "object",
       "description": "Operating system properties",
-      "required": [
-        "name",
-        "version",
-        "version_major"
-      ],
+      "required": ["name", "version", "version_major"],
       "properties": {
         "name": {
           "type": "string",
@@ -257,22 +243,12 @@
     "device": {
       "type": "object",
       "description": "Device properties",
-      "required": [
-        "type"
-      ],
+      "required": ["type"],
       "properties": {
         "type": {
           "type": "string",
           "description": "Device type info",
-          "enum": [
-            "mobile",
-            "desktop",
-            "tablet",
-            "tv",
-            "gaming_console",
-            "bot",
-            "other"
-          ],
+          "enum": ["mobile", "desktop", "tablet", "tv", "gaming_console", "bot", "other"],
           "readOnly": true
         },
         "name": {
@@ -315,7 +291,7 @@
           "properties": {
             "plan": {
               "type": "number",
-              "description": "Session plan: 1 is the 'lite' plan, 2 is the 'replay' plan",
+              "description": "Session plan: 1 is the plan without replay, 2 is the plan with replay",
               "enum": [1, 2]
             }
           }

--- a/dd-sdk-android/src/main/json/rum/_perf-metric-schema.json
+++ b/dd-sdk-android/src/main/json/rum/_perf-metric-schema.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "_perf-metric-schema.json",
+  "title": "RumPerfMetric",
+  "type": "object",
+  "description": "Schema of properties for a technical performance metric",
+  "required": ["min", "max", "average"],
+  "properties": {
+    "min": {
+      "type": "number",
+      "description": "The minimum value seen for this metric during the view's lifetime.",
+      "readOnly": true
+    },
+    "max": {
+      "type": "number",
+      "description": "The maximum value seen for this metric during the view's lifetime.",
+      "readOnly": true
+    },
+    "average": {
+      "type": "number",
+      "description": "The average value for this metric during the view's lifetime.",
+      "readOnly": true
+    },
+    "metric_max": {
+      "type": "number",
+      "description": "The maximum possible value we could see for this metric, if such a max is relevant and can vary from session to session.",
+      "readOnly": true
+    }
+  }
+}

--- a/dd-sdk-android/src/main/json/rum/action-schema.json
+++ b/dd-sdk-android/src/main/json/rum/action-schema.json
@@ -9,10 +9,7 @@
       "$ref": "_common-schema.json"
     },
     {
-      "required": [
-        "type",
-        "action"
-      ],
+      "required": ["type", "action"],
       "properties": {
         "type": {
           "type": "string",
@@ -23,9 +20,7 @@
         "action": {
           "type": "object",
           "description": "Action properties",
-          "required": [
-            "type"
-          ],
+          "required": ["type"],
           "properties": {
             "type": {
               "type": "string",
@@ -48,9 +43,7 @@
             "target": {
               "type": "object",
               "description": "Action target properties",
-              "required": [
-                "name"
-              ],
+              "required": ["name"],
               "properties": {
                 "name": {
                   "type": "string",
@@ -63,9 +56,7 @@
             "frustration": {
               "type": "object",
               "description": "Action frustration properties",
-              "required": [
-                "type"
-              ],
+              "required": ["type"],
               "properties": {
                 "type": {
                   "type": "array",
@@ -82,9 +73,7 @@
             "error": {
               "type": "object",
               "description": "Properties of the errors of the action",
-              "required": [
-                "count"
-              ],
+              "required": ["count"],
               "properties": {
                 "count": {
                   "type": "integer",
@@ -98,9 +87,7 @@
             "crash": {
               "type": "object",
               "description": "Properties of the crashes of the action",
-              "required": [
-                "count"
-              ],
+              "required": ["count"],
               "properties": {
                 "count": {
                   "type": "integer",
@@ -114,9 +101,7 @@
             "long_task": {
               "type": "object",
               "description": "Properties of the long tasks of the action",
-              "required": [
-                "count"
-              ],
+              "required": ["count"],
               "properties": {
                 "count": {
                   "type": "integer",
@@ -130,9 +115,7 @@
             "resource": {
               "type": "object",
               "description": "Properties of the resources of the action",
-              "required": [
-                "count"
-              ],
+              "required": ["count"],
               "properties": {
                 "count": {
                   "type": "integer",

--- a/dd-sdk-android/src/main/json/rum/view-schema.json
+++ b/dd-sdk-android/src/main/json/rum/view-schema.json
@@ -20,14 +20,7 @@
         "view": {
           "type": "object",
           "description": "View properties",
-          "required": [
-            "id",
-            "url",
-            "time_spent",
-            "action",
-            "error",
-            "resource"
-          ],
+          "required": ["id", "url", "time_spent", "action", "error", "resource"],
           "properties": {
             "loading_time": {
               "type": "integer",
@@ -82,7 +75,7 @@
             },
             "cumulative_layout_shift": {
               "type": "number",
-              "description": "Total layout shift score that occured on the view",
+              "description": "Total layout shift score that occurred on the view",
               "minimum": 0,
               "readOnly": true
             },
@@ -107,6 +100,12 @@
             "load_event": {
               "type": "integer",
               "description": "Duration in ns to the end of the load event handler execution",
+              "minimum": 0,
+              "readOnly": true
+            },
+            "first_byte": {
+              "type": "integer",
+              "description": "Duration in ns to the response start of the document request",
               "minimum": 0,
               "readOnly": true
             },
@@ -282,6 +281,18 @@
               "type": "number",
               "description": "Minimum refresh rate during the view’s lifetime (in frames per second)",
               "readOnly": true
+            },
+            "flutter_build_time": {
+              "description": "Time taken for Flutter 'build' methods.",
+              "allOf": [{ "$ref": "_perf-metric-schema.json" }]
+            },
+            "flutter_raster_time": {
+              "description": "Time taken for Flutter to rasterize the view.",
+              "allOf": [{ "$ref": "_perf-metric-schema.json" }]
+            },
+            "js_refresh_rate": {
+              "description": "The JavaScript refresh rate for React Native",
+              "allOf": [{ "$ref": "_perf-metric-schema.json" }]
             }
           },
           "readOnly": true

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumPerformanceMetric.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumPerformanceMetric.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum
+
+/**
+ * A cross-platform technical performance metric.
+ * @see [RumMonitor]
+ */
+enum class RumPerformanceMetric {
+    /** The amount of time Flutter spent in its `build` method for this view. */
+    FLUTTER_BUILD_TIME,
+
+    /** The amount of time Flutter spent rasterizing the view. */
+    FLUTTER_RASTER_TIME,
+
+    /** The JavaScript refresh rate of a React Native view. */
+    JS_REFRESH_RATE
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/_RumInternalProxy.kt
@@ -31,4 +31,8 @@ class _RumInternalProxy internal constructor(private val rumMonitor: AdvancedRum
     fun addLongTask(durationNs: Long, target: String) {
         rumMonitor.addLongTask(durationNs, target)
     }
+
+    fun updatePerformanceMetric(metric: RumPerformanceMetric, value: Double) {
+        rumMonitor.updatePerformanceMetric(metric, value)
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -8,6 +8,7 @@ package com.datadog.android.rum.internal.domain.scope
 
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.Time
@@ -183,6 +184,12 @@ internal sealed class RumRawEvent {
     ) : RumRawEvent()
 
     internal data class SendCustomActionNow(
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
+    internal data class UpdatePerformanceMetric(
+        val metric: RumPerformanceMetric,
+        val value: Double,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -8,6 +8,7 @@ package com.datadog.android.rum.internal.monitor
 
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
+import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.internal.debug.RumDebugListener
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.model.ViewEvent
@@ -46,4 +47,6 @@ internal interface AdvancedRumMonitor : RumMonitor {
     fun sendErrorTelemetryEvent(message: String, throwable: Throwable?)
 
     fun sendErrorTelemetryEvent(message: String, stack: String?, kind: String?)
+
+    fun updatePerformanceMetric(metric: RumPerformanceMetric, value: Double)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -17,6 +17,7 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
+import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum._RumInternalProxy
@@ -345,6 +346,10 @@ internal class DatadogRumMonitor(
 
     override fun sendErrorTelemetryEvent(message: String, stack: String?, kind: String?) {
         handleEvent(RumRawEvent.SendTelemetry(TelemetryType.ERROR, message, stack, kind))
+    }
+
+    override fun updatePerformanceMetric(metric: RumPerformanceMetric, value: Double) {
+        handleEvent(RumRawEvent.UpdatePerformanceMetric(metric, value))
     }
 
     override fun _getInternal(): _RumInternalProxy? {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumInternalProxyTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.utils.forge.Configurator
 import com.nhaarman.mockitokotlin2.verify
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -43,5 +44,22 @@ internal class RumInternalProxyTest {
 
         // Then
         verify(mockRumMonitor).addLongTask(time, target)
+    }
+
+    @Test
+    fun `M proxy updatePerformanceMetric to RumMonitor W updatePerformanceMetric()`(
+        forge: Forge
+    ) {
+        // Given
+        val metric = forge.aValueFrom(RumPerformanceMetric::class.java)
+        val value = forge.aDouble()
+        val mockRumMonitor = mock(AdvancedRumMonitor::class.java)
+        val proxy = _RumInternalProxy(mockRumMonitor)
+
+        // When
+        proxy.updatePerformanceMetric(metric, value)
+
+        // Then
+        verify(mockRumMonitor).updatePerformanceMetric(metric, value)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -478,6 +478,64 @@ internal class ViewEventAssert(actual: ViewEvent) :
         return this
     }
 
+    fun hasFlutterBuildTime(value: ViewEvent.FlutterBuildTime?): ViewEventAssert {
+        performanceMetricsAreClose("flutterBuildTime", actual.view.flutterBuildTime, value)
+        return this
+    }
+
+    fun hasFlutterRasterTime(value: ViewEvent.FlutterBuildTime?): ViewEventAssert {
+        performanceMetricsAreClose("flutterRasterTime", actual.view.flutterRasterTime, value)
+        return this
+    }
+
+    fun hasJsRefreshRate(value: ViewEvent.FlutterBuildTime?): ViewEventAssert {
+        performanceMetricsAreClose("jsRefreshRate", actual.view.jsRefreshRate, value)
+        return this
+    }
+
+    private fun performanceMetricsAreClose(
+        metric: String,
+        actualBuildTime: ViewEvent.FlutterBuildTime?,
+        expectedBuildTime: ViewEvent.FlutterBuildTime?
+    ) {
+        if (actualBuildTime == null || expectedBuildTime == null) {
+            assertThat(actualBuildTime)
+                .overridingErrorMessage(
+                    "Expected the event data to have view.$metric of" +
+                        " $expectedBuildTime but was $actualBuildTime"
+                )
+                .isEqualTo(expectedBuildTime)
+        } else {
+            assertThat(actualBuildTime.min.toDouble())
+                .overridingErrorMessage(
+                    "Expected the event data to have view.$metric.min to be close to" +
+                        "${expectedBuildTime.min} but was ${actualBuildTime.min}"
+                )
+                .isCloseTo(expectedBuildTime.min.toDouble(), Percentage.withPercentage(0.1))
+
+            assertThat(actualBuildTime.max.toDouble())
+                .overridingErrorMessage(
+                    "Expected the event data to have view.$metric.max to be close to" +
+                        " ${expectedBuildTime.max} but was ${actualBuildTime.max}"
+                )
+                .isCloseTo(expectedBuildTime.max.toDouble(), Percentage.withPercentage(0.1))
+
+            assertThat(actualBuildTime.average.toDouble())
+                .overridingErrorMessage(
+                    "Expected the event data to have view.$metric.min to be close to" +
+                        " ${expectedBuildTime.average} but was ${actualBuildTime.average}"
+                )
+                .isCloseTo(expectedBuildTime.average.toDouble(), Percentage.withPercentage(0.1))
+
+            assertThat(actualBuildTime.metricMax)
+                .overridingErrorMessage(
+                    "Expected the event data to have view.$metric.metricMax to be equal to" +
+                        " ${expectedBuildTime.metricMax} but was ${actualBuildTime.metricMax}"
+                )
+                .isEqualTo(expectedBuildTime.metricMax)
+        }
+    }
+
     companion object {
 
         internal val ONE_SECOND_NS = TimeUnit.SECONDS.toNanos(1)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -75,12 +75,6 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import java.util.Arrays
-import java.util.Locale
-import java.util.UUID
-import java.util.concurrent.TimeUnit
-import kotlin.math.max
-import kotlin.math.min
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Assumptions.assumeTrue
 import org.junit.jupiter.api.BeforeEach
@@ -94,6 +88,12 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
+import java.util.Arrays
+import java.util.Locale
+import java.util.UUID
+import java.util.concurrent.TimeUnit
+import kotlin.math.max
+import kotlin.math.min
 
 @Extensions(
     ExtendWith(MockitoExtension::class),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1441,6 +1441,7 @@ internal class DatadogRumMonitorTest {
 
         // When
         testedMonitor.updatePerformanceMetric(metric, value)
+        Thread.sleep(PROCESSING_DELAY)
 
         // Then
         argumentCaptor<RumRawEvent.UpdatePerformanceMetric> {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.RumErrorSourceType
@@ -1427,6 +1428,28 @@ internal class DatadogRumMonitorTest {
             assertThat(lastValue.type).isEqualTo(TelemetryType.ERROR)
             assertThat(lastValue.stack).isEqualTo(throwable?.loggableStackTrace())
             assertThat(lastValue.kind).isEqualTo(throwable?.javaClass?.canonicalName)
+        }
+    }
+
+    @Test
+    fun `M handle performance metric update W updatePerformanceMetric()`(
+        forge: Forge
+    ) {
+        // Given
+        val metric = forge.aValueFrom(RumPerformanceMetric::class.java)
+        val value = forge.aDouble()
+
+        // When
+        testedMonitor.updatePerformanceMetric(metric, value)
+
+        // Then
+        argumentCaptor<RumRawEvent.UpdatePerformanceMetric> {
+            verify(mockScope).handleEvent(
+                capture(),
+                eq(mockWriter)
+            )
+            assertThat(lastValue.metric).isEqualTo(metric)
+            assertThat(lastValue.value).isEqualTo(value)
         }
     }
 

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
@@ -26,6 +26,7 @@ import com.datadog.android.nightly.utils.sendRandomActionOutcomeEvent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.tools.unit.forge.aThrowable
 import fr.xgouchet.elmyr.junit4.ForgeRule
@@ -175,6 +176,26 @@ class RumMonitorE2ETests {
             Thread.sleep(timing)
             measure(testMethodName) {
                 GlobalRum.get().addTiming(RUM_TIMING_NAME)
+            }
+        }
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.rum._RumInternalProxy#fun updatePerformanceMetric(RumPerformanceMetric, Double)
+     */
+    @Test
+    fun rum_rummonitor_updatePerformanceMetric() {
+        val testMethodName = "rum_rummonitor_updatePerformanceMetric"
+        val viewKey = forge.aViewKey()
+        val viewName = forge.aViewName()
+        val metric = forge.aValueFrom(RumPerformanceMetric::class.java)
+        val value = forge.aDouble(0.25, 1.5)
+        executeInsideView(viewKey, viewName, testMethodName) {
+            measure(testMethodName) {
+                GlobalRum.get()._getInternal()?.updatePerformanceMetric(
+                    metric = metric,
+                    value = value
+                )
             }
         }
     }


### PR DESCRIPTION
### What does this PR do?

This creates an internal API for adding cross platform technical performance metrics (currently only Flutter Build Time, Flutter Raster Time and JS Refresh Rate). Each update is a single sample, which is aggregated via the same method as the Vitals aggregation, and posted to View events.

### Motivation

The Flutter and React Native SDKs will use this method to send in their performance metrics. The API was left open to potentially support sending different metrics in the future just by adding to the enum and serializing to the proper property on the View event.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

