### PR TITLE
RUMM-2900 make tests more accurate with url case sensitivity

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogInterceptorTest.kt
@@ -58,7 +58,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
 import java.io.IOException
-import java.util.Locale
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -193,7 +192,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).startResource(
                 requestId,
                 fakeMethod,
-                fakeUrl.lowercase(Locale.US),
+                fakeUrl,
                 expectedStartAttrs
             )
             verify(rumMonitor.mockInstance).stopResource(
@@ -231,7 +230,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).startResource(
                 requestId,
                 fakeMethod,
-                fakeUrl.lowercase(Locale.US),
+                fakeUrl,
                 expectedStartAttrs
             )
             verify(rumMonitor.mockInstance).stopResource(
@@ -279,7 +278,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).startResource(
                 requestId,
                 fakeMethod,
-                fakeUrl.lowercase(Locale.US),
+                fakeUrl,
                 emptyMap()
             )
             verify(rumMonitor.mockInstance).stopResource(
@@ -325,7 +324,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).startResource(
                 requestId,
                 fakeMethod,
-                fakeUrl.lowercase(Locale.US),
+                fakeUrl,
                 emptyMap()
             )
             verify(rumMonitor.mockInstance).stopResource(
@@ -384,7 +383,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).startResource(
                 requestId,
                 fakeMethod,
-                fakeUrl.lowercase(Locale.US),
+                fakeUrl,
                 expectedStartAttrs
             )
             verify(rumMonitor.mockInstance).stopResource(
@@ -441,7 +440,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).startResource(
                 requestId,
                 fakeMethod,
-                fakeUrl.lowercase(Locale.US),
+                fakeUrl,
                 expectedStartAttrs
             )
             verify(rumMonitor.mockInstance).stopResource(
@@ -481,7 +480,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).startResource(
                 requestId,
                 fakeMethod,
-                fakeUrl.lowercase(Locale.US),
+                fakeUrl,
                 expectedStartAttrs
             )
             verify(rumMonitor.mockInstance).stopResource(
@@ -519,7 +518,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).startResource(
                 requestId,
                 fakeMethod,
-                fakeUrl.lowercase(Locale.US),
+                fakeUrl,
                 expectedStartAttrs
             )
             verify(rumMonitor.mockInstance).stopResource(
@@ -552,13 +551,13 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).startResource(
                 requestId,
                 fakeMethod,
-                fakeUrl.lowercase(Locale.US),
+                fakeUrl,
                 expectedStartAttrs
             )
             verify(rumMonitor.mockInstance).stopResourceWithError(
                 requestId,
                 null,
-                "OkHttp request error $fakeMethod ${fakeUrl.lowercase(Locale.US)}",
+                "OkHttp request error $fakeMethod $fakeUrl",
                 RumErrorSource.NETWORK,
                 throwable,
                 fakeAttributes

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -871,7 +871,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan, never()).finish()
@@ -887,7 +887,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan, never()).finish()
@@ -903,7 +903,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan, never()).finish()
@@ -917,7 +917,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", 404)
         verify(mockSpan, never()).finish()
@@ -936,7 +936,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             testedInterceptor.intercept(mockChain)
         }
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("error.type", throwable.javaClass.canonicalName)
         verify(mockSpan).setTag("error.msg", throwable.message)
@@ -982,7 +982,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(localSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(localSpan).setTag("http.url", fakeUrl)
         verify(localSpan).setTag("http.method", fakeMethod)
         verify(localSpan).setTag("http.status_code", statusCode)
         verify(localSpan, never()).finish()
@@ -1018,11 +1018,11 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         val response2 = testedInterceptor.intercept(mockChain)
         val expectedResponse2 = fakeResponse
 
-        verify(localSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(localSpan).setTag("http.url", fakeUrl)
         verify(localSpan).setTag("http.method", fakeMethod)
         verify(localSpan).setTag("http.status_code", statusCode)
         verify(localSpan, never()).finish()
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan, never()).finish()
@@ -1054,7 +1054,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan).setTag(tagKey, tagValue)
@@ -1080,7 +1080,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan).setTag(tagKey, tagValue)
@@ -1126,7 +1126,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             testedInterceptor.intercept(mockChain)
         }
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("error.type", throwable.javaClass.canonicalName)
         verify(mockSpan).setTag("error.msg", throwable.message)
@@ -1264,7 +1264,9 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         val protocol = forge.anElementFrom("http", "https")
         val host = knownHost ?: forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN)
         val path = forge.anAlphaNumericalString()
-        return "$protocol://$host/$path"
+        // RUMM-2900 host is by definition case insensitive,
+        // and OkHttp lowercases it when building the request
+        return "$protocol://${host.lowercase(Locale.US)}/$path"
     }
 
     private fun forgeRequest(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNonDdTracerTest.kt
@@ -72,7 +72,6 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
-import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
@@ -968,7 +967,7 @@ internal open class TracingInterceptorNonDdTracerTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan).finish()
@@ -1004,7 +1003,7 @@ internal open class TracingInterceptorNonDdTracerTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan).finish()
@@ -1020,7 +1019,7 @@ internal open class TracingInterceptorNonDdTracerTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan).finish()
@@ -1034,7 +1033,7 @@ internal open class TracingInterceptorNonDdTracerTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", 404)
         verify(mockSpan).finish()
