### PR TITLE
RUMM-2864 add support to AP1

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -9,21 +9,21 @@ object com.datadog.android.Datadog
   fun enableRumDebugging(Boolean)
   val _internal: _InternalProxy
 object com.datadog.android.DatadogEndpoint
-  const val LOGS_US1: String
-  const val LOGS_US3: String
-  const val LOGS_US5: String
-  const val LOGS_US1_FED: String
-  const val LOGS_EU1: String
-  const val TRACES_US1: String
-  const val TRACES_US3: String
-  const val TRACES_US5: String
-  const val TRACES_US1_FED: String
-  const val TRACES_EU1: String
-  const val RUM_US1: String
-  const val RUM_US3: String
-  const val RUM_US5: String
-  const val RUM_US1_FED: String
-  const val RUM_EU1: String
+  DEPRECATED const val LOGS_US1: String
+  DEPRECATED const val LOGS_US3: String
+  DEPRECATED const val LOGS_US5: String
+  DEPRECATED const val LOGS_US1_FED: String
+  DEPRECATED const val LOGS_EU1: String
+  DEPRECATED const val TRACES_US1: String
+  DEPRECATED const val TRACES_US3: String
+  DEPRECATED const val TRACES_US5: String
+  DEPRECATED const val TRACES_US1_FED: String
+  DEPRECATED const val TRACES_EU1: String
+  DEPRECATED const val RUM_US1: String
+  DEPRECATED const val RUM_US3: String
+  DEPRECATED const val RUM_US5: String
+  DEPRECATED const val RUM_US1_FED: String
+  DEPRECATED const val RUM_EU1: String
   const val NTP_0: String
   const val NTP_1: String
   const val NTP_2: String
@@ -52,15 +52,16 @@ open class com.datadog.android.DatadogInterceptor : com.datadog.android.tracing.
   override fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
   override fun canSendSpan(): Boolean
 enum com.datadog.android.DatadogSite
-  constructor(String)
+  constructor(String, String)
   - US1
   - US3
   - US5
-  - US1_FED
   - EU1
-  fun logsEndpoint(): String
-  fun tracesEndpoint(): String
-  fun rumEndpoint(): String
+  - AP1
+  - US1_FED
+  - STAGING
+  constructor(String)
+  val intakeEndpoint: String
 class com.datadog.android._InternalProxy
   class _TelemetryProxy
     fun debug(String)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogEndpoint.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogEndpoint.kt
