### PR TITLE
RUMM-3041 The RumEventMapper checks ViewEvents by reference

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapper.kt
@@ -83,7 +83,7 @@ internal data class RumEventMapper(
         // In case the event is of type ViewEvent this cannot be null according with the interface
         // but it can happen that if used from Java code to have null values. In this case we will
         // log a warning and we will use the original event.
-        return if (event is ViewEvent && (mappedEvent == null || mappedEvent != event)) {
+        return if (event is ViewEvent && (mappedEvent == null || mappedEvent !== event)) {
             internalLogger.log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
@@ -363,7 +363,7 @@ internal class RumEventMapperTest {
         val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
 
         // THEN
-        assertThat(mappedRumEvent).isEqualTo(fakeRumEvent)
+        assertThat(mappedRumEvent).isSameAs(fakeRumEvent)
         verify(logger.mockInternalLogger).log(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
@@ -442,6 +442,109 @@ internal class RumEventMapperTest {
         val fakeRumEvent = forge.getForgery<LongTaskEvent>()
         whenever(mockLongTaskEventMapper.map(fakeRumEvent))
             .thenReturn(forge.getForgery())
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        verify(logger.mockInternalLogger).log(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
+
+        )
+    }
+
+    @Test
+    fun `M use the original event W map returns a copy { ViewEvent }`(forge: Forge) {
+        // GIVEN
+        val fakeRumEvent = forge.getForgery<ViewEvent>()
+        whenever(mockViewEventMapper.map(fakeRumEvent))
+            .thenReturn(fakeRumEvent.copy())
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isSameAs(fakeRumEvent)
+        verify(logger.mockInternalLogger).log(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            RumEventMapper.VIEW_EVENT_NULL_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
+        )
+    }
+
+    @Test
+    fun `M return null event W map returns a copy { ResourceEvent }`(forge: Forge) {
+        // GIVEN
+        val fakeRumEvent = forge.getForgery<ResourceEvent>()
+        whenever(mockResourceEventMapper.map(fakeRumEvent))
+            .thenReturn(fakeRumEvent.copy())
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        verify(logger.mockInternalLogger).log(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
+
+        )
+    }
+
+    @Test
+    fun `M return null event W map returns a copy { not a crash ErrorEvent }`(
+        @Forgery fakeRumEvent: ErrorEvent
+    ) {
+        // GIVEN
+        val fakeNoCrashEvent = fakeRumEvent.copy(
+            error = fakeRumEvent.error.copy(isCrash = false)
+        )
+        whenever(mockErrorEventMapper.map(fakeNoCrashEvent))
+            .thenReturn(fakeNoCrashEvent.copy())
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeNoCrashEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        verify(logger.mockInternalLogger).log(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE
+                .format(Locale.US, fakeNoCrashEvent)
+        )
+    }
+
+    @Test
+    fun `M return null event W map returns a copy { ActionEvent }`(forge: Forge) {
+        // GIVEN
+        val fakeRumEvent = forge.getForgery<ActionEvent>()
+        whenever(mockActionEventMapper.map(fakeRumEvent))
+            .thenReturn(fakeRumEvent.copy())
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNull()
+        verify(logger.mockInternalLogger).log(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            RumEventMapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
+
+        )
+    }
+
+    @Test
+    fun `M return null event W map returns a copy { LongTaskEvent }`(forge: Forge) {
+        // GIVEN
+        val fakeRumEvent = forge.getForgery<LongTaskEvent>()
+        whenever(mockLongTaskEventMapper.map(fakeRumEvent))
+            .thenReturn(fakeRumEvent.copy())
 
         // WHEN
         val mappedRumEvent = testedRumEventMapper.map(fakeRumEvent)


### PR DESCRIPTION
### What does this PR do?

There was a bug in the `RumEventMapper` because for the `ViewEvent` we were comparing the original object with the mapped one by value and not by reference as required.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

