### PR TITLE
Filter out telemetry in the assertions of instrumented RUM tests

### DIFF
--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/RumTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/RumTest.kt
@@ -32,7 +32,11 @@ internal abstract class RumTest<R : Activity, T : MockServerActivityTestRule<R>>
                     .isNotNull
                     .hasHeader(HeadersAssert.HEADER_CT, RuntimeConfig.CONTENT_TYPE_TEXT)
                 if (request.textBody != null) {
-                    sentGestureEvents += rumPayloadToJsonList(request.textBody)
+                    val rumPayload = rumPayloadToJsonList(request.textBody).filterNot {
+                        it.has("type") &&
+                            it.getAsJsonPrimitive("type").asString == "telemetry"
+                    }
+                    sentGestureEvents += rumPayload
                 }
             }
         sentGestureEvents.verifyEventMatches(expectedEvents)


### PR DESCRIPTION
### What does this PR do?

Follow-up for #1118: now we have configuration telemetry event [sent with the delay](https://github.com/DataDog/dd-sdk-android/blob/b260f33d8355290d3606f8bab085786a4791d940/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt#L418), which makes RUM instrumented tests flaky, because configuration telemetry event may or may not be in the intercepted RUM requests.

This changes filters out telemetry events from the list of RUM events against which the assertion will be done.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

