### PR TITLE
RUMM-2787: Use message bus to report Java crashes to RUM

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -13,9 +13,7 @@ import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.isWorkManagerInitialized
 import com.datadog.android.core.internal.utils.triggerUploadWorker
 import com.datadog.android.log.internal.LogsFeature
-import com.datadog.android.rum.GlobalRum
-import com.datadog.android.rum.RumErrorSource
-import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
+import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.core.DatadogCore
 import java.lang.ref.WeakReference
@@ -47,17 +45,26 @@ internal class DatadogExceptionHandler(
                 )
             )
         } else {
-            devLogger.i("Logs feature is not registered, won't report crash as log.")
+            devLogger.i(MISSING_LOGS_FEATURE_INFO)
         }
 
-        // TODO RUMM-2697 Use message bus to communicate with RUM
         // write a RUM Error too
-        (GlobalRum.get() as? AdvancedRumMonitor)?.addCrash(
-            createCrashMessage(e),
-            RumErrorSource.SOURCE,
-            e
-        )
+        val rumFeature = sdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)
+        if (rumFeature != null) {
+            rumFeature.sendEvent(
+                mapOf(
+                    "type" to "crash",
+                    "throwable" to e,
+                    "message" to createCrashMessage(e),
+                    "source" to "source"
+                )
+            )
+        } else {
+            devLogger.i(MISSING_RUM_FEATURE_INFO)
+        }
 
