### PR TITLE
RUMM-3051: Remove okhttp3.internal package usage

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/RequestUniqueIdentifier.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/net/RequestUniqueIdentifier.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.core.internal.net
 
 import okhttp3.Request
-import okhttp3.internal.Util
+import java.io.IOException
 
 /**
  * Generates an identifier to uniquely track requests.
@@ -16,11 +16,25 @@ internal fun identifyRequest(request: Request): String {
     val method = request.method()
     val url = request.url()
     val body = request.body()
-    return if (body == null || body == Util.EMPTY_REQUEST) {
+    return if (body == null) {
         "$method•$url"
     } else {
-        val contentLength = body.contentLength()
+        val contentLength = try {
+            body.contentLength()
+        } catch (@Suppress("SwallowedException") ioe: IOException) {
+            0
+        }
         val contentType = body.contentType()
-        "$method•$url•$contentLength•$contentType"
+        // TODO RUMM-3062 It is possible that if requests are say GZIPed (as an example), or maybe
+        //  streaming case (?), they all will have contentLength = -1, so if they target the same URL
+        //  they are going to have same identifier, messing up reporting.
+        //  -1 is valid return value for contentLength() call according to the docs and stands
+        //  for "unknown" case.
+        //  We need to have a more precise identification.
+        if (contentType != null || contentLength != 0L) {
+            "$method•$url•$contentLength•$contentType"
+        } else {
+            "$method•$url"
+        }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Fixes #1282. This PR removes `okhttp3.internal` package usage, we were using `okhttp3.internal.Util.EMPTY_REQUEST`.

There is a [warning](https://square.github.io/okhttp/changelogs/upgrading_to_okhttp_4/#internal-api-changes) about `okhttp3.internal` package usage for OkHttp 4.x, but with OkHttp 4.x this usage didn't cause any problems - the class and field were still there.

However, it seems things are finally moved for OkHttp 5.x (which is in alpha for now, changelog is [here](https://square.github.io/okhttp/changelogs/changelog/)), so to be on the safe side we are getting rid of reference to `okhttp3.internal`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

