### PR TITLE
Add a logger method to log error information from strings

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -211,6 +211,7 @@ class com.datadog.android.log.Logger
   fun e(String, Throwable? = null, Map<String, Any?> = emptyMap())
   fun wtf(String, Throwable? = null, Map<String, Any?> = emptyMap())
   fun log(Int, String, Throwable? = null, Map<String, Any?> = emptyMap())
+  fun log(Int, String, String?, String?, String?, Map<String, Any?> = emptyMap())
   class Builder
     fun build(): Logger
     fun setServiceName(String): Builder

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -157,7 +157,6 @@ internal constructor(internal var handler: LogHandler) {
      * @param throwable a (nullable) throwable to be logged with the message
      * @param attributes a map of attributes to include only for this message. If an attribute with
      * the same key already exist in this logger, it will be overridden (just for this message)
-     *
      */
     @JvmOverloads
     fun log(
@@ -167,6 +166,30 @@ internal constructor(internal var handler: LogHandler) {
         attributes: Map<String, Any?> = emptyMap()
     ) {
         internalLog(priority, message, throwable, attributes)
+    }
+
+    /**
+     * Sends a log message with strings for error information.
+     *
+     * @param priority the priority level (must be one of the Android Log.* constants)
+     * @param message the message to be logged
+     * @param errorKind the kind of error to be logged with the message
+     * @param errorMessage the message from the error to be logged with this message
+     * @param errorStack the stack trace from the error to be logged with this message
+     * @param attributes a map of attributes to include only for this message. If an attribute with
+     * the same key already exist in this logger, it will be overridden (just for this message)
+     */
+    @JvmOverloads
+    @Suppress("LongParameterList")
+    fun log(
+        priority: Int,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        errorStack: String?,
+        attributes: Map<String, Any?> = emptyMap()
+    ) {
+        internalLog(priority, message, errorKind, errorMessage, errorStack, attributes)
     }
 
     // endregion
@@ -576,6 +599,31 @@ internal constructor(internal var handler: LogHandler) {
         combinedAttributes.putAll(attributes)
         combinedAttributes.putAll(localAttributes)
         handler.handleLog(level, message, throwable, combinedAttributes, tags, timestamp)
+    }
+
+    @Suppress("LongParameterList")
+    internal fun internalLog(
+        level: Int,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        errorStack: String?,
+        localAttributes: Map<String, Any?>,
+        timestamp: Long? = null
+    ) {
+        val combinedAttributes = mutableMapOf<String, Any?>()
+        combinedAttributes.putAll(attributes)
+        combinedAttributes.putAll(localAttributes)
+        handler.handleLog(
+            level,
+            message,
+            errorKind,
+            errorMessage,
+            errorStack,
+            combinedAttributes,
+            tags,
+            timestamp
+        )
     }
 
     private fun addTagInternal(tag: String) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -171,11 +171,15 @@ internal constructor(internal var handler: LogHandler) {
     /**
      * Sends a log message with strings for error information.
      *
+     * This method is meant for non-native or cross platform frameworks (such as React Native or
+     * Flutter) to send error information to Datadog. Although it can be used directly, it is
+     * recommended to use other methods declared on `Logger`.
+     *
      * @param priority the priority level (must be one of the Android Log.* constants)
      * @param message the message to be logged
      * @param errorKind the kind of error to be logged with the message
      * @param errorMessage the message from the error to be logged with this message
-     * @param errorStack the stack trace from the error to be logged with this message
+     * @param errorStacktrace the stack trace from the error to be logged with this message
      * @param attributes a map of attributes to include only for this message. If an attribute with
      * the same key already exist in this logger, it will be overridden (just for this message)
      */
@@ -186,10 +190,10 @@ internal constructor(internal var handler: LogHandler) {
         message: String,
         errorKind: String?,
         errorMessage: String?,
-        errorStack: String?,
+        errorStacktrace: String?,
         attributes: Map<String, Any?> = emptyMap()
     ) {
-        internalLog(priority, message, errorKind, errorMessage, errorStack, attributes)
+        internalLog(priority, message, errorKind, errorMessage, errorStacktrace, attributes)
     }
 
     // endregion
@@ -607,7 +611,7 @@ internal constructor(internal var handler: LogHandler) {
         message: String,
         errorKind: String?,
         errorMessage: String?,
-        errorStack: String?,
+        errorStacktrace: String?,
         localAttributes: Map<String, Any?>,
         timestamp: Long? = null
     ) {
@@ -619,7 +623,7 @@ internal constructor(internal var handler: LogHandler) {
             message,
             errorKind,
             errorMessage,
-            errorStack,
+            errorStacktrace,
             combinedAttributes,
             tags,
             timestamp

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/CombinedLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/CombinedLogHandler.kt
@@ -28,7 +28,7 @@ internal class CombinedLogHandler(
         message: String,
         errorKind: String?,
         errorMessage: String?,
-        errorStack: String?,
+        errorStacktrace: String?,
         attributes: Map<String, Any?>,
         tags: Set<String>,
         timestamp: Long?
@@ -39,7 +39,7 @@ internal class CombinedLogHandler(
                 message,
                 errorKind,
                 errorMessage,
-                errorStack,
+                errorStacktrace,
                 attributes,
                 tags,
                 timestamp

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/CombinedLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/CombinedLogHandler.kt
@@ -23,5 +23,29 @@ internal class CombinedLogHandler(
         handlers.forEach { it.handleLog(level, message, throwable, attributes, tags, timestamp) }
     }
 
+    override fun handleLog(
+        level: Int,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        errorStack: String?,
+        attributes: Map<String, Any?>,
+        tags: Set<String>,
+        timestamp: Long?
+    ) {
+        handlers.forEach {
+            it.handleLog(
+                level,
+                message,
+                errorKind,
+                errorMessage,
+                errorStack,
+                attributes,
+                tags,
+                timestamp
+            )
+        }
+    }
+
     // endregion
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/ConditionalLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/ConditionalLogHandler.kt
@@ -29,7 +29,7 @@ internal class ConditionalLogHandler(
         message: String,
         errorKind: String?,
         errorMessage: String?,
-        errorStack: String?,
+        errorStacktrace: String?,
         attributes: Map<String, Any?>,
         tags: Set<String>,
         timestamp: Long?
@@ -41,7 +41,7 @@ internal class ConditionalLogHandler(
                 message,
                 errorKind,
                 errorMessage,
-                errorStack,
+                errorStacktrace,
                 attributes,
                 tags,
                 timestamp

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/ConditionalLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/ConditionalLogHandler.kt
@@ -23,4 +23,29 @@ internal class ConditionalLogHandler(
             delegateHandler.handleLog(level, message, throwable, attributes, tags, timestamp)
         }
     }
+
+    override fun handleLog(
+        level: Int,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        errorStack: String?,
+        attributes: Map<String, Any?>,
+        tags: Set<String>,
+        timestamp: Long?
+    ) {
+        @Suppress("UnsafeThirdPartyFunctionCall") // internal safe call
+        if (condition(level, null)) {
+            delegateHandler.handleLog(
+                level,
+                message,
+                errorKind,
+                errorMessage,
+                errorStack,
+                attributes,
+                tags,
+                timestamp
+            )
+        }
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -49,6 +49,40 @@ internal class DatadogLogHandler(
         }
     }
 
+    override fun handleLog(
+        level: Int,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        errorStack: String?,
+        attributes: Map<String, Any?>,
+        tags: Set<String>,
+        timestamp: Long?
+    ) {
+        if (level < minLogPriority) {
+            return
+        }
+
+        val resolvedTimeStamp = timestamp ?: System.currentTimeMillis()
+        if (sampler.sample()) {
+            val log = createLog(
+                level,
+                message,
+                errorKind,
+                errorMessage,
+                errorStack,
+                attributes,
+                tags,
+                resolvedTimeStamp
+            )
+            writer.write(log)
+        }
+
+        if (level >= AndroidLog.ERROR) {
+            GlobalRum.get().addErrorWithStacktrace(message, RumErrorSource.LOGGER, errorStack, attributes)
+        }
+    }
+
     // endregion
 
     // region Internal
@@ -66,6 +100,31 @@ internal class DatadogLogHandler(
             level,
             message,
             throwable,
+            attributes,
+            tags,
+            timestamp,
+            bundleWithRum = bundleWithRum,
+            bundleWithTraces = bundleWithTraces
+        )
+    }
+
+    @Suppress("LongParameterList")
+    private fun createLog(
+        level: Int,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        errorStack: String?,
+        attributes: Map<String, Any?>,
+        tags: Set<String>,
+        timestamp: Long
+    ): LogEvent {
+        return logGenerator.generateLog(
+            level,
+            message,
+            errorKind,
+            errorMessage,
+            errorStack,
             attributes,
             tags,
             timestamp,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -54,7 +54,7 @@ internal class DatadogLogHandler(
         message: String,
         errorKind: String?,
         errorMessage: String?,
-        errorStack: String?,
+        errorStacktrace: String?,
         attributes: Map<String, Any?>,
         tags: Set<String>,
         timestamp: Long?
@@ -70,7 +70,7 @@ internal class DatadogLogHandler(
                 message,
                 errorKind,
                 errorMessage,
-                errorStack,
+                errorStacktrace,
                 attributes,
                 tags,
                 resolvedTimeStamp
@@ -79,7 +79,7 @@ internal class DatadogLogHandler(
         }
 
         if (level >= AndroidLog.ERROR) {
-            GlobalRum.get().addErrorWithStacktrace(message, RumErrorSource.LOGGER, errorStack, attributes)
+            GlobalRum.get().addErrorWithStacktrace(message, RumErrorSource.LOGGER, errorStacktrace, attributes)
         }
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/InternalLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/InternalLogHandler.kt
@@ -47,4 +47,42 @@ internal class InternalLogHandler(
             )
         }
     }
+
+    override fun handleLog(
+        level: Int,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        errorStack: String?,
+        attributes: Map<String, Any?>,
+        tags: Set<String>,
+        timestamp: Long?
+    ) {
+        val reportLevel = level and TELEMETRY_LOG_FLAG.inv()
+        logcatLogHandler.handleLog(
+            reportLevel,
+            message,
+            errorKind,
+            errorMessage,
+            errorStack,
+            attributes,
+            tags,
+            timestamp
+        )
+
+        val forwardTelemetry = (level and TELEMETRY_LOG_FLAG) != 0
+
+        if (forwardTelemetry) {
+            telemetryLogHandler.handleLog(
+                reportLevel,
+                message,
+                errorKind,
+                errorMessage,
+                errorStack,
+                attributes,
+                tags,
+                timestamp
+            )
+        }
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/InternalLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/InternalLogHandler.kt
@@ -53,7 +53,7 @@ internal class InternalLogHandler(
         message: String,
         errorKind: String?,
         errorMessage: String?,
-        errorStack: String?,
+        errorStacktrace: String?,
         attributes: Map<String, Any?>,
         tags: Set<String>,
         timestamp: Long?
@@ -64,7 +64,7 @@ internal class InternalLogHandler(
             message,
             errorKind,
             errorMessage,
-            errorStack,
+            errorStacktrace,
             attributes,
             tags,
             timestamp
@@ -78,7 +78,7 @@ internal class InternalLogHandler(
                 message,
                 errorKind,
                 errorMessage,
-                errorStack,
+                errorStacktrace,
                 attributes,
                 tags,
                 timestamp

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogHandler.kt
@@ -17,11 +17,35 @@ internal interface LogHandler {
      * @param throwable a (nullable) throwable to be logged with the message
      * @param attributes a map of attributes to include only for this message. If an attribute with
      * the same key already exists in this logger, it will be overridden (just for this message)
+     * @param tags the tags for this message
+     * @param timestamp the time at which this log occurred
      */
     fun handleLog(
         level: Int,
         message: String,
         throwable: Throwable? = null,
+        attributes: Map<String, Any?> = emptyMap(),
+        tags: Set<String> = emptySet(),
+        timestamp: Long? = null
+    )
+
+    /**
+     * Handle the log.
+     * @param message the message to be logged
+     * @param errorKind the kind of error to be logged with the message
+     * @param errorMessage the message from the error to be logged with this message
+     * @param errorStack the stack trace from the error to be logged with this message
+     * @param attributes a map of attributes to include only for this message. If an attribute with
+     * the same key already exists in this logger, it will be overridden (just for this message)
+     * @param tags the tags for this message
+     * @param timestamp the time at which this log occurred
+     */
+    fun handleLog(
+        level: Int,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        errorStack: String?,
         attributes: Map<String, Any?> = emptyMap(),
         tags: Set<String> = emptySet(),
         timestamp: Long? = null

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogHandler.kt
@@ -34,7 +34,7 @@ internal interface LogHandler {
      * @param message the message to be logged
      * @param errorKind the kind of error to be logged with the message
      * @param errorMessage the message from the error to be logged with this message
-     * @param errorStack the stack trace from the error to be logged with this message
+     * @param errorStacktrace the stack trace from the error to be logged with this message
      * @param attributes a map of attributes to include only for this message. If an attribute with
      * the same key already exists in this logger, it will be overridden (just for this message)
      * @param tags the tags for this message
@@ -45,7 +45,7 @@ internal interface LogHandler {
         message: String,
         errorKind: String?,
         errorMessage: String?,
-        errorStack: String?,
+        errorStacktrace: String?,
         attributes: Map<String, Any?> = emptyMap(),
         tags: Set<String> = emptySet(),
         timestamp: Long? = null

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
@@ -39,6 +39,29 @@ internal class LogcatLogHandler(
         }
     }
 
+    override fun handleLog(
+        level: Int,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        errorStack: String?,
+        attributes: Map<String, Any?>,
+        tags: Set<String>,
+        timestamp: Long?
+    ) {
+        val stackElement = getCallerStackElement()
+        val tag = resolveTag(stackElement)
+        val suffix = resolveSuffix(stackElement)
+        Log.println(level, tag, message + suffix)
+        if (errorStack != null) {
+            Log.println(
+                level,
+                tag,
+                errorStack
+            )
+        }
+    }
+
     // endregion
 
     // region Internal

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/LogcatLogHandler.kt
@@ -44,7 +44,7 @@ internal class LogcatLogHandler(
         message: String,
         errorKind: String?,
         errorMessage: String?,
-        errorStack: String?,
+        errorStacktrace: String?,
         attributes: Map<String, Any?>,
         tags: Set<String>,
         timestamp: Long?
@@ -53,11 +53,11 @@ internal class LogcatLogHandler(
         val tag = resolveTag(stackElement)
         val suffix = resolveSuffix(stackElement)
         Log.println(level, tag, message + suffix)
-        if (errorStack != null) {
+        if (errorStacktrace != null) {
             Log.println(
                 level,
                 tag,
-                errorStack
+                errorStacktrace
             )
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/TelemetryLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/TelemetryLogHandler.kt
@@ -30,13 +30,13 @@ internal class TelemetryLogHandler(private val telemetry: Telemetry) : LogHandle
         message: String,
         errorKind: String?,
         errorMessage: String?,
-        errorStack: String?,
+        errorStacktrace: String?,
         attributes: Map<String, Any?>,
         tags: Set<String>,
         timestamp: Long?
     ) {
         if (level == AndroidLog.ERROR || level == AndroidLog.WARN) {
-            telemetry.error(message, stack = errorStack, kind = errorKind)
+            telemetry.error(message, stack = errorStacktrace, kind = errorKind)
         } else {
             telemetry.debug(message)
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/TelemetryLogHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/logger/TelemetryLogHandler.kt
@@ -24,4 +24,21 @@ internal class TelemetryLogHandler(private val telemetry: Telemetry) : LogHandle
             telemetry.debug(message)
         }
     }
+
+    override fun handleLog(
+        level: Int,
+        message: String,
+        errorKind: String?,
+        errorMessage: String?,
+        errorStack: String?,
+        attributes: Map<String, Any?>,
+        tags: Set<String>,
+        timestamp: Long?
+    ) {
+        if (level == AndroidLog.ERROR || level == AndroidLog.WARN) {
+            telemetry.error(message, stack = errorStack, kind = errorKind)
+        } else {
+            telemetry.debug(message)
+        }
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -216,6 +216,11 @@ interface RumMonitor {
 
     /**
      * Notifies that an error occurred in the active View.
+     *
+     * This method is meant for non-native or cross platform frameworks (such as React Native or
+     * Flutter) to send error information to Datadog. Although it can be used directly, it is
+     * recommended to pass a Throwable instead.
+     *
      * @param message a message explaining the error
      * @param source the source of the error
      * @param stacktrace the error stacktrace information

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -46,6 +46,7 @@ import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import io.opentracing.noop.NoopTracerFactory
@@ -295,6 +296,61 @@ internal class DatadogLogHandlerTest {
     }
 
     @Test
+    fun `forward log to LogWriter with error strings`(
+        @StringForgery errorKind: String,
+        @StringForgery errorMessage: String,
+        @StringForgery errorStack: String
+    ) {
+        val now = System.currentTimeMillis()
+
+        testedHandler.handleLog(
+            fakeLevel,
+            fakeMessage,
+            errorKind,
+            errorMessage,
+            errorStack,
+            fakeAttributes,
+            fakeTags
+        )
+
+        argumentCaptor<LogEvent>().apply {
+            verify(mockWriter).write(capture())
+
+            assertThat(lastValue)
+                .hasServiceName(fakeServiceName)
+                .hasLoggerName(fakeLoggerName)
+                .hasThreadName(Thread.currentThread().name)
+                .hasStatus(fakeLevel.asLogStatus())
+                .hasMessage(fakeMessage)
+                .hasDateAround(now)
+                .hasNetworkInfo(fakeNetworkInfo)
+                .hasUserInfo(fakeUserInfo)
+                .hasExactlyAttributes(
+                    fakeAttributes + mapOf(
+                        LogAttributes.RUM_APPLICATION_ID to rumMonitor.context.applicationId,
+                        LogAttributes.RUM_SESSION_ID to rumMonitor.context.sessionId,
+                        LogAttributes.RUM_VIEW_ID to rumMonitor.context.viewId,
+                        LogAttributes.RUM_ACTION_ID to rumMonitor.context.actionId
+                    )
+                )
+                .hasExactlyTags(
+                    fakeTags + setOf(
+                        "${LogAttributes.ENV}:$fakeEnvName",
+                        "${LogAttributes.APPLICATION_VERSION}:$fakeAppVersion",
+                        "${LogAttributes.VARIANT}:$fakeVariant"
+                    )
+                )
+                .hasError(
+                    LogEvent.Error(
+                        kind = errorKind,
+                        message = errorMessage,
+                        stack = errorStack
+                    )
+                )
+        }
+    }
+
+    @Test
     fun `doesn't forward low level log to RumMonitor`(forge: Forge) {
         fakeLevel = forge.anInt(AndroidLog.VERBOSE, AndroidLog.ERROR)
 
@@ -343,6 +399,54 @@ internal class DatadogLogHandlerTest {
             fakeMessage,
             RumErrorSource.LOGGER,
             fakeThrowable,
+            fakeAttributes
+        )
+    }
+
+    @Test
+    fun `doesn't forward low level log with string errors to RumMonitor`(
+        forge: Forge,
+        @StringForgery errorKind: String,
+        @StringForgery errorMessage: String,
+        @StringForgery errorStack: String
+    ) {
+        fakeLevel = forge.anInt(AndroidLog.VERBOSE, AndroidLog.ERROR)
+
+        testedHandler.handleLog(
+            fakeLevel,
+            fakeMessage,
+            errorKind,
+            errorMessage,
+            errorStack,
+            fakeAttributes,
+            fakeTags
+        )
+
+        verifyZeroInteractions(rumMonitor.mockInstance)
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [AndroidLog.ERROR, AndroidLog.ASSERT])
+    fun `forward error log with error strings to RumMonitor`(
+        logLevel: Int,
+        @StringForgery errorKind: String,
+        @StringForgery errorMessage: String,
+        @StringForgery errorStack: String
+    ) {
+        testedHandler.handleLog(
+            logLevel,
+            fakeMessage,
+            errorKind,
+            errorMessage,
+            errorStack,
+            fakeAttributes,
+            fakeTags
+        )
+
+        verify(rumMonitor.mockInstance).addErrorWithStacktrace(
+            fakeMessage,
+            RumErrorSource.LOGGER,
+            errorStack,
             fakeAttributes
         )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/InternalLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/InternalLogHandlerTest.kt
@@ -101,4 +101,81 @@ internal class InternalLogHandlerTest {
         verify(mockLogcatLogHandler).handleLog(expectedLevels.getValue(level), message)
         verify(mockTelemetryLogHandler).handleLog(expectedLevels.getValue(level), message)
     }
+
+    @Test
+    fun `𝕄 report logcat only 𝕎 handleLog( { error strings } ) { no telemetry flag }`(
+        @StringForgery message: String,
+        @StringForgery errorKind: String,
+        @StringForgery errorStack: String,
+        forge: Forge
+    ) {
+        // Given
+        val level = forge.anElementFrom(
+            AndroidLog.ASSERT,
+            AndroidLog.VERBOSE,
+            AndroidLog.DEBUG,
+            AndroidLog.INFO,
+            AndroidLog.WARN,
+            AndroidLog.ERROR
+        )
+
+        // When
+        testedHandler.handleLog(
+            level,
+            message,
+            errorKind,
+            null,
+            errorStack
+        )
+
+        // Then
+        verify(mockLogcatLogHandler).handleLog(level, message, errorKind, null, errorStack)
+        verifyZeroInteractions(mockTelemetryLogHandler)
+    }
+
+    @Test
+    fun `𝕄 report logcat and telemetry 𝕎 handleLog( { error strings } ) { with telemetry flag }`(
+        @StringForgery message: String,
+        @StringForgery errorKind: String,
+        @StringForgery errorStack: String,
+        forge: Forge
+    ) {
+        // Given
+        val level = forge.anElementFrom(
+            ERROR_WITH_TELEMETRY_LEVEL,
+            WARN_WITH_TELEMETRY_LEVEL,
+            DEBUG_WITH_TELEMETRY_LEVEL
+        )
+
+        val expectedLevels = mapOf(
+            ERROR_WITH_TELEMETRY_LEVEL to AndroidLog.ERROR,
+            WARN_WITH_TELEMETRY_LEVEL to AndroidLog.WARN,
+            DEBUG_WITH_TELEMETRY_LEVEL to AndroidLog.DEBUG
+        )
+
+        // When
+        testedHandler.handleLog(
+            level,
+            message,
+            errorKind,
+            null,
+            errorStack
+        )
+
+        // Then
+        verify(mockLogcatLogHandler).handleLog(
+            expectedLevels.getValue(level),
+            message,
+            errorKind,
+            null,
+            errorStack
+        )
+        verify(mockTelemetryLogHandler).handleLog(
+            expectedLevels.getValue(level),
+            message,
+            errorKind,
+            null,
+            errorStack
+        )
+    }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/TelemetryLogHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/logger/TelemetryLogHandlerTest.kt
@@ -79,4 +79,45 @@ internal class TelemetryLogHandlerTest {
         verify(mockTelemetry).debug(message)
         verifyNoMoreInteractions(mockTelemetry)
     }
+
+    @Test
+    fun `𝕄 report ERROR and WARN as error 𝕎 handleLog( { error strings } )`(
+        @StringForgery message: String,
+        forge: Forge
+    ) {
+        // Given
+        val level = forge.anElementFrom(AndroidLog.ERROR, AndroidLog.WARN)
+        val errorKind = forge.anAlphabeticalString()
+        val errorMessage = forge.anAlphabeticalString()
+        val errorStack = forge.anAlphabeticalString()
+
+        // When
+        testedHandler.handleLog(level, message, errorKind, errorMessage, errorStack)
+
+        // Then
+        verify(mockTelemetry).error(message, errorStack, errorKind)
+        verifyNoMoreInteractions(mockTelemetry)
+    }
+
+    @Test
+    fun `𝕄 report any non-ERROR or WARN as debug 𝕎 handleLog( { error strings } )`(
+        @StringForgery message: String,
+        forge: Forge
+    ) {
+        // Given
+        var level = forge.anInt()
+        while (level in setOf(AndroidLog.ERROR, AndroidLog.WARN)) {
+            level = forge.anInt()
+        }
+        val errorKind = forge.anAlphabeticalString()
+        val errorMessage = forge.anAlphabeticalString()
+        val errorStack = forge.anAlphabeticalString()
+
+        // When
+        testedHandler.handleLog(level, message, errorKind, errorMessage, errorStack)
+
+        // Then
+        verify(mockTelemetry).debug(message)
+        verifyNoMoreInteractions(mockTelemetry)
+    }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/MixedWebViewEventConsumerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/MixedWebViewEventConsumerTest.kt
@@ -252,7 +252,7 @@ internal class MixedWebViewEventConsumerTest {
                     fakeBadJsonFormatEvent
                 )
             ),
-            argThat { this is JsonParseException },
+            argThat<Throwable> { this is JsonParseException },
             any(),
             any(),
             anyOrNull()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
@@ -559,7 +559,7 @@ internal class WebViewRumEventConsumerTest {
         verify(logger.mockSdkLogHandler).handleLog(
             eq(ERROR_WITH_TELEMETRY_LEVEL),
             eq(WebViewRumEventConsumer.JSON_PARSING_ERROR_MESSAGE),
-            any(),
+            any<Throwable>(),
             anyOrNull(),
             anyOrNull(),
             anyOrNull()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.nightly.logs
 
+import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
@@ -271,6 +272,29 @@ class LoggerE2ETests {
             logger.wtf(
                 fakeMessage,
                 fakeThrowable,
+                attributes
+            )
+        }
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.log.Logger#fun log(Int, String, String?, String?, String?, Map<String, Any?> = emptyMap())
+     */
+    @Test
+    fun logs_logger_log_with_error_strings() {
+        val testMethodName = "logs_logger_log_with_error_strings"
+        val fakeMessage = forge.anAlphaNumericalString()
+        val fakeErroKind = forge.anAlphabeticalString()
+        val fakeErrorMessage = forge.anAlphaNumericalString()
+        val fakeErrorStack = forge.anAlphaNumericalString()
+        val attributes = defaultTestAttributes(testMethodName)
+        measure(testMethodName) {
+            logger.log(
+                Log.INFO,
+                fakeMessage,
+                fakeErroKind,
+                fakeErrorMessage,
+                fakeErrorStack,
                 attributes
             )
         }


### PR DESCRIPTION
### What does this PR do?

Add a logger method to log error information from strings.  This is needed for Flutter and React Native to pass their stack traces to the SDK for serialization.

I added a method to Logger (without adding any additional convenience methods, as Flutter and ReactNative likely won't use them anyway) as well as a new method to the LogHandler interface, which I propagated to all of the implementations.

### Motivation

Cross Platform frameworks needed a way to post errors / stack traces to logs, which we do using Strings.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

