### PR TITLE
RUMM-2755: Remove site property from DatadogContext

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -2010,7 +2010,7 @@ interface com.datadog.android.v2.api.SdkCore
 data class com.datadog.android.v2.api.context.CarrierInfo
   constructor(String?, String?)
 data class com.datadog.android.v2.api.context.DatadogContext
-  constructor(com.datadog.android.DatadogSite, String, String, String, String, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, com.datadog.android.privacy.TrackingConsent, Map<String, Map<String, Any?>>)
+  constructor(String, String, String, String, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, com.datadog.android.privacy.TrackingConsent, Map<String, Map<String, Any?>>)
 data class com.datadog.android.v2.api.context.DeviceInfo
   constructor(String, String, String, DeviceType, String, String, String, String, String)
 enum com.datadog.android.v2.api.context.DeviceType

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/context/DatadogContext.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/context/DatadogContext.kt
@@ -6,12 +6,10 @@
 
 package com.datadog.android.v2.api.context
 
-import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 
 /**
  * Contains system information, as well as user-specific and feature specific context info.
- * @property site [Datadog Site](https://docs.datadoghq.com/getting_started/site/) for data uploads.
  * @property clientToken the client token allowing for data uploads to
  * [Datadog Site](https://docs.datadoghq.com/getting_started/site/).
  * @property service the name of the service that data is generated from. Used for
@@ -34,7 +32,6 @@ import com.datadog.android.privacy.TrackingConsent
  * the parent SDK instance
  */
 data class DatadogContext(
-    val site: DatadogSite,
     val clientToken: String,
     val service: String,
     val env: String,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/DatadogContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/DatadogContextProvider.kt
@@ -17,7 +17,6 @@ internal class DatadogContextProvider(val coreFeature: CoreFeature) : ContextPro
     override val context: DatadogContext
         get() {
             return DatadogContext(
-                site = coreFeature.site,
                 clientToken = coreFeature.clientToken,
                 service = coreFeature.serviceName,
                 env = coreFeature.envName,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/NoOpContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/NoOpContextProvider.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.v2.core.internal
 
-import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.DeviceInfo
@@ -20,7 +19,6 @@ internal class NoOpContextProvider : ContextProvider {
     // TODO RUMM-0000 this one is quite ugly. Should return type be nullable?
     override val context: DatadogContext
         get() = DatadogContext(
-            site = DatadogSite.US1,
             clientToken = "",
             service = "",
             env = "",

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.utils.forge
 
-import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.context.DatadogContext
 import fr.xgouchet.elmyr.Forge
@@ -17,7 +16,6 @@ class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
 
     override fun getForgery(forge: Forge): DatadogContext {
         return DatadogContext(
-            site = forge.aValueFrom(DatadogSite::class.java),
             clientToken = forge.anHexadecimalString().lowercase(Locale.US),
             service = forge.anAlphabeticalString(),
             version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/DatadogContextProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/DatadogContextProviderTest.kt
@@ -94,7 +94,6 @@ internal class DatadogContextProviderTest {
 
         // Then
         assertThat(context.env).isEqualTo(coreFeature.mockInstance.envName)
-        assertThat(context.site).isEqualTo(coreFeature.mockInstance.site)
         assertThat(context.clientToken).isEqualTo(coreFeature.mockInstance.clientToken)
         assertThat(context.service).isEqualTo(coreFeature.mockInstance.serviceName)
         assertThat(context.env).isEqualTo(coreFeature.mockInstance.envName)


### PR DESCRIPTION
### What does this PR do?

`site` property is not used neither in the write, nor in the upload flows by the features, so removing it from `DatadogContext`. Also it is not possible to have it when custom URLs are used anyway.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

