### PR TITLE
Disable Kronos sync for all unit-tests impacted

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -130,9 +130,6 @@ internal class CoreFeature {
 
     internal val featuresContext: MutableMap<String, Map<String, Any?>> = ConcurrentHashMap()
 
-    // TESTS ONLY, to prevent Kronos spinning sync threads in unit-tests
-    internal var disableKronosBackgroundSync = false
-
     fun initialize(
         appContext: Context,
         sdkInstanceId: String,
@@ -567,6 +564,12 @@ internal class CoreFeature {
         const val DRAIN_WAIT_SECONDS = 10L
         const val NTP_CACHE_EXPIRATION_MINUTES = 30L
         const val NTP_DELAY_BETWEEN_SYNCS_MINUTES = 5L
+
+        // TESTS ONLY, to prevent Kronos spinning sync threads in unit-tests, otherwise
+        // LoggingSyncListener can interact with internalLogger, breaking mockito
+        // verification expectations.
+        // TODO RUMM-0000 isolate Kronos somehow for unit-tests
+        internal var disableKronosBackgroundSync = false
 
         // endregion
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -11,6 +11,7 @@ import android.content.Context
 import android.net.ConnectivityManager
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
@@ -87,6 +88,8 @@ internal class DatadogTest {
 
         // Prevent crash when initializing RumFeature
         mockChoreographerInstance()
+
+        CoreFeature.disableKronosBackgroundSync = true
     }
 
     @AfterEach

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -115,8 +115,8 @@ internal class CoreFeatureTest {
 
     @BeforeEach
     fun `set up`() {
+        CoreFeature.disableKronosBackgroundSync = true
         testedFeature = CoreFeature()
-        testedFeature.disableKronosBackgroundSync = true
         whenever(appContext.mockInstance.getSystemService(Context.CONNECTIVITY_SERVICE))
             .doReturn(mockConnectivityMgr)
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -13,6 +13,7 @@ import androidx.work.impl.WorkManagerImpl
 import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.upload.UploadWorker
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
@@ -61,6 +62,8 @@ internal class WorkManagerUtilsTest {
     @BeforeEach
     fun `set up`(forge: Forge) {
         mockChoreographerInstance()
+
+        CoreFeature.disableKronosBackgroundSync = true
 
         Datadog.initialize(
             appContext.mockInstance,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -13,6 +13,7 @@ import androidx.work.impl.WorkManagerImpl
 import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
+import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.upload.UploadWorker
 import com.datadog.android.core.internal.thread.waitToIdle
 import com.datadog.android.core.internal.utils.TAG_DATADOG_UPLOAD
@@ -116,6 +117,8 @@ internal class DatadogExceptionHandlerTest {
 
         whenever(mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)) doReturn mockLogsFeatureScope
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+
+        CoreFeature.disableKronosBackgroundSync = true
 
         Datadog.initialize(
             appContext.mockInstance,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/config/CoreFeatureTestConfiguration.kt
@@ -131,7 +131,6 @@ internal class CoreFeatureTestConfiguration<T : Context>(
     }
 
     private fun configureCoreFeature() {
-        whenever(mockInstance.disableKronosBackgroundSync) doReturn true
         whenever(mockInstance.isMainProcess) doReturn true
         whenever(mockInstance.envName) doReturn fakeEnvName
         whenever(mockInstance.serviceName) doReturn fakeServiceName

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
@@ -80,6 +80,8 @@ internal class DatadogCoreInitializationTest {
     fun `set up`() {
         // Prevent crash when initializing RumFeature
         mockChoreographerInstance()
+
+        CoreFeature.disableKronosBackgroundSync = true
     }
 
     @AfterEach

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
@@ -93,6 +93,8 @@ internal class DatadogCoreTest {
         // Prevent crash when initializing RumFeature
         mockChoreographerInstance()
 
+        CoreFeature.disableKronosBackgroundSync = true
+
         testedCore = DatadogCore(
             appContext.mockInstance,
             fakeCredentials,


### PR DESCRIPTION
### What does this PR do?

Another attempt to fix flaky tests - we will disable Kronos sync for all the tests which are instantiating `CoreFeature` under the hood (which are calling `Datadog.initialize` or create `DatadogCore` instances).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

