### PR TITLE
RUMM-2689 SR Flush buffered motion event positions periodically

### DIFF
--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/RecorderWindowCallbackTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/RecorderWindowCallbackTest.kt
@@ -13,10 +13,12 @@ import com.datadog.android.sessionreplay.processor.Processor
 import com.datadog.android.sessionreplay.utils.ForgeConfigurator
 import com.datadog.android.sessionreplay.utils.TimeProvider
 import com.datadog.tools.unit.forge.aThrowable
+import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
@@ -72,7 +74,9 @@ internal class RecorderWindowCallbackTest {
             fakeDensity.toFloat(),
             mockWrappedCallback,
             mockTimeProvider,
-            copyEvent = { it }
+            copyEvent = { it },
+            TEST_MOTION_UPDATE_DELAY_THRESHOLD_NS,
+            TEST_FLUSH_BUFFER_THRESHOLD_NS
         )
     }
 
@@ -163,41 +167,173 @@ internal class RecorderWindowCallbackTest {
     }
 
     @Test
-    fun `M update the positions W onTouchEvent() { ActionMove }`(forge: Forge) {
-        // Given
-        val fakePositions = forge.positions()
-        val relatedMotionEvent = fakePositions.asMotionEvent(MotionEvent.ACTION_MOVE)
-
-        // When
-        testedWindowCallback.dispatchTouchEvent(relatedMotionEvent)
-
-        // Then
-        assertThat(testedWindowCallback.positions).isEqualTo(fakePositions)
-    }
-
-    @Test
-    fun `M debounce the positions update W onTouchEvent() { multiple ActionMove }`(forge: Forge) {
+    fun `M debounce the positions update W onTouchEvent() {one gesture cycle}`(forge: Forge) {
         // Given
         val fakeEvent1Positions = forge.positions()
-        val relatedMotionEvent1 = fakeEvent1Positions.asMotionEvent(MotionEvent.ACTION_MOVE)
+        val relatedMotionEvent1 = fakeEvent1Positions.asMotionEvent(MotionEvent.ACTION_DOWN)
         val fakeEvent2Positions = forge.positions()
         val relatedMotionEvent2 = fakeEvent2Positions.asMotionEvent(MotionEvent.ACTION_MOVE)
         val fakeEvent3Positions = forge.positions()
         val relatedMotionEvent3 = fakeEvent3Positions.asMotionEvent(MotionEvent.ACTION_MOVE)
+        val fakeEvent4Positions = forge.positions()
+        val relatedMotionEvent4 = fakeEvent4Positions.asMotionEvent(MotionEvent.ACTION_MOVE)
+        val fakeEvent5Positions = forge.positions()
+        val relatedMotionEvent5 = fakeEvent5Positions.asMotionEvent(MotionEvent.ACTION_UP)
 
         // When
         testedWindowCallback.dispatchTouchEvent(relatedMotionEvent1)
-        // must skip 2 as the motion update delay was not reached
         testedWindowCallback.dispatchTouchEvent(relatedMotionEvent2)
+        // must skip 3 as the motion update delay was not reached
+        testedWindowCallback.dispatchTouchEvent(relatedMotionEvent3)
         Thread.sleep(
             TimeUnit.NANOSECONDS
-                .toMillis(RecorderWindowCallback.MOTION_UPDATE_DELAY_NS)
+                .toMillis(TEST_MOTION_UPDATE_DELAY_THRESHOLD_NS)
         )
-        testedWindowCallback.dispatchTouchEvent(relatedMotionEvent3)
+        testedWindowCallback.dispatchTouchEvent(relatedMotionEvent4)
+
+        testedWindowCallback.dispatchTouchEvent(relatedMotionEvent5)
 
         // Then
-        assertThat(testedWindowCallback.positions)
-            .isEqualTo(fakeEvent1Positions + fakeEvent3Positions)
+        verify(mockProcessor).process(
+            MobileSegment.MobileIncrementalData.TouchData(
+                fakeEvent1Positions +
+                    fakeEvent2Positions +
+                    fakeEvent4Positions +
+                    fakeEvent5Positions
+            )
+        )
+    }
+
+    @Test
+    fun `M perform intermediary flush W onTouchEvent() {one long gesture cycle}`(forge: Forge) {
+        // Given
+        val fakeDownEventPositions = forge.positions()
+        val fakeDownEvent = fakeDownEventPositions.asMotionEvent(MotionEvent.ACTION_DOWN)
+        val fakeMovePositionsBeforeFlush = forge.aList(size = forge.anInt(min = 1, max = 5)) {
+            positions()
+        }
+        val fakeMoveEventsBeforeFlush = fakeMovePositionsBeforeFlush
+            .map { it.asMotionEvent(MotionEvent.ACTION_MOVE) }
+        val fakeMovePositionsAfterFlush = forge.aList(size = forge.anInt(min = 1, max = 5)) {
+            positions()
+        }
+        val fakeMoveEventsAfterFlush = fakeMovePositionsAfterFlush
+            .map { it.asMotionEvent(MotionEvent.ACTION_MOVE) }
+        val fakeUpEventPositions = forge.positions()
+        val fakeUpEvent = fakeUpEventPositions.asMotionEvent(MotionEvent.ACTION_UP)
+        val expectedTouchData1 = MobileSegment.MobileIncrementalData.TouchData(
+            fakeDownEventPositions +
+                fakeMovePositionsBeforeFlush.flatten()
+        )
+        val expectedTouchData2 = MobileSegment.MobileIncrementalData.TouchData(
+            fakeMovePositionsAfterFlush.flatten() +
+                fakeUpEventPositions
+        )
+
+        // When
+        testedWindowCallback.dispatchTouchEvent(fakeDownEvent)
+
+        fakeMoveEventsBeforeFlush.forEachIndexed { index, event ->
+            if (index == fakeMoveEventsBeforeFlush.size - 1) {
+                Thread.sleep(TimeUnit.NANOSECONDS.toMillis(TEST_FLUSH_BUFFER_THRESHOLD_NS))
+            } else {
+                Thread.sleep(TimeUnit.NANOSECONDS.toMillis(TEST_MOTION_UPDATE_DELAY_THRESHOLD_NS))
+            }
+            testedWindowCallback.dispatchTouchEvent(event)
+        }
+        fakeMoveEventsAfterFlush.forEach {
+            Thread.sleep(TimeUnit.NANOSECONDS.toMillis(TEST_MOTION_UPDATE_DELAY_THRESHOLD_NS))
+            testedWindowCallback.dispatchTouchEvent(it)
+        }
+
+        testedWindowCallback.dispatchTouchEvent(fakeUpEvent)
+
+        // Then
+        val argumentCaptor = argumentCaptor<MobileSegment.MobileIncrementalData.TouchData>()
+        verify(mockProcessor, times(2)).process(argumentCaptor.capture())
+        assertThat(argumentCaptor.firstValue).isEqualTo(expectedTouchData1)
+        assertThat(argumentCaptor.lastValue).isEqualTo(expectedTouchData2)
+    }
+
+    @Test
+    fun `M always collect the first move event after down W onTouchEvent()`(forge: Forge) {
+        // Given
+        val fakeGesture1DownPositions = forge.positions()
+        val fakeGesture1DownEvent = fakeGesture1DownPositions.asMotionEvent(MotionEvent.ACTION_DOWN)
+        val fakeGesture1MovePositions = forge.positions()
+        val fakeGesture1MoveEvent = fakeGesture1MovePositions.asMotionEvent(MotionEvent.ACTION_MOVE)
+        val fakeGesture1UpPositions = forge.positions()
+        val fakeGesture1UpEvent = fakeGesture1UpPositions.asMotionEvent(MotionEvent.ACTION_UP)
+
+        val fakeGesture2DownPositions = forge.positions()
+        val fakeGesture2DownEvent = fakeGesture2DownPositions.asMotionEvent(MotionEvent.ACTION_DOWN)
+        val fakeGesture2MovePositions = forge.positions()
+        val fakeGesture2MoveEvent = fakeGesture2MovePositions.asMotionEvent(MotionEvent.ACTION_MOVE)
+        val fakeGesture2UpPositions = forge.positions()
+        val fakeGesture2UpEvent = fakeGesture2UpPositions.asMotionEvent(MotionEvent.ACTION_UP)
+
+        val expectedTouchData1 = MobileSegment.MobileIncrementalData.TouchData(
+            fakeGesture1DownPositions +
+                fakeGesture1MovePositions +
+                fakeGesture1UpPositions
+        )
+
+        val expectedTouchData2 = MobileSegment.MobileIncrementalData.TouchData(
+            fakeGesture2DownPositions +
+                fakeGesture2MovePositions +
+                fakeGesture2UpPositions
+        )
+
+        // When
+        testedWindowCallback.dispatchTouchEvent(fakeGesture1DownEvent)
+        testedWindowCallback.dispatchTouchEvent(fakeGesture1MoveEvent)
+        testedWindowCallback.dispatchTouchEvent(fakeGesture1UpEvent)
+        testedWindowCallback.dispatchTouchEvent(fakeGesture2DownEvent)
+        testedWindowCallback.dispatchTouchEvent(fakeGesture2MoveEvent)
+        testedWindowCallback.dispatchTouchEvent(fakeGesture2UpEvent)
+
+        // Then
+        val argumentCaptor = argumentCaptor<MobileSegment.MobileIncrementalData.TouchData>()
+        verify(mockProcessor, times(2)).process(argumentCaptor.capture())
+        assertThat(argumentCaptor.firstValue).isEqualTo(expectedTouchData1)
+        assertThat(argumentCaptor.lastValue).isEqualTo(expectedTouchData2)
+    }
+
+    @Test
+    fun `M flush the intermediary positions W onTouchEvent() {move event longer than threshold}`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeDownPositions = forge.positions()
+        val fakeDownEvent = fakeDownPositions.asMotionEvent(MotionEvent.ACTION_DOWN)
+        val fakeEvent1MovePositions = forge.positions()
+        val fakeMotion1Event = fakeEvent1MovePositions.asMotionEvent(MotionEvent.ACTION_MOVE)
+        val fakeEvent2MovePositions = forge.positions()
+        val fakeMotion2Event = fakeEvent2MovePositions.asMotionEvent(MotionEvent.ACTION_MOVE)
+
+        val expectedTouchData1 = MobileSegment.MobileIncrementalData.TouchData(
+            fakeDownPositions +
+                fakeEvent1MovePositions
+        )
+        val expectedTouchData2 = MobileSegment.MobileIncrementalData.TouchData(fakeEvent2MovePositions)
+
+        // When
+        testedWindowCallback.dispatchTouchEvent(fakeDownEvent)
+        Thread.sleep(
+            TimeUnit.NANOSECONDS.toMillis(TEST_FLUSH_BUFFER_THRESHOLD_NS)
+        )
+        testedWindowCallback.dispatchTouchEvent(fakeMotion1Event)
+        Thread.sleep(
+            TimeUnit.NANOSECONDS
+                .toMillis(TEST_FLUSH_BUFFER_THRESHOLD_NS)
+        )
+        testedWindowCallback.dispatchTouchEvent(fakeMotion2Event)
+
+        // Then
+        val argumentCaptor = argumentCaptor<MobileSegment.MobileIncrementalData.TouchData>()
+        verify(mockProcessor, times(2)).process(argumentCaptor.capture())
+        assertThat(argumentCaptor.firstValue).isEqualTo(expectedTouchData1)
+        assertThat(argumentCaptor.lastValue).isEqualTo(expectedTouchData2)
     }
 
     @Test
@@ -269,5 +405,12 @@ internal class RecorderWindowCallbackTest {
 
     companion object {
         private val FLOAT_MAX_INT_VALUE = Math.pow(2.0, 23.0).toFloat()
+
+        // We need to test with higher threshold values in order to avoid flakiness
+        private val TEST_MOTION_UPDATE_DELAY_THRESHOLD_NS: Long =
+            TimeUnit.MILLISECONDS.toNanos(100)
+
+        private val TEST_FLUSH_BUFFER_THRESHOLD_NS: Long =
+            TEST_MOTION_UPDATE_DELAY_THRESHOLD_NS * 10
     }
 }


### PR DESCRIPTION
### What does this PR do?

Before for each intercepted gesture in SR we were buffering all the gesture `MotionEvents` as `TouchData.Position` from the moment we received the `MotionEvent.ACTION_DOWN` until the moment we received the `MotionEvent.ACTION_UP`. 
If the gesture was long enough this approach could create some glitches in the player (if you have a fragments view pager the gesture could start playing after half of the new fragment became visible already). In order to avoid this we will flush the buffer every 160 ms, equivalent to 16 frames. This is a heuristically determined value and probably we will adjust it during dogfooding.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

