### PR TITLE
RUMM-2998 Add view to multiple wireframes mapper capability

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/NodeFlattener.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/NodeFlattener.kt
@@ -19,11 +19,12 @@ internal class NodeFlattener(private val wireframeUtils: WireframeUtils = Wirefr
         stack.push(root)
         while (stack.isNotEmpty()) {
             val node = stack.pop()
-            var wireframe = node.wireframe
-            wireframeUtils.resolveWireframeClip(wireframe, node.parents)?.let { clip ->
-                wireframe = wireframe.copy(clip = clip)
-            }
-            list.add(wireframe)
+            node.wireframes
+                .map { wireframe ->
+                    val clip = wireframeUtils.resolveWireframeClip(wireframe, node.parents)
+                    wireframe.copy(clip = clip)
+                }
+                .forEach { list.add(it) }
 
             for (i in node.children.count() - 1 downTo 0) {
                 stack.push(node.children[i])

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/Node.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/Node.kt
@@ -9,7 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 import com.datadog.android.sessionreplay.model.MobileSegment
 
 internal data class Node(
-    val wireframe: MobileSegment.Wireframe,
+    val wireframes: List<MobileSegment.Wireframe>,
     val children: List<Node> = emptyList(),
     val parents: List<MobileSegment.Wireframe> = emptyList()
 )

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -51,14 +51,14 @@ internal class SnapshotProducer(
             // It is too complex to de - structure this in multiple wireframes
             // and we cannot actually get all the details here.
             return Node(
-                wireframe = wireframeMapper.imageMapper.map(view, pixelsDensity)
+                wireframes = wireframeMapper.imageMapper.map(view, pixelsDensity)
             )
         }
 
         val childNodes = LinkedList<Node>()
-        val wireframe = wireframeMapper.map(view, pixelsDensity)
+        val wireframes = wireframeMapper.map(view, pixelsDensity)
         if (view is ViewGroup && view.childCount > 0) {
-            val parentsCopy = LinkedList(parents).apply { add(wireframe) }
+            val parentsCopy = LinkedList(parents).apply { addAll(wireframes) }
             for (i in 0 until view.childCount) {
                 val viewChild = view.getChildAt(i) ?: continue
                 convertViewToNode(viewChild, pixelsDensity, parentsCopy)?.let {
@@ -69,13 +69,13 @@ internal class SnapshotProducer(
 
         return Node(
             children = childNodes,
-            wireframe = wireframe,
+            wireframes = wireframes,
             parents = parents
         )
     }
 
     private fun resolveRootBackgroundFromTheme(theme: Theme, rootView: View, snapshot: Node): Node {
-        val rootShapeStyle = snapshot.wireframe.shapeStyle()
+        val rootShapeStyle = snapshot.wireframes.map { it.shapeStyle() }.firstOrNull { it != null }
         // we add a shapeStyle based on the Theme color in case the
         // root wireframe does not have a ShapeStyle
         if (rootShapeStyle == null) {
@@ -88,7 +88,10 @@ internal class SnapshotProducer(
                     backgroundColor = colorAndAlphaAsHexa,
                     opacity = rootView.alpha
                 )
-                return snapshot.copy(wireframe = snapshot.wireframe.copy(shapeStyle = shapeStyle))
+                return snapshot.copy(
+                    wireframes = snapshot.wireframes
+                        .map { wireframe -> wireframe.copy(shapeStyle = shapeStyle) }
+                )
             }
         }
         return snapshot

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonWireframeMapper.kt
@@ -13,7 +13,8 @@ internal class ButtonWireframeMapper(
     private val textWireframeMapper: TextWireframeMapper = TextWireframeMapper()
 ) :
     WireframeMapper<Button, MobileSegment.Wireframe.TextWireframe> {
-    override fun map(view: Button, pixelsDensity: Float): MobileSegment.Wireframe.TextWireframe {
+    override fun map(view: Button, pixelsDensity: Float):
+        List<MobileSegment.Wireframe.TextWireframe> {
         return textWireframeMapper.map(view, pixelsDensity)
     }
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/GenericWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/GenericWireframeMapper.kt
@@ -19,7 +19,7 @@ internal abstract class GenericWireframeMapper(
     private val buttonMapper: ButtonWireframeMapper
 ) : WireframeMapper<View, MobileSegment.Wireframe> {
 
-    override fun map(view: View, pixelsDensity: Float): MobileSegment.Wireframe {
+    override fun map(view: View, pixelsDensity: Float): List<MobileSegment.Wireframe> {
         return when {
             Button::class.java.isAssignableFrom(view::class.java) -> {
                 buttonMapper.map(view as Button, pixelsDensity)

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextWireframeMapper.kt
@@ -16,20 +16,23 @@ internal open class TextWireframeMapper(
     private val viewWireframeMapper: ViewWireframeMapper = ViewWireframeMapper()
 ) : BaseWireframeMapper<TextView, MobileSegment.Wireframe.TextWireframe>() {
 
-    override fun map(view: TextView, pixelsDensity: Float): MobileSegment.Wireframe.TextWireframe {
-        val shapeWireframe = viewWireframeMapper.map(view, pixelsDensity)
-        return MobileSegment.Wireframe.TextWireframe(
-            shapeWireframe.id,
-            shapeWireframe.x,
-            shapeWireframe.y,
-            shapeWireframe.width,
-            shapeWireframe.height,
-            shapeStyle = shapeWireframe.shapeStyle,
-            border = shapeWireframe.border,
-            text = resolveTextValue(view),
-            textStyle = resolveTextStyle(view, pixelsDensity),
-            textPosition = resolveTextPosition(view, pixelsDensity)
-        )
+    override fun map(view: TextView, pixelsDensity: Float):
+        List<MobileSegment.Wireframe.TextWireframe> {
+        val shapeWireframes = viewWireframeMapper.map(view, pixelsDensity)
+        return shapeWireframes.map { shapeWireframe ->
+            MobileSegment.Wireframe.TextWireframe(
+                shapeWireframe.id,
+                shapeWireframe.x,
+                shapeWireframe.y,
+                shapeWireframe.width,
+                shapeWireframe.height,
+                shapeStyle = shapeWireframe.shapeStyle,
+                border = shapeWireframe.border,
+                text = resolveTextValue(view),
+                textStyle = resolveTextStyle(view, pixelsDensity),
+                textPosition = resolveTextPosition(view, pixelsDensity)
+            )
+        }
     }
 
     protected open fun resolveTextValue(textView: TextView): String {

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewScreenshotWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewScreenshotWireframeMapper.kt
@@ -16,8 +16,9 @@ internal class ViewScreenshotWireframeMapper(
 ) : BaseWireframeMapper<View, MobileSegment.Wireframe.ShapeWireframe>() {
 
     override fun map(view: View, pixelsDensity: Float):
-        MobileSegment.Wireframe.ShapeWireframe {
-        return viewWireframeMapper.map(view, pixelsDensity)
-            .copy(border = MobileSegment.ShapeBorder("#000000ff", 1))
+        List<MobileSegment.Wireframe.ShapeWireframe> {
+        return viewWireframeMapper.map(view, pixelsDensity).map {
+            it.copy(border = MobileSegment.ShapeBorder("#000000ff", 1))
+        }
     }
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapper.kt
@@ -18,7 +18,7 @@ import com.datadog.android.sessionreplay.model.MobileSegment
 internal class ViewWireframeMapper :
     BaseWireframeMapper<View, MobileSegment.Wireframe.ShapeWireframe>() {
 
-    override fun map(view: View, pixelsDensity: Float): MobileSegment.Wireframe.ShapeWireframe {
+    override fun map(view: View, pixelsDensity: Float): List<MobileSegment.Wireframe.ShapeWireframe> {
         val scaledHeight = view.height.densityNormalized(pixelsDensity).toLong()
         val scaledWidth = view.width.densityNormalized(pixelsDensity).toLong()
         val coordinates = IntArray(2)
@@ -28,14 +28,16 @@ internal class ViewWireframeMapper :
         val x = coordinates[0].densityNormalized(pixelsDensity).toLong()
         val y = coordinates[1].densityNormalized(pixelsDensity).toLong()
         val styleBorderPair = view.background?.resolveShapeStyleAndBorder(view.alpha)
-        return MobileSegment.Wireframe.ShapeWireframe(
-            resolveViewId(view),
-            x,
-            y,
-            scaledWidth,
-            scaledHeight,
-            shapeStyle = styleBorderPair?.first,
-            border = styleBorderPair?.second
+        return listOf(
+            MobileSegment.Wireframe.ShapeWireframe(
+                resolveViewId(view),
+                x,
+                y,
+                scaledWidth,
+                scaledHeight,
+                shapeStyle = styleBorderPair?.first,
+                border = styleBorderPair?.second
+            )
         )
     }
 

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper.kt
@@ -10,5 +10,5 @@ import android.view.View
 import com.datadog.android.sessionreplay.model.MobileSegment
 
 internal interface WireframeMapper<T : View, S : MobileSegment.Wireframe> {
-    fun map(view: T, pixelsDensity: Float): S
+    fun map(view: T, pixelsDensity: Float): List<S>
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/NodeForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/NodeForgeryFactory.kt
@@ -14,10 +14,10 @@ internal class NodeForgeryFactory : ForgeryFactory<Node> {
 
     override fun getForgery(forge: Forge): Node {
         return Node(
-            wireframe = forge.getForgery(),
+            wireframes = forge.aList { getForgery() },
             children = forge.aList {
                 Node(
-                    wireframe = getForgery(),
+                    wireframes = forge.aList { getForgery() },
                     parents = aList { getForgery() }
                 )
             },

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessorTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessorTest.kt
@@ -299,7 +299,7 @@ internal class RecordedDataProcessorTest {
             fakeRootWidth,
             fakeRootHeight
         )
-        val fakeSnapshots = listOf(Node(wireframe = rootWireframe))
+        val fakeSnapshots = listOf(Node(wireframes = listOf(rootWireframe)))
         whenever(mockNodeFlattener.flattenNode(fakeSnapshots[0])).thenReturn(listOf(rootWireframe))
 
         // When
@@ -324,13 +324,14 @@ internal class RecordedDataProcessorTest {
         val fakeRootHeight = forge.aLong(min = 700)
         val fakeSnapshots = listOf(
             Node(
-                wireframe =
-                MobileSegment.Wireframe.ShapeWireframe(
-                    0,
-                    0,
-                    0,
-                    fakeRootWidth,
-                    fakeRootHeight
+                wireframes = listOf(
+                    MobileSegment.Wireframe.ShapeWireframe(
+                        0,
+                        0,
+                        0,
+                        fakeRootWidth,
+                        fakeRootHeight
+                    )
                 )
             )
         )
@@ -408,7 +409,7 @@ internal class RecordedDataProcessorTest {
             fakeRootWidth,
             fakeRootHeight
         )
-        val fakeSnapshot3 = listOf(Node(rootWireframe))
+        val fakeSnapshot3 = listOf(Node(wireframes = listOf(rootWireframe)))
         whenever(mockNodeFlattener.flattenNode(fakeSnapshot3[0])).thenReturn(listOf(rootWireframe))
 
         testedProcessor.processScreenSnapshots(fakeSnapshot1)
@@ -824,12 +825,14 @@ internal class RecordedDataProcessorTest {
 
     private fun Forge.aSingleLevelSnapshot(): Node {
         return Node(
-            MobileSegment.Wireframe.ShapeWireframe(
-                aLong(min = 0),
-                aLong(min = 0),
-                aLong(min = 0),
-                aLong(min = 0),
-                aLong(min = 0)
+            wireframes = listOf(
+                MobileSegment.Wireframe.ShapeWireframe(
+                    aLong(min = 0),
+                    aLong(min = 0),
+                    aLong(min = 0),
+                    aLong(min = 0),
+                    aLong(min = 0)
+                )
             )
         )
     }
@@ -844,7 +847,7 @@ internal class RecordedDataProcessorTest {
 
         @JvmStatic
         fun processorArguments(): List<Any> {
-            val fakeSnapshots = FORGE.aList { Node(wireframe = FORGE.getForgery()) }
+            val fakeSnapshots = FORGE.aList { Node(wireframes = FORGE.aList { FORGE.getForgery() }) }
             val fakeTouchRecords = FORGE.aList {
                 FORGE.getForgery<MobileSegment.MobileRecord.MobileIncrementalSnapshotRecord>()
             }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AllowAllWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AllowAllWireframeMapperTest.kt
@@ -73,13 +73,13 @@ internal class AllowAllWireframeMapperTest {
         // Given
         val mockView: View = mock()
         whenever(mockViewWireframeMapper.map(mockView, fakePixelDensity))
-            .thenReturn(mockShapeWireframe)
+            .thenReturn(listOf(mockShapeWireframe))
 
         // When
-        val wireframe = testedAllowAllWireframeMapper.map(mockView, fakePixelDensity)
+        val wireframes = testedAllowAllWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        assertThat(wireframe).isEqualTo(mockShapeWireframe)
+        assertThat(wireframes).isEqualTo(listOf(mockShapeWireframe))
     }
 
     @Test
@@ -87,13 +87,13 @@ internal class AllowAllWireframeMapperTest {
         // Given
         val mockView: ImageView = mock()
         whenever(mockImageWireframeMapper.map(mockView, fakePixelDensity))
-            .thenReturn(mockImageWireframe)
+            .thenReturn(listOf(mockImageWireframe))
 
         // When
-        val wireframe = testedAllowAllWireframeMapper.map(mockView, fakePixelDensity)
+        val wireframes = testedAllowAllWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        assertThat(wireframe).isEqualTo(mockImageWireframe)
+        assertThat(wireframes).isEqualTo(listOf(mockImageWireframe))
     }
 
     @Test
@@ -101,13 +101,13 @@ internal class AllowAllWireframeMapperTest {
         // Given
         val mockView: TextView = mock()
         whenever(mockTextWireframeMapper.map(mockView, fakePixelDensity))
-            .thenReturn(mockTextWireframe)
+            .thenReturn(listOf(mockTextWireframe))
 
         // When
-        val wireframe = testedAllowAllWireframeMapper.map(mockView, fakePixelDensity)
+        val wireframes = testedAllowAllWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        assertThat(wireframe).isEqualTo(mockTextWireframe)
+        assertThat(wireframes).isEqualTo(listOf(mockTextWireframe))
     }
 
     @Test
@@ -115,13 +115,13 @@ internal class AllowAllWireframeMapperTest {
         // Given
         val mockView: Button = mock()
         whenever(mockButtonWireframeMapper.map(mockView, fakePixelDensity))
-            .thenReturn(mockButtonWireframe)
+            .thenReturn(listOf(mockButtonWireframe))
 
         // When
-        val wireframe = testedAllowAllWireframeMapper.map(mockView, fakePixelDensity)
+        val wireframes = testedAllowAllWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        assertThat(wireframe).isEqualTo(mockButtonWireframe)
+        assertThat(wireframes).isEqualTo(listOf(mockButtonWireframe))
     }
 
     @Test

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseTextViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseTextViewWireframeMapperTest.kt
@@ -61,18 +61,19 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
         }
 
         // When
-        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockTextView.toTextWireframe()
-            .copy(
+        val expectedWireframes = mockTextView.toTextWireframes().map {
+            it.copy(
                 textStyle = MobileSegment.TextStyle(
                     expectedFontFamily,
                     fakeFontSize.toLong().densityNormalized(fakePixelDensity),
                     fakeStyleColor
                 )
             )
-        assertThat(textWireframe).isEqualTo(expectedWireframe)
+        }
+        assertThat(textWireframes).isEqualTo(expectedWireframes)
     }
 
     @ParameterizedTest
@@ -90,17 +91,18 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
         }
 
         // When
-        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockTextView.toTextWireframe().copy(
-            textPosition = MobileSegment
-                .TextPosition(
+        val expectedWireframes = mockTextView.toTextWireframes().map {
+            it.copy(
+                textPosition = MobileSegment.TextPosition(
                     padding = MobileSegment.Padding(0, 0, 0, 0),
                     alignment = expectedTextAlignment
                 )
-        )
-        assertThat(textWireframe).isEqualTo(expectedWireframe)
+            )
+        }
+        assertThat(textWireframes).isEqualTo(expectedWireframes)
     }
 
     @ParameterizedTest
@@ -119,17 +121,18 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
         }
 
         // When
-        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockTextView.toTextWireframe().copy(
-            textPosition = MobileSegment
-                .TextPosition(
+        val expectedWireframes = mockTextView.toTextWireframes().map {
+            it.copy(
+                textPosition = MobileSegment.TextPosition(
                     padding = MobileSegment.Padding(0, 0, 0, 0),
                     alignment = expectedTextAlignment
                 )
-        )
-        assertThat(textWireframe).isEqualTo(expectedWireframe)
+            )
+        }
+        assertThat(textWireframes).isEqualTo(expectedWireframes)
     }
 
     @Test
@@ -155,20 +158,22 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
         )
 
         // When
-        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockTextView.toTextWireframe().copy(
-            textPosition = MobileSegment.TextPosition(
-                padding = expectedWireframeTextPadding,
-                alignment = MobileSegment.Alignment(
-                    MobileSegment.Horizontal.LEFT,
-                    MobileSegment.Vertical
-                        .CENTER
+        val expectedWireframes = mockTextView.toTextWireframes().map {
+            it.copy(
+                textPosition = MobileSegment.TextPosition(
+                    padding = expectedWireframeTextPadding,
+                    alignment = MobileSegment.Alignment(
+                        MobileSegment.Horizontal.LEFT,
+                        MobileSegment.Vertical
+                            .CENTER
+                    )
                 )
             )
-        )
-        assertThat(textWireframe).isEqualTo(expectedWireframe)
+        }
+        assertThat(textWireframes).isEqualTo(expectedWireframes)
     }
 
     @Test
@@ -200,17 +205,18 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
         }
 
         // When
-        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockTextView.toTextWireframe().copy(
-            shapeStyle = MobileSegment
-                .ShapeStyle(
+        val expectedWireframes = mockTextView.toTextWireframes().map {
+            it.copy(
+                shapeStyle = MobileSegment.ShapeStyle(
                     backgroundColor = fakeStyleColor,
                     opacity = fakeViewAlpha,
                     cornerRadius = null
                 )
-        )
-        assertThat(textWireframe).isEqualTo(expectedWireframe)
+            )
+        }
+        assertThat(textWireframes).isEqualTo(expectedWireframes)
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapperTest.kt
@@ -24,44 +24,48 @@ internal abstract class BaseWireframeMapperTest {
     @FloatForgery(min = 1f, max = 10f)
     var fakePixelDensity: Float = 1f
 
-    protected fun View.toShapeWireframe(): MobileSegment.Wireframe.ShapeWireframe {
+    protected fun View.toShapeWireframes(): List<MobileSegment.Wireframe.ShapeWireframe> {
         val coordinates = IntArray(2)
         this.getLocationOnScreen(coordinates)
         val x = coordinates[0].densityNormalized(fakePixelDensity).toLong()
         val y = coordinates[1].densityNormalized(fakePixelDensity).toLong()
-        return MobileSegment.Wireframe.ShapeWireframe(
-            System.identityHashCode(this).toLong(),
-            x = x,
-            y = y,
-            width = width.toLong().densityNormalized(fakePixelDensity),
-            height = height.toLong().densityNormalized(fakePixelDensity)
+        return listOf(
+            MobileSegment.Wireframe.ShapeWireframe(
+                System.identityHashCode(this).toLong(),
+                x = x,
+                y = y,
+                width = width.toLong().densityNormalized(fakePixelDensity),
+                height = height.toLong().densityNormalized(fakePixelDensity)
+            )
         )
     }
 
-    protected fun TextView.toTextWireframe(): MobileSegment.Wireframe.TextWireframe {
+    protected fun TextView.toTextWireframes(): List<MobileSegment.Wireframe.TextWireframe> {
         val coordinates = IntArray(2)
         this.getLocationOnScreen(coordinates)
         val x = coordinates[0].densityNormalized(fakePixelDensity).toLong()
         val y = coordinates[1].densityNormalized(fakePixelDensity).toLong()
-        return MobileSegment.Wireframe.TextWireframe(
-            System.identityHashCode(this).toLong(),
-            x = x,
-            y = y,
-            text = resolveTextValue(this),
-            width = width.toLong().densityNormalized(fakePixelDensity),
-            height = height.toLong().densityNormalized(fakePixelDensity),
-            textStyle = MobileSegment.TextStyle(
-                "sans-serif",
-                0,
-                "#000000ff"
-            ),
-            textPosition = MobileSegment.TextPosition(
-                MobileSegment.Padding(0, 0, 0, 0),
-                alignment =
-                MobileSegment.Alignment(
-                    MobileSegment.Horizontal.LEFT,
-                    MobileSegment.Vertical
-                        .CENTER
+        return listOf(
+            MobileSegment.Wireframe.TextWireframe(
+                System.identityHashCode(this).toLong(),
+                x = x,
+                y = y,
+                text = resolveTextValue(this),
+                width = width.toLong().densityNormalized(fakePixelDensity),
+                height = height.toLong().densityNormalized(fakePixelDensity),
+                textStyle = MobileSegment.TextStyle(
+                    "sans-serif",
+                    0,
+                    "#000000ff"
+                ),
+                textPosition = MobileSegment.TextPosition(
+                    MobileSegment.Padding(0, 0, 0, 0),
+                    alignment =
+                    MobileSegment.Alignment(
+                        MobileSegment.Horizontal.LEFT,
+                        MobileSegment.Vertical
+                            .CENTER
+                    )
                 )
             )
         )

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonWireframeMapperTest.kt
@@ -68,18 +68,19 @@ internal class ButtonWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val buttonWireframe = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
+        val buttonWireframes = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockButton.toTextWireframe()
-            .copy(
+        val expectedWireframes = mockButton.toTextWireframes().map {
+            it.copy(
                 textStyle = MobileSegment.TextStyle(
                     expectedFontFamily,
                     fakeFontSize.toLong().densityNormalized(fakePixelDensity),
                     fakeStyleColor
                 )
             )
-        assertThat(buttonWireframe).isEqualTo(expectedWireframe)
+        }
+        assertThat(buttonWireframes).isEqualTo(expectedWireframes)
     }
 
     @Test
@@ -92,11 +93,11 @@ internal class ButtonWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val buttonWireframe = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
+        val buttonWireframes = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockButton.toTextWireframe().copy(text = fakeText)
-        assertThat(buttonWireframe).isEqualTo(expectedWireframe)
+        val expectedWireframes = mockButton.toTextWireframes().map { it.copy(text = fakeText) }
+        assertThat(buttonWireframes).isEqualTo(expectedWireframes)
     }
 
     @ParameterizedTest
@@ -114,17 +115,18 @@ internal class ButtonWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val buttonWireframe = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
+        val buttonWireframes = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockButton.toTextWireframe().copy(
-            textPosition = MobileSegment
-                .TextPosition(
+        val expectedWireframes = mockButton.toTextWireframes().map {
+            it.copy(
+                textPosition = MobileSegment.TextPosition(
                     padding = MobileSegment.Padding(0, 0, 0, 0),
                     alignment = expectedTextAlignment
                 )
-        )
-        assertThat(buttonWireframe).isEqualTo(expectedWireframe)
+            )
+        }
+        assertThat(buttonWireframes).isEqualTo(expectedWireframes)
     }
 
     @ParameterizedTest
@@ -144,17 +146,18 @@ internal class ButtonWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val buttonWireframe = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
+        val buttonWireframes = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockButton.toTextWireframe().copy(
-            textPosition = MobileSegment
-                .TextPosition(
+        val expectedWireframes = mockButton.toTextWireframes().map {
+            it.copy(
+                textPosition = MobileSegment.TextPosition(
                     padding = MobileSegment.Padding(0, 0, 0, 0),
                     alignment = expectedTextAlignment
                 )
-        )
-        assertThat(buttonWireframe).isEqualTo(expectedWireframe)
+            )
+        }
+        assertThat(buttonWireframes).isEqualTo(expectedWireframes)
     }
 
     @Test
@@ -167,10 +170,10 @@ internal class ButtonWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val buttonWireframe = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
+        val buttonWireframes = testedButtonWireframeMapper.map(mockButton, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockButton.toTextWireframe().copy(text = fakeText)
-        assertThat(buttonWireframe).isEqualTo(expectedWireframe)
+        val expectedWireframes = mockButton.toTextWireframes().map { it.copy(text = fakeText) }
+        assertThat(buttonWireframes).isEqualTo(expectedWireframes)
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllTextViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllTextViewWireframeMapperTest.kt
@@ -67,11 +67,13 @@ internal class MaskAllTextViewWireframeMapperTest : BaseTextViewWireframeMapperT
         }
 
         // When
-        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockTextView.toTextWireframe().copy(text = fakeMaskedStringValue)
-        assertThat(textWireframe).isEqualTo(expectedWireframe)
+        val expectedWireframes = mockTextView
+            .toTextWireframes()
+            .map { it.copy(text = fakeMaskedStringValue) }
+        assertThat(textWireframes).isEqualTo(expectedWireframes)
     }
 
     // endregion

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllWireframeMapperTest.kt
@@ -74,13 +74,13 @@ internal class MaskAllWireframeMapperTest {
         // Given
         val mockView: View = mock()
         whenever(mockViewWireframeMapper.map(mockView, fakePixelDensity))
-            .thenReturn(mockShapeWireframe)
+            .thenReturn(listOf(mockShapeWireframe))
 
         // When
-        val wireframe = testedMaskAllWireframeMapper.map(mockView, fakePixelDensity)
+        val wireframes = testedMaskAllWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        assertThat(wireframe).isEqualTo(mockShapeWireframe)
+        assertThat(wireframes).isEqualTo(listOf(mockShapeWireframe))
     }
 
     @Test
@@ -88,13 +88,13 @@ internal class MaskAllWireframeMapperTest {
         // Given
         val mockView: ImageView = mock()
         whenever(mockImageWireframeMapper.map(mockView, fakePixelDensity))
-            .thenReturn(mockImageWireframe)
+            .thenReturn(listOf(mockImageWireframe))
 
         // When
-        val wireframe = testedMaskAllWireframeMapper.map(mockView, fakePixelDensity)
+        val wireframes = testedMaskAllWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        assertThat(wireframe).isEqualTo(mockImageWireframe)
+        assertThat(wireframes).isEqualTo(listOf(mockImageWireframe))
     }
 
     @Test
@@ -102,13 +102,13 @@ internal class MaskAllWireframeMapperTest {
         // Given
         val mockView: TextView = mock()
         whenever(mockMaskAllTextWireframeMapper.map(mockView, fakePixelDensity))
-            .thenReturn(mockMaskedTextWireframe)
+            .thenReturn(listOf(mockMaskedTextWireframe))
 
         // When
-        val wireframe = testedMaskAllWireframeMapper.map(mockView, fakePixelDensity)
+        val wireframes = testedMaskAllWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        assertThat(wireframe).isEqualTo(mockMaskedTextWireframe)
+        assertThat(wireframes).isEqualTo(listOf(mockMaskedTextWireframe))
     }
 
     @Test
@@ -116,13 +116,13 @@ internal class MaskAllWireframeMapperTest {
         // Given
         val mockView: Button = mock()
         whenever(mockButtonWireframeMapper.map(mockView, fakePixelDensity))
-            .thenReturn(mockButtonWireframe)
+            .thenReturn(listOf(mockButtonWireframe))
 
         // When
-        val wireframe = testedMaskAllWireframeMapper.map(mockView, fakePixelDensity)
+        val wireframes = testedMaskAllWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        assertThat(wireframe).isEqualTo(mockButtonWireframe)
+        assertThat(wireframes).isEqualTo(listOf(mockButtonWireframe))
     }
 
     @Test

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewWireframeMapperTest.kt
@@ -42,10 +42,10 @@ internal class TextViewWireframeMapperTest : BaseTextViewWireframeMapperTest() {
         }
 
         // When
-        val textWireframe = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
+        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockTextView.toTextWireframe().copy(text = fakeText)
-        assertThat(textWireframe).isEqualTo(expectedWireframe)
+        val expectedWireframes = mockTextView.toTextWireframes().map { it.copy(text = fakeText) }
+        assertThat(textWireframes).isEqualTo(expectedWireframes)
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewScreenshotWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewScreenshotWireframeMapperTest.kt
@@ -42,11 +42,12 @@ internal class ViewScreenshotWireframeMapperTest : BaseWireframeMapperTest() {
         // Given
         val mockView: View = forge.aMockView()
         // When
-        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+        val shapeWireframes = testedWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockView.toShapeWireframe()
-            .copy(border = MobileSegment.ShapeBorder("#000000ff", 1))
-        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+        val expectedWireframes = mockView.toShapeWireframes().map {
+            it.copy(border = MobileSegment.ShapeBorder("#000000ff", 1))
+        }
+        assertThat(shapeWireframes).isEqualTo(expectedWireframes)
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapperTest.kt
@@ -52,13 +52,13 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
     fun `M resolve a ShapeWireframe W map()`(forge: Forge) {
         // Given
         val mockView: View = forge.aMockView()
-        val expectedWireframe = mockView.toShapeWireframe()
+        val expectedWireframes = mockView.toShapeWireframes()
 
         // When
-        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+        val shapeWireframes = testedWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+        assertThat(shapeWireframes).isEqualTo(expectedWireframes)
     }
 
     @Test
@@ -69,7 +69,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val shapeWireframes = mockViews.map {
+        val shapeWireframes = mockViews.flatMap {
             testedWireframeMapper.map(
                 it,
                 fakePixelDensity
@@ -111,18 +111,19 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+        val shapeWireframes = testedWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockView.toShapeWireframe().copy(
-            shapeStyle = MobileSegment
-                .ShapeStyle(
+        val expectedWireframes = mockView.toShapeWireframes().map {
+            it.copy(
+                shapeStyle = MobileSegment.ShapeStyle(
                     backgroundColor = fakeStyleColor,
                     opacity = fakeViewAlpha,
                     cornerRadius = null
                 )
-        )
-        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+            )
+        }
+        assertThat(shapeWireframes).isEqualTo(expectedWireframes)
     }
 
     @RequiresApi(Build.VERSION_CODES.M)
@@ -157,18 +158,19 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+        val shapeWireframes = testedWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockView.toShapeWireframe().copy(
-            shapeStyle = MobileSegment
-                .ShapeStyle(
+        val expectedWireframes = mockView.toShapeWireframes().map {
+            it.copy(
+                shapeStyle = MobileSegment.ShapeStyle(
                     backgroundColor = fakeStyleColor,
                     opacity = fakeViewAlpha,
                     cornerRadius = null
                 )
-        )
-        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+            )
+        }
+        assertThat(shapeWireframes).isEqualTo(expectedWireframes)
     }
 
     @Test
@@ -199,12 +201,13 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+        val shapeWireframes = testedWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockView.toShapeWireframe()
-            .copy(border = MobileSegment.ShapeBorder("#000000ff", 1))
-        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+        val expectedWireframes = mockView.toShapeWireframes().map {
+            it.copy(border = MobileSegment.ShapeBorder("#000000ff", 1))
+        }
+        assertThat(shapeWireframes).isEqualTo(expectedWireframes)
     }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
@@ -240,18 +243,19 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+        val shapeWireframes = testedWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockView.toShapeWireframe().copy(
-            shapeStyle = MobileSegment
-                .ShapeStyle(
+        val expectedWireframes = mockView.toShapeWireframes().map {
+            it.copy(
+                shapeStyle = MobileSegment.ShapeStyle(
                     backgroundColor = fakeStyleColor,
                     opacity = fakeViewAlpha,
                     cornerRadius = null
                 )
-        )
-        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+            )
+        }
+        assertThat(shapeWireframes).isEqualTo(expectedWireframes)
     }
 
     @Test
@@ -283,14 +287,13 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+        val shapeWireframes = testedWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockView.toShapeWireframe().copy(
-            border = MobileSegment.ShapeBorder
-            ("#000000ff", 1)
-        )
-        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+        val expectedWireframes = mockView.toShapeWireframes().map {
+            it.copy(border = MobileSegment.ShapeBorder("#000000ff", 1))
+        }
+        assertThat(shapeWireframes).isEqualTo(expectedWireframes)
     }
 
     @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
@@ -310,11 +313,12 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val shapeWireframe = testedWireframeMapper.map(mockView, fakePixelDensity)
+        val shapeWireframes = testedWireframeMapper.map(mockView, fakePixelDensity)
 
         // Then
-        val expectedWireframe = mockView.toShapeWireframe()
-            .copy(border = MobileSegment.ShapeBorder("#000000ff", 1))
-        assertThat(shapeWireframe).isEqualTo(expectedWireframe)
+        val expectedWireframes = mockView.toShapeWireframes().map {
+            it.copy(border = MobileSegment.ShapeBorder("#000000ff", 1))
+        }
+        assertThat(shapeWireframes).isEqualTo(expectedWireframes)
     }
 }


### PR DESCRIPTION
### What does this PR do?

Currently our `ViewToWireframe` mappers resolve a `View` as a single `Wireframe` . Following the RFC for recording/representing input elements we will need to add the capability to our mappers to resolve a `View` as a collection of `Wireframe`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

