### PR TITLE
Improve batch upload wait timeout handling

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -20,10 +20,12 @@ import com.datadog.android.v2.core.internal.storage.BatchConfirmation
 import com.datadog.android.v2.core.internal.storage.BatchId
 import com.datadog.android.v2.core.internal.storage.BatchReader
 import com.datadog.android.v2.core.internal.storage.Storage
+import com.datadog.tools.unit.forge.aThrowable
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.same
@@ -113,7 +115,8 @@ internal class DataUploadRunnableTest {
             mockContextProvider,
             mockNetworkInfoProvider,
             mockSystemInfoProvider,
-            fakeUploadFrequency
+            fakeUploadFrequency,
+            TEST_BATCH_UPLOAD_WAIT_TIMEOUT_MS
         )
     }
 
@@ -328,7 +331,7 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `M not send batch W run() { batteryFullOrCharging, powerSaveMode}`(
+    fun `M not send batch W run() { batteryFullOrCharging, powerSaveMode }`(
         @IntForgery(min = 0, max = 100) batteryLevel: Int
     ) {
         // Given
@@ -353,7 +356,7 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `M not send batch W run() { batteryLeveHigh, powerSaveMode}`(
+    fun `M not send batch W run() { batteryLeveHigh, powerSaveMode }`(
         @IntForgery(min = DataUploadRunnable.LOW_BATTERY_THRESHOLD + 1) batteryLevel: Int
     ) {
         // Given
@@ -378,7 +381,7 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `M not send batch W run() { onExternalPower, powerSaveMode}`(
+    fun `M not send batch W run() { onExternalPower, powerSaveMode }`(
         @IntForgery(min = 0, max = DataUploadRunnable.LOW_BATTERY_THRESHOLD) batteryLevel: Int
     ) {
         // Given
@@ -879,5 +882,74 @@ internal class DataUploadRunnableTest {
                 next
             }
         }
+    }
+
+    // region async
+
+    @Test
+    fun `𝕄 respect batch wait upload timeout 𝕎 run()`() {
+        // Given
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
+            // imitate async which never completes
+        }
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `𝕄 stop waiting 𝕎 run() { exception is thrown }`(
+        @StringForgery batch: List<String>,
+        @StringForgery batchMeta: String,
+        forge: Forge
+    ) {
+        // Given
+        val batchId = mock<BatchId>()
+        val batchReader = mock<BatchReader>()
+        val batchData = batch.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
+
+        whenever(batchReader.read()) doReturn batchData
+        whenever(batchReader.currentMetadata()) doReturn batchMetadata
+
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
+            Thread {
+                it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+            }.start()
+        }
+
+        whenever(
+            mockDataUploader.upload(
+                fakeContext,
+                batchData,
+                batchMetadata
+            )
+        ) doThrow forge.aThrowable()
+
+        // When
+        val start = System.currentTimeMillis()
+        testedRunnable.run()
+
+        // Then
+        assertThat(System.currentTimeMillis() - start)
+            .isLessThan(TEST_BATCH_UPLOAD_WAIT_TIMEOUT_MS)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    // endregion
+
+    companion object {
+        const val TEST_BATCH_UPLOAD_WAIT_TIMEOUT_MS = 100L
     }
 }


### PR DESCRIPTION
### What does this PR do?

This change improves lock handling scenario in the batch upload. Before, if any exception would happen during the batch upload if `Storage#readNextBatch` is async (which is not the case right now), lock would be removed only after timeout. Now lock is removed immediately. 

This is mostly a safeguard if at any point `Storage#readNextBatch` becomes async, but we probably need to revert the switch to async-like API in the upload pipeline back to the blocking API, because async one doesn't really bring any benefit and actually makes code more complex.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

