### PR TITLE
Move package from AndroidManifest to namespace plugin config property for Session Replay module

### DIFF
--- a/library/dd-sdk-android-session-replay/build.gradle.kts
+++ b/library/dd-sdk-android-session-replay/build.gradle.kts
@@ -43,6 +43,8 @@ android {
         setLibraryVersion()
     }
 
+    namespace = "com.datadog.android.sessionreplay"
+
     sourceSets.named("main") {
         java.srcDir("src/main/kotlin")
     }

--- a/library/dd-sdk-android-session-replay/src/main/AndroidManifest.xml
+++ b/library/dd-sdk-android-session-replay/src/main/AndroidManifest.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
-  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
-  ~ Copyright 2016-Present Datadog, Inc.
-  -->
-
-<manifest package="com.datadog.android.sessionreplay">
-
-</manifest>


### PR DESCRIPTION
### What does this PR do?

With AGP 7.3.0 `package` property in `AndroidManifest` is obsolete, `namespace` property in the AGP configuration should be used instead.

Since `AndroidManfest` is empty after the removal, it is deleted.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

