### PR TITLE
RUMM-2713: Move global RUM context into generic feature context storage

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitor.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitor.kt
@@ -469,9 +469,11 @@ class KotlinFileVisitor {
         val functionType = firstChildNode("functionType")
 
         val receiver = functionType.firstChildNodeOrNull("receiverType")?.typeName()
-        val params = functionType.firstChildNode("functionTypeParameters")
-            .childrenNodes("type")
-            .joinToString(", ") { it.typeName() }
+        val functionTypeParamsNode = functionType.firstChildNode("functionTypeParameters")
+        val params =
+            (functionTypeParamsNode.firstChildNodeOrNull("parameter") ?: functionTypeParamsNode)
+                .childrenNodes("type")
+                .joinToString(", ") { it.typeName() }
         val returns = functionType.firstChildNode("type").typeName()
 
         return if (receiver == null) {

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitorTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitorTest.kt
@@ -594,6 +594,7 @@ internal class KotlinFileVisitorTest {
                 fun unit(block : (String) -> Unit) {}
                 fun nullable(block : (String) -> Any?) {}
                 fun withReceiver(block : String.() -> Int) {}
+                fun withNamedArgumentOfLambda(block : (name: String) -> Unit) {}
             }
             """.trimIndent()
         )
@@ -605,7 +606,8 @@ internal class KotlinFileVisitorTest {
                 "  fun withInputs((String, Char) -> Int)\n" +
                 "  fun unit((String) -> Unit)\n" +
                 "  fun nullable((String) -> Any?)\n" +
-                "  fun withReceiver(String.() -> Int)\n",
+                "  fun withReceiver(String.() -> Int)\n" +
+                "  fun withNamedArgumentOfLambda((String) -> Unit)\n",
             testedVisitor.description.toString()
         )
     }

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1864,7 +1864,7 @@ interface com.datadog.android.v2.api.SdkCore
   fun stop()
   fun clearAllData()
   fun flushStoredData()
-  fun updateFeatureContext(String, () -> Unit)
+  fun updateFeatureContext(String, (MutableMap<String, Any?>) -> Unit)
   fun getFeatureContext(String): Map<String, Any?>
   fun setEventReceiver(String, FeatureEventReceiver)
   fun removeEventReceiver(String)

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1864,8 +1864,8 @@ interface com.datadog.android.v2.api.SdkCore
   fun stop()
   fun clearAllData()
   fun flushStoredData()
-  fun setFeatureContext(String, Map<String, Any?>)
-  fun updateFeatureContext(String, Map<String, Any?>)
+  fun updateFeatureContext(String, () -> Unit)
+  fun getFeatureContext(String): Map<String, Any?>
   fun setEventReceiver(String, FeatureEventReceiver)
   fun removeEventReceiver(String)
 enum com.datadog.android.v2.api.SdkEndpoint

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -44,6 +44,7 @@ import com.datadog.android.rum.tracking.NoOpTrackingStrategy
 import com.datadog.android.rum.tracking.NoOpViewTrackingStrategy
 import com.datadog.android.rum.tracking.TrackingStrategy
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
+import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.core.internal.storage.DataWriter
 import com.datadog.android.v2.core.internal.storage.NoOpDataWriter
 import java.util.concurrent.ExecutorService
@@ -53,6 +54,7 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class RumFeature(
+    private val sdkCore: SdkCore,
     private val coreFeature: CoreFeature
 ) {
     internal var dataWriter: DataWriter<Any> = NoOpDataWriter()
@@ -210,6 +212,7 @@ internal class RumFeature(
         periodInMs: Long
     ) {
         val readerRunnable = VitalReaderRunnable(
+            sdkCore,
             vitalReader,
             vitalObserver,
             vitalExecutorService,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumContext.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/RumContext.kt
@@ -21,7 +21,55 @@ internal data class RumContext(
     val viewType: RumViewScope.RumViewType = RumViewScope.RumViewType.NONE
 ) {
 
+    fun toMap(): Map<String, Any?> {
+        return mapOf(
+            APPLICATION_ID to applicationId,
+            SESSION_ID to sessionId,
+            SESSION_STATE to sessionState,
+            VIEW_ID to viewId,
+            VIEW_NAME to viewName,
+            VIEW_URL to viewUrl,
+            VIEW_TYPE to viewType,
+            ACTION_ID to actionId
+        )
+    }
+
     companion object {
         val NULL_UUID = UUID(0, 0).toString()
+
+        // be careful when changing values below, they may be indirectly referenced (as string
+        // literal) from other modules
+        const val APPLICATION_ID = "application_id"
+        const val SESSION_ID = "session_id"
+        const val SESSION_STATE = "session_state"
+        const val VIEW_ID = "view_id"
+        const val VIEW_NAME = "view_name"
+        const val VIEW_URL = "view_url"
+        const val VIEW_TYPE = "view_type"
+        const val ACTION_ID = "action_id"
+
+        fun fromFeatureContext(featureContext: Map<String, Any?>): RumContext {
+            val applicationId = featureContext[APPLICATION_ID] as? String
+            val sessionId = featureContext[SESSION_ID] as? String
+            val sessionState = featureContext[SESSION_STATE] as? RumSessionScope.State
+                ?: RumSessionScope.State.NOT_TRACKED
+            val viewId = featureContext[VIEW_ID] as? String
+            val viewName = featureContext[VIEW_NAME] as? String
+            val viewUrl = featureContext[VIEW_URL] as? String
+            val viewType = featureContext[VIEW_TYPE] as? RumViewScope.RumViewType
+                ?: RumViewScope.RumViewType.NONE
+            val actionId = featureContext[ACTION_ID] as? String
+
+            return RumContext(
+                applicationId = applicationId ?: NULL_UUID,
+                sessionId = sessionId ?: NULL_UUID,
+                sessionState = sessionState,
+                viewId = viewId,
+                viewName = viewName,
+                viewUrl = viewUrl,
+                viewType = viewType,
+                actionId = actionId
+            )
+        }
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -10,8 +10,8 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
-import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.v2.api.SdkCore
@@ -65,7 +65,9 @@ internal class RumSessionScope(
     )
 
     init {
-        GlobalRum.updateRumContext(getRumContext())
+        sdkCore.updateFeatureContext(RumFeature.RUM_FEATURE_NAME) {
+            it.putAll(getRumContext().toMap())
+        }
     }
 
     enum class State {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/vitals/VitalReaderRunnable.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/vitals/VitalReaderRunnable.kt
@@ -7,12 +7,14 @@
 package com.datadog.android.rum.internal.vitals
 
 import com.datadog.android.core.internal.utils.scheduleSafe
-import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
+import com.datadog.android.v2.api.SdkCore
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
 
 internal class VitalReaderRunnable(
+    val sdkCore: SdkCore,
     val reader: VitalReader,
     val observer: VitalObserver,
     val executor: ScheduledExecutorService,
@@ -20,7 +22,9 @@ internal class VitalReaderRunnable(
 ) : Runnable {
 
     override fun run() {
-        if (GlobalRum.getRumContext().viewType == RumViewScope.RumViewType.FOREGROUND) {
+        val rumContext = sdkCore.getFeatureContext(RumFeature.RUM_FEATURE_NAME)
+        val rumViewType = rumContext["view_type"] as? RumViewScope.RumViewType
+        if (rumViewType == RumViewScope.RumViewType.FOREGROUND) {
             val data = reader.readVitalData()
             if (data != null) {
                 observer.onNewSample(data)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -29,7 +29,7 @@ internal class SessionReplayFeature(
         (RecordWriter, Configuration.Feature.SessionReplay) ->
         LifecycleCallback = { recordWriter, configuration ->
             SessionReplayLifecycleCallback(
-                SessionReplayRumContextProvider(),
+                SessionReplayRumContextProvider(sdkCore),
                 configuration.privacy,
                 recordWriter,
                 SessionReplayTimeProvider(coreFeature.contextProvider),

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayRecordCallback.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayRecordCallback.kt
@@ -9,7 +9,7 @@ package com.datadog.android.sessionreplay.internal
 import com.datadog.android.sessionreplay.RecordCallback
 import com.datadog.android.v2.api.SdkCore
 
-internal class SessionReplayRecordCallback(private val datadogCore: SdkCore) : RecordCallback {
+internal class SessionReplayRecordCallback(private val sdkCore: SdkCore) : RecordCallback {
     override fun onStartRecording() {
         updateRecording(true)
     }
@@ -19,10 +19,10 @@ internal class SessionReplayRecordCallback(private val datadogCore: SdkCore) : R
     }
 
     private fun updateRecording(isRecording: Boolean) {
-        val featureContext = mapOf(SessionReplayFeature.IS_RECORDING_CONTEXT_KEY to isRecording)
-        datadogCore.updateFeatureContext(
-            SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME,
-            featureContext
-        )
+        sdkCore.updateFeatureContext(
+            SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME
+        ) {
+            it[SessionReplayFeature.IS_RECORDING_CONTEXT_KEY] = isRecording
+        }
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayRumContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayRumContextProvider.kt
@@ -6,20 +6,21 @@
 
 package com.datadog.android.sessionreplay.internal
 
-import com.datadog.android.rum.GlobalRum
-import com.datadog.android.rum.internal.domain.RumContext.Companion.NULL_UUID
+import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.sessionreplay.utils.RumContextProvider
 import com.datadog.android.sessionreplay.utils.SessionReplayRumContext
+import com.datadog.android.v2.api.SdkCore
 
-internal class SessionReplayRumContextProvider : RumContextProvider {
+internal class SessionReplayRumContextProvider(
+    private val sdkCore: SdkCore
+) : RumContextProvider {
     override fun getRumContext(): SessionReplayRumContext {
-        return GlobalRum.getRumContext().let {
-            SessionReplayRumContext(
-                applicationId = it.applicationId,
-                sessionId = it.sessionId,
-                viewId = it.viewId
-                    ?: NULL_UUID
-            )
-        }
+        val rumContext = sdkCore.getFeatureContext(RumFeature.RUM_FEATURE_NAME)
+        return SessionReplayRumContext(
+            applicationId = rumContext["application_id"] as? String ?: RumContext.NULL_UUID,
+            sessionId = rumContext["session_id"] as? String ?: RumContext.NULL_UUID,
+            viewId = rumContext["view_id"] as? String ?: RumContext.NULL_UUID
+        )
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/SdkCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/SdkCore.kt
@@ -102,21 +102,27 @@ interface SdkCore {
      */
     fun flushStoredData()
 
-    /**
-     * Sets the context for the particular feature.
-     *
-     * @param featureName Feature name.
-     * @param context Context to set.
-     */
-    fun setFeatureContext(featureName: String, context: Map<String, Any?>)
-
+    // TODO RUMM-0000 Should feature context methods be moved into the FeatureScope maybe?
     /**
      * Updates the context if exists with the new entries. If there is no context yet for the
      * provided [featureName], a new one will be created.
      *
-     * @param entries Entries to add to the existing or new context.
+     * @param featureName Feature name.
+     * @param updateCallback Provides current feature context for the update. If there is no feature
+     * with the given name registered, callback won't be called.
      */
-    fun updateFeatureContext(featureName: String, entries: Map<String, Any?>)
+    fun updateFeatureContext(
+        featureName: String,
+        updateCallback: (context: MutableMap<String, Any?>) -> Unit
+    )
+
+    /**
+     * Retrieves the context for the particular feature.
+     *
+     * @param featureName Feature name.
+     * @return Context for the given feature or empty map if feature is not registered.
+     */
+    fun getFeatureContext(featureName: String): Map<String, Any?>
 
     /**
      * Sets event receiver for the given feature.

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/ContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/ContextProvider.kt
@@ -18,5 +18,5 @@ internal interface ContextProvider {
 
     fun setFeatureContext(feature: String, context: Map<String, Any?>)
 
-    fun updateFeatureContext(feature: String, entries: Map<String, Any?>)
+    fun getFeatureContext(feature: String): Map<String, Any?>
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/DatadogContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/DatadogContextProvider.kt
@@ -84,10 +84,8 @@ internal class DatadogContextProvider(val coreFeature: CoreFeature) : ContextPro
         coreFeature.featuresContext[feature] = context
     }
 
-    override fun updateFeatureContext(feature: String, entries: Map<String, Any?>) {
-        val featureContext = coreFeature.featuresContext[feature]?.toMutableMap() ?: mutableMapOf()
-        featureContext.putAll(entries)
-        coreFeature.featuresContext[feature] = featureContext
+    override fun getFeatureContext(feature: String): Map<String, Any?> {
+        return coreFeature.featuresContext[feature] ?: emptyMap()
     }
 
     private fun NetworkInfoV1.Connectivity.asV2(): NetworkInfo.Connectivity {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/NoOpContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/NoOpContextProvider.kt
@@ -54,7 +54,5 @@ internal class NoOpContextProvider : ContextProvider {
         // no-op
     }
 
-    override fun updateFeatureContext(feature: String, entries: Map<String, Any?>) {
-        // no-op
-    }
+    override fun getFeatureContext(feature: String): Map<String, Any?> = emptyMap()
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
@@ -27,10 +27,10 @@ internal class WebViewLogEventConsumer(
     @WorkerThread
     override fun consume(event: Pair<JsonObject, String>) {
         if (event.second == USER_LOG_EVENT_TYPE) {
-            val rumContext = rumContextProvider.getRumContext()
             sdkCore.getFeature(WebViewLogsFeature.WEB_LOGS_FEATURE_NAME)
                 ?.withWriteContext { datadogContext, eventBatchWriter ->
-                    val mappedEvent = map(event.first, rumContext, datadogContext)
+                    val rumContext = rumContextProvider.getRumContext(datadogContext)
+                    val mappedEvent = map(event.first, datadogContext, rumContext)
                     userLogsWriter.write(eventBatchWriter, mappedEvent)
                 }
         }
@@ -38,8 +38,8 @@ internal class WebViewLogEventConsumer(
 
     private fun map(
         event: JsonObject,
-        rumContext: RumContext?,
-        datadogContext: DatadogContext
+        datadogContext: DatadogContext,
+        rumContext: RumContext?
     ): JsonObject {
         addDdTags(event, datadogContext)
         correctDate(event, datadogContext)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
@@ -33,18 +33,18 @@ internal class WebViewRumEventConsumer(
     override fun consume(event: JsonObject) {
         // make sure we send a noop event to the RumSessionScope to refresh the session if needed
         GlobalRum.notifyIngestedWebViewEvent()
-        val rumContext = contextProvider.getRumContext()
         sdkCore.getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)
             ?.withWriteContext { datadogContext, eventBatchWriter ->
-                val mappedEvent = map(event, rumContext, datadogContext)
+                val rumContext = contextProvider.getRumContext(datadogContext)
+                val mappedEvent = map(event, datadogContext, rumContext)
                 dataWriter.write(eventBatchWriter, mappedEvent)
             }
     }
 
     private fun map(
         event: JsonObject,
-        rumContext: RumContext?,
-        datadogContext: DatadogContext
+        datadogContext: DatadogContext,
+        rumContext: RumContext?
     ): JsonObject {
         try {
             val timeOffset = event.get(VIEW_KEY_NAME)?.asJsonObject?.get(VIEW_ID_KEY_NAME)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapper.kt
@@ -22,7 +22,7 @@ internal class WebViewRumEventMapper {
     )
     fun mapEvent(
         event: JsonObject,
-        context: RumContext?,
+        rumContext: RumContext?,
         timeOffset: Long
     ): JsonObject {
         event.get(DATE_KEY_NAME)?.asLong?.let {
@@ -34,12 +34,12 @@ internal class WebViewRumEventMapper {
             ddSession.addProperty(SESSION_PLAN_KEY_NAME, ViewEvent.Plan.PLAN_1.toJson().asInt)
             dd.add(DD_SESSION_KEY_NAME, ddSession)
         }
-        if (context != null) {
+        if (rumContext != null) {
             val application = event.getAsJsonObject(APPLICATION_KEY_NAME)?.asJsonObject
                 ?: JsonObject()
             val session = event.getAsJsonObject(SESSION_KEY_NAME)?.asJsonObject ?: JsonObject()
-            application.addProperty(ID_KEY_NAME, context.applicationId)
-            session.addProperty(ID_KEY_NAME, context.sessionId)
+            application.addProperty(ID_KEY_NAME, rumContext.applicationId)
+            session.addProperty(ID_KEY_NAME, rumContext.sessionId)
             event.add(APPLICATION_KEY_NAME, application)
             event.add(SESSION_KEY_NAME, session)
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.log.internal
 
-import android.app.Application
 import android.util.Log
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.model.NetworkInfo
@@ -15,8 +14,8 @@ import com.datadog.android.event.MapperSerializer
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.internal.domain.event.LogEventMapperWrapper
 import com.datadog.android.log.model.LogEvent
-import com.datadog.android.utils.config.ApplicationContextTestConfiguration
-import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
+import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.extension.toIsoFormattedTimestamp
 import com.datadog.android.utils.forge.Configurator
@@ -103,6 +102,9 @@ internal class LogsFeatureTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
+    @Forgery
+    lateinit var fakeRumContext: RumContext
+
     @StringForgery(StringForgeryType.HEXADECIMAL)
     lateinit var fakeSpanId: String
 
@@ -135,7 +137,10 @@ internal class LogsFeatureTest {
         fakeDatadogContext = fakeDatadogContext.copy(
             time = fakeDatadogContext.time.copy(
                 serverTimeOffsetMs = fakeServerTimeOffset
-            )
+            ),
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(RumFeature.RUM_FEATURE_NAME, fakeRumContext.toMap())
+            }
         )
 
         GlobalTracer.registerIfAbsent(mockTracer)
@@ -337,10 +342,10 @@ internal class LogsFeatureTest {
                 .hasUserInfo(fakeDatadogContext.userInfo)
                 .hasExactlyAttributes(
                     mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to rumMonitor.context.applicationId,
-                        LogAttributes.RUM_SESSION_ID to rumMonitor.context.sessionId,
-                        LogAttributes.RUM_VIEW_ID to rumMonitor.context.viewId,
-                        LogAttributes.RUM_ACTION_ID to rumMonitor.context.actionId,
+                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
+                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
+                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
+                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId,
                         LogAttributes.DD_TRACE_ID to fakeTraceId,
                         LogAttributes.DD_SPAN_ID to fakeSpanId
                     )
@@ -395,10 +400,10 @@ internal class LogsFeatureTest {
                 .hasUserInfo(fakeDatadogContext.userInfo)
                 .hasExactlyAttributes(
                     fakeAttributes + mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to rumMonitor.context.applicationId,
-                        LogAttributes.RUM_SESSION_ID to rumMonitor.context.sessionId,
-                        LogAttributes.RUM_VIEW_ID to rumMonitor.context.viewId,
-                        LogAttributes.RUM_ACTION_ID to rumMonitor.context.actionId,
+                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
+                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
+                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
+                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId,
                         LogAttributes.DD_TRACE_ID to fakeTraceId,
                         LogAttributes.DD_SPAN_ID to fakeSpanId
                     )
@@ -462,10 +467,10 @@ internal class LogsFeatureTest {
                 .hasUserInfo(fakeDatadogContext.userInfo)
                 .hasExactlyAttributes(
                     fakeAttributes + mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to rumMonitor.context.applicationId,
-                        LogAttributes.RUM_SESSION_ID to rumMonitor.context.sessionId,
-                        LogAttributes.RUM_VIEW_ID to rumMonitor.context.viewId,
-                        LogAttributes.RUM_ACTION_ID to rumMonitor.context.actionId,
+                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
+                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
+                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
+                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId,
                         LogAttributes.DD_TRACE_ID to fakeTraceId,
                         LogAttributes.DD_SPAN_ID to fakeSpanId
                     )
@@ -522,10 +527,10 @@ internal class LogsFeatureTest {
                 .hasNetworkInfo(fakeDatadogContext.networkInfo)
                 .hasExactlyAttributes(
                     fakeAttributes + mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to rumMonitor.context.applicationId,
-                        LogAttributes.RUM_SESSION_ID to rumMonitor.context.sessionId,
-                        LogAttributes.RUM_VIEW_ID to rumMonitor.context.viewId,
-                        LogAttributes.RUM_ACTION_ID to rumMonitor.context.actionId
+                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
+                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
+                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
+                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId
                     )
                 )
                 .hasExactlyTags(
@@ -635,10 +640,10 @@ internal class LogsFeatureTest {
                 .hasNetworkInfo(fakeNetworkInfo)
                 .hasExactlyAttributes(
                     fakeAttributes + mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to rumMonitor.context.applicationId,
-                        LogAttributes.RUM_SESSION_ID to rumMonitor.context.sessionId,
-                        LogAttributes.RUM_VIEW_ID to rumMonitor.context.viewId,
-                        LogAttributes.RUM_ACTION_ID to rumMonitor.context.actionId,
+                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
+                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
+                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
+                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId,
                         LogAttributes.DD_TRACE_ID to fakeTraceId,
                         LogAttributes.DD_SPAN_ID to fakeSpanId
                     )
@@ -695,10 +700,10 @@ internal class LogsFeatureTest {
                 .hasNetworkInfo(fakeDatadogContext.networkInfo)
                 .hasExactlyAttributes(
                     fakeAttributes + mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to rumMonitor.context.applicationId,
-                        LogAttributes.RUM_SESSION_ID to rumMonitor.context.sessionId,
-                        LogAttributes.RUM_VIEW_ID to rumMonitor.context.viewId,
-                        LogAttributes.RUM_ACTION_ID to rumMonitor.context.actionId,
+                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
+                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
+                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
+                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId,
                         LogAttributes.DD_TRACE_ID to fakeTraceId,
                         LogAttributes.DD_SPAN_ID to fakeSpanId
                     )
@@ -759,10 +764,10 @@ internal class LogsFeatureTest {
                 .hasUserInfo(fakeDatadogContext.userInfo)
                 .hasExactlyAttributes(
                     mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to rumMonitor.context.applicationId,
-                        LogAttributes.RUM_SESSION_ID to rumMonitor.context.sessionId,
-                        LogAttributes.RUM_VIEW_ID to rumMonitor.context.viewId,
-                        LogAttributes.RUM_ACTION_ID to rumMonitor.context.actionId,
+                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
+                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
+                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
+                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId,
                         LogAttributes.DD_TRACE_ID to fakeTraceId,
                         LogAttributes.DD_SPAN_ID to fakeSpanId
                     )
@@ -812,14 +817,12 @@ internal class LogsFeatureTest {
     }
 
     companion object {
-        val appContext = ApplicationContextTestConfiguration(Application::class.java)
-        val rumMonitor = GlobalRumMonitorTestConfiguration()
         val logger = LoggerTestConfiguration()
 
         @TestConfigurationsProvider
         @JvmStatic
         fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(appContext, logger, rumMonitor)
+            return listOf(logger)
         }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/GlobalRumTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/GlobalRumTest.kt
@@ -6,14 +6,11 @@
 
 package com.datadog.android.rum
 
-import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn
 import com.datadog.tools.unit.extensions.ProhibitLeavingStaticMocksExtension
-import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
-import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -88,29 +85,5 @@ internal class GlobalRumTest {
 
         // Then
         verifyZeroInteractions(mockNoOpRumMonitor)
-    }
-
-    @Test
-    fun `M update RUM context W updateRumContext()`() {
-        // Given
-        val newContext = mock<RumContext>()
-
-        // When
-        GlobalRum.updateRumContext(newContext)
-
-        // Then
-        assertThat(GlobalRum.getRumContext()).isEqualTo(newContext)
-    }
-
-    @Test
-    fun `M not update RUM context W updateRumContext() { applyOnlyIf predicate returns false }`() {
-        // Given
-        val newContext = mock<RumContext>()
-
-        // When
-        GlobalRum.updateRumContext(newContext, applyOnlyIf = { false })
-
-        // Then
-        assertThat(GlobalRum.getRumContext()).isNotEqualTo(newContext)
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
@@ -69,7 +69,7 @@ internal class RumMonitorBuilderTest {
         whenever(mockSdkCore.coreFeature) doReturn coreFeature.mockInstance
         whenever(mockSdkCore.contextProvider) doReturn mock()
 
-        rumFeature = RumFeature(coreFeature.mockInstance)
+        rumFeature = RumFeature(mockSdkCore, coreFeature.mockInstance)
         rumFeature.initialize(appContext.mockInstance, fakeConfig)
         whenever(mockSdkCore.rumFeature) doReturn rumFeature
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -26,6 +26,7 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.core.internal.storage.NoOpDataWriter
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -72,12 +73,15 @@ internal class RumFeatureTest {
     @Mock
     lateinit var mockChoreographer: Choreographer
 
+    @Mock
+    lateinit var mockSdkCore: SdkCore
+
     @BeforeEach
     fun `set up RUM`() {
         doNothing().whenever(mockChoreographer).postFrameCallback(any())
         mockChoreographerInstance(mockChoreographer)
 
-        testedFeature = RumFeature(coreFeature.mockInstance)
+        testedFeature = RumFeature(mockSdkCore, coreFeature.mockInstance)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/RumContextTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/RumContextTest.kt
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.domain
+
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(ForgeExtension::class)
+@ForgeConfiguration(Configurator::class)
+internal class RumContextTest {
+
+    @RepeatedTest(8)
+    fun `𝕄 return the same object 𝕎 toMap + fromFeatureContext()`(
+        @Forgery fakeRumContext: RumContext
+    ) {
+        // Given
+        val anotherRumContext = RumContext.fromFeatureContext(fakeRumContext.toMap())
+
+        // Then
+        assertThat(anotherRumContext).isEqualTo(fakeRumContext)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.domain.scope
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.utils.config.LoggerTestConfiguration
@@ -24,6 +25,7 @@ import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.isA
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.same
@@ -128,6 +130,28 @@ internal class RumSessionScopeTest {
         // whatever happens
         assertThat(testedScope.isActive()).isTrue()
     }
+
+    // region RUM Feature Context
+
+    @Test
+    fun `𝕄 update RUM feature context 𝕎 init()`() {
+        // Given
+        val expectedContext = testedScope.getRumContext()
+
+        // Then
+        argumentCaptor<(MutableMap<String, Any?>) -> Unit> {
+            verify(mockSdkCore).updateFeatureContext(eq(RumFeature.RUM_FEATURE_NAME), capture())
+
+            val rumContext = mutableMapOf<String, Any?>()
+            lastValue.invoke(rumContext)
+
+            assertThat(rumContext["application_id"]).isEqualTo(expectedContext.applicationId)
+            assertThat(rumContext["session_id"]).isEqualTo(expectedContext.sessionId)
+            assertThat(rumContext["session_state"]).isEqualTo(expectedContext.sessionState)
+        }
+    }
+
+    // endregion
 
     // region childScope
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayRecordCallbackTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayRecordCallbackTest.kt
@@ -7,7 +7,10 @@
 package com.datadog.android.sessionreplay.internal
 
 import com.datadog.android.v2.api.SdkCore
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.verify
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -38,10 +41,19 @@ internal class SessionReplayRecordCallbackTest {
         testedRecordCallback.onStartRecording()
 
         // Then
-        verify(mockDatadogCore).updateFeatureContext(
-            SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME,
-            mapOf(SessionReplayFeature.IS_RECORDING_CONTEXT_KEY to true)
-        )
+        argumentCaptor<(MutableMap<String, Any?>) -> Unit> {
+            verify(mockDatadogCore).updateFeatureContext(
+                eq(SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME),
+                capture()
+            )
+
+            val featureContext = mutableMapOf<String, Any?>()
+            lastValue.invoke(featureContext)
+
+            assertThat(
+                featureContext[SessionReplayFeature.IS_RECORDING_CONTEXT_KEY] as? Boolean
+            ).isTrue
+        }
     }
 
     @Test
@@ -50,9 +62,18 @@ internal class SessionReplayRecordCallbackTest {
         testedRecordCallback.onStopRecording()
 
         // Then
-        verify(mockDatadogCore).updateFeatureContext(
-            SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME,
-            mapOf(SessionReplayFeature.IS_RECORDING_CONTEXT_KEY to false)
-        )
+        argumentCaptor<(MutableMap<String, Any?>) -> Unit> {
+            verify(mockDatadogCore).updateFeatureContext(
+                eq(SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME),
+                capture()
+            )
+
+            val featureContext = mutableMapOf<String, Any?>()
+            lastValue.invoke(featureContext)
+
+            assertThat(
+                featureContext[SessionReplayFeature.IS_RECORDING_CONTEXT_KEY] as? Boolean
+            ).isFalse
+        }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/GlobalRumMonitorTestConfiguration.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/GlobalRumMonitorTestConfiguration.kt
@@ -8,7 +8,6 @@ package com.datadog.android.utils.config
 
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.NoOpRumMonitor
-import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.tools.unit.extensions.config.MockTestConfiguration
 import fr.xgouchet.elmyr.Forge
@@ -16,20 +15,15 @@ import fr.xgouchet.elmyr.Forge
 internal class GlobalRumMonitorTestConfiguration :
     MockTestConfiguration<AdvancedRumMonitor>(AdvancedRumMonitor::class.java) {
 
-    lateinit var context: RumContext
-
     override fun setUp(forge: Forge) {
         super.setUp(forge)
         GlobalRum.monitor = mockInstance
         GlobalRum.isRegistered.set(true)
-        context = forge.getForgery()
-        GlobalRum.updateRumContext(context)
     }
 
     override fun tearDown(forge: Forge) {
         GlobalRum.monitor = NoOpRumMonitor()
         GlobalRum.isRegistered.set(false)
-        GlobalRum.updateRumContext(RumContext())
         GlobalRum.globalAttributes.clear()
         super.tearDown(forge)
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/DatadogContextProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/DatadogContextProviderTest.kt
@@ -172,46 +172,6 @@ internal class DatadogContextProviderTest {
         assertThat(coreFeature.mockInstance.featuresContext[feature]).isEqualTo(context)
     }
 
-    @Test
-    fun `𝕄 update feature context 𝕎 updateFeatureContext() { no previous context }`(
-        @StringForgery feature: String,
-        @MapForgery(
-            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
-            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
-        ) entries: Map<String, String>
-    ) {
-        // Given
-
-        // When
-        testedProvider.updateFeatureContext(feature, entries)
-
-        // Then
-        assertThat(coreFeature.mockInstance.featuresContext[feature]).isEqualTo(entries)
-    }
-
-    @Test
-    fun `𝕄 update feature context 𝕎 updateFeatureContext() { with previous context }`(
-        @StringForgery feature: String,
-        @MapForgery(
-            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
-            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
-        ) previousContext: Map<String, String>,
-        @MapForgery(
-            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
-            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
-        ) entries: Map<String, String>
-    ) {
-        // Given
-        testedProvider.setFeatureContext(feature, previousContext)
-        val expectedContext = previousContext.toMutableMap().apply { putAll(entries) }
-
-        // When
-        testedProvider.updateFeatureContext(feature, entries)
-
-        // Then
-        assertThat(coreFeature.mockInstance.featuresContext[feature]).isEqualTo(expectedContext)
-    }
-
     companion object {
         val appContext = ApplicationContextTestConfiguration(Application::class.java)
         val coreFeature = CoreFeatureTestConfiguration(appContext)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
@@ -157,7 +157,7 @@ internal class WebViewLogEventConsumerTest {
         @Forgery fakeRumContext: RumContext
     ) {
         // Given
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(fakeRumContext)
+        whenever(mockRumContextProvider.getRumContext(fakeDatadogContext)) doReturn fakeRumContext
         val expectedDate = fakeTimeOffset +
             fakeWebLogEvent.get(WebViewLogEventConsumer.DATE_KEY_NAME).asLong
         var expectedTags = mobileSdkDdtags()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
@@ -8,14 +8,15 @@ package com.datadog.android.webview.internal.rum
 
 import com.datadog.android.log.internal.utils.ERROR_WITH_TELEMETRY_LEVEL
 import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
-import com.datadog.android.utils.config.SessionScopeTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.aRumEventAsJson
 import com.datadog.android.v2.api.EventBatchWriter
@@ -103,6 +104,9 @@ internal class WebViewRumEventConsumerTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
+    @Forgery
+    lateinit var fakeRumContext: RumContext
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeTags = if (forge.aBool()) {
@@ -120,8 +124,8 @@ internal class WebViewRumEventConsumerTest {
         )
 
         whenever(
-            mockRumContextProvider.getRumContext()
-        ) doReturn sessionScopeTestConfiguration.fakeRumContext
+            mockRumContextProvider.getRumContext(any())
+        ) doReturn fakeRumContext
 
         whenever(
             mockSdkCore.getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)
@@ -156,7 +160,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeViewEventAsJson,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenReturn(fakeMappedViewEvent)
@@ -178,7 +182,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeViewEventAsJson,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenReturn(fakeMappedViewEvent)
@@ -193,7 +197,7 @@ internal class WebViewRumEventConsumerTest {
     @Test
     fun `M write the mapped event W consume(){ no RUM context, view event }`(forge: Forge) {
         // Given
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(null)
+        whenever(mockRumContextProvider.getRumContext(fakeDatadogContext)) doReturn null
         val fakeViewEvent: ViewEvent = forge.getForgery()
         val fakeViewEventAsJson = fakeViewEvent.toJson().asJsonObject
         whenever(
@@ -224,7 +228,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeActionEventAsJson,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenReturn(fakeMappedActionEvent)
@@ -245,7 +249,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeActionEventAsJson,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenReturn(fakeMappedActionEvent)
@@ -260,7 +264,7 @@ internal class WebViewRumEventConsumerTest {
     @Test
     fun `M write the mapped event W consume(){ no RUM context, action event }`(forge: Forge) {
         // Given
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(null)
+        whenever(mockRumContextProvider.getRumContext(fakeDatadogContext)) doReturn null
         val fakeActionEvent: ActionEvent = forge.getForgery()
         val fakeActionEventAsJson = fakeActionEvent.toJson().asJsonObject
         whenever(
@@ -290,7 +294,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeResourceEventAsJson,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenReturn(fakeMappedResourceEvent)
@@ -311,7 +315,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeResourceEventAsJson,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenReturn(fakeMappedResourceEvent)
@@ -326,7 +330,7 @@ internal class WebViewRumEventConsumerTest {
     @Test
     fun `M write the mapped event W consume(){ no RUM context, resource event }`(forge: Forge) {
         // Given
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(null)
+        whenever(mockRumContextProvider.getRumContext(fakeDatadogContext)) doReturn null
         val fakeResourceEvent: ResourceEvent = forge.getForgery()
         val fakeResourceEventAsJson = fakeResourceEvent.toJson().asJsonObject
         whenever(
@@ -356,7 +360,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeErrorEventAsJson,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenReturn(fakeMappedErrorEvent)
@@ -377,7 +381,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeErrorEventAsJson,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenReturn(fakeMappedErrorEvent)
@@ -392,7 +396,7 @@ internal class WebViewRumEventConsumerTest {
     @Test
     fun `M write the mapped event W consume(){ no RUM context, error event}`(forge: Forge) {
         // Given
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(null)
+        whenever(mockRumContextProvider.getRumContext(fakeDatadogContext)) doReturn null
         val fakeErrorEvent: ErrorEvent = forge.getForgery()
         val fakeErrorEventAsJson = fakeErrorEvent.toJson().asJsonObject
         whenever(
@@ -422,7 +426,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeLongTaskEventAsJson,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenReturn(fakeMappedLongTaskEvent)
@@ -443,7 +447,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeLongTaskEventAsJson,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         )
@@ -459,7 +463,7 @@ internal class WebViewRumEventConsumerTest {
     @Test
     fun `M write the mapped event W consume(){ no RUM context, longtask event }`(forge: Forge) {
         // Given
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(null)
+        whenever(mockRumContextProvider.getRumContext(fakeDatadogContext)) doReturn null
         val fakeLongTaskEvent: LongTaskEvent = forge.getForgery()
         val fakeLongTaskEventAsJson = fakeLongTaskEvent.toJson().asJsonObject
         whenever(
@@ -492,7 +496,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeRumEvent,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenThrow(fakeException)
@@ -512,7 +516,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeRumEvent,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenThrow(fakeException)
@@ -537,7 +541,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeRumEvent,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 0
             )
         ).thenReturn(fakeMappedRumEvent)
@@ -559,7 +563,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeRumEvent,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 0
             )
         ).thenReturn(fakeMappedRumEvent)
@@ -581,7 +585,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeRumEvent,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 0
             )
         ).thenReturn(fakeMappedRumEvent)
@@ -630,7 +634,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 any(),
-                eq(sessionScopeTestConfiguration.fakeRumContext),
+                eq(fakeRumContext),
                 eq(fakeServerTimeOffsetInMillis)
             )
         ).thenReturn(fakeMappedViewEvent)
@@ -643,7 +647,7 @@ internal class WebViewRumEventConsumerTest {
         // Then
         verify(mockWebViewRumEventMapper, times(3)).mapEvent(
             fakeEvent,
-            sessionScopeTestConfiguration.fakeRumContext,
+            fakeRumContext,
             fakeServerTimeOffsetInMillis
         )
     }
@@ -678,18 +682,17 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeEvent,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeServerTimeOffsetInMillis
             )
         ).thenReturn(fakeEvent)
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 fakeEvent2,
-                sessionScopeTestConfiguration.fakeRumContext,
+                fakeRumContext,
                 fakeSecondServerTimeOffset
             )
-        )
-            .thenReturn(fakeEvent2)
+        ).thenReturn(fakeEvent2)
 
         // When
         testedConsumer.consume(fakeEvent)
@@ -698,12 +701,12 @@ internal class WebViewRumEventConsumerTest {
         // Then
         verify(mockWebViewRumEventMapper).mapEvent(
             fakeEvent,
-            sessionScopeTestConfiguration.fakeRumContext,
+            fakeRumContext,
             fakeServerTimeOffsetInMillis
         )
         verify(mockWebViewRumEventMapper).mapEvent(
             fakeEvent2,
-            sessionScopeTestConfiguration.fakeRumContext,
+            fakeRumContext,
             fakeSecondServerTimeOffset
         )
     }
@@ -747,7 +750,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 any(),
-                eq(sessionScopeTestConfiguration.fakeRumContext),
+                eq(fakeRumContext),
                 any()
             )
         ).thenReturn(fakeMappedViewEvent)
@@ -809,7 +812,7 @@ internal class WebViewRumEventConsumerTest {
         whenever(
             mockWebViewRumEventMapper.mapEvent(
                 any(),
-                eq(sessionScopeTestConfiguration.fakeRumContext),
+                eq(fakeRumContext),
                 any()
             )
         ).thenReturn(fakeMappedViewEvent)
@@ -829,13 +832,13 @@ internal class WebViewRumEventConsumerTest {
     // endregion
 
     companion object {
-        val sessionScopeTestConfiguration = SessionScopeTestConfiguration()
+        val rumMonitor = GlobalRumMonitorTestConfiguration()
         val logger = LoggerTestConfiguration()
 
         @TestConfigurationsProvider
         @JvmStatic
         fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(logger, sessionScopeTestConfiguration)
+            return listOf(logger, rumMonitor)
         }
 
         @JvmStatic

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventMapperTest.kt
@@ -6,21 +6,19 @@
 
 package com.datadog.android.webview.internal.rum
 
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
-import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.extension.getString
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.aRumEventAsJson
-import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.assertj.JsonObjectAssert.Companion.assertThat
-import com.datadog.tools.unit.extensions.TestConfigurationExtension
-import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.google.gson.JsonObject
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -34,8 +32,7 @@ import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class),
-    ExtendWith(TestConfigurationExtension::class)
+    ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
@@ -45,6 +42,10 @@ internal class WebViewRumEventMapperTest {
 
     @LongForgery
     var fakeServerTimeOffset: Long = 0L
+
+    @Forgery
+    lateinit var fakeRumContext: RumContext
+
     lateinit var fakeTags: Map<String, String>
 
     @BeforeEach
@@ -68,7 +69,7 @@ internal class WebViewRumEventMapperTest {
         // When
         val mappedEvent = testedWebViewRumEventMapper.mapEvent(
             fakeRumJsonObject,
-            rumMonitor.context,
+            fakeRumContext,
             fakeServerTimeOffset
         )
 
@@ -89,7 +90,7 @@ internal class WebViewRumEventMapperTest {
         // When
         val mappedEvent = testedWebViewRumEventMapper.mapEvent(
             fakeRumJsonObject,
-            rumMonitor.context,
+            fakeRumContext,
             fakeServerTimeOffset
         )
 
@@ -110,7 +111,7 @@ internal class WebViewRumEventMapperTest {
         // When
         val mappedEvent = testedWebViewRumEventMapper.mapEvent(
             fakeRumJsonObject,
-            rumMonitor.context,
+            fakeRumContext,
             fakeServerTimeOffset
         )
 
@@ -131,7 +132,7 @@ internal class WebViewRumEventMapperTest {
         // When
         val mappedEvent = testedWebViewRumEventMapper.mapEvent(
             fakeRumJsonObject,
-            rumMonitor.context,
+            fakeRumContext,
             fakeServerTimeOffset
         )
 
@@ -152,7 +153,7 @@ internal class WebViewRumEventMapperTest {
         // When
         val mappedEvent = testedWebViewRumEventMapper.mapEvent(
             fakeRumJsonObject,
-            rumMonitor.context,
+            fakeRumContext,
             fakeServerTimeOffset
         )
 
@@ -176,7 +177,7 @@ internal class WebViewRumEventMapperTest {
         // When
         val mappedEvent = testedWebViewRumEventMapper.mapEvent(
             fakeRumJsonObject,
-            rumMonitor.context,
+            fakeRumContext,
             fakeServerTimeOffset
         )
 
@@ -251,9 +252,9 @@ internal class WebViewRumEventMapperTest {
             .isEqualTo(expectedEvent)
 
         assertThat(mappedEvent.getAsJsonObject(WebViewRumEventMapper.APPLICATION_KEY_NAME))
-            .hasField(WebViewRumEventMapper.ID_KEY_NAME, rumMonitor.context.applicationId)
+            .hasField(WebViewRumEventMapper.ID_KEY_NAME, fakeRumContext.applicationId)
         assertThat(mappedEvent.getAsJsonObject(WebViewRumEventMapper.SESSION_KEY_NAME))
-            .hasField(WebViewRumEventMapper.ID_KEY_NAME, rumMonitor.context.sessionId)
+            .hasField(WebViewRumEventMapper.ID_KEY_NAME, fakeRumContext.sessionId)
         assertThat(mappedEvent).hasField(
             WebViewRumEventMapper.DATE_KEY_NAME,
             expectedDate
@@ -265,15 +266,5 @@ internal class WebViewRumEventMapperTest {
             WebViewRumEventMapper.SESSION_PLAN_KEY_NAME,
             ViewEvent.Plan.PLAN_1.toJson().asLong
         )
-    }
-
-    companion object {
-        val rumMonitor = GlobalRumMonitorTestConfiguration()
-
-        @TestConfigurationsProvider
-        @JvmStatic
-        fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(rumMonitor)
-        }
     }
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -1103,7 +1103,9 @@ datadog:
       - "kotlin.collections.Map.mapKeys(kotlin.Function1)"
       - "kotlin.collections.Map.mapNotNull(kotlin.Function1)"
       - "kotlin.collections.Map.mapValues(kotlin.Function1)"
+      - "kotlin.collections.Map.orEmpty()"
       - "kotlin.collections.Map.toMutableMap()"
+      - "kotlin.collections.MutableCollection.flatMap(kotlin.Function1)"
       - "kotlin.collections.MutableCollection.forEach(kotlin.Function1)"
       - "kotlin.collections.MutableCollection.toList()"
       - "kotlin.collections.MutableIterator.hasNext()"
@@ -1174,6 +1176,7 @@ datadog:
       - "kotlin.collections.MutableSet.map(kotlin.Function1)"
       - "kotlin.collections.MutableSet.remove(java.io.File)"
       - "kotlin.collections.MutableSet.remove(com.datadog.android.v2.core.internal.storage.ConsentAwareStorage.Batch)"
+      - "kotlin.collections.Set.forEach(kotlin.Function1)"
       - "kotlin.sequences.Sequence.filter(kotlin.Function1)"
       - "kotlin.sequences.Sequence.forEach(kotlin.Function1)"
       # endregion

--- a/instrumented/integration/proguard-rules.pro
+++ b/instrumented/integration/proguard-rules.pro
@@ -10,9 +10,8 @@
 -keepnames class com.datadog.android.Datadog {
     *;
 }
-# Required because we need access to GlobalRum.activeContext and GlobalRum.isRegistered by reflection
+# Required because we need access to GlobalRum.isRegistered by reflection
 -keepnames class com.datadog.android.rum.GlobalRum {
-    private java.util.concurrent.atomic.AtomicReference activeContext;
     private java.util.concurrent.atomic.AtomicBoolean isRegistered;
 }
 

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ExpectedEvents.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ExpectedEvents.kt
@@ -6,11 +6,10 @@
 
 package com.datadog.android.sdk.integration.rum
 
-import com.datadog.android.rum.GlobalRum
-import com.datadog.tools.unit.getFieldValue
+import com.datadog.android.Datadog
+import com.datadog.android.v2.api.SdkCore
 import com.datadog.tools.unit.getStaticValue
 import com.google.gson.JsonElement
-import java.util.concurrent.atomic.AtomicReference
 
 internal data class ExpectedRumContext(
     val applicationId: String,
@@ -69,12 +68,11 @@ internal enum class ErrorSource(val sourceName: String) {
 }
 
 private fun rumContextValues(): Triple<String, String, String> {
-    val rumContextRef: AtomicReference<Any> =
-        GlobalRum::class.java.getStaticValue("activeContext")
-    val rumContext = rumContextRef.get()
-    val appId: String = rumContext.getFieldValue("applicationId")
-    val sessionId: String = rumContext.getFieldValue("sessionId")
-    val viewId: String? = rumContext.getFieldValue("viewId")
+    val sdkCore: SdkCore = Datadog::class.java.getStaticValue("globalSdkCore")
+    val rumContext: Map<String, Any?> = sdkCore.getFeatureContext("rum")
+    val appId: String = rumContext["application_id"] as String
+    val sessionId: String = rumContext["session_id"] as String
+    val viewId: String? = rumContext["view_id"] as String?
     return Triple(appId, sessionId, viewId ?: "null")
 }
 

--- a/instrumented/nightly-tests/proguard-rules.pro
+++ b/instrumented/nightly-tests/proguard-rules.pro
@@ -14,9 +14,8 @@
 -keepnames class com.datadog.android.Datadog {
     *;
 }
-# Required because we need access to GlobalRum.activeContext and GlobalRum.isRegistered by reflection
+# Required because we need access to GlobalRum.isRegistered by reflection
 -keepnames class com.datadog.android.rum.GlobalRum {
-    private java.util.concurrent.atomic.AtomicReference activeContext;
     private java.util.concurrent.atomic.AtomicBoolean isRegistered;
 }
 


### PR DESCRIPTION
### What does this PR do?

This change removes global RUM context from `GlobalRum` singleton by moving it to the feature's context (`DatadogContext#featuresContext`).

Now RUM context will be stored in the generic dictionary `Map<String, Any?>` and can be accessed either by calling `DatadogContext#featuresContext` or by calling `SdkCore#getFeatureContext`.

Also `SdkCore#setFeatureContext` is removed in the favour of `SdkCore#updateFeatureContext` method which gives a mutable dictionary for the update, final update is thread-safe.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

