### PR TITLE
RUMM-2783 Provide SR touch data following the new proposed format

### DIFF
--- a/library/dd-sdk-android-session-replay/apiSurface
+++ b/library/dd-sdk-android-session-replay/apiSurface
@@ -121,6 +121,13 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
       companion object 
         fun fromJson(kotlin.String): ViewportResizeData
         fun fromJsonObject(com.google.gson.JsonObject): ViewportResizeData
+    data class PointerInteractionData : MobileIncrementalData
+      constructor(PointerEventType, PointerType, kotlin.Long, kotlin.Number, kotlin.Number)
+      val source: kotlin.Long
+      override fun toJson(): com.google.gson.JsonElement
+      companion object 
+        fun fromJson(kotlin.String): PointerInteractionData
+        fun fromJsonObject(com.google.gson.JsonObject): PointerInteractionData
     companion object 
       fun fromJson(kotlin.String): MobileIncrementalData
       fun fromJsonObject(com.google.gson.JsonObject): MobileIncrementalData
@@ -249,6 +256,22 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Source
+  enum PointerEventType
+    constructor(kotlin.String)
+    - DOWN
+    - UP
+    - MOVE
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): PointerEventType
+  enum PointerType
+    constructor(kotlin.String)
+    - MOUSE
+    - TOUCH
+    - PEN
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): PointerType
   enum Horizontal
     constructor(kotlin.String)
     - LEFT

--- a/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/common/pointer-interaction-data-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/common/pointer-interaction-data-schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/common/pointer-interaction-data-schema.json",
+  "title": "PointerInteractionData",
+  "type": "object",
+  "description": "Schema of a PointerInteractionData.",
+  "allOf": [
+    {
+      "required": ["source"],
+      "properties": {
+        "source": {
+          "type": "integer",
+          "const": 9,
+          "description": "The source of this type of incremental data.",
+          "readOnly": true
+        }
+      }
+    },
+    {
+      "$ref": "pointer-interaction-schema.json"
+    }
+  ]
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/common/pointer-interaction-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/common/pointer-interaction-schema.json
@@ -1,0 +1,34 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "session-replay/common/pointer-interaction-schema.json",
+  "title": "PointerInteraction",
+  "type": "object",
+  "description": "Schema of a PointerInteraction.",
+  "required": ["pointerEventType", "pointerType", "pointerId", "x", "y"],
+  "properties": {
+    "pointerEventType": {
+      "type": "string",
+      "description": "Schema of an PointerEventType",
+      "enum": ["down", "up", "move"],
+      "readOnly": true
+    },
+    "pointerType": {
+      "type": "string",
+      "description": "Schema of an PointerType",
+      "enum": ["mouse", "touch", "pen"],
+      "readOnly": true
+    },
+    "pointerId": {
+      "type": "integer",
+      "description": "Id of the pointer of this PointerInteraction."
+    },
+    "x": {
+      "type": "number",
+      "description": "X-axis coordinate for this PointerInteraction."
+    },
+    "y": {
+      "type": "number",
+      "description": "Y-axis coordinate for this PointerInteraction."
+    }
+  }
+}

--- a/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/incremental-data-schema.json
+++ b/library/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/incremental-data-schema.json
@@ -13,6 +13,9 @@
     },
     {
       "$ref": "../common/viewport-resize-data-schema.json"
+    },
+    {
+      "$ref": "../common/pointer-interaction-data-schema.json"
     }
   ]
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayLifecycleCallback.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayLifecycleCallback.kt
@@ -9,7 +9,7 @@ package com.datadog.android.sessionreplay
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
-import com.datadog.android.sessionreplay.processor.SnapshotProcessor
+import com.datadog.android.sessionreplay.processor.RecordedDataProcessor
 import com.datadog.android.sessionreplay.recorder.Recorder
 import com.datadog.android.sessionreplay.recorder.ScreenRecorder
 import com.datadog.android.sessionreplay.recorder.SnapshotProducer
