### PR TITLE
RUMM-2834: Tracing feature stores context in the common context storage

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/DatadogLogGenerator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/domain/DatadogLogGenerator.kt
@@ -10,10 +10,10 @@ import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.internal.utils.buildLogDateFormat
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.NetworkInfo
 import com.datadog.android.v2.api.context.UserInfo
-import io.opentracing.util.GlobalTracer
 import java.util.Date
 
 @Suppress("TooManyFunctions")
@@ -126,8 +126,13 @@ internal class DatadogLogGenerator(
         networkInfo: NetworkInfo?
     ): LogEvent {
         val resolvedTimestamp = timestamp + datadogContext.time.serverTimeOffsetMs
-        val combinedAttributes =
-            resolveAttributes(datadogContext, attributes, bundleWithTraces, bundleWithRum)
+        val combinedAttributes = resolveAttributes(
+            datadogContext,
+            attributes,
+            bundleWithTraces,
+            threadName,
+            bundleWithRum
+        )
         val formattedDate = synchronized(simpleDateFormat) {
             @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
             simpleDateFormat.format(Date(resolvedTimestamp))
@@ -240,15 +245,17 @@ internal class DatadogLogGenerator(
         datadogContext: DatadogContext,
         attributes: Map<String, Any?>,
         bundleWithTraces: Boolean,
+        threadName: String,
         bundleWithRum: Boolean
     ): MutableMap<String, Any?> {
         val combinedAttributes = mutableMapOf<String, Any?>().apply { putAll(attributes) }
-        if (bundleWithTraces && GlobalTracer.isRegistered()) {
-            val tracer = GlobalTracer.get()
-            val activeContext = tracer.activeSpan()?.context()
-            if (activeContext != null) {
-                combinedAttributes[LogAttributes.DD_TRACE_ID] = activeContext.toTraceId()
-                combinedAttributes[LogAttributes.DD_SPAN_ID] = activeContext.toSpanId()
+        if (bundleWithTraces) {
+            datadogContext.featuresContext[TracingFeature.TRACING_FEATURE_NAME]?.let {
+                val threadLocalContext = it["context@$threadName"] as? Map<*, *>
+                if (threadLocalContext != null) {
+                    combinedAttributes[LogAttributes.DD_TRACE_ID] = threadLocalContext["trace_id"]
+                    combinedAttributes[LogAttributes.DD_SPAN_ID] = threadLocalContext["span_id"]
+                }
             }
         }
         if (bundleWithRum) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/FeatureScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/FeatureScope.kt
@@ -17,7 +17,9 @@ interface FeatureScope {
      * @param forceNewBatch if `true` forces the [EventBatchWriter] to write in a new file and
      * not reuse the already existing pending data persistence file. By default it is `false`.
      * @param callback an operation called with an up-to-date [DatadogContext]
-     * and an [EventBatchWriter]. Callback will be executed on a worker thread from I/O pool
+     * and an [EventBatchWriter]. Callback will be executed on a worker thread from I/O pool.
+     * [DatadogContext] will have a state created at the moment this method is called, before the
+     * thread switch for the callback invocation.
      */
     fun withWriteContext(
         forceNewBatch: Boolean = false,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/DatadogLogGeneratorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/domain/DatadogLogGeneratorTest.kt
@@ -11,58 +11,38 @@ import com.datadog.android.log.assertj.LogEventAssert.Companion.assertThat
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.utils.extension.asLogStatus
 import com.datadog.android.utils.extension.toIsoFormattedTimestamp
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.NetworkInfo
 import com.datadog.android.v2.api.context.UserInfo
-import com.datadog.opentracing.DDSpanContext
-import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.forge.aThrowable
-import com.datadog.tools.unit.setStaticValue
-import com.datadog.trace.api.interceptor.MutableSpan
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import io.opentracing.Span
-import io.opentracing.Tracer
-import io.opentracing.util.GlobalTracer
 import org.assertj.core.api.Assertions
-import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
-    ExtendWith(ForgeExtension::class),
-    ExtendWith(TestConfigurationExtension::class)
+    ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
 internal class DatadogLogGeneratorTest {
 
     lateinit var testedLogGenerator: DatadogLogGenerator
-
-    @Mock
-    lateinit var mockTracer: Tracer
-
-    @Mock
-    lateinit var mockSpanContext: DDSpanContext
-
-    @Mock(extraInterfaces = [MutableSpan::class])
-    lateinit var mockSpan: Span
 
     lateinit var fakeServiceName: String
     lateinit var fakeLoggerName: String
@@ -118,22 +98,21 @@ internal class DatadogLogGeneratorTest {
                         "action_id" to fakeRumContext.actionId
                     )
                 )
+                put(
+                    TracingFeature.TRACING_FEATURE_NAME,
+                    mapOf(
+                        "context@$fakeThreadName" to mapOf(
+                            "span_id" to fakeSpanId,
+                            "trace_id" to fakeTraceId
+                        )
+                    )
+                )
             }
         )
 
-        whenever(mockTracer.activeSpan()).thenReturn(mockSpan)
-        whenever(mockSpan.context()) doReturn mockSpanContext
-        whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
-        whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
-        GlobalTracer.registerIfAbsent(mockTracer)
         testedLogGenerator = DatadogLogGenerator(
             fakeServiceName
         )
-    }
-
-    @AfterEach
-    fun `tear down`() {
-        GlobalTracer::class.java.setStaticValue("isRegistered", false)
     }
 
     @Test
@@ -662,9 +641,25 @@ internal class DatadogLogGeneratorTest {
     }
 
     @Test
-    fun `M do nothing W required to bundle the trace information {no active Span}`() {
+    fun `M do nothing W required to bundle the trace information {no active Span for given thread}`(
+        @StringForgery fakeOtherThreadName: String,
+        @StringForgery(StringForgeryType.HEXADECIMAL) fakeOtherThreadSpanId: String,
+        @StringForgery(StringForgeryType.HEXADECIMAL) fakeOtherThreadTraceId: String
+    ) {
         // GIVEN
-        whenever(mockTracer.activeSpan()).doReturn(null)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                put(
+                    TracingFeature.TRACING_FEATURE_NAME,
+                    mapOf(
+                        "context@$fakeOtherThreadName" to mapOf(
+                            "span_id" to fakeOtherThreadSpanId,
+                            "trace_id" to fakeOtherThreadTraceId
+                        )
+                    )
+                )
+            }
+        )
 
         // WHEN
         val log = testedLogGenerator.generateLog(
@@ -691,9 +686,13 @@ internal class DatadogLogGeneratorTest {
     }
 
     @Test
-    fun `M do nothing W required to bundle the trace information {AndroidTracer not registered}`() {
+    fun `M do nothing W required to bundle the trace information {no tracing feature context}`() {
         // GIVEN
-        GlobalTracer::class.java.setStaticValue("isRegistered", false)
+        fakeDatadogContext = fakeDatadogContext.copy(
+            featuresContext = fakeDatadogContext.featuresContext.toMutableMap().apply {
+                remove(TracingFeature.TRACING_FEATURE_NAME)
+            }
+        )
 
         // WHEN
         val log = testedLogGenerator.generateLog(
@@ -721,9 +720,6 @@ internal class DatadogLogGeneratorTest {
 
     @Test
     fun `M do nothing W not required to bundle the trace information`() {
-        // GIVEN
-        GlobalTracer::class.java.setStaticValue("isRegistered", false)
-
         // WHEN
         val log = testedLogGenerator.generateLog(
             fakeLevel,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/internal/AndroidTracerTest.kt
@@ -27,8 +27,11 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.trace.api.Config
 import com.datadog.trace.common.writer.Writer
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.inOrder
 import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.verify
@@ -56,6 +59,7 @@ import org.mockito.quality.Strictness
 import java.math.BigInteger
 import java.util.Random
 import java.util.UUID
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -567,6 +571,98 @@ internal class AndroidTracerTest {
     }
 
     // endregion
+
+    @Test
+    fun `M report active span context for the thread W build`(forge: Forge) {
+        // Given
+        val tracer = testedTracerBuilder
+            .setServiceName(fakeServiceName)
+            .build()
+        // call to updateFeatureContext is guarded by "synchronize" in the real implementation,
+        // but since we are using mock here, let's use thread-safe map instead.
+        val tracingContext = ConcurrentHashMap<String, Any?>()
+        whenever(
+            mockSdkCore.updateFeatureContext(eq(TracingFeature.TRACING_FEATURE_NAME), any())
+        ) doAnswer {
+            val callback = it.getArgument<(context: MutableMap<String, Any?>) -> Unit>(1)
+            callback.invoke(tracingContext)
+        }
+        val errorCollector = mutableListOf<Throwable>()
+
+        // When+Then
+        val threads = forge.aList(forge.anInt(min = 2, max = 5)) {
+            Thread {
+                val threadName = Thread.currentThread().name
+
+                val parentSpan = tracer.buildSpan(forge.anAlphabeticalString()).start()
+                val parentActiveScope = tracer.activateSpan(parentSpan)
+
+                with(tracingContext.activeContext(threadName)) {
+                    assertThat(this!!["span_id"]).isEqualTo(parentSpan.context().toSpanId())
+                    assertThat(this["trace_id"]).isEqualTo(parentSpan.context().toTraceId())
+                }
+
+                // should update the context for the child span
+                val childActiveSpan = tracer.buildSpan(forge.anAlphabeticalString())
+                    .asChildOf(parentSpan).start()
+                val childActiveScope = tracer.activateSpan(childActiveSpan)
+
+                with(tracingContext.activeContext(threadName)) {
+                    assertThat(this!!["span_id"]).isEqualTo(childActiveSpan.context().toSpanId())
+                    assertThat(this["trace_id"]).isEqualTo(childActiveSpan.context().toTraceId())
+                }
+
+                // should not update the context for the child non-active span
+                val childNonActiveSpan = tracer.buildSpan(forge.anAlphabeticalString())
+                    .asChildOf(parentSpan).start()
+
+                with(tracingContext.activeContext(threadName)) {
+                    assertThat(this!!["span_id"]).isEqualTo(childActiveSpan.context().toSpanId())
+                    assertThat(this["trace_id"]).isEqualTo(childActiveSpan.context().toTraceId())
+                }
+
+                childNonActiveSpan.finish()
+
+                with(tracingContext.activeContext(threadName)) {
+                    assertThat(this!!["span_id"]).isEqualTo(childActiveSpan.context().toSpanId())
+                    assertThat(this["trace_id"]).isEqualTo(childActiveSpan.context().toTraceId())
+                }
+
+                // should restore context of parent span
+                childActiveSpan.finish()
+                childActiveScope.close()
+
+                with(tracingContext.activeContext(threadName)) {
+                    assertThat(this!!["span_id"]).isEqualTo(parentSpan.context().toSpanId())
+                    assertThat(this["trace_id"]).isEqualTo(parentSpan.context().toTraceId())
+                }
+
+                // should clean everything
+                parentSpan.finish()
+                parentActiveScope.close()
+
+                assertThat(tracingContext.activeContext(threadName)).isNull()
+            }.apply {
+                setUncaughtExceptionHandler { _, e ->
+                    synchronized(errorCollector) {
+                        errorCollector += e
+                    }
+                }
+            }
+        }
+
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        if (errorCollector.isNotEmpty()) {
+            // if there are multiple, we need only one to start debugging
+            throw errorCollector[0]
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun Map<String, Any?>.activeContext(threadName: String) =
+        this["context@$threadName"] as? Map<String, String>
 
     companion object {
         val appContext = ApplicationContextTestConfiguration(Context::class.java)


### PR DESCRIPTION
### What does this PR do?

This change makes tracing feature to store its context (active span) in the common context storage.

The tricky part is that active span (span backed by the current active scope) is thread-local, so each thread may have its own active span. To support such thread-local storage I'm using `addScopeListener` API to associate the active context with the particular thread and then later to read it from `DatadogContext` for the particular thread as well (reminder: `DatadogContext` is created on the caller thread). 


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

