### PR TITLE
RUMM-2684: Observe uncaught exception in executors

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -44,6 +44,8 @@ import com.datadog.android.core.internal.system.NoOpAndroidInfoProvider
 import com.datadog.android.core.internal.system.NoOpAppVersionProvider
 import com.datadog.android.core.internal.system.NoOpSystemInfoProvider
 import com.datadog.android.core.internal.system.SystemInfoProvider
+import com.datadog.android.core.internal.thread.LoggingScheduledThreadPoolExecutor
+import com.datadog.android.core.internal.thread.LoggingThreadPoolExecutor
 import com.datadog.android.core.internal.time.KronosTimeProvider
 import com.datadog.android.core.internal.time.LoggingSyncListener
 import com.datadog.android.core.internal.time.NoOpTimeProvider
@@ -393,14 +395,16 @@ internal class CoreFeature {
 
     private fun setupExecutors() {
         @Suppress("UnsafeThirdPartyFunctionCall") // pool size can't be <= 0
-        uploadExecutorService = ScheduledThreadPoolExecutor(CORE_DEFAULT_POOL_SIZE)
+        uploadExecutorService =
+            LoggingScheduledThreadPoolExecutor(CORE_DEFAULT_POOL_SIZE, devLogger)
         @Suppress("UnsafeThirdPartyFunctionCall") // workQueue can't be null
-        persistenceExecutorService = ThreadPoolExecutor(
+        persistenceExecutorService = LoggingThreadPoolExecutor(
             CORE_DEFAULT_POOL_SIZE,
             Runtime.getRuntime().availableProcessors(),
             THREAD_POOL_MAX_KEEP_ALIVE_MS,
             TimeUnit.MILLISECONDS,
-            LinkedBlockingDeque()
+            LinkedBlockingDeque(),
+            devLogger
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -219,7 +219,7 @@ internal class SdkFeature(
         this.fileOrchestrator = fileOrchestrator
 
         return ConsentAwareStorage(
-            executor = coreFeature.persistenceExecutorService,
+            executorService = coreFeature.persistenceExecutorService,
             grantedOrchestrator = fileOrchestrator.grantedOrchestrator,
             pendingOrchestrator = fileOrchestrator.pendingOrchestrator,
             batchEventsReaderWriter = BatchFileReaderWriter.create(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/thread/LoggingScheduledThreadPoolExecutor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/thread/LoggingScheduledThreadPoolExecutor.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.thread
+
+import com.datadog.android.log.Logger
+import java.util.concurrent.ScheduledThreadPoolExecutor
+
+/**
+ * [ScheduledThreadPoolExecutor] with a [ScheduledThreadPoolExecutor.afterExecute] hook,
+ * which will log any unhandled exception raised.
+ */
+internal class LoggingScheduledThreadPoolExecutor(corePoolSize: Int, private val logger: Logger) :
+    ScheduledThreadPoolExecutor(corePoolSize) {
+    override fun afterExecute(r: Runnable?, t: Throwable?) {
+        @Suppress("UnsafeThirdPartyFunctionCall") // we just call super
+        super.afterExecute(r, t)
+        loggingAfterExecute(r, t, logger)
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/thread/LoggingThreadPoolExecutor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/thread/LoggingThreadPoolExecutor.kt
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.thread
+
+import com.datadog.android.log.Logger
+import java.util.concurrent.BlockingQueue
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+/**
+ * [ThreadPoolExecutor] with a [ThreadPoolExecutor.afterExecute] hook, which will log any unhandled
+ * exception raised.
+ */
+internal class LoggingThreadPoolExecutor(
+    corePoolSize: Int,
+    maximumPoolSize: Int,
+    keepAliveTime: Long,
+    unit: TimeUnit?,
+    workQueue: BlockingQueue<Runnable>?,
+    private val logger: Logger
+) : ThreadPoolExecutor(corePoolSize, maximumPoolSize, keepAliveTime, unit, workQueue) {
+
+    override fun afterExecute(r: Runnable?, t: Throwable?) {
+        @Suppress("UnsafeThirdPartyFunctionCall") // we just call super
+        super.afterExecute(r, t)
+        loggingAfterExecute(r, t, logger)
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/thread/ThreadExt.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/thread/ThreadExt.kt
@@ -7,6 +7,11 @@
 package com.datadog.android.core.internal.thread
 
 import com.datadog.android.core.internal.utils.sdkLogger
+import com.datadog.android.log.Logger
+import com.datadog.android.log.internal.utils.ERROR_WITH_TELEMETRY_LEVEL
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.Future
 
 /**
  * A utility method to perform a Thread.sleep() safely.
@@ -30,3 +35,38 @@ internal fun sleepSafe(durationMs: Long): Boolean {
         return false
     }
 }
+
+/**
+ * Logs any exception raised during the execution. Tested indirectly using
+ * the tests of [LoggingThreadPoolExecutor] and [LoggingScheduledThreadPoolExecutor].
+ */
+internal fun loggingAfterExecute(task: Runnable?, t: Throwable?, logger: Logger) {
+    var throwable = t
+    if (t == null && task is Future<*> && task.isDone) {
+        try {
+            task.get()
+        } catch (ce: CancellationException) {
+            throwable = ce
+        } catch (ee: ExecutionException) {
+            throwable = ee.cause
+        } catch (ie: InterruptedException) {
+            // ignore/reset
+            try {
+                Thread.currentThread().interrupt()
+            } catch (se: SecurityException) {
+                // this should not happen
+                sdkLogger.e("Thread was unable to set its own interrupted state", se)
+            }
+        }
+    }
+    if (throwable != null) {
+        logger.log(
+            ERROR_WITH_TELEMETRY_LEVEL,
+            ERROR_UNCAUGHT_EXECUTION_EXCEPTION,
+            throwable
+        )
+    }
+}
+
+internal const val ERROR_UNCAUGHT_EXECUTION_EXCEPTION =
+    "Uncaught exception during the task execution"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -16,6 +16,7 @@ import com.datadog.android.core.configuration.VitalsUpdateFrequency
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.event.NoOpEventMapper
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
+import com.datadog.android.core.internal.thread.LoggingScheduledThreadPoolExecutor
 import com.datadog.android.core.internal.thread.NoOpScheduledExecutorService
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.executeSafe
@@ -48,7 +49,6 @@ import com.datadog.android.v2.core.internal.storage.NoOpDataWriter
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.ScheduledExecutorService
-import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
@@ -186,7 +186,7 @@ internal class RumFeature(
 
     private fun initializeVitalReaders(periodInMs: Long) {
         @Suppress("UnsafeThirdPartyFunctionCall") // pool size can't be <= 0
-        vitalExecutorService = ScheduledThreadPoolExecutor(1)
+        vitalExecutorService = LoggingScheduledThreadPoolExecutor(1, devLogger)
 
         initializeVitalMonitor(CPUVitalReader(), cpuVitalMonitor, periodInMs)
         initializeVitalMonitor(MemoryVitalReader(), memoryVitalMonitor, periodInMs)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorage.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorage.kt
@@ -19,11 +19,11 @@ import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.api.context.DatadogContext
 import java.io.File
 import java.util.Locale
-import java.util.concurrent.Executor
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.RejectedExecutionException
 
 internal class ConsentAwareStorage(
-    private val executor: Executor,
+    private val executorService: ExecutorService,
     private val grantedOrchestrator: FileOrchestrator,
     private val pendingOrchestrator: FileOrchestrator,
     private val batchEventsReaderWriter: BatchFileReaderWriter,
@@ -52,7 +52,7 @@ internal class ConsentAwareStorage(
 
         try {
             @Suppress("UnsafeThirdPartyFunctionCall") // command is never null
-            executor.execute {
+            executorService.submit {
                 val batchFile = orchestrator?.getWritableFile()
                 val metadataFile = if (batchFile != null) {
                     orchestrator.getMetadataFile(batchFile)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/thread/AbstractLoggingExecutorServiceTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/thread/AbstractLoggingExecutorServiceTest.kt
@@ -1,0 +1,188 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.thread
+
+import com.datadog.android.log.Logger
+import com.datadog.android.log.internal.utils.ERROR_WITH_TELEMETRY_LEVEL
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.forge.aThrowable
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.isA
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ExecutorService
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal abstract class AbstractLoggingExecutorServiceTest<T : ExecutorService> {
+
+    lateinit var testedExecutor: T
+
+    @Mock
+    lateinit var mockLogger: Logger
+
+    @BeforeEach
+    fun `set up`() {
+        testedExecutor = createTestedExecutorService()
+    }
+
+    @AfterEach
+    fun `tear down`() {
+        testedExecutor.shutdownNow()
+    }
+
+    abstract fun createTestedExecutorService(): T
+
+    // region execute
+
+    @Test
+    fun `𝕄 log nothing 𝕎 execute() { task completes normally }`() {
+        // When
+        testedExecutor.execute {
+            // no-op
+        }
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        verifyZeroInteractions(mockLogger)
+    }
+
+    @Test
+    fun `𝕄 log nothing 𝕎 execute() { worker thread was interrupted }`() {
+        // When
+        testedExecutor.execute {
+            Thread.currentThread().interrupt()
+        }
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        verifyZeroInteractions(mockLogger)
+    }
+
+    @Test
+    fun `𝕄 log error + exception 𝕎 execute() { task throws an exception }`(
+        forge: Forge
+    ) {
+        // Given
+        val throwable = forge.aThrowable()
+
+        // When
+        testedExecutor.execute {
+            throw throwable
+        }
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        verify(mockLogger)
+            .log(
+                ERROR_WITH_TELEMETRY_LEVEL,
+                ERROR_UNCAUGHT_EXECUTION_EXCEPTION,
+                throwable
+            )
+    }
+
+    // endregion
+
+    // region submit
+
+    @Test
+    fun `𝕄 log nothing 𝕎 submit() { task completes normally }`() {
+        // When
+        val futureTask = testedExecutor.submit {
+            // no-op
+        }
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        assertThat(futureTask.isDone).isTrue
+
+        verifyZeroInteractions(mockLogger)
+    }
+
+    @Test
+    fun `𝕄 log nothing 𝕎 submit() { worker thread was interrupted }`() {
+        // When
+        val futureTask = testedExecutor.submit {
+            Thread.currentThread().interrupt()
+        }
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        assertThat(futureTask.isDone).isTrue
+
+        verifyZeroInteractions(mockLogger)
+    }
+
+    @Test
+    fun `𝕄 log error + exception 𝕎 submit() { task throws an exception }`(
+        forge: Forge
+    ) {
+        // Given
+        val throwable = forge.aThrowable()
+
+        // When
+        val futureTask = testedExecutor.submit {
+            throw throwable
+        }
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        assertThat(futureTask.isDone).isTrue
+
+        verify(mockLogger)
+            .log(
+                ERROR_WITH_TELEMETRY_LEVEL,
+                ERROR_UNCAUGHT_EXECUTION_EXCEPTION,
+                throwable
+            )
+    }
+
+    @Test
+    fun `𝕄 log error + exception 𝕎 submit() { task was cancelled }`() {
+        // When
+        val futureTask = testedExecutor.submit {
+            Thread.sleep(500)
+        }
+        futureTask.cancel(true)
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        assertThat(futureTask.isCancelled).isTrue
+
+        verify(mockLogger)
+            .log(
+                eq(ERROR_WITH_TELEMETRY_LEVEL),
+                eq(ERROR_UNCAUGHT_EXECUTION_EXCEPTION),
+                isA<CancellationException>(),
+                eq(emptyMap())
+            )
+    }
+
+    // endregion
+
+    companion object {
+        const val DEFAULT_SLEEP_DURATION_MS = 50L
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/thread/LoggingScheduledThreadPoolExecutorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/thread/LoggingScheduledThreadPoolExecutorTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.thread
+
+import com.datadog.android.log.internal.utils.ERROR_WITH_TELEMETRY_LEVEL
+import com.datadog.tools.unit.forge.aThrowable
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.isA
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import fr.xgouchet.elmyr.Forge
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import java.util.concurrent.CancellationException
+import java.util.concurrent.ScheduledThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+internal class LoggingScheduledThreadPoolExecutorTest :
+    AbstractLoggingExecutorServiceTest<ScheduledThreadPoolExecutor>() {
+
+    override fun createTestedExecutorService(): ScheduledThreadPoolExecutor {
+        return LoggingScheduledThreadPoolExecutor(1, mockLogger)
+    }
+
+    @Test
+    fun `𝕄 log nothing 𝕎 schedule() { task completes normally }`() {
+        // When
+        val futureTask = testedExecutor.schedule({
+            // no-op
+        }, 1, TimeUnit.MILLISECONDS)
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        assertThat(futureTask.isDone).isTrue
+
+        verifyZeroInteractions(mockLogger)
+    }
+
+    @Test
+    fun `𝕄 log nothing 𝕎 schedule() { worker thread was interrupted }`() {
+        // When
+        val futureTask = testedExecutor.submit {
+            Thread.currentThread().interrupt()
+        }
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        assertThat(futureTask.isDone).isTrue
+
+        verifyZeroInteractions(mockLogger)
+    }
+
+    @Test
+    fun `𝕄 log error + exception 𝕎 schedule() { task throws an exception }`(
+        forge: Forge
+    ) {
+        // Given
+        val throwable = forge.aThrowable()
+
+        // When
+        val futureTask = testedExecutor.schedule({
+            throw throwable
+        }, 1, TimeUnit.MILLISECONDS)
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        assertThat(futureTask.isDone).isTrue
+
+        verify(mockLogger)
+            .log(
+                ERROR_WITH_TELEMETRY_LEVEL,
+                ERROR_UNCAUGHT_EXECUTION_EXCEPTION,
+                throwable
+            )
+    }
+
+    @Test
+    fun `𝕄 log error + exception 𝕎 schedule() { task is cancelled }`() {
+        // When
+        val futureTask = testedExecutor.schedule({
+            Thread.sleep(500)
+        }, 1, TimeUnit.MILLISECONDS)
+        futureTask.cancel(true)
+        Thread.sleep(DEFAULT_SLEEP_DURATION_MS)
+
+        // Then
+        assertThat(futureTask.isCancelled).isTrue
+
+        verify(mockLogger)
+            .log(
+                eq(ERROR_WITH_TELEMETRY_LEVEL),
+                eq(ERROR_UNCAUGHT_EXECUTION_EXCEPTION),
+                isA<CancellationException>(),
+                eq(emptyMap())
+            )
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/thread/LoggingThreadPoolExecutorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/thread/LoggingThreadPoolExecutorTest.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.thread
+
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.TimeUnit
+
+internal class LoggingThreadPoolExecutorTest :
+    AbstractLoggingExecutorServiceTest<LoggingThreadPoolExecutor>() {
+    override fun createTestedExecutorService(): LoggingThreadPoolExecutor {
+        return LoggingThreadPoolExecutor(
+            corePoolSize = 1,
+            maximumPoolSize = 1,
+            keepAliveTime = 100,
+            TimeUnit.MILLISECONDS,
+            LinkedBlockingDeque(),
+            mockLogger
+        )
+    }
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -655,6 +655,7 @@ datadog:
       - "java.util.concurrent.ExecutorService.awaitTermination(kotlin.Long, java.util.concurrent.TimeUnit):java.lang.InterruptedException"
       - "java.util.concurrent.ExecutorService.execute(java.lang.Runnable):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
       - "java.util.concurrent.ExecutorService.submit(java.lang.Runnable):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
+      - "java.util.concurrent.Future.get():java.lang.InterruptedException,java.util.concurrent.CancellationException,java.util.concurrent.ExecutionException"
       - "java.util.concurrent.ScheduledExecutorService.schedule(java.lang.Runnable, kotlin.Long, java.util.concurrent.TimeUnit):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.constructor(kotlin.Int):java.lang.IllegalArgumentException"
       - "java.util.concurrent.ScheduledThreadPoolExecutor.awaitTermination(kotlin.Long, java.util.concurrent.TimeUnit):java.lang.InterruptedException"


### PR DESCRIPTION
### What does this PR do?

Turns out we were swallowing uncaught exceptions raised during the execution of the tasks submitted via `Executor#execute`, `ExecutorService#submit` or `ScheduledExecutorService#schedule` calls, because the behavior is like the following:

* If uncaught exception is raised for task submitted via `Executor#execute`, then worker thread is killed and exception is printed to the console.
* If uncaught exception is raised for task submitted via `ExecutorService#submit` or `ScheduledExecutorService#schedule`, then worker thread is kept running and exception is thrown on the thread is which doing `Future#get` call (normally the thread getting the result). We were always ignoring the `Future` returned after the task is submitted, so we were swallowing such exceptions.

This change closes this gap by adding the hook to the `ThreadPoolExecutor#afterExecute` method, which allows to observe such uncaught exceptions. `ThreadPoolExecutor#afterExecute` is called on the thread which did the actual task execution.

The logic of this hook is taken from the [afterExecute documentation](https://docs.oracle.com/javase/7/docs/api/java/util/concurrent/ThreadPoolExecutor.html#afterExecute(java.lang.Runnable,%20java.lang.Throwable)).

Exceptions will be sent to the `devLogger` and to the internal telemetry as well.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

