### PR TITLE
RUMM-2516: Remove cross platform duplicates crashes

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -359,7 +359,7 @@ internal open class RumViewScope(
         val rumContext = getRumContext()
 
         val updatedAttributes = addExtraAttributes(event.attributes)
-        val isFatal = updatedAttributes.remove(RumAttributes.INTERNAL_ERROR_IS_CRASH) as? Boolean
+        val isFatal = updatedAttributes.remove(RumAttributes.INTERNAL_ERROR_IS_CRASH) as? Boolean == true || event.isFatal
         val errorType = event.type ?: event.throwable?.javaClass?.canonicalName
         val throwableMessage = event.throwable?.message ?: ""
         val message = if (throwableMessage.isNotBlank() && event.message != throwableMessage) {
@@ -380,7 +380,7 @@ internal open class RumViewScope(
                         message = message,
                         source = event.source.toSchemaSource(),
                         stack = event.stacktrace ?: event.throwable?.loggableStackTrace(),
-                        isCrash = event.isFatal || (isFatal ?: false),
+                        isCrash = isFatal,
                         type = errorType,
                         sourceType = event.sourceType.toSchemaSourceType()
                     ),
@@ -432,7 +432,7 @@ internal open class RumViewScope(
                 writer.write(eventBatchWriter, errorEvent)
             }
 
-        if (event.isFatal) {
+        if (isFatal) {
             errorCount++
             crashCount++
             sendViewUpdate(event, writer)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -359,7 +359,11 @@ internal open class RumViewScope(
         val rumContext = getRumContext()
 
         val updatedAttributes = addExtraAttributes(event.attributes)
-        val isFatal = updatedAttributes.remove(RumAttributes.INTERNAL_ERROR_IS_CRASH) as? Boolean == true || event.isFatal
+        val isFatal = updatedAttributes
+            .remove(RumAttributes.INTERNAL_ERROR_IS_CRASH) as? Boolean == true || event.isFatal
+        // if a cross-platform crash was already reported, do not send its native version
+        if (crashCount > 0 && isFatal) return
+
         val errorType = event.type ?: event.throwable?.javaClass?.canonicalName
         val throwableMessage = event.throwable?.message ?: ""
         val message = if (throwableMessage.isNotBlank() && event.message != throwableMessage) {


### PR DESCRIPTION
### What does this PR do?

- Makes sure a view update is sent when a cross-platform crash is detected
- Do not send the native crash if there already was a crash

### Motivation

Remove duplicated errors for JS crashes in React Native.
I'm not sure why we had 2 different behaviours in the first place depending on whether the crash was cross-platform or native: https://github.com/DataDog/dd-sdk-android/pull/764

### Review checklist (to be filled by reviewers)

- [x] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [x] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [x] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

