### PR TITLE
RUMM-2599 ApplicationLaunch logic changes

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/AppStartTimeProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/AppStartTimeProvider.kt
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal
+
+internal interface AppStartTimeProvider {
+    /**
+     * Provide the application start time in nanoseconds from device boot, or our best guess if
+     * the actual start time is not available
+     */
+    val appStartTimeNs: Long
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/DefaultAppStartTimeProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/DefaultAppStartTimeProvider.kt
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal
+
+import android.annotation.SuppressLint
+import android.os.Build
+import android.os.Process
+import android.os.SystemClock
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
+import java.util.concurrent.TimeUnit
+
+internal class DefaultAppStartTimeProvider(
+    buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider()
+) : AppStartTimeProvider {
+
+    override val appStartTimeNs: Long by lazy(LazyThreadSafetyMode.PUBLICATION) {
+        @SuppressLint("NewApi")
+        when {
+            buildSdkVersionProvider.version() >= Build.VERSION_CODES.N -> {
+                val diffMs = SystemClock.elapsedRealtime() - Process.getStartElapsedRealtime()
+                System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(diffMs)
+            }
+            else -> RumFeature.startupTimeNs
+        }
+    }
+}

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -8,10 +8,10 @@ package com.datadog.android.rum.internal.domain.scope
 
 import androidx.annotation.WorkerThread
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.system.BuildSdkVersionProvider
-import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
 import com.datadog.android.core.internal.utils.percent
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.internal.AppStartTimeProvider
+import com.datadog.android.rum.internal.DefaultAppStartTimeProvider
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -37,7 +37,7 @@ internal class RumSessionScope(
     frameRateVitalMonitor: VitalMonitor,
     internal val sessionListener: RumSessionListener?,
     contextProvider: ContextProvider,
-    buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider(),
+    appStartTimeProvider: AppStartTimeProvider = DefaultAppStartTimeProvider(),
     private val sessionInactivityNanos: Long = DEFAULT_SESSION_INACTIVITY_NS,
     private val sessionMaxDurationNanos: Long = DEFAULT_SESSION_MAX_DURATION_NS
 ) : RumScope {
@@ -61,7 +61,7 @@ internal class RumSessionScope(
         cpuVitalMonitor,
         memoryVitalMonitor,
         frameRateVitalMonitor,
-        buildSdkVersionProvider,
+        appStartTimeProvider,
         contextProvider
     )
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/DefaultAppStartTimeProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/DefaultAppStartTimeProviderTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal
+
+import android.os.Build
+import android.os.Process
+import android.os.SystemClock
+import com.datadog.android.core.internal.system.BuildSdkVersionProvider
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.data.Offset
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import java.util.concurrent.TimeUnit
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+class DefaultAppStartTimeProviderTest {
+    @Test
+    fun `M return process start time W appStartTime { N+ }`() {
+        // GIVEN
+        val mockBuildSdkVersionProvider: BuildSdkVersionProvider = mock()
+        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.BASE
+        val diffMs = SystemClock.elapsedRealtime() - Process.getStartElapsedRealtime()
+        val startTimeNs = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(diffMs)
+
+        // WHEN
+        val timeProvider = DefaultAppStartTimeProvider(mockBuildSdkVersionProvider)
+        val providedStartTime = timeProvider.appStartTimeNs
+
+        // THEN
+        assertThat(providedStartTime)
+            .isCloseTo(startTimeNs, Offset.offset(TimeUnit.MILLISECONDS.toNanos(100)))
+    }
+
+    @Test
+    fun `M return rum load time W appStartTime { Legacy }`(
+        @IntForgery(min = Build.VERSION_CODES.KITKAT, max = Build.VERSION_CODES.N) apiVersion: Int
+    ) {
+        // GIVEN
+        val mockBuildSdkVersionProvider: BuildSdkVersionProvider = mock()
+        whenever(mockBuildSdkVersionProvider.version()) doReturn apiVersion
+        val startTimeNs = RumFeature.startupTimeNs
+
+        // WHEN
+        val timeProvider = DefaultAppStartTimeProvider(mockBuildSdkVersionProvider)
+        val providedStartTime = timeProvider.appStartTimeNs
+
+        // THEN
+        assertThat(providedStartTime).isEqualTo(startTimeNs)
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -7,8 +7,8 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.internal.AppStartTimeProvider
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.vitals.VitalMonitor
@@ -88,7 +88,7 @@ internal class RumSessionScopeTest {
     lateinit var mockSessionListener: RumSessionListener
 
     @Mock
-    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+    lateinit var mockAppStartTimeProvider: AppStartTimeProvider
 
     @Mock
     lateinit var mockContextProvider: ContextProvider
@@ -999,7 +999,7 @@ internal class RumSessionScopeTest {
             mockFrameRateVitalMonitor,
             mockSessionListener,
             mockContextProvider,
-            mockBuildSdkVersionProvider,
+            mockAppStartTimeProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS
         )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -7,19 +7,22 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import android.app.ActivityManager.RunningAppProcessInfo
-import android.os.Build
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
-import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.internal.AppStartTimeProvider
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.utils.config.InternalLoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.EventBatchWriter
+import com.datadog.android.v2.api.FeatureScope
 import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.DatadogContext
@@ -31,20 +34,20 @@ import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.atLeastOnce
+import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.eq
 import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.same
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
-import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.core.data.Offset
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -92,7 +95,7 @@ internal class RumViewManagerScopeTest {
     lateinit var mockContextProvider: ContextProvider
 
     @Mock
-    lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
+    lateinit var mockAppStartTimeProvider: AppStartTimeProvider
 
     @Mock
     lateinit var mockSdkCore: SdkCore
@@ -117,7 +120,7 @@ internal class RumViewManagerScopeTest {
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
         whenever(mockChildScope.isActive()) doReturn true
-        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.BASE
+        whenever(mockAppStartTimeProvider.appStartTimeNs) doReturn fakeTime.deviceTimeNs
 
         testedScope = RumViewManagerScope(
             mockParentScope,
@@ -128,7 +131,7 @@ internal class RumViewManagerScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockBuildSdkVersionProvider,
+            mockAppStartTimeProvider,
             mockContextProvider
         )
     }
@@ -146,6 +149,7 @@ internal class RumViewManagerScopeTest {
     fun `𝕄 delegate to child scope 𝕎 handleEvent()`() {
         // Given
         val fakeEvent: RumRawEvent = mock()
+        whenever(fakeEvent.eventTime) doReturn Time()
         testedScope.childrenScopes.add(mockChildScope)
 
         // When
@@ -446,7 +450,7 @@ internal class RumViewManagerScopeTest {
             cpuVitalMonitor = mockCpuVitalMonitor,
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
-            buildSdkVersionProvider = mockBuildSdkVersionProvider,
+            appStartTimeProvider = mockAppStartTimeProvider,
             contextProvider = mockContextProvider
         )
         testedScope.childrenScopes.add(mockChildScope)
@@ -476,7 +480,7 @@ internal class RumViewManagerScopeTest {
             cpuVitalMonitor = mockCpuVitalMonitor,
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
-            buildSdkVersionProvider = mockBuildSdkVersionProvider,
+            appStartTimeProvider = mockAppStartTimeProvider,
             contextProvider = mockContextProvider
         )
         testedScope.applicationDisplayed = true
@@ -514,23 +518,26 @@ internal class RumViewManagerScopeTest {
     // region AppLaunch View
 
     @Test
-    fun `𝕄 start an AppLaunch ViewScope 𝕎 handleEvent { app not displayed, event is relevant }`(
+    fun `𝕄 start an AppLaunch ViewScope 𝕎 handleEvent { app not displayed, any event }`(
         forge: Forge
     ) {
         // Given
         CoreFeature.processImportance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND
         testedScope.applicationDisplayed = false
+        val appStartTimeNs = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(500)
+        whenever(mockAppStartTimeProvider.appStartTimeNs) doReturn appStartTimeNs
         val fakeEvent = forge.validAppLaunchEvent()
 
         // When
         testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
+        val appStartTimeMs = TimeUnit.MILLISECONDS.toMillis(appStartTimeNs)
         assertThat(testedScope.childrenScopes).hasSize(1)
         assertThat(testedScope.childrenScopes[0])
             .isInstanceOfSatisfying(RumViewScope::class.java) {
                 assertThat(it.eventTimestamp)
-                    .isEqualTo(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
+                    .isEqualTo(resolveExpectedTimestamp(appStartTimeMs))
                 assertThat(it.keyRef.get()).isEqualTo(RumViewManagerScope.RUM_APP_LAUNCH_VIEW_URL)
                 assertThat(it.name).isEqualTo(RumViewManagerScope.RUM_APP_LAUNCH_VIEW_NAME)
                 assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)
@@ -580,21 +587,6 @@ internal class RumViewManagerScopeTest {
     }
 
     @Test
-    fun `𝕄 not start an AppLaunch ViewScope 𝕎 handleEvent { app not displayed, evt not relevant}`(
-        forge: Forge
-    ) {
-        // Given
-        testedScope.applicationDisplayed = false
-        val fakeEvent = forge.invalidAppLaunchEvent()
-
-        // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        assertThat(testedScope.childrenScopes).hasSize(0)
-    }
-
-    @Test
     fun `𝕄 not start an AppLaunch ViewScope 𝕎 handleEvent { app displ, evt relev, active view}`(
         forge: Forge
     ) {
@@ -608,7 +600,7 @@ internal class RumViewManagerScopeTest {
             cpuVitalMonitor = mockCpuVitalMonitor,
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
-            buildSdkVersionProvider = mockBuildSdkVersionProvider,
+            appStartTimeProvider = mockAppStartTimeProvider,
             contextProvider = mockContextProvider
         )
         testedScope.childrenScopes.add(mockChildScope)
@@ -622,25 +614,6 @@ internal class RumViewManagerScopeTest {
         // Then
         assertThat(testedScope.childrenScopes).hasSize(1)
         assertThat(testedScope.childrenScopes[0]).isSameAs(mockChildScope)
-    }
-
-    @Test
-    fun `𝕄 send warn dev log 𝕎 handleEvent { app not displayed, app launch event not relevant}`(
-        forge: Forge
-    ) {
-        // Given
-        testedScope.applicationDisplayed = false
-        val fakeEvent = forge.invalidAppLaunchEvent()
-
-        // When
-        testedScope.handleEvent(fakeEvent, mockWriter)
-
-        // Then
-        verify(logger.mockInternalLogger).log(
-            InternalLogger.Level.WARN,
-            InternalLogger.Target.USER,
-            RumViewManagerScope.MESSAGE_MISSING_VIEW
-        )
     }
 
     @Test
@@ -663,52 +636,40 @@ internal class RumViewManagerScopeTest {
     // region ApplicationStarted
 
     @Test
-    fun `𝕄 send ApplicationStarted event 𝕎 onViewDisplayed() {Legacy}`(
-        forge: Forge,
-        @IntForgery(min = Build.VERSION_CODES.KITKAT, max = Build.VERSION_CODES.N) apiVersion: Int
+    fun `𝕄 send ApplicationStarted event 𝕎 handleEvent ()`(
+        forge: Forge
     ) {
         // Given
+        // Because we have to test that the `application_started` action is written, we need to set
+        // up the feature scope properly
+        val mockRumFeatureScope: FeatureScope = mock()
+        val mockEventBatchWriter: EventBatchWriter = mock()
+        whenever(mockSdkCore.getFeature(RumFeature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+        }
+        val appStartTimeNs = System.nanoTime() - TimeUnit.MILLISECONDS.toNanos(500)
+        whenever(mockAppStartTimeProvider.appStartTimeNs) doReturn appStartTimeNs
         CoreFeature.processImportance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-        whenever(mockBuildSdkVersionProvider.version()) doReturn apiVersion
-        val childView: RumViewScope = mock()
-        val startViewEvent = forge.startViewEvent()
+
+        val fakeEvent = forge.addErrorEvent()
 
         // When
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
+        testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
-        argumentCaptor<RumRawEvent> {
-            verify(childView).handleEvent(capture(), same(mockWriter))
+        val appStartTimeMs = TimeUnit.NANOSECONDS.toMillis(appStartTimeNs)
+        argumentCaptor<ActionEvent> {
+            verify(mockWriter, atLeastOnce()).write(eq(mockEventBatchWriter), capture())
+            assertThat(firstValue.action.type).isEqualTo(ActionEvent.ActionEventActionType.APPLICATION_START)
+            // Application start event occurse at the start time
+            assertThat(firstValue.date).isEqualTo(resolveExpectedTimestamp(appStartTimeMs))
 
-            val event = firstValue as RumRawEvent.ApplicationStarted
-            assertThat(event.applicationStartupNanos).isEqualTo(RumFeature.startupTimeNs)
+            // Duration lasts until the first event is sent to RUM (whatever that is)
+            val loadingTime = fakeEvent.eventTime.nanoTime - appStartTimeNs
+            assertThat(firstValue.action.loadingTime).isEqualTo(loadingTime)
         }
-        verifyZeroInteractions(mockWriter)
-    }
-
-    @Test
-    fun `𝕄 send ApplicationStarted event 𝕎 onViewDisplayed() {Nougat+}`(
-        forge: Forge,
-        @IntForgery(min = Build.VERSION_CODES.N) apiVersion: Int
-    ) {
-        // Given
-        CoreFeature.processImportance = RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-        whenever(mockBuildSdkVersionProvider.version()) doReturn apiVersion
-        val childView: RumViewScope = mock()
-        val startViewEvent = forge.startViewEvent()
-
-        // When
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
-
-        // Then
-        argumentCaptor<RumRawEvent> {
-            verify(childView).handleEvent(capture(), same(mockWriter))
-
-            val event = firstValue as RumRawEvent.ApplicationStarted
-            assertThat(event.applicationStartupNanos)
-                .isCloseTo(System.nanoTime(), Offset.offset(TimeUnit.MILLISECONDS.toNanos(100)))
-        }
-        verifyZeroInteractions(mockWriter)
     }
 
     @Test
@@ -721,7 +682,7 @@ internal class RumViewManagerScopeTest {
         val startViewEvent = forge.startViewEvent()
 
         // When
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
+        testedScope.handleEvent(startViewEvent, mockWriter)
 
         // Then
         verifyZeroInteractions(childView, mockWriter)
@@ -750,7 +711,7 @@ internal class RumViewManagerScopeTest {
         val startViewEvent = forge.startViewEvent()
 
         // When
-        testedScope.onViewDisplayed(startViewEvent, childView, mockWriter)
+        testedScope.handleEvent(startViewEvent, mockWriter)
 
         // Then
         verifyZeroInteractions(childView, mockWriter)


### PR DESCRIPTION
### What does this PR do?

ApplicationLaunch now starts immediately when the first event is sent to RUM provided we are in the Foreground. The view's start time is now the process start time (or as close as we can get it), and the `application_start` event is also triggered immediately. The "duration" of the `application_start` event is equal to the time from when the process started, until the first event sent to RUM.

### Additional Notes

This may change the timing for `application_start` for some clients, but should make it shorter in most cases since instead of timing to first view (or first event that causes ApplicationLaunch) we time until the first event sent to RUM regardless of what that event is.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

