### PR TITLE
Fix flaky ANR detection test

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
@@ -126,7 +126,9 @@ internal class ANRDetectorRunnableTest {
             reset(mockHandler)
 
             lastValue.run()
-            Thread.sleep(TEST_ANR_TEST_DELAY_MS)
+            // +10 is to remove flakiness, otherwise it seems current thread can resume execution
+            // before AND test thread
+            Thread.sleep(TEST_ANR_TEST_DELAY_MS + 10)
             verify(mockHandler).post(capture())
             lastValue.run()
         }


### PR DESCRIPTION
### What does this PR do?

This change fixes flaky test by adding a bit more delay for the main thread, because otherwise it seems it can continue the execution before the ANR detection thread (which is sleeping for the same amount of time [here](https://github.com/DataDog/dd-sdk-android/blob/8ba3c1fea0df6b8651bcd6de9ece9daed5151e22/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt#L56)).

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

