### PR TITLE
Add telemetry configuration mapper

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -67,6 +67,8 @@ class com.datadog.android._InternalProxy
     fun error(String, String?, String?)
   val _telemetry: _TelemetryProxy
   fun setCustomAppVersion(String)
+  companion object 
+    fun setTelemetryConfigurationEventMapper(com.datadog.android.core.configuration.Configuration.Builder, com.datadog.android.event.EventMapper<com.datadog.android.telemetry.model.TelemetryConfigurationEvent>): com.datadog.android.core.configuration.Configuration.Builder
 enum com.datadog.android.core.configuration.BatchSize
   constructor(Long)
   - SMALL

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/_InternalProxy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/_InternalProxy.kt
@@ -6,8 +6,11 @@
 
 package com.datadog.android
 
+import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.CoreFeature
+import com.datadog.android.event.EventMapper
 import com.datadog.android.telemetry.internal.Telemetry
+import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 
 /**
  * This class exposes internal methods that are used by other Datadog modules and cross platform
@@ -47,5 +50,15 @@ class _InternalProxy internal constructor(telemetry: Telemetry) {
 
     fun setCustomAppVersion(version: String) {
         CoreFeature.packageVersionProvider.version = version
+    }
+
+    companion object {
+        @Suppress("FunctionMaxLength")
+        fun setTelemetryConfigurationEventMapper(
+            builder: Configuration.Builder,
+            eventMapper: EventMapper<TelemetryConfigurationEvent>
+        ): Configuration.Builder {
+            return builder.setTelemetryConfigurationEventMapper(eventMapper)
+        }
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -44,6 +44,7 @@ import com.datadog.android.rum.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.tracking.TrackingStrategy
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
+import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 import okhttp3.Authenticator
 import java.net.Proxy
 import java.util.Locale
@@ -578,6 +579,16 @@ internal constructor(
                 proxy = proxy,
                 proxyAuth = authenticator ?: Authenticator.NONE
             )
+            return this
+        }
+
+        @Suppress("FunctionMaxLength")
+        internal fun setTelemetryConfigurationEventMapper(eventMapper: EventMapper<TelemetryConfigurationEvent>): Builder {
+            applyIfFeatureEnabled(PluginFeature.RUM, "setTelemetryConfigurationEventMapper") {
+                rumConfig = rumConfig.copy(
+                    rumEventMapper = getRumEventMapper().copy(telemetryConfigurationMapper = eventMapper)
+                )
+            }
             return this
         }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
@@ -29,7 +29,8 @@ internal data class RumEventMapper(
     val errorEventMapper: EventMapper<ErrorEvent> = NoOpEventMapper(),
     val resourceEventMapper: EventMapper<ResourceEvent> = NoOpEventMapper(),
     val actionEventMapper: EventMapper<ActionEvent> = NoOpEventMapper(),
-    val longTaskEventMapper: EventMapper<LongTaskEvent> = NoOpEventMapper()
+    val longTaskEventMapper: EventMapper<LongTaskEvent> = NoOpEventMapper(),
+    val telemetryConfigurationMapper: EventMapper<TelemetryConfigurationEvent> = NoOpEventMapper()
 ) : EventMapper<Any> {
 
     override fun map(event: Any): Any? {
@@ -55,9 +56,9 @@ internal data class RumEventMapper(
             }
             is ResourceEvent -> resourceEventMapper.map(event)
             is LongTaskEvent -> longTaskEventMapper.map(event)
+            is TelemetryConfigurationEvent -> telemetryConfigurationMapper.map(event)
             is TelemetryDebugEvent,
-            is TelemetryErrorEvent,
-            is TelemetryConfigurationEvent -> event
+            is TelemetryErrorEvent -> event
             else -> {
                 sdkLogger.warningWithTelemetry(
                     NO_EVENT_MAPPER_ASSIGNED_WARNING_MESSAGE

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.util.Log
 import com.datadog.android.DatadogEndpoint
 import com.datadog.android.DatadogSite
+import com.datadog.android._InternalProxy
 import com.datadog.android.core.internal.event.NoOpEventMapper
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.NoOpSpanEventMapper
@@ -35,6 +36,7 @@ import com.datadog.android.rum.tracking.InteractionPredicate
 import com.datadog.android.rum.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
+import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -757,6 +759,30 @@ internal class ConfigurationBuilderTest {
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
         val expectedRumEventMapper = RumEventMapper(longTaskEventMapper = eventMapper)
+        assertThat(config.rumConfig).isEqualTo(
+            Configuration.DEFAULT_RUM_CONFIG.copy(
+                rumEventMapper = expectedRumEventMapper
+            )
+        )
+        assertThat(config.additionalConfig).isEmpty()
+    }
+
+    @Test
+    fun `𝕄 build config with RUM Telemetry eventMapper 𝕎 _InternalProxy setTelemetryConfigurationEventMapper() & build()`() {
+        // Given
+        val eventMapper: EventMapper<TelemetryConfigurationEvent> = mock()
+
+        // When
+        val builder = testedBuilder
+        _InternalProxy.setTelemetryConfigurationEventMapper(builder, eventMapper)
+        val config = builder.build()
+        
+        // Then
+        assertThat(config.coreConfig).isEqualTo(Configuration.DEFAULT_CORE_CONFIG)
+        assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
+        assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
+        assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
+        val expectedRumEventMapper = RumEventMapper(telemetryConfigurationMapper = eventMapper)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 rumEventMapper = expectedRumEventMapper

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
@@ -71,6 +71,9 @@ internal class RumEventMapperTest {
     @Mock
     lateinit var mockLongTaskEventMapper: EventMapper<LongTaskEvent>
 
+    @Mock
+    lateinit var mockTelemetryConfigurationMapper: EventMapper<TelemetryConfigurationEvent>
+
     @BeforeEach
     fun `set up`() {
         whenever(mockViewEventMapper.map(any())).thenAnswer { it.arguments[0] }
@@ -80,7 +83,8 @@ internal class RumEventMapperTest {
             viewEventMapper = mockViewEventMapper,
             resourceEventMapper = mockResourceEventMapper,
             errorEventMapper = mockErrorEventMapper,
-            longTaskEventMapper = mockLongTaskEventMapper
+            longTaskEventMapper = mockLongTaskEventMapper,
+            telemetryConfigurationMapper = mockTelemetryConfigurationMapper
         )
     }
 
@@ -211,14 +215,19 @@ internal class RumEventMapperTest {
     }
 
     @Test
-    fun `M return the original event W map { TelemetryConfigurationEvent }`(
+    fun `M return the bundled event W map { TelemetryConfigurationEvent }`(
         @Forgery telemetryConfigurationEvent: TelemetryConfigurationEvent
     ) {
+        // GIVEN
+        whenever(mockTelemetryConfigurationMapper.map(telemetryConfigurationEvent))
+            .thenReturn(telemetryConfigurationEvent)
+
         // WHEN
         val mappedRumEvent = testedRumEventMapper.map(telemetryConfigurationEvent)
 
         // THEN
         verifyZeroInteractions(logger.mockSdkLogHandler)
+        verify(mockTelemetryConfigurationMapper).map(telemetryConfigurationEvent)
         assertThat(mappedRumEvent).isSameAs(telemetryConfigurationEvent)
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumEventMapperFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/RumEventMapperFactory.kt
@@ -18,7 +18,8 @@ internal class RumEventMapperFactory : ForgeryFactory<RumEventMapper> {
             viewEventMapper = mock(),
             actionEventMapper = mock(),
             resourceEventMapper = mock(),
-            errorEventMapper = mock()
+            errorEventMapper = mock(),
+            telemetryConfigurationMapper = mock()
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

This will allow cross platform SDKs to modify the configuration before sending it to telemetry.

The actual function on `Configuration.Builder` is internal, and exposed through the companion object on `_InternalTelemetry` to make it obvious this is meant as an internal mechanism.

### Additional Notes

Currently, this method is useless because none of the properties on `TelemetryConfigurationEvent` are mutable, but a PR is up modify the schema to fix that.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

