### PR TITLE
Fix flaky TLV format reader test

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
@@ -404,6 +404,8 @@ internal class PlainBatchFileReaderWriterTest {
                         metaBytes.apply {
                             set(
                                 1,
+                                // first 2 bytes of meta should be 1, so to generate
+                                // wrong block we need any value != 1
                                 forge.anElementFrom(
                                     0,
                                     forge.anInt(min = 2, max = Byte.MAX_VALUE + 1)
@@ -411,8 +413,10 @@ internal class PlainBatchFileReaderWriterTest {
                             )
                         } + eventBytes
                     } else {
+                        // first 2 bytes of event should be 0, so to generate
+                        // wrong block we need any value != 0
                         metaBytes + eventBytes.apply {
-                            set(1, forge.anInt(min = 0, max = Byte.MAX_VALUE + 1).toByte())
+                            set(1, forge.anInt(min = 1, max = Byte.MAX_VALUE + 1).toByte())
                         }
                     }
                 } else {


### PR DESCRIPTION
### What does this PR do?

This change fixes flaky test - it was allowing to generate the value of block type which is perfectly correct instead of incorrect.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

