### PR TITLE
RUMM-2929: Session replay configuration extracted into dedicated class

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -224,7 +224,7 @@ tasks.register("buildNdkIntegrationTestsArtifacts") {
     dependsOn(":instrumented:integration:assembleDebug")
 }
 
-nightlyTestsCoverageConfig(threshold = 0.87f)
+nightlyTestsCoverageConfig(threshold = 0.90f)
 kover {
     isDisabled = false
     disabledProjects = setOf(

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -84,7 +84,7 @@ enum com.datadog.android.core.configuration.BatchSize
   - LARGE
 data class com.datadog.android.core.configuration.Configuration
   class Builder
-    constructor(Boolean, Boolean, Boolean, Boolean, Boolean)
+    constructor(Boolean, Boolean, Boolean, Boolean)
     fun build(): Configuration
     fun setUseDeveloperModeWhenDebuggable(Boolean): Builder
     fun setFirstPartyHosts(List<String>): Builder
@@ -94,7 +94,6 @@ data class com.datadog.android.core.configuration.Configuration
     fun useCustomTracesEndpoint(String): Builder
     fun useCustomCrashReportsEndpoint(String): Builder
     fun useCustomRumEndpoint(String): Builder
-    fun useCustomSessionReplayEndpoint(String): Builder
     fun trackInteractions(Array<com.datadog.android.rum.tracking.ViewAttributesProvider> = emptyArray(), com.datadog.android.rum.tracking.InteractionPredicate = NoOpInteractionPredicate()): Builder
     fun disableInteractionTracking(): Builder
     fun trackLongTasks(Long = DEFAULT_LONG_TASK_THRESHOLD_MS): Builder
@@ -116,7 +115,6 @@ data class com.datadog.android.core.configuration.Configuration
     fun setAdditionalConfiguration(Map<String, Any>): Builder
     fun setProxy(java.net.Proxy, okhttp3.Authenticator?): Builder
     fun setEncryption(com.datadog.android.security.Encryption): Builder
-    fun setSessionReplayPrivacy(com.datadog.android.sessionreplay.SessionReplayPrivacy): Builder
     fun setVitalsUpdateFrequency(VitalsUpdateFrequency): Builder
 data class com.datadog.android.core.configuration.Credentials
   constructor(String, String, String, String?, String? = null)
@@ -238,7 +236,6 @@ enum com.datadog.android.plugin.Feature
   - CRASH
   - TRACE
   - RUM
-  - SESSION_REPLAY
 enum com.datadog.android.privacy.TrackingConsent
   - GRANTED
   - NOT_GRANTED

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -452,6 +452,12 @@ DEPRECATED open class com.datadog.android.rum.webview.RumWebViewClient : android
 interface com.datadog.android.security.Encryption
   fun encrypt(ByteArray): ByteArray
   fun decrypt(ByteArray): ByteArray
+data class com.datadog.android.sessionreplay.internal.SessionReplayConfiguration
+  class Builder
+    fun useSite(com.datadog.android.DatadogSite): Builder
+    fun useCustomEndpoint(String): Builder
+    fun setPrivacy(com.datadog.android.sessionreplay.SessionReplayPrivacy): Builder
+    fun build(): SessionReplayConfiguration
 class com.datadog.android.sqlite.DatadogDatabaseErrorHandler : android.database.DatabaseErrorHandler
   constructor(android.database.DatabaseErrorHandler = DefaultDatabaseErrorHandler())
   override fun onCorruption(android.database.sqlite.SQLiteDatabase)

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -7,8 +7,7 @@ object com.datadog.android.Datadog
   fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
   fun addUserExtraInfo(Map<String, Any?> = emptyMap())
   fun enableRumDebugging(Boolean)
-  fun stopSessionRecording()
-  fun startSessionRecording()
+  fun registerFeature(com.datadog.android.v2.api.Feature)
   val _internal: _InternalProxy
 object com.datadog.android.DatadogEndpoint
   const val LOGS_US1: String
@@ -455,6 +454,16 @@ data class com.datadog.android.sessionreplay.internal.SessionReplayConfiguration
     fun useCustomEndpoint(String): Builder
     fun setPrivacy(com.datadog.android.sessionreplay.SessionReplayPrivacy): Builder
     fun build(): SessionReplayConfiguration
+class com.datadog.android.sessionreplay.internal.SessionReplayFeature : com.datadog.android.v2.api.StorageBackedFeature, com.datadog.android.v2.api.FeatureEventReceiver
+  constructor(SessionReplayConfiguration)
+  override val name: String
+  override fun onInitialize(com.datadog.android.v2.api.SdkCore, android.content.Context)
+  override val requestFactory: com.datadog.android.v2.api.RequestFactory
+  override val storageConfiguration: com.datadog.android.v2.api.FeatureStorageConfiguration
+  override fun onStop()
+  fun stopRecording()
+  fun startRecording()
+  override fun onReceive(Any)
 class com.datadog.android.sqlite.DatadogDatabaseErrorHandler : android.database.DatabaseErrorHandler
   constructor(android.database.DatabaseErrorHandler = DefaultDatabaseErrorHandler())
   override fun onCorruption(android.database.sqlite.SQLiteDatabase)
@@ -483,6 +492,7 @@ interface com.datadog.android.v2.api.EventBatchWriter
 interface com.datadog.android.v2.api.Feature
   val name: String
   fun onInitialize(SdkCore, android.content.Context)
+  fun onStop()
 interface com.datadog.android.v2.api.FeatureConfiguration
   fun register(SdkCore)
 interface com.datadog.android.v2.api.FeatureEventReceiver

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -14,6 +14,7 @@ import com.datadog.android.core.internal.utils.telemetry
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
+import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.UserInfo
@@ -222,23 +223,12 @@ object Datadog {
     }
 
     /**
-     * Stops the session recording.
+     * TODO RUMM-0000 Temporary thing until we decide on the SDK instance handling.
      *
-     * Session Replay feature will only work for recorded
-     * sessions.
+     * @param feature Feature to register.
      */
-    fun stopSessionRecording() {
-        (globalSdkCore as? DatadogCore)?.sessionReplayFeature?.stopRecording()
-    }
-
-    /**
-     * Starts/resumes the session recording.
-     *
-     * Session Replay feature will only work for recorded
-     * sessions.
-     */
-    fun startSessionRecording() {
-        (globalSdkCore as? DatadogCore)?.sessionReplayFeature?.startRecording()
+    fun registerFeature(feature: Feature) {
+        globalSdkCore.registerFeature(feature)
     }
 
     /**

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -99,6 +99,8 @@ internal class SdkFeature(
 
     fun stop() {
         if (initialized.get()) {
+            wrappedFeature.onStop()
+
             unregisterPlugins()
             uploadScheduler.stopScheduling()
             uploadScheduler = NoOpUploadScheduler()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -32,7 +32,7 @@ internal class CrashReportsFeature(
         initialized.set(true)
     }
 
-    fun stop() {
+    override fun onStop() {
         resetOriginalExceptionHandler()
         initialized.set(false)
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -58,7 +58,7 @@ internal class LogsFeature(
     override val storageConfiguration: FeatureStorageConfiguration =
         FeatureStorageConfiguration.DEFAULT
 
-    internal fun stop() {
+    override fun onStop() {
         sdkCore.removeEventReceiver(LOGS_FEATURE_NAME)
         dataWriter = NoOpDataWriter()
         initialized.set(false)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/Feature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/plugin/Feature.kt
@@ -13,6 +13,5 @@ enum class Feature(internal val featureName: String) {
     LOG("Logging"),
     CRASH("Crash Reporting"),
     TRACE("Tracing"),
-    RUM("RUM"),
-    SESSION_REPLAY("Session Replay")
+    RUM("RUM")
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -132,7 +132,7 @@ internal class RumFeature(
     override val storageConfiguration: FeatureStorageConfiguration =
         FeatureStorageConfiguration.DEFAULT
 
-    fun stop() {
+    override fun onStop() {
         sdkCore.removeEventReceiver(RUM_FEATURE_NAME)
 
         unregisterTrackingStrategies(appContext)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayConfiguration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayConfiguration.kt
@@ -1,0 +1,61 @@
+package com.datadog.android.sessionreplay.internal
+
+import com.datadog.android.DatadogEndpoint
+import com.datadog.android.DatadogSite
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
+
+/**
+ * An object describing the configuration of the Session Replay.
+ */
+data class SessionReplayConfiguration
+internal constructor(
+    internal val endpointUrl: String,
+    internal val privacy: SessionReplayPrivacy
+) {
+
+    /**
+     * A Builder class for a [SessionReplayConfiguration].
+     */
+    class Builder {
+        private var endpointUrl = DatadogEndpoint.SESSION_REPLAY_US1
+        private var privacy = SessionReplayPrivacy.MASK_ALL
+
+        /**
+         * Let the Session Replay target your preferred Datadog's site.
+         */
+        fun useSite(site: DatadogSite): Builder {
+            endpointUrl = site.sessionReplayEndpoint()
+            return this
+        }
+
+        /**
+         * Let the Session Replay target a custom server.
+         */
+        fun useCustomEndpoint(endpoint: String): Builder {
+            endpointUrl = endpoint
+            return this
+        }
+
+        /**
+         * Sets the privacy rule for the Session Replay feature.
+         * If not specified all the elements will be masked by default (MASK_ALL).
+         * @see SessionReplayPrivacy.ALLOW_ALL
+         * @see SessionReplayPrivacy.MASK_ALL
+         */
+        fun setPrivacy(privacy: SessionReplayPrivacy): Builder {
+            this.privacy = privacy
+            return this
+        }
+
+        /**
+         * Builds a [Configuration] based on the current state of this Builder.
+         */
+        fun build(): SessionReplayConfiguration {
+            return SessionReplayConfiguration(
+                endpointUrl = endpointUrl,
+                privacy = privacy
+            )
+        }
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -25,10 +25,23 @@ import com.datadog.android.v2.api.StorageBackedFeature
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
-internal class SessionReplayFeature(
-    private val configuration: SessionReplayConfiguration,
-    private val sessionReplayCallbackProvider:
-        (SdkCore, RecordWriter) -> LifecycleCallback = { sdkCore, recordWriter ->
+/**
+ * Session Replay feature class, which needs to be registered with Datadog SDK instance.
+ */
+class SessionReplayFeature internal constructor(
+    configuration: SessionReplayConfiguration,
+    private val sessionReplayCallbackProvider: (SdkCore, RecordWriter) -> LifecycleCallback
+) : StorageBackedFeature, FeatureEventReceiver {
+
+    /**
+     * Creates Session Replay feature.
+     *
+     * @param configuration Session Replay configuration, which can be created
+     * using [SessionReplayConfiguration.Builder].
+     */
+    constructor(configuration: SessionReplayConfiguration) : this(
+        configuration,
+        { sdkCore, recordWriter ->
             SessionReplayLifecycleCallback(
                 SessionReplayRumContextProvider(sdkCore),
                 configuration.privacy,
@@ -37,7 +50,7 @@ internal class SessionReplayFeature(
                 SessionReplayRecordCallback(sdkCore)
             )
         }
-) : StorageBackedFeature, FeatureEventReceiver {
+    )
 
     internal lateinit var appContext: Context
     internal lateinit var sdkCore: SdkCore
@@ -71,7 +84,7 @@ internal class SessionReplayFeature(
     override val storageConfiguration: FeatureStorageConfiguration =
         FeatureStorageConfiguration.DEFAULT
 
-    internal fun stop() {
+    override fun onStop() {
         stopRecording()
         dataWriter = NoOpRecordWriter()
         sessionReplayCallback = NoOpLifecycleCallback()
@@ -86,13 +99,33 @@ internal class SessionReplayFeature(
 
     // region SessionReplayFeature
 
-    internal fun stopRecording() {
+    /**
+     * Stops the session recording.
+     *
+     * Session Replay feature will only work for recorded
+     * sessions.
+     */
+    fun stopRecording() {
         if (isRecording.getAndSet(false)) {
             unregisterCallback(appContext)
         }
     }
 
-    internal fun startRecording() {
+    /**
+     * Starts/resumes the session recording.
+     *
+     * Session Replay feature will only work for recorded
+     * sessions.
+     */
+    fun startRecording() {
+        if (!initialized.get()) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.USER,
+                CANNOT_START_RECORDING_NOT_INITIALIZED
+            )
+            return
+        }
         if (!isRecording.getAndSet(true)) {
             registerCallback(appContext)
         }
@@ -159,7 +192,7 @@ internal class SessionReplayFeature(
 
     // endregion
 
-    companion object {
+    internal companion object {
         internal const val UNSUPPORTED_EVENT_TYPE =
             "Session Replay feature receive an event of unsupported type=%s."
         internal const val UNKNOWN_EVENT_TYPE_PROPERTY_VALUE =
@@ -167,6 +200,8 @@ internal class SessionReplayFeature(
         internal const val EVENT_MISSING_MANDATORY_FIELDS = "Session Replay feature received an " +
             "event where one or more mandatory (keepSession) fields" +
             " are either missing or have wrong type."
+        internal const val CANNOT_START_RECORDING_NOT_INITIALIZED =
+            "Cannot start session recording, because Session Replay feature is not initialized."
         const val SESSION_REPLAY_FEATURE_NAME = "session-replay"
         const val SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY = "type"
         const val RUM_SESSION_RENEWED_BUS_MESSAGE = "rum_session_renewed"

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -8,7 +8,6 @@ package com.datadog.android.sessionreplay.internal
 
 import android.app.Application
 import android.content.Context
-import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.sessionreplay.LifecycleCallback
 import com.datadog.android.sessionreplay.RecordWriter
@@ -27,7 +26,7 @@ import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class SessionReplayFeature(
-    private val configuration: Configuration.Feature.SessionReplay,
+    private val configuration: SessionReplayConfiguration,
     private val sessionReplayCallbackProvider:
         (SdkCore, RecordWriter) -> LifecycleCallback = { sdkCore, recordWriter ->
             SessionReplayLifecycleCallback(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracingFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/tracing/internal/TracingFeature.kt
@@ -42,7 +42,7 @@ internal class TracingFeature(
     override val storageConfiguration: FeatureStorageConfiguration =
         FeatureStorageConfiguration.DEFAULT
 
-    fun stop() {
+    override fun onStop() {
         dataWriter = NoOpWriter()
         initialized.set(false)
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/Feature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/Feature.kt
@@ -25,4 +25,10 @@ interface Feature {
      * @param appContext Application context.
      */
     fun onInitialize(sdkCore: SdkCore, appContext: Context)
+
+    /**
+     * This method is called during feature de-initialization. At this stage feature should stop
+     * itself and release resources held.
+     */
+    fun onStop()
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -30,8 +30,6 @@ import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
-import com.datadog.android.sessionreplay.internal.SessionReplayConfiguration
-import com.datadog.android.sessionreplay.internal.SessionReplayFeature
 import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureEventReceiver
@@ -73,7 +71,6 @@ internal class DatadogCore(
     internal var crashReportsFeature: CrashReportsFeature? = null
     internal var webViewLogsFeature: WebViewLogsFeature? = null
     internal var webViewRumFeature: WebViewRumFeature? = null
-    internal var sessionReplayFeature: SessionReplayFeature? = null
 
     // TODO RUMM-0000 handle context
     internal val contextProvider: ContextProvider?
@@ -179,21 +176,18 @@ internal class DatadogCore(
 
     /** @inheritDoc */
     override fun stop() {
-        logsFeature?.stop()
-        logsFeature = null
-        tracingFeature?.stop()
-        tracingFeature = null
-        rumFeature?.stop()
-        rumFeature = null
-        crashReportsFeature?.stop()
-        crashReportsFeature = null
-        webViewLogsFeature?.stop()
-        webViewLogsFeature = null
-        webViewRumFeature?.stop()
-        webViewRumFeature = null
-        sessionReplayFeature?.stop()
-        sessionReplayFeature = null
-
+        features.forEach {
+            it.value.stop()
+            // TODO RUMM-0000 Temporary thing
+            when (it.key) {
+                LogsFeature.LOGS_FEATURE_NAME -> logsFeature = null
+                TracingFeature.TRACING_FEATURE_NAME -> tracingFeature = null
+                RumFeature.RUM_FEATURE_NAME -> rumFeature = null
+                CrashReportsFeature.CRASH_FEATURE_NAME -> crashReportsFeature = null
+                WebViewLogsFeature.WEB_LOGS_FEATURE_NAME -> webViewLogsFeature = null
+                WebViewRumFeature.WEB_RUM_FEATURE_NAME -> webViewRumFeature = null
+            }
+        }
         features.clear()
 
         coreFeature.stop()
@@ -304,8 +298,6 @@ internal class DatadogCore(
         initializeTracingFeature(mutableConfig.tracesConfig)
         initializeRumFeature(mutableConfig.rumConfig)
         initializeCrashReportFeature(mutableConfig.crashReportConfig)
-        // TODO RUMM-0000 Temporary thing, will be solved in next commit
-        initializeSessionReplayFeature(SessionReplayConfiguration.Builder().build())
 
         coreFeature.ndkCrashHandler.handleNdkCrash(this)
 
@@ -359,14 +351,6 @@ internal class DatadogCore(
             val webViewRumFeature = WebViewRumFeature(configuration.endpointUrl, coreFeature)
             this.webViewRumFeature = webViewRumFeature
             registerFeature(webViewRumFeature)
-        }
-    }
-
-    private fun initializeSessionReplayFeature(configuration: SessionReplayConfiguration?) {
-        if (configuration != null) {
-            val sessionReplayFeature = SessionReplayFeature(configuration)
-            this.sessionReplayFeature = sessionReplayFeature
-            registerFeature(sessionReplayFeature)
         }
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -30,6 +30,7 @@ import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
+import com.datadog.android.sessionreplay.internal.SessionReplayConfiguration
 import com.datadog.android.sessionreplay.internal.SessionReplayFeature
 import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.v2.api.Feature
@@ -303,7 +304,8 @@ internal class DatadogCore(
         initializeTracingFeature(mutableConfig.tracesConfig)
         initializeRumFeature(mutableConfig.rumConfig)
         initializeCrashReportFeature(mutableConfig.crashReportConfig)
-        initializeSessionReplayFeature(mutableConfig.sessionReplayConfig)
+        // TODO RUMM-0000 Temporary thing, will be solved in next commit
+        initializeSessionReplayFeature(SessionReplayConfiguration.Builder().build())
 
         coreFeature.ndkCrashHandler.handleNdkCrash(this)
 
@@ -360,7 +362,7 @@ internal class DatadogCore(
         }
     }
 
-    private fun initializeSessionReplayFeature(configuration: Configuration.Feature.SessionReplay?) {
+    private fun initializeSessionReplayFeature(configuration: SessionReplayConfiguration?) {
         if (configuration != null) {
             val sessionReplayFeature = SessionReplayFeature(configuration)
             this.sessionReplayFeature = sessionReplayFeature

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeature.kt
@@ -39,7 +39,7 @@ internal class WebViewLogsFeature(
     override val storageConfiguration: FeatureStorageConfiguration =
         FeatureStorageConfiguration.DEFAULT
 
-    fun stop() {
+    override fun onStop() {
         dataWriter = NoOpDataWriter()
         initialized.set(false)
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
@@ -43,7 +43,7 @@ internal class WebViewRumFeature(
     override val storageConfiguration: FeatureStorageConfiguration =
         FeatureStorageConfiguration.DEFAULT
 
-    fun stop() {
+    override fun onStop() {
         dataWriter = NoOpDataWriter()
         initialized.set(false)
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -13,7 +13,6 @@ import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.internal.RumFeature
-import com.datadog.android.sessionreplay.internal.SessionReplayFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.InternalLoggerTestConfiguration
@@ -328,42 +327,6 @@ internal class DatadogTest {
 
         // Then
         verify(mockCore).clearAllData()
-    }
-
-    @Test
-    fun `M delegate to SessionReplayFeature W startSessionRecording()`() {
-        // Given
-        val mockSessionReplayFeature: SessionReplayFeature = mock()
-        val mockCore = mock<DatadogCore> {
-            whenever(it.sessionReplayFeature).thenReturn(mockSessionReplayFeature)
-        }
-        val previousCore = Datadog.globalSdkCore
-        Datadog.globalSdkCore = mockCore
-
-        // When
-        Datadog.startSessionRecording()
-
-        // Then
-        verify(mockSessionReplayFeature).startRecording()
-        Datadog.globalSdkCore = previousCore
-    }
-
-    @Test
-    fun `M delegate to SessionReplayFeature W stopSessionRecording()`() {
-        // Given
-        val mockSessionReplayFeature: SessionReplayFeature = mock()
-        val mockCore = mock<DatadogCore> {
-            whenever(it.sessionReplayFeature).thenReturn(mockSessionReplayFeature)
-        }
-        val previousCore = Datadog.globalSdkCore
-        Datadog.globalSdkCore = mockCore
-
-        // When
-        Datadog.stopSessionRecording()
-
-        // Then
-        verify(mockSessionReplayFeature).stopRecording()
-        Datadog.globalSdkCore = previousCore
     }
 
     companion object {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -180,8 +180,7 @@ internal class DatadogTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         ).build()
 
         // When
@@ -200,8 +199,7 @@ internal class DatadogTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         ).build()
 
         // When
@@ -282,8 +280,7 @@ internal class DatadogTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .build()
         val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
@@ -305,8 +302,7 @@ internal class DatadogTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .build()
         val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -75,14 +75,11 @@ import java.util.Locale
     ExtendWith(ApiLevelExtension::class),
     ExtendWith(TestConfigurationExtension::class)
 )
-@MockitoSettings()
+@MockitoSettings
 @ForgeConfiguration(value = Configurator::class)
 internal class ConfigurationBuilderTest {
 
     lateinit var testedBuilder: Configuration.Builder
-
-    @StringForgery
-    lateinit var fakeEnvName: String
 
     @BeforeEach
     fun `set up`() {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -36,7 +36,6 @@ import com.datadog.android.rum.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
 import com.datadog.android.security.Encryption
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 import com.datadog.android.utils.config.InternalLoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
@@ -87,8 +86,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
     }
 
@@ -158,13 +156,6 @@ internal class ConfigurationBuilderTest {
             )
         )
         assertThat(config.additionalConfig).isEmpty()
-        assertThat(config.sessionReplayConfig).isEqualTo(
-            Configuration.Feature.SessionReplay(
-                endpointUrl = DatadogEndpoint.SESSION_REPLAY_US1,
-                plugins = emptyList(),
-                privacy = SessionReplayPrivacy.MASK_ALL
-            )
-        )
     }
 
     @Test
@@ -174,8 +165,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = false,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
 
         // When
@@ -196,8 +186,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = false,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
 
         // When
@@ -218,8 +207,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = false,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
 
         // When
@@ -240,8 +228,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
 
         // When
@@ -252,29 +239,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.tracesConfig).isNotNull
         assertThat(config.crashReportConfig).isNotNull
         assertThat(config.rumConfig).isNull()
-        assertThat(config.additionalConfig).isEmpty()
-    }
-
-    @Test
-    fun `𝕄 build config without sessionReplayConfig 𝕎 build() { SessionReplay disabled }`() {
-        // Given
-        testedBuilder = Configuration.Builder(
-            logsEnabled = true,
-            tracesEnabled = true,
-            crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = false
-        )
-
-        // When
-        val config = testedBuilder.build()
-
-        // Then
-        assertThat(config.logsConfig).isNotNull
-        assertThat(config.tracesConfig).isNotNull
-        assertThat(config.crashReportConfig).isNotNull
-        assertThat(config.rumConfig).isNotNull
-        assertThat(config.sessionReplayConfig).isNull()
         assertThat(config.additionalConfig).isEmpty()
     }
 
@@ -301,11 +265,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = site.rumEndpoint())
         )
-        assertThat(config.sessionReplayConfig).isEqualTo(
-            Configuration.DEFAULT_SESSION_REPLAY_CONFIG.copy(
-                endpointUrl = site.sessionReplayEndpoint()
-            )
-        )
         assertThat(config.additionalConfig).isEmpty()
     }
 
@@ -314,8 +273,7 @@ internal class ConfigurationBuilderTest {
         @StringForgery(regex = "https://[a-z]+\\.com") logsUrl: String,
         @StringForgery(regex = "https://[a-z]+\\.com") tracesUrl: String,
         @StringForgery(regex = "https://[a-z]+\\.com") crashReportsUrl: String,
-        @StringForgery(regex = "https://[a-z]+\\.com") rumUrl: String,
-        @StringForgery(regex = "https://[a-z]+\\.com") sessionReplayUrl: String
+        @StringForgery(regex = "https://[a-z]+\\.com") rumUrl: String
     ) {
         // When
         val config = testedBuilder
@@ -323,7 +281,6 @@ internal class ConfigurationBuilderTest {
             .useCustomTracesEndpoint(tracesUrl)
             .useCustomCrashReportsEndpoint(crashReportsUrl)
             .useCustomRumEndpoint(rumUrl)
-            .useCustomSessionReplayEndpoint(sessionReplayUrl)
             .build()
 
         // Then
@@ -344,10 +301,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = rumUrl)
         )
-        assertThat(config.sessionReplayConfig).isEqualTo(
-            Configuration
-                .DEFAULT_SESSION_REPLAY_CONFIG.copy(endpointUrl = sessionReplayUrl)
-        )
         assertThat(config.additionalConfig).isEmpty()
     }
 
@@ -356,8 +309,7 @@ internal class ConfigurationBuilderTest {
         @StringForgery(regex = "http://[a-z]+\\.com") logsUrl: String,
         @StringForgery(regex = "http://[a-z]+\\.com") tracesUrl: String,
         @StringForgery(regex = "http://[a-z]+\\.com") crashReportsUrl: String,
-        @StringForgery(regex = "http://[a-z]+\\.com") rumUrl: String,
-        @StringForgery(regex = "http://[a-z]+\\.com") sessionReplayUrl: String
+        @StringForgery(regex = "http://[a-z]+\\.com") rumUrl: String
     ) {
         // When
         val config = testedBuilder
@@ -365,7 +317,6 @@ internal class ConfigurationBuilderTest {
             .useCustomTracesEndpoint(tracesUrl)
             .useCustomCrashReportsEndpoint(crashReportsUrl)
             .useCustomRumEndpoint(rumUrl)
-            .useCustomSessionReplayEndpoint(sessionReplayUrl)
             .build()
 
         // Then
@@ -385,10 +336,6 @@ internal class ConfigurationBuilderTest {
         )
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = rumUrl)
-        )
-        assertThat(config.sessionReplayConfig).isEqualTo(
-            Configuration
-                .DEFAULT_SESSION_REPLAY_CONFIG.copy(endpointUrl = sessionReplayUrl)
         )
         assertThat(config.additionalConfig).isEmpty()
     }
@@ -434,8 +381,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         assertThat(config.rumConfig!!)
             .hasUserActionTrackingStrategyLegacy()
             .hasActionTargetAttributeProviders(mockProviders)
@@ -457,8 +402,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         assertThat(config.rumConfig!!)
             .hasUserActionTrackingStrategyLegacy()
             .hasDefaultActionTargetAttributeProviders()
@@ -483,8 +426,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         assertThat(config.rumConfig!!)
             .hasUserActionTrackingStrategyLegacy()
             .hasInteractionPredicate(mockInteractionPredicate)
@@ -506,8 +447,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         assertThat(config.rumConfig!!)
             .hasUserActionTrackingStrategyLegacy()
             .hasInteractionPredicateOfType(NoOpInteractionPredicate::class.java)
@@ -537,8 +476,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         assertThat(config.rumConfig!!)
             .hasUserActionTrackingStrategyApi29()
             .hasActionTargetAttributeProviders(mockProviders)
@@ -563,8 +500,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 longTaskTrackingStrategy = MainLooperLongTaskStrategy(durationMs)
@@ -612,8 +547,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 userActionTrackingStrategy = UserActionTrackingStrategyLegacy(
@@ -662,8 +595,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 samplingRate = sampling
@@ -686,8 +617,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 telemetrySamplingRate = sampling
@@ -711,8 +640,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
                 backgroundEventTracking = backgroundEventEnabled
@@ -736,8 +663,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         val expectedRumEventMapper = RumEventMapper(viewEventMapper = eventMapper)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
@@ -762,8 +687,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         val expectedRumEventMapper = RumEventMapper(resourceEventMapper = eventMapper)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
@@ -788,8 +711,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         val expectedRumEventMapper = RumEventMapper(actionEventMapper = eventMapper)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
@@ -814,8 +735,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         val expectedRumEventMapper = RumEventMapper(errorEventMapper = eventMapper)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
@@ -840,8 +759,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.logsConfig).isEqualTo(Configuration.DEFAULT_LOGS_CONFIG)
         assertThat(config.tracesConfig).isEqualTo(Configuration.DEFAULT_TRACING_CONFIG)
         assertThat(config.crashReportConfig).isEqualTo(Configuration.DEFAULT_CRASH_CONFIG)
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG)
         val expectedRumEventMapper = RumEventMapper(longTaskEventMapper = eventMapper)
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(
@@ -913,40 +830,7 @@ internal class ConfigurationBuilderTest {
                 plugins = listOf(rumPlugin)
             )
         )
-        assertThat(config.sessionReplayConfig?.plugins).isEmpty()
         assertThat(config.additionalConfig).isEmpty()
-    }
-
-    @Test
-    fun `M do nothing W addPlugin { SessionReplay feature }`() {
-        // Given
-        val sessionReplayPlugin: DatadogPlugin = mock()
-
-        // When
-        val config = testedBuilder
-            .addPlugin(sessionReplayPlugin, Feature.SESSION_REPLAY)
-            .build()
-
-        // then
-        assertThat(config.sessionReplayConfig?.plugins).isEmpty()
-    }
-
-    @Test
-    fun `M warn user that plugins are deprecated W addPlugin { SessionReplay feature }`() {
-        // Given
-        val sessionReplayPlugin: DatadogPlugin = mock()
-
-        // When
-        testedBuilder
-            .addPlugin(sessionReplayPlugin, Feature.SESSION_REPLAY)
-            .build()
-
-        // then
-        verify(logger.mockInternalLogger).log(
-            InternalLogger.Level.WARN,
-            InternalLogger.Target.USER,
-            Configuration.PLUGINS_DEPRECATED_WARN_MESSAGE
-        )
     }
 
     @Test
@@ -956,8 +840,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
 
         // When
@@ -984,8 +867,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
 
         // When
@@ -1010,8 +892,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
         val viewStrategy: ViewTrackingStrategy = mock()
 
@@ -1039,8 +920,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
 
         // When
@@ -1065,8 +945,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
         val eventMapper: ViewEventMapper = mock()
 
@@ -1092,8 +971,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
         val eventMapper: EventMapper<ResourceEvent> = mock()
 
@@ -1119,8 +997,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
         val eventMapper: EventMapper<ActionEvent> = mock()
 
@@ -1146,8 +1023,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
         val eventMapper: EventMapper<ErrorEvent> = mock()
 
@@ -1173,8 +1049,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
         val eventMapper: EventMapper<LongTaskEvent> = mock()
 
@@ -1200,8 +1075,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = false,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
         val logsPlugin: DatadogPlugin = mock()
 
@@ -1227,8 +1101,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = false,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
         val tracesPlugin: DatadogPlugin = mock()
 
@@ -1254,8 +1127,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = false,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
         val crashPlugin: DatadogPlugin = mock()
 
@@ -1281,8 +1153,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
         val rumPlugin: DatadogPlugin = mock()
 
@@ -1310,8 +1181,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = forge.aBool(),
             tracesEnabled = forge.aBool(),
             crashReportsEnabled = forge.aBool(),
-            rumEnabled = forge.aBool(),
-            sessionReplayEnabled = forge.aBool()
+            rumEnabled = forge.aBool()
         )
         val mockPlugin: DatadogPlugin = mock()
 
@@ -1339,8 +1209,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = false,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
 
         // When
@@ -1367,8 +1236,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = false,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
 
         // When
@@ -1395,8 +1263,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = false,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
 
         // When
@@ -1423,8 +1290,7 @@ internal class ConfigurationBuilderTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = false,
-            sessionReplayEnabled = true
+            rumEnabled = false
         )
 
         // When
@@ -1841,18 +1707,6 @@ internal class ConfigurationBuilderTest {
         assertThat(config.rumConfig).isEqualTo(
             Configuration.DEFAULT_RUM_CONFIG.copy(vitalsMonitorUpdateFrequency = fakeFrequency)
         )
-    }
-
-    @Test
-    fun `M use the given privacy rule W setSessionReplayPrivacy`(
-        @Forgery fakePrivacy: SessionReplayPrivacy
-    ) {
-        // When
-        val config = testedBuilder.setSessionReplayPrivacy(fakePrivacy).build()
-
-        // Then
-        assertThat(config.sessionReplayConfig)
-            .isEqualTo(Configuration.DEFAULT_SESSION_REPLAY_CONFIG.copy(privacy = fakePrivacy))
     }
 
     companion object {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -261,6 +261,18 @@ internal class SdkFeatureTest {
     }
 
     @Test
+    fun `𝕄 call wrapped feature onStop 𝕎 stop()`() {
+        // Given
+        testedFeature.initialize(mockSdkCore, appContext.mockInstance, mockPlugins)
+
+        // When
+        testedFeature.stop()
+
+        // Then
+        verify(mockWrappedFeature).onStop()
+    }
+
+    @Test
     fun `𝕄 initialize only once 𝕎 initialize() twice`() {
         // Given
         testedFeature.initialize(mockSdkCore, appContext.mockInstance, mockPlugins)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -74,8 +74,7 @@ internal class WorkManagerUtilsTest {
                 logsEnabled = true,
                 tracesEnabled = true,
                 crashReportsEnabled = true,
-                rumEnabled = true,
-                sessionReplayEnabled = true
+                rumEnabled = true
             ).build(),
             TrackingConsent.GRANTED
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -67,14 +67,14 @@ internal class CrashReportsFeatureTest {
     }
 
     @Test
-    fun `𝕄 restore original crash handler 𝕎 stop()`() {
+    fun `𝕄 restore original crash handler 𝕎 onStop()`() {
         // Given
         val mockOriginalHandler: Thread.UncaughtExceptionHandler = mock()
         Thread.setDefaultUncaughtExceptionHandler(mockOriginalHandler)
 
         // When
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         val finalHandler = Thread.getDefaultUncaughtExceptionHandler()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -125,8 +125,7 @@ internal class DatadogExceptionHandlerTest {
                 logsEnabled = true,
                 tracesEnabled = true,
                 crashReportsEnabled = true,
-                rumEnabled = true,
-                sessionReplayEnabled = true
+                rumEnabled = true
             ).build(),
             TrackingConsent.GRANTED
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -318,12 +318,12 @@ internal class RumFeatureTest {
     }
 
     @Test
-    fun `𝕄 use noop viewTrackingStrategy 𝕎 stop()`() {
+    fun `𝕄 use noop viewTrackingStrategy 𝕎 onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         assertThat(testedFeature.viewTrackingStrategy)
@@ -331,12 +331,12 @@ internal class RumFeatureTest {
     }
 
     @Test
-    fun `𝕄 use noop userActionTrackingStrategy 𝕎 stop()`() {
+    fun `𝕄 use noop userActionTrackingStrategy 𝕎 onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         assertThat(testedFeature.actionTrackingStrategy)
@@ -344,7 +344,7 @@ internal class RumFeatureTest {
     }
 
     @Test
-    fun `𝕄 unregister strategies 𝕎 stop()`() {
+    fun `𝕄 unregister strategies 𝕎 onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
         val mockActionTrackingStrategy: UserActionTrackingStrategy = mock()
@@ -355,7 +355,7 @@ internal class RumFeatureTest {
         testedFeature.longTaskTrackingStrategy = mockLongTaskTrackingStrategy
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         verify(mockActionTrackingStrategy).unregister(appContext.mockInstance)
@@ -364,24 +364,24 @@ internal class RumFeatureTest {
     }
 
     @Test
-    fun `𝕄 reset eventMapper 𝕎 stop()`() {
+    fun `𝕄 reset eventMapper 𝕎 onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         assertThat(testedFeature.rumEventMapper).isInstanceOf(NoOpEventMapper::class.java)
     }
 
     @Test
-    fun `𝕄 reset data writer 𝕎 stop()`() {
+    fun `𝕄 reset data writer 𝕎 onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         assertThat(testedFeature.dataWriter).isInstanceOf(NoOpDataWriter::class.java)
@@ -423,26 +423,26 @@ internal class RumFeatureTest {
     }
 
     @Test
-    fun `𝕄 shut down vital executor 𝕎 stop()`() {
+    fun `𝕄 shut down vital executor 𝕎 onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
         val mockVitalExecutorService: ScheduledThreadPoolExecutor = mock()
         testedFeature.vitalExecutorService = mockVitalExecutorService
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         verify(mockVitalExecutorService).shutdownNow()
     }
 
     @Test
-    fun `𝕄 reset vital executor 𝕎 stop()`() {
+    fun `𝕄 reset vital executor 𝕎 onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         assertThat(testedFeature.vitalExecutorService)
@@ -450,12 +450,12 @@ internal class RumFeatureTest {
     }
 
     @Test
-    fun `𝕄 reset vital monitors 𝕎 stop()`() {
+    fun `𝕄 reset vital monitors 𝕎 onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         assertThat(testedFeature.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayConfigurationBuilderTest.kt
@@ -1,0 +1,72 @@
+package com.datadog.android.sessionreplay.internal
+
+import com.datadog.android.DatadogEndpoint
+import com.datadog.android.DatadogSite
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@ForgeConfiguration(value = Configurator::class)
+internal class SessionReplayConfigurationBuilderTest {
+
+    lateinit var testedBuilder: SessionReplayConfiguration.Builder
+
+    @BeforeEach
+    fun `set up`() {
+        testedBuilder = SessionReplayConfiguration.Builder()
+    }
+
+    @Test
+    fun `𝕄 use sensible defaults 𝕎 build()`() {
+        // When
+        val config = testedBuilder.build()
+
+        // Then
+        assertThat(config.endpointUrl).isEqualTo(DatadogEndpoint.SESSION_REPLAY_US1)
+        assertThat(config.privacy).isEqualTo(SessionReplayPrivacy.MASK_ALL)
+    }
+
+    @Test
+    fun `𝕄 build config with custom site 𝕎 useSite() and build()`(
+        @Forgery site: DatadogSite
+    ) {
+        // When
+        val config = testedBuilder.useSite(site).build()
+
+        // Then
+        assertThat(config.endpointUrl).isEqualTo(site.sessionReplayEndpoint())
+    }
+
+    @Test
+    fun `𝕄 build config with custom site 𝕎 useCustomEndpoint() and build()`(
+        @StringForgery(regex = "https://[a-z]+\\.com") sessionReplayUrl: String
+    ) {
+        // When
+        val config = testedBuilder.useCustomEndpoint(sessionReplayUrl).build()
+
+        // Then
+        assertThat(config.endpointUrl).isEqualTo(sessionReplayUrl)
+    }
+
+    @Test
+    fun `𝕄 use the given privacy rule 𝕎 setSessionReplayPrivacy`(
+        @Forgery fakePrivacy: SessionReplayPrivacy
+    ) {
+        // When
+        val config = testedBuilder.setPrivacy(fakePrivacy).build()
+
+        // Then
+        assertThat(config.privacy).isEqualTo(fakePrivacy)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -122,12 +122,12 @@ internal class SessionReplayFeatureTest {
     }
 
     @Test
-    fun `M unregister the Session Replay lifecycle callback W stop()`() {
+    fun `M unregister the Session Replay lifecycle callback W onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         verify(mockSessionReplayLifecycleCallback)
@@ -135,12 +135,12 @@ internal class SessionReplayFeatureTest {
     }
 
     @Test
-    fun `M reset the Session Replay lifecycle callback W stop()`() {
+    fun `M reset the Session Replay lifecycle callback W onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         assertThat(testedFeature.sessionReplayCallback)
@@ -268,6 +268,21 @@ internal class SessionReplayFeatureTest {
         testedFeature.startRecording()
 
         // Then
+        verifyZeroInteractions(mockSessionReplayLifecycleCallback)
+    }
+
+    @Test
+    fun `M log warning and do nothing W startRecording() { feature is not initialized }`() {
+        // When
+        testedFeature.startRecording()
+
+        // Then
+        verify(logger.mockInternalLogger)
+            .log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.USER,
+                SessionReplayFeature.CANNOT_START_RECORDING_NOT_INITIALIZED
+            )
         verifyZeroInteractions(mockSessionReplayLifecycleCallback)
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.sessionreplay.internal
 
 import android.app.Application
-import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.sessionreplay.SessionReplayLifecycleCallback
 import com.datadog.android.sessionreplay.internal.domain.SessionReplayRequestFactory
 import com.datadog.android.sessionreplay.internal.storage.SessionReplayRecordWriter
@@ -55,7 +54,7 @@ internal class SessionReplayFeatureTest {
     private lateinit var testedFeature: SessionReplayFeature
 
     @Forgery
-    lateinit var fakeConfigurationFeature: Configuration.Feature.SessionReplay
+    lateinit var fakeConfigurationFeature: SessionReplayConfiguration
 
     @Mock
     lateinit var mockSessionReplayLifecycleCallback: SessionReplayLifecycleCallback

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -302,8 +302,7 @@ internal class TelemetryEventHandlerTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .sampleRumSessions(sessionSampleRate.toFloat())
             .sampleTelemetry(telemetrySamplingRate.toFloat())
@@ -333,8 +332,7 @@ internal class TelemetryEventHandlerTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         ).apply {
             if (useProxy) {
                 setProxy(mock(), forge.aNullable { mock() })
@@ -364,8 +362,7 @@ internal class TelemetryEventHandlerTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         ).apply {
             if (useLocalEncryption) {
                 setEncryption(mock())
@@ -399,8 +396,7 @@ internal class TelemetryEventHandlerTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = trackErrors,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .trackFrustrations(trackFrustrations)
             .useViewTrackingStrategy(forge.aViewTrackingStrategy(vts))
@@ -437,8 +433,7 @@ internal class TelemetryEventHandlerTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setBatchSize(batchSize)
             .setUploadFrequency(uploadFrequency)
@@ -470,8 +465,7 @@ internal class TelemetryEventHandlerTest {
             logsEnabled = true,
             tracesEnabled = useTracing || forge.aBool(),
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         ).build()
         val configRawEvent = forge.createRumRawTelemetryConfigurationEvent(configuration)
         if (useTracing) {
@@ -500,8 +494,7 @@ internal class TelemetryEventHandlerTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         ).build()
         val configRawEvent = forge.createRumRawTelemetryConfigurationEvent(configuration)
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationForgeryFactory.kt
@@ -19,7 +19,6 @@ internal class ConfigurationForgeryFactory :
             tracesConfig = forge.getForgery(),
             crashReportConfig = forge.getForgery(),
             rumConfig = forge.getForgery(),
-            sessionReplayConfig = forge.getForgery(),
             additionalConfig = forge.aMap { aString() to aString() }
         )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -30,7 +30,7 @@ internal class Configurator :
         forge.addFactory(UserInfoForgeryFactory())
         forge.addFactory(FilePersistenceConfigForgeryFactory())
         forge.addFactory(AndroidInfoProviderForgeryFactory())
-        forge.addFactory(ConfigurationSessionReplayForgeryFactory())
+        forge.addFactory(SessionReplayConfigurationForgeryFactory())
         forge.addFactory(FeatureStorageConfigurationForgeryFactory())
 
         // IO

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/SessionReplayConfigurationForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/SessionReplayConfigurationForgeryFactory.kt
@@ -6,15 +6,15 @@
 
 package com.datadog.android.utils.forge
 
-import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.internal.SessionReplayConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-internal class ConfigurationSessionReplayForgeryFactory :
-    ForgeryFactory<Configuration.Feature.SessionReplay> {
-    override fun getForgery(forge: Forge): Configuration.Feature.SessionReplay {
-        return Configuration.Feature.SessionReplay(
+internal class SessionReplayConfigurationForgeryFactory :
+    ForgeryFactory<SessionReplayConfiguration> {
+    override fun getForgery(forge: Forge): SessionReplayConfiguration {
+        return SessionReplayConfiguration(
             endpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
             privacy = forge.aValueFrom(SessionReplayPrivacy::class.java)
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
@@ -97,16 +97,14 @@ internal class DatadogCoreInitializationTest {
         @BoolForgery logsEnabled: Boolean,
         @BoolForgery tracingEnabled: Boolean,
         @BoolForgery crashReportEnabled: Boolean,
-        @BoolForgery rumEnabled: Boolean,
-        @BoolForgery sessionReplayEnabled: Boolean
+        @BoolForgery rumEnabled: Boolean
     ) {
         // Given
         val configuration = Configuration.Builder(
             logsEnabled = logsEnabled,
             tracesEnabled = tracingEnabled,
             crashReportsEnabled = crashReportEnabled,
-            rumEnabled = rumEnabled,
-            sessionReplayEnabled = sessionReplayEnabled
+            rumEnabled = rumEnabled
         ).build()
 
         // When
@@ -163,8 +161,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = false,
             tracesEnabled = false,
             crashReportsEnabled = false,
-            rumEnabled = true,
-            sessionReplayEnabled = false
+            rumEnabled = true
         ).build()
 
         // When
@@ -190,8 +187,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = false,
             crashReportsEnabled = false,
-            rumEnabled = false,
-            sessionReplayEnabled = false
+            rumEnabled = false
         ).build()
 
         // When
@@ -223,8 +219,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         ).build()
 
         // Then
@@ -252,8 +247,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         ).build()
 
         // When
@@ -283,8 +277,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         ).build()
 
         // When
@@ -306,8 +299,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setUseDeveloperModeWhenDebuggable(true)
             .build()
@@ -331,8 +323,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setUseDeveloperModeWhenDebuggable(true)
             .build()
@@ -357,8 +348,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to source))
             .build()
@@ -380,8 +370,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to source))
             .build()
@@ -403,8 +392,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(mapOf(Datadog.DD_SOURCE_TAG to source))
             .build()
@@ -426,8 +414,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(customAttributes.nonNullData)
             .build()
@@ -449,8 +436,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion))
             .build()
@@ -472,8 +458,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(
                 mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion)
@@ -497,8 +482,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(mapOf(Datadog.DD_SDK_VERSION_TAG to sdkVersion))
             .build()
@@ -520,8 +504,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(customAttributes.nonNullData)
             .build()
@@ -543,8 +526,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(mapOf(Datadog.DD_APP_VERSION_TAG to appVersion))
             .build()
@@ -566,8 +548,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(
                 mapOf(Datadog.DD_APP_VERSION_TAG to forge.aWhitespaceString())
@@ -593,8 +574,7 @@ internal class DatadogCoreInitializationTest {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .setAdditionalConfiguration(mapOf(Datadog.DD_APP_VERSION_TAG to forge.anInt()))
             .build()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
@@ -22,7 +22,6 @@ import com.datadog.android.plugin.DatadogRumContext
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
-import com.datadog.android.sessionreplay.internal.SessionReplayFeature
 import com.datadog.android.tracing.internal.TracingFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.InternalLoggerTestConfiguration
@@ -469,21 +468,27 @@ internal class DatadogCoreTest {
         testedCore.webViewRumFeature = mockWebViewRumFeature
         val mockCrashReportsFeature = mock<CrashReportsFeature>()
         testedCore.crashReportsFeature = mockCrashReportsFeature
-        val mockSessionReplayFeature = mock<SessionReplayFeature>()
-        testedCore.sessionReplayFeature = mockSessionReplayFeature
+
+        val sdkFeatureMocks = listOf(
+            RumFeature.RUM_FEATURE_NAME,
+            TracingFeature.TRACING_FEATURE_NAME,
+            LogsFeature.LOGS_FEATURE_NAME,
+            WebViewLogsFeature.WEB_LOGS_FEATURE_NAME,
+            WebViewRumFeature.WEB_RUM_FEATURE_NAME
+        ).map {
+            it to mock<SdkFeature>()
+        }
+
+        sdkFeatureMocks.forEach { testedCore.features += it }
 
         // When
         testedCore.stop()
 
         // Then
         verify(mockCoreFeature).stop()
-        verify(mockRumFeature).stop()
-        verify(mockTracingFeature).stop()
-        verify(mockLogsFeature).stop()
-        verify(mockWebViewRumFeature).stop()
-        verify(mockWebViewLogsFeature).stop()
-        verify(mockCrashReportsFeature).stop()
-        verify(mockSessionReplayFeature).stop()
+        sdkFeatureMocks.forEach {
+            verify(it.second).stop()
+        }
 
         assertThat(testedCore.rumFeature).isNull()
         assertThat(testedCore.tracingFeature).isNull()
@@ -491,7 +496,6 @@ internal class DatadogCoreTest {
         assertThat(testedCore.webViewLogsFeature).isNull()
         assertThat(testedCore.webViewRumFeature).isNull()
         assertThat(testedCore.crashReportsFeature).isNull()
-        assertThat(testedCore.sessionReplayFeature).isNull()
         assertThat(testedCore.contextProvider).isNull()
 
         assertThat(testedCore.features).isEmpty()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeatureTest.kt
@@ -67,12 +67,12 @@ internal class WebViewLogsFeatureTest {
     }
 
     @Test
-    fun `𝕄 reset data writer 𝕎 stop()`() {
+    fun `𝕄 reset data writer 𝕎 onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, mock())
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         assertThat(testedFeature.dataWriter)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
@@ -88,12 +88,12 @@ internal class WebViewRumFeatureTest {
     }
 
     @Test
-    fun `𝕄 reset data writer 𝕎 stop()`() {
+    fun `𝕄 reset data writer 𝕎 onStop()`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, mock())
 
         // When
-        testedFeature.stop()
+        testedFeature.onStop()
 
         // Then
         assertThat(testedFeature.dataWriter).isInstanceOf(NoOpDataWriter::class.java)

--- a/instrumentation-tools/nightly_tests_code_coverage.py
+++ b/instrumentation-tools/nightly_tests_code_coverage.py
@@ -72,7 +72,8 @@ def fetch_already_covered_apis(tests_directory_path: str) -> set:
         Feature(f'{tests_directory_path}/{NIGHTLY_TESTS_PACKAGE}/rum'),
         Feature(f'{tests_directory_path}/{NIGHTLY_TESTS_PACKAGE}/trace'),
         Feature(f'{tests_directory_path}/{NIGHTLY_TESTS_PACKAGE}/webview'),
-        Feature(f'{tests_directory_path}/{NIGHTLY_TESTS_PACKAGE}/main')
+        Feature(f'{tests_directory_path}/{NIGHTLY_TESTS_PACKAGE}/main'),
+        Feature(f'{tests_directory_path}/{NIGHTLY_TESTS_PACKAGE}/crash'),
     ]
     for feature in features:
         covered_apis.update(feature.fetch_test_cases())

--- a/instrumentation-tools/src/constants.py
+++ b/instrumentation-tools/src/constants.py
@@ -11,5 +11,6 @@ IGNORED_TYPES = [
     "com.datadog.android.rum.model.ErrorEvent$Dd",
     "com.datadog.android.rum.model.LongTaskEvent$Dd",
     "com.datadog.android.telemetry.model.TelemetryDebugEvent$Dd",
-    "com.datadog.android.telemetry.model.TelemetryErrorEvent$Dd"
+    "com.datadog.android.telemetry.model.TelemetryErrorEvent$Dd",
+    "com.datadog.android.telemetry.model.TelemetryConfigurationEvent$Dd"
 ]

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -18,6 +18,8 @@ import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.security.Encryption
+import com.datadog.android.sessionreplay.internal.SessionReplayConfiguration
+import com.datadog.android.sessionreplay.internal.SessionReplayFeature
 import com.datadog.android.tracing.AndroidTracer
 import com.datadog.tools.unit.getStaticValue
 import com.datadog.tools.unit.setStaticValue
@@ -53,6 +55,9 @@ internal class EncryptionTest {
         val credentials = createCredentials()
 
         Datadog.initialize(targetContext, credentials, configuration, TrackingConsent.PENDING)
+
+        val sessionReplayConfig = SessionReplayConfiguration.Builder().build()
+        Datadog.registerFeature(SessionReplayFeature(sessionReplayConfig))
 
         val rumMonitor = RumMonitor.Builder().build()
         GlobalRum.registerIfAbsent(rumMonitor)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -141,8 +141,7 @@ internal class EncryptionTest {
                 logsEnabled = true,
                 tracesEnabled = true,
                 crashReportsEnabled = true,
-                rumEnabled = true,
-                sessionReplayEnabled = true
+                rumEnabled = true
             )
             .setEncryption(encryption)
             .build()

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
@@ -11,6 +11,7 @@ import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.log.Logger
+import com.datadog.android.sessionreplay.internal.SessionReplayConfiguration
 import com.datadog.android.tracing.AndroidTracer
 import java.util.UUID
 
@@ -71,8 +72,12 @@ internal object RuntimeConfig {
             .useCustomLogsEndpoint(logsEndpointUrl)
             .useCustomRumEndpoint(rumEndpointUrl)
             .useCustomTracesEndpoint(tracesEndpointUrl)
-            .useCustomSessionReplayEndpoint(sessionReplayEndpointUrl)
             .setUploadFrequency(UploadFrequency.FREQUENT)
+    }
+
+    fun sessionReplayConfigBuilder(): SessionReplayConfiguration.Builder {
+        return SessionReplayConfiguration.Builder()
+            .useCustomEndpoint(sessionReplayEndpointUrl)
     }
 
     val keyValuePairsTags = mapOf(

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
@@ -66,8 +66,7 @@ internal object RuntimeConfig {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .useCustomLogsEndpoint(logsEndpointUrl)
             .useCustomRumEndpoint(rumEndpointUrl)

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash/NdkCrashHandlerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash/NdkCrashHandlerE2ETests.kt
@@ -85,8 +85,7 @@ class NdkCrashHandlerE2ETests {
                     logsEnabled = true,
                     tracesEnabled = true,
                     crashReportsEnabled = true,
-                    rumEnabled = true,
-                    sessionReplayEnabled = true
+                    rumEnabled = true
                 )
                 .setEncryption(NeverUseThatEncryption())
                 .build()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
@@ -194,8 +194,7 @@ class LogsConfigE2ETests {
                         logsEnabled = true,
                         tracesEnabled = true,
                         rumEnabled = true,
-                        crashReportsEnabled = true,
-                        sessionReplayEnabled = true
+                        crashReportsEnabled = true
                     )
                     .setEncryption(TestEncryption())
                     .build()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -24,6 +24,9 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useCustomTracesEndpoint(String): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun addPlugin(com.datadog.android.plugin.DatadogPlugin, com.datadog.android.plugin.Feature): Builder
+ * apiMethodSignature: com.datadog.android.sessionreplay.internal.SessionReplayConfiguration$Builder#fun setPrivacy(com.datadog.android.sessionreplay.SessionReplayPrivacy): Builder
+ * apiMethodSignature: com.datadog.android.sessionreplay.internal.SessionReplayConfiguration$Builder#fun useCustomEndpoint(String): Builder
+ * apiMethodSignature: com.datadog.android.sessionreplay.internal.SessionReplayConfiguration$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
  * apiMethodSignature: com.datadog.android.rum.RumMonitor$Builder#fun setSessionListener(RumSessionListener): Builder
  * apiMethodSignature: com.datadog.android.log.Logger#fun log(Int, String, Throwable? = null, Map<String, Any?> = emptyMap())
  * apiMethodSignature: com.datadog.android.plugin.DatadogPluginConfig#constructor(android.content.Context, String, String, com.datadog.android.privacy.TrackingConsent)

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
@@ -302,8 +302,7 @@ class RumConfigE2ETests {
                     logsEnabled = true,
                     tracesEnabled = true,
                     rumEnabled = true,
-                    crashReportsEnabled = true,
-                    sessionReplayEnabled = true
+                    crashReportsEnabled = true
                 ).setRumActionEventMapper(
                     eventMapper = object : EventMapper<ActionEvent> {
                         override fun map(event: ActionEvent): ActionEvent? {
@@ -662,8 +661,7 @@ class RumConfigE2ETests {
                         logsEnabled = true,
                         tracesEnabled = true,
                         rumEnabled = true,
-                        crashReportsEnabled = true,
-                        sessionReplayEnabled = true
+                        crashReportsEnabled = true
                     )
                     .setEncryption(TestEncryption())
                     .build()
@@ -700,8 +698,7 @@ class RumConfigE2ETests {
                         logsEnabled = true,
                         tracesEnabled = true,
                         rumEnabled = true,
-                        crashReportsEnabled = true,
-                        sessionReplayEnabled = true
+                        crashReportsEnabled = true
                     )
                     .useViewTrackingStrategy(strategy)
                     .setVitalsUpdateFrequency(VitalsUpdateFrequency.NEVER)
@@ -754,8 +751,7 @@ class RumConfigE2ETests {
                         logsEnabled = true,
                         tracesEnabled = true,
                         rumEnabled = true,
-                        crashReportsEnabled = true,
-                        sessionReplayEnabled = true
+                        crashReportsEnabled = true
                     )
                     .useViewTrackingStrategy(strategy)
                     .setVitalsUpdateFrequency(fakeFrequency)

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
@@ -363,8 +363,7 @@ class SpanConfigE2ETests {
                         logsEnabled = true,
                         tracesEnabled = true,
                         rumEnabled = true,
-                        crashReportsEnabled = true,
-                        sessionReplayEnabled = true
+                        crashReportsEnabled = true
                     )
                     .setEncryption(TestEncryption())
                     .build()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -113,15 +113,13 @@ fun defaultConfigurationBuilder(
     logsEnabled: Boolean = true,
     tracesEnabled: Boolean = true,
     crashReportsEnabled: Boolean = true,
-    rumEnabled: Boolean = true,
-    sessionReplayEnabled: Boolean = true
+    rumEnabled: Boolean = true
 ): Configuration.Builder {
     val configBuilder = Configuration.Builder(
         logsEnabled,
         tracesEnabled,
         crashReportsEnabled,
-        rumEnabled,
-        sessionReplayEnabled
+        rumEnabled
     )
     return configBuilder
         .sampleTelemetry(100f)

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/JvmCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/JvmCrashService.kt
@@ -66,8 +66,7 @@ internal open class JvmCrashService : CrashService() {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = crashReportsEnabled,
-            rumEnabled = rumEnabled,
-            sessionReplayEnabled = true
+            rumEnabled = rumEnabled
         ).sampleTelemetry(HUNDRED_PERCENT)
         Datadog.initialize(
             this,

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/NdkCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/NdkCrashService.kt
@@ -73,8 +73,7 @@ internal open class NdkCrashService : CrashService() {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = rumEnabled,
-            sessionReplayEnabled = true
+            rumEnabled = rumEnabled
         ).sampleTelemetry(HUNDRED_PERCENT)
         if (ndkCrashReportsEnabled) {
             @Suppress("DEPRECATION")

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -36,6 +36,8 @@ import com.datadog.android.sample.picture.CoilImageLoader
 import com.datadog.android.sample.picture.FrescoImageLoader
 import com.datadog.android.sample.picture.PicassoImageLoader
 import com.datadog.android.sample.user.UserFragment
+import com.datadog.android.sessionreplay.internal.SessionReplayConfiguration
+import com.datadog.android.sessionreplay.internal.SessionReplayFeature
 import com.datadog.android.timber.DatadogTree
 import com.datadog.android.tracing.AndroidTracer
 import com.datadog.android.tracing.TracingInterceptor
@@ -113,6 +115,15 @@ class SampleApplication : Application() {
             preferences.getTrackingConsent()
         )
         Datadog.setVerbosity(Log.VERBOSE)
+
+        val sessionReplayConfig = SessionReplayConfiguration.Builder().apply {
+            if (BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL.isNotBlank()) {
+                useCustomEndpoint(BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL)
+            }
+        }.build()
+        val sessionReplayFeature = SessionReplayFeature(sessionReplayConfig)
+        Datadog.registerFeature(sessionReplayFeature)
+
         Datadog.enableRumDebugging(true)
         setUserInfo(
             preferences.getUserId(),
@@ -211,9 +222,6 @@ class SampleApplication : Application() {
         }
         if (BuildConfig.DD_OVERRIDE_RUM_URL.isNotBlank()) {
             configBuilder.useCustomRumEndpoint(BuildConfig.DD_OVERRIDE_RUM_URL)
-        }
-        if (BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL.isNotBlank()) {
-            configBuilder.useCustomSessionReplayEndpoint(BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL)
         }
         return configBuilder.build()
     }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -148,8 +148,7 @@ class SampleApplication : Application() {
             logsEnabled = true,
             tracesEnabled = true,
             crashReportsEnabled = true,
-            rumEnabled = true,
-            sessionReplayEnabled = true
+            rumEnabled = true
         )
             .sampleTelemetry(100f)
             .setFirstPartyHosts(tracedHosts)


### PR DESCRIPTION
### What does this PR do?

This change creates `SessionReplayConfiguration` class with the method to configure Session Replay feature (because extracted from `Configuration.Feature.SessionReplay`) and also makes the necessary changes to use `SdkCore#registerFeature` to dynamically add configured Session Replay feature to the SDK.

Main points:

* `SessionReplayConfiguration` is used instead of just `Configuration`, because the assumption is that in SDK v2 user may add several features, and if we simply use `Configuration` for each of them (even though each class will be in the different module/package), this will introduce the clash during the import.
* Currently the public Session Replay classes are in the internal `com.datadog.android.sessionreplay.internal` package, this will be solved with the next PR where Session Replay code completely moves to its own module (I didn't want to make a big diff here).
* I tried to split the changes here in 3 commits, so that it is easier to review and each commit allows the build.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

