### PR TITLE
Suppress the deprecation of Bundle#get in nightly test

### DIFF
--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashService.kt
@@ -19,6 +19,9 @@ internal abstract class CrashService : Service() {
         GlobalRum.registerIfAbsent(RumMonitor.Builder().build())
         extras?.let { bundle ->
             bundle.keySet().forEach {
+                // TODO RUMM-2717 Bundle#get is deprecated, but there is no replacement for it.
+                // Issue is opened in the Google Issue Tracker.
+                @Suppress("DEPRECATION")
                 GlobalRum.addAttribute(it, bundle[it])
             }
         }


### PR DESCRIPTION
### What does this PR do?

Fixes a compilation error after [migration to Android 13](https://github.com/DataDog/dd-sdk-android/pull/1130), where `Bundle#get` was deprecated.

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