+        // TODO RUMM-0000 If DatadogExceptionHandler goes into dedicated module (module of 1 class
+        //  only?), we have to wait for the write in some other way
         // give some time to the persistence executor service to finish its tasks
         val coreFeature = (Datadog.globalSdkCore as? DatadogCore)?.coreFeature
         if (coreFeature != null) {
@@ -113,5 +120,9 @@ internal class DatadogExceptionHandler(
         internal const val EXECUTOR_NOT_IDLED_WARNING_MESSAGE =
             "Datadog SDK is in an unexpected state due to an ongoing crash. " +
                 "Some events could be lost."
+        internal const val MISSING_LOGS_FEATURE_INFO =
+            "Logs feature is not registered, won't report crash as log."
+        internal const val MISSING_RUM_FEATURE_INFO =
+            "RUM feature is not registered, won't report crash as RUM event."
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -21,10 +21,8 @@ import com.datadog.android.core.internal.utils.UPLOAD_WORKER_NAME
 import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.privacy.TrackingConsent
-import com.datadog.android.rum.GlobalRum
-import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
-import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.config.LoggerTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
 import com.datadog.android.utils.extension.mockChoreographerInstance
@@ -52,7 +50,6 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import io.opentracing.util.GlobalTracer
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
 import org.junit.jupiter.api.AfterEach
@@ -95,6 +92,9 @@ internal class DatadogExceptionHandlerTest {
     lateinit var mockLogsFeatureScope: FeatureScope
 
     @Mock
+    lateinit var mockRumFeatureScope: FeatureScope
+
+    @Mock
     lateinit var mockWorkManager: WorkManagerImpl
 
     @Forgery
@@ -117,6 +117,7 @@ internal class DatadogExceptionHandlerTest {
         mockChoreographerInstance()
 
         whenever(mockSdkCore.getFeature(LogsFeature.LOGS_FEATURE_NAME)) doReturn mockLogsFeatureScope
+        whenever(mockSdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
 
         Datadog.initialize(
             appContext.mockInstance,
@@ -145,7 +146,28 @@ internal class DatadogExceptionHandlerTest {
         Thread.setDefaultUncaughtExceptionHandler(originalHandler)
         WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", null)
         Datadog.stop()
-        GlobalTracer::class.java.setStaticValue("isRegistered", false)
+    }
+
+    // region Forward to Logs
+
+    @Test
+    fun `M log dev info W caught exception { no Logs feature registered }`() {
+        // Given
+        whenever(mockSdkCore.getFeature(LogsFeature.LOGS_FEATURE_NAME)) doReturn null
+
+        Thread.setDefaultUncaughtExceptionHandler(null)
+        testedHandler.register()
+        val currentThread = Thread.currentThread()
+
+        // When
+        testedHandler.uncaughtException(currentThread, fakeThrowable)
+
+        // Then
+        verify(logger.mockDevLogHandler)
+            .handleLog(
+                Log.INFO,
+                DatadogExceptionHandler.MISSING_LOGS_FEATURE_INFO
+            )
     }
 
     @Test
@@ -183,82 +205,6 @@ internal class DatadogExceptionHandlerTest {
             )
         }
         verifyZeroInteractions(mockPreviousHandler)
-    }
-
-    @Test
-    fun `M wait for the executor to idle W exception caught`() {
-        // Given
-        val mockScheduledThreadExecutor: ThreadPoolExecutor = mock()
-        (Datadog.globalSdkCore as DatadogCore).coreFeature
-            .persistenceExecutorService = mockScheduledThreadExecutor
-        Thread.setDefaultUncaughtExceptionHandler(null)
-        testedHandler.register()
-        val currentThread = Thread.currentThread()
-
-        // When
-        testedHandler.uncaughtException(currentThread, fakeThrowable)
-
-        // Then
-        verify(mockScheduledThreadExecutor)
-            .waitToIdle(DatadogExceptionHandler.MAX_WAIT_FOR_IDLE_TIME_IN_MS)
-        verify(logger.mockDevLogHandler, never()).handleLog(
-            Log.WARN,
-            DatadogExceptionHandler.EXECUTOR_NOT_IDLED_WARNING_MESSAGE
-        )
-    }
-
-    @Test
-    fun `M log warning message W exception caught { executor could not be idled }`() {
-        // Given
-        val mockScheduledThreadExecutor: ThreadPoolExecutor = mock {
-            whenever(it.taskCount).thenReturn(2)
-            whenever(it.completedTaskCount).thenReturn(0)
-        }
-        (Datadog.globalSdkCore as DatadogCore).coreFeature
-            .persistenceExecutorService = mockScheduledThreadExecutor
-        Thread.setDefaultUncaughtExceptionHandler(null)
-        testedHandler.register()
-        val currentThread = Thread.currentThread()
-
-        // When
-        testedHandler.uncaughtException(currentThread, fakeThrowable)
-
-        // Then
-        verify(logger.mockDevLogHandler).handleLog(
-            Log.WARN,
-            DatadogExceptionHandler.EXECUTOR_NOT_IDLED_WARNING_MESSAGE
-        )
-    }
-
-    @Test
-    fun `M schedule the worker W logging an exception`() {
-        // Given
-        whenever(
-            mockWorkManager.enqueueUniqueWork(
-                ArgumentMatchers.anyString(),
-                any(),
-                any<OneTimeWorkRequest>()
-            )
-        ) doReturn mock()
-
-        WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
-        Thread.setDefaultUncaughtExceptionHandler(null)
-        testedHandler.register()
-        val currentThread = Thread.currentThread()
-
-        // When
-        testedHandler.uncaughtException(currentThread, fakeThrowable)
-
-        // Then
-        verify(mockWorkManager)
-            .enqueueUniqueWork(
-                eq(UPLOAD_WORKER_NAME),
-                eq(ExistingWorkPolicy.REPLACE),
-                argThat<OneTimeWorkRequest> {
-                    this.workSpec.workerClassName == UploadWorker::class.java.canonicalName &&
-                        this.tags.contains(TAG_DATADOG_UPLOAD)
-                }
-            )
     }
 
     @Test
@@ -413,8 +359,108 @@ internal class DatadogExceptionHandlerTest {
         verify(mockPreviousHandler).uncaughtException(thread, fakeThrowable)
     }
 
+    // endregion
+
     @Test
-    fun `M register RUM Error W RumMonitor registered { exception with message }`() {
+    fun `M wait for the executor to idle W exception caught`() {
+        // Given
+        val mockScheduledThreadExecutor: ThreadPoolExecutor = mock()
+        (Datadog.globalSdkCore as DatadogCore).coreFeature
+            .persistenceExecutorService = mockScheduledThreadExecutor
+        Thread.setDefaultUncaughtExceptionHandler(null)
+        testedHandler.register()
+        val currentThread = Thread.currentThread()
+
+        // When
+        testedHandler.uncaughtException(currentThread, fakeThrowable)
+
+        // Then
+        verify(mockScheduledThreadExecutor)
+            .waitToIdle(DatadogExceptionHandler.MAX_WAIT_FOR_IDLE_TIME_IN_MS)
+        verify(logger.mockDevLogHandler, never()).handleLog(
+            Log.WARN,
+            DatadogExceptionHandler.EXECUTOR_NOT_IDLED_WARNING_MESSAGE
+        )
+    }
+
+    @Test
+    fun `M log warning message W exception caught { executor could not be idled }`() {
+        // Given
+        val mockScheduledThreadExecutor: ThreadPoolExecutor = mock {
+            whenever(it.taskCount).thenReturn(2)
+            whenever(it.completedTaskCount).thenReturn(0)
+        }
+        (Datadog.globalSdkCore as DatadogCore).coreFeature
+            .persistenceExecutorService = mockScheduledThreadExecutor
+        Thread.setDefaultUncaughtExceptionHandler(null)
+        testedHandler.register()
+        val currentThread = Thread.currentThread()
+
+        // When
+        testedHandler.uncaughtException(currentThread, fakeThrowable)
+
+        // Then
+        verify(logger.mockDevLogHandler).handleLog(
+            Log.WARN,
+            DatadogExceptionHandler.EXECUTOR_NOT_IDLED_WARNING_MESSAGE
+        )
+    }
+
+    @Test
+    fun `M schedule the worker W logging an exception`() {
+        // Given
+        whenever(
+            mockWorkManager.enqueueUniqueWork(
+                ArgumentMatchers.anyString(),
+                any(),
+                any<OneTimeWorkRequest>()
+            )
+        ) doReturn mock()
+
+        WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
+        Thread.setDefaultUncaughtExceptionHandler(null)
+        testedHandler.register()
+        val currentThread = Thread.currentThread()
+
+        // When
+        testedHandler.uncaughtException(currentThread, fakeThrowable)
+
+        // Then
+        verify(mockWorkManager)
+            .enqueueUniqueWork(
+                eq(UPLOAD_WORKER_NAME),
+                eq(ExistingWorkPolicy.REPLACE),
+                argThat<OneTimeWorkRequest> {
+                    this.workSpec.workerClassName == UploadWorker::class.java.canonicalName &&
+                        this.tags.contains(TAG_DATADOG_UPLOAD)
+                }
+            )
+    }
+
+    // region Forward to RUM
+
+    @Test
+    fun `M log dev info W caught exception { no RUM feature registered }`() {
+        // Given
+        whenever(mockSdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)) doReturn null
+
+        Thread.setDefaultUncaughtExceptionHandler(null)
+        testedHandler.register()
+        val currentThread = Thread.currentThread()
+
+        // When
+        testedHandler.uncaughtException(currentThread, fakeThrowable)
+
+        // Then
+        verify(logger.mockDevLogHandler)
+            .handleLog(
+                Log.INFO,
+                DatadogExceptionHandler.MISSING_RUM_FEATURE_INFO
+            )
+    }
+
+    @Test
+    fun `M register RUM Error W RUM feature is registered { exception with message }`() {
         // Given
         val currentThread = Thread.currentThread()
 
@@ -422,16 +468,28 @@ internal class DatadogExceptionHandlerTest {
         testedHandler.uncaughtException(currentThread, fakeThrowable)
 
         // Then
-        verify(rumMonitor.mockInstance).addCrash(
-            fakeThrowable.message!!,
-            RumErrorSource.SOURCE,
-            fakeThrowable
-        )
+        argumentCaptor<Any> {
+            verify(mockRumFeatureScope).sendEvent(capture())
+
+            assertThat(lastValue).isInstanceOf(Map::class.java)
+
+            @Suppress("UNCHECKED_CAST")
+            val crashEvent = lastValue as Map<String, Any?>
+
+            assertThat(crashEvent).isEqualTo(
+                mapOf(
+                    "type" to "crash",
+                    "throwable" to fakeThrowable,
+                    "message" to fakeThrowable.message,
+                    "source" to "source"
+                )
+            )
+        }
         verify(mockPreviousHandler).uncaughtException(currentThread, fakeThrowable)
     }
 
     @RepeatedTest(2)
-    fun `M register RUM Error W RumMonitor registered { exception without message }`(
+    fun `M register RUM Error W RUM feature is registered { exception without message }`(
         forge: Forge
     ) {
         // Given
@@ -442,16 +500,28 @@ internal class DatadogExceptionHandlerTest {
         testedHandler.uncaughtException(currentThread, throwable)
 
         // Then
-        verify(rumMonitor.mockInstance).addCrash(
-            "Application crash detected: ${throwable.javaClass.canonicalName}",
-            RumErrorSource.SOURCE,
-            throwable
-        )
+        argumentCaptor<Any> {
+            verify(mockRumFeatureScope).sendEvent(capture())
+
+            assertThat(lastValue).isInstanceOf(Map::class.java)
+
+            @Suppress("UNCHECKED_CAST")
+            val crashEvent = lastValue as Map<String, Any?>
+
+            assertThat(crashEvent).isEqualTo(
+                mapOf(
+                    "type" to "crash",
+                    "throwable" to throwable,
+                    "message" to "Application crash detected: ${throwable.javaClass.canonicalName}",
+                    "source" to "source"
+                )
+            )
+        }
         verify(mockPreviousHandler).uncaughtException(currentThread, throwable)
     }
 
     @Test
-    fun `M register RUM Error W RumMonitor registered { exception without message or class }`() {
+    fun `M register RUM Error W RUM feature is registered { exception without message or class }`() {
         // Given
         val currentThread = Thread.currentThread()
         val throwable = object : RuntimeException() {}
@@ -460,49 +530,27 @@ internal class DatadogExceptionHandlerTest {
         testedHandler.uncaughtException(currentThread, throwable)
 
         // Then
-        verify(rumMonitor.mockInstance).addCrash(
-            "Application crash detected: ${throwable.javaClass.simpleName}",
-            RumErrorSource.SOURCE,
-            throwable
-        )
-        verify(mockPreviousHandler).uncaughtException(currentThread, throwable)
-    }
-
-    @Test
-    fun `M not add RUM information W no RUM Monitor registered`() {
-        // Given
-        val currentThread = Thread.currentThread()
-        GlobalRum.isRegistered.set(false)
-        val now = System.currentTimeMillis()
-
-        // When
-        testedHandler.uncaughtException(currentThread, fakeThrowable)
-
-        // Then
         argumentCaptor<Any> {
-            verify(mockLogsFeatureScope).sendEvent(capture())
+            verify(mockRumFeatureScope).sendEvent(capture())
 
             assertThat(lastValue).isInstanceOf(Map::class.java)
 
             @Suppress("UNCHECKED_CAST")
-            val logEvent =
-                (lastValue as Map<String, Any?>).toMutableMap()
-            val timestamp = logEvent.remove("timestamp") as? Long
+            val crashEvent = lastValue as Map<String, Any?>
 
-            assertThat(timestamp).isCloseTo(now, Offset.offset(200))
-            assertThat(logEvent).isEqualTo(
+            assertThat(crashEvent).isEqualTo(
                 mapOf(
-                    "threadName" to currentThread.name,
-                    "throwable" to fakeThrowable,
-                    "syncWrite" to true,
-                    "message" to fakeThrowable.message,
                     "type" to "crash",
-                    "loggerName" to DatadogExceptionHandler.LOGGER_NAME
+                    "throwable" to throwable,
+                    "message" to "Application crash detected: ${throwable.javaClass.simpleName}",
+                    "source" to "source"
                 )
             )
         }
-        verify(mockPreviousHandler).uncaughtException(currentThread, fakeThrowable)
+        verify(mockPreviousHandler).uncaughtException(currentThread, throwable)
     }
+
+    // endregion
 
     private fun Forge.aThrowableWithoutMessage(): Throwable {
         val exceptionClass = anElementFrom(
@@ -536,14 +584,13 @@ internal class DatadogExceptionHandlerTest {
 
     companion object {
         val appContext = ApplicationContextTestConfiguration(Context::class.java)
-        val rumMonitor = GlobalRumMonitorTestConfiguration()
         val mainLooper = MainLooperTestConfiguration()
         val logger = LoggerTestConfiguration()
 
         @TestConfigurationsProvider
         @JvmStatic
         fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(logger, appContext, rumMonitor, mainLooper)
+            return listOf(logger, appContext, mainLooper)
         }
     }
 }

--- a/detekt.yml
+++ b/detekt.yml
@@ -1224,6 +1224,7 @@ datadog:
       - "kotlin.String.count(kotlin.Function1)"
       - "kotlin.String.endsWith(kotlin.Char, kotlin.Boolean)"
       - "kotlin.String.endsWith(kotlin.String, kotlin.Boolean)"
+      - "kotlin.String.equals(kotlin.String?, kotlin.Boolean)"
       - "kotlin.String.filter(kotlin.Function1)"
       - "kotlin.String.format(java.util.Locale?, kotlin.Array)"
       - "kotlin.String.format(java.util.Locale?, kotlin.String, kotlin.Array)"


### PR DESCRIPTION
### What does this PR do?

This changes makes Java crash reporting use message bus to forward crash to RUM (as RUM error).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

