### PR TITLE
Fix flaky BroadcastReceiverSystemInfoProvider test

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
@@ -16,6 +16,7 @@ import android.os.PowerManager
 import com.datadog.android.core.internal.receiver.ThreadSafeReceiver
 import com.datadog.android.core.internal.utils.sdkLogger
 import com.datadog.android.log.internal.utils.debugWithTelemetry
+import kotlin.math.roundToInt
 
 internal class BroadcastReceiverSystemInfoProvider(
     private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider()
@@ -79,7 +80,9 @@ internal class BroadcastReceiverSystemInfoProvider(
         val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, DEFAULT_BATTERY_SCALE)
         val pluggedStatus = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, BATTERY_UNPLUGGED)
         val batteryStatus = SystemInfo.BatteryStatus.fromAndroidStatus(status)
-        val batteryLevel = (level * DEFAULT_BATTERY_SCALE) / scale
+
+        @Suppress("UnsafeThirdPartyFunctionCall") // Not a NaN here
+        val batteryLevel = ((level * DEFAULT_BATTERY_SCALE.toFloat()) / scale).roundToInt()
         val onExternalPowerSource = pluggedStatus in PLUGGED_IN_STATUS_VALUES
         val batteryFullOrCharging = batteryStatus in batteryFullOrChargingStatus
         systemInfo = systemInfo.copy(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProviderTest.kt
@@ -41,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import kotlin.math.roundToInt
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -129,7 +130,7 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.LOLLIPOP
 
         val batteryIntent: Intent = mock()
-        val scaledLevel = (level * scale) / 100
+        val scaledLevel = ((level * scale) / 100f).roundToInt()
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_STATUS), any()))
             .doReturn(status.androidStatus())
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_PLUGGED), any()))
@@ -166,7 +167,7 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.KITKAT
 
         val batteryIntent: Intent = mock()
-        val scaledLevel = (level * scale) / 100
+        val scaledLevel = ((level * scale) / 100f).roundToInt()
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_STATUS), any()))
             .doReturn(status.androidStatus())
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_PLUGGED), any()))
@@ -221,7 +222,7 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         @IntForgery(min = 50, max = 10000) scale: Int
     ) {
         // Given
-        val scaledLevel = (level * scale) / 100
+        val scaledLevel = ((level * scale) / 100f).roundToInt()
         whenever(mockIntent.getIntExtra(eq(BatteryManager.EXTRA_STATUS), any()))
             .doReturn(status.androidStatus())
         whenever(mockIntent.getIntExtra(eq(BatteryManager.EXTRA_LEVEL), any())) doReturn scaledLevel
@@ -337,7 +338,7 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         @IntForgery(min = 50, max = 10000) scale: Int
     ) {
         // Given
-        val scaledLevel = (level * scale) / 100
+        val scaledLevel = ((level * scale) / 100f).roundToInt()
         val batteryIntent: Intent = mock()
         whenever(
             batteryIntent.getIntExtra(
@@ -371,7 +372,7 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         @IntForgery(min = 50, max = 10000) scale: Int
     ) {
         // Given
-        val scaledLevel = (level * scale) / 100
+        val scaledLevel = ((level * scale) / 100f).roundToInt()
         val batteryIntent: Intent = mock()
         whenever(
             batteryIntent.getIntExtra(
@@ -409,7 +410,7 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         @IntForgery(min = 50, max = 10000) scale: Int
     ) {
         // Given
-        val scaledLevel = (level * scale) / 100
+        val scaledLevel = ((level * scale) / 100f).roundToInt()
         val batteryIntent: Intent = mock()
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_SCALE), any())) doReturn scale
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_LEVEL), any())) doReturn
@@ -435,7 +436,7 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         @IntForgery(min = 50, max = 10000) scale: Int
     ) {
         // Given
-        val scaledLevel = (level * scale) / 100
+        val scaledLevel = ((level * scale) / 100f).roundToInt()
         val batteryIntent: Intent = mock()
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_SCALE), any())) doReturn scale
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_LEVEL), any())) doReturn


### PR DESCRIPTION
### What does this PR do?

This change fixes a flaky failure:

```
BroadcastReceiverSystemInfoProviderTest > M read system info W register() {Lollipop}(BatteryStatus, int, int, boolean) > com.datadog.android.core.internal.system.BroadcastReceiverSystemInfoProviderTest.M read system info W register() {Lollipop}(BatteryStatus, int, int, boolean)[6] FAILED
    java.lang.AssertionError at BroadcastReceiverSystemInfoProviderTest.kt:153
```

It happens because of the `Float` to `Int` conversion in the following operations:

```
> in code (level * 100) / scale
> in test (level * scale) / 100
```
Since this conversion simply truncates the floating part we may end up loosing too much precision for the final comparison. This change instead of the truncation of the decimal part does a proper rounding.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

