### PR TITLE
Shutdown Kronos clock only after executors

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -201,6 +201,11 @@ internal object CoreFeature {
             contextRef.clear()
 
             trackingConsentProvider.unregisterAllCallbacks()
+
+            cleanupApplicationInfo()
+            cleanupProviders()
+            shutDownExecutors()
+
             try {
                 kronosClock.shutdown()
             } catch (ise: IllegalStateException) {
@@ -209,9 +214,6 @@ internal object CoreFeature {
                 sdkLogger.e("Trying to shut down Kronos when it is already not running", ise)
             }
 
-            cleanupApplicationInfo()
-            cleanupProviders()
-            shutDownExecutors()
             initialized.set(false)
             ndkCrashHandler = NoOpNdkCrashHandler()
             trackingConsentProvider = NoOpConsentProvider()


### PR DESCRIPTION
### What does this PR do?

It is possible that Kronos is accessed from tasks still running on executors (like from telemetry caught during some I/O operation) and it will lead to the `IllegalStateException`, like here:

```
11-04 04:04:42.160: E/AndroidRuntime(7085): Process: com.datadog.android.sdk.integration, PID: 7085
11-04 04:04:42.160: E/AndroidRuntime(7085): java.lang.IllegalStateException: Service already shutdown
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.lyft.kronos.internal.ntp.SntpServiceImpl.ensureServiceIsRunning(SntpService.kt:142)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.lyft.kronos.internal.ntp.SntpServiceImpl.currentTime(SntpService.kt:98)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.lyft.kronos.internal.KronosClockImpl.getCurrentTime(KronosClockImpl.kt:19)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.lyft.kronos.KronosClock$DefaultImpls.getCurrentTimeMs(Clock.kt:39)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.lyft.kronos.internal.KronosClockImpl.getCurrentTimeMs(KronosClockImpl.kt:8)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.core.internal.time.KronosTimeProvider.getServerOffsetMillis(KronosTimeProvider.kt:25)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.telemetry.internal.TelemetryEventHandler.handleEvent(TelemetryEventHandler.kt:40)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.rum.internal.monitor.DatadogRumMonitor.handleEvent$dd_sdk_android_debug(DatadogRumMonitor.kt:385)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.rum.internal.monitor.DatadogRumMonitor.sendErrorTelemetryEvent(DatadogRumMonitor.kt:346)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.telemetry.internal.Telemetry.error(Telemetry.kt:21)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.log.internal.logger.TelemetryLogHandler.handleLog(TelemetryLogHandler.kt:22)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.log.internal.logger.InternalLogHandler.handleLog(InternalLogHandler.kt:40)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.log.Logger.internalLog$dd_sdk_android_debug(Logger.kt:566)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.log.Logger.internalLog$dd_sdk_android_debug$default(Logger.kt:556)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.log.Logger.log(Logger.kt:169)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.log.internal.utils.LogUtilsKt.errorWithTelemetry(LogUtils.kt:45)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.log.internal.utils.LogUtilsKt.errorWithTelemetry$default(LogUtils.kt:40)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.core.internal.persistence.file.batch.PlainBatchFileReaderWriter.writeData(PlainBatchFileReaderWriter.kt:50)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.v2.core.internal.storage.FileEventBatchWriter.write(FileEventBatchWriter.kt:48)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.rum.internal.domain.RumDataWriter.write(RumDataWriter.kt:43)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.rum.internal.domain.scope.RumViewScope$sendViewUpdate$1.invoke(RumViewScope.kt:726)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.rum.internal.domain.scope.RumViewScope$sendViewUpdate$1.invoke(RumViewScope.kt:660)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.core.internal.SdkFeature$withWriteContext$1.invoke(SdkFeature.kt:135)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.core.internal.SdkFeature$withWriteContext$1.invoke(SdkFeature.kt:134)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.v2.core.internal.storage.ConsentAwareStorage.writeCurrentBatch$lambda-0(ConsentAwareStorage.kt:74)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.v2.core.internal.storage.ConsentAwareStorage.$r8$lambda$VSlkAQX2O5ir-BQmjPcJjBdEv4c(Unknown Source:0)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at com.datadog.android.v2.core.internal.storage.ConsentAwareStorage$$ExternalSyntheticLambda0.run(Unknown Source:6)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
11-04 04:04:42.160: E/AndroidRuntime(7085): 	at java.lang.Thread.run(Thread.java:764)
```

This change modifies SDK shutdown sequence, so that Kronos is shutdown only after all executors are shut down, meaning there is no tasks running left.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

