### PR TITLE
Add version to top level project for nexusPublishing extension

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.datadog.gradle.config.nightlyTestsCoverageConfig
+import com.datadog.gradle.config.AndroidConfig
 
 /*
  * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
@@ -11,6 +12,8 @@ plugins {
     id("io.github.gradle-nexus.publish-plugin")
     id("org.jetbrains.kotlinx.kover")
 }
+
+version = AndroidConfig.VERSION.name
 
 buildscript {
     repositories {


### PR DESCRIPTION
### What does this PR do?

It appears the nexusPublishing extension only evaluates whether a deployment goes to staging or not at the Project level, so we need to add the version at that level in order for snapshot builds to go through

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

