### PR TITLE
Fix flaky rum_rummonitor_add_background_custom_action_with_outcome nightly test

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBackgroundE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBackgroundE2ETests.kt
@@ -76,7 +76,10 @@ class RumMonitorBackgroundE2ETests {
     fun rum_rummonitor_stop_background_action_with_outcome() {
         val testMethodName = "rum_rummonitor_stop_background_action_with_outcome"
         val actionName = forge.anActionName()
-        val type = forge.aValueFrom(RumActionType::class.java)
+        val type = forge.aValueFrom(
+            RumActionType::class.java,
+            exclude = listOf(RumActionType.BACK)
+        )
         GlobalRum.get().startUserAction(
             type,
             actionName,


### PR DESCRIPTION
### What does this PR do?

This test is flaky, because it allowed to generate `back` action type, which has empty `action.name`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

