### PR TITLE
RUMM-2868: Apply extra sampling rate to the configuration telemetry

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -307,7 +307,7 @@ interface RumMonitor {
                     handler = Handler(Looper.getMainLooper()),
                     telemetryEventHandler = TelemetryEventHandler(
                         sdkCore = datadogCore,
-                        RateBasedSampler(rumFeature.telemetrySamplingRate.percent())
+                        eventSampler = RateBasedSampler(rumFeature.telemetrySamplingRate.percent())
                     ),
                     firstPartyHostDetector = coreFeature.firstPartyHostDetector,
                     cpuVitalMonitor = rumFeature.cpuVitalMonitor,


### PR DESCRIPTION
### What does this PR do?

This change applies extra sampling rate (20%) to the configuration telemetry events on top of the telemetry sampling rate configured.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

