### PR TITLE
RUMM-3060: Associate DatadogEventBridge with the particular SDK instance

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -547,12 +547,12 @@ class com.datadog.android.v2.log.net.LogsRequestFactory : com.datadog.android.v2
   override fun create(com.datadog.android.v2.api.context.DatadogContext, List<ByteArray>, ByteArray?): com.datadog.android.v2.api.Request
   companion object 
 class com.datadog.android.webview.DatadogEventBridge
-  constructor()
-  constructor(List<String>)
+  constructor(com.datadog.android.v2.api.SdkCore)
+  constructor(com.datadog.android.v2.api.SdkCore, List<String>)
   fun send(String)
   fun getAllowedWebViewHosts(): String
   companion object 
-    fun setup(android.webkit.WebView)
+    fun setup(com.datadog.android.v2.api.SdkCore, android.webkit.WebView)
 class com.datadog.tools.annotation.NoOpImplementation
 data class com.datadog.android.rum.model.ActionChildProperties
   constructor(Action? = null)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -64,8 +64,6 @@ internal class DatadogCore(
     internal val features: MutableMap<String, SdkFeature> = mutableMapOf()
 
     internal var rumFeature: RumFeature? = null
-    internal var webViewLogsFeature: WebViewLogsFeature? = null
-    internal var webViewRumFeature: WebViewRumFeature? = null
 
     // TODO RUMM-0000 handle context
     internal val contextProvider: ContextProvider?
@@ -128,7 +126,6 @@ internal class DatadogCore(
             feature
         )
         features[feature.name] = sdkFeature
-        // TODO RUMM-2943 get rid of plugins -> only NDK crash reporting
         sdkFeature.initialize(
             this,
             context.applicationContext
@@ -140,7 +137,6 @@ internal class DatadogCore(
                 // TODO RUMM-0000 Related to above, read from configuration, for now use default
                 DatadogEndpoint.LOGS_US1
             )
-            this.webViewLogsFeature = webViewLogsFeature
             registerFeature(webViewLogsFeature)
         }
     }
@@ -189,8 +185,6 @@ internal class DatadogCore(
             // TODO RUMM-0000 Temporary thing
             when (it.key) {
                 Feature.RUM_FEATURE_NAME -> rumFeature = null
-                WebViewLogsFeature.WEB_LOGS_FEATURE_NAME -> webViewLogsFeature = null
-                WebViewRumFeature.WEB_RUM_FEATURE_NAME -> webViewRumFeature = null
             }
         }
         features.clear()
@@ -326,7 +320,6 @@ internal class DatadogCore(
             registerFeature(rumFeature)
 
             val webViewRumFeature = WebViewRumFeature(configuration.endpointUrl, coreFeature)
-            this.webViewRumFeature = webViewRumFeature
             registerFeature(webViewRumFeature)
         }
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/DatadogEventBridge.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/webview/DatadogEventBridge.kt
@@ -9,17 +9,19 @@ package com.datadog.android.webview
 import android.webkit.JavascriptInterface
 import android.webkit.WebView
 import androidx.annotation.MainThread
-import com.datadog.android.Datadog
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.v2.api.InternalLogger
+import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.core.DatadogCore
 import com.datadog.android.webview.internal.MixedWebViewEventConsumer
 import com.datadog.android.webview.internal.NoOpWebViewEventConsumer
 import com.datadog.android.webview.internal.WebViewEventConsumer
 import com.datadog.android.webview.internal.log.WebViewLogEventConsumer
+import com.datadog.android.webview.internal.log.WebViewLogsFeature
 import com.datadog.android.webview.internal.rum.WebViewRumEventConsumer
 import com.datadog.android.webview.internal.rum.WebViewRumEventContextProvider