@@ -20,6 +20,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [app.datadoghq.com](https://app.datadoghq.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US1.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val LOGS_US1: String = "https://logs.browser-intake-datadoghq.com"
 
     /**
@@ -27,6 +34,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [us3.datadoghq.com](https://us3.datadoghq.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US3.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val LOGS_US3: String = "https://logs.browser-intake-us3-datadoghq.com"
 
     /**
@@ -34,6 +48,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [us5.datadoghq.com](https://us5.datadoghq.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US5.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val LOGS_US5: String = "https://logs.browser-intake-us5-datadoghq.com"
 
     /**
@@ -41,6 +62,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [app.ddog-gov.com](https://app.ddog-gov.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US1_FED.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val LOGS_US1_FED: String = "https://logs.browser-intake-ddog-gov.com"
 
     /**
@@ -48,6 +76,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [app.datadoghq.eu](https://app.datadoghq.eu)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.EU1.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val LOGS_EU1: String = "https://mobile-http-intake.logs.datadoghq.eu"
 
     // endregion
@@ -59,6 +94,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [app.datadoghq.com](https://app.datadoghq.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US1.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val TRACES_US1: String = "https://trace.browser-intake-datadoghq.com"
 
     /**
@@ -66,6 +108,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [us3.datadoghq.com](https://us3.datadoghq.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US3.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val TRACES_US3: String = "https://trace.browser-intake-us3-datadoghq.com"
 
     /**
@@ -73,6 +122,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [us5.datadoghq.com](https://us5.datadoghq.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US5.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val TRACES_US5: String = "https://trace.browser-intake-us5-datadoghq.com"
 
     /**
@@ -80,6 +136,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [app.ddog-gov.com](https://app.ddog-gov.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US1_FED.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val TRACES_US1_FED: String = "https://trace.browser-intake-ddog-gov.com"
 
     /**
@@ -87,6 +150,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [app.datadoghq.eu](https://app.datadoghq.eu)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.EU1.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val TRACES_EU1: String = "https:/public-trace-http-intake.logs.datadoghq.eu"
 
     // endregion
@@ -98,6 +168,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [app.datadoghq.com](https://app.datadoghq.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US1.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val RUM_US1: String = "https://rum.browser-intake-datadoghq.com"
 
     /**
@@ -105,6 +182,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [us3.datadoghq.com](https://us3.datadoghq.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US3.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val RUM_US3: String = "https://rum.browser-intake-us3-datadoghq.com"
 
     /**
@@ -112,6 +196,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [us5.datadoghq.com](https://us5.datadoghq.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US5.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val RUM_US5: String = "https://rum.browser-intake-us5-datadoghq.com"
 
     /**
@@ -119,6 +210,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [app.ddog-gov.com](https://app.ddog-gov.com)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.US1_FED.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val RUM_US1_FED: String = "https://rum.browser-intake-ddog-gov.com"
 
     /**
@@ -126,6 +224,13 @@ object DatadogEndpoint {
      * Use this in your [Configuration] if you log on [app.datadoghq.eu](https://app.datadoghq.eu)
      * @see [Configuration]
      */
+    @Deprecated(
+        "This endpoint is deprecated, use the DatadogSite#intakeEndpoint property instead",
+        ReplaceWith(
+            "DatadogSite.EU1.intakeEndpoint",
+            "com.datadog.android.DatadogSite"
+        )
+    )
     const val RUM_EU1: String = "https://rum-http-intake.logs.datadoghq.eu"
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogSite.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogSite.kt
@@ -11,14 +11,16 @@ package com.datadog.android
  *
  * @property siteName Explicit site name property introduced in order to have a consistent SDK
  * instance ID (because this value is used there) in case if enum values are renamed.
+ * @property intakeHostName the host name for the given site.
  */
 // TODO RUMM-0000 Remove logs, traces, rum endpoint methods, because this class is for core SDK v2
 // TODO RUMM-0000 Since it is used in SDK v2 context, what should be the value for custom endpoints?
-enum class DatadogSite(val siteName: String) {
+enum class DatadogSite(val siteName: String, private val intakeHostName: String) {
+
     /**
      *  The US1 site: [app.datadoghq.com](https://app.datadoghq.com).
      */
-    US1("us1"),
+    US1("us1", "browser-intake-datadoghq.com"),
 
     /**
      *  The US3 site: [us3.datadoghq.com](https://us3.datadoghq.com).
@@ -31,51 +33,35 @@ enum class DatadogSite(val siteName: String) {
     US5("us5"),
 
     /**
-     *  The US1_FED site (FedRAMP compatible): [app.ddog-gov.com](https://app.ddog-gov.com).
-     */
-    US1_FED("us1_fed"),
-
-    /**
      *  The EU1 site: [app.datadoghq.eu](https://app.datadoghq.eu).
      */
-    EU1("eu1");
+    EU1("eu1", "browser-intake-datadoghq.eu"),
 
     /**
-     * Returns the endpoint to use to upload Logs to this site.
+     *  The AP1 site: [ap1.datadoghq.com](https://ap1.datadoghq.com).
      */
-    fun logsEndpoint(): String {
-        return when (this) {
-            US1 -> DatadogEndpoint.LOGS_US1
-            US3 -> DatadogEndpoint.LOGS_US3
-            US5 -> DatadogEndpoint.LOGS_US5
-            US1_FED -> DatadogEndpoint.LOGS_US1_FED
-            EU1 -> DatadogEndpoint.LOGS_EU1
-        }
-    }
+    AP1("ap1"),
 
     /**
-     * Returns the endpoint to use to upload Spans to this site.
+     *  The US1_FED site (FedRAMP compatible): [app.ddog-gov.com](https://app.ddog-gov.com).
      */
-    fun tracesEndpoint(): String {
-        return when (this) {
-            US1 -> DatadogEndpoint.TRACES_US1
-            US3 -> DatadogEndpoint.TRACES_US3
-            US5 -> DatadogEndpoint.TRACES_US5
-            US1_FED -> DatadogEndpoint.TRACES_US1_FED
-            EU1 -> DatadogEndpoint.TRACES_EU1
-        }
-    }
+    US1_FED("us1_fed", "browser-intake-ddog-gov.com"),
 
     /**
-     * Returns the endpoint to use to upload RUM Events to this site.
+     *  The STAGING site (internal usage only): [app.datad0g.com](https://app.datad0g.com).
      */
-    fun rumEndpoint(): String {
-        return when (this) {
-            US1 -> DatadogEndpoint.RUM_US1
-            US3 -> DatadogEndpoint.RUM_US3
-            US5 -> DatadogEndpoint.RUM_US5
-            US1_FED -> DatadogEndpoint.RUM_US1_FED
-            EU1 -> DatadogEndpoint.RUM_EU1
-        }
-    }
+    STAGING("staging", "browser-intake-datad0g.com");
+
+    /**
+     * Constructor using the generic way to build the intake endpoint host from the site name.
+     * @param siteName Explicit site name property introduced in order to have a consistent SDK
+     * instance ID (because this value is used there) in case if enum values are renamed.
+     */
+    constructor(siteName: String) : this(
+        siteName,
+        "browser-intake-$siteName-datadoghq.com"
+    )
+
+    /** The intake endpoint url. */
+    val intakeEndpoint: String = "https://$intakeHostName"
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -12,7 +12,6 @@ import android.os.Build
 import android.os.Looper
 import androidx.annotation.FloatRange
 import com.datadog.android.Datadog
-import com.datadog.android.DatadogEndpoint
 import com.datadog.android.DatadogInterceptor
 import com.datadog.android.DatadogSite
 import com.datadog.android.core.internal.event.NoOpEventMapper
@@ -243,10 +242,10 @@ internal constructor(
          * Let the SDK target your preferred Datadog's site.
          */
         fun useSite(site: DatadogSite): Builder {
-            logsConfig = logsConfig.copy(endpointUrl = site.logsEndpoint())
-            tracesConfig = tracesConfig.copy(endpointUrl = site.tracesEndpoint())
-            crashReportConfig = crashReportConfig.copy(endpointUrl = site.logsEndpoint())
-            rumConfig = rumConfig.copy(endpointUrl = site.rumEndpoint())
+            logsConfig = logsConfig.copy(endpointUrl = site.intakeEndpoint)
+            tracesConfig = tracesConfig.copy(endpointUrl = site.intakeEndpoint)
+            crashReportConfig = crashReportConfig.copy(endpointUrl = site.intakeEndpoint)
+            rumConfig = rumConfig.copy(endpointUrl = site.intakeEndpoint)
             coreConfig = coreConfig.copy(needsClearTextHttp = false, site = site)
             return this
         }
@@ -712,21 +711,21 @@ internal constructor(
             site = DatadogSite.US1
         )
         internal val DEFAULT_LOGS_CONFIG = Feature.Logs(
-            endpointUrl = DatadogEndpoint.LOGS_US1,
+            endpointUrl = DatadogSite.US1.intakeEndpoint,
             plugins = emptyList(),
             logsEventMapper = NoOpEventMapper()
         )
         internal val DEFAULT_CRASH_CONFIG = Feature.CrashReport(
-            endpointUrl = DatadogEndpoint.LOGS_US1,
+            endpointUrl = DatadogSite.US1.intakeEndpoint,
             plugins = emptyList()
         )
         internal val DEFAULT_TRACING_CONFIG = Feature.Tracing(
-            endpointUrl = DatadogEndpoint.TRACES_US1,
+            endpointUrl = DatadogSite.US1.intakeEndpoint,
             plugins = emptyList(),
             spanEventMapper = NoOpSpanEventMapper()
         )
         internal val DEFAULT_RUM_CONFIG = Feature.RUM(
-            endpointUrl = DatadogEndpoint.RUM_US1,
+            endpointUrl = DatadogSite.US1.intakeEndpoint,
             plugins = emptyList(),
             samplingRate = DEFAULT_SAMPLING_RATE,
             telemetrySamplingRate = DEFAULT_TELEMETRY_SAMPLING_RATE,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogSiteTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogSiteTest.kt
@@ -10,15 +10,12 @@ import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
-import java.util.stream.Stream
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -28,77 +25,38 @@ import java.util.stream.Stream
 @ForgeConfiguration(Configurator::class)
 internal class DatadogSiteTest {
 
-    @ParameterizedTest
-    @MethodSource("provideSiteWithLogsEndpoint")
-    fun `𝕄 return logs endpoint 𝕎 logsEndpoint()`(
-        site: DatadogSite,
-        expectedEndpoint: String
-    ) {
-        // When
-        val logsEndpoint = site.logsEndpoint()
-
-        // Then
-        assertThat(logsEndpoint).isEqualTo(expectedEndpoint)
+    @Test
+    fun `𝕄 return intake endpoint 𝕎 intakeEndpoint {US1}`() {
+        assertThat(DatadogSite.US1.intakeEndpoint).isEqualTo("https://browser-intake-datadoghq.com")
     }
 
-    @ParameterizedTest
-    @MethodSource("provideSiteWithTracesEndpoint")
-    fun `𝕄 return traces endpoint 𝕎 tracesEndpoint()`(
-        site: DatadogSite,
-        expectedEndpoint: String
-    ) {
-        // When
-        val tracesEndpoint = site.tracesEndpoint()
-
-        // Then
-        assertThat(tracesEndpoint).isEqualTo(expectedEndpoint)
+    @Test
+    fun `𝕄 return intake endpoint 𝕎 intakeEndpoint {US3}`() {
+        assertThat(DatadogSite.US3.intakeEndpoint).isEqualTo("https://browser-intake-us3-datadoghq.com")
     }
 
-    @ParameterizedTest
-    @MethodSource("provideSiteWithRumEndpoint")
-    fun `𝕄 return rum endpoint 𝕎 rumEndpoint()`(
-        site: DatadogSite,
-        expectedEndpoint: String
-    ) {
-        // When
-        val rumEndpoint = site.rumEndpoint()
-
-        // Then
-        assertThat(rumEndpoint).isEqualTo(expectedEndpoint)
+    @Test
+    fun `𝕄 return intake endpoint 𝕎 intakeEndpoint {US5}`() {
+        assertThat(DatadogSite.US5.intakeEndpoint).isEqualTo("https://browser-intake-us5-datadoghq.com")
     }
 
-    companion object {
-        @JvmStatic
-        fun provideSiteWithLogsEndpoint(): Stream<Arguments?>? {
-            return Stream.of(
-                Arguments.of(DatadogSite.US1, DatadogEndpoint.LOGS_US1),
-                Arguments.of(DatadogSite.US3, DatadogEndpoint.LOGS_US3),
-                Arguments.of(DatadogSite.US5, DatadogEndpoint.LOGS_US5),
-                Arguments.of(DatadogSite.US1_FED, DatadogEndpoint.LOGS_US1_FED),
-                Arguments.of(DatadogSite.EU1, DatadogEndpoint.LOGS_EU1)
-            )
-        }
+    @Test
+    fun `𝕄 return intake endpoint 𝕎 intakeEndpoint {US1-FED}`() {
+        assertThat(DatadogSite.US1_FED.intakeEndpoint).isEqualTo("https://browser-intake-ddog-gov.com")
+    }
 
-        @JvmStatic
-        fun provideSiteWithTracesEndpoint(): Stream<Arguments?>? {
-            return Stream.of(
-                Arguments.of(DatadogSite.US1, DatadogEndpoint.TRACES_US1),
-                Arguments.of(DatadogSite.US3, DatadogEndpoint.TRACES_US3),
-                Arguments.of(DatadogSite.US5, DatadogEndpoint.TRACES_US5),
-                Arguments.of(DatadogSite.US1_FED, DatadogEndpoint.TRACES_US1_FED),
-                Arguments.of(DatadogSite.EU1, DatadogEndpoint.TRACES_EU1)
-            )
-        }
+    @Test
+    fun `𝕄 return intake endpoint 𝕎 intakeEndpoint {EU1}`() {
+        assertThat(DatadogSite.EU1.intakeEndpoint).isEqualTo("https://browser-intake-datadoghq.eu")
+    }
 
-        @JvmStatic
-        fun provideSiteWithRumEndpoint(): Stream<Arguments?>? {
-            return Stream.of(
-                Arguments.of(DatadogSite.US1, DatadogEndpoint.RUM_US1),
-                Arguments.of(DatadogSite.US3, DatadogEndpoint.RUM_US3),
-                Arguments.of(DatadogSite.US5, DatadogEndpoint.RUM_US5),
-                Arguments.of(DatadogSite.US1_FED, DatadogEndpoint.RUM_US1_FED),
-                Arguments.of(DatadogSite.EU1, DatadogEndpoint.RUM_EU1)
-            )
-        }
+    @Test
+    fun `𝕄 return intake endpoint 𝕎 intakeEndpoint {AP1}`() {
+        assertThat(DatadogSite.AP1.intakeEndpoint).isEqualTo("https://browser-intake-ap1-datadoghq.com")
+    }
+
+    @Test
+    fun `𝕄 return intake endpoint 𝕎 intakeEndpoint {STAGING}`() {
+        assertThat(DatadogSite.STAGING.intakeEndpoint).isEqualTo("https://browser-intake-datad0g.com")
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -9,7 +9,6 @@
 package com.datadog.android.core.configuration
 
 import android.os.Build
-import com.datadog.android.DatadogEndpoint
 import com.datadog.android.DatadogSite
 import com.datadog.android._InternalProxy
 import com.datadog.android.core.internal.event.NoOpEventMapper
@@ -116,7 +115,7 @@ internal class ConfigurationBuilderTest {
         )
         assertThat(config.logsConfig).isEqualTo(
             Configuration.Feature.Logs(
-                endpointUrl = DatadogEndpoint.LOGS_US1,
+                endpointUrl = DatadogSite.US1.intakeEndpoint,
                 plugins = emptyList(),
                 logsEventMapper = NoOpEventMapper()
             )
@@ -126,7 +125,7 @@ internal class ConfigurationBuilderTest {
             .ignoringFields("spanEventMapper")
             .isEqualTo(
                 Configuration.Feature.Tracing(
-                    endpointUrl = DatadogEndpoint.TRACES_US1,
+                    endpointUrl = DatadogSite.US1.intakeEndpoint,
                     plugins = emptyList(),
                     spanEventMapper = NoOpSpanEventMapper()
                 )
@@ -135,13 +134,13 @@ internal class ConfigurationBuilderTest {
             .isInstanceOf(NoOpSpanEventMapper::class.java)
         assertThat(config.crashReportConfig).isEqualTo(
             Configuration.Feature.CrashReport(
-                endpointUrl = DatadogEndpoint.LOGS_US1,
+                endpointUrl = DatadogSite.US1.intakeEndpoint,
                 plugins = emptyList()
             )
         )
         assertThat(config.rumConfig).isEqualTo(
             Configuration.Feature.RUM(
-                endpointUrl = DatadogEndpoint.RUM_US1,
+                endpointUrl = DatadogSite.US1.intakeEndpoint,
                 plugins = emptyList(),
                 samplingRate = Configuration.DEFAULT_SAMPLING_RATE,
                 telemetrySamplingRate = Configuration.DEFAULT_TELEMETRY_SAMPLING_RATE,
@@ -258,16 +257,16 @@ internal class ConfigurationBuilderTest {
             Configuration.DEFAULT_CORE_CONFIG.copy(site = site)
         )
         assertThat(config.logsConfig).isEqualTo(
-            Configuration.DEFAULT_LOGS_CONFIG.copy(endpointUrl = site.logsEndpoint())
+            Configuration.DEFAULT_LOGS_CONFIG.copy(endpointUrl = site.intakeEndpoint)
         )
         assertThat(config.tracesConfig).isEqualTo(
-            Configuration.DEFAULT_TRACING_CONFIG.copy(endpointUrl = site.tracesEndpoint())
+            Configuration.DEFAULT_TRACING_CONFIG.copy(endpointUrl = site.intakeEndpoint)
         )
         assertThat(config.crashReportConfig).isEqualTo(
-            Configuration.DEFAULT_CRASH_CONFIG.copy(endpointUrl = site.logsEndpoint())
+            Configuration.DEFAULT_CRASH_CONFIG.copy(endpointUrl = site.intakeEndpoint)
         )
         assertThat(config.rumConfig).isEqualTo(
-            Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = site.rumEndpoint())
+            Configuration.DEFAULT_RUM_CONFIG.copy(endpointUrl = site.intakeEndpoint)
         )
         assertThat(config.additionalConfig).isEmpty()
     }

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -68,7 +68,7 @@ android {
 
     flavorDimensions += listOf("version")
     productFlavors {
-        val regions = arrayOf("us1", "us3", "us5", "us1_fed", "eu1", "staging")
+        val regions = arrayOf("us1", "us3", "us5", "us1_fed", "eu1", "ap1", "staging")
 
         regions.forEachIndexed { index, region ->
             register(region) {


### PR DESCRIPTION
### What does this PR do?

Adds support to the AP1 (Japan) datacenter

### Additional Notes

We also use subdomainless endpoints, which are not necessary since API v2 where the track is part of the path. 

