### PR TITLE
Remove Companion objects with non-public member from Public API

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -57,7 +57,6 @@ open class com.datadog.android.DatadogInterceptor : com.datadog.android.tracing.
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
   override fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
   override fun canSendSpan(): Boolean
-  companion object 
 enum com.datadog.android.DatadogSite
   constructor(String)
   - US1
@@ -119,7 +118,6 @@ data class com.datadog.android.core.configuration.Configuration
     fun setEncryption(com.datadog.android.security.Encryption): Builder
     fun setSessionReplayPrivacy(com.datadog.android.sessionreplay.SessionReplayPrivacy): Builder
     fun setVitalsUpdateFrequency(VitalsUpdateFrequency): Builder
-  companion object 
 data class com.datadog.android.core.configuration.Credentials
   constructor(String, String, String, String?, String? = null)
   companion object 
@@ -325,7 +323,6 @@ interface com.datadog.android.rum.RumMonitor
     fun sampleRumSessions(Float): Builder
     fun setSessionListener(RumSessionListener): Builder
     fun build(): RumMonitor
-    companion object 
 enum com.datadog.android.rum.RumPerformanceMetric
   - FLUTTER_BUILD_TIME
   - FLUTTER_RASTER_TIME
@@ -346,7 +343,6 @@ enum com.datadog.android.rum.RumResourceKind
   - CSS
   - MEDIA
   - OTHER
-  companion object 
 interface com.datadog.android.rum.RumSessionListener
   fun onSessionStarted(String, Boolean)
 class com.datadog.android.rum._RumInternalProxy
@@ -363,7 +359,6 @@ class com.datadog.android.rum.resource.RumResourceInputStream : java.io.InputStr
   override fun mark(Int)
   override fun reset()
   override fun close()
-  companion object 
 open class com.datadog.android.rum.tracking.AcceptAllActivities : ComponentPredicate<android.app.Activity>
   override fun accept(android.app.Activity): Boolean
   override fun getViewName(android.app.Activity): String?
@@ -396,7 +391,6 @@ abstract class com.datadog.android.rum.tracking.ActivityLifecycleTrackingStrateg
   override fun onActivityResumed(android.app.Activity)
   protected fun convertToRumAttributes(android.content.Intent?): Map<String, Any?>
   protected fun convertToRumAttributes(android.os.Bundle?): Map<String, Any?>
-  companion object 
 class com.datadog.android.rum.tracking.ActivityViewTrackingStrategy : ActivityLifecycleTrackingStrategy, ViewTrackingStrategy
   constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
   override fun onActivityCreated(android.app.Activity, android.os.Bundle?)
@@ -461,7 +455,6 @@ interface com.datadog.android.security.Encryption
 class com.datadog.android.sqlite.DatadogDatabaseErrorHandler : android.database.DatabaseErrorHandler
   constructor(android.database.DatabaseErrorHandler = DefaultDatabaseErrorHandler())
   override fun onCorruption(android.database.sqlite.SQLiteDatabase)
-  companion object 
 class com.datadog.android.tracing.AndroidTracer : com.datadog.opentracing.DDTracer
   override fun buildSpan(String): DDSpanBuilder
   class Builder
@@ -481,7 +474,6 @@ open class com.datadog.android.tracing.TracingInterceptor : okhttp3.Interceptor
   constructor(TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
   protected open fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
-  companion object 
 interface com.datadog.android.v2.api.EventBatchWriter
   fun currentMetadata(): ByteArray?
   fun write(ByteArray, ByteArray?): Boolean

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogInterceptor.kt
@@ -285,7 +285,7 @@ internal constructor(
 
     // endregion
 
-    companion object {
+    internal companion object {
 
         internal const val WARN_RUM_DISABLED =
             "You set up a DatadogInterceptor, but RUM features are disabled." +

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -708,7 +708,7 @@ internal constructor(
 
     // endregion
 
-    companion object {
+    internal companion object {
         internal const val DEFAULT_SAMPLING_RATE: Float = 100f
         internal const val DEFAULT_TELEMETRY_SAMPLING_RATE: Float = 20f
         internal const val DEFAULT_LONG_TASK_THRESHOLD_MS = 100L

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -328,7 +328,7 @@ interface RumMonitor {
             }
         }
 
-        companion object {
+        internal companion object {
             internal const val RUM_NOT_ENABLED_ERROR_MESSAGE =
                 "You're trying to create a RumMonitor instance, " +
                     "but the SDK was not initialized or RUM feature was disabled " +

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumResourceKind.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumResourceKind.kt
@@ -29,9 +29,8 @@ enum class RumResourceKind(internal val value: String) {
     MEDIA("media"),
     OTHER("other");
 
-    companion object {
+    internal companion object {
 
-        @JvmStatic
         internal fun fromMimeType(mimeType: String): RumResourceKind {
             val baseType = mimeType.substringBefore('/').lowercase(Locale.US)
             val subtype = mimeType.substringAfter('/').substringBefore(';').lowercase(Locale.US)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/resource/RumResourceInputStream.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/resource/RumResourceInputStream.kt
@@ -170,7 +170,7 @@ class RumResourceInputStream(
 
     // endregion
 
-    companion object {
+    internal companion object {
         internal const val METHOD: String = "GET"
 
         internal const val ERROR_CLOSE = "Error closing input stream"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
@@ -128,7 +128,7 @@ abstract class ActivityLifecycleTrackingStrategy :
 
     // endregion
 
-    companion object {
+    internal companion object {
         internal const val ARGUMENT_TAG = "view.arguments"
         internal const val INTENT_ACTION_TAG = "view.intent.action"
         internal const val INTENT_URI_TAG = "view.intent.uri"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandler.kt
@@ -40,7 +40,7 @@ class DatadogDatabaseErrorHandler(
             )
     }
 
-    companion object {
+    internal companion object {
         internal const val DATABASE_CORRUPTION_ERROR_MESSAGE =
             "Corruption reported by sqlite database: %s"
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/TracingInterceptor.kt
@@ -393,7 +393,7 @@ internal constructor(
 
     // endregion
 
-    companion object {
+    internal companion object {
         internal const val SPAN_NAME = "okhttp.request"
 
         internal const val RESOURCE_NAME_404 = "404"


### PR DESCRIPTION
### What does this PR do?

Small change to remove companion objects with only non-public members from the public API. Otherwise empty `Companion` class may be hanging in the suggestions list on the user side.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

