### PR TITLE
Disable Kronos background sync in the CoreFeature unit test

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -148,7 +148,8 @@ internal class CoreFeature {
         resolveProcessInfo(appContext)
         initializeClockSync(appContext)
         setupOkHttpClient(configuration)
-        firstPartyHostHeaderTypeResolver.addKnownHostsWithHeaderTypes(configuration.firstPartyHostsWithHeaderTypes)
+        firstPartyHostHeaderTypeResolver
+            .addKnownHostsWithHeaderTypes(configuration.firstPartyHostsWithHeaderTypes)
         webViewTrackingHosts = configuration.webViewTrackingHosts
         androidInfoProvider = DefaultAndroidInfoProvider(appContext)
         setupExecutors()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -116,6 +116,7 @@ internal class CoreFeatureTest {
     @BeforeEach
     fun `set up`() {
         testedFeature = CoreFeature()
+        testedFeature.disableKronosBackgroundSync = true
         whenever(appContext.mockInstance.getSystemService(Context.CONNECTIVITY_SERVICE))
             .doReturn(mockConnectivityMgr)
     }
@@ -217,6 +218,7 @@ internal class CoreFeatureTest {
             assertThat(allValues)
                 .containsInstanceOf(BroadcastReceiverSystemInfoProvider::class.java)
             assertThat(allValues.none { it is BroadcastReceiverNetworkInfoProvider })
+                .isTrue
             verify(mockConnectivityMgr)
                 .registerDefaultNetworkCallback(isA<CallbackNetworkInfoProvider>())
         }


### PR DESCRIPTION
### What does this PR do?

I hope this should fix some flakiness in tests, related to the fact that during `CoreFeature` initialization Kronos can do background sync without a special flag set, and this background sync can call `internalLogger` which can be a mock at the time, adding unwanted interactions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

