### PR TITLE
Remove non-existent function in dogfood script

### DIFF
--- a/dogfood.py
+++ b/dogfood.py
@@ -132,7 +132,6 @@ def update_dependant(version: str, target: str, gh_token: str, dry_run: bool) ->
     repo.git.checkout('HEAD', b=branch_name)
 
     previous_version = generate_target_code(target, temp_dir_path, version)
-    update_version_table(target, temp_dir_path, version)
 
     if not repo.is_dirty():
         print("Nothing to commit, all is in order-")


### PR DESCRIPTION
### What does this PR do?

Follow-up for https://github.com/DataDog/dd-sdk-android/pull/1120: remove the usage of the function which was deleted. Otherwise it breaks all the dogfood updates with exception like this:

```
Traceback (most recent call last):
  File "dogfood.py", line 160, in <module>
    sys.exit(run_main())
  File "dogfood.py", line 156, in run_main
    return update_dependant(cli_args.version, cli_args.target, gh_token, cli_args.dry_run)
  File "dogfood.py", line 135, in update_dependant
    update_version_table(target, temp_dir_path, version)
NameError: name 'update_version_table' is not defined
```

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

