### PR TITLE
RUMM-2753: Improve SDK performance a bit

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -1867,6 +1867,7 @@ interface com.datadog.android.v2.api.RequestFactory
     const val QUERY_PARAM_SOURCE: String
     const val QUERY_PARAM_TAGS: String
 interface com.datadog.android.v2.api.SdkCore
+  val time: com.datadog.android.v2.api.context.TimeInfo
   fun registerFeature(String, FeatureStorageConfiguration, FeatureUploadConfiguration)
   fun getFeature(String): FeatureScope?
   fun setVerbosity(Int)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -15,9 +15,9 @@ import com.datadog.android.core.model.UserInfo
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.android.v2.core.internal.HashGenerator
 import com.datadog.android.v2.core.internal.Sha256HashGenerator
 import java.util.concurrent.atomic.AtomicBoolean

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/DefaultAndroidInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/DefaultAndroidInfoProvider.kt
@@ -23,59 +23,52 @@ internal class DefaultAndroidInfoProvider(
     // lazy is just to avoid breaking the tests (because without lazy type is resolved at the
     // construction time and Build.MODEL is null in unit-tests) and also to have value resolved
     // once to avoid different values for foldables during the application lifecycle
-    override val deviceType: DeviceType by lazy {
+    override val deviceType: DeviceType by lazy(LazyThreadSafetyMode.PUBLICATION) {
         resolveDeviceType(
             appContext,
             sdkVersionProvider
         )
     }
 
-    override val deviceName: String
-        get() {
-            return if (deviceBrand.isEmpty()) {
-                deviceModel
-            } else if (deviceModel.contains(deviceBrand)) {
-                deviceModel
-            } else {
-                "$deviceBrand $deviceModel"
-            }
+    override val deviceName: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        if (deviceBrand.isEmpty()) {
+            deviceModel
+        } else if (deviceModel.contains(deviceBrand)) {
+            deviceModel
+        } else {
+            "$deviceBrand $deviceModel"
         }
+    }
 
-    override val deviceBrand: String
-        get() {
-            return Build.BRAND.replaceFirstChar {
-                if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString()
-            }
+    override val deviceBrand: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        Build.BRAND.replaceFirstChar {
+            if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString()
         }
+    }
 
-    override val deviceModel: String
-        get() {
-            return Build.MODEL
-        }
+    override val deviceModel: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        Build.MODEL
+    }
 
-    override val deviceBuildId: String
-        get() {
-            return Build.ID
-        }
+    override val deviceBuildId: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        Build.ID
+    }
 
     override val osName: String = "Android"
 
-    override val osVersion: String
-        get() {
-            return Build.VERSION.RELEASE
-        }
+    override val osVersion: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        Build.VERSION.RELEASE
+    }
 
-    override val osMajorVersion: String
-        get() {
-            // result of split always have at least 1 element
-            @Suppress("UnsafeThirdPartyFunctionCall")
-            return osVersion.split('.').first()
-        }
+    override val osMajorVersion: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        // result of split always have at least 1 element
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        osVersion.split('.').first()
+    }
 
