### PR TITLE
Nightly tests improvements

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -63,6 +63,8 @@ import,org.jetbrains,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin 
 import,org.jetbrains.kotlin,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors
 import,org.jetbrains.kotlinx,Apache-2.0,Copyright 2010-2019 JetBrains s.r.o. and Kotlin Programming Language contributors
 import,org.reactivestreams,"CC0",Copyright 2014 Reactive Streams
+import(test),androidx.concurrent,Apache-2.0,__
+import(test),androidx.dynamicanimation,Apache-2.0,__
 import(test),androidx.exifinterface,Apache-2.0,Copyright 2018 The Android Open Source Project
 import(test),androidx.test,Apache-2.0,Copyright 2018 The Android Open Source Project
 import(test),androidx.test.espresso,Apache-2.0,Copyright 2018 The Android Open Source Project

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataFlusher.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/data/upload/DataFlusher.kt
@@ -33,7 +33,11 @@ internal class DataFlusher(
         toUploadFiles.forEach {
             val batch = fileReader.readData(it)
             val metaFile = fileOrchestrator.getMetadataFile(it)
-            val meta = if (metaFile != null) metadataFileReader.readData(metaFile) else null
+            val meta = if (metaFile != null && metaFile.existsSafe()) {
+                metadataFileReader.readData(metaFile)
+            } else {
+                null
+            }
             uploader.upload(context, batch, meta)
             fileMover.delete(it)
             if (metaFile?.existsSafe() == true) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/FileEventBatchWriter.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/storage/FileEventBatchWriter.kt
@@ -10,6 +10,7 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.FileWriter
+import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.v2.api.EventBatchWriter
 import com.datadog.android.v2.api.InternalLogger
 import java.io.File
@@ -26,7 +27,7 @@ internal class FileEventBatchWriter(
 
     @WorkerThread
     override fun currentMetadata(): ByteArray? {
-        if (metadataFile == null) return null
+        if (metadataFile == null || !metadataFile.existsSafe()) return null
 
         return metadataReaderWriter.readData(metadataFile)
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,11 +35,11 @@ jUnitVintage = "5.7.1"
 jUnitMockitoExt = "3.4.6"
 
 # Android JUnit
-androidXJunitRunner = "1.4.0"
-androidXJunitRules = "1.4.0"
-androidXExtJunit = "1.1.3"
-androidXJunitCore = "1.4.0"
-espresso = "3.4.0"
+androidXJunitRunner = "1.5.0"
+androidXJunitRules = "1.5.0"
+androidXExtJunit = "1.1.4"
+androidXJunitCore = "1.5.0"
+espresso = "3.5.0"
 
 # Tests Tools
 assertJ = "3.18.1"

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingActivity.kt
@@ -55,7 +55,7 @@ internal open class ResourceTrackingActivity : AppCompatActivity() {
     // endregion
 
     companion object {
-        internal const val HOST = "source.unsplash.com"
-        internal const val RANDOM_URL = "https://$HOST/random/800x450"
+        internal const val HOST = "picsum.photos"
+        internal const val RANDOM_URL = "https://$HOST/800/450"
     }
 }

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingCustomSpanAttributesActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingCustomSpanAttributesActivity.kt
@@ -41,6 +41,6 @@ internal class ResourceTrackingCustomSpanAttributesActivity : ResourceTrackingAc
 
     companion object {
         internal const val TEST_METHOD_NAME = "rum_resource_tracking_with_custom_span_attributes"
-        internal const val RANDOM_RESOURCE_WITH_CUSTOM_SPAN = "https://$HOST/random/25x25"
+        internal const val RANDOM_RESOURCE_WITH_CUSTOM_SPAN = "https://$HOST/25/25"
     }
 }

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingNetworkInterceptorActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingNetworkInterceptorActivity.kt
@@ -46,6 +46,6 @@ internal class ResourceTrackingNetworkInterceptorActivity : ResourceTrackingActi
 
     companion object {
         internal const val RANDOM_RESOURCE_WITH_REDIRECT_URL =
-            "https://$HOST/random/20x20"
+            "https://$HOST/20/20"
     }
 }


### PR DESCRIPTION
### What does this PR do?

Some improvements for the nightly tests run:

* Don't attempt to read metadata if meta file doesn't exist (doesn't impact the functionality, just removes some error noise).
* Update Android X test libraries for the better compatibility with API 33.
* Replace [source.unsplash.com](source.unsplash.com) with [picsum.photos](picsum.photos), because the former is not reliable anymore (it was deprecated one year ago and is currently down for few days already).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

