### PR TITLE
Fix possible crash during the telemetry processing

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -306,7 +306,6 @@ interface RumMonitor {
                     handler = Handler(Looper.getMainLooper()),
                     telemetryEventHandler = TelemetryEventHandler(
                         sdkCore = datadogCore,
-                        coreFeature.timeProvider,
                         RateBasedSampler(rumFeature.telemetrySamplingRate / 100)
                     ),
                     firstPartyHostDetector = coreFeature.firstPartyHostDetector,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -9,7 +9,6 @@ package com.datadog.android.telemetry.internal
 import androidx.annotation.WorkerThread
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.sampling.Sampler
-import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.RumFeature
@@ -30,7 +29,6 @@ import java.util.Locale
 
 internal class TelemetryEventHandler(
     internal val sdkCore: SdkCore,
-    private val timeProvider: TimeProvider,
     internal val eventSampler: Sampler,
     internal val maxEventCountPerSession: Int = MAX_EVENTS_PER_SESSION
 ) : RumSessionListener {
@@ -45,10 +43,9 @@ internal class TelemetryEventHandler(
 
         seenInCurrentSession.add(event.identity)
 
-        val timestamp = event.eventTime.timestamp + timeProvider.getServerOffsetMillis()
-
         sdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)
             ?.withWriteContext { datadogContext, eventBatchWriter ->
+                val timestamp = event.eventTime.timestamp + datadogContext.time.serverTimeOffsetMs
                 val telemetryEvent: Any? = when (event.type) {
                     TelemetryType.DEBUG -> {
                         createDebugEvent(datadogContext, timestamp, event.message)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -12,7 +12,6 @@ import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.core.configuration.VitalsUpdateFrequency
 import com.datadog.android.core.internal.sampling.Sampler
-import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
@@ -86,9 +85,6 @@ internal class TelemetryEventHandlerTest {
     private lateinit var testedTelemetryHandler: TelemetryEventHandler
 
     @Mock
-    lateinit var mockTimeProvider: TimeProvider
-
-    @Mock
     lateinit var mockWriter: DataWriter<Any>
 
     @Mock
@@ -115,8 +111,6 @@ internal class TelemetryEventHandlerTest {
     fun `set up`(forge: Forge) {
         fakeServerOffset = forge.aLong(-50000, 50000)
 
-        whenever(mockTimeProvider.getServerOffsetMillis()) doReturn fakeServerOffset
-
         fakeDatadogContext = fakeDatadogContext.copy(
             source = "android",
             featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
@@ -129,7 +123,10 @@ internal class TelemetryEventHandlerTest {
                         "action_id" to fakeRumContext.actionId
                     )
                 )
-            }
+            },
+            time = fakeDatadogContext.time.copy(
+                serverTimeOffsetMs = fakeServerOffset
+            )
         )
 
         whenever(mockSampler.sample()) doReturn true
@@ -145,7 +142,6 @@ internal class TelemetryEventHandlerTest {
         testedTelemetryHandler =
             TelemetryEventHandler(
                 mockSdkCore,
-                mockTimeProvider,
                 mockSampler,
                 MAX_EVENTS_PER_SESSION_TEST
             )


### PR DESCRIPTION
### What does this PR do?

It is possible to have a crash like this:

```
java.lang.IllegalStateException: Service already shutdown
	at com.lyft.kronos.internal.ntp.SntpServiceImpl.ensureServiceIsRunning(SntpService.kt:142)
	at com.lyft.kronos.internal.ntp.SntpServiceImpl.currentTime(SntpService.kt:98)
	at com.lyft.kronos.internal.KronosClockImpl.getCurrentTime(KronosClockImpl.kt:19)
	at com.lyft.kronos.KronosClock$DefaultImpls.getCurrentTimeMs(Clock.kt:39)
	at com.lyft.kronos.internal.KronosClockImpl.getCurrentTimeMs(KronosClockImpl.kt:8)
	at com.datadog.android.core.internal.time.KronosTimeProvider.getServerOffsetMillis(KronosTimeProvider.kt:25)
	at com.datadog.android.telemetry.internal.TelemetryEventHandler.handleEvent(TelemetryEventHandler.kt:48)
	at com.datadog.android.rum.internal.monitor.DatadogRumMonitor.handleEvent$dd_sdk_android_debug(DatadogRumMonitor.kt:399)
	at com.datadog.android.rum.internal.monitor.DatadogRumMonitor.sendErrorTelemetryEvent(DatadogRumMonitor.kt:347)
	at com.datadog.android.telemetry.internal.Telemetry.error(Telemetry.kt:21)
	at com.datadog.android.log.internal.logger.TelemetryLogHandler.handleLog(TelemetryLogHandler.kt:22)
	at com.datadog.android.log.internal.logger.InternalLogHandler.handleLog(InternalLogHandler.kt:40)
	at com.datadog.android.log.Logger.internalLog$dd_sdk_android_debug(Logger.kt:596)
	at com.datadog.android.log.Logger.internalLog$dd_sdk_android_debug$default(Logger.kt:583)
	at com.datadog.android.log.Logger.log(Logger.kt:168)
	at com.datadog.android.log.internal.utils.LogUtilsKt.errorWithTelemetry(LogUtils.kt:45)
	at com.datadog.android.log.internal.utils.LogUtilsKt.errorWithTelemetry$default(LogUtils.kt:40)
	at com.datadog.android.core.internal.persistence.file.batch.BatchFileOrchestrator.isRootDirValid(BatchFileOrchestrator.kt:136)
	at com.datadog.android.core.internal.persistence.file.batch.BatchFileOrchestrator.getRootDir(BatchFileOrchestrator.kt:90)
	at com.datadog.android.core.internal.persistence.file.advanced.ConsentAwareFileMigrator.migrateData(ConsentAwareFileMigrator.kt:55)
	at com.datadog.android.core.internal.persistence.file.advanced.ConsentAwareFileMigrator.migrateData(ConsentAwareFileMigrator.kt:19)
	at com.datadog.android.core.internal.persistence.file.advanced.ConsentAwareFileOrchestrator.handleConsentChange(ConsentAwareFileOrchestrator.kt:88)
	at com.datadog.android.core.internal.persistence.file.advanced.ConsentAwareFileOrchestrator.onConsentUpdated(ConsentAwareFileOrchestrator.kt:74)
	at com.datadog.android.core.internal.privacy.TrackingConsentProvider.notifyCallbacks(TrackingConsentProvider.kt:59)
	at com.datadog.android.core.internal.privacy.TrackingConsentProvider.setConsent(TrackingConsentProvider.kt:40)
	at com.datadog.android.v2.core.DatadogCore.setTrackingConsent(DatadogCore.kt:156)
	at com.datadog.android.Datadog.initialize(Datadog.kt:73)
	at com.datadog.android.nightly.utils.MiscUtilsKt.initializeSdk(MiscUtils.kt:98)
	at com.datadog.android.nightly.utils.MiscUtilsKt.initializeSdk$default(MiscUtils.kt:91)
	at com.datadog.android.nightly.rum.RumViewTrackingE2ETests$rum_activity_view_tracking_strategy$1.invoke(RumViewTrackingE2ETests.kt:57)
	at com.datadog.android.nightly.rum.RumViewTrackingE2ETests$rum_activity_view_tracking_strategy$1.invoke(RumViewTrackingE2ETests.kt:48)
	at com.datadog.android.nightly.utils.MeasureUtilsKt.measureSdkInitialize(MeasureUtils.kt:27)
	at com.datadog.android.nightly.rum.RumViewTrackingE2ETests.rum_activity_view_tracking_strategy(RumViewTrackingE2ETests.kt:48)
```

It happens because we trigger the task of the consent update check, which is async and at the same time SDK is shutdown. Since we let existing tasks to complete during the executor shutdown, it may be the case when there is no folder anymore, so error is triggered which is processed by telemetry.

And since Kronos was shutdown, we get an exception trying to get server offset.

This change relies on the `DatadogContext` instead, which is created only if feature is still there. Features are removed before `CoreFeature` is stopped, so I hope this change should fix the issue.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

