### PR TITLE
RUMM-2931 prevent reporting ANR when app is in background

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -19,6 +19,7 @@ import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
 import com.datadog.android.core.internal.utils.devLogger
 import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -120,6 +121,10 @@ internal class RumViewManagerScope(
         event: RumRawEvent,
         writer: DataWriter<Any>
     ) {
+        if (event is RumRawEvent.AddError && event.throwable is ANRException) {
+            // RUMM-2931 ignore ANR detected when the app is not in foreground
+            return
+        }
         val isValidBackgroundEvent = event.javaClass in validBackgroundEventTypes
         val isSilentOrphanEvent = event.javaClass in silentOrphanEventTypes
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -12,7 +12,10 @@ import android.util.Log
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.FirstPartyHostDetector
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
+import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -347,6 +350,26 @@ internal class RumViewManagerScopeTest {
         // Given
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.invalidBackgroundEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).hasSize(0)
+    }
+
+    @Test
+    fun `𝕄 not start a bg ViewScope 𝕎 handleEvent { app displayed, event is background ANR}`() {
+        // Given
+        testedScope.applicationDisplayed = true
+        val fakeEvent = RumRawEvent.AddError(
+            message = ANRDetectorRunnable.ANR_MESSAGE,
+            source = RumErrorSource.SOURCE,
+            stacktrace = null,
+            throwable = ANRException(Thread.currentThread()),
+            isFatal = false,
+            attributes = emptyMap()
+        )
 
         // When
         testedScope.handleEvent(fakeEvent, mockWriter)


### PR DESCRIPTION
### What does this PR do?

Fixes #1067 

This PR prevents reporting false positive ANRs when the application is in background. 

### Motivation

In some cases (#1067) the host application is in background and the SDK detekts multiple SDKs that are not actually perceived by the end user.