### PR TITLE
RUMM-2693 Increase the screen snapshot frequency

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/RecorderOnDrawListener.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/RecorderOnDrawListener.kt
@@ -56,6 +56,6 @@ internal class RecorderOnDrawListener(
     }
 
     companion object {
-        const val DEBOUNCE_DURATION_IN_MILLIS: Long = 16
+        const val DEBOUNCE_DURATION_IN_MILLIS: Long = 4
     }
 }


### PR DESCRIPTION
### What does this PR do?

When replaying scrolling effects the 16ms delay was too big as it could indefinitely postpone a snapshot during a continuous scrolling. We are currently lowering that to 4ms and based on the tests everything looks fine. During dogfooding we might need to adjust this value again or maybe just remove it but for performance reasons we will keep it for now.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

