### PR TITLE
Use lazy initialization of network-related properties in SampleApplication to be able to pick global first party hosts

### DIFF
--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -66,20 +66,26 @@ class SampleApplication : Application() {
         "datadoghq.dev"
     )
 
-    private val okHttpClient = OkHttpClient.Builder()
-        .addInterceptor(RumInterceptor(traceSamplingRate = 100f))
-        .addNetworkInterceptor(TracingInterceptor(traceSamplingRate = 100f))
-        .eventListenerFactory(DatadogEventListener.Factory())
-        .build()
+    // TODO RUMM-0000 lazy is needed here, because without it global first party host detector is
+    //  not available yet at the interceptor construction time
+    private val okHttpClient by lazy {
+        OkHttpClient.Builder()
+            .addInterceptor(RumInterceptor(traceSamplingRate = 100f))
+            .addNetworkInterceptor(TracingInterceptor(traceSamplingRate = 100f))
+            .eventListenerFactory(DatadogEventListener.Factory())
+            .build()
+    }
 
-    private val retrofitClient = Retrofit.Builder()
-        .baseUrl("https://api.datadoghq.com/api/v2/")
-        .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
-        .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
-        .client(okHttpClient)
-        .build()
+    private val retrofitClient by lazy {
+        Retrofit.Builder()
+            .baseUrl("https://api.datadoghq.com/api/v2/")
+            .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
+            .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
+            .client(okHttpClient)
+            .build()
+    }
 
-    private val retrofitBaseDataSource = retrofitClient.create(RemoteDataSource::class.java)
+    private val retrofitBaseDataSource by lazy { retrofitClient.create(RemoteDataSource::class.java) }
 
     override fun onCreate() {
         super.onCreate()


### PR DESCRIPTION
### What does this PR do?

Currently properties of `SampleApplication` are initialized before `onCreate` method completes, and since `DatadogInterceptor`/`TracingInterceptor` resolve global first party host detector at the construction time, it is not available at this moment (because Datadog SDK is not yet initialized), so not resource tracing is available.

This change fixes it by switching to the lazy initialization.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

