### PR TITLE
RUMM-2828: Send logs for Span using message bus

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/AndroidTracer.kt
@@ -9,7 +9,6 @@ package com.datadog.android.tracing
 import com.datadog.android.Datadog
 import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.log.LogAttributes
-import com.datadog.android.log.Logger
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.tracing.internal.data.NoOpWriter
 import com.datadog.android.tracing.internal.handlers.AndroidSpanLogsHandler
@@ -73,9 +72,7 @@ class AndroidTracer internal constructor(
         private val globalTags: MutableMap<String, String> = mutableMapOf()
 
         constructor() : this(
-            AndroidSpanLogsHandler(
-                Logger.Builder().setLoggerName(TRACE_LOGGER_NAME).build()
-            )
+            AndroidSpanLogsHandler(Datadog.globalSdkCore)
         )
 
         // region Public API
@@ -218,8 +215,6 @@ class AndroidTracer internal constructor(
         // the minimum closed spans required for triggering a flush and deliver
         // everything to the writer
         internal const val DEFAULT_PARTIAL_MIN_FLUSH = 5
-
-        internal const val TRACE_LOGGER_NAME = "trace"
 
         internal const val TRACE_ID_BIT_SIZE = 63
 


### PR DESCRIPTION
### What does this PR do?

This change removes direct dependency between `AndroidSpanLogsHandler` and `Logger` to allow sending logs for the particular span (via `Span.log` API) using message bus.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

