### PR TITLE
Fix some nightly tests flakiness

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBackgroundE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBackgroundE2ETests.kt
@@ -170,9 +170,11 @@ class RumMonitorBackgroundE2ETests {
         val testMethodName = "rum_rummonitor_add_background_non_custom_action_with_outcome"
         val actionName = forge.anActionName()
         val attributes = defaultTestAttributes(testMethodName)
+        // BACK has no action.name (only action.target.name), so we need to exclude it, because
+        // assertion is relying on action.name
         val actionType = forge.aValueFrom(
             RumActionType::class.java,
-            exclude = listOf(RumActionType.CUSTOM)
+            exclude = listOf(RumActionType.CUSTOM, RumActionType.BACK)
         )
         measure(testMethodName) {
             GlobalRum.get().addUserAction(

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
@@ -262,7 +262,10 @@ class RumMonitorE2ETests {
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
         val attributes = defaultTestAttributes(testMethodName)
-        val actionType = forge.aValueFrom(RumActionType::class.java)
+        // BACK has no action.name (only action.target.name), so we need to exclude it, because
+        // assertion is relying on action.name
+        val actionType =
+            forge.aValueFrom(RumActionType::class.java, exclude = listOf(RumActionType.BACK))
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().startUserAction(
@@ -342,7 +345,9 @@ class RumMonitorE2ETests {
         val viewKey = forge.aViewKey()
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
-        val type = forge.aValueFrom(RumActionType::class.java)
+        // BACK has no action.name (only action.target.name), so we need to exclude it, because
+        // assertion is relying on action.name
+        val type = forge.aValueFrom(RumActionType::class.java, exclude = listOf(RumActionType.BACK))
         val stopActionAttributes = forge.exhaustiveAttributes()
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startUserAction(
@@ -419,7 +424,12 @@ class RumMonitorE2ETests {
         val viewName = forge.aViewName()
         val actionName = forge.anActionName()
         val attributes = defaultTestAttributes(testMethodName)
-        val actionType = forge.aValueFrom(RumActionType::class.java)
+        // BACK has no action.name (only action.target.name), so we need to exclude it, because
+        // assertion is relying on action.name
+        val actionType = forge.aValueFrom(
+            RumActionType::class.java,
+            exclude = listOf(RumActionType.BACK)
+        )
         executeInsideView(viewKey, viewName, testMethodName) {
             measure(testMethodName) {
                 GlobalRum.get().addUserAction(
@@ -444,7 +454,12 @@ class RumMonitorE2ETests {
         val viewName = forge.aViewName()
         val activeActionName = forge.anActionName(prefix = "rumActiveAction")
         val customActionName = forge.anActionName()
-        val actionType = forge.aValueFrom(RumActionType::class.java)
+        // BACK has no action.name (only action.target.name), so we need to exclude it, because
+        // assertion is relying on action.name
+        val actionType = forge.aValueFrom(
+            RumActionType::class.java,
+            exclude = listOf(RumActionType.BACK)
+        )
         val attributes = defaultTestAttributes(testMethodName)
         executeInsideView(viewKey, viewName, testMethodName) {
             GlobalRum.get().startUserAction(

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.nightly.webview
 
 import androidx.test.core.app.ActivityScenario.launch
+import androidx.test.espresso.web.model.Atoms.script
 import androidx.test.espresso.web.sugar.Web.onWebView
 import androidx.test.espresso.web.webdriver.DriverAtoms.findElement
 import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
@@ -102,7 +103,12 @@ internal class WebViewTrackingE2ETests {
         initSdk()
         launch(WebViewTrackingActivity::class.java)
 
-        onWebView().withElement(findElement(Locator.ID, "display-image")).perform(webClick())
+        // with https://github.com/DataDog/browser-sdk/pull/1731 pointerdown event is required
+        // before emitting click event for the RUM action to be registered
+        with(onWebView().withElement(findElement(Locator.ID, "display-image"))) {
+            perform(script("arguments[0].dispatchEvent(new PointerEvent('pointerdown'))"))
+            perform(webClick())
+        }
     }
 
     /**


### PR DESCRIPTION
### What does this PR do?

This change fixes some flakiness in our tests:

* Some tests rely on the `action.name` assertion, but in case of `action.type=back` there is no `action.name`, only `action.target.name`. So we need to exclude `back` action type from such tests.
* With https://github.com/DataDog/browser-sdk/pull/1731 `browser-sdk` requires an element to have `pointerdown` event before the actual click to register RUM action. The change is done instrumented test to add the necessary event.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

