### PR TITLE
SR use case insensitive when checking wireframe background color opacity

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/WireframeUtils.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/processor/WireframeUtils.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.processor
 
 import com.datadog.android.sessionreplay.model.MobileSegment
+import java.util.Locale
 import kotlin.math.max
 
 internal class WireframeUtils {
@@ -86,7 +87,7 @@ internal class WireframeUtils {
     private fun MobileSegment.ShapeStyle.isOpaque(): Boolean {
         return this.opacity == FULL_OPACITY_ALPHA &&
             this.backgroundColor != null &&
-            this.backgroundColor.takeLast(2) == FULL_OPACITY_ALPHA_AS_HEXA_STRING
+            this.backgroundColor.takeLast(2).lowercase(Locale.US) == FULL_OPACITY_STRING_HEXA
     }
 
     private fun MobileSegment.Wireframe.ShapeWireframe.bounds(): Bounds {
@@ -121,7 +122,7 @@ internal class WireframeUtils {
     )
 
     companion object {
-        const val FULL_OPACITY_ALPHA_AS_HEXA_STRING = "FF"
-        const val FULL_OPACITY_ALPHA = 1f
+        private const val FULL_OPACITY_STRING_HEXA = "ff"
+        private const val FULL_OPACITY_ALPHA = 1f
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/processor/WireframeUtilsTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/processor/WireframeUtilsTest.kt
@@ -371,7 +371,11 @@ internal class WireframeUtilsTest {
                 width = fakeWidth,
                 height = fakeHeight,
                 shapeStyle = forge.forgeNonTransparentShapeStyle()
-                    .copy(backgroundColor = forge.aStringMatching("#[0-9A-F]{6}[0-9A-E]{2}"))
+                    .copy(
+                        backgroundColor = forge.aStringMatching(
+                            "#[0-9A-Fa-f]{6}[0-9A-Ea-e]{2}"
+                        )
+                    )
             )
             fakeCoverAllWireframe
         }
@@ -736,7 +740,7 @@ internal class WireframeUtilsTest {
 
     private fun Forge.forgeNonTransparentShapeStyle(): MobileSegment.ShapeStyle {
         return MobileSegment.ShapeStyle(
-            backgroundColor = aStringMatching("#[0-9A-F]{6}FF"),
+            backgroundColor = aStringMatching("#[0-9A-Fa-f]{6}[fF]{2}"),
             opacity = 1f,
             cornerRadius = aPositiveLong()
         )

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/ShapeStyleForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/ShapeStyleForgeryFactory.kt
@@ -15,7 +15,7 @@ internal class ShapeStyleForgeryFactory :
     override fun getForgery(forge: Forge): MobileSegment.ShapeStyle {
         return MobileSegment.ShapeStyle(
             backgroundColor = forge.aNullable {
-                forge.aStringMatching("#[0-9A-F]{6}FF")
+                forge.aStringMatching("#[0-9A-Fa-f]{6}[fF]{2}")
             },
             opacity = forge.aFloat(min = 0f, max = 1f),
             cornerRadius = forge.aPositiveLong()


### PR DESCRIPTION
### What does this PR do?

We were using assuming that the Wireframe `backgroundColor` will always be reported in capital letters when checking for its opacity. This was buggy and in this PR we are fixing this by using a case insensitive `RegEx` instead.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