+import com.datadog.android.webview.internal.rum.WebViewRumFeature
 import com.google.gson.JsonArray
 
 /**
@@ -32,6 +34,7 @@ import com.google.gson.JsonArray
  */
 class DatadogEventBridge
 internal constructor(
+    private val sdkCore: SdkCore,
     internal val webViewEventConsumer: WebViewEventConsumer<String>,
     private val allowedHosts: List<String>
 ) {
@@ -42,10 +45,15 @@ internal constructor(
      * The goal is to make those events part of a unique mobile session.
      * Please note that the WebView events will not be tracked unless the web page's URL Host is part of
      * the list defined in the global [Configuration], or in the constructor.
+     *
+     * @param sdkCore SDK on which to attach the bridge.
      * @see [Configuration.Builder.setWebViewTrackingHosts]
      */
-    constructor() : this(
-        buildWebViewEventConsumer(),
+    constructor(
+        sdkCore: SdkCore
+    ) : this(
+        sdkCore,
+        buildWebViewEventConsumer(sdkCore),
         emptyList()
     )
 
@@ -55,12 +63,15 @@ internal constructor(
      * The goal is to make those events part of a unique mobile session.
      * Please note that the WebView events will not be tracked unless the web page's URL Host is part of
      * the list defined in the global [Configuration], or in the constructor.
+     *
+     * @param sdkCore SDK instance on which to attach the bridge.
      * @param allowedHosts a list of all the hosts that you want to track when loaded in the
      * WebView (e.g.: `listOf("example.com", "example.net")`).
      * @see [Configuration.Builder.setWebViewTrackingHosts]
      */
-    constructor(allowedHosts: List<String>) : this(
-        buildWebViewEventConsumer(),
+    constructor(sdkCore: SdkCore, allowedHosts: List<String>) : this(
+        sdkCore,
+        buildWebViewEventConsumer(sdkCore),
         allowedHosts
     )
 
@@ -88,7 +99,7 @@ internal constructor(
         allowedHosts.forEach {
             origins.add(it)
         }
-        val coreFeature = (Datadog.globalSdkCore as? DatadogCore)?.coreFeature
+        val coreFeature = (sdkCore as? DatadogCore)?.coreFeature
         coreFeature?.webViewTrackingHosts?.forEach {
             origins.add(it)
         }
@@ -117,11 +128,12 @@ internal constructor(
          * ```
          * webView.webViewClient = WebViewClient()
          * ```
-         * @param webView the webView on which to attach the bridge
+         * @param sdkCore SDK instance on which to attach the bridge.
+         * @param webView the webView on which to attach the bridge.
          * [More here](https://developer.android.com/guide/webapps/webview#HandlingNavigation).
          */
         @MainThread
-        fun setup(webView: WebView) {
+        fun setup(sdkCore: SdkCore, webView: WebView) {
             if (!webView.settings.javaScriptEnabled) {
                 internalLogger.log(
                     InternalLogger.Level.WARN,
@@ -129,13 +141,14 @@ internal constructor(
                     JAVA_SCRIPT_NOT_ENABLED_WARNING_MESSAGE
                 )
             }
-            webView.addJavascriptInterface(DatadogEventBridge(), DATADOG_EVENT_BRIDGE_NAME)
+            webView.addJavascriptInterface(DatadogEventBridge(sdkCore), DATADOG_EVENT_BRIDGE_NAME)
         }
 
-        private fun buildWebViewEventConsumer(): WebViewEventConsumer<String> {
-            val datadogCore = Datadog.globalSdkCore as? DatadogCore
-            val webViewRumFeature = datadogCore?.webViewRumFeature
-            val webViewLogsFeature = datadogCore?.webViewLogsFeature
+        private fun buildWebViewEventConsumer(sdkCore: SdkCore): WebViewEventConsumer<String> {
+            val webViewRumFeature = sdkCore.getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)
+                ?.unwrap<WebViewRumFeature>()
+            val webViewLogsFeature = sdkCore.getFeature(WebViewLogsFeature.WEB_LOGS_FEATURE_NAME)
+                ?.unwrap<WebViewLogsFeature>()
             val contextProvider = WebViewRumEventContextProvider()
 
             if (webViewLogsFeature == null || webViewRumFeature == null) {
@@ -143,12 +156,12 @@ internal constructor(
             } else {
                 return MixedWebViewEventConsumer(
                     WebViewRumEventConsumer(
-                        sdkCore = datadogCore,
+                        sdkCore = sdkCore,
                         dataWriter = webViewRumFeature.dataWriter,
                         contextProvider = contextProvider
                     ),
                     WebViewLogEventConsumer(
-                        sdkCore = datadogCore,
+                        sdkCore = sdkCore,
                         userLogsWriter = webViewLogsFeature.dataWriter,
                         rumContextProvider = contextProvider
                     )

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
@@ -119,12 +119,10 @@ internal class DatadogCoreInitializationTest {
         }
         if (rumEnabled) {
             assertThat(testedCore.rumFeature!!.initialized.get()).isTrue()
-            assertThat(testedCore.webViewRumFeature!!.initialized.get()).isTrue()
             assertThat(testedCore.getFeature(Feature.RUM_FEATURE_NAME)).isNotNull
             assertThat(testedCore.getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)).isNotNull
         } else {
             assertThat(testedCore.rumFeature).isNull()
-            assertThat(testedCore.webViewRumFeature).isNull()
             assertThat(testedCore.getFeature(Feature.RUM_FEATURE_NAME)).isNull()
             assertThat(testedCore.getFeature(WebViewRumFeature.WEB_RUM_FEATURE_NAME)).isNull()
         }
@@ -146,7 +144,6 @@ internal class DatadogCoreInitializationTest {
         // Then
         assertThat(testedCore.coreFeature.initialized.get()).isTrue()
         assertThat(testedCore.rumFeature!!.initialized.get()).isTrue()
-        assertThat(testedCore.webViewRumFeature!!.initialized.get()).isTrue()
         verify(logger.mockInternalLogger).log(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
@@ -170,7 +167,6 @@ internal class DatadogCoreInitializationTest {
         // Then
         assertThat(testedCore.coreFeature.initialized.get()).isTrue()
         assertThat(testedCore.rumFeature).isNull()
-        assertThat(testedCore.webViewRumFeature).isNull()
         verify(logger.mockInternalLogger, never())
             .log(
                 any(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
@@ -441,10 +441,6 @@ internal class DatadogCoreTest {
         testedCore.coreFeature = mockCoreFeature
         val mockRumFeature = mock<RumFeature>()
         testedCore.rumFeature = mockRumFeature
-        val mockWebViewLogsFeature = mock<WebViewLogsFeature>()
-        testedCore.webViewLogsFeature = mockWebViewLogsFeature
-        val mockWebViewRumFeature = mock<WebViewRumFeature>()
-        testedCore.webViewRumFeature = mockWebViewRumFeature
 
         val sdkFeatureMocks = listOf(
             Feature.RUM_FEATURE_NAME,
@@ -468,8 +464,6 @@ internal class DatadogCoreTest {
         }
 
         assertThat(testedCore.rumFeature).isNull()
-        assertThat(testedCore.webViewLogsFeature).isNull()
-        assertThat(testedCore.webViewRumFeature).isNull()
         assertThat(testedCore.contextProvider).isNull()
 
         assertThat(testedCore.features).isEmpty()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
@@ -42,7 +42,7 @@ internal class WebViewTrackingE2ETests {
     // region Tests
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor()
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setWebViewTrackingHosts(List<String>): Builder
@@ -54,7 +54,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(List<String>)
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore, List<String>)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      */
@@ -72,7 +72,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor()
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      */
@@ -90,7 +90,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor()
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setWebViewTrackingHosts(List<String>): Builder
      */
@@ -108,7 +108,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor()
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setWebViewTrackingHosts(List<String>): Builder
@@ -122,7 +122,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor()
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setWebViewTrackingHosts(List<String>): Builder
@@ -137,7 +137,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor()
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setWebViewTrackingHosts(List<String>): Builder

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/WebViewTrackingActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/WebViewTrackingActivity.kt
@@ -10,6 +10,7 @@ import android.os.Bundle
 import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AppCompatActivity
+import com.datadog.android.Datadog
 import com.datadog.android.nightly.R
 import com.datadog.android.nightly.utils.measure
 import com.datadog.android.webview.DatadogEventBridge
@@ -35,7 +36,7 @@ internal open class WebViewTrackingActivity : AppCompatActivity() {
     }
 
     open fun setupWebView(webView: WebView) {
-        val datadogEventBridge = DatadogEventBridge()
+        val datadogEventBridge = DatadogEventBridge(Datadog.globalSdkCore)
         measure(TEST_METHOD_NAME) {
             webView.addJavascriptInterface(datadogEventBridge, "DatadogEventBridge")
         }

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/WebViewTrackingBridgeHostsActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/WebViewTrackingBridgeHostsActivity.kt
@@ -7,13 +7,14 @@
 package com.datadog.android.nightly.activities
 
 import android.webkit.WebView
+import com.datadog.android.Datadog
 import com.datadog.android.nightly.utils.measure
 import com.datadog.android.webview.DatadogEventBridge
 
 internal class WebViewTrackingBridgeHostsActivity : WebViewTrackingActivity() {
 
     override fun setupWebView(webView: WebView) {
-        val datadogEventBridge = DatadogEventBridge(listOf("datadoghq.dev"))
+        val datadogEventBridge = DatadogEventBridge(Datadog.globalSdkCore, listOf("datadoghq.dev"))
         measure(TEST_METHOD_NAME) {
             webView.addJavascriptInterface(datadogEventBridge, "DatadogEventBridge")
         }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/WebFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/WebFragment.kt
@@ -13,6 +13,7 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
+import com.datadog.android.Datadog
 import com.datadog.android.sample.R
 import com.datadog.android.webview.DatadogEventBridge
 
@@ -32,7 +33,7 @@ internal class WebFragment : Fragment() {
         webView = rootView.findViewById(R.id.webview)
         webView.webViewClient = WebViewClient()
         webView.settings.javaScriptEnabled = true
-        DatadogEventBridge.setup(webView)
+        DatadogEventBridge.setup(Datadog.globalSdkCore, webView)
         return rootView
     }
 


### PR DESCRIPTION
### What does this PR do?

This change makes `DatadogEventBridge` to require SDK instance explicitly via its public API. This is needed in order to avoid having a dependency on `DatadogCore` class, which won't be available after the WebView-related code extraction into the dedicated module.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