-    override val architecture: String
-        get() {
-            return System.getProperty("os.arch") ?: "unknown"
-        }
+    override val architecture: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        System.getProperty("os.arch") ?: "unknown"
+    }
 
     companion object {
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -80,7 +80,7 @@ internal open class RumViewScope(
         private set
     private val startedNanos: Long = eventTime.nanoTime
 
-    internal val serverTimeOffsetInMs = contextProvider.context.time.serverTimeOffsetMs
+    internal val serverTimeOffsetInMs = sdkCore.time.serverTimeOffsetMs
     internal val eventTimestamp = eventTime.timestamp + serverTimeOffsetInMs
 
     internal var activeActionScope: RumScope? = null

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -9,7 +9,6 @@ package com.datadog.android.sessionreplay.internal
 import android.app.Application
 import android.content.Context
 import com.datadog.android.core.configuration.Configuration
-import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.sessionreplay.LifecycleCallback
 import com.datadog.android.sessionreplay.RecordWriter
@@ -23,7 +22,6 @@ import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class SessionReplayFeature(
-    private val coreFeature: CoreFeature,
     private val sdkCore: SdkCore,
     private val sessionReplayCallbackProvider:
         (RecordWriter, Configuration.Feature.SessionReplay) ->
@@ -32,7 +30,7 @@ internal class SessionReplayFeature(
                 SessionReplayRumContextProvider(sdkCore),
                 configuration.privacy,
                 recordWriter,
-                SessionReplayTimeProvider(coreFeature.contextProvider),
+                SessionReplayTimeProvider(sdkCore),
                 SessionReplayRecordCallback(sdkCore)
             )
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/time/SessionReplayTimeProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/time/SessionReplayTimeProvider.kt
@@ -8,22 +8,21 @@ package com.datadog.android.sessionreplay.internal.time
 
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.sessionreplay.utils.TimeProvider
-import com.datadog.android.v2.api.context.DatadogContext
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.api.SdkCore
 
 internal class SessionReplayTimeProvider(
-    private val contextProvider: ContextProvider,
+    private val sdkCore: SdkCore,
     private val currentTimeProvider: () -> Long =
         { System.currentTimeMillis() }
 ) : TimeProvider {
     override fun getDeviceTimestamp(): Long {
         return currentTimeProvider() +
-            resolveRumViewTimestampOffset(contextProvider.context)
+            resolveRumViewTimestampOffset()
     }
 
-    private fun resolveRumViewTimestampOffset(datadogContext: DatadogContext): Long {
-        val rumFeatureContext = datadogContext.featuresContext[RumFeature.RUM_FEATURE_NAME]
-        val timestampOffset = rumFeatureContext?.get(RumFeature.VIEW_TIMESTAMP_OFFSET_IN_MS_KEY)
+    private fun resolveRumViewTimestampOffset(): Long {
+        val rumFeatureContext = sdkCore.getFeatureContext(RumFeature.RUM_FEATURE_NAME)
+        val timestampOffset = rumFeatureContext[RumFeature.VIEW_TIMESTAMP_OFFSET_IN_MS_KEY]
         return if (timestampOffset is Long) timestampOffset else 0L
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt
@@ -13,9 +13,9 @@ import com.datadog.android.log.Logger
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.tracing.internal.data.NoOpWriter
 import com.datadog.android.tracing.internal.handlers.AndroidSpanLogsHandler
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.opentracing.DDTracer
 import com.datadog.opentracing.LogHandler
 import com.datadog.trace.api.Config

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/SdkCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/SdkCore.kt
@@ -9,14 +9,18 @@ package com.datadog.android.v2.api
 import com.datadog.android.Datadog
 import com.datadog.android.core.model.UserInfo
 import com.datadog.android.privacy.TrackingConsent
-import com.datadog.tools.annotation.NoOpImplementation
+import com.datadog.android.v2.api.context.TimeInfo
 
 /**
  * SdkCore is the entry point to register Datadog features to the core registry.
  */
 @Suppress("ComplexInterface", "TooManyFunctions")
-@NoOpImplementation
 interface SdkCore {
+
+    /**
+     * The current time (both device and server).
+     */
+    val time: TimeInfo
 
     /**
      * Registers a feature to this instance of the Datadog SDK.

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/NoOpSdkCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/NoOpSdkCore.kt
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core
+
+import com.datadog.android.core.model.UserInfo
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.v2.api.FeatureEventReceiver
+import com.datadog.android.v2.api.FeatureScope
+import com.datadog.android.v2.api.FeatureStorageConfiguration
+import com.datadog.android.v2.api.FeatureUploadConfiguration
+import com.datadog.android.v2.api.SdkCore
+import com.datadog.android.v2.api.context.TimeInfo
+import java.util.concurrent.TimeUnit
+
+internal class NoOpSdkCore : SdkCore {
+    override val time: TimeInfo = with(System.currentTimeMillis()) {
+        TimeInfo(
+            deviceTimeNs = TimeUnit.MILLISECONDS.toNanos(this),
+            serverTimeNs = TimeUnit.MILLISECONDS.toNanos(this),
+            serverTimeOffsetNs = 0L,
+            serverTimeOffsetMs = 0L
+        )
+    }
+
+    override fun registerFeature(
+        featureName: String,
+        storageConfiguration: FeatureStorageConfiguration,
+        uploadConfiguration: FeatureUploadConfiguration
+    ) = Unit
+
+    override fun getFeature(featureName: String): FeatureScope? = null
+
+    override fun setVerbosity(level: Int) = Unit
+
+    override fun getVerbosity(): Int = 0
+
+    override fun setTrackingConsent(consent: TrackingConsent) = Unit
+
+    override fun setUserInfo(userInfo: UserInfo) = Unit
+
+    override fun addUserProperties(extraInfo: Map<String, Any?>) = Unit
+
+    override fun stop() = Unit
+
+    override fun clearAllData() = Unit
+
+    override fun flushStoredData() = Unit
+
+    override fun updateFeatureContext(
+        featureName: String,
+        updateCallback: Function1<MutableMap<String, Any?>, Unit>
+    ) = Unit
+
+    override fun getFeatureContext(featureName: String): Map<String, Any?> = emptyMap()
+
+    override fun setEventReceiver(featureName: String, `receiver`: FeatureEventReceiver) = Unit
+
+    override fun removeEventReceiver(featureName: String) = Unit
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
@@ -19,8 +19,8 @@ import com.datadog.android.tracing.TracingInterceptorNotSendingSpanTest
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutTracesTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorWithoutTracesTest.kt
@@ -23,8 +23,8 @@ import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.forge.exhaustiveAttributes
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.opentracing.DDSpan
 import com.datadog.opentracing.DDSpanContext
 import com.datadog.opentracing.DDTracer

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -21,8 +21,8 @@ import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
 import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.android.v2.core.internal.HashGenerator
 import com.datadog.android.v2.core.internal.Sha256HashGenerator
 import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -18,9 +18,9 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.EventBatchWriter
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.android.v2.core.internal.ContextProvider
 import com.datadog.android.v2.core.internal.net.DataUploader
 import com.datadog.android.v2.core.internal.storage.BatchConfirmation

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -21,8 +21,8 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
@@ -21,8 +21,8 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -20,6 +20,7 @@ import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.DatadogContext
+import com.datadog.android.v2.api.context.TimeInfo
 import com.datadog.android.v2.core.internal.ContextProvider
 import com.datadog.android.v2.core.internal.storage.DataWriter
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -99,12 +100,16 @@ internal class RumViewManagerScopeTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
+    @Forgery
+    lateinit var fakeTime: TimeInfo
+
     @BoolForgery
     var fakeTrackFrustrations: Boolean = true
 
     @BeforeEach
     fun `set up`() {
         whenever(mockContextProvider.context) doReturn fakeDatadogContext
+        whenever(mockSdkCore.time) doReturn fakeTime
 
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
@@ -698,7 +703,7 @@ internal class RumViewManagerScopeTest {
     // endregion
 
     private fun resolveExpectedTimestamp(timestamp: Long): Long {
-        return timestamp + fakeDatadogContext.time.serverTimeOffsetMs
+        return timestamp + fakeTime.serverTimeOffsetMs
     }
 
     companion object {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
@@ -20,8 +20,8 @@ import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.tracking.OreoFragmentLifecycleCallbacks
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.tools.unit.ObjectTest
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.annotations.TestTargetApi

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -27,8 +27,8 @@ import com.datadog.android.rum.internal.tracking.ViewLoadingTimer
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -12,7 +12,6 @@ import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.sessionreplay.SessionReplayLifecycleCallback
 import com.datadog.android.sessionreplay.internal.storage.SessionReplayRecordWriter
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
-import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.SdkCore
@@ -65,7 +64,6 @@ internal class SessionReplayFeatureTest {
     @BeforeEach
     fun `set up`() {
         testedFeature = SessionReplayFeature(
-            coreFeature.mockInstance,
             mockSDKCore
         ) { _, _ -> mockSessionReplayLifecycleCallback }
     }
@@ -84,7 +82,6 @@ internal class SessionReplayFeatureTest {
     fun `𝕄 initialize session replay callback 𝕎 initialize()`() {
         // Given
         testedFeature = SessionReplayFeature(
-            coreFeature.mockInstance,
             mockSDKCore
         )
 
@@ -100,7 +97,6 @@ internal class SessionReplayFeatureTest {
     fun `𝕄 set the feature event receiver 𝕎 initialize()`() {
         // Given
         testedFeature = SessionReplayFeature(
-            coreFeature.mockInstance,
             mockSDKCore
         )
 
@@ -413,13 +409,12 @@ internal class SessionReplayFeatureTest {
 
     companion object {
         val appContext = ApplicationContextTestConfiguration(Application::class.java)
-        val coreFeature = CoreFeatureTestConfiguration(appContext)
         val logger = LoggerTestConfiguration()
 
         @TestConfigurationsProvider
         @JvmStatic
         fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(appContext, coreFeature, logger)
+            return listOf(appContext, logger)
         }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -17,8 +17,8 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.opentracing.DDTracer
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerTest.kt
@@ -18,8 +18,8 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.opentracing.DDTracer
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
@@ -16,8 +16,8 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.opentracing.DDSpanContext
 import com.datadog.opentracing.DDTracer
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorTest.kt
@@ -15,8 +15,8 @@ import com.datadog.android.core.internal.sampling.Sampler
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.opentracing.DDSpanContext
 import com.datadog.opentracing.DDTracer
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
@@ -17,8 +17,8 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.opentracing.DDSpan
 import com.datadog.opentracing.LogHandler
 import com.datadog.opentracing.scopemanager.ScopeTestHelper

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/DatadogEventBridgeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/DatadogEventBridgeTest.kt
@@ -15,8 +15,8 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.NoOpSdkCore
 import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.android.webview.internal.MixedWebViewEventConsumer
 import com.datadog.android.webview.internal.log.WebViewLogEventConsumer
 import com.datadog.android.webview.internal.log.WebViewLogsFeature


### PR DESCRIPTION
### What does this PR do?

This change does the following:

* Wraps OS/device info in `lazy`, because it shouldn't be changed during the app lifetime anyway. `PUBLICATION` mode is used for `lazy` which is using `compareAndSet` vs synchronisation by default (see docs for the difference), which should be a bit faster.
* `SdkCore` gets `time` property in order to avoid pulling the whole `DatadogContext` when only time piece is needed. I had to implement `NoOpSdkCore` by hand because of that, because no-op generation doesn't support properties and anyway if it would it cannot know what default value of `TimeInfo` to create.
* Usage of `CoreFeature` is completely removed from the `SessionReplay` feature.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

