### PR TITLE
RUMM-2685 Start/Stop Session recording based on the RUM session state

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -93,7 +93,7 @@ data class com.datadog.android.core.configuration.Configuration
     fun useCustomTracesEndpoint(String): Builder
     fun useCustomCrashReportsEndpoint(String): Builder
     fun useCustomRumEndpoint(String): Builder
-    fun useSessionReplayEndpoint(String): Builder
+    fun useCustomSessionReplayEndpoint(String): Builder
     fun trackInteractions(Array<com.datadog.android.rum.tracking.ViewAttributesProvider> = emptyArray(), com.datadog.android.rum.tracking.InteractionPredicate = NoOpInteractionPredicate()): Builder
     fun disableInteractionTracking(): Builder
     fun trackLongTasks(Long = DEFAULT_LONG_TASK_THRESHOLD_MS): Builder

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -278,7 +278,7 @@ internal constructor(
         /**
          * Let the SDK target a custom server for the Session Replay feature.
          */
-        fun useSessionReplayEndpoint(endpoint: String): Builder {
+        fun useCustomSessionReplayEndpoint(endpoint: String): Builder {
             applyIfFeatureEnabled(
                 PluginFeature.SESSION_REPLAY,
                 "useCustomSessionReplayEndpoint"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -27,7 +27,7 @@ import java.util.concurrent.atomic.AtomicLong
 @Suppress("LongParameterList")
 internal class RumSessionScope(
     private val parentScope: RumScope,
-    sdkCore: SdkCore,
+    private val sdkCore: SdkCore,
     internal val samplingRate: Float,
     internal val backgroundTrackingEnabled: Boolean,
     internal val trackFrustrations: Boolean,
@@ -149,12 +149,22 @@ internal class RumSessionScope(
         sessionId = UUID.randomUUID().toString()
         sessionStartNs.set(nanoTime)
         sessionListener?.onSessionStarted(sessionId, !keepSession)
+        sdkCore.getFeature(SESSION_REPLAY_FEATURE_NAME)?.sendEvent(
+            mapOf(
+                SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RUM_KEEP_SESSION_BUS_MESSAGE_KEY to keepSession
+            )
+        )
     }
 
     // endregion
 
     companion object {
 
+        internal const val SESSION_REPLAY_FEATURE_NAME = "session-replay"
+        internal const val SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY = "type"
+        internal const val RUM_SESSION_RENEWED_BUS_MESSAGE = "rum_session_renewed"
+        internal const val RUM_KEEP_SESSION_BUS_MESSAGE_KEY = "keepSession"
         internal val DEFAULT_SESSION_INACTIVITY_NS = TimeUnit.MINUTES.toNanos(15)
         internal val DEFAULT_SESSION_MAX_DURATION_NS = TimeUnit.HOURS.toNanos(4)
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -634,7 +634,7 @@ internal open class RumViewScope(
         val memoryInfo = lastMemoryInfo
         val refreshRateInfo = lastFrameRateInfo
         val isSlowRendered = resolveRefreshRateInfo(refreshRateInfo)
-
+        val documentVersion = version
         sdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)
             ?.withWriteContext { datadogContext, eventBatchWriter ->
 
@@ -700,7 +700,7 @@ internal open class RumViewScope(
                     ),
                     context = ViewEvent.Context(additionalProperties = attributes),
                     dd = ViewEvent.Dd(
-                        documentVersion = version,
+                        documentVersion = documentVersion,
                         session = ViewEvent.DdSession(plan = ViewEvent.Plan.PLAN_1)
                     )
                 )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -323,7 +323,7 @@ internal class ConfigurationBuilderTest {
             .useCustomTracesEndpoint(tracesUrl)
             .useCustomCrashReportsEndpoint(crashReportsUrl)
             .useCustomRumEndpoint(rumUrl)
-            .useSessionReplayEndpoint(sessionReplayUrl)
+            .useCustomSessionReplayEndpoint(sessionReplayUrl)
             .build()
 
         // Then
@@ -365,7 +365,7 @@ internal class ConfigurationBuilderTest {
             .useCustomTracesEndpoint(tracesUrl)
             .useCustomCrashReportsEndpoint(crashReportsUrl)
             .useCustomRumEndpoint(rumUrl)
-            .useSessionReplayEndpoint(sessionReplayUrl)
+            .useCustomSessionReplayEndpoint(sessionReplayUrl)
             .build()
 
         // Then

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.rum.internal.domain.event.RumEventSourceProvider
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.FeatureScope
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.core.internal.ContextProvider
 import com.datadog.android.v2.core.internal.storage.DataWriter
@@ -22,11 +23,14 @@ import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.isA
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.same
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
@@ -108,12 +112,17 @@ internal class RumSessionScopeTest {
 
     lateinit var fakeInitialViewEvent: RumRawEvent
 
+    @Mock
+    lateinit var mockSessionReplayFeatureScope: FeatureScope
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeInitialViewEvent = forge.startViewEvent()
 
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
+        whenever(mockSdkCore.getFeature(RumSessionScope.SESSION_REPLAY_FEATURE_NAME)) doReturn
+            mockSessionReplayFeatureScope
 
         initializeTestedScope()
     }
@@ -739,6 +748,214 @@ internal class RumSessionScopeTest {
             .isNotEqualTo(initialContext.sessionId)
         verify(mockSessionListener).onSessionStarted(initialContext.sessionId, true)
         verify(mockSessionListener).onSessionStarted(context.sessionId, true)
+    }
+
+    // endregion
+
+    // region Session Replay Event Bus
+
+    @Test
+    fun `𝕄 notify Session Replay feature 𝕎 session is updated {tracked, timed out}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // When
+        Thread.sleep(TEST_MAX_DURATION_MS)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // Then
+        val argumentCaptor = argumentCaptor<Any>()
+        verify(mockSessionReplayFeatureScope, times(2))
+            .sendEvent(argumentCaptor.capture())
+        assertThat(argumentCaptor.firstValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to true
+            )
+        )
+        assertThat(argumentCaptor.secondValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to true
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 notify Session Replay feature 𝕎 session is updated {tracked, expired}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // When
+        Thread.sleep(TEST_INACTIVITY_MS)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // Then
+        val argumentCaptor = argumentCaptor<Any>()
+        verify(mockSessionReplayFeatureScope, times(2))
+            .sendEvent(argumentCaptor.capture())
+        assertThat(argumentCaptor.firstValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to true
+            )
+        )
+        assertThat(argumentCaptor.secondValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to true
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 notify Session Replay feature 𝕎 session is updated {tracked, manual reset}`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // When
+        testedScope.handleEvent(RumRawEvent.ResetSession(), mockWriter)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // Then
+        val argumentCaptor = argumentCaptor<Any>()
+        verify(mockSessionReplayFeatureScope, times(2))
+            .sendEvent(argumentCaptor.capture())
+        assertThat(argumentCaptor.firstValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to true
+            )
+        )
+        assertThat(argumentCaptor.secondValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to true
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 notify Session Replay feature 𝕎 session is updated {not tracked, timed out}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(0f)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // When
+        Thread.sleep(TEST_MAX_DURATION_MS)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // Then
+        val argumentCaptor = argumentCaptor<Any>()
+        verify(mockSessionReplayFeatureScope, times(2))
+            .sendEvent(argumentCaptor.capture())
+        assertThat(argumentCaptor.firstValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to false
+            )
+        )
+        assertThat(argumentCaptor.secondValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to false
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 notify Session Replay feature 𝕎 session is updated {not tracked, expired}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(0f)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // When
+        Thread.sleep(TEST_INACTIVITY_MS)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // Then
+        val argumentCaptor = argumentCaptor<Any>()
+        verify(mockSessionReplayFeatureScope, times(2))
+            .sendEvent(argumentCaptor.capture())
+        assertThat(argumentCaptor.firstValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to false
+            )
+        )
+        assertThat(argumentCaptor.secondValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to false
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 notify Session Replay feature 𝕎 session is updated {not tracked, manual reset}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(0f)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // When
+        testedScope.handleEvent(RumRawEvent.ResetSession(), mockWriter)
+        testedScope.handleEvent(forge.startViewEvent(), mockWriter)
+
+        // Then
+        val argumentCaptor = argumentCaptor<Any>()
+        verify(mockSessionReplayFeatureScope, times(2))
+            .sendEvent(argumentCaptor.capture())
+        assertThat(argumentCaptor.firstValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to false
+            )
+        )
+        assertThat(argumentCaptor.secondValue).isEqualTo(
+            mapOf(
+                RumSessionScope.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                    RumSessionScope.RUM_SESSION_RENEWED_BUS_MESSAGE,
+                RumSessionScope.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to false
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 session is updated {no SessionReplay feature registered}`(
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockSdkCore.getFeature(RumSessionScope.SESSION_REPLAY_FEATURE_NAME))
+            .thenReturn(null)
+
+        // When
+        initializeTestedScope(forge.aFloat())
+
+        // Then
+        verifyZeroInteractions(mockSessionReplayFeatureScope)
     }
 
     // endregion

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
@@ -64,7 +64,12 @@ internal open class MockServerActivityTestRule<T : Activity>(
         mockWebServer.setDispatcher(
             object : Dispatcher() {
                 override fun dispatch(request: RecordedRequest): MockResponse {
-                    if (keepRequests) {
+                    val requestUrl = request.requestUrl.toString()
+                    if (keepRequests &&
+                        !requestUrl.startsWith(RuntimeConfig.sessionReplayEndpointUrl)
+                    ) {
+                        // for now the SR requests will be dropped as we do not support them
+                        // in our integration tests
                         handleRequest(request)
                     } else {
                         Log.w(TAG, "Dropping @request:$request")
@@ -83,6 +88,7 @@ internal open class MockServerActivityTestRule<T : Activity>(
             RuntimeConfig.logsEndpointUrl = "$it/$LOGS_URL_SUFFIX"
             RuntimeConfig.tracesEndpointUrl = "$it/$TRACES_URL_SUFFIX"
             RuntimeConfig.rumEndpointUrl = "$it/$RUM_URL_SUFFIX"
+            RuntimeConfig.sessionReplayEndpointUrl = "$it/$SESSION_REPlAY_URL_SUFFIX"
         }
 
         super.beforeActivityLaunched()
@@ -191,6 +197,7 @@ internal open class MockServerActivityTestRule<T : Activity>(
         const val LOGS_URL_SUFFIX = "logs"
         const val TRACES_URL_SUFFIX = "traces"
         const val RUM_URL_SUFFIX = "rum"
+        const val SESSION_REPlAY_URL_SUFFIX = "session-replay"
         const val CONNECTION_ISSUE_PATH = "/connection-issue"
     }
 }

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
@@ -27,6 +27,7 @@ internal object RuntimeConfig {
     var logsEndpointUrl: String = LOCALHOST
     var tracesEndpointUrl: String = LOCALHOST
     var rumEndpointUrl: String = LOCALHOST
+    var sessionReplayEndpointUrl: String = LOCALHOST
 
     val LONG_TASK_LARGE_THRESHOLD = Long.MAX_VALUE
 
@@ -71,6 +72,7 @@ internal object RuntimeConfig {
             .useCustomLogsEndpoint(logsEndpointUrl)
             .useCustomRumEndpoint(rumEndpointUrl)
             .useCustomTracesEndpoint(tracesEndpointUrl)
+            .useCustomSessionReplayEndpoint(sessionReplayEndpointUrl)
             .setUploadFrequency(UploadFrequency.FREQUENT)
     }
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -203,7 +203,7 @@ class SampleApplication : Application() {
             configBuilder.useCustomRumEndpoint(BuildConfig.DD_OVERRIDE_RUM_URL)
         }
         if (BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL.isNotBlank()) {
-            configBuilder.useSessionReplayEndpoint(BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL)
+            configBuilder.useCustomSessionReplayEndpoint(BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL)
         }
         return configBuilder.build()
     }


### PR DESCRIPTION
### What does this PR do?

In this PR we are making sure that the Session recording is being stopped/resumed according with the RUM session state: tracked or not tracked.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

