### PR TITLE
RUMM-2476: Target Android 13

### DIFF
--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -25,16 +25,11 @@ RUN set -x \
  && rm -rf /var/lib/apt/lists/*
 
 ENV GRADLE_VERSION 7.5
-ENV ANDROID_COMPILE_SDK 31
-ENV ANDROID_BUILD_TOOLS 31.0.0
-ENV ANDROID_SDK_TOOLS 7583922
-ENV NDK_VERSION 22.1.7171670
+ENV ANDROID_COMPILE_SDK 33
+ENV ANDROID_BUILD_TOOLS 33.0.0
+ENV ANDROID_SDK_TOOLS 8512546
+ENV NDK_VERSION 25.1.8937393
 ENV CMAKE_VERSION 3.22.1
-# Docker image is shared between branches and some older versions (1.14 and below) need to have CMAKE 3.10
-# Can be removed at some point
-ENV CMAKE_VERSION_LEGACY 3.10.2.4988404
-
-
 
 RUN apt update && apt install -y python3
 
@@ -73,7 +68,6 @@ RUN \
     echo y | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS}" >/dev/null && \
     echo y | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --install "ndk;${NDK_VERSION}" >/dev/null && \
     echo y | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --install "cmake;${CMAKE_VERSION}" >/dev/null && \
-    echo y | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --install "cmake;${CMAKE_VERSION_LEGACY}" >/dev/null && \
     yes | android-sdk-linux/cmdline-tools/latest/bin/sdkmanager --licenses
 
 RUN set -x \

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/Dependencies.kt
@@ -11,7 +11,7 @@ object Dependencies {
     object Versions {
 
         // NDK
-        const val Ndk = "22.1.7171670"
+        const val Ndk = "25.1.8937393"
         const val CMake = "3.22.1"
     }
 

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -11,12 +11,12 @@ import com.datadog.gradle.utils.Version
 
 object AndroidConfig {
 
-    const val TARGET_SDK = 31
+    const val TARGET_SDK = 33
     const val MIN_SDK = 19
 
     // this is temporary, until we bump min sdk. Compose requires min sdk 21.
     const val MIN_SDK_FOR_COMPOSE = 21
-    const val BUILD_TOOLS_VERSION = "31.0.0"
+    const val BUILD_TOOLS_VERSION = "33.0.0"
 
     val VERSION = Version(1, 15, 0, Version.Type.Snapshot)
 }

--- a/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation.kt
+++ b/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation.kt
@@ -86,6 +86,9 @@ internal class ComposeNavigationObserver(
         val attributes = mutableMapOf<String, Any?>()
 
         bundle.keySet().forEach {
+            // TODO RUMM-2717 Bundle#get is deprecated, but there is no replacement for it.
+            // Issue is opened in the Google Issue Tracker.
+            @Suppress("DEPRECATION")
             attributes["$ARGUMENT_TAG.$it"] = bundle.get(it)
         }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal
 
 import android.app.ActivityManager
 import android.content.Context
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Process
@@ -306,14 +307,8 @@ internal object CoreFeature {
 
     private fun readApplicationInformation(appContext: Context, credentials: Credentials) {
         packageName = appContext.packageName
-        val packageInfo = try {
-            appContext.packageManager.getPackageInfo(packageName, 0)
-        } catch (e: PackageManager.NameNotFoundException) {
-            devLogger.e("Unable to read your application's version name", e)
-            null
-        }
         packageVersionProvider = DefaultAppVersionProvider(
-            packageInfo?.let {
+            getPackageInfo(appContext)?.let {
                 // we need to use the deprecated method because getLongVersionCode method is only
                 // available from API 28 and above
                 @Suppress("DEPRECATION")
@@ -326,6 +321,22 @@ internal object CoreFeature {
         envName = credentials.envName
         variant = credentials.variant
         contextRef = WeakReference(appContext)
+    }
+
+    private fun getPackageInfo(appContext: Context): PackageInfo? {
+        return try {
+            with(appContext.packageManager) {
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                    getPackageInfo(packageName, PackageManager.PackageInfoFlags.of(0))
+                } else {
+                    @Suppress("DEPRECATION")
+                    getPackageInfo(packageName, 0)
+                }
+            }
+        } catch (e: PackageManager.NameNotFoundException) {
+            devLogger.e("Unable to read your application's version name", e)
+            null
+        }
     }
 
     private fun readConfigurationSettings(configuration: Configuration.Core) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
@@ -94,6 +94,9 @@ abstract class ActivityLifecycleTrackingStrategy :
 
         intent.extras?.let { bundle ->
             bundle.keySet().forEach {
+                // TODO RUMM-2717 Bundle#get is deprecated, but there is no replacement for it.
+                // Issue is opened in the Google Issue Tracker.
+                @Suppress("DEPRECATION")
                 attributes["$ARGUMENT_TAG.$it"] = bundle.get(it)
             }
         }
@@ -111,6 +114,9 @@ abstract class ActivityLifecycleTrackingStrategy :
         val attributes = mutableMapOf<String, Any?>()
 
         bundle.keySet().forEach {
+            // TODO RUMM-2717 Bundle#get is deprecated, but there is no replacement for it.
+            // Issue is opened in the Google Issue Tracker.
+            @Suppress("DEPRECATION")
             attributes["$ARGUMENT_TAG.$it"] = bundle.get(it)
         }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -253,7 +253,32 @@ internal class CoreFeatureTest {
     }
 
     @Test
-    fun `𝕄 initializes app info 𝕎 initialize()`() {
+    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
+    fun `𝕄 initializes app info 𝕎 initialize() { LOLLIPOP }`() {
+        // When
+        CoreFeature.initialize(
+            appContext.mockInstance,
+            fakeCredentials,
+            fakeConfig,
+            fakeConsent
+        )
+
+        // Then
+        assertThat(CoreFeature.clientToken).isEqualTo(fakeCredentials.clientToken)
+        assertThat(CoreFeature.packageName).isEqualTo(appContext.fakePackageName)
+        assertThat(CoreFeature.packageVersionProvider.version).isEqualTo(appContext.fakeVersionName)
+        assertThat(CoreFeature.serviceName).isEqualTo(fakeCredentials.serviceName)
+        assertThat(CoreFeature.envName).isEqualTo(fakeCredentials.envName)
+        assertThat(CoreFeature.variant).isEqualTo(fakeCredentials.variant)
+        assertThat(CoreFeature.rumApplicationId).isEqualTo(fakeCredentials.rumApplicationId)
+        assertThat(CoreFeature.contextRef.get()).isEqualTo(appContext.mockInstance)
+        assertThat(CoreFeature.batchSize).isEqualTo(fakeConfig.batchSize)
+        assertThat(CoreFeature.uploadFrequency).isEqualTo(fakeConfig.uploadFrequency)
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.TIRAMISU)
+    fun `𝕄 initializes app info 𝕎 initialize() { TIRAMISU }`() {
         // When
         CoreFeature.initialize(
             appContext.mockInstance,
@@ -352,9 +377,48 @@ internal class CoreFeatureTest {
     }
 
     @Test
-    fun `𝕄 initializes app info 𝕎 initialize() {unknown package name}`() {
+    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
+    fun `𝕄 initializes app info 𝕎 initialize() {unknown package name, LOLLIPOP}`() {
         // Given
+        @Suppress("DEPRECATION")
         whenever(appContext.mockPackageManager.getPackageInfo(appContext.fakePackageName, 0))
+            .doThrow(PackageManager.NameNotFoundException())
+        whenever(appContext.mockInstance.getSystemService(Context.CONNECTIVITY_SERVICE))
+            .doReturn(mockConnectivityMgr)
+
+        // When
+        CoreFeature.initialize(
+            appContext.mockInstance,
+            fakeCredentials.copy(rumApplicationId = null),
+            fakeConfig,
+            fakeConsent
+        )
+
+        // Then
+        assertThat(CoreFeature.clientToken).isEqualTo(fakeCredentials.clientToken)
+        assertThat(CoreFeature.packageName).isEqualTo(appContext.fakePackageName)
+        assertThat(CoreFeature.packageVersionProvider.version).isEqualTo(
+            CoreFeature.DEFAULT_APP_VERSION
+        )
+        assertThat(CoreFeature.serviceName).isEqualTo(fakeCredentials.serviceName)
+        assertThat(CoreFeature.envName).isEqualTo(fakeCredentials.envName)
+        assertThat(CoreFeature.variant).isEqualTo(fakeCredentials.variant)
+        assertThat(CoreFeature.rumApplicationId).isNull()
+        assertThat(CoreFeature.contextRef.get()).isEqualTo(appContext.mockInstance)
+        assertThat(CoreFeature.batchSize).isEqualTo(fakeConfig.batchSize)
+        assertThat(CoreFeature.uploadFrequency).isEqualTo(fakeConfig.uploadFrequency)
+    }
+
+    @Test
+    @TestTargetApi(Build.VERSION_CODES.TIRAMISU)
+    fun `𝕄 initializes app info 𝕎 initialize() {unknown package name, TIRAMISU}`() {
+        // Given
+        whenever(
+            appContext.mockPackageManager.getPackageInfo(
+                appContext.fakePackageName,
+                PackageManager.PackageInfoFlags.of(0)
+            )
+        )
             .doThrow(PackageManager.NameNotFoundException())
         whenever(appContext.mockInstance.getSystemService(Context.CONNECTIVITY_SERVICE))
             .doReturn(mockConnectivityMgr)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/ApplicationContextTestConfiguration.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/ApplicationContextTestConfiguration.kt
@@ -87,8 +87,14 @@ internal open class ApplicationContextTestConfiguration<T : Context>(klass: Clas
 
     private fun mockPackageManager() {
         mockPackageManager = mock()
+        whenever(
+            mockPackageManager.getPackageInfo(
+                fakePackageName,
+                PackageManager.PackageInfoFlags.of(0)
+            )
+        ) doReturn fakePackageInfo
+        @Suppress("DEPRECATION")
         whenever(mockPackageManager.getPackageInfo(fakePackageName, 0)) doReturn fakePackageInfo
-        whenever(mockPackageManager.getApplicationInfo(fakePackageName, 0)) doReturn fakeAppInfo
     }
 
     // endregion

--- a/detekt.yml
+++ b/detekt.yml
@@ -588,6 +588,7 @@ datadog:
     knownThrowingCalls:
       # region Android
       - "android.app.Activity.findNavController(kotlin.Int):java.lang.IllegalStateException"
+      - "android.content.pm.PackageManager.getPackageInfo(kotlin.String, android.content.pm.PackageManager.PackageInfoFlags):android.content.pm.PackageManager.NameNotFoundException"
       - "android.content.pm.PackageManager.getPackageInfo(kotlin.String, kotlin.Int):android.content.pm.PackageManager.NameNotFoundException"
       - "android.content.res.Resources.getResourceEntryName(kotlin.Int):android.content.res.Resources.NotFoundException"
       - "android.database.sqlite.SQLiteDatabase.beginTransaction():java.lang.IllegalStateException"
@@ -744,6 +745,7 @@ datadog:
       - "android.content.IntentFilter.constructor()"
       - "android.content.IntentFilter.constructor(kotlin.String)"
       - "android.content.pm.PackageManager.hasSystemFeature(kotlin.String)"
+      - "android.content.pm.PackageManager.PackageInfoFlags.of(kotlin.Long)"
       - "android.content.res.AssetManager.open(kotlin.String, kotlin.Int)"
       - "android.database.DatabaseErrorHandler.onCorruption(android.database.sqlite.SQLiteDatabase)"
       - "android.database.DefaultDatabaseErrorHandler.constructor()"

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/utils/BundleExtensions.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/utils/BundleExtensions.kt
@@ -15,6 +15,9 @@ fun Bundle?.asMap(): Map<String, Any?> {
 
     return keySet()
         .fold(mutableMapOf()) { map, key ->
+            // TODO RUMM-2717 Bundle#get is deprecated, but there is no replacement for it.
+            // Issue is opened in the Google Issue Tracker.
+            @Suppress("DEPRECATION")
             map[key] = this[key]
             map
         }

--- a/sample/kotlin/src/main/cpp/datadog-native-sample-lib.cpp
+++ b/sample/kotlin/src/main/cpp/datadog-native-sample-lib.cpp
@@ -16,9 +16,12 @@ void crash_with_sigabrt_signal() {
 }
 #pragma clang diagnostic pop
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wreturn-type"
 int crash_with_sigill_signal() {
     // do not return anything to simulate the SIGILL
 }
+#pragma clang diagnostic pop
 
 extern "C" JNIEXPORT void JNICALL
 Java_com_datadog_android_sample_crash_CrashFragment_simulateNdkCrash(


### PR DESCRIPTION
### What does this PR do?

This change adds support of Android 13 by doing the following:

* Build tooling and target API are now set to API 33.
* API changes are addressed.
* Docker image is updated to use build tooling for API 33.

Important points:

* `BaseBundle#get` type-agnostic call is deprecated, but there is no replacement. https://issuetracker.google.com/issues/243119654 is opened to track this (we are not alone here).
* NDK version was bumped to v25 (changelog is [here](https://developer.android.com/ndk/downloads/revision_history), it still supports KitKat, so it is fine to do the version bump)
* Legacy Cmake was removed from the docker image, because by some reason it is not shown in the list of the available packages for the latest version of `sdkmanager` for Linux (when I download latest `cmdline-tools` for Mac, Cmake 3.10 is there by some reason). Anyway, I think it is fine to get rid of it, because unlikely we will have a need to build older SDK releases in our CI.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

