### PR TITLE
Remove Flutter from Dogfooding scripts

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -414,18 +414,6 @@ notify:dogfood-bridge:
     - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_token --with-decryption --query "Parameter.Value" --out text >> ./gh_token
     - python3 dogfood.py -v $CI_COMMIT_TAG -t bridge
 
-notify:dogfood-flutter:
-  tags: [ "runner:main" ]
-  only:
-    - tags
-  image: $CI_IMAGE_DOCKER
-  stage: notify
-  when: on_success
-  script:
-    - pip3 install GitPython requests
-    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gh_token --with-decryption --query "Parameter.Value" --out text >> ./gh_token
-    - python3 dogfood.py -v $CI_COMMIT_TAG -t flutter
-
 notify:dogfood-gradle-plugin:
   tags: [ "runner:main" ]
   only:

--- a/dogfood.py
+++ b/dogfood.py
@@ -21,18 +21,13 @@ TARGET_APP = "app"
 TARGET_DEMO = "demo"
 TARGET_BRIDGE = "bridge"
 TARGET_GRADLE_PLUGIN = "gradle-plugin"
-TARGET_FLUTTER = "flutter"
 
 REPOSITORIES = {
     TARGET_APP: "datadog-android",
     TARGET_DEMO: "shopist-android",
     TARGET_BRIDGE: "dd-bridge-android",
     TARGET_GRADLE_PLUGIN: "dd-sdk-android-gradle-plugin",
-    TARGET_FLUTTER: "dd-sdk-flutter"
-}
-
-DOC_FILE_PATH = {
-    TARGET_FLUTTER: os.path.join("packages", "datadog_flutter_plugin", "README.md")
+    # Flutter is not needed because it pulls updates instead of being pushed them with the dogfood script.
 }
 
 FILE_PATH = {
@@ -40,7 +35,6 @@ FILE_PATH = {
     TARGET_DEMO: os.path.join("gradle", "libs.versions.toml"),
     TARGET_BRIDGE: os.path.join("gradle", "libs.versions.toml"),
     TARGET_GRADLE_PLUGIN: os.path.join("gradle", "libs.versions.toml"),
-    TARGET_FLUTTER: os.path.join("packages", "datadog_flutter_plugin", "android", "build.gradle")
 }
 
 PREFIX = {
@@ -48,7 +42,6 @@ PREFIX = {
     TARGET_DEMO: "datadogSdk",
     TARGET_BRIDGE: "datadogSdk",
     TARGET_GRADLE_PLUGIN: "datadogSdk",
-    TARGET_FLUTTER: "ext.datadog_sdk_version"
 }
 
 
@@ -57,7 +50,7 @@ def parse_arguments(args: list) -> Namespace:
 
     parser.add_argument("-v", "--version", required=True, help="the version of the SDK")
     parser.add_argument("-t", "--target", required=True,
-                        choices=[TARGET_APP, TARGET_DEMO, TARGET_BRIDGE, TARGET_GRADLE_PLUGIN, TARGET_FLUTTER],
+                        choices=[TARGET_APP, TARGET_DEMO, TARGET_BRIDGE, TARGET_GRADLE_PLUGIN],
                         help="the target repository")
     parser.add_argument("-d", "--dry-run", required=False, dest="dry_run",
                         help="Don't push changes or create a PR.", action="store_true")
@@ -86,38 +79,6 @@ def github_create_pr(repository: str, branch_name: str, base_name: str, version:
     else:
         print("pull request failed " + str(response.status_code) + '\n' + response.text)
         return 1
-
-def update_version_table(target: str, temp_dir_path: str, version: str):
-    if not target in DOC_FILE_PATH:
-        return
-    
-    doc_path = DOC_FILE_PATH[target]
-
-    print("Updating documentation with version " + version)
-    target_file = os.path.join(temp_dir_path, doc_path)
-    with open(target_file, 'r+', encoding="utf-8") as readme:
-        lines = readme.readlines()
-        in_table = False
-        android_sdk_column = None
-        for idx, line in enumerate(lines):
-            if in_table:
-                if line.startswith('[//]: #'):
-                    # All done
-                    break
-                elif line.startswith('|'):
-                    columns = list(filter(None, map(str.strip, line.split('|'))))
-                    if 'Android SDK' in columns:
-                        android_sdk_column = columns.index('Android SDK')
-                    elif ':-' in columns[0]:
-                        continue
-                    elif android_sdk_column is not None:
-                        columns[android_sdk_column] = version
-                        lines[idx] = '| ' + ' | '.join(columns) + ' |\n'
-            elif line.startswith('[//]: # (SDK Table)'):
-                in_table = True
-
-        readme.seek(0)
-        readme.write(''.join(lines))
 
 def generate_target_code(target: str, temp_dir_path: str, version: str):
     print("Generating code with version " + version)


### PR DESCRIPTION
### What does this PR do?

Removes all dogfooding steps that push new versions to the Flutter repo.

### Motivation

Flutter is now developing off source and will "pull" new versions when it deploys. This removes the Android step of "pushing" the new releases as that is no longer necessary

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

