### PR TITLE
Update Realm version to remove warning about registerTransform usage in AGP

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,7 @@ kotlinGrammarParser = "9b264ee"
 jsonSchemaValidator = "1.12.1"
 
 # Integrations
-realm = "10.12.0"
+realm = "10.13.1-transformer-api"
 sqlDelight = "1.5.1"
 coil = "1.0.0"
 fresco = "2.3.0"


### PR DESCRIPTION
### What does this PR do?

This change bumps Realm plugin version to the one which doesn't use `registerTransform` API in AGP (see details [here](https://github.com/realm/realm-java/blob/release/transformer-api/CHANGELOG.md)).

It will remove the following build warning:

> WARNING:API 'android.registerTransform' is obsolete.
It will be removed in version 8.0 of the Android Gradle plugin.
The Transform API is removed to improve build performance. Projects that use the
Transform API force the Android Gradle plugin to use a less optimized flow for the
build that can result in large regressions in build times. It?s also difficult to
use the Transform API and combine it with other Gradle features; the replacement
APIs aim to make it easier to extend the build without introducing performance or
correctness issues.
There is no single replacement for the Transform API?there are new, targeted
APIs for each use case. All the replacement APIs are in the
`androidComponents {}` block.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

