### PR TITLE
RUMM-2496 SR Correctly handle clipped elements and scrollable lists

### DIFF
--- a/detekt.yml
+++ b/detekt.yml
@@ -900,6 +900,7 @@ datadog:
       - "java.util.LinkedList.add(com.datadog.android.privacy.TrackingConsentProviderCallback)"
       - "java.util.LinkedList.add(com.datadog.android.sessionreplay.model.MobileSegment.Add)"
       - "java.util.LinkedList.add(com.datadog.android.sessionreplay.model.MobileSegment.Remove)"
+      - "java.util.LinkedList.add(com.datadog.android.sessionreplay.model.MobileSegment.Wireframe)"
       - "java.util.LinkedList.add(com.datadog.android.sessionreplay.model.MobileSegment.WireframeUpdateMutation)"
       - "java.util.LinkedList.addFirst(android.view.View)"
       - "java.util.LinkedList.add(com.datadog.android.sessionreplay.recorder.Node)"

--- a/library/dd-sdk-android-session-replay/apiSurface
+++ b/library/dd-sdk-android-session-replay/apiSurface
@@ -126,13 +126,13 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
   sealed class Wireframe
     abstract fun toJson(): com.google.gson.JsonElement
     data class ShapeWireframe : Wireframe
-      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null)
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, WireframeClip? = null, ShapeStyle? = null, ShapeBorder? = null)
       val type: kotlin.String
       override fun toJson(): com.google.gson.JsonElement
       companion object 
         fun fromJson(kotlin.String): ShapeWireframe
     data class TextWireframe : Wireframe
-      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, ShapeStyle? = null, ShapeBorder? = null, kotlin.String, TextStyle, TextPosition? = null)
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, WireframeClip? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String, TextStyle, TextPosition? = null)
       val type: kotlin.String
       override fun toJson(): com.google.gson.JsonElement
       companion object 
@@ -152,13 +152,13 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
   sealed class WireframeUpdateMutation
     abstract fun toJson(): com.google.gson.JsonElement
     data class TextWireframeUpdate : WireframeUpdateMutation
-      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, TextStyle? = null, TextPosition? = null)
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, WireframeClip? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, TextStyle? = null, TextPosition? = null)
       val type: kotlin.String
       override fun toJson(): com.google.gson.JsonElement
       companion object 
         fun fromJson(kotlin.String): TextWireframeUpdate
     data class ShapeWireframeUpdate : WireframeUpdateMutation
-      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, ShapeStyle? = null, ShapeBorder? = null)
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, WireframeClip? = null, ShapeStyle? = null, ShapeBorder? = null)
       val type: kotlin.String
       override fun toJson(): com.google.gson.JsonElement
       companion object 
@@ -170,6 +170,11 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Position
+  data class WireframeClip
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): WireframeClip
   data class ShapeStyle
     constructor(kotlin.String? = null, kotlin.Number? = null, kotlin.Number? = null)
     fun toJson(): com.google.gson.JsonElement

--- a/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/_common-wireframe-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/_common-wireframe-schema.json
@@ -30,6 +30,9 @@
       "type": "integer",
       "description": "The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.",
       "readOnly": true
+    },
+    "clip": {
+      "$ref": "wireframe-clip-schema.json"
     }
   }
 }

--- a/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/_common-wireframe-update-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/_common-wireframe-update-schema.json
@@ -30,6 +30,9 @@
       "type": "integer",
       "description": "The height in pixels of the UI element, normalized based on the device pixels per inch density (DPI). Example: if a device has a DPI = 2, the height of all UI elements is divided by 2 to get a normalized height.",
       "readOnly": true
+    },
+    "clip": {
+      "$ref": "wireframe-clip-schema.json"
     }
   }
 }

--- a/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/wireframe-clip-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/wireframe-clip-schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/mobile/wireframe-clip-schema.json",
+  "title": "WireframeClip",
+  "type": "object",
+  "description": "Schema of clipping information for a Wireframe.",
+  "properties": {
+    "top": {
+      "type": "integer",
+      "description": "The amount of space in pixels that needs to be clipped (masked) at the top of the wireframe.",
+      "readOnly": true
+    },
+    "bottom": {
+      "type": "integer",
+      "description": "The amount of space in pixels that needs to be clipped (masked) at the bottom of the wireframe.",
+      "readOnly": true
+    },
+    "left": {
+      "type": "integer",
+      "description": "The amount of space in pixels that needs to be clipped (masked) at the left of the wireframe.",
+      "readOnly": true
+    },
+    "right": {
+      "type": "integer",
+      "description": "The amount of space in pixels that needs to be clipped (masked) at the right of the wireframe.",
+      "readOnly": true
+    }
+  }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/MobileSegmentExt.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/MobileSegmentExt.kt
@@ -8,19 +8,10 @@ package com.datadog.android.sessionreplay.processor
 
 import com.datadog.android.sessionreplay.model.MobileSegment
 
