### PR TITLE
Provide frozen snapshot of features context when requested

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/DatadogContextProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/DatadogContextProviderTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.utils.forge.exhaustiveAttributes
 import com.datadog.android.v2.api.context.NetworkInfo
 import com.datadog.android.v2.api.context.UserInfo
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -20,6 +21,7 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.AdvancedForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.LongForgery
@@ -154,6 +156,48 @@ internal class DatadogContextProviderTest {
         assertThat(context.trackingConsent).isEqualTo(fakeTrackingConsent)
 
         assertThat(context.featuresContext).isEqualTo(coreFeature.mockInstance.featuresContext)
+    }
+
+    @Test
+    fun `𝕄 create a frozen feature context 𝕎 context {feature context is changed after context creation}`(
+        forge: Forge
+    ) {
+        // Given
+        val mutableFeaturesContext = forge.aMap<String, Map<String, Any?>> {
+            aString() to forge.exhaustiveAttributes()
+        }.toMutableMap()
+
+        // create it explicitly, without relying on the same .toMap code as in the source
+        val featuresContextSnapshot = mutableMapOf<String, Map<String, Any?>>()
+        mutableFeaturesContext.forEach { (key, value) ->
+            val featureSnapshot = mutableMapOf<String, Any?>()
+            featuresContextSnapshot[key] = featureSnapshot.apply {
+                value.forEach { (innerKey, innerValue) ->
+                    this[innerKey] = innerValue
+                }
+            }
+        }
+
+        whenever(coreFeature.mockInstance.featuresContext) doReturn mutableFeaturesContext
+
+        val context = testedProvider.context
+
+        // When
+        mutableFeaturesContext.values.forEach { innerMap ->
+            val keysToRemove = innerMap.keys.take(forge.anInt(min = 0, max = innerMap.keys.size))
+            keysToRemove.forEach {
+                (innerMap as MutableMap<*, *>).remove(it)
+            }
+        }
+        val keysToRemove = mutableFeaturesContext.keys
+            .take(forge.anInt(min = 0, max = mutableFeaturesContext.keys.size))
+        keysToRemove.forEach {
+            mutableFeaturesContext.remove(it)
+        }
+
+        // Then
+        assertThat(mutableFeaturesContext).isNotEqualTo(featuresContextSnapshot)
+        assertThat(context.featuresContext).isEqualTo(featuresContextSnapshot)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This change fixes a possible concurrency issue, when feature context can be modified by another thread while it is read by the caller. To solve this we are going to make a snapshot for the top 2 levels (features and feature-specific keys), this should be enough to get completely immutable map for cases of storage for our features (they are storing only strings, which are immutable, and no deeper than 2 levels).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

