### PR TITLE
RUMM-2789: Use message bus to report NDK crashes to RUM

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -28,6 +28,7 @@ import com.datadog.android.core.internal.net.info.CallbackNetworkInfoProvider
 import com.datadog.android.core.internal.net.info.NetworkInfoDeserializer
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.net.info.NoOpNetworkInfoProvider
+import com.datadog.android.core.internal.persistence.JsonObjectDeserializer
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
@@ -58,7 +59,6 @@ import com.datadog.android.core.internal.user.UserInfoDeserializer
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.privacy.TrackingConsent
-import com.datadog.android.rum.internal.domain.event.RumEventDeserializer
 import com.datadog.android.rum.internal.ndk.DatadogNdkCrashHandler
 import com.datadog.android.rum.internal.ndk.NdkCrashHandler
 import com.datadog.android.rum.internal.ndk.NdkCrashLogDeserializer
@@ -236,14 +236,12 @@ internal class CoreFeature {
                 storageDir,
                 persistenceExecutorService,
                 NdkCrashLogDeserializer(sdkLogger),
-                RumEventDeserializer(),
+                rumEventDeserializer = JsonObjectDeserializer(),
                 NetworkInfoDeserializer(sdkLogger),
                 UserInfoDeserializer(sdkLogger),
                 sdkLogger,
-                timeProvider,
                 rumFileReader = BatchFileReaderWriter.create(sdkLogger, localDataEncryption),
-                envFileReader = FileReaderWriter.create(sdkLogger, localDataEncryption),
-                androidInfoProvider = androidInfoProvider
+                envFileReader = FileReaderWriter.create(sdkLogger, localDataEncryption)
             )
             ndkCrashHandler.prepareData()
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/NetworkInfoDeserializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/info/NetworkInfoDeserializer.kt
@@ -15,7 +15,7 @@ import java.util.Locale
 
 internal class NetworkInfoDeserializer(
     private val internalLogger: Logger
-) : Deserializer<NetworkInfo> {
+) : Deserializer<String, NetworkInfo> {
 
     override fun deserialize(model: String): NetworkInfo? {
         return try {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/Deserializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/Deserializer.kt
@@ -7,14 +7,14 @@
 package com.datadog.android.core.internal.persistence
 
 /**
- * The Serializer<T> generic interface. Should be implemented by any custom serializer.
+ * The Deserializer<P, R> generic interface. Should be implemented by any custom deserializer.
  */
-internal interface Deserializer<T : Any> {
+internal interface Deserializer<P : Any, R : Any> {
 
     /**
-     * Deserializes the data into a String.
-     * @return the model represented by the given String, or null when deserialization
-     * is impossible
+     * Deserializes the data from the given payload type into given output type.
+     * @return the model represented by the given payload, or null when deserialization
+     * is impossible.
      */
-    fun deserialize(model: String): T?
+    fun deserialize(model: P): R?
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/JsonObjectDeserializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/JsonObjectDeserializer.kt
@@ -4,31 +4,29 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.rum.internal.ndk
+package com.datadog.android.core.internal.persistence
 
-import com.datadog.android.core.internal.persistence.Deserializer
-import com.datadog.android.log.Logger
+import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.internal.utils.errorWithTelemetry
+import com.google.gson.JsonObject
 import com.google.gson.JsonParseException
+import com.google.gson.JsonParser
 import java.util.Locale
 
-internal class NdkCrashLogDeserializer(
-    private val internalLogger: Logger
-) : Deserializer<String, NdkCrashLog> {
-
-    override fun deserialize(model: String): NdkCrashLog? {
+internal class JsonObjectDeserializer : Deserializer<String, JsonObject> {
+    override fun deserialize(model: String): JsonObject? {
         return try {
-            NdkCrashLog.fromJson(model)
-        } catch (e: JsonParseException) {
-            internalLogger.errorWithTelemetry(
+            JsonParser.parseString(model).asJsonObject
+        } catch (jpe: JsonParseException) {
+            sdkLogger.errorWithTelemetry(
                 DESERIALIZE_ERROR_MESSAGE_FORMAT.format(Locale.US, model),
-                e
+                jpe
             )
             null
-        } catch (e: IllegalStateException) {
-            internalLogger.errorWithTelemetry(
+        } catch (ise: IllegalStateException) {
+            sdkLogger.errorWithTelemetry(
                 DESERIALIZE_ERROR_MESSAGE_FORMAT.format(Locale.US, model),
-                e
+                ise
             )
             null
         }
@@ -36,6 +34,6 @@ internal class NdkCrashLogDeserializer(
 
     companion object {
         const val DESERIALIZE_ERROR_MESSAGE_FORMAT =
-            "Error while trying to deserialize the serialized NDK Crash info: %s"
+            "Error while trying to deserialize the serialized RumEvent: %s"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/user/UserInfoDeserializer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/user/UserInfoDeserializer.kt
@@ -15,7 +15,7 @@ import java.util.Locale
 
 internal class UserInfoDeserializer(
     private val internalLogger: Logger
-) : Deserializer<UserInfo> {
+) : Deserializer<String, UserInfo> {
 
     override fun deserialize(model: String): UserInfo? {
         return try {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -37,10 +37,9 @@ internal class DatadogExceptionHandler(
                 mapOf(
                     "threadName" to t.name,
                     "throwable" to e,
-                    "syncWrite" to true,
                     "timestamp" to System.currentTimeMillis(),
                     "message" to createCrashMessage(e),
-                    "type" to "crash",
+                    "type" to "jvm_crash",
                     "loggerName" to LOGGER_NAME
                 )
             )
@@ -53,10 +52,9 @@ internal class DatadogExceptionHandler(
         if (rumFeature != null) {
             rumFeature.sendEvent(
                 mapOf(
-                    "type" to "crash",
+                    "type" to "jvm_crash",
                     "throwable" to e,
-                    "message" to createCrashMessage(e),
-                    "source" to "source"
+                    "message" to createCrashMessage(e)
                 )
             )
         } else {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashEventHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashEventHandler.kt
@@ -1,0 +1,180 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.ndk
+
+import com.datadog.android.core.internal.persistence.Deserializer
+import com.datadog.android.core.internal.utils.devLogger
+import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.domain.event.RumEventDeserializer
+import com.datadog.android.rum.internal.domain.scope.toErrorSchemaType
+import com.datadog.android.rum.internal.domain.scope.tryFromSource
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.v2.api.SdkCore
+import com.datadog.android.v2.api.context.DatadogContext
+import com.datadog.android.v2.core.internal.storage.DataWriter
+import com.google.gson.JsonObject
+import java.util.concurrent.TimeUnit
+
+internal class DatadogNdkCrashEventHandler(
+    private val rumEventDeserializer: Deserializer<JsonObject, Any> = RumEventDeserializer()
+) : NdkCrashEventHandler {
+
+    @Suppress("ComplexCondition")
+    override fun handleEvent(event: Map<*, *>, sdkCore: SdkCore, rumWriter: DataWriter<Any>) {
+        val rumFeature = sdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)
+
+        if (rumFeature == null) {
+            devLogger.i(INFO_RUM_FEATURE_NOT_REGISTERED)
+            return
+        }
+
+        val timestamp = event["timestamp"] as? Long
+        val signalName = event["signalName"] as? String
+        val stacktrace = event["stacktrace"] as? String
+        val errorLogMessage = event["message"] as? String
+        val lastViewEvent = (event["lastViewEvent"] as? JsonObject)?.let {
+            rumEventDeserializer.deserialize(it) as? ViewEvent
+        }
+
+        if (timestamp == null || signalName == null || stacktrace == null ||
+            errorLogMessage == null || lastViewEvent == null
+        ) {
+            devLogger.w(NDK_CRASH_EVENT_MISSING_MANDATORY_FIELDS)
+            return
+        }
+
+        val now = System.currentTimeMillis()
+        rumFeature.withWriteContext { datadogContext, eventBatchWriter ->
+            val toSendErrorEvent = resolveErrorEventFromViewEvent(
+                datadogContext,
+                errorLogMessage,
+                timestamp,
+                stacktrace,
+                signalName,
+                lastViewEvent
+            )
+            @Suppress("ThreadSafety") // called in a worker thread context
+            rumWriter.write(eventBatchWriter, toSendErrorEvent)
+            val sessionsTimeDifference = now - lastViewEvent.date
+            if (sessionsTimeDifference < VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD) {
+                val updatedViewEvent = updateViewEvent(lastViewEvent)
+                @Suppress("ThreadSafety") // called in a worker thread context
+                rumWriter.write(eventBatchWriter, updatedViewEvent)
+            }
+        }
+    }
+
+    @Suppress("LongMethod", "LongParameterList")
+    private fun resolveErrorEventFromViewEvent(
+        datadogContext: DatadogContext,
+        errorLogMessage: String,
+        timestamp: Long,
+        stacktrace: String,
+        signalName: String,
+        viewEvent: ViewEvent
+    ): ErrorEvent {
+        val connectivity = viewEvent.connectivity?.let {
+            val connectivityStatus =
+                ErrorEvent.Status.valueOf(it.status.name)
+            val connectivityInterfaces = it.interfaces.map { ErrorEvent.Interface.valueOf(it.name) }
+            val cellular = ErrorEvent.Cellular(
+                it.cellular?.technology,
+                it.cellular?.carrierName
+            )
+            ErrorEvent.Connectivity(connectivityStatus, connectivityInterfaces, cellular)
+        }
+        val additionalProperties = viewEvent.context?.additionalProperties ?: mutableMapOf()
+        val additionalUserProperties = viewEvent.usr?.additionalProperties ?: mutableMapOf()
+        val user = viewEvent.usr
+        val hasUserInfo = user?.id != null || user?.name != null ||
+            user?.email != null || additionalUserProperties.isNotEmpty()
+        val deviceInfo = datadogContext.deviceInfo
+
+        return ErrorEvent(
+            date = timestamp + datadogContext.time.serverTimeOffsetMs,
+            application = ErrorEvent.Application(viewEvent.application.id),
+            service = viewEvent.service,
+            session = ErrorEvent.ErrorEventSession(
+                viewEvent.session.id,
+                ErrorEvent.ErrorEventSessionType.USER
+            ),
+            source = viewEvent.source?.toJson()?.asString?.let {
+                ErrorEvent.ErrorEventSource.tryFromSource(
+                    it
+                )
+            },
+            view = ErrorEvent.View(
+                id = viewEvent.view.id,
+                name = viewEvent.view.name,
+                referrer = viewEvent.view.referrer,
+                url = viewEvent.view.url
+            ),
+            usr = if (!hasUserInfo) {
+                null
+            } else {
+                ErrorEvent.Usr(
+                    user?.id,
+                    user?.name,
+                    user?.email,
+                    additionalUserProperties
+                )
+            },
+            connectivity = connectivity,
+            os = ErrorEvent.Os(
+                name = deviceInfo.osName,
+                version = deviceInfo.osVersion,
+                versionMajor = deviceInfo.osMajorVersion
+            ),
+            device = ErrorEvent.Device(
+                type = deviceInfo.deviceType.toErrorSchemaType(),
+                name = deviceInfo.deviceName,
+                model = deviceInfo.deviceModel,
+                brand = deviceInfo.deviceBrand,
+                architecture = deviceInfo.architecture
+            ),
+            dd = ErrorEvent.Dd(session = ErrorEvent.DdSession(plan = ErrorEvent.Plan.PLAN_1)),
+            context = ErrorEvent.Context(additionalProperties = additionalProperties),
+            error = ErrorEvent.Error(
+                message = errorLogMessage,
+                source = ErrorEvent.ErrorSource.SOURCE,
+                stack = stacktrace,
+                isCrash = true,
+                type = signalName,
+                sourceType = ErrorEvent.SourceType.ANDROID
+            ),
+            version = viewEvent.version
+        )
+    }
+
+    private fun updateViewEvent(lastViewEvent: ViewEvent): ViewEvent {
+        val currentCrash = lastViewEvent.view.crash
+        val newCrash = currentCrash?.copy(count = currentCrash.count + 1) ?: ViewEvent.Crash(1)
+        return lastViewEvent.copy(
+            view = lastViewEvent.view.copy(
+                crash = newCrash,
+                isActive = false
+            ),
+            dd = lastViewEvent.dd.copy(
+                documentVersion = lastViewEvent.dd.documentVersion + 1
+            )
+        )
+    }
+
+    // endregion
+
+    companion object {
+        internal const val INFO_RUM_FEATURE_NOT_REGISTERED =
+            "RUM feature is not registered, won't report NDK crash info as RUM error."
+        internal const val NDK_CRASH_EVENT_MISSING_MANDATORY_FIELDS =
+            "RUM feature received a NDK crash event" +
+                " where one or more mandatory (timestamp, signalName, stacktrace," +
+                " message, lastViewEvent) fields are either missing or have wrong type."
+
+        internal val VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD = TimeUnit.HOURS.toMillis(4)
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashHandler.kt
@@ -13,8 +13,6 @@ import com.datadog.android.core.internal.persistence.file.batch.BatchFileReader
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.listFilesSafe
 import com.datadog.android.core.internal.persistence.file.readTextSafe
-import com.datadog.android.core.internal.system.AndroidInfoProvider
-import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.core.internal.utils.join
 import com.datadog.android.log.LogAttributes
@@ -22,33 +20,26 @@ import com.datadog.android.log.Logger
 import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.log.internal.utils.errorWithTelemetry
 import com.datadog.android.rum.internal.RumFeature
-import com.datadog.android.rum.internal.domain.scope.toErrorSchemaType
-import com.datadog.android.rum.internal.domain.scope.tryFromSource
-import com.datadog.android.rum.model.ErrorEvent
-import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.NetworkInfo
 import com.datadog.android.v2.api.context.UserInfo
-import com.datadog.android.v2.core.internal.storage.DataWriter
+import com.google.gson.JsonObject
 import java.io.File
 import java.util.Locale
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.RejectedExecutionException
-import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")
 internal class DatadogNdkCrashHandler(
     storageDir: File,
     private val dataPersistenceExecutorService: ExecutorService,
-    private val ndkCrashLogDeserializer: Deserializer<NdkCrashLog>,
-    private val rumEventDeserializer: Deserializer<Any>,
-    private val networkInfoDeserializer: Deserializer<NetworkInfo>,
-    private val userInfoDeserializer: Deserializer<UserInfo>,
+    private val ndkCrashLogDeserializer: Deserializer<String, NdkCrashLog>,
+    private val rumEventDeserializer: Deserializer<String, JsonObject>,
+    private val networkInfoDeserializer: Deserializer<String, NetworkInfo>,
+    private val userInfoDeserializer: Deserializer<String, UserInfo>,
     private val internalLogger: Logger,
-    internal val timeProvider: TimeProvider,
     private val rumFileReader: BatchFileReader,
-    private val envFileReader: FileReader,
-    private val androidInfoProvider: AndroidInfoProvider
+    private val envFileReader: FileReader
 ) : NdkCrashHandler {
 
     internal val ndkCrashDataDirectory: File = getNdkGrantedDir(storageDir)
@@ -72,15 +63,12 @@ internal class DatadogNdkCrashHandler(
         }
     }
 
-    override fun handleNdkCrash(
-        sdkCore: SdkCore,
-        rumWriter: DataWriter<Any>
-    ) {
+    override fun handleNdkCrash(sdkCore: SdkCore) {
         try {
             @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
             dataPersistenceExecutorService.submit {
                 @Suppress("ThreadSafety")
-                checkAndHandleNdkCrashReport(sdkCore, rumWriter)
+                checkAndHandleNdkCrashReport(sdkCore)
             }
         } catch (e: RejectedExecutionException) {
             internalLogger.errorWithTelemetry(ERROR_TASK_REJECTED, e)
@@ -100,8 +88,6 @@ internal class DatadogNdkCrashHandler(
             ndkCrashDataDirectory.listFilesSafe()?.forEach {
                 when (it.name) {
                     // TODO RUMM-1944 Data from NDK should be also encrypted
-                    // TODO RUMM-2697 Use message bus to communicate with RUM, RUM classes
-                    //  won't be explicitly available
                     CRASH_DATA_FILE_NAME -> lastSerializedNdkCrashLog = it.readTextSafe()
                     RUM_VIEW_EVENT_FILE_NAME ->
                         lastSerializedRumViewEvent =
@@ -142,10 +128,7 @@ internal class DatadogNdkCrashHandler(
     }
 
     @WorkerThread
-    private fun checkAndHandleNdkCrashReport(
-        sdkCore: SdkCore,
-        rumWriter: DataWriter<Any>
-    ) {
+    private fun checkAndHandleNdkCrashReport(sdkCore: SdkCore) {
         val lastSerializedRumViewEvent = lastSerializedRumViewEvent
         val lastSerializedUserInformation: String? = lastSerializedUserInformation
         val lastSerializedNdkCrashLog: String? = lastSerializedNdkCrashLog
@@ -153,7 +136,7 @@ internal class DatadogNdkCrashHandler(
         if (lastSerializedNdkCrashLog != null) {
             val lastNdkCrashLog = ndkCrashLogDeserializer.deserialize(lastSerializedNdkCrashLog)
             val lastRumViewEvent = lastSerializedRumViewEvent?.let {
-                rumEventDeserializer.deserialize(it) as? ViewEvent
+                rumEventDeserializer.deserialize(it)
             }
             val lastUserInfo = lastSerializedUserInformation?.let {
                 userInfoDeserializer.deserialize(it)
@@ -163,7 +146,6 @@ internal class DatadogNdkCrashHandler(
             }
             handleNdkCrashLog(
                 sdkCore,
-                rumWriter,
                 lastNdkCrashLog,
                 lastRumViewEvent,
                 lastUserInfo,
@@ -183,9 +165,8 @@ internal class DatadogNdkCrashHandler(
     @WorkerThread
     private fun handleNdkCrashLog(
         sdkCore: SdkCore,
-        rumWriter: DataWriter<Any>,
         ndkCrashLog: NdkCrashLog?,
-        lastViewEvent: ViewEvent?,
+        lastViewEvent: JsonObject?,
         lastUserInfo: UserInfo?,
         lastNetworkInfo: NetworkInfo?
     ) {
@@ -195,15 +176,34 @@ internal class DatadogNdkCrashHandler(
         val errorLogMessage = LOG_CRASH_MSG.format(Locale.US, ndkCrashLog.signalName)
         val logAttributes: Map<String, String>
         if (lastViewEvent != null) {
-            logAttributes = mapOf(
-                LogAttributes.RUM_SESSION_ID to lastViewEvent.session.id,
-                LogAttributes.RUM_APPLICATION_ID to lastViewEvent.application.id,
-                LogAttributes.RUM_VIEW_ID to lastViewEvent.view.id,
-                LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace
-            )
+            val (applicationId, sessionId, viewId) = try {
+                val extractId = { property: String ->
+                    lastViewEvent.getAsJsonObject(property)
+                        .getAsJsonPrimitive("id")
+                        .asString
+                }
+                val applicationId = extractId("application")
+                val sessionId = extractId("session")
+                val viewId = extractId("view")
+                Triple(applicationId, sessionId, viewId)
+            } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                internalLogger.w(WARN_CANNOT_READ_VIEW_INFO_DATA, e)
+                Triple(null, null, null)
+            }
+            logAttributes = if (applicationId != null && sessionId != null && viewId != null) {
+                mapOf(
+                    LogAttributes.RUM_SESSION_ID to sessionId,
+                    LogAttributes.RUM_APPLICATION_ID to applicationId,
+                    LogAttributes.RUM_VIEW_ID to viewId,
+                    LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace
+                )
+            } else {
+                mapOf(
+                    LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace
+                )
+            }
             updateViewEventAndSendError(
                 sdkCore,
-                rumWriter,
                 errorLogMessage,
                 ndkCrashLog,
                 lastViewEvent
@@ -224,35 +224,32 @@ internal class DatadogNdkCrashHandler(
         )
     }
 
+    @Suppress("StringLiteralDuplication")
     @WorkerThread
     private fun updateViewEventAndSendError(
         sdkCore: SdkCore,
-        rumWriter: DataWriter<Any>,
         errorLogMessage: String,
         ndkCrashLog: NdkCrashLog,
-        lastViewEvent: ViewEvent
+        lastViewEvent: JsonObject
     ) {
-        val toSendErrorEvent = resolveErrorEventFromViewEvent(
-            errorLogMessage,
-            ndkCrashLog,
-            lastViewEvent
-        )
-        val now = System.currentTimeMillis()
         val rumFeature = sdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)
         if (rumFeature != null) {
-            rumFeature.withWriteContext { _, eventBatchWriter ->
-                rumWriter.write(eventBatchWriter, toSendErrorEvent)
-                val sessionsTimeDifference = now - lastViewEvent.date
-                if (sessionsTimeDifference < VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD) {
-                    val updatedViewEvent = updateViewEvent(lastViewEvent)
-                    rumWriter.write(eventBatchWriter, updatedViewEvent)
-                }
-            }
+            rumFeature.sendEvent(
+                mapOf(
+                    "type" to "ndk_crash",
+                    "timestamp" to ndkCrashLog.timestamp,
+                    "signalName" to ndkCrashLog.signalName,
+                    "stacktrace" to ndkCrashLog.stacktrace,
+                    "message" to errorLogMessage,
+                    "lastViewEvent" to lastViewEvent
+                )
+            )
         } else {
             devLogger.i(INFO_RUM_FEATURE_NOT_REGISTERED)
         }
     }
 
+    @Suppress("StringLiteralDuplication")
     @WorkerThread
     private fun sendCrashLogEvent(
         sdkCore: SdkCore,
@@ -267,12 +264,10 @@ internal class DatadogNdkCrashHandler(
             logsFeature.sendEvent(
                 mapOf(
                     "loggerName" to LOGGER_NAME,
-                    "type" to "crash",
+                    "type" to "ndk_crash",
                     "message" to errorLogMessage,
                     "attributes" to logAttributes,
                     "timestamp" to ndkCrashLog.timestamp,
-                    "bundleWithTraces" to false,
-                    "bundleWithRum" to false,
                     "networkInfo" to lastNetworkInfo,
                     "userInfo" to lastUserInfo
                 )
@@ -280,97 +275,6 @@ internal class DatadogNdkCrashHandler(
         } else {
             devLogger.i(INFO_LOGS_FEATURE_NOT_REGISTERED)
         }
-    }
-
-    private fun updateViewEvent(lastViewEvent: ViewEvent): ViewEvent {
-        val currentCrash = lastViewEvent.view.crash
-        val newCrash = currentCrash?.copy(count = currentCrash.count + 1) ?: ViewEvent.Crash(1)
-        return lastViewEvent.copy(
-            view = lastViewEvent.view.copy(
-                crash = newCrash,
-                isActive = false
-            ),
-            dd = lastViewEvent.dd.copy(
-                documentVersion = lastViewEvent.dd.documentVersion + 1
-            )
-        )
-    }
-
-    @Suppress("LongMethod")
-    private fun resolveErrorEventFromViewEvent(
-        errorLogMessage: String,
-        ndkCrashLog: NdkCrashLog,
-        viewEvent: ViewEvent
-    ): ErrorEvent {
-        val connectivity = viewEvent.connectivity?.let {
-            val connectivityStatus =
-                ErrorEvent.Status.valueOf(it.status.name)
-            val connectivityInterfaces = it.interfaces.map { ErrorEvent.Interface.valueOf(it.name) }
-            val cellular = ErrorEvent.Cellular(
-                it.cellular?.technology,
-                it.cellular?.carrierName
-            )
-            ErrorEvent.Connectivity(connectivityStatus, connectivityInterfaces, cellular)
-        }
-        val additionalProperties = viewEvent.context?.additionalProperties ?: mutableMapOf()
-        val additionalUserProperties = viewEvent.usr?.additionalProperties ?: mutableMapOf()
-        val user = viewEvent.usr
-        val hasUserInfo = user?.id != null || user?.name != null ||
-            user?.email != null || additionalUserProperties.isNotEmpty()
-        return ErrorEvent(
-            date = ndkCrashLog.timestamp + timeProvider.getServerOffsetMillis(),
-            application = ErrorEvent.Application(viewEvent.application.id),
-            service = viewEvent.service,
-            session = ErrorEvent.ErrorEventSession(
-                viewEvent.session.id,
-                ErrorEvent.ErrorEventSessionType.USER
-            ),
-            source = viewEvent.source?.toJson()?.asString?.let {
-                ErrorEvent.ErrorEventSource.tryFromSource(
-                    it
-                )
-            },
-            view = ErrorEvent.View(
-                id = viewEvent.view.id,
-                name = viewEvent.view.name,
-                referrer = viewEvent.view.referrer,
-                url = viewEvent.view.url
-            ),
-            usr = if (!hasUserInfo) {
-                null
-            } else {
-                ErrorEvent.Usr(
-                    user?.id,
-                    user?.name,
-                    user?.email,
-                    additionalUserProperties
-                )
-            },
-            connectivity = connectivity,
-            os = ErrorEvent.Os(
-                name = androidInfoProvider.osName,
-                version = androidInfoProvider.osVersion,
-                versionMajor = androidInfoProvider.osMajorVersion
-            ),
-            device = ErrorEvent.Device(
-                type = androidInfoProvider.deviceType.toErrorSchemaType(),
-                name = androidInfoProvider.deviceName,
-                model = androidInfoProvider.deviceModel,
-                brand = androidInfoProvider.deviceBrand,
-                architecture = androidInfoProvider.architecture
-            ),
-            dd = ErrorEvent.Dd(session = ErrorEvent.DdSession(plan = ErrorEvent.Plan.PLAN_1)),
-            context = ErrorEvent.Context(additionalProperties = additionalProperties),
-            error = ErrorEvent.Error(
-                message = errorLogMessage,
-                source = ErrorEvent.ErrorSource.SOURCE,
-                stack = ndkCrashLog.stacktrace,
-                isCrash = true,
-                type = ndkCrashLog.signalName,
-                sourceType = ErrorEvent.SourceType.ANDROID
-            ),
-            version = viewEvent.version
-        )
     }
 
     @SuppressWarnings("TooGenericExceptionCaught")
@@ -391,7 +295,6 @@ internal class DatadogNdkCrashHandler(
     // endregion
 
     companion object {
-        internal val VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD = TimeUnit.HOURS.toMillis(4)
 
         internal const val RUM_VIEW_EVENT_FILE_NAME = "last_view_event"
         internal const val CRASH_DATA_FILE_NAME = "crash_log"
@@ -404,6 +307,9 @@ internal class DatadogNdkCrashHandler(
         internal const val ERROR_READ_NDK_DIR = "Error while trying to read the NDK crash directory"
 
         internal const val ERROR_TASK_REJECTED = "Unable to schedule operation on the executor"
+
+        internal const val WARN_CANNOT_READ_VIEW_INFO_DATA =
+            "Cannot read application, session, view IDs data from view event."
 
         internal const val INFO_LOGS_FEATURE_NOT_REGISTERED =
             "Logs feature is not registered, won't report NDK crash info as log."

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashEventHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/ndk/NdkCrashEventHandler.kt
@@ -7,11 +7,8 @@
 package com.datadog.android.rum.internal.ndk
 
 import com.datadog.android.v2.api.SdkCore
-import com.datadog.tools.annotation.NoOpImplementation
+import com.datadog.android.v2.core.internal.storage.DataWriter
 
-@NoOpImplementation
-internal interface NdkCrashHandler {
-    fun prepareData()
-
-    fun handleNdkCrash(sdkCore: SdkCore)
+internal interface NdkCrashEventHandler {
+    fun handleEvent(event: Map<*, *>, sdkCore: SdkCore, rumWriter: DataWriter<Any>)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -44,7 +44,6 @@ import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.TimeInfo
 import com.datadog.android.v2.api.context.UserInfo
 import com.datadog.android.v2.core.internal.ContextProvider
-import com.datadog.android.v2.core.internal.storage.NoOpDataWriter
 import com.datadog.android.v2.log.internal.net.LogsRequestFactory
 import com.datadog.android.v2.rum.internal.net.RumRequestFactory
 import com.datadog.android.v2.tracing.internal.net.TracesRequestFactory
@@ -298,10 +297,7 @@ internal class DatadogCore(
         initializeCrashReportFeature(mutableConfig.crashReportConfig, appContext)
         initializeSessionReplayFeature(mutableConfig.sessionReplayConfig, appContext)
 
-        coreFeature.ndkCrashHandler.handleNdkCrash(
-            this,
-            rumFeature?.dataWriter ?: NoOpDataWriter()
-        )
+        coreFeature.ndkCrashHandler.handleNdkCrash(this)
 
         setupLifecycleMonitorCallback(appContext)
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -813,8 +813,6 @@ internal class CoreFeatureTest {
                         CoreFeature.DATADOG_STORAGE_DIR_NAME.format(Locale.US, fakeSdkInstanceId)
                     )
                 )
-                assertThat(it.timeProvider)
-                    .isInstanceOf(KronosTimeProvider::class.java)
             }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/JsonObjectDeserializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/persistence/JsonObjectDeserializerTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence
+
+import com.datadog.android.utils.forge.Configurator
+import com.google.gson.JsonObject
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class JsonObjectDeserializerTest {
+
+    private val testedDeserializer = JsonObjectDeserializer()
+
+    @Test
+    fun `𝕄 deserialize a serialized JsonObject 𝕎 deserialize()`(
+        @Forgery fakeJsonObject: JsonObject
+    ) {
+        // Given
+        val fakeModel = fakeJsonObject.toString()
+
+        // When
+        val deserialized = testedDeserializer.deserialize(fakeModel)
+
+        // Then
+        assertThat(deserialized.toString()).isEqualTo(fakeModel)
+    }
+
+    @Test
+    fun `𝕄 return null 𝕎 deserialize() { json array }`(
+        @Forgery fakeJsonObject: JsonObject
+    ) {
+        // Given
+        val fakeModel = "[$fakeJsonObject]"
+
+        // When
+        val deserialized = testedDeserializer.deserialize(fakeModel)
+
+        // Then
+        assertThat(deserialized).isNull()
+    }
+
+    @Test
+    fun `𝕄 return null 𝕎 deserialize() { malformed model }`(
+        @StringForgery fakeModel: String
+    ) {
+        // When
+        val deserialized = testedDeserializer.deserialize(fakeModel)
+
+        // Then
+        assertThat(deserialized).isNull()
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -197,9 +197,8 @@ internal class DatadogExceptionHandlerTest {
                 mapOf(
                     "threadName" to currentThread.name,
                     "throwable" to fakeThrowable,
-                    "syncWrite" to true,
                     "message" to fakeThrowable.message,
-                    "type" to "crash",
+                    "type" to "jvm_crash",
                     "loggerName" to DatadogExceptionHandler.LOGGER_NAME
                 )
             )
@@ -232,9 +231,8 @@ internal class DatadogExceptionHandlerTest {
                 mapOf(
                     "threadName" to currentThread.name,
                     "throwable" to fakeThrowable,
-                    "syncWrite" to true,
                     "message" to fakeThrowable.message,
-                    "type" to "crash",
+                    "type" to "jvm_crash",
                     "loggerName" to DatadogExceptionHandler.LOGGER_NAME
                 )
             )
@@ -268,9 +266,8 @@ internal class DatadogExceptionHandlerTest {
                 mapOf(
                     "threadName" to currentThread.name,
                     "throwable" to throwable,
-                    "syncWrite" to true,
                     "message" to "Application crash detected: ${throwable.javaClass.canonicalName}",
-                    "type" to "crash",
+                    "type" to "jvm_crash",
                     "loggerName" to DatadogExceptionHandler.LOGGER_NAME
                 )
             )
@@ -304,9 +301,8 @@ internal class DatadogExceptionHandlerTest {
                 mapOf(
                     "threadName" to currentThread.name,
                     "throwable" to throwable,
-                    "syncWrite" to true,
                     "message" to "Application crash detected: ${throwable.javaClass.simpleName}",
-                    "type" to "crash",
+                    "type" to "jvm_crash",
                     "loggerName" to DatadogExceptionHandler.LOGGER_NAME
                 )
             )
@@ -349,9 +345,8 @@ internal class DatadogExceptionHandlerTest {
                 mapOf(
                     "threadName" to thread.name,
                     "throwable" to fakeThrowable,
-                    "syncWrite" to true,
                     "message" to fakeThrowable.message,
-                    "type" to "crash",
+                    "type" to "jvm_crash",
                     "loggerName" to DatadogExceptionHandler.LOGGER_NAME
                 )
             )
@@ -478,10 +473,9 @@ internal class DatadogExceptionHandlerTest {
 
             assertThat(crashEvent).isEqualTo(
                 mapOf(
-                    "type" to "crash",
+                    "type" to "jvm_crash",
                     "throwable" to fakeThrowable,
-                    "message" to fakeThrowable.message,
-                    "source" to "source"
+                    "message" to fakeThrowable.message
                 )
             )
         }
@@ -510,10 +504,9 @@ internal class DatadogExceptionHandlerTest {
 
             assertThat(crashEvent).isEqualTo(
                 mapOf(
-                    "type" to "crash",
+                    "type" to "jvm_crash",
                     "throwable" to throwable,
-                    "message" to "Application crash detected: ${throwable.javaClass.canonicalName}",
-                    "source" to "source"
+                    "message" to "Application crash detected: ${throwable.javaClass.canonicalName}"
                 )
             )
         }
@@ -540,10 +533,9 @@ internal class DatadogExceptionHandlerTest {
 
             assertThat(crashEvent).isEqualTo(
                 mapOf(
-                    "type" to "crash",
+                    "type" to "jvm_crash",
                     "throwable" to throwable,
-                    "message" to "Application crash detected: ${throwable.javaClass.simpleName}",
-                    "source" to "source"
+                    "message" to "Application crash detected: ${throwable.javaClass.simpleName}"
                 )
             )
         }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -56,6 +56,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -180,6 +182,8 @@ internal class LogsFeatureTest {
         )
     }
 
+    // region FeatureEventReceiver#onReceive
+
     @Test
     fun `𝕄 log warning and do nothing 𝕎 onReceive() { unknown event type }`() {
         // Given
@@ -231,195 +235,14 @@ internal class LogsFeatureTest {
         )
     }
 
-    @Test
-    fun `𝕄 log warning and do nothing 𝕎 onReceive() { missing mandatory fields }`(
-        @StringForgery fakeThreadName: String,
-        @LongForgery fakeTimestamp: Long,
-        @StringForgery fakeMessage: String,
-        @StringForgery fakeLoggerName: String,
-        forge: Forge
-    ) {
-        // Given
-        testedFeature.dataWriter = mockDataWriter
-        val event = mutableMapOf(
-            "type" to "crash",
-            "threadName" to fakeThreadName,
-            "timestamp" to fakeTimestamp,
-            "message" to fakeMessage,
-            "loggerName" to fakeLoggerName
-        )
+    // endregion
 
-        event.remove(
-            forge.anElementFrom(event.keys.filterNot { it == "type" })
-        )
+    // region FeatureEventReceiver#onReceive
 
-        // When
-        testedFeature.onReceive(event)
-
-        // Then
-        verify(logger.mockDevLogHandler)
-            .handleLog(
-                Log.WARN,
-                LogsFeature.EVENT_MISSING_MANDATORY_FIELDS
-            )
-
-        verifyZeroInteractions(
-            mockSdkCore,
-            mockDataWriter
-        )
-    }
-
-    @Test
-    fun `𝕄 log warning and do nothing 𝕎 onReceive() { wrong type for mandatory fields }`(
-        @StringForgery fakeThreadName: String,
-        @LongForgery fakeTimestamp: Long,
-        @StringForgery fakeMessage: String,
-        @StringForgery fakeLoggerName: String,
-        forge: Forge
-    ) {
-        // Given
-        testedFeature.dataWriter = mockDataWriter
-        val event = mutableMapOf<String, Any>(
-            "type" to "crash",
-            "threadName" to fakeThreadName,
-            "timestamp" to fakeTimestamp,
-            "message" to fakeMessage,
-            "loggerName" to fakeLoggerName
-        )
-
-        event[forge.anElementFrom(event.keys.filterNot { it == "type" })] = Any()
-
-        // When
-        testedFeature.onReceive(event)
-
-        // Then
-        verify(logger.mockDevLogHandler)
-            .handleLog(
-                Log.WARN,
-                LogsFeature.EVENT_MISSING_MANDATORY_FIELDS
-            )
-
-        verifyZeroInteractions(
-            mockSdkCore,
-            mockDataWriter
-        )
-    }
-
-    @Test
-    fun `𝕄 write crash log event 𝕎 onReceive() { bare minimum }`(
-        @StringForgery fakeThreadName: String,
-        @LongForgery fakeTimestamp: Long,
-        @StringForgery fakeMessage: String,
-        @StringForgery fakeLoggerName: String
-    ) {
-        // Given
-        testedFeature.dataWriter = mockDataWriter
-        val event = mapOf(
-            "type" to "crash",
-            "threadName" to fakeThreadName,
-            "timestamp" to fakeTimestamp,
-            "message" to fakeMessage,
-            "loggerName" to fakeLoggerName
-        )
-
-        // When
-        testedFeature.onReceive(event)
-
-        // Then
-        argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
-
-            val log = lastValue
-
-            assertThatLog(log)
-                .hasStatus(LogEvent.Status.EMERGENCY)
-                .hasLoggerName(fakeLoggerName)
-                .hasServiceName(fakeDatadogContext.service)
-                .hasMessage(fakeMessage)
-                .hasThreadName(fakeThreadName)
-                .hasDate((fakeTimestamp + fakeServerTimeOffset).toIsoFormattedTimestamp())
-                .hasNetworkInfo(fakeDatadogContext.networkInfo)
-                .hasUserInfo(fakeDatadogContext.userInfo)
-                .hasExactlyAttributes(
-                    mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
-                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
-                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
-                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId,
-                        LogAttributes.DD_TRACE_ID to fakeTraceId,
-                        LogAttributes.DD_SPAN_ID to fakeSpanId
-                    )
-                )
-                .hasExactlyTags(
-                    setOf(
-                        "${LogAttributes.ENV}:${fakeDatadogContext.env}",
-                        "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
-                    )
-                )
-        }
-    }
-
-    @Test
-    fun `𝕄 write crash log event 𝕎 onReceive() { with attributes }`(
-        @StringForgery fakeThreadName: String,
-        @LongForgery fakeTimestamp: Long,
-        @StringForgery fakeMessage: String,
-        @StringForgery fakeLoggerName: String,
-        forge: Forge
-    ) {
-        // Given
-        testedFeature.dataWriter = mockDataWriter
-        val fakeAttributes = forge.exhaustiveAttributes()
-        val event = mapOf(
-            "type" to "crash",
-            "threadName" to fakeThreadName,
-            "timestamp" to fakeTimestamp,
-            "message" to fakeMessage,
-            "loggerName" to fakeLoggerName,
-            "attributes" to fakeAttributes
-        )
-
-        // When
-        testedFeature.onReceive(event)
-
-        // Then
-        argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
-
-            val log = lastValue
-
-            assertThatLog(log)
-                .hasStatus(LogEvent.Status.EMERGENCY)
-                .hasLoggerName(fakeLoggerName)
-                .hasServiceName(fakeDatadogContext.service)
-                .hasMessage(fakeMessage)
-                .hasThreadName(fakeThreadName)
-                .hasDate((fakeTimestamp + fakeServerTimeOffset).toIsoFormattedTimestamp())
-                .hasNetworkInfo(fakeDatadogContext.networkInfo)
-                .hasUserInfo(fakeDatadogContext.userInfo)
-                .hasExactlyAttributes(
-                    fakeAttributes + mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
-                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
-                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
-                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId,
-                        LogAttributes.DD_TRACE_ID to fakeTraceId,
-                        LogAttributes.DD_SPAN_ID to fakeSpanId
-                    )
-                )
-                .hasExactlyTags(
-                    setOf(
-                        "${LogAttributes.ENV}:${fakeDatadogContext.env}",
-                        "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
-                    )
-                )
-        }
-    }
-
-    @Test
-    fun `𝕄 write crash log event 𝕎 onReceive() { with throwable }`(
+    @ParameterizedTest
+    @EnumSource
+    fun `𝕄 log warning and do nothing 𝕎 onReceive() { corrupted mandatory fields, JVM crash }`(
+        missingType: ValueMissingType,
         @StringForgery fakeThreadName: String,
         @LongForgery fakeTimestamp: Long,
         @StringForgery fakeMessage: String,
@@ -429,14 +252,60 @@ internal class LogsFeatureTest {
         // Given
         testedFeature.dataWriter = mockDataWriter
         val fakeThrowable = forge.aThrowable()
-        val fakeAttributes = forge.exhaustiveAttributes()
-        val event = mapOf(
-            "type" to "crash",
+        val event = mutableMapOf<String, Any?>(
+            "type" to "jvm_crash",
             "threadName" to fakeThreadName,
             "timestamp" to fakeTimestamp,
             "message" to fakeMessage,
             "loggerName" to fakeLoggerName,
-            "attributes" to fakeAttributes,
+            "throwable" to fakeThrowable
+        )
+
+        when (missingType) {
+            ValueMissingType.MISSING -> event.remove(
+                forge.anElementFrom(event.keys.filterNot { it == "type" })
+            )
+            ValueMissingType.NULL -> event[
+                forge.anElementFrom(event.keys.filterNot { it == "type" })
+            ] = null
+            ValueMissingType.WRONG_TYPE -> event[
+                forge.anElementFrom(event.keys.filterNot { it == "type" })
+            ] = Any()
+        }
+
+        // When
+        testedFeature.onReceive(event)
+
+        // Then
+        verify(logger.mockDevLogHandler)
+            .handleLog(
+                Log.WARN,
+                LogsFeature.JVM_CRASH_EVENT_MISSING_MANDATORY_FIELDS_WARNING
+            )
+
+        verifyZeroInteractions(
+            mockSdkCore,
+            mockDataWriter
+        )
+    }
+
+    @Test
+    fun `𝕄 write crash log event 𝕎 onReceive() { JVM crash }`(
+        @StringForgery fakeThreadName: String,
+        @LongForgery fakeTimestamp: Long,
+        @StringForgery fakeMessage: String,
+        @StringForgery fakeLoggerName: String,
+        forge: Forge
+    ) {
+        // Given
+        testedFeature.dataWriter = mockDataWriter
+        val fakeThrowable = forge.aThrowable()
+        val event = mapOf(
+            "type" to "jvm_crash",
+            "threadName" to fakeThreadName,
+            "timestamp" to fakeTimestamp,
+            "message" to fakeMessage,
+            "loggerName" to fakeLoggerName,
             "throwable" to fakeThrowable
         )
 
@@ -466,7 +335,7 @@ internal class LogsFeatureTest {
                 .hasNetworkInfo(fakeDatadogContext.networkInfo)
                 .hasUserInfo(fakeDatadogContext.userInfo)
                 .hasExactlyAttributes(
-                    fakeAttributes + mapOf(
+                    mapOf(
                         LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
                         LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
                         LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
@@ -486,244 +355,12 @@ internal class LogsFeatureTest {
     }
 
     @Test
-    fun `𝕄 write crash log event 𝕎 onReceive() { bundleWithTraces = false }`(
+    fun `𝕄 write crash log event and wait 𝕎 onReceive() { JVM crash }`(
         @StringForgery fakeThreadName: String,
         @LongForgery fakeTimestamp: Long,
         @StringForgery fakeMessage: String,
         @StringForgery fakeLoggerName: String,
         forge: Forge
-    ) {
-        // Given
-        testedFeature.dataWriter = mockDataWriter
-
-        val fakeAttributes = forge.exhaustiveAttributes()
-        val event = mapOf(
-            "type" to "crash",
-            "threadName" to fakeThreadName,
-            "timestamp" to fakeTimestamp,
-            "message" to fakeMessage,
-            "loggerName" to fakeLoggerName,
-            "attributes" to fakeAttributes,
-            "bundleWithTraces" to false
-        )
-
-        // When
-        testedFeature.onReceive(event)
-
-        // Then
-        argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
-
-            val log = lastValue
-
-            assertThatLog(log)
-                .hasStatus(LogEvent.Status.EMERGENCY)
-                .hasLoggerName(fakeLoggerName)
-                .hasServiceName(fakeDatadogContext.service)
-                .hasMessage(fakeMessage)
-                .hasThreadName(fakeThreadName)
-                .hasDate((fakeTimestamp + fakeServerTimeOffset).toIsoFormattedTimestamp())
-                .hasUserInfo(fakeDatadogContext.userInfo)
-                .hasNetworkInfo(fakeDatadogContext.networkInfo)
-                .hasExactlyAttributes(
-                    fakeAttributes + mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
-                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
-                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
-                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId
-                    )
-                )
-                .hasExactlyTags(
-                    setOf(
-                        "${LogAttributes.ENV}:${fakeDatadogContext.env}",
-                        "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
-                    )
-                )
-        }
-    }
-
-    @Test
-    fun `𝕄 write crash log event 𝕎 onReceive() { bundleWithRum = false }`(
-        @StringForgery fakeThreadName: String,
-        @LongForgery fakeTimestamp: Long,
-        @StringForgery fakeMessage: String,
-        @StringForgery fakeLoggerName: String,
-        forge: Forge
-    ) {
-        // Given
-        testedFeature.dataWriter = mockDataWriter
-        val fakeAttributes = forge.exhaustiveAttributes()
-        val event = mapOf(
-            "type" to "crash",
-            "threadName" to fakeThreadName,
-            "timestamp" to fakeTimestamp,
-            "message" to fakeMessage,
-            "loggerName" to fakeLoggerName,
-            "attributes" to fakeAttributes,
-            "bundleWithRum" to false
-        )
-
-        // When
-        testedFeature.onReceive(event)
-
-        // Then
-        argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
-
-            val log = lastValue
-
-            assertThatLog(log)
-                .hasStatus(LogEvent.Status.EMERGENCY)
-                .hasLoggerName(fakeLoggerName)
-                .hasServiceName(fakeDatadogContext.service)
-                .hasMessage(fakeMessage)
-                .hasThreadName(fakeThreadName)
-                .hasDate((fakeTimestamp + fakeServerTimeOffset).toIsoFormattedTimestamp())
-                .hasUserInfo(fakeDatadogContext.userInfo)
-                .hasNetworkInfo(fakeDatadogContext.networkInfo)
-                .hasExactlyAttributes(
-                    fakeAttributes + mapOf(
-                        LogAttributes.DD_TRACE_ID to fakeTraceId,
-                        LogAttributes.DD_SPAN_ID to fakeSpanId
-                    )
-                )
-                .hasExactlyTags(
-                    setOf(
-                        "${LogAttributes.ENV}:${fakeDatadogContext.env}",
-                        "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
-                    )
-                )
-        }
-    }
-
-    @Test
-    fun `𝕄 write crash log event 𝕎 onReceive() { explicit network info }`(
-        @StringForgery fakeThreadName: String,
-        @LongForgery fakeTimestamp: Long,
-        @StringForgery fakeMessage: String,
-        @StringForgery fakeLoggerName: String,
-        @Forgery fakeNetworkInfo: NetworkInfo,
-        forge: Forge
-    ) {
-        // Given
-        testedFeature.dataWriter = mockDataWriter
-        val fakeAttributes = forge.exhaustiveAttributes()
-        val event = mapOf(
-            "type" to "crash",
-            "threadName" to fakeThreadName,
-            "timestamp" to fakeTimestamp,
-            "message" to fakeMessage,
-            "loggerName" to fakeLoggerName,
-            "attributes" to fakeAttributes,
-            "networkInfo" to fakeNetworkInfo
-        )
-
-        // When
-        testedFeature.onReceive(event)
-
-        // Then
-        argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
-
-            val log = lastValue
-
-            assertThatLog(log)
-                .hasStatus(LogEvent.Status.EMERGENCY)
-                .hasLoggerName(fakeLoggerName)
-                .hasServiceName(fakeDatadogContext.service)
-                .hasMessage(fakeMessage)
-                .hasThreadName(fakeThreadName)
-                .hasDate((fakeTimestamp + fakeServerTimeOffset).toIsoFormattedTimestamp())
-                .hasUserInfo(fakeDatadogContext.userInfo)
-                .hasNetworkInfo(fakeNetworkInfo)
-                .hasExactlyAttributes(
-                    fakeAttributes + mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
-                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
-                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
-                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId,
-                        LogAttributes.DD_TRACE_ID to fakeTraceId,
-                        LogAttributes.DD_SPAN_ID to fakeSpanId
-                    )
-                )
-                .hasExactlyTags(
-                    setOf(
-                        "${LogAttributes.ENV}:${fakeDatadogContext.env}",
-                        "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
-                    )
-                )
-        }
-    }
-
-    @Test
-    fun `𝕄 write crash log event 𝕎 onReceive() { explicit user info }`(
-        @StringForgery fakeThreadName: String,
-        @LongForgery fakeTimestamp: Long,
-        @StringForgery fakeMessage: String,
-        @StringForgery fakeLoggerName: String,
-        @Forgery fakeUserInfo: UserInfo,
-        forge: Forge
-    ) {
-        // Given
-        testedFeature.dataWriter = mockDataWriter
-        val fakeAttributes = forge.exhaustiveAttributes()
-        val event = mapOf(
-            "type" to "crash",
-            "threadName" to fakeThreadName,
-            "timestamp" to fakeTimestamp,
-            "message" to fakeMessage,
-            "loggerName" to fakeLoggerName,
-            "attributes" to fakeAttributes,
-            "userInfo" to fakeUserInfo
-        )
-
-        // When
-        testedFeature.onReceive(event)
-
-        // Then
-        argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
-
-            val log = lastValue
-
-            assertThatLog(log)
-                .hasStatus(LogEvent.Status.EMERGENCY)
-                .hasLoggerName(fakeLoggerName)
-                .hasServiceName(fakeDatadogContext.service)
-                .hasMessage(fakeMessage)
-                .hasThreadName(fakeThreadName)
-                .hasDate((fakeTimestamp + fakeServerTimeOffset).toIsoFormattedTimestamp())
-                .hasUserInfo(fakeUserInfo)
-                .hasNetworkInfo(fakeDatadogContext.networkInfo)
-                .hasExactlyAttributes(
-                    fakeAttributes + mapOf(
-                        LogAttributes.RUM_APPLICATION_ID to fakeRumContext.applicationId,
-                        LogAttributes.RUM_SESSION_ID to fakeRumContext.sessionId,
-                        LogAttributes.RUM_VIEW_ID to fakeRumContext.viewId,
-                        LogAttributes.RUM_ACTION_ID to fakeRumContext.actionId,
-                        LogAttributes.DD_TRACE_ID to fakeTraceId,
-                        LogAttributes.DD_SPAN_ID to fakeSpanId
-                    )
-                )
-                .hasExactlyTags(
-                    setOf(
-                        "${LogAttributes.ENV}:${fakeDatadogContext.env}",
-                        "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
-                    )
-                )
-        }
-    }
-
-    @Test
-    fun `𝕄 write crash log event and wait 𝕎 onReceive() { syncWrite = true }`(
-        @StringForgery fakeThreadName: String,
-        @LongForgery fakeTimestamp: Long,
-        @StringForgery fakeMessage: String,
-        @StringForgery fakeLoggerName: String
     ) {
         // Given
         whenever(mockLogsFeatureScope.withWriteContext(any(), any())) doAnswer {
@@ -735,13 +372,14 @@ internal class LogsFeatureTest {
             }
         }
         testedFeature.dataWriter = mockDataWriter
+        val fakeThrowable = forge.aThrowable()
         val event = mapOf(
-            "type" to "crash",
+            "type" to "jvm_crash",
             "threadName" to fakeThreadName,
             "timestamp" to fakeTimestamp,
             "message" to fakeMessage,
             "loggerName" to fakeLoggerName,
-            "syncWrite" to true
+            "throwable" to fakeThrowable
         )
 
         // When
@@ -783,11 +421,12 @@ internal class LogsFeatureTest {
     }
 
     @Test
-    fun `𝕄 write crash log event and not wait 𝕎 onReceive() { syncWrite = true + timeout }`(
+    fun `𝕄 not wait forever for crash log write 𝕎 onReceive() { JVM crash, timeout }`(
         @StringForgery fakeThreadName: String,
         @LongForgery fakeTimestamp: Long,
         @StringForgery fakeMessage: String,
-        @StringForgery fakeLoggerName: String
+        @StringForgery fakeLoggerName: String,
+        forge: Forge
     ) {
         // Given
         whenever(mockLogsFeatureScope.withWriteContext(any(), any())) doAnswer {
@@ -799,13 +438,14 @@ internal class LogsFeatureTest {
             }
         }
         testedFeature.dataWriter = mockDataWriter
+        val fakeThrowable = forge.aThrowable()
         val event = mapOf(
-            "type" to "crash",
+            "type" to "jvm_crash",
             "threadName" to fakeThreadName,
             "timestamp" to fakeTimestamp,
             "message" to fakeMessage,
             "loggerName" to fakeLoggerName,
-            "syncWrite" to true
+            "throwable" to fakeThrowable
         )
 
         // When
@@ -814,6 +454,211 @@ internal class LogsFeatureTest {
         // Then
         verify(mockLogsFeatureScope).withWriteContext(any(), any())
         verifyZeroInteractions(mockDataWriter)
+    }
+
+    // endregion
+
+    // region FeatureEventReceiver#onReceive + ndk crash event
+
+    @ParameterizedTest
+    @EnumSource(ValueMissingType::class)
+    fun `𝕄 log warning and do nothing 𝕎 onReceive() { corrupted mandatory fields, NDK crash }`(
+        missingType: ValueMissingType,
+        @LongForgery fakeTimestamp: Long,
+        @StringForgery fakeMessage: String,
+        @StringForgery fakeLoggerName: String,
+        forge: Forge
+    ) {
+        // Given
+        testedFeature.dataWriter = mockDataWriter
+        val fakeAttributes = forge.exhaustiveAttributes()
+        val event = mutableMapOf<String, Any?>(
+            "type" to "ndk_crash",
+            "timestamp" to fakeTimestamp,
+            "message" to fakeMessage,
+            "loggerName" to fakeLoggerName,
+            "attributes" to fakeAttributes
+        )
+
+        when (missingType) {
+            ValueMissingType.MISSING -> event.remove(
+                forge.anElementFrom(event.keys.filterNot { it == "type" })
+            )
+            ValueMissingType.NULL -> event[
+                forge.anElementFrom(event.keys.filterNot { it == "type" })
+            ] = null
+            ValueMissingType.WRONG_TYPE -> event[
+                forge.anElementFrom(event.keys.filterNot { it == "type" })
+            ] = Any()
+        }
+
+        // When
+        testedFeature.onReceive(event)
+
+        // Then
+        verify(logger.mockDevLogHandler)
+            .handleLog(
+                Log.WARN,
+                LogsFeature.NDK_CRASH_EVENT_MISSING_MANDATORY_FIELDS_WARNING
+            )
+
+        verifyZeroInteractions(
+            mockSdkCore,
+            mockDataWriter
+        )
+    }
+
+    @Test
+    fun `𝕄 write crash log event 𝕎 onReceive() { NDK crash }`(
+        @LongForgery fakeTimestamp: Long,
+        @StringForgery fakeMessage: String,
+        @StringForgery fakeLoggerName: String,
+        forge: Forge
+    ) {
+        // Given
+        testedFeature.dataWriter = mockDataWriter
+        val fakeAttributes = forge.exhaustiveAttributes()
+        val event = mutableMapOf<String, Any?>(
+            "type" to "ndk_crash",
+            "timestamp" to fakeTimestamp,
+            "message" to fakeMessage,
+            "loggerName" to fakeLoggerName,
+            "attributes" to fakeAttributes
+        )
+
+        // When
+        testedFeature.onReceive(event)
+
+        // Then
+        argumentCaptor<LogEvent> {
+            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
+
+            val log = lastValue
+
+            assertThatLog(log)
+                .hasStatus(LogEvent.Status.EMERGENCY)
+                .hasLoggerName(fakeLoggerName)
+                .hasServiceName(fakeDatadogContext.service)
+                .hasMessage(fakeMessage)
+                .hasThreadName(Thread.currentThread().name)
+                .hasDate((fakeTimestamp + fakeServerTimeOffset).toIsoFormattedTimestamp())
+                .hasNetworkInfo(fakeDatadogContext.networkInfo)
+                .hasUserInfo(fakeDatadogContext.userInfo)
+                .hasExactlyAttributes(fakeAttributes)
+                .hasExactlyTags(
+                    setOf(
+                        "${LogAttributes.ENV}:${fakeDatadogContext.env}",
+                        "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                    )
+                )
+        }
+    }
+
+    @Test
+    fun `𝕄 write crash log event 𝕎 onReceive() { NDK crash, explicit network info }`(
+        @LongForgery fakeTimestamp: Long,
+        @StringForgery fakeMessage: String,
+        @StringForgery fakeLoggerName: String,
+        @Forgery fakeNetworkInfo: NetworkInfo,
+        forge: Forge
+    ) {
+        // Given
+        testedFeature.dataWriter = mockDataWriter
+        val fakeAttributes = forge.exhaustiveAttributes()
+        val event = mutableMapOf<String, Any?>(
+            "type" to "ndk_crash",
+            "timestamp" to fakeTimestamp,
+            "message" to fakeMessage,
+            "loggerName" to fakeLoggerName,
+            "attributes" to fakeAttributes,
+            "networkInfo" to fakeNetworkInfo
+        )
+
+        // When
+        testedFeature.onReceive(event)
+
+        // Then
+        argumentCaptor<LogEvent> {
+            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
+
+            val log = lastValue
+
+            assertThatLog(log)
+                .hasStatus(LogEvent.Status.EMERGENCY)
+                .hasLoggerName(fakeLoggerName)
+                .hasServiceName(fakeDatadogContext.service)
+                .hasMessage(fakeMessage)
+                .hasThreadName(Thread.currentThread().name)
+                .hasDate((fakeTimestamp + fakeServerTimeOffset).toIsoFormattedTimestamp())
+                .hasUserInfo(fakeDatadogContext.userInfo)
+                .hasNetworkInfo(fakeNetworkInfo)
+                .hasExactlyAttributes(fakeAttributes)
+                .hasExactlyTags(
+                    setOf(
+                        "${LogAttributes.ENV}:${fakeDatadogContext.env}",
+                        "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                    )
+                )
+        }
+    }
+
+    @Test
+    fun `𝕄 write crash log event 𝕎 onReceive() { NDK crash, explicit user info }`(
+        @LongForgery fakeTimestamp: Long,
+        @StringForgery fakeMessage: String,
+        @StringForgery fakeLoggerName: String,
+        @Forgery fakeUserInfo: UserInfo,
+        forge: Forge
+    ) {
+        // Given
+        testedFeature.dataWriter = mockDataWriter
+        val fakeAttributes = forge.exhaustiveAttributes()
+        val event = mutableMapOf<String, Any?>(
+            "type" to "ndk_crash",
+            "timestamp" to fakeTimestamp,
+            "message" to fakeMessage,
+            "loggerName" to fakeLoggerName,
+            "attributes" to fakeAttributes,
+            "userInfo" to fakeUserInfo
+        )
+
+        // When
+        testedFeature.onReceive(event)
+
+        // Then
+        argumentCaptor<LogEvent> {
+            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
+
+            val log = lastValue
+
+            assertThatLog(log)
+                .hasStatus(LogEvent.Status.EMERGENCY)
+                .hasLoggerName(fakeLoggerName)
+                .hasServiceName(fakeDatadogContext.service)
+                .hasMessage(fakeMessage)
+                .hasThreadName(Thread.currentThread().name)
+                .hasDate((fakeTimestamp + fakeServerTimeOffset).toIsoFormattedTimestamp())
+                .hasUserInfo(fakeUserInfo)
+                .hasNetworkInfo(fakeDatadogContext.networkInfo)
+                .hasExactlyAttributes(fakeAttributes)
+                .hasExactlyTags(
+                    setOf(
+                        "${LogAttributes.ENV}:${fakeDatadogContext.env}",
+                        "${LogAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
+                        "${LogAttributes.VARIANT}:${fakeDatadogContext.variant}"
+                    )
+                )
+        }
+    }
+
+    // endregion
+
+    enum class ValueMissingType {
+        MISSING,
+        NULL,
+        WRONG_TYPE
     }
 
     companion object {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventDeserializerTest.kt
@@ -81,7 +81,8 @@ internal class RumEventDeserializerTest {
     ) {
         // GIVEN
         val fakeViewEvent = forge.getForgery(ViewEvent::class.java)
-        val serializedEvent = serializer.serialize(fakeViewEvent)
+        val serializedEvent = JsonParser.parseString(serializer.serialize(fakeViewEvent))
+            .asJsonObject
 
         // WHEN
         val deserializedEvent = testedDeserializer.deserialize(serializedEvent) as ViewEvent
@@ -96,7 +97,8 @@ internal class RumEventDeserializerTest {
     ) {
         // GIVEN
         val fakeResourceEvent = forge.getForgery(ResourceEvent::class.java)
-        val serializedEvent = serializer.serialize(fakeResourceEvent)
+        val serializedEvent = JsonParser.parseString(serializer.serialize(fakeResourceEvent))
+            .asJsonObject
 
         // WHEN
         val deserializedEvent = testedDeserializer.deserialize(serializedEvent) as ResourceEvent
@@ -111,7 +113,8 @@ internal class RumEventDeserializerTest {
     ) {
         // GIVEN
         val fakeActionEvent = forge.getForgery(ActionEvent::class.java)
-        val serializedEvent = serializer.serialize(fakeActionEvent)
+        val serializedEvent = JsonParser.parseString(serializer.serialize(fakeActionEvent))
+            .asJsonObject
 
         // WHEN
         val deserializedEvent = testedDeserializer.deserialize(serializedEvent) as ActionEvent
@@ -126,7 +129,8 @@ internal class RumEventDeserializerTest {
     ) {
         // GIVEN
         val fakeErrorEvent = forge.getForgery(ErrorEvent::class.java)
-        val serializedEvent = serializer.serialize(fakeErrorEvent)
+        val serializedEvent = JsonParser.parseString(serializer.serialize(fakeErrorEvent))
+            .asJsonObject
 
         // WHEN
         val deserializedEvent = testedDeserializer.deserialize(serializedEvent) as ErrorEvent
@@ -141,7 +145,8 @@ internal class RumEventDeserializerTest {
     ) {
         // GIVEN
         val fakeLongTaskEvent = forge.getForgery(LongTaskEvent::class.java)
-        val serializedEvent = serializer.serialize(fakeLongTaskEvent)
+        val serializedEvent = JsonParser.parseString(serializer.serialize(fakeLongTaskEvent))
+            .asJsonObject
 
         // WHEN
         val deserializedEvent = testedDeserializer.deserialize(serializedEvent) as LongTaskEvent
@@ -156,7 +161,8 @@ internal class RumEventDeserializerTest {
     ) {
         // GIVEN
         val fakeTelemetryDebugEvent = forge.getForgery(TelemetryDebugEvent::class.java)
-        val serializedEvent = serializer.serialize(fakeTelemetryDebugEvent)
+        val serializedEvent = JsonParser.parseString(serializer.serialize(fakeTelemetryDebugEvent))
+            .asJsonObject
 
         // WHEN
         val deserializedEvent = testedDeserializer.deserialize(serializedEvent)
@@ -174,7 +180,8 @@ internal class RumEventDeserializerTest {
     ) {
         // GIVEN
         val fakeTelemetryErrorEvent = forge.getForgery(TelemetryErrorEvent::class.java)
-        val serializedEvent = serializer.serialize(fakeTelemetryErrorEvent)
+        val serializedEvent = JsonParser.parseString(serializer.serialize(fakeTelemetryErrorEvent))
+            .asJsonObject
 
         // WHEN
         val deserializedEvent = testedDeserializer.deserialize(serializedEvent)
@@ -187,19 +194,11 @@ internal class RumEventDeserializerTest {
     }
 
     @Test
-    fun `𝕄 return null W deserialize { wrong Json format }`() {
-        // WHEN
-        val deserializedEvent = testedDeserializer.deserialize("{]}")
-
-        // THEN
-        assertThat(deserializedEvent).isNull()
-    }
-
-    @Test
     fun `𝕄 return null W deserialize { wrong bundled RUM event type }`() {
         // GIVEN
         val fakeBadFormatEvent = Any()
-        val serializedEvent = serializer.serialize(fakeBadFormatEvent)
+        val serializedEvent = JsonParser.parseString(serializer.serialize(fakeBadFormatEvent))
+            .asJsonObject
 
         // WHEN
         val deserializedEvent = testedDeserializer.deserialize(serializedEvent)
@@ -225,7 +224,6 @@ internal class RumEventDeserializerTest {
                 val telemetry = getAsJsonObject("telemetry")
                 telemetry.addProperty("status", forge.anAlphabeticalString())
             }
-            .toString()
 
         // WHEN
         val deserializedEvent = testedDeserializer.deserialize(eventWithWrongStatus)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashEventHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashEventHandlerTest.kt
@@ -1,0 +1,483 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.ndk
+
+import android.util.Log
+import com.datadog.android.core.internal.persistence.Deserializer
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.assertj.ErrorEventAssert
+import com.datadog.android.rum.assertj.ViewEventAssert
+import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.domain.scope.toErrorSchemaType
+import com.datadog.android.rum.model.ErrorEvent
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.utils.config.LoggerTestConfiguration
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.EventBatchWriter
+import com.datadog.android.v2.api.FeatureScope
+import com.datadog.android.v2.api.SdkCore
+import com.datadog.android.v2.api.context.DatadogContext
+import com.datadog.android.v2.api.context.UserInfo
+import com.datadog.android.v2.core.internal.storage.DataWriter
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.google.gson.JsonObject
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doAnswer
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyZeroInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DatadogNdkCrashEventHandlerTest {
+
+    private lateinit var testedHandler: NdkCrashEventHandler
+
+    @Mock
+    lateinit var mockSdkCore: SdkCore
+
+    @Mock
+    lateinit var mockRumFeatureScope: FeatureScope
+
+    @Mock
+    lateinit var mockRumWriter: DataWriter<Any>
+
+    @Mock
+    lateinit var mockRumEventDeserializer: Deserializer<JsonObject, Any>
+
+    @Mock
+    lateinit var mockEventBatchWriter: EventBatchWriter
+
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockSdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+        }
+
+        testedHandler = DatadogNdkCrashEventHandler(
+            rumEventDeserializer = mockRumEventDeserializer
+        )
+    }
+
+    @Test
+    fun `𝕄 send RUM view+error 𝕎 handleEvent()`(
+        @StringForgery crashMessage: String,
+        @LongForgery(min = 1) fakeTimestamp: Long,
+        @StringForgery fakeSignalName: String,
+        @StringForgery fakeStacktrace: String,
+        @Forgery viewEvent: ViewEvent,
+        @Forgery fakeUserInfo: UserInfo,
+        forge: Forge
+    ) {
+        // Given
+        val fakeServerOffset =
+            forge.aLong(min = -fakeTimestamp, max = Long.MAX_VALUE - fakeTimestamp)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(
+                serverTimeOffsetMs = fakeServerOffset
+            )
+        )
+
+        val fakeViewEvent = viewEvent.copy(
+            date = System.currentTimeMillis() - forge.aLong(
+                min = 0L,
+                max = DatadogNdkCrashEventHandler.VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD - 1000
+            ),
+            usr = ViewEvent.Usr(
+                id = fakeUserInfo.id,
+                name = fakeUserInfo.name,
+                email = fakeUserInfo.email,
+                additionalProperties = fakeUserInfo.additionalProperties.toMutableMap()
+            )
+        )
+        val fakeViewEventJson = fakeViewEvent.toJson().asJsonObject
+
+        whenever(mockRumEventDeserializer.deserialize(fakeViewEventJson))
+            .doReturn(fakeViewEvent)
+
+        val fakeEvent = mapOf(
+            "timestamp" to fakeTimestamp,
+            "signalName" to fakeSignalName,
+            "stacktrace" to fakeStacktrace,
+            "message" to crashMessage,
+            "lastViewEvent" to fakeViewEventJson
+        )
+
+        // When
+        testedHandler.handleEvent(fakeEvent, mockSdkCore, mockRumWriter)
+
+        // Then
+        argumentCaptor<Any> {
+            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+
+            ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasApplicationId(fakeViewEvent.application.id)
+                .hasSessionId(fakeViewEvent.session.id)
+                .hasView(
+                    fakeViewEvent.view.id,
+                    fakeViewEvent.view.name,
+                    fakeViewEvent.view.url
+                )
+                .hasMessage(crashMessage)
+                .hasStackTrace(fakeStacktrace)
+                .isCrash(true)
+                .hasErrorSource(RumErrorSource.SOURCE)
+                .hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
+                .hasTimestamp(fakeTimestamp + fakeServerOffset)
+                .hasUserInfo(
+                    UserInfo(
+                        fakeViewEvent.usr?.id,
+                        fakeViewEvent.usr?.name,
+                        fakeViewEvent.usr?.email,
+                        fakeViewEvent.usr?.additionalProperties.orEmpty()
+                    )
+                )
+                .hasErrorType(fakeSignalName)
+                .hasLiteSessionPlan()
+                .hasDeviceInfo(
+                    fakeDatadogContext.deviceInfo.deviceName,
+                    fakeDatadogContext.deviceInfo.deviceModel,
+                    fakeDatadogContext.deviceInfo.deviceBrand,
+                    fakeDatadogContext.deviceInfo.deviceType.toErrorSchemaType(),
+                    fakeDatadogContext.deviceInfo.architecture
+                )
+                .hasOsInfo(
+                    fakeDatadogContext.deviceInfo.osName,
+                    fakeDatadogContext.deviceInfo.osVersion,
+                    fakeDatadogContext.deviceInfo.osMajorVersion
+                )
+
+            ViewEventAssert.assertThat(secondValue as ViewEvent)
+                .hasVersion(fakeViewEvent.dd.documentVersion + 1)
+                .hasCrashCount((fakeViewEvent.view.crash?.count ?: 0) + 1)
+                .isActive(false)
+        }
+    }
+
+    @Test
+    fun `𝕄 send RUM view+error 𝕎 handleEvent() {view without usr}`(
+        @StringForgery crashMessage: String,
+        @LongForgery(min = 1) fakeTimestamp: Long,
+        @StringForgery fakeSignalName: String,
+        @StringForgery fakeStacktrace: String,
+        @Forgery viewEvent: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val fakeServerOffset =
+            forge.aLong(min = -fakeTimestamp, max = Long.MAX_VALUE - fakeTimestamp)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(
+                serverTimeOffsetMs = fakeServerOffset
+            )
+        )
+
+        val fakeViewEvent = viewEvent.copy(
+            date = System.currentTimeMillis() - forge.aLong(
+                min = 0L,
+                max = DatadogNdkCrashEventHandler.VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD - 1000
+            ),
+            usr = null
+        )
+        val fakeViewEventJson = fakeViewEvent.toJson().asJsonObject
+        val fakeEvent = mapOf(
+            "timestamp" to fakeTimestamp,
+            "signalName" to fakeSignalName,
+            "stacktrace" to fakeStacktrace,
+            "message" to crashMessage,
+            "lastViewEvent" to fakeViewEventJson
+        )
+
+        whenever(mockRumEventDeserializer.deserialize(fakeViewEventJson))
+            .doReturn(fakeViewEvent)
+
+        // When
+        testedHandler.handleEvent(fakeEvent, mockSdkCore, mockRumWriter)
+
+        // Then
+        argumentCaptor<Any> {
+            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+
+            ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasApplicationId(fakeViewEvent.application.id)
+                .hasSessionId(fakeViewEvent.session.id)
+                .hasView(
+                    fakeViewEvent.view.id,
+                    fakeViewEvent.view.name,
+                    fakeViewEvent.view.url
+                )
+                .hasMessage(crashMessage)
+                .hasStackTrace(fakeStacktrace)
+                .isCrash(true)
+                .hasErrorSource(RumErrorSource.SOURCE)
+                .hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
+                .hasTimestamp(fakeTimestamp + fakeServerOffset)
+                .hasNoUserInfo()
+                .hasErrorType(fakeSignalName)
+                .hasLiteSessionPlan()
+                .hasDeviceInfo(
+                    fakeDatadogContext.deviceInfo.deviceName,
+                    fakeDatadogContext.deviceInfo.deviceModel,
+                    fakeDatadogContext.deviceInfo.deviceBrand,
+                    fakeDatadogContext.deviceInfo.deviceType.toErrorSchemaType(),
+                    fakeDatadogContext.deviceInfo.architecture
+                )
+                .hasOsInfo(
+                    fakeDatadogContext.deviceInfo.osName,
+                    fakeDatadogContext.deviceInfo.osVersion,
+                    fakeDatadogContext.deviceInfo.osMajorVersion
+                )
+
+            ViewEventAssert.assertThat(secondValue as ViewEvent)
+                .hasVersion(fakeViewEvent.dd.documentVersion + 1)
+                .hasCrashCount((fakeViewEvent.view.crash?.count ?: 0) + 1)
+                .isActive(false)
+        }
+    }
+
+    @Test
+    fun `𝕄 send only RUM error 𝕎 handleEvent() {view is too old}`(
+        @StringForgery crashMessage: String,
+        @LongForgery(min = 1) fakeTimestamp: Long,
+        @StringForgery fakeSignalName: String,
+        @StringForgery fakeStacktrace: String,
+        @Forgery viewEvent: ViewEvent,
+        @Forgery fakeUserInfo: UserInfo,
+        forge: Forge
+    ) {
+        // Given
+        val fakeServerOffset =
+            forge.aLong(min = -fakeTimestamp, max = Long.MAX_VALUE - fakeTimestamp)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            time = fakeDatadogContext.time.copy(
+                serverTimeOffsetMs = fakeServerOffset
+            )
+        )
+        val fakeViewEvent = viewEvent.copy(
+            date = System.currentTimeMillis() - forge.aLong(
+                min = DatadogNdkCrashEventHandler.VIEW_EVENT_AVAILABILITY_TIME_THRESHOLD + 1
+            ),
+            usr = ViewEvent.Usr(
+                id = fakeUserInfo.id,
+                name = fakeUserInfo.name,
+                email = fakeUserInfo.email,
+                additionalProperties = fakeUserInfo.additionalProperties.toMutableMap()
+            )
+        )
+        val fakeViewEventJson = fakeViewEvent.toJson().asJsonObject
+        whenever(mockRumEventDeserializer.deserialize(fakeViewEventJson))
+            .doReturn(fakeViewEvent)
+        val expectedErrorEventSource = with(fakeViewEvent.source) {
+            if (this != null) {
+                ErrorEvent.ErrorEventSource.fromJson(this.toJson().asString)
+            } else {
+                null
+            }
+        }
+        val fakeEvent = mapOf(
+            "timestamp" to fakeTimestamp,
+            "signalName" to fakeSignalName,
+            "stacktrace" to fakeStacktrace,
+            "message" to crashMessage,
+            "lastViewEvent" to fakeViewEventJson
+        )
+
+        // When
+        testedHandler.handleEvent(fakeEvent, mockSdkCore, mockRumWriter)
+
+        // Then
+        argumentCaptor<Any> {
+            verify(mockRumWriter, times(1)).write(eq(mockEventBatchWriter), capture())
+
+            ErrorEventAssert.assertThat(firstValue as ErrorEvent)
+                .hasApplicationId(fakeViewEvent.application.id)
+                .hasSessionId(fakeViewEvent.session.id)
+                .hasView(
+                    fakeViewEvent.view.id,
+                    fakeViewEvent.view.name,
+                    fakeViewEvent.view.url
+                )
+                .hasMessage(crashMessage)
+                .hasStackTrace(fakeStacktrace)
+                .isCrash(true)
+                .hasErrorSource(RumErrorSource.SOURCE)
+                .hasErrorSourceType(ErrorEvent.SourceType.ANDROID)
+                .hasTimestamp(fakeTimestamp + fakeServerOffset)
+                .hasUserInfo(
+                    UserInfo(
+                        fakeViewEvent.usr?.id,
+                        fakeViewEvent.usr?.name,
+                        fakeViewEvent.usr?.email,
+                        fakeViewEvent.usr?.additionalProperties.orEmpty()
+                    )
+                )
+                .hasErrorType(fakeSignalName)
+                .hasLiteSessionPlan()
+                .hasSource(expectedErrorEventSource)
+                .hasDeviceInfo(
+                    fakeDatadogContext.deviceInfo.deviceName,
+                    fakeDatadogContext.deviceInfo.deviceModel,
+                    fakeDatadogContext.deviceInfo.deviceBrand,
+                    fakeDatadogContext.deviceInfo.deviceType.toErrorSchemaType(),
+                    fakeDatadogContext.deviceInfo.architecture
+                )
+                .hasOsInfo(
+                    fakeDatadogContext.deviceInfo.osName,
+                    fakeDatadogContext.deviceInfo.osVersion,
+                    fakeDatadogContext.deviceInfo.osMajorVersion
+                )
+        }
+    }
+
+    @Test
+    fun `𝕄 not send RUM event 𝕎 handleEvent() { RUM feature is not registered }`(
+        @StringForgery crashMessage: String,
+        @LongForgery(min = 1) fakeTimestamp: Long,
+        @StringForgery fakeSignalName: String,
+        @StringForgery fakeStacktrace: String,
+        @Forgery viewEvent: ViewEvent
+    ) {
+        // Given
+        val fakeViewEventJson = viewEvent.toJson().asJsonObject
+        whenever(mockSdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)) doReturn null
+        val fakeEvent = mapOf(
+            "timestamp" to fakeTimestamp,
+            "signalName" to fakeSignalName,
+            "stacktrace" to fakeStacktrace,
+            "message" to crashMessage,
+            "lastViewEvent" to fakeViewEventJson
+        )
+
+        // When
+        testedHandler.handleEvent(fakeEvent, mockSdkCore, mockRumWriter)
+
+        // Then
+        verifyZeroInteractions(mockRumWriter, mockEventBatchWriter)
+        verify(logger.mockDevLogHandler)
+            .handleLog(
+                Log.INFO,
+                DatadogNdkCrashEventHandler.INFO_RUM_FEATURE_NOT_REGISTERED
+            )
+    }
+
+    @Test
+    fun `𝕄 not send RUM event 𝕎 handleEvent() { corrupted event, view json deserialization fails }`(
+        @StringForgery crashMessage: String,
+        @LongForgery(min = 1) fakeTimestamp: Long,
+        @StringForgery fakeSignalName: String,
+        @StringForgery fakeStacktrace: String,
+        @Forgery fakeViewEventJson: JsonObject
+    ) {
+        // Given
+        val fakeEvent = mutableMapOf(
+            "timestamp" to fakeTimestamp,
+            "signalName" to fakeSignalName,
+            "stacktrace" to fakeStacktrace,
+            "message" to crashMessage,
+            "lastViewEvent" to fakeViewEventJson
+        )
+        whenever(mockRumEventDeserializer.deserialize(fakeViewEventJson)) doReturn null
+
+        // When
+        testedHandler.handleEvent(fakeEvent, mockSdkCore, mockRumWriter)
+
+        // Then
+        verifyZeroInteractions(mockRumWriter, mockEventBatchWriter)
+        verify(logger.mockDevLogHandler)
+            .handleLog(
+                Log.WARN,
+                DatadogNdkCrashEventHandler.NDK_CRASH_EVENT_MISSING_MANDATORY_FIELDS
+            )
+    }
+
+    @ParameterizedTest
+    @EnumSource(ValueMissingType::class)
+    fun `𝕄 not send RUM event 𝕎 handleEvent() { corrupted event }`(
+        missingType: ValueMissingType,
+        @StringForgery crashMessage: String,
+        @LongForgery(min = 1) fakeTimestamp: Long,
+        @StringForgery fakeSignalName: String,
+        @StringForgery fakeStacktrace: String,
+        @Forgery viewEvent: ViewEvent,
+        forge: Forge
+    ) {
+        // Given
+        val fakeViewEventJson = viewEvent.toJson().asJsonObject
+        val fakeEvent = mutableMapOf(
+            "timestamp" to fakeTimestamp,
+            "signalName" to fakeSignalName,
+            "stacktrace" to fakeStacktrace,
+            "message" to crashMessage,
+            "lastViewEvent" to fakeViewEventJson
+        )
+
+        when (missingType) {
+            ValueMissingType.MISSING -> fakeEvent.remove(forge.anElementFrom(fakeEvent.keys))
+            ValueMissingType.NULL -> fakeEvent[forge.anElementFrom(fakeEvent.keys)] = null
+            ValueMissingType.WRONG_TYPE -> fakeEvent[forge.anElementFrom(fakeEvent.keys)] = Any()
+        }
+
+        // When
+        testedHandler.handleEvent(fakeEvent, mockSdkCore, mockRumWriter)
+
+        // Then
+        verifyZeroInteractions(mockRumWriter, mockEventBatchWriter)
+        verify(logger.mockDevLogHandler)
+            .handleLog(
+                Log.WARN,
+                DatadogNdkCrashEventHandler.NDK_CRASH_EVENT_MISSING_MANDATORY_FIELDS
+            )
+    }
+
+    enum class ValueMissingType {
+        MISSING,
+        NULL,
+        WRONG_TYPE
+    }
+
+    companion object {
+        val logger = LoggerTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(logger)
+        }
+    }
+}

--- a/detekt.yml
+++ b/detekt.yml
@@ -1212,9 +1212,11 @@ datadog:
       - "kotlin.Long.or(kotlin.Long)"
       - "kotlin.Number.toLong()"
       # endregion
-      # region Kotlin Pair
+      # region Kotlin Pair + Triple
       - "kotlin.Pair.constructor(com.datadog.android.sessionreplay.model.MobileSegment, com.google.gson.JsonObject)"
       - "kotlin.Pair.constructor(com.datadog.android.sessionreplay.utils.SessionReplayRumContext, com.google.gson.JsonArray)"
+      - "kotlin.Triple.constructor(kotlin.Nothing?, kotlin.Nothing?, kotlin.Nothing?)"
+      - "kotlin.Triple.constructor(kotlin.String, kotlin.String, kotlin.String)"
       # endregion
       # region Kotlin String
       - "kotlin.String.all(kotlin.Function1)"


### PR DESCRIPTION
### What does this PR do?

This PR changes the way NDK crashes are reported to RUM: now they will be sent through the message bus, because RUM feature may be optional and will reside in another module anyway.

Also there are now 2 different message types for the crashes coming to Logs and RUM: `jvm_crash` and `ndk_crash`. This way the code is simpler and is easier to test.

`DatadogNdkCrashHandler` now reads last view event as JSON (because RUM-specific deserializers won't be available), takes view ID, session ID and application ID from it and passes it to the RUM feature where further deserialization from `JsonObject` to the RUM-specific type is done.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

