### PR TITLE
Cherry-pick: RUMM-2903 detect device's refresh rate from vital monitor

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -97,6 +97,8 @@ internal class RumFeature(
     fun initialize(context: Context, configuration: Configuration.Feature.RUM) {
         dataWriter = createDataWriter(configuration)
 
+        appContext = context.applicationContext
+
         samplingRate = configuration.samplingRate
         telemetrySamplingRate = configuration.telemetrySamplingRate
         backgroundEventTracking = configuration.backgroundEventTracking
@@ -112,8 +114,6 @@ internal class RumFeature(
         initializeANRDetector()
 
         registerTrackingStrategies(context)
-
-        appContext = context.applicationContext
 
         sdkCore.setEventReceiver(RUM_FEATURE_NAME, this)
 
@@ -235,7 +235,9 @@ internal class RumFeature(
         initializeVitalMonitor(CPUVitalReader(), cpuVitalMonitor, periodInMs)
         initializeVitalMonitor(MemoryVitalReader(), memoryVitalMonitor, periodInMs)
 
-        val vitalFrameCallback = VitalFrameCallback(frameRateVitalMonitor) { initialized.get() }
+        val vitalFrameCallback = VitalFrameCallback(appContext, frameRateVitalMonitor) {
+            initialized.get()
+        }
         try {
             Choreographer.getInstance().postFrameCallback(vitalFrameCallback)
         } catch (e: IllegalStateException) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/vitals/VitalFrameCallback.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/vitals/VitalFrameCallback.kt
@@ -6,7 +6,9 @@
 
 package com.datadog.android.rum.internal.vitals
 
+import android.content.Context
 import android.view.Choreographer
+import android.view.WindowManager
 import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.v2.api.InternalLogger
 import java.util.concurrent.TimeUnit
@@ -15,6 +17,7 @@ import java.util.concurrent.TimeUnit
  * Reads the UI framerate based on the [Choreographer.FrameCallback] and notify a [VitalObserver].
  */
 internal class VitalFrameCallback(
+    private val appContext: Context,
     private val observer: VitalObserver,
     private val keepRunning: () -> Boolean
 ) : Choreographer.FrameCallback {
@@ -27,7 +30,9 @@ internal class VitalFrameCallback(
         if (lastFrameTimestampNs != 0L) {
             val durationNs = (frameTimeNanos - lastFrameTimestampNs).toDouble()
             if (durationNs > 0.0) {
-                val frameRate = ONE_SECOND_NS / durationNs
+                val refreshRateScale = detectRefreshRateScale()
+                val rawFps = ONE_SECOND_NS / durationNs
+                val frameRate = rawFps * refreshRateScale
                 if (frameRate in VALID_FPS_RANGE) {
                     observer.onNewSample(frameRate)
                 }
@@ -50,13 +55,35 @@ internal class VitalFrameCallback(
         }
     }
 
+    @Suppress("DEPRECATION")
+    private fun detectRefreshRateScale(): Double {
+        val windowManager = appContext.getSystemService(Context.WINDOW_SERVICE) as? WindowManager
+        return if (windowManager == null) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                "WindowManager is null, can't detect max refresh rate!"
+            )
+            1.0
+        } else if (windowManager.defaultDisplay == null) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.MAINTAINER,
+                "Display is null, can't detect max refresh rate!"
+            )
+            1.0
+        } else {
+            STANDARD_FPS / windowManager.defaultDisplay.refreshRate
+        }
+    }
+
     // endregion
 
     companion object {
         val ONE_SECOND_NS: Double = TimeUnit.SECONDS.toNanos(1).toDouble()
 
         private const val MIN_FPS: Double = 1.0
-        private const val MAX_FPS: Double = 240.0
-        val VALID_FPS_RANGE = MIN_FPS.rangeTo(MAX_FPS)
+        private const val STANDARD_FPS: Double = 60.0
+        val VALID_FPS_RANGE = MIN_FPS.rangeTo(STANDARD_FPS)
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactory.kt
@@ -39,6 +39,7 @@ internal class SessionReplayRequestFactory(
     ): Request {
         val serializedSegmentPair = batchToSegmentsMapper.map(batchData)
         if (serializedSegmentPair == null) {
+            @Suppress("ThrowingInternalException")
             throw InvalidPayloadFormatException(
                 "The payload format was broken and an upload" +
                     " request could not be created"


### PR DESCRIPTION
### What does this PR do?

Cherry-pick fix made in https://github.com/DataDog/dd-sdk-android/pull/1251 into the 1.17.0 release.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

