### PR TITLE
RUMM-2885 Add `addFeatureFlagEvaluation` function for RUM

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -309,6 +309,7 @@ interface com.datadog.android.rum.RumMonitor
   fun addError(String, RumErrorSource, Throwable?, Map<String, Any?>)
   fun addErrorWithStacktrace(String, RumErrorSource, String?, Map<String, Any?>)
   fun addTiming(String)
+  fun addFeatureFlagEvaluation(String, Any)
   fun _getInternal(): _RumInternalProxy?
   class Builder
     fun sampleRumSessions(Float): Builder
@@ -890,7 +891,7 @@ data class com.datadog.android.rum.model.ActionEvent
     companion object 
       fun fromJson(kotlin.String): Type
 data class com.datadog.android.rum.model.ErrorEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, ErrorEventSession, ErrorEventSource? = null, View, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Error)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, ErrorEventSession, ErrorEventSource? = null, View, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Action? = null, Error, Context? = null)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 
@@ -1573,7 +1574,7 @@ data class com.datadog.android.rum.model.RumPerfMetric
     fun fromJson(kotlin.String): RumPerfMetric
     fun fromJsonObject(com.google.gson.JsonObject): RumPerfMetric
 data class com.datadog.android.rum.model.ViewEvent
-  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, ViewEventSession, Source? = null, View, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null)
+  constructor(kotlin.Long, Application, kotlin.String? = null, kotlin.String? = null, ViewEventSession, Source? = null, View, Usr? = null, Connectivity? = null, Display? = null, Synthetics? = null, CiTest? = null, Os? = null, Device? = null, Dd, Context? = null, Context? = null)
   val type: kotlin.String
   fun toJson(): com.google.gson.JsonElement
   companion object 

--- a/dd-sdk-android/src/main/json/rum/error-schema.json
+++ b/dd-sdk-android/src/main/json/rum/error-schema.json
@@ -185,6 +185,12 @@
             }
           },
           "readOnly": true
+        },
+        "feature_flags": {
+          "type": "object",
+          "description": "Feature flags properties",
+          "additionalProperties": true,
+          "readOnly": true
         }
       }
     }

--- a/dd-sdk-android/src/main/json/rum/resource-schema.json
+++ b/dd-sdk-android/src/main/json/rum/resource-schema.json
@@ -245,7 +245,7 @@
             },
             "rule_psr": {
               "type": "number",
-              "description": "tracing sample rate in decimal format",
+              "description": "trace sample rate in decimal format",
               "minimum": 0,
               "maximum": 1,
               "readOnly": true

--- a/dd-sdk-android/src/main/json/rum/view-schema.json
+++ b/dd-sdk-android/src/main/json/rum/view-schema.json
@@ -297,6 +297,12 @@
           },
           "readOnly": true
         },
+        "feature_flags": {
+          "type": "object",
+          "description": "Feature flags properties",
+          "additionalProperties": true,
+          "readOnly": true
+        },
         "_dd": {
           "type": "object",
           "description": "Internal properties",

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -244,6 +244,17 @@ interface RumMonitor {
     )
 
     /**
+     * Adds result of evaluating a feature flag to the view.
+     * Feature flag evaluations are local to the active view and are cleared when the view is stopped.
+     * @param name the name of the feature flag
+     * @param value the value the feature flag evaluated to
+     */
+    fun addFeatureFlagEvaluation(
+        name: String,
+        value: Any
+    )
+
+    /**
      * For Datadog internal use only.
      *
      * @see _RumInternalProxy

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -188,6 +188,12 @@ internal sealed class RumRawEvent {
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
+    internal data class AddFeatureFlagEvaluation(
+        val name: String,
+        val value: Any,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
     internal data class UpdatePerformanceMetric(
         val metric: RumPerformanceMetric,
         val value: Double,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -250,6 +250,15 @@ internal class DatadogRumMonitor(
         )
     }
 
+    override fun addFeatureFlagEvaluation(name: String, value: Any) {
+        handleEvent(
+            RumRawEvent.AddFeatureFlagEvaluation(
+                name,
+                value
+            )
+        )
+    }
+
     // endregion
 
     // region AdvancedRumMonitor

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -15,6 +15,7 @@ import com.datadog.android.v2.api.context.NetworkInfo
 import com.datadog.android.v2.api.context.UserInfo
 import org.assertj.core.api.AbstractObjectAssert
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.entry
 import org.assertj.core.data.Offset
 
 internal class ErrorEventAssert(actual: ErrorEvent) :
@@ -466,6 +467,14 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
                     " but instead was: ${actual.version}"
             )
             .isEqualTo(version)
+        return this
+    }
+
+    fun hasFeatureFlag(flagName: String, flagValue: Any): ErrorEventAssert {
+        assertThat(actual.featureFlags)
+            .isNotNull
+        assertThat(actual.featureFlags?.additionalProperties)
+            .contains(entry(flagName, flagValue))
         return this
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -11,6 +11,7 @@ import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.v2.api.context.NetworkInfo
 import com.datadog.android.v2.api.context.UserInfo
 import org.assertj.core.api.AbstractObjectAssert
+import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset
 import org.assertj.core.data.Percentage
@@ -618,6 +619,14 @@ internal class ViewEventAssert(actual: ViewEvent) :
                     " but instead was: ${actual.version}"
             )
             .isEqualTo(version)
+        return this
+    }
+
+    fun hasFeatureFlag(flagName: String, flagValue: Any): ViewEventAssert {
+        assertThat(actual.featureFlags)
+            .isNotNull
+        assertThat(actual.featureFlags?.additionalProperties)
+            .contains(Assertions.entry(flagName, flagValue))
         return this
     }
 

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
@@ -181,6 +181,23 @@ class RumMonitorE2ETests {
     }
 
     /**
+     * apiMethodSignature: com.datadog.android.rum.RumMonitor#fun addFeatureFlagEvaluation(String, Any)
+     */
+    @Test
+    fun rum_rummonitor_addFeatureFlagEvaluation() {
+        val testMethodName = "rum_rummonitor_addFeatureFlagEvaluation"
+        val viewKey = forge.aViewKey()
+        val viewName = forge.aViewName()
+        val flagName = forge.anAlphaNumericalString()
+        val flagValue = forge.anAlphaNumericalString()
+        executeInsideView(viewKey, viewName, testMethodName) {
+            measure(testMethodName) {
+                GlobalRum.get().addFeatureFlagEvaluation(flagName, flagValue)
+            }
+        }
+    }
+
+    /**
      * apiMethodSignature: com.datadog.android.rum._RumInternalProxy#fun updatePerformanceMetric(RumPerformanceMetric, Double)
      */
     @Test


### PR DESCRIPTION
### What does this PR do?

`addFeatureFlagEvalutaion` adds the result of evaluating a feature flag to a view, which is key / value pair. These feature flags are sent with any subsequent View updates, as well as on Errors until the view is stopped.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