-internal fun MobileSegment.Wireframe.bounds(): Bounds {
+internal fun MobileSegment.Wireframe.copy(clip: MobileSegment.WireframeClip?):
+    MobileSegment.Wireframe {
     return when (this) {
-        is MobileSegment.Wireframe.ShapeWireframe -> this.bounds()
-        is MobileSegment.Wireframe.TextWireframe -> this.bounds()
+        is MobileSegment.Wireframe.ShapeWireframe -> this.copy(clip = clip)
+        is MobileSegment.Wireframe.TextWireframe -> this.copy(clip = clip)
     }
 }
-
-internal fun MobileSegment.Wireframe.ShapeWireframe.bounds(): Bounds {
-    return Bounds(x, y, width, height)
-}
-
-internal fun MobileSegment.Wireframe.TextWireframe.bounds(): Bounds {
-    return Bounds(x, y, width, height)
-}
-
-internal data class Bounds(val x: Long, val y: Long, val width: Long, val height: Long)

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/MutationResolver.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/MutationResolver.kt
@@ -218,6 +218,12 @@ internal class MutationResolver {
         if (prevWireframe.shapeStyle != currentWireframe.shapeStyle) {
             mutation = mutation.copy(shapeStyle = currentWireframe.shapeStyle)
         }
+        if (prevWireframe.clip != currentWireframe.clip) {
+            mutation = mutation.copy(
+                clip = currentWireframe.clip
+                    ?: MobileSegment.WireframeClip(0, 0, 0, 0)
+            )
+        }
 
         return mutation
     }
@@ -279,6 +285,12 @@ internal class MutationResolver {
         }
         if (prevWireframe.textPosition != currentWireframe.textPosition) {
             mutation = mutation.copy(textPosition = currentWireframe.textPosition)
+        }
+        if (prevWireframe.clip != currentWireframe.clip) {
+            mutation = mutation.copy(
+                clip = currentWireframe.clip
+                    ?: MobileSegment.WireframeClip(0, 0, 0, 0)
+            )
         }
 
         return mutation

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/SnapshotProcessor.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/SnapshotProcessor.kt
@@ -36,11 +36,6 @@ internal class SnapshotProcessor(
 
     @MainThread
     override fun process(node: Node, orientationChanged: OrientationChanged?) {
-        if (node.wireframes.isEmpty()) {
-            // TODO: RUMM-2397 Add the proper logs here once the sdkLogger will be added
-            return
-        }
-
         buildRunnable { timestamp, newContext, currentContext ->
             Runnable {
                 @Suppress("ThreadSafety") // this runs inside an executor

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/WireframeUtils.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/WireframeUtils.kt
@@ -1,0 +1,104 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.processor
+
+import com.datadog.android.sessionreplay.model.MobileSegment
+import kotlin.math.max
+
+internal class WireframeUtils {
+
+    internal fun resolveWireframeClip(
+        wireframe: MobileSegment.Wireframe,
+        parents: List<MobileSegment.Wireframe>
+    ): MobileSegment.WireframeClip? {
+        var clipTop = 0L
+        var clipLeft = 0L
+        var clipRight = 0L
+        var clipBottom = 0L
+        val wireframeBounds = wireframe.bounds()
+
+        parents.map { it.bounds() }.forEach {
+            clipTop = max(it.top - wireframeBounds.top, clipTop)
+            clipBottom = max(wireframeBounds.bottom - it.bottom, clipBottom)
+            clipLeft = max(it.left - wireframeBounds.left, clipLeft)
+            clipRight = max(wireframeBounds.right - it.right, clipRight)
+        }
+
+        @Suppress("ComplexCondition")
+        return if (clipTop > 0 || clipBottom > 0 || clipLeft > 0 || clipRight > 0) {
+            MobileSegment.WireframeClip(
+                top = clipTop,
+                bottom = clipBottom,
+                left = clipLeft,
+                right = clipRight
+            )
+        } else {
+            null
+        }
+    }
+
+    internal fun checkIsValidWireframe(
+        wireframe: MobileSegment.Wireframe,
+        topWireframes: List<MobileSegment.Wireframe>
+    ): Boolean {
+        val wireframeBounds = wireframe.bounds()
+        if (wireframeBounds.width <= 0 || wireframeBounds.height <= 0) {
+            return false
+        }
+        topWireframes.forEach {
+            if (it.bounds().isCovering(wireframeBounds)) {
+                return false
+            }
+        }
+        return true
+    }
+
+    private fun Bounds.isCovering(other: Bounds): Boolean {
+        return left <= other.left &&
+            right >= other.right &&
+            top <= other.top &&
+            bottom >= other.bottom
+    }
+
+    private fun MobileSegment.Wireframe.bounds(): Bounds {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe -> this.bounds()
+            is MobileSegment.Wireframe.TextWireframe -> this.bounds()
+        }
+    }
+
+    private fun MobileSegment.Wireframe.ShapeWireframe.bounds(): Bounds {
+        return Bounds(
+            left = x + (clip?.left ?: 0),
+            right = x + width - (clip?.right ?: 0),
+            top = y + (clip?.top ?: 0),
+            bottom = y + height - (clip?.bottom ?: 0),
+            width = width,
+            height = height
+        )
+    }
+
+    private fun MobileSegment.Wireframe.TextWireframe.bounds(): Bounds {
+        return Bounds(
+            left = x + (clip?.left ?: 0),
+            right = x + width - (clip?.right ?: 0),
+            top = y + (clip?.top ?: 0),
+            bottom = y + height - (clip?.bottom ?: 0),
+            width = width,
+            height = height
+        )
+    }
+
+    internal data class Bounds(
+        val left: Long,
+        val right: Long,
+        val top: Long,
+        val bottom: Long,
+        val width: Long,
+        val height: Long
+    )
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/Node.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/Node.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.recorder
 import com.datadog.android.sessionreplay.model.MobileSegment
 
 internal data class Node(
-    val wireframes: List<MobileSegment.Wireframe>,
-    val children: List<Node> = emptyList()
+    val wireframe: MobileSegment.Wireframe,
+    val children: List<Node> = emptyList(),
+    val parents: List<MobileSegment.Wireframe> = emptyList()
 )

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/ViewUtils.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/ViewUtils.kt
@@ -1,0 +1,46 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder
+
+import android.os.Build
+import android.view.View
+import android.view.ViewStub
+import androidx.appcompat.widget.ActionBarContextView
+import androidx.appcompat.widget.Toolbar
+
+internal class ViewUtils {
+
+    private val systemViewIds by lazy {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+            setOf(android.R.id.navigationBarBackground, android.R.id.statusBarBackground)
+        } else {
+            emptySet()
+        }
+    }
+
+    internal fun checkIfNotVisible(view: View): Boolean {
+        return !view.isShown || view.width <= 0 || view.height <= 0
+    }
+
+    internal fun checkIfSystemNoise(view: View): Boolean {
+        return view.id in systemViewIds ||
+            view is ViewStub ||
+            view is ActionBarContextView
+    }
+
+    internal fun checkIsToolbar(view: View): Boolean {
+        return (
+            Toolbar::class.java.isAssignableFrom(view::class.java) &&
+                view.id == androidx.appcompat.R.id.action_bar
+            ) ||
+            (
+                Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
+                    android.widget.Toolbar::class.java
+                        .isAssignableFrom(view::class.java)
+                )
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapper.kt
@@ -24,7 +24,7 @@ internal class ViewWireframeMapper :
         val coordinates = IntArray(2)
         // this will always have size >= 2
         @Suppress("UnsafeThirdPartyFunctionCall")
-        view.getLocationInWindow(coordinates)
+        view.getLocationOnScreen(coordinates)
         val x = coordinates[0].densityNormalized(pixelsDensity).toLong()
         val y = coordinates[1].densityNormalized(pixelsDensity).toLong()
         val styleBorderPair = view.background?.resolveShapeStyleAndBorder()

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/processor/MutationResolverTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/processor/MutationResolverTest.kt
@@ -355,6 +355,75 @@ internal class MutationResolverTest {
     }
 
     @Test
+    fun `M identify the updated wireframes W resolveMutations {Shape, clip}`(forge: Forge) {
+        // Given
+        val fakePrevSnapshot = forge.aList(size = forge.anInt(min = 2, max = 10)) {
+            forge.getForgery(MobileSegment.Wireframe.ShapeWireframe::class.java)
+        }
+        val fakeUpdateSize = forge.anInt(min = 1, max = fakePrevSnapshot.size)
+        val fakeUpdatedWireframes = fakePrevSnapshot
+            .take(fakeUpdateSize)
+            .map {
+                it.copy(
+                    clip = forge.getForgery()
+                )
+            }
+        val fakeCurrentSnapshot = fakeUpdatedWireframes + fakePrevSnapshot.drop(fakeUpdateSize)
+        val expectedUpdates = fakeUpdatedWireframes.map {
+            MobileSegment.WireframeUpdateMutation.ShapeWireframeUpdate(
+                id = it.id(),
+                clip = it.clip
+            )
+        }
+
+        // When
+        val mutations = testedMutationResolver.resolveMutations(
+            fakePrevSnapshot,
+            fakeCurrentSnapshot
+        )
+
+        // Then
+        assertThat(mutations?.adds).isNullOrEmpty()
+        assertThat(mutations?.removes).isNullOrEmpty()
+        assertThat(mutations?.updates).isEqualTo(expectedUpdates)
+    }
+
+    @Test
+    fun `M provide an empty clip W resolveMutations {Shape, new clip is null}`(forge: Forge) {
+        // Given
+        val fakePrevSnapshot = forge.aList(size = forge.anInt(min = 2, max = 10)) {
+            forge.getForgery(MobileSegment.Wireframe.ShapeWireframe::class.java)
+                .copy(clip = forge.getForgery())
+        }
+        val fakeUpdateSize = forge.anInt(min = 1, max = fakePrevSnapshot.size)
+        val fakeUpdatedWireframes = fakePrevSnapshot
+            .take(fakeUpdateSize)
+            .map {
+                it.copy(
+                    clip = null
+                )
+            }
+        val fakeCurrentSnapshot = fakeUpdatedWireframes + fakePrevSnapshot.drop(fakeUpdateSize)
+        val expectedUpdates = fakeUpdatedWireframes.map {
+            MobileSegment.WireframeUpdateMutation.ShapeWireframeUpdate(
+                id = it.id(),
+                clip = MobileSegment.WireframeClip(0, 0, 0, 0)
+            )
+        }
+
+        // When
+        val mutations = testedMutationResolver.resolveMutations(
+            fakePrevSnapshot,
+            fakeCurrentSnapshot
+        )
+
+        // Then
+        assertThat(mutations?.adds).isNullOrEmpty()
+        assertThat(mutations?.removes).isNullOrEmpty()
+        assertThat(mutations?.updates).isEqualTo(expectedUpdates)
+    }
+
+    @Test
     fun `M return empty mutations W resolveMutation {Shape wireframes types are not matching}`(
         forge: Forge
     ) {
@@ -625,6 +694,75 @@ internal class MutationResolverTest {
             MobileSegment.WireframeUpdateMutation.TextWireframeUpdate(
                 id = it.id(),
                 textPosition = it.textPosition
+            )
+        }
+
+        // When
+        val mutations = testedMutationResolver.resolveMutations(
+            fakePrevSnapshot,
+            fakeCurrentSnapshot
+        )
+
+        // Then
+        assertThat(mutations?.adds).isNullOrEmpty()
+        assertThat(mutations?.removes).isNullOrEmpty()
+        assertThat(mutations?.updates).isEqualTo(expectedUpdates)
+    }
+
+    @Test
+    fun `M identify the updated wireframes W resolveMutations {Text, clip}`(forge: Forge) {
+        // Given
+        val fakePrevSnapshot = forge.aList(size = forge.anInt(min = 2, max = 10)) {
+            forge.getForgery(MobileSegment.Wireframe.TextWireframe::class.java)
+        }
+        val fakeUpdateSize = forge.anInt(min = 1, max = fakePrevSnapshot.size)
+        val fakeUpdatedWireframes = fakePrevSnapshot
+            .take(fakeUpdateSize)
+            .map {
+                it.copy(
+                    clip = forge.getForgery()
+                )
+            }
+        val fakeCurrentSnapshot = fakeUpdatedWireframes + fakePrevSnapshot.drop(fakeUpdateSize)
+        val expectedUpdates = fakeUpdatedWireframes.map {
+            MobileSegment.WireframeUpdateMutation.TextWireframeUpdate(
+                id = it.id(),
+                clip = it.clip
+            )
+        }
+
+        // When
+        val mutations = testedMutationResolver.resolveMutations(
+            fakePrevSnapshot,
+            fakeCurrentSnapshot
+        )
+
+        // Then
+        assertThat(mutations?.adds).isNullOrEmpty()
+        assertThat(mutations?.removes).isNullOrEmpty()
+        assertThat(mutations?.updates).isEqualTo(expectedUpdates)
+    }
+
+    @Test
+    fun `M provide an empty clip W resolveMutations {Text, new clip is null}`(forge: Forge) {
+        // Given
+        val fakePrevSnapshot = forge.aList(size = forge.anInt(min = 2, max = 10)) {
+            forge.getForgery(MobileSegment.Wireframe.TextWireframe::class.java)
+                .copy(clip = forge.getForgery())
+        }
+        val fakeUpdateSize = forge.anInt(min = 1, max = fakePrevSnapshot.size)
+        val fakeUpdatedWireframes = fakePrevSnapshot
+            .take(fakeUpdateSize)
+            .map {
+                it.copy(
+                    clip = null
+                )
+            }
+        val fakeCurrentSnapshot = fakeUpdatedWireframes + fakePrevSnapshot.drop(fakeUpdateSize)
+        val expectedUpdates = fakeUpdatedWireframes.map {
+            MobileSegment.WireframeUpdateMutation.TextWireframeUpdate(
+                id = it.id(),
+                clip = MobileSegment.WireframeClip(0, 0, 0, 0)
             )
         }
 

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/processor/NodeFlattenerTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/processor/NodeFlattenerTest.kt
@@ -9,6 +9,9 @@ package com.datadog.android.sessionreplay.processor
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.Node
 import com.datadog.android.sessionreplay.utils.ForgeConfigurator
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -17,6 +20,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
@@ -34,9 +38,14 @@ internal class NodeFlattenerTest {
 
     lateinit var testedNodeFlattener: NodeFlattener
 
+    @Mock
+    lateinit var mockWireframeUtils: WireframeUtils
+
     @BeforeEach
     fun `set up`() {
-        testedNodeFlattener = NodeFlattener()
+        whenever(mockWireframeUtils.checkIsValidWireframe(any(), any()))
+            .thenReturn(true)
+        testedNodeFlattener = NodeFlattener(mockWireframeUtils)
     }
 
     // region Unit Tests
@@ -50,13 +59,15 @@ internal class NodeFlattenerTest {
         val wireframes = testedNodeFlattener.flattenNode(fakeSnapshot)
 
         // Then
-        val expectedList = fakeSnapshot.wireframes +
-            fakeSnapshot.children[0].wireframes +
-            fakeSnapshot.children[0].children[0].wireframes +
-            fakeSnapshot.children[0].children[1].wireframes +
-            fakeSnapshot.children[1].wireframes +
-            fakeSnapshot.children[1].children[0].wireframes +
-            fakeSnapshot.children[1].children[1].wireframes
+        val expectedList = listOf(
+            fakeSnapshot.wireframe,
+            fakeSnapshot.children[0].wireframe,
+            fakeSnapshot.children[0].children[0].wireframe,
+            fakeSnapshot.children[0].children[1].wireframe,
+            fakeSnapshot.children[1].wireframe,
+            fakeSnapshot.children[1].children[0].wireframe,
+            fakeSnapshot.children[1].children[1].wireframe
+        )
         assertThat(wireframes).isEqualTo(expectedList)
     }
 
@@ -85,78 +96,23 @@ internal class NodeFlattenerTest {
     }
 
     @Test
-    fun `M filter out the completely covered wireframes W process`(forge: Forge) {
+    fun `M filter out the invalid wireframe W process`(forge: Forge) {
         // Given
-        var fakeSnapshot = forge.aSnapshot(2)
-        val topWireframeId = forge.aLong(min = 0)
-        val topWireframe = fakeSnapshot.children[1].wireframes[0].copy(topWireframeId)
-        val childrenWithCoverUpWireframe = fakeSnapshot.children +
-            Node(wireframes = listOf(topWireframe))
-        fakeSnapshot = fakeSnapshot.copy(children = childrenWithCoverUpWireframe)
+        val expectedList: MutableList<MobileSegment.Wireframe> =
+            Array<MobileSegment.Wireframe>(forge.anInt(min = 10, max = 20)) {
+                forge.getForgery<MobileSegment.Wireframe.ShapeWireframe>()
+            }.toMutableList()
+        val fakeSnapshot = generateTreeFromList(expectedList)
+
+        val randomIndex = forge.anInt(min = 0, max = expectedList.size)
+        val excludedWireframe = expectedList.removeAt(randomIndex)
+        whenever(mockWireframeUtils.checkIsValidWireframe(eq(excludedWireframe), any()))
+            .thenReturn(false)
 
         // When
         val wireframes = testedNodeFlattener.flattenNode(fakeSnapshot)
 
         // Then
-        // The added wireframe completely covers the previous one + its children in the list. The
-        // previous wireframe and it children will therefore be removed.
-        val expectedList = fakeSnapshot.wireframes +
-            fakeSnapshot.children[0].wireframes +
-            fakeSnapshot.children[0].children[0].wireframes +
-            fakeSnapshot.children[0].children[1].wireframes +
-            topWireframe
-        assertThat(wireframes).isEqualTo(expectedList)
-    }
-
-    @Test
-    fun `M filter out wireframes with invalid width W process`(forge: Forge) {
-        // Given
-        var fakeSnapshot = forge.aSnapshot(1)
-        val invalidWidthWireframe: MobileSegment.Wireframe = if (forge.aBool()) {
-            forge.getForgery<MobileSegment.Wireframe.ShapeWireframe>()
-                .copy(width = forge.aLong(max = 1))
-        } else {
-            forge.getForgery<MobileSegment.Wireframe.TextWireframe>()
-                .copy(width = forge.aLong(max = 1))
-        }
-        val childrenWithCoverUpWireframe = fakeSnapshot.children + Node(
-            wireframes = listOf(invalidWidthWireframe)
-        )
-        fakeSnapshot = fakeSnapshot.copy(children = childrenWithCoverUpWireframe)
-
-        // When
-        val wireframes = testedNodeFlattener.flattenNode(fakeSnapshot)
-
-        // Then
-        val expectedList = fakeSnapshot.wireframes +
-            fakeSnapshot.children[0].wireframes +
-            fakeSnapshot.children[1].wireframes
-        assertThat(wireframes).isEqualTo(expectedList)
-    }
-
-    @Test
-    fun `M filter out wireframes with invalid height W process`(forge: Forge) {
-        // Given
-        var fakeSnapshot = forge.aSnapshot(1)
-        val invalidHeightWireframe: MobileSegment.Wireframe = if (forge.aBool()) {
-            forge.getForgery<MobileSegment.Wireframe.ShapeWireframe>()
-                .copy(height = forge.aLong(max = 1))
-        } else {
-            forge.getForgery<MobileSegment.Wireframe.TextWireframe>()
-                .copy(height = forge.aLong(max = 1))
-        }
-        val childrenWithCoverUpWireframe = fakeSnapshot.children + Node(
-            wireframes = listOf(invalidHeightWireframe)
-        )
-        fakeSnapshot = fakeSnapshot.copy(children = childrenWithCoverUpWireframe)
-
-        // When
-        val wireframes = testedNodeFlattener.flattenNode(fakeSnapshot)
-
-        // Then
-        val expectedList = fakeSnapshot.wireframes +
-            fakeSnapshot.children[0].wireframes +
-            fakeSnapshot.children[1].wireframes
         assertThat(wireframes).isEqualTo(expectedList)
     }
 
@@ -193,8 +149,15 @@ internal class NodeFlattenerTest {
         (this.children as LinkedList).add(node)
     }
 
-    private fun MobileSegment.Wireframe.toNode(): Node {
-        return Node(wireframes = mutableListOf(this), children = LinkedList())
+    private fun MobileSegment.Wireframe.toNode(parent: Node? = null): Node {
+        val parents = parent?.parents ?: emptyList()
+        whenever(mockWireframeUtils.resolveWireframeClip(this, parents))
+            .thenReturn(this.clip())
+        return Node(
+            wireframe = this,
+            children = LinkedList(),
+            parents = parents
+        )
     }
 
     private fun Forge.aSnapshot(treeLevel: Int, childrenSize: Int = 2): Node {
@@ -202,14 +165,13 @@ internal class NodeFlattenerTest {
         val baseHeight = aLong(min = 300, max = 400)
         val dimensionsMultiplierFactor = childrenSize.toFloat().pow(treeLevel).toLong()
         val root = Node(
-            wireframes = listOf(
-                MobileSegment.Wireframe.ShapeWireframe(
-                    0,
-                    0,
-                    0,
-                    baseWidth * dimensionsMultiplierFactor,
-                    baseHeight * dimensionsMultiplierFactor
-                )
+            wireframe =
+            MobileSegment.Wireframe.ShapeWireframe(
+                0,
+                0,
+                0,
+                baseWidth * dimensionsMultiplierFactor,
+                baseHeight * dimensionsMultiplierFactor
             )
         )
         return root.copy(children = snapshots(root, 1, treeLevel, childrenSize))
@@ -226,8 +188,8 @@ internal class NodeFlattenerTest {
 
     private fun Forge.snapshots(parent: Node, treeLevel: Int, maxTreeLevel: Int, childrenSize: Int):
         List<Node> {
-        val startIdIndex = childrenSize * parent.wireframes[0].id()
-        val parentWireframeBounds = parent.wireframes[0].bounds()
+        val startIdIndex = childrenSize * parent.wireframe.id()
+        val parentWireframeBounds = parent.wireframe.bounds()
         val parentWidth = parentWireframeBounds.width
         val parentHeight = parentWireframeBounds.height
         val parentY = parentWireframeBounds.y
@@ -244,7 +206,7 @@ internal class NodeFlattenerTest {
                 val minY = parentY + maxHeight * it
                 val minX = parentX + maxWidth * it
                 val wireframe = forgeWireframe(nodeId, minX, minY, maxWidth, maxHeight)
-                var node = Node(wireframes = listOf(wireframe))
+                var node = Node(wireframe = wireframe)
                 node = node.copy(
                     children = snapshots(
                         node,
@@ -286,6 +248,15 @@ internal class NodeFlattenerTest {
                 Bounds(this.x, this.y, this.width, this.height)
             is MobileSegment.Wireframe.TextWireframe ->
                 Bounds(this.x, this.y, this.width, this.height)
+        }
+    }
+
+    private fun MobileSegment.Wireframe.clip(): MobileSegment.WireframeClip? {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe ->
+                clip
+            is MobileSegment.Wireframe.TextWireframe ->
+                clip
         }
     }
 

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/processor/SnapshotProcessorTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/processor/SnapshotProcessorTest.kt
@@ -253,18 +253,6 @@ internal class SnapshotProcessorTest {
     }
 
     @Test
-    fun `M do nothing W process { snapshot is empty }`(forge: Forge) {
-        // Given
-        val fakeSnapshot = forge.aSingleLevelSnapshot().copy(wireframes = emptyList())
-
-        // When
-        testedProcessor.process(fakeSnapshot)
-
-        // Then
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
     fun `M send MetaRecord first W process { snapshot on a new view }`(forge: Forge) {
         // Given
         val fakeRootWidth = forge.aLong(min = 400)
@@ -276,11 +264,7 @@ internal class SnapshotProcessorTest {
             fakeRootWidth,
             fakeRootHeight
         )
-        val fakeSnapshot = Node(
-            wireframes = listOf(
-                rootWireframe
-            )
-        )
+        val fakeSnapshot = Node(wireframe = rootWireframe)
         whenever(mockNodeFlattener.flattenNode(fakeSnapshot)).thenReturn(listOf(rootWireframe))
 
         // When
@@ -302,14 +286,13 @@ internal class SnapshotProcessorTest {
         val fakeRootWidth = forge.aLong(min = 400)
         val fakeRootHeight = forge.aLong(min = 700)
         val fakeSnapshot = Node(
-            wireframes = listOf(
-                MobileSegment.Wireframe.ShapeWireframe(
-                    0,
-                    0,
-                    0,
-                    fakeRootWidth,
-                    fakeRootHeight
-                )
+            wireframe =
+            MobileSegment.Wireframe.ShapeWireframe(
+                0,
+                0,
+                0,
+                fakeRootWidth,
+                fakeRootHeight
             )
         )
 
@@ -379,11 +362,7 @@ internal class SnapshotProcessorTest {
             fakeRootWidth,
             fakeRootHeight
         )
-        val fakeSnapshot3 = Node(
-            wireframes = listOf(
-                rootWireframe
-            )
-        )
+        val fakeSnapshot3 = Node(rootWireframe)
         whenever(mockNodeFlattener.flattenNode(fakeSnapshot3)).thenReturn(listOf(rootWireframe))
 
         testedProcessor.process(fakeSnapshot1)
@@ -751,14 +730,12 @@ internal class SnapshotProcessorTest {
 
     private fun Forge.aSingleLevelSnapshot(): Node {
         return Node(
-            wireframes = listOf(
-                MobileSegment.Wireframe.ShapeWireframe(
-                    aLong(min = 0),
-                    aLong(min = 0),
-                    aLong(min = 0),
-                    aLong(min = 0),
-                    aLong(min = 0)
-                )
+            MobileSegment.Wireframe.ShapeWireframe(
+                aLong(min = 0),
+                aLong(min = 0),
+                aLong(min = 0),
+                aLong(min = 0),
+                aLong(min = 0)
             )
         )
     }
@@ -769,14 +746,13 @@ internal class SnapshotProcessorTest {
         @JvmStatic
         fun processorArguments(): List<Any> {
             val fakeSnapshot = Node(
-                wireframes = listOf(
-                    MobileSegment.Wireframe.ShapeWireframe(
-                        0,
-                        0,
-                        0,
-                        0,
-                        0
-                    )
+                wireframe =
+                MobileSegment.Wireframe.ShapeWireframe(
+                    0,
+                    0,
+                    0,
+                    0,
+                    0
                 )
             )
 

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/processor/WireframeUtilsTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/processor/WireframeUtilsTest.kt
@@ -1,0 +1,722 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.processor
+
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.ForgeConfigurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import kotlin.math.abs
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class WireframeUtilsTest {
+
+    lateinit var testedWireframeUtils: WireframeUtils
+
+    @BeforeEach
+    fun `set up`() {
+        testedWireframeUtils = WireframeUtils()
+    }
+
+    // region Clipping resolver
+
+    @ParameterizedTest
+    @MethodSource("resolveClipWireframes")
+    fun `M correctly resolve the Wireframe clip W resolveWireframeClip {clipLeft}`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedClipLeft = forge.aLong(min = 0, max = 100)
+
+        val fakeParentWireframe = fakeWireframe.copy(
+            x = fakeWireframe.x() + fakeExpectedClipLeft,
+            y = fakeWireframe.y(),
+            width = fakeWireframe.width(),
+            height = fakeWireframe.height()
+        )
+        val fakExpectedClip = MobileSegment.WireframeClip(
+            top = 0,
+            left = fakeExpectedClipLeft,
+            right = 0,
+            bottom = 0
+        )
+        val fakeParents = listOf(fakeParentWireframe)
+
+        // Then
+        assertThat(testedWireframeUtils.resolveWireframeClip(fakeWireframe, fakeParents))
+            .isEqualTo(fakExpectedClip)
+    }
+
+    @ParameterizedTest
+    @MethodSource("resolveClipWireframes")
+    fun `M correctly resolve the Wireframe clip W resolveWireframeClip {clipRight}`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedClipRight = forge.aLong(min = 0, max = 100)
+
+        val fakeParentWireframe = fakeWireframe.copy(
+            x = fakeWireframe.x(),
+            y = fakeWireframe.y(),
+            width = fakeWireframe.width() - fakeExpectedClipRight,
+            height = fakeWireframe.height()
+        )
+        val fakExpectedClip = MobileSegment.WireframeClip(
+            top = 0,
+            right = fakeExpectedClipRight,
+            left = 0,
+            bottom = 0
+        )
+        val fakeParents = listOf(fakeParentWireframe)
+
+        // Then
+        assertThat(testedWireframeUtils.resolveWireframeClip(fakeWireframe, fakeParents))
+            .isEqualTo(fakExpectedClip)
+    }
+
+    @ParameterizedTest
+    @MethodSource("resolveClipWireframes")
+    fun `M correctly resolve the Wireframe clip W resolveWireframeClip {clipTop}`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedClipTop = forge.aLong(min = 0, max = 100)
+
+        val fakeParentWireframe = fakeWireframe.copy(
+            x = fakeWireframe.x(),
+            y = fakeWireframe.y() + fakeExpectedClipTop,
+            width = fakeWireframe.width(),
+            height = fakeWireframe.height()
+        )
+        val fakExpectedClip = MobileSegment.WireframeClip(
+            top = fakeExpectedClipTop,
+            right = 0,
+            left = 0,
+            bottom = 0
+        )
+        val fakeParents = listOf(fakeParentWireframe)
+
+        // Then
+        assertThat(testedWireframeUtils.resolveWireframeClip(fakeWireframe, fakeParents))
+            .isEqualTo(fakExpectedClip)
+    }
+
+    @ParameterizedTest
+    @MethodSource("resolveClipWireframes")
+    fun `M correctly resolve the Wireframe clip W resolveWireframeClip {clipBottom}`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedClipBottom = forge.aLong(min = 0, max = 100)
+
+        val fakeParentWireframe = fakeWireframe.copy(
+            x = fakeWireframe.x(),
+            y = fakeWireframe.y(),
+            width = fakeWireframe.width(),
+            height = fakeWireframe.height() - fakeExpectedClipBottom
+        )
+        val fakExpectedClip = MobileSegment.WireframeClip(
+            top = 0,
+            right = 0,
+            left = 0,
+            bottom = fakeExpectedClipBottom
+        )
+        val fakeParents = listOf(fakeParentWireframe)
+
+        // Then
+        assertThat(testedWireframeUtils.resolveWireframeClip(fakeWireframe, fakeParents))
+            .isEqualTo(fakExpectedClip)
+    }
+
+    @ParameterizedTest
+    @MethodSource("resolveClipWireframes")
+    fun `M correctly resolve the Wireframe clip W resolveWireframeClip {clip all sides}`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val fakeExpectedClipBottom = forge.aLong(min = 0, max = 5)
+        val fakeExpectedClipTop = forge.aLong(min = 0, max = 5)
+        val fakeExpectedClipLeft = forge.aLong(min = 0, max = 5)
+        val fakeExpectedClipRight = forge.aLong(min = 0, max = 5)
+
+        val fakeParentWireframe = fakeWireframe.copy(
+            x = fakeWireframe.x() + fakeExpectedClipLeft,
+            y = fakeWireframe.y() + fakeExpectedClipTop,
+            width = fakeWireframe.width() - fakeExpectedClipRight - fakeExpectedClipLeft,
+            height = fakeWireframe.height() - fakeExpectedClipBottom - fakeExpectedClipTop
+        )
+        val fakExpectedClip = MobileSegment.WireframeClip(
+            top = fakeExpectedClipTop,
+            right = fakeExpectedClipRight,
+            left = fakeExpectedClipLeft,
+            bottom = fakeExpectedClipBottom
+        )
+
+        val fakeRandomParents: List<MobileSegment.Wireframe> = forge.aList<MobileSegment.Wireframe> {
+            val aClipLeft = forge.aLong(min = -100, max = fakeExpectedClipLeft)
+            val aClipTop = forge.aLong(min = -100, max = fakeExpectedClipTop)
+            val aClipRight = forge.aLong(min = -100, max = fakeExpectedClipRight) - aClipLeft
+            val aClipBottom = forge.aLong(min = -100, max = fakeExpectedClipBottom) - aClipTop
+            fakeWireframe.apply {
+                copy(
+                    x = fakeWireframe.x() + aClipLeft,
+                    y = fakeWireframe.y() + aClipTop,
+                    width = fakeWireframe.width() - aClipRight,
+                    height = fakeWireframe.height() - aClipBottom
+                )
+            }
+        }.toMutableList()
+        val randomIndex = forge.anInt(min = 0, max = fakeRandomParents.size)
+        val fakeParents = fakeRandomParents.toMutableList().apply {
+            add(randomIndex, fakeParentWireframe)
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.resolveWireframeClip(fakeWireframe, fakeParents))
+            .isEqualTo(fakExpectedClip)
+    }
+
+    @ParameterizedTest
+    @MethodSource("resolveClipWireframes")
+    fun `M return null W resolveWireframeClip {inside parents bounds}`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val fakeParents: List<MobileSegment.Wireframe> = forge.aList {
+            val fakeSpaceTop = forge.aLong(min = 0, max = 100)
+            val fakeSpaceLeft = forge.aLong(min = 0, max = 100)
+            fakeWireframe.copy(
+                x = fakeWireframe.x() - fakeSpaceLeft,
+                y = fakeWireframe.y() - fakeSpaceTop,
+                width = fakeWireframe.width() + fakeSpaceLeft + forge.aLong(min = 0, max = 100),
+                height = fakeWireframe.height() + fakeSpaceTop + forge.aLong(min = 0, max = 100)
+            )
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.resolveWireframeClip(fakeWireframe, fakeParents))
+            .isNull()
+    }
+
+    @Test
+    fun `M return null W resolveWireframeClip{no parents}`(forge: Forge) {
+        // Given
+        val wireframe: MobileSegment.Wireframe = forge.getForgery()
+
+        // Then
+        assertThat(testedWireframeUtils.resolveWireframeClip(wireframe, emptyList())).isNull()
+    }
+
+    // endregion
+
+    // region is valid Wireframe
+
+    @ParameterizedTest
+    @MethodSource("coverAllWireframes")
+    fun `M return false W checkIsValidWireframe(){ covered by another }`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val topWireframes = forge.aList {
+            val fakeX = forge.aLong(min = -100, max = fakeWireframe.x())
+            val fakeY = forge.aLong(min = -100, max = fakeWireframe.y())
+            val fakeMinWidth = abs(fakeX) - abs(fakeWireframe.x()) + fakeWireframe.width()
+            val fakeMinHeight = abs(fakeY) - abs(fakeWireframe.y()) + fakeWireframe.height()
+            val fakeWidth = forge.aLong(min = fakeMinWidth, max = Int.MAX_VALUE.toLong())
+            val fakeHeight = forge.aLong(min = fakeMinHeight, max = Int.MAX_VALUE.toLong())
+            val fakeCoverAllWireframe = fakeWireframe.copy(
+                x = fakeX,
+                y = fakeY,
+                width = fakeWidth,
+                height = fakeHeight
+            )
+            fakeCoverAllWireframe
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, topWireframes)).isFalse
+    }
+
+    @ParameterizedTest
+    @MethodSource("coverAllWireframes")
+    fun `M return true W checkIsValidWireframe(){ top is bigger }`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val topWireframes = forge.aList {
+            val fakeY = forge.aLong(min = fakeWireframe.y() + 1)
+            val fakeCoverAllWireframe = fakeWireframe.copy(
+                x = fakeWireframe.x(),
+                y = fakeY,
+                width = fakeWireframe.width(),
+                height = fakeWireframe.height()
+            )
+            fakeCoverAllWireframe
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, topWireframes)).isTrue
+    }
+
+    @ParameterizedTest
+    @MethodSource("coverAllWireframes")
+    fun `M return true W checkIsValidWireframe(){ bottom is bigger }`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val topWireframes = forge.aList {
+            val fakeHeight = forge.aLong(min = 0, max = fakeWireframe.height() - 1)
+            val fakeCoverAllWireframe = fakeWireframe.copy(
+                x = fakeWireframe.x(),
+                y = fakeWireframe.y(),
+                width = fakeWireframe.width(),
+                height = fakeHeight
+            )
+            fakeCoverAllWireframe
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, topWireframes)).isTrue
+    }
+
+    @ParameterizedTest
+    @MethodSource("coverAllWireframes")
+    fun `M return true W checkIsValidWireframe(){ left is bigger }`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val topWireframes = forge.aList {
+            val fakeX = forge.aLong(min = fakeWireframe.x() + 1)
+            val fakeCoverAllWireframe = fakeWireframe.copy(
+                x = fakeX,
+                y = fakeWireframe.y(),
+                width = fakeWireframe.width(),
+                height = fakeWireframe.height()
+            )
+            fakeCoverAllWireframe
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, topWireframes)).isTrue
+    }
+
+    @ParameterizedTest
+    @MethodSource("coverAllWireframes")
+    fun `M return true W checkIsValidWireframe(){ right is bigger }`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val topWireframes = forge.aList {
+            val fakeWidth = forge.aLong(min = 0, max = fakeWireframe.width() - 1)
+            val fakeCoverAllWireframe = fakeWireframe.copy(
+                x = fakeWireframe.x(),
+                y = fakeWireframe.y(),
+                width = fakeWidth,
+                height = fakeWireframe.height()
+            )
+            fakeCoverAllWireframe
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, topWireframes)).isTrue
+    }
+
+    @ParameterizedTest
+    @MethodSource("coverAllWireframes")
+    fun `M return true W checkIsValidWireframe(){ all sides are bigger }`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val topWireframes = forge.aList {
+            val fakeX = forge.aLong(min = fakeWireframe.x() + 1)
+            val fakeY = forge.aLong(min = fakeWireframe.y() + 1)
+            val fakeWidth = forge.aLong(min = 0, max = fakeWireframe.width() - 1)
+            val fakeHeight = forge.aLong(min = 0, max = fakeWireframe.height() - 1)
+            val fakeCoverAllWireframe = fakeWireframe.copy(
+                x = fakeX,
+                y = fakeY,
+                width = fakeWidth,
+                height = fakeHeight
+            )
+            fakeCoverAllWireframe
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, topWireframes)).isTrue
+    }
+
+    @ParameterizedTest
+    @MethodSource("coverAllWireframes")
+    fun `M return true W checkIsValidWireframe(){ parent clip left is bigger }`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val topWireframes = forge.aList {
+            val fakeWireframeClipLeft = fakeWireframe.clip()?.left ?: 0
+            val fakeParentClipLeft = forge.aLong(
+                min = fakeWireframeClipLeft + 1,
+                max = fakeWireframeClipLeft + 10
+            )
+            val fakeParentClip = fakeWireframe.clip()?.copy(left = fakeParentClipLeft)
+                ?: MobileSegment.WireframeClip(left = fakeParentClipLeft)
+            val fakeCoverAllWireframe = fakeWireframe.copy(clip = fakeParentClip)
+            fakeCoverAllWireframe
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, topWireframes)).isTrue
+    }
+
+    @ParameterizedTest
+    @MethodSource("coverAllWireframes")
+    fun `M return true W checkIsValidWireframe(){ parent clip right is bigger }`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val topWireframes = forge.aList {
+            val fakeWireframeClipRight = fakeWireframe.clip()?.right ?: 0
+            val fakeParentClipRight = forge.aLong(
+                min = fakeWireframeClipRight + 1,
+                max = fakeWireframeClipRight + 10
+            )
+            val fakeParentClip = fakeWireframe.clip()?.copy(right = fakeParentClipRight)
+                ?: MobileSegment.WireframeClip(right = fakeParentClipRight)
+            val fakeCoverAllWireframe = fakeWireframe.copy(clip = fakeParentClip)
+            fakeCoverAllWireframe
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, topWireframes)).isTrue
+    }
+
+    @ParameterizedTest
+    @MethodSource("coverAllWireframes")
+    fun `M return true W checkIsValidWireframe(){ parent clip top is bigger }`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val topWireframes = forge.aList {
+            val fakeWireframeClipTop = fakeWireframe.clip()?.top ?: 0
+            val fakeParentClipTop = forge.aLong(
+                min = fakeWireframeClipTop + 1,
+                max = fakeWireframeClipTop + 10
+            )
+            val fakeParentClip = fakeWireframe.clip()?.copy(top = fakeParentClipTop)
+                ?: MobileSegment.WireframeClip(top = fakeParentClipTop)
+            val fakeCoverAllWireframe = fakeWireframe.copy(clip = fakeParentClip)
+            fakeCoverAllWireframe
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, topWireframes)).isTrue
+    }
+
+    @ParameterizedTest
+    @MethodSource("coverAllWireframes")
+    fun `M return true W checkIsValidWireframe(){ parent clip bottom is bigger }`(
+        fakeWireframe: MobileSegment.Wireframe,
+        forge: Forge
+    ) {
+        // Given
+        val topWireframes = forge.aList {
+            val fakeWireframeClipBottom = fakeWireframe.clip()?.bottom ?: 0
+            val fakeParentClipBottom = forge.aLong(
+                min = fakeWireframeClipBottom + 1,
+                max = fakeWireframeClipBottom + 10
+            )
+            val fakeParentClip = fakeWireframe.clip()?.copy(bottom = fakeParentClipBottom)
+                ?: MobileSegment.WireframeClip(bottom = fakeParentClipBottom)
+            val fakeCoverAllWireframe = fakeWireframe.copy(clip = fakeParentClip)
+            fakeCoverAllWireframe
+        }
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, topWireframes)).isTrue
+    }
+
+    @Test
+    fun `M return false W checkIsValidWireframe(){ wireframe width is 0 }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeTopWireframes: MutableList<MobileSegment.Wireframe> =
+            forge.aList { getForgeryWithIntRangeCoordinates() }.toMutableList()
+        val fakeWireframe = forge.getForgeryWithIntRangeCoordinates().copyWithWidth(width = 0)
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, fakeTopWireframes))
+            .isFalse
+    }
+
+    @Test
+    fun `M return true W checkIsValidWireframe(){ wireframe not covered }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeTopWireframes: MutableList<MobileSegment.Wireframe> =
+            forge.aList { getForgeryWithIntRangeCoordinates() }.toMutableList()
+        val fakeWireframe = forge.getForgeryWithIntRangeCoordinates().copyWithHeight(height = 0)
+
+        // Then
+        assertThat(testedWireframeUtils.checkIsValidWireframe(fakeWireframe, fakeTopWireframes))
+            .isFalse
+    }
+
+    // endregion
+
+    // region Internal
+
+    private fun MobileSegment.Wireframe.copy(
+        x: Long,
+        y: Long,
+        width: Long,
+        height: Long,
+        clip: MobileSegment.WireframeClip?
+    ):
+        MobileSegment.Wireframe {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe -> copy(
+                x = x,
+                y = y,
+                width = width,
+                height = height,
+                clip = clip
+            )
+            is MobileSegment.Wireframe.TextWireframe -> copy(
+                x = x,
+                y = y,
+                width = width,
+                height = height,
+                clip = clip
+            )
+        }
+    }
+
+    private fun MobileSegment.Wireframe.copy(x: Long, y: Long, width: Long, height: Long):
+        MobileSegment.Wireframe {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe -> copy(
+                x = x,
+                y = y,
+                width = width,
+                height = height
+            )
+            is MobileSegment.Wireframe.TextWireframe -> copy(
+                x = x,
+                y = y,
+                width = width,
+                height = height
+            )
+        }
+    }
+
+    private fun MobileSegment.Wireframe.copyWithWidth(width: Long):
+        MobileSegment.Wireframe {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe -> copy(width = width)
+            is MobileSegment.Wireframe.TextWireframe -> copy(width = width)
+        }
+    }
+
+    private fun MobileSegment.Wireframe.copyWithHeight(height: Long):
+        MobileSegment.Wireframe {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe -> copy(height = height)
+            is MobileSegment.Wireframe.TextWireframe -> copy(height = height)
+        }
+    }
+
+    private fun MobileSegment.Wireframe.clip(): MobileSegment.WireframeClip? {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe -> clip
+            is MobileSegment.Wireframe.TextWireframe -> clip
+        }
+    }
+
+    private fun MobileSegment.Wireframe.x(): Long {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe -> x
+            is MobileSegment.Wireframe.TextWireframe -> x
+        }
+    }
+
+    private fun MobileSegment.Wireframe.y(): Long {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe -> y
+            is MobileSegment.Wireframe.TextWireframe -> y
+        }
+    }
+
+    private fun MobileSegment.Wireframe.width(): Long {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe -> width
+            is MobileSegment.Wireframe.TextWireframe -> width
+        }
+    }
+
+    private fun MobileSegment.Wireframe.height(): Long {
+        return when (this) {
+            is MobileSegment.Wireframe.ShapeWireframe -> height
+            is MobileSegment.Wireframe.TextWireframe -> height
+        }
+    }
+
+    private fun Forge.getForgeryWithIntRangeCoordinates(): MobileSegment.Wireframe {
+        return getForgery<MobileSegment.Wireframe.ShapeWireframe>()
+            .copy(
+                x = aLong(min = 1, max = 100),
+                y = aLong(min = 1, max = 100),
+                width = aLong(min = 1, max = 100),
+                height = aLong(min = 1, max = 100)
+            )
+    }
+    // endregion
+
+    companion object {
+        val forge = Forge()
+
+        private fun MobileSegment.Wireframe.copy(
+            x: Long,
+            y: Long,
+            width: Long,
+            height: Long,
+            clip: MobileSegment.WireframeClip?
+        ):
+            MobileSegment.Wireframe {
+            return when (this) {
+                is MobileSegment.Wireframe.ShapeWireframe -> copy(
+                    x = x,
+                    y = y,
+                    width = width,
+                    height = height,
+                    clip = clip
+                )
+                is MobileSegment.Wireframe.TextWireframe -> copy(
+                    x = x,
+                    y = y,
+                    width = width,
+                    height = height,
+                    clip = clip
+                )
+            }
+        }
+
+        private fun MobileSegment.Wireframe.copy(x: Long, y: Long, width: Long, height: Long):
+            MobileSegment.Wireframe {
+            return when (this) {
+                is MobileSegment.Wireframe.ShapeWireframe -> copy(
+                    x = x,
+                    y = y,
+                    width = width,
+                    height = height
+                )
+                is MobileSegment.Wireframe.TextWireframe -> copy(
+                    x = x,
+                    y = y,
+                    width = width,
+                    height = height
+                )
+            }
+        }
+
+        @JvmStatic
+        fun resolveClipWireframes(): List<MobileSegment.Wireframe> {
+            ForgeConfigurator().configure(forge)
+            val negativeCoordinatesWireframe = forge.getForgery<MobileSegment.Wireframe>()
+                .copy(
+                    x = forge.aLong(min = -100, max = 0),
+                    y = forge.aLong(min = -100, max = 0),
+                    width = forge.aLong(min = 2, max = 100),
+                    height = forge.aLong(min = 2, max = 100),
+                    clip = null
+                )
+            val positiveCoordinatesWireframe = forge.getForgery<MobileSegment.Wireframe>()
+                .copy(
+                    x = forge.aLong(min = 0, max = 100),
+                    y = forge.aLong(min = 0, max = 100),
+                    width = forge.aLong(min = 2, max = 100),
+                    height = forge.aLong(min = 2, max = 100),
+                    clip = null
+                )
+            return listOf(negativeCoordinatesWireframe, positiveCoordinatesWireframe)
+        }
+
+        @JvmStatic
+        fun coverAllWireframes(): List<MobileSegment.Wireframe> {
+            ForgeConfigurator().configure(forge)
+            val negativeCoordinatesWireframe = forge.getForgery<MobileSegment.Wireframe>()
+                .copy(
+                    x = forge.aLong(min = -100, max = 0),
+                    y = forge.aLong(min = -100, max = 0),
+                    width = forge.aLong(min = 1, max = 100),
+                    height = forge.aLong(min = 1, max = 100),
+                    clip = forge.getForgery()
+                )
+            val positiveCoordinatesWireframe = forge.getForgery<MobileSegment.Wireframe>()
+                .copy(
+                    x = forge.aLong(min = 0, max = 100),
+                    y = forge.aLong(min = 0, max = 100),
+                    width = forge.aLong(min = 2, max = 100),
+                    height = forge.aLong(min = 2, max = 100),
+                    clip = forge.getForgery()
+                )
+            val negativeCoordinatesWireframeNoClip = forge.getForgery<MobileSegment.Wireframe>()
+                .copy(
+                    x = forge.aLong(min = -100, max = 0),
+                    y = forge.aLong(min = -100, max = 0),
+                    width = forge.aLong(min = 2, max = 100),
+                    height = forge.aLong(min = 2, max = 100),
+                    clip = null
+                )
+            val positiveCoordinatesWireframeNoClip = forge.getForgery<MobileSegment.Wireframe>()
+                .copy(
+                    x = forge.aLong(min = 0, max = 100),
+                    y = forge.aLong(min = 0, max = 100),
+                    width = forge.aLong(min = 2, max = 100),
+                    height = forge.aLong(min = 2, max = 100),
+                    clip = null
+                )
+            return listOf(
+                negativeCoordinatesWireframe,
+                positiveCoordinatesWireframe,
+                negativeCoordinatesWireframeNoClip,
+                positiveCoordinatesWireframeNoClip
+            )
+        }
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/ForgeExt.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/ForgeExt.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.recorder
 
 import android.view.View
 import android.view.ViewGroup
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
@@ -38,8 +39,7 @@ internal inline fun <reified T : View> Forge.aMockView(): T {
     return mock {
         val absX = anInt(min = 0)
         val absY = anInt(min = 0)
-        val locationInWindow = intArrayOf(absX, absY)
-        whenever(it.getLocationInWindow(locationInWindow)).then {
+        whenever(it.getLocationOnScreen(any())).thenAnswer {
             val location = (
                 it.arguments[0]
                     as IntArray

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/ViewUtilsTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/ViewUtilsTest.kt
@@ -1,0 +1,195 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.recorder
+
+import android.os.Build
+import android.view.View
+import android.view.ViewStub
+import androidx.annotation.RequiresApi
+import androidx.appcompat.widget.ActionBarContextView
+import androidx.appcompat.widget.Toolbar
+import com.datadog.android.sessionreplay.utils.ForgeConfigurator
+import com.datadog.tools.unit.annotations.TestTargetApi
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class ViewUtilsTest {
+
+    lateinit var testedViewUtils: ViewUtils
+
+    @BeforeEach
+    fun `set up`() {
+        testedViewUtils = ViewUtils()
+    }
+
+    // region Visibility
+
+    @Test
+    fun `M return true W checkIfNotVisible(view isShown false)`(forge: Forge) {
+        // Given
+        val mockView = forge.aMockView<View>().apply {
+            whenever(this.isShown).thenReturn(false)
+        }
+
+        // When
+        assertThat(testedViewUtils.checkIfNotVisible(mockView)).isTrue
+    }
+
+    @Test
+    fun `M return true W checkIfNotVisible(view width is 0)`(forge: Forge) {
+        // Given
+        val mockView = forge.aMockView<View>().apply {
+            whenever(this.width).thenReturn(0)
+        }
+
+        // When
+        assertThat(testedViewUtils.checkIfNotVisible(mockView)).isTrue
+    }
+
+    @Test
+    fun `M return true W checkIfNotVisible(view height is 0)`(forge: Forge) {
+        // Given
+        val mockView: View = forge.aMockView<View>().apply {
+            whenever(this.height).thenReturn(0)
+        }
+
+        // When
+        assertThat(testedViewUtils.checkIfNotVisible(mockView)).isTrue
+    }
+
+    @Test
+    fun `M return false W checkIfNotVisible(view is visible)`(forge: Forge) {
+        // Given
+        val mockView = forge.aMockView<View>().apply {
+            whenever(this.isShown).thenReturn(true)
+        }
+
+        // When
+        assertThat(testedViewUtils.checkIfNotVisible(mockView)).isFalse
+    }
+
+    // endregion
+
+    // region System Noise
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    fun `M return true W checkIfSystemNoise(){view the navigationBarBackground }`(forge: Forge) {
+        // Given
+        val mockView = forge
+            .aMockView<View>()
+            .apply {
+                whenever(this.id).thenReturn(android.R.id.navigationBarBackground)
+            }
+
+        // Then
+        assertThat(testedViewUtils.checkIfSystemNoise(mockView)).isTrue
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    fun `M return true W checkIfSystemNoise(){view is statusBarBackground }`(forge: Forge) {
+        // Given
+        val mockView = forge
+            .aMockView<View>()
+            .apply {
+                whenever(this.id).thenReturn(android.R.id.statusBarBackground)
+            }
+
+        // Then
+        assertThat(testedViewUtils.checkIfSystemNoise(mockView)).isTrue
+    }
+
+    @Test
+    fun `M return true W checkIfSystemNoise(){view is ViewStub }`() {
+        // Given
+        val mockView: ViewStub = mock()
+
+        // Then
+        assertThat(testedViewUtils.checkIfSystemNoise(mockView)).isTrue
+    }
+
+    @Test
+    fun `M return true W checkIfSystemNoise(){view is ActionBarContextView }`() {
+        // Given
+        val mockView: ActionBarContextView = mock()
+
+        // Then
+        assertThat(testedViewUtils.checkIfSystemNoise(mockView)).isTrue
+    }
+
+    @Test
+    fun `M return false W checkIfSystemNoise(){view is not system noise }`(forge: Forge) {
+        // Given
+        val mockView = forge.aMockView<View>()
+
+        // Then
+        assertThat(testedViewUtils.checkIfSystemNoise(mockView)).isFalse
+    }
+
+    // endregion
+
+    // region Toolbar
+
+    @Test
+    fun `M return true W checkIsToolbar(){view androidx Toolbar }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockToolBar: Toolbar = forge.aMockView<Toolbar>().apply {
+            whenever(this.id).thenReturn(androidx.appcompat.R.id.action_bar)
+        }
+
+        // Then
+        assertThat(testedViewUtils.checkIsToolbar(mockToolBar)).isTrue
+    }
+
+    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
+    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
+    @Test
+    fun `M return true W checkIsToolbar(){view android Toolbar }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockToolBar: android.widget.Toolbar = forge.aMockView()
+
+        // Then
+        assertThat(testedViewUtils.checkIsToolbar(mockToolBar)).isTrue
+    }
+
+    @Test
+    fun `M return false W checkIsToolbar(){view is not toolbar }`(forge: Forge) {
+        // Given
+        val mockView = forge.aMockView<View>()
+
+        // Then
+        assertThat(testedViewUtils.checkIsToolbar(mockView)).isFalse
+    }
+
+    // endregion
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseWireframeMapperTest.kt
@@ -26,7 +26,7 @@ internal abstract class BaseWireframeMapperTest {
 
     protected fun View.toShapeWireframe(): MobileSegment.Wireframe.ShapeWireframe {
         val coordinates = IntArray(2)
-        this.getLocationInWindow(coordinates)
+        this.getLocationOnScreen(coordinates)
         val x = coordinates[0].densityNormalized(fakePixelDensity).toLong()
         val y = coordinates[1].densityNormalized(fakePixelDensity).toLong()
         return MobileSegment.Wireframe.ShapeWireframe(
@@ -40,7 +40,7 @@ internal abstract class BaseWireframeMapperTest {
 
     protected fun TextView.toTextWireframe(): MobileSegment.Wireframe.TextWireframe {
         val coordinates = IntArray(2)
-        this.getLocationInWindow(coordinates)
+        this.getLocationOnScreen(coordinates)
         val x = coordinates[0].densityNormalized(fakePixelDensity).toLong()
         val y = coordinates[1].densityNormalized(fakePixelDensity).toLong()
         return MobileSegment.Wireframe.TextWireframe(

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/ForgeConfigurator.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/ForgeConfigurator.kt
@@ -30,5 +30,6 @@ internal class ForgeConfigurator : BaseConfigurator() {
         forge.addFactory(MetaRecordForgeryFactory())
         forge.addFactory(ViewEndRecordForgeryFactory())
         forge.addFactory(EnrichedRecordForgeryFactory())
+        forge.addFactory(WireframeClipForgeryFactory())
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/NodeForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/NodeForgeryFactory.kt
@@ -13,6 +13,15 @@ import fr.xgouchet.elmyr.ForgeryFactory
 internal class NodeForgeryFactory : ForgeryFactory<Node> {
 
     override fun getForgery(forge: Forge): Node {
-        return Node(wireframes = forge.aList(forge.anInt(min = 2, max = 10)) { forge.getForgery() })
+        return Node(
+            wireframe = forge.getForgery(),
+            children = forge.aList {
+                Node(
+                    wireframe = getForgery(),
+                    parents = aList { getForgery() }
+                )
+            },
+            parents = forge.aList { getForgery() }
+        )
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/ShapeWireframeForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/ShapeWireframeForgeryFactory.kt
@@ -33,6 +33,9 @@ internal class ShapeWireframeForgeryFactory :
                     forge.aStringMatching("#[0-9A-F]{6}FF"),
                     forge.aPositiveLong(strict = true)
                 )
+            },
+            clip = forge.aNullable {
+                getForgery()
             }
         )
     }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/ShapeWireframeMutationForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/ShapeWireframeMutationForgeryFactory.kt
@@ -34,6 +34,9 @@ internal class ShapeWireframeMutationForgeryFactory :
                     forge.aStringMatching("#[0-9A-F]{6}FF"),
                     forge.aPositiveLong(strict = true)
                 )
+            },
+            clip = forge.aNullable {
+                getForgery()
             }
         )
     }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/TextWireframeForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/TextWireframeForgeryFactory.kt
@@ -53,6 +53,9 @@ internal class TextWireframeForgeryFactory :
                         )
                     }
                 )
+            },
+            clip = forge.aNullable {
+                getForgery()
             }
         )
     }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/TextWireframeMutationForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/TextWireframeMutationForgeryFactory.kt
@@ -56,6 +56,9 @@ internal class TextWireframeMutationForgeryFactory :
                         )
                     }
                 )
