### PR TITLE
RUMM-2918: Add registerFeature method

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -521,7 +521,7 @@ interface com.datadog.android.v2.api.RequestFactory
     const val QUERY_PARAM_TAGS: String
 interface com.datadog.android.v2.api.SdkCore
   val time: com.datadog.android.v2.api.context.TimeInfo
-  fun registerFeature(String, FeatureStorageConfiguration, FeatureUploadConfiguration)
+  fun registerFeature(Feature)
   fun getFeature(String): FeatureScope?
   fun setVerbosity(Int)
   fun getVerbosity(): Int

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -4,14 +4,19 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
+@file:Suppress("DEPRECATION")
+
 package com.datadog.android.error.internal
 
 import android.content.Context
+import com.datadog.android.plugin.DatadogPlugin
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.SdkCore
 import java.util.concurrent.atomic.AtomicBoolean
 
-internal class CrashReportsFeature : Feature {
+internal class CrashReportsFeature(
+    internal val plugins: List<DatadogPlugin>
+) : Feature {
 
     internal val initialized = AtomicBoolean(false)
     internal var originalUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
@@ -32,7 +32,7 @@ abstract class ActivityLifecycleTrackingStrategy :
                 InternalLogger.Level.ERROR,
                 InternalLogger.Target.USER,
                 "In order to use the RUM automatic tracking feature you will have" +
-                    "to use the Application context when initializing the SDK"
+                    " to use the Application context when initializing the SDK"
             )
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/SdkCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/SdkCore.kt
@@ -25,15 +25,9 @@ interface SdkCore {
     /**
      * Registers a feature to this instance of the Datadog SDK.
      *
-     * @param featureName the name of the feature
-     * @param storageConfiguration the configuration for storing tracked data
-     * @param uploadConfiguration the configuration for uploading stored data
+     * @param feature the feature to be registered.
      */
-    fun registerFeature(
-        featureName: String,
-        storageConfiguration: FeatureStorageConfiguration,
-        uploadConfiguration: FeatureUploadConfiguration
-    )
+    fun registerFeature(feature: Feature)
 
     /**
      * Retrieves a registered feature.

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/NoOpSdkCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/NoOpSdkCore.kt
@@ -7,10 +7,9 @@
 package com.datadog.android.v2.core
 
 import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureEventReceiver
 import com.datadog.android.v2.api.FeatureScope
-import com.datadog.android.v2.api.FeatureStorageConfiguration
-import com.datadog.android.v2.api.FeatureUploadConfiguration
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.TimeInfo
 import com.datadog.android.v2.api.context.UserInfo
@@ -26,11 +25,7 @@ internal class NoOpSdkCore : SdkCore {
         )
     }
 
-    override fun registerFeature(
-        featureName: String,
-        storageConfiguration: FeatureStorageConfiguration,
-        uploadConfiguration: FeatureUploadConfiguration
-    ) = Unit
+    override fun registerFeature(feature: Feature) = Unit
 
     override fun getFeature(featureName: String): FeatureScope? = null
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -45,7 +45,7 @@ internal class CrashReportsFeatureTest {
 
     @BeforeEach
     fun `set up crash reports`() {
-        testedFeature = CrashReportsFeature()
+        testedFeature = CrashReportsFeature(plugins = emptyList())
         jvmExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR adds `SdkCore#registerFeature(Feature)` method, which takes `Feature` interface. This method is supposed to be called from outside of `DatadogCore`, but for now it is called from `initialize`.

`SdkFeature` as internal class wraps `Feature` and creates storage/uploader only if needed (only if `StorageBackedFeature` interface is implemented).

Maybe some things will change things later internally, but from the public perspective this method is here to stay.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

