### PR TITLE
Fix NPE on Flutter Unit Tests

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/DefaultAndroidInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/DefaultAndroidInfoProvider.kt
@@ -41,17 +41,17 @@ internal class DefaultAndroidInfoProvider(
     }
 
     override val deviceBrand: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        Build.BRAND.replaceFirstChar {
+        Build.BRAND?.replaceFirstChar {
             if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString()
-        }
+        } ?: ""
     }
 
     override val deviceModel: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        Build.MODEL
+        Build.MODEL ?: ""
     }
 
     override val deviceBuildId: String by lazy(LazyThreadSafetyMode.PUBLICATION) {
-        Build.ID
+        Build.ID ?: ""
     }
 
     override val osName: String = "Android"


### PR DESCRIPTION
### What does this PR do?

Because Flutter flushes during unit tests, the Build properties used in the DefaultAndroidInfoProvider are accessed and they return null, causing an NPE. This checks if the properties are null and returns empty strings instead.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

