### PR TITLE
RUMM-2038 Use safe context for directBootAware host apps

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -12,6 +12,7 @@ import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Process
+import androidx.annotation.RequiresApi
 import com.datadog.android.BuildConfig
 import com.datadog.android.DatadogEndpoint
 import com.datadog.android.DatadogSite
@@ -251,8 +252,13 @@ internal class CoreFeature {
     }
 
     private fun initializeClockSync(appContext: Context) {
+        val safeContext = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+            getSafeContext(appContext)
+        } else {
+            appContext
+        }
         kronosClock = AndroidClockFactory.createKronosClock(
-            appContext,
+            safeContext,
             ntpHosts = listOf(
                 DatadogEndpoint.NTP_0,
                 DatadogEndpoint.NTP_1,
@@ -272,6 +278,16 @@ internal class CoreFeature {
                 }
             }
         }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.N)
+    private fun getSafeContext(appContext: Context): Context {
+        // When the host app uses the `directBootAware` flag on a  file encrypted device,
+        // the app can wake up during the boot sequence before the device is unlocked
+        // This mean any file I/O or access to shared preferences will throw an exception
+        // This safe context creates a device-protected storage which can be used for non sensitive
+        // data. It should not be used to store the data captured by the SDK.
+        return appContext.createDeviceProtectedStorageContext() ?: appContext
     }
 
     private fun readApplicationInformation(appContext: Context, credentials: Credentials) {

--- a/docs/mobile_data_collected.md
+++ b/docs/mobile_data_collected.md
@@ -215,8 +215,8 @@ Before data is uploaded to Datadog, it is stored in cleartext in your applicatio
 
 ## Direct Boot mode support
 
-If your application supports [Direct Boot mode][7], please note that data captured before the device 
-is unlocked won't be captured, since the Credential encrypted storage won't be available yet.
+If your application supports [Direct Boot mode][7], note that data captured before the device 
+is unlocked won't be captured, since the credential encrypted storage won't be available yet.
 
 ## Further Reading
 

--- a/docs/mobile_data_collected.md
+++ b/docs/mobile_data_collected.md
@@ -213,6 +213,11 @@ Network errors include information about failing HTTP requests. The following fa
 
 Before data is uploaded to Datadog, it is stored in cleartext in your application's cache directory. This cache folder is protected by [Android's Application Sandbox][6], meaning that on most devices this data can't be read by other applications. However, if the mobile device is rooted, or someone tempers with the Linux kernel, the stored data might become readable.
 
+## Direct Boot mode support
+
+If your application supports [Direct Boot mode][7], please note that data captured before the device 
+is unlocked won't be captured, since the Credential encrypted storage won't be available yet.
+
 ## Further Reading
 
 {{< partial name="whats-next/whats-next.html" >}}
@@ -223,3 +228,4 @@ Before data is uploaded to Datadog, it is stored in cleartext in your applicatio
 [4]: https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/
 [5]: https://docs.datadoghq.com/real_user_monitoring/android/advanced_configuration/#track-user-sessions
 [6]: https://source.android.com/security/app-sandbox
+[7]: https://developer.android.com/training/articles/direct-boot


### PR DESCRIPTION
Fixes #854
Fixes #1116

### What does this PR do?

Uses the `createDeviceProtectedStorageContext` to ensure Kronos works in all edge cases. 
Note that the safe context should only be used for Kronos. 