+            },
+            clip = forge.aNullable {
+                getForgery()
             }
         )
     }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/WireframeClipForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/WireframeClipForgeryFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.utils
+
+import com.datadog.android.sessionreplay.model.MobileSegment
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class WireframeClipForgeryFactory :
+    ForgeryFactory<MobileSegment.WireframeClip> {
+    override fun getForgery(forge: Forge): MobileSegment.WireframeClip {
+        return MobileSegment.WireframeClip(
+            top = forge.aNullable { aLong(min = 0, max = 100) },
+            bottom = forge.aNullable { aLong(min = 0, max = 100) },
+            left = forge.aNullable { aLong(min = 0, max = 100) },
+            right = forge.aNullable { aLong(min = 0, max = 100) }
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

In this PR we are introducing the capability of the SR recorder to add the clipping property to each `Wireframe` whenever it is outside of any of its parents bounds. The following updates where added:

- the `WireframeClip` optional property was added into the `Wireframe` and `WireframeUpdate` SR schemas
- SR recorder keeps track of all the parents when resolving an element in the tree to a `Node`
- when processing the tree of `Nodes` into a `List<Wireframe>` we keep track of the parents for each of the `Wireframe` and we are computing the `WireframeClip` property. This will solve also the issue when a `Wireframe` is rendered inside a `ScrollableList`
- when excluding the completely overlayed `Wireframe` we take into account also the `clipping` dimensions 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

