### PR TITLE
RUMM-2898 Add hasReplay=true only when the view produced SR records

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/FeaturesContextResolver.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/FeaturesContextResolver.kt
@@ -11,11 +11,11 @@ import com.datadog.android.v2.api.context.DatadogContext
 
 internal class FeaturesContextResolver {
 
-    fun resolveHasReplay(context: DatadogContext): Boolean {
+    fun resolveHasReplay(context: DatadogContext, viewId: String): Boolean {
         val sessionReplayContext =
             context.featuresContext[SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME]
         return (
-            sessionReplayContext?.get(SessionReplayFeature.IS_RECORDING_CONTEXT_KEY)
+            sessionReplayContext?.get(viewId)
                 as? Boolean
             ) ?: false
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -207,7 +207,10 @@ internal class RumActionScope(
         sdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)
             ?.withWriteContext { datadogContext, eventBatchWriter ->
                 val user = datadogContext.userInfo
-                val hasReplay = featuresContextResolver.resolveHasReplay(datadogContext)
+                val hasReplay = featuresContextResolver.resolveHasReplay(
+                    datadogContext,
+                    rumContext.viewId.orEmpty()
+                )
 
                 val frustrations = mutableListOf<ActionEvent.Type>()
                 if (trackFrustrations && eventErrorCount > 0 && actualType == RumActionType.TAP) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -185,7 +185,10 @@ internal class RumResourceScope(
         sdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)
             ?.withWriteContext { datadogContext, eventBatchWriter ->
                 val user = datadogContext.userInfo
-                val hasReplay = featuresContextResolver.resolveHasReplay(datadogContext)
+                val hasReplay = featuresContextResolver.resolveHasReplay(
+                    datadogContext,
+                    rumContext.viewId.orEmpty()
+                )
                 val duration = resolveResourceDuration(eventTime)
                 val resourceEvent = ResourceEvent(
                     date = eventTimestamp,
@@ -299,7 +302,10 @@ internal class RumResourceScope(
         sdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)
             ?.withWriteContext { datadogContext, eventBatchWriter ->
                 val user = datadogContext.userInfo
-                val hasReplay = featuresContextResolver.resolveHasReplay(datadogContext)
+                val hasReplay = featuresContextResolver.resolveHasReplay(
+                    datadogContext,
+                    rumContext.viewId.orEmpty()
+                )
                 val errorEvent = ErrorEvent(
                     date = eventTimestamp,
                     error = ErrorEvent.Error(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -158,6 +158,5 @@ internal class SessionReplayFeature(
         const val SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY = "type"
         const val RUM_SESSION_RENEWED_BUS_MESSAGE = "rum_session_renewed"
         const val RUM_KEEP_SESSION_BUS_MESSAGE_KEY = "keepSession"
-        const val IS_RECORDING_CONTEXT_KEY = "is_recording"
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayRecordCallback.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayRecordCallback.kt
@@ -10,19 +10,10 @@ import com.datadog.android.sessionreplay.RecordCallback
 import com.datadog.android.v2.api.SdkCore
 
 internal class SessionReplayRecordCallback(private val sdkCore: SdkCore) : RecordCallback {
-    override fun onStartRecording() {
-        updateRecording(true)
-    }
 
-    override fun onStopRecording() {
-        updateRecording(false)
-    }
-
-    private fun updateRecording(isRecording: Boolean) {
-        sdkCore.updateFeatureContext(
-            SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME
-        ) {
-            it[SessionReplayFeature.IS_RECORDING_CONTEXT_KEY] = isRecording
+    override fun onRecordForViewSent(viewId: String) {
+        sdkCore.updateFeatureContext(SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME) {
+            it[viewId] = true
         }
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/FeaturesContextResolverTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/FeaturesContextResolverTest.kt
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
+import java.util.UUID
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -31,8 +32,11 @@ internal class FeaturesContextResolverTest {
 
     lateinit var testedFeaturesContextResolver: FeaturesContextResolver
 
+    lateinit var fakeViewId: String
+
     @BeforeEach
-    fun `set up`() {
+    fun `set up`(forge: Forge) {
+        fakeViewId = forge.getForgery<UUID>().toString()
         testedFeaturesContextResolver = FeaturesContextResolver()
     }
 
@@ -43,13 +47,16 @@ internal class FeaturesContextResolverTest {
             .copy(
                 featuresContext = mapOf(
                     SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME to
-                        mapOf(SessionReplayFeature.IS_RECORDING_CONTEXT_KEY to true)
+                        mapOf(fakeViewId.toString() to true)
                 )
 
             )
 
         // When
-        val hasReplay = testedFeaturesContextResolver.resolveHasReplay(fakeSdkContext)
+        val hasReplay = testedFeaturesContextResolver.resolveHasReplay(
+            fakeSdkContext,
+            fakeViewId
+        )
         assertThat(hasReplay).isTrue
     }
 
@@ -60,13 +67,16 @@ internal class FeaturesContextResolverTest {
             .copy(
                 featuresContext = mapOf(
                     SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME to
-                        mapOf(SessionReplayFeature.IS_RECORDING_CONTEXT_KEY to false)
+                        mapOf(fakeViewId.toString() to false)
                 )
 
             )
 
         // When
-        val hasReplay = testedFeaturesContextResolver.resolveHasReplay(fakeSdkContext)
+        val hasReplay = testedFeaturesContextResolver.resolveHasReplay(
+            fakeSdkContext,
+            fakeViewId
+        )
         assertThat(hasReplay).isFalse
     }
 
@@ -77,23 +87,28 @@ internal class FeaturesContextResolverTest {
             .copy(featuresContext = emptyMap())
 
         // When
-        val hasReplay = testedFeaturesContextResolver.resolveHasReplay(fakeSdkContext)
+        val hasReplay = testedFeaturesContextResolver.resolveHasReplay(
+            fakeSdkContext,
+            fakeViewId
+        )
         assertThat(hasReplay).isFalse
     }
 
     @Test
-    fun `M return false W resolveHasReplay {isRecording context key does not exist}`(forge: Forge) {
-        // Given
+    fun `M return false W resolveHasReplay {no entry for viewId}`(forge: Forge) {
         val fakeSdkContext = forge.getForgery<DatadogContext>()
             .copy(
                 featuresContext = mapOf(
                     SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME to
-                        emptyMap()
+                        forge.aMap { forge.aString() to forge.aString() }
                 )
             )
 
         // When
-        val hasReplay = testedFeaturesContextResolver.resolveHasReplay(fakeSdkContext)
+        val hasReplay = testedFeaturesContextResolver.resolveHasReplay(
+            fakeSdkContext,
+            fakeViewId
+        )
         assertThat(hasReplay).isFalse
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -151,8 +151,12 @@ internal class RumActionScopeTest {
             val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
-        whenever(mockFeaturesContextResolver.resolveHasReplay(fakeDatadogContext))
-            .thenReturn(fakeHasReplay)
+        whenever(
+            mockFeaturesContextResolver.resolveHasReplay(
+                fakeDatadogContext,
+                fakeParentContext.viewId.orEmpty()
+            )
+        ).thenReturn(fakeHasReplay)
 
         testedScope = RumActionScope(
             mockParentScope,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -170,8 +170,12 @@ internal class RumResourceScopeTest {
         whenever(mockContextProvider.context) doReturn fakeDatadogContext
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         doAnswer { false }.whenever(mockDetector).isFirstPartyUrl(any<String>())
-        whenever(mockFeaturesContextResolver.resolveHasReplay(fakeDatadogContext))
-            .thenReturn(fakeHasReplay)
+        whenever(
+            mockFeaturesContextResolver.resolveHasReplay(
+                fakeDatadogContext,
+                fakeParentContext.viewId.orEmpty()
+            )
+        ).thenReturn(fakeHasReplay)
         whenever(mockSdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
             val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)

--- a/library/dd-sdk-android-session-replay/apiSurface
+++ b/library/dd-sdk-android-session-replay/apiSurface
@@ -2,8 +2,7 @@ interface com.datadog.android.sessionreplay.LifecycleCallback : android.app.Appl
   fun register(android.app.Application)
   fun unregisterAndStopRecorders(android.app.Application)
 interface com.datadog.android.sessionreplay.RecordCallback
-  fun onStartRecording()
-  fun onStopRecording()
+  fun onRecordForViewSent(String)
 interface com.datadog.android.sessionreplay.RecordWriter
   fun write(com.datadog.android.sessionreplay.processor.EnrichedRecord)
 class com.datadog.android.sessionreplay.SessionReplayLifecycleCallback : LifecycleCallback

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/NoOpRecordCallback.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/NoOpRecordCallback.kt
@@ -7,9 +7,7 @@
 package com.datadog.android.sessionreplay
 
 internal class NoOpRecordCallback : RecordCallback {
-    public override fun onStartRecording() {
-    }
 
-    public override fun onStopRecording() {
+    override fun onRecordForViewSent(viewId: String) {
     }
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/RecordCallback.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/RecordCallback.kt
@@ -13,12 +13,8 @@ package com.datadog.android.sessionreplay
 interface RecordCallback {
 
     /**
-     * Called when we started recording the current screen.
+     * Notifies when a view session replay record was sent.
+     * @param viewId as String
      */
-    fun onStartRecording()
-
-    /**
-     * Called when we stopped recording the current screen.
-     */
-    fun onStopRecording()
+    fun onRecordForViewSent(viewId: String)
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayLifecycleCallback.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayLifecycleCallback.kt
@@ -46,11 +46,11 @@ class SessionReplayLifecycleCallback(
             rumContextProvider,
             timeProvider,
             processorExecutorService,
-            recordWriter
+            recordWriter,
+            recordCallback
         ),
         SnapshotProducer(privacy.mapper()),
-        timeProvider,
-        recordCallback
+        timeProvider
     )
 
     // region callback

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/ScreenRecorder.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/ScreenRecorder.kt
@@ -9,8 +9,6 @@ package com.datadog.android.sessionreplay.recorder
 import android.app.Activity
 import android.view.ViewTreeObserver
 import android.view.Window
-import com.datadog.android.sessionreplay.NoOpRecordCallback
-import com.datadog.android.sessionreplay.RecordCallback
 import com.datadog.android.sessionreplay.processor.Processor
 import com.datadog.android.sessionreplay.recorder.callback.NoOpWindowCallback
 import com.datadog.android.sessionreplay.recorder.callback.RecorderWindowCallback
@@ -21,8 +19,7 @@ import java.util.WeakHashMap
 internal class ScreenRecorder(
     private val processor: Processor,
     private val snapshotProducer: SnapshotProducer,
-    private val timeProvider: TimeProvider,
-    private val recordCallback: RecordCallback = NoOpRecordCallback()
+    private val timeProvider: TimeProvider
 ) : Recorder {
     internal val windowsListeners: WeakHashMap<Window, ViewTreeObserver.OnDrawListener> =
         WeakHashMap()
@@ -44,12 +41,10 @@ internal class ScreenRecorder(
             decorView.viewTreeObserver?.addOnDrawListener(onDrawListener)
             wrapWindowCallback(window, screenDensity)
         }
-        recordCallback.onStartRecording()
     }
 
     override fun stopRecording(windows: List<Window>) {
         stopRecordingAndRemove(windows)
-        recordCallback.onStopRecording()
     }
 
     override fun stopRecording() {
@@ -58,7 +53,6 @@ internal class ScreenRecorder(
             unwrapWindowCallback(it.key)
         }
         windowsListeners.clear()
-        recordCallback.onStopRecording()
     }
 
     private fun stopRecordingAndRemove(windows: List<Window>) {

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/ScreenRecorderTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/ScreenRecorderTest.kt
@@ -12,7 +12,6 @@ import android.util.DisplayMetrics
 import android.view.View
 import android.view.ViewTreeObserver
 import android.view.Window
-import com.datadog.android.sessionreplay.RecordCallback
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.processor.Processor
 import com.datadog.android.sessionreplay.recorder.callback.NoOpWindowCallback
@@ -26,7 +25,6 @@ import com.nhaarman.mockitokotlin2.mock
 import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
-import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -65,9 +63,6 @@ internal class ScreenRecorderTest {
 
     lateinit var mockActivity: Activity
 
-    @Mock
-    lateinit var mockRecordCallback: RecordCallback
-
     @BeforeEach
     fun `set up`(forge: Forge) {
         mockActivity = forge.aMockedActivity()
@@ -75,8 +70,7 @@ internal class ScreenRecorderTest {
         testedRecorder = ScreenRecorder(
             mockProcessor,
             mockSnapshotProducer,
-            mockTimeProvider,
-            mockRecordCallback
+            mockTimeProvider
         )
     }
 
@@ -352,53 +346,6 @@ internal class ScreenRecorderTest {
         fakeWindowsList.forEach {
             verify(it, never()).callback = any()
         }
-    }
-
-    // endregion
-
-    // region Record Callback
-
-    @Test
-    fun `M notify the callback W startRecording()`(forge: Forge) {
-        // Given
-        val mockWindows = forge.aMockedWindowsList()
-
-        // When
-        testedRecorder.startRecording(mockWindows, mockActivity)
-
-        // Then
-        verify(mockRecordCallback).onStartRecording()
-        verifyNoMoreInteractions(mockRecordCallback)
-    }
-
-    @Test
-    fun `M notify the callback W stopRecording(windows)`(forge: Forge) {
-        // Given
-        val mockWindows = forge.aMockedWindowsList()
-        testedRecorder.startRecording(mockWindows, mockActivity)
-
-        // When
-        testedRecorder.stopRecording(mockWindows)
-
-        // Then
-        verify(mockRecordCallback).onStartRecording()
-        verify(mockRecordCallback).onStopRecording()
-        verifyNoMoreInteractions(mockRecordCallback)
-    }
-
-    @Test
-    fun `M notify the callback W stopRecording`(forge: Forge) {
-        // Given
-        val mockWindows = forge.aMockedWindowsList()
-        testedRecorder.startRecording(mockWindows, mockActivity)
-
-        // When
-        testedRecorder.stopRecording()
-
-        // Then
-        verify(mockRecordCallback).onStartRecording()
-        verify(mockRecordCallback).onStopRecording()
-        verifyNoMoreInteractions(mockRecordCallback)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

We were adding the has_replay:true property on the RUM events whenever the SR is recording no matter if the view in progress produced any records or not. Following the latest discussions we needed to fix this and set this property to true only if there was at least one SR record sent for this event.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

There is still a corner case for which this flag can have wrong values due to the async way of intercommunication between our features but this was explained in the PR comments and for now we are accepting this as a non blocker issue.
 
### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

