### PR TITLE
Fix flaky telemetry test

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -31,7 +31,7 @@ import com.datadog.android.telemetry.model.TelemetryConfigurationEvent.ViewTrack
 internal class TelemetryEventHandler(
     internal val sdkCore: SdkCore,
     internal val eventSampler: Sampler,
-    internal val maxEventCountPerSession: Int = MAX_EVENTS_PER_SESSION
+    private val maxEventCountPerSession: Int = MAX_EVENTS_PER_SESSION
 ) : RumSessionListener {
 
     private var trackNetworkRequests = false


### PR DESCRIPTION
### What does this PR do?

This changes fixes flaky `TelemetryEventHandlerTest#𝕄 count the limit only after the sampling 𝕎 handleEvent(SendTelemetry)` test.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

