### PR TITLE
RUMM-2927: Logs feature configuration is extracted into dedicated class

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/log/internal/net/LogsRequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/log/internal/net/LogsRequestFactory.kt
@@ -14,7 +14,7 @@ import java.util.Locale
 import java.util.UUID
 
 internal class LogsRequestFactory(
-    private val endpointUrl: String
+    internal val endpointUrl: String
 ) : RequestFactory {
 
     override fun create(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureBuilderTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.log.internal
+
+import com.datadog.android.DatadogEndpoint
+import com.datadog.android.DatadogSite
+import com.datadog.android.core.internal.event.NoOpEventMapper
+import com.datadog.android.event.EventMapper
+import com.datadog.android.log.model.LogEvent
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.log.internal.net.LogsRequestFactory
+import com.nhaarman.mockitokotlin2.mock
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@ForgeConfiguration(Configurator::class)
+internal class LogsFeatureBuilderTest {
+
+    private val testedBuilder: LogsFeature.Builder = LogsFeature.Builder()
+
+    @Test
+    fun `𝕄 use sensible defaults 𝕎 build()`() {
+        // When
+        val config = testedBuilder.build()
+
+        // Then
+        val requestFactory = config.requestFactory
+        assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
+        assertThat((requestFactory as LogsRequestFactory).endpointUrl)
+            .isEqualTo(DatadogEndpoint.LOGS_US1)
+
+        assertThat(config.eventMapper).isInstanceOf(NoOpEventMapper::class.java)
+    }
+
+    @Test
+    fun `𝕄 build feature with custom site 𝕎 useSite() and build()`(
+        @Forgery site: DatadogSite
+    ) {
+        // When
+        val config = testedBuilder.useSite(site).build()
+
+        // Then
+        val requestFactory = config.requestFactory
+        assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
+        assertThat((requestFactory as LogsRequestFactory).endpointUrl)
+            .isEqualTo(site.logsEndpoint())
+    }
+
+    @Test
+    fun `𝕄 build feature with custom site 𝕎 useCustomEndpoint() and build()`(
+        @StringForgery(regex = "https://[a-z]+\\.com") logsEndpointUrl: String
+    ) {
+        // When
+        val config = testedBuilder.useCustomEndpoint(logsEndpointUrl).build()
+
+        // Then
+        val requestFactory = config.requestFactory
+        assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
+        assertThat((requestFactory as LogsRequestFactory).endpointUrl)
+            .isEqualTo(logsEndpointUrl)
+    }
+
+    @Test
+    fun `𝕄 build feature with Log eventMapper 𝕎 setLogEventMapper() and build()`() {
+        // Given
+        val mockEventMapper: EventMapper<LogEvent> = mock()
+
+        // When
+        val config = testedBuilder
+            .setLogEventMapper(mockEventMapper)
+            .build()
+
+        // Then
+        assertThat(config.eventMapper).isEqualTo(mockEventMapper)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This change creates `LogsFeature.Builder` class which allow to make a configuration of the `LogsFeature` to be created. It will replace `Configuration.Feature.Logs` usage (in the next PRs).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

