### PR TITLE
RUMM-2298 Correctly resolve ShapeStyle opacity in Wireframes

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapper.kt
@@ -27,7 +27,7 @@ internal class ViewWireframeMapper :
         view.getLocationOnScreen(coordinates)
         val x = coordinates[0].densityNormalized(pixelsDensity).toLong()
         val y = coordinates[1].densityNormalized(pixelsDensity).toLong()
-        val styleBorderPair = view.background?.resolveShapeStyleAndBorder()
+        val styleBorderPair = view.background?.resolveShapeStyleAndBorder(view.alpha)
         return MobileSegment.Wireframe.ShapeWireframe(
             resolveViewId(view),
             x,
@@ -39,18 +39,18 @@ internal class ViewWireframeMapper :
         )
     }
 
-    private fun Drawable.resolveShapeStyleAndBorder():
+    private fun Drawable.resolveShapeStyleAndBorder(viewAlpha: Float):
         Pair<MobileSegment.ShapeStyle?, MobileSegment.ShapeBorder?>? {
         return if (this is ColorDrawable) {
             val color = colorAndAlphaAsStringHexa(color, alpha.toLong())
-            MobileSegment.ShapeStyle(color, alpha) to null
+            MobileSegment.ShapeStyle(color, viewAlpha) to null
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
             this is RippleDrawable &&
             numberOfLayers >= 1
         ) {
-            getDrawable(0).resolveShapeStyleAndBorder()
+            getDrawable(0).resolveShapeStyleAndBorder(viewAlpha)
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && this is InsetDrawable) {
-            drawable?.resolveShapeStyleAndBorder()
+            drawable?.resolveShapeStyleAndBorder(viewAlpha)
         } else {
             // We cannot handle this drawable so we will use a border to delimit its container
             // bounds.

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseTextViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseTextViewWireframeMapperTest.kt
@@ -177,6 +177,7 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
     ) {
         // Given
         val fakeStyleColor = forge.aStringMatching("#[0-9a-f]{8}")
+        val fakeViewAlpha = forge.aFloat(min = 0f, max = 1f)
         val fakeDrawableColor = fakeStyleColor
             .substring(1)
             .toLong(16)
@@ -195,6 +196,7 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
             whenever(this.background).thenReturn(mockDrawable)
             whenever(this.text).thenReturn(fakeText)
             whenever(this.typeface).thenReturn(mock())
+            whenever(this.alpha).thenReturn(fakeViewAlpha)
         }
 
         // When
@@ -205,7 +207,7 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
             shapeStyle = MobileSegment
                 .ShapeStyle(
                     backgroundColor = fakeStyleColor,
-                    opacity = fakeDrawableAlpha,
+                    opacity = fakeViewAlpha,
                     cornerRadius = null
                 )
         )

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ViewWireframeMapperTest.kt
@@ -89,6 +89,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         forge: Forge
     ) {
         // Given
+        val fakeViewAlpha = forge.aFloat(min = 0f, max = 1f)
         val fakeStyleColor = forge.aStringMatching("#[0-9a-f]{8}")
         val fakeDrawableColor = fakeStyleColor
             .substring(1)
@@ -106,6 +107,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         }
         val mockView = forge.aMockView<View>().apply {
             whenever(this.background).thenReturn(mockDrawable)
+            whenever(this.alpha).thenReturn(fakeViewAlpha)
         }
 
         // When
@@ -116,7 +118,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
             shapeStyle = MobileSegment
                 .ShapeStyle(
                     backgroundColor = fakeStyleColor,
-                    opacity = fakeDrawableAlpha,
+                    opacity = fakeViewAlpha,
                     cornerRadius = null
                 )
         )
@@ -130,6 +132,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         forge: Forge
     ) {
         // Given
+        val fakeViewAlpha = forge.aFloat(min = 0f, max = 1f)
         val fakeStyleColor = forge.aStringMatching("#[0-9a-f]{8}")
         val fakeDrawableColor = fakeStyleColor
             .substring(1)
@@ -150,6 +153,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         }
         val mockView = forge.aMockView<View>().apply {
             whenever(this.background).thenReturn(mockInsetDrawable)
+            whenever(this.alpha).thenReturn(fakeViewAlpha)
         }
 
         // When
@@ -160,7 +164,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
             shapeStyle = MobileSegment
                 .ShapeStyle(
                     backgroundColor = fakeStyleColor,
-                    opacity = fakeDrawableAlpha,
+                    opacity = fakeViewAlpha,
                     cornerRadius = null
                 )
         )
@@ -210,6 +214,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         forge: Forge
     ) {
         // Given
+        val fakeViewAlpha = forge.aFloat(min = 0f, max = 1f)
         val fakeStyleColor = forge.aStringMatching("#[0-9a-f]{8}")
         val fakeDrawableColor = fakeStyleColor
             .substring(1)
@@ -231,6 +236,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         }
         val mockView = forge.aMockView<View>().apply {
             whenever(this.background).thenReturn(mockRipple)
+            whenever(this.alpha).thenReturn(fakeViewAlpha)
         }
 
         // When
@@ -241,7 +247,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
             shapeStyle = MobileSegment
                 .ShapeStyle(
                     backgroundColor = fakeStyleColor,
-                    opacity = fakeDrawableAlpha,
+                    opacity = fakeViewAlpha,
                     cornerRadius = null
                 )
         )


### PR DESCRIPTION
### What does this PR do?

Previously we were resolving the `ShapeStyle` opacity from the `View.backround` which is not correct. For example a `TextView` can use a transparent background but still have a visible content. We need to resolve this attribute directly from the `View.alpha` property.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