@@ -1053,7 +1052,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             testedInterceptor.intercept(mockChain)
         }
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("error.type", throwable.javaClass.canonicalName)
         verify(mockSpan).setTag("error.msg", throwable.message)
@@ -1100,7 +1099,7 @@ internal open class TracingInterceptorNonDdTracerTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(localSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(localSpan).setTag("http.url", fakeUrl)
         verify(localSpan).setTag("http.method", fakeMethod)
         verify(localSpan).setTag("http.status_code", statusCode)
         verify(localSpan).finish()
@@ -1136,11 +1135,11 @@ internal open class TracingInterceptorNonDdTracerTest {
         val response2 = testedInterceptor.intercept(mockChain)
         val expectedResponse2 = fakeResponse
 
-        verify(localSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(localSpan).setTag("http.url", fakeUrl)
         verify(localSpan).setTag("http.method", fakeMethod)
         verify(localSpan).setTag("http.status_code", statusCode)
         verify(localSpan).finish()
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan).finish()
@@ -1172,7 +1171,7 @@ internal open class TracingInterceptorNonDdTracerTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan).setTag(tagKey, tagValue)
@@ -1198,7 +1197,7 @@ internal open class TracingInterceptorNonDdTracerTest {
 
         val response = testedInterceptor.intercept(mockChain)
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan).setTag(tagKey, tagValue)
@@ -1244,7 +1243,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             testedInterceptor.intercept(mockChain)
         }
 
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("error.type", throwable.javaClass.canonicalName)
         verify(mockSpan).setTag("error.msg", throwable.message)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/tracing/TracingInterceptorNotSendingSpanTest.kt
@@ -907,7 +907,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val response = testedInterceptor.intercept(mockChain)
 
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan, never()).finish()
@@ -925,8 +925,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val response = testedInterceptor.intercept(mockChain)
 
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(mockSpan as MutableSpan).setResourceName(fakeUrl.lowercase(Locale.US))
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan as MutableSpan).setResourceName(fakeUrl)
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan as MutableSpan).setError(true)
@@ -945,8 +945,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val response = testedInterceptor.intercept(mockChain)
 
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(mockSpan as MutableSpan).setResourceName(fakeUrl.lowercase(Locale.US))
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan as MutableSpan).setResourceName(fakeUrl)
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan as MutableSpan, never()).setError(true)
@@ -963,7 +963,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val response = testedInterceptor.intercept(mockChain)
 
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", 404)
         verify(mockSpan as MutableSpan).setError(true)
@@ -986,7 +986,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         }
 
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("error.type", throwable.javaClass.canonicalName)
         verify(mockSpan).setTag("error.msg", throwable.message)
@@ -1034,7 +1034,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val response = testedInterceptor.intercept(mockChain)
 
         verify(localSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(localSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(localSpan).setTag("http.url", fakeUrl)
         verify(localSpan).setTag("http.method", fakeMethod)
         verify(localSpan).setTag("http.status_code", statusCode)
         verify(localSpan, never()).finish()
@@ -1072,13 +1072,13 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val expectedResponse2 = fakeResponse
 
         verify(localSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(localSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(localSpan).setTag("http.url", fakeUrl)
         verify(localSpan).setTag("http.method", fakeMethod)
         verify(localSpan).setTag("http.status_code", statusCode)
         verify(localSpan, never()).finish()
         verify(localSpan as MutableSpan).drop()
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan, never()).finish()
@@ -1112,7 +1112,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val response = testedInterceptor.intercept(mockChain)
 
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan).setTag(tagKey, tagValue)
@@ -1140,7 +1140,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val response = testedInterceptor.intercept(mockChain)
 
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("http.status_code", statusCode)
         verify(mockSpan).setTag(tagKey, tagValue)
@@ -1188,7 +1188,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         }
 
         verify(mockSpanBuilder).withOrigin(getExpectedOrigin())
-        verify(mockSpan).setTag("http.url", fakeUrl.lowercase(Locale.US))
+        verify(mockSpan).setTag("http.url", fakeUrl)
         verify(mockSpan).setTag("http.method", fakeMethod)
         verify(mockSpan).setTag("error.type", throwable.javaClass.canonicalName)
         verify(mockSpan).setTag("error.msg", throwable.message)
@@ -1321,7 +1321,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val protocol = forge.anElementFrom("http", "https")
         val host = knownHost ?: forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN)
         val path = forge.anAlphaNumericalString()
-        return "$protocol://$host/$path"
+        // RUMM-2900 host is by definition case insensitive,
+        // and OkHttp lowercases it when building the request
+        return "$protocol://${host.lowercase(Locale.US)}/$path"
     }
 
     private fun forgeRequest(


### PR DESCRIPTION
### What does this PR do?

We used to require all urls to be fully lowercase in our tests assertions, as case sensitivity used to make the tests fail. 
After investigation, we noticed that OKHttp automatically standardize the host name to be all lowercasen because the host name [by definition (RFC-4343)](https://www.rfc-editor.org/rfc/rfc4343#section-3). 

> According to the original DNS design decision, comparisons on name lookup for DNS queries should be case insensitive.

This PR updates our test to follow closely this principle and OkHttp behavior, by forging random URLs with a lowercase hostname, and a path that is still case sensitive.