@@ -41,7 +41,7 @@ class SessionReplayLifecycleCallback(
         LinkedBlockingDeque()
     )
     internal var recorder: Recorder = ScreenRecorder(
-        SnapshotProcessor(
+        RecordedDataProcessor(
             rumContextProvider,
             timeProvider,
             processorExecutorService,

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/Processor.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/Processor.kt
@@ -11,7 +11,7 @@ import com.datadog.android.sessionreplay.recorder.Node
 import com.datadog.android.sessionreplay.recorder.OrientationChanged
 
 internal interface Processor {
-    fun process(node: Node, orientationChanged: OrientationChanged? = null)
+    fun processScreenSnapshot(node: Node, orientationChanged: OrientationChanged? = null)
 
-    fun process(touchData: MobileSegment.MobileIncrementalData.TouchData)
+    fun processTouchEventsRecords(touchEventsRecords: List<MobileSegment.MobileRecord>)
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/RecorderOnDrawListener.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/RecorderOnDrawListener.kt
@@ -31,7 +31,7 @@ internal class RecorderOnDrawListener(
         trackedActivity.get()?.let { activity ->
             activity.window?.let {
                 snapshotProducer.produce(it.decorView, pixelsDensity)?.let { node ->
-                    processor.process(node, resolveOrientationChange(activity, it.decorView))
+                    processor.processScreenSnapshot(node, resolveOrientationChange(activity, it.decorView))
                 }
             }
         }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/RecorderOnDrawListenerTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/RecorderOnDrawListenerTest.kt
@@ -117,7 +117,7 @@ internal class RecorderOnDrawListenerTest {
 
         // Then
         val argumentCaptor = argumentCaptor<OrientationChanged>()
-        verify(mockProcessor).process(
+        verify(mockProcessor).processScreenSnapshot(
             eq(fakeNode),
             argumentCaptor.capture()
         )
@@ -153,7 +153,7 @@ internal class RecorderOnDrawListenerTest {
 
         // Then
         val argumentCaptor = argumentCaptor<OrientationChanged>()
-        verify(mockProcessor).process(eq(fakeNode), argumentCaptor.capture())
+        verify(mockProcessor).processScreenSnapshot(eq(fakeNode), argumentCaptor.capture())
         assertThat(argumentCaptor.firstValue)
             .isEqualTo(
                 OrientationChanged(
@@ -174,7 +174,7 @@ internal class RecorderOnDrawListenerTest {
 
         // Then
         val argumentCaptor = argumentCaptor<OrientationChanged>()
-        verify(mockProcessor, times(2)).process(
+        verify(mockProcessor, times(2)).processScreenSnapshot(
             eq(fakeNode),
             argumentCaptor.capture()
         )
@@ -205,7 +205,7 @@ internal class RecorderOnDrawListenerTest {
 
         // Then
         val argumentCaptor = argumentCaptor<OrientationChanged>()
-        verify(mockProcessor, times(2)).process(
+        verify(mockProcessor, times(2)).processScreenSnapshot(
             eq(fakeNode),
             argumentCaptor.capture()
         )

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/ForgeConfigurator.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/ForgeConfigurator.kt
@@ -36,5 +36,6 @@ internal class ForgeConfigurator : BaseConfigurator() {
         forge.addFactory(ViewEndRecordForgeryFactory())
         forge.addFactory(EnrichedRecordForgeryFactory())
         forge.addFactory(WireframeClipForgeryFactory())
+        forge.addFactory(PointerInteractionDataForgeryFactory())
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/PointerInteractionDataForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/PointerInteractionDataForgeryFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.utils
+
+import com.datadog.android.sessionreplay.model.MobileSegment
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class PointerInteractionDataForgeryFactory :
+    ForgeryFactory<MobileSegment.MobileIncrementalData.PointerInteractionData> {
+    override fun getForgery(forge: Forge):
+        MobileSegment.MobileIncrementalData.PointerInteractionData {
+        return MobileSegment.MobileIncrementalData.PointerInteractionData(
+            pointerEventType = forge.aValueFrom(MobileSegment.PointerEventType::class.java),
+            pointerType = forge.aValueFrom(MobileSegment.PointerType::class.java),
+            pointerId = forge.aPositiveLong(),
+            x = forge.aLong(),
+            y = forge.aLong()
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

As a follow up task on the approved [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/2717813560/RFC+2022-11-16+-+Multi+touch+support+in+the+renderer) we will be sending each touch event as a single `PointerInteractionData` in a `MobileIncrementalSnapshotRecord`. This will allow the player to treat the `touch events` related records as any other record and not have to do extra operations to flatten the `TouchData#positions` in multiple records as before.
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

