### PR TITLE
RUMM-2780: Synchronize access to DatadogRumMonitor#rootScope when processing fatal error

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -392,8 +392,10 @@ internal class DatadogRumMonitor(
 
     internal fun handleEvent(event: RumRawEvent) {
         if (event is RumRawEvent.AddError && event.isFatal) {
-            @Suppress("ThreadSafety") // Crash handling, can't delegate to another thread
-            rootScope.handleEvent(event, writer)
+            synchronized(rootScope) {
+                @Suppress("ThreadSafety") // Crash handling, can't delegate to another thread
+                rootScope.handleEvent(event, writer)
+            }
         } else if (event is RumRawEvent.SendTelemetry) {
             @Suppress("ThreadSafety") // TODO RUMM-1503 delegate to another thread
             telemetryEventHandler.handleEvent(event, writer)


### PR DESCRIPTION
### What does this PR do?

Fixes #1178. When processing fatal error `rootScope` should be synchronized as well, as for the normal flow.

Otherwise 2 threads may enter `RumScope` simultaneously, leading to the different bugs like `ConcurrentModificationException`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

