### PR TITLE
RUMM-2845: Speed up build of sample app for CodeQL scan

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -47,7 +47,7 @@ jobs:
 
     # Manually build the java bytecode
     - name: Execute Gradle build
-      run: ./gradlew assemble
+      run: ./gradlew assembleAll
 
     # Perform the analysis
     - name: Perform CodeQL Analysis


### PR DESCRIPTION
### What does this PR do?

Gradle build for the CodeQL scan take 35-40 minutes it seems, because all the variants ((`eu1`, `us1`, `us3`, `us5`, `us1_fed`, `staging`) x (`debug`,`release`) = 12) are built (it takes majority of the build).

~~To speed it up and still have a complete coverage of all the binaries which can be created in the customer environment (not only release artifacts, but also binaries which can be created by cloning this repo), let's build only `us1` flavor for sample app, because all DC flavors are the same code-wise.~~

To speed it up we are going to build only releasable modules.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

