### PR TITLE
Move LogsRequestFactory into Logs module, update coverage for nightly tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -252,7 +252,7 @@ tasks.register("buildNdkIntegrationTestsArtifacts") {
     dependsOn(":instrumented:integration:assembleDebug")
 }
 
-nightlyTestsCoverageConfig(threshold = 0.81f)
+nightlyTestsCoverageConfig(threshold = 0.85f)
 kover {
     isDisabled = false
     disabledProjects = setOf(

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -541,10 +541,6 @@ data class com.datadog.android.v2.api.context.UserInfo
   constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, Map<kotlin.String, kotlin.Any?> = emptyMap())
 interface com.datadog.android.v2.core.storage.DataWriter<T>
   fun write(com.datadog.android.v2.api.EventBatchWriter, T): Boolean
-class com.datadog.android.v2.log.net.LogsRequestFactory : com.datadog.android.v2.api.RequestFactory
-  constructor(String)
-  override fun create(com.datadog.android.v2.api.context.DatadogContext, List<ByteArray>, ByteArray?): com.datadog.android.v2.api.Request
-  companion object 
 class com.datadog.tools.annotation.NoOpImplementation
 data class com.datadog.android.rum.model.ActionChildProperties
   constructor(Action? = null)

--- a/instrumentation-tools/src/constants.py
+++ b/instrumentation-tools/src/constants.py
@@ -9,7 +9,8 @@ API_SURFACE_PATHS = [
     "library/dd-sdk-android-session-replay/apiSurface",
     "library/dd-sdk-android-logs/apiSurface",
     "library/dd-sdk-android-ndk/apiSurface",
-    "library/dd-sdk-android-trace/apiSurface"
+    "library/dd-sdk-android-trace/apiSurface",
+    "library/dd-sdk-android-webview/apiSurface"
 ]
 NIGHTLY_TESTS_DIRECTORY_PATH = "instrumented/nightly-tests/src/androidTest/kotlin"
 NIGHTLY_TESTS_PACKAGE = "com/datadog/android/nightly"

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
@@ -108,7 +108,7 @@ class LogsConfigE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
+     * apiMethodSignature: com.datadog.android.log.LogsFeature$Builder#fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
      */
     @Test
     fun logs_config_set_event_mapper() {
@@ -144,7 +144,7 @@ class LogsConfigE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
+     * apiMethodSignature: com.datadog.android.log.LogsFeature$Builder#fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
      */
     @Test
     fun logs_config_set_event_mapper_with_drop_event() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -18,9 +18,7 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setUseDeveloperModeWhenDebuggable(Boolean): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setAdditionalConfiguration(Map<String, Any>): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useCustomCrashReportsEndpoint(String): Builder
- * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useCustomLogsEndpoint(String): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useCustomRumEndpoint(String): Builder
- * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useCustomTracesEndpoint(String): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun addPlugin(com.datadog.android.plugin.DatadogPlugin, com.datadog.android.plugin.Feature): Builder
  * apiMethodSignature: com.datadog.android.core.sampling.RateBasedSampler#constructor(Double)
@@ -31,7 +29,6 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.sessionreplay.SessionReplayConfiguration$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
  * apiMethodSignature: com.datadog.android.rum.RumMonitor$Builder#fun setSessionListener(RumSessionListener): Builder
  * apiMethodSignature: com.datadog.android.log.Logger#fun log(Int, String, Throwable? = null, Map<String, Any?> = emptyMap())
- * apiMethodSignature: com.datadog.android.plugin.DatadogPluginConfig#constructor(android.content.Context, String, String, com.datadog.android.privacy.TrackingConsent)
  * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setLogcatLogsEnabled(Boolean): Builder
  * apiMethodSignature: com.datadog.android._InternalProxy$_TelemetryProxy#fun debug(String)
  * apiMethodSignature: com.datadog.android._InternalProxy$_TelemetryProxy#fun error(String, String?, String?)
@@ -42,5 +39,8 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.rum.resource.RumResourceInputStream#constructor(java.io.InputStream, String)
  * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#fun startTracking()
  * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#fun stopTracking()
- * apiMethodSignature: com.datadog.android.v2.log.net.LogsRequestFactory#constructor(String)
+ * apiMethodSignature: com.datadog.android.log.LogsFeature$Builder#fun useCustomEndpoint(String): Builder
+ * apiMethodSignature: com.datadog.android.log.LogsFeature$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
+ * apiMethodSignature: com.datadog.android.trace.TracingFeature$Builder#fun useCustomEndpoint(String): Builder
+ * apiMethodSignature: com.datadog.android.trace.TracingFeature$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
  */

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
@@ -112,7 +112,7 @@ class SpanConfigE2ETests {
 
     /**
      * apiMethodSignature: com.datadog.android.trace.AndroidTracer$Builder#constructor()
-     * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setSpanEventMapper(com.datadog.android.trace.internal.domain.event.SpanEventMapper): Builder
+     * apiMethodSignature: com.datadog.android.trace.TracingFeature$Builder#fun setSpanEventMapper(com.datadog.android.trace.internal.domain.event.SpanEventMapper): Builder
      */
     @Test
     fun trace_config_set_span_event_mapper() {

--- a/library/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/LogsFeature.kt
+++ b/library/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/LogsFeature.kt
@@ -18,6 +18,7 @@ import com.datadog.android.event.NoOpEventMapper
 import com.datadog.android.log.internal.domain.DatadogLogGenerator
 import com.datadog.android.log.internal.domain.event.LogEventMapperWrapper
 import com.datadog.android.log.internal.domain.event.LogEventSerializer
+import com.datadog.android.log.internal.net.LogsRequestFactory
 import com.datadog.android.log.internal.storage.LogsDataWriter
 import com.datadog.android.log.internal.storage.NoOpDataWriter
 import com.datadog.android.log.model.LogEvent
@@ -32,7 +33,6 @@ import com.datadog.android.v2.api.StorageBackedFeature
 import com.datadog.android.v2.api.context.NetworkInfo
 import com.datadog.android.v2.api.context.UserInfo
 import com.datadog.android.v2.core.storage.DataWriter
-import com.datadog.android.v2.log.net.LogsRequestFactory
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit

--- a/library/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/net/LogsRequestFactory.kt
+++ b/library/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/net/LogsRequestFactory.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.v2.log.net
+package com.datadog.android.log.internal.net
 
 import com.datadog.android.core.internal.utils.join
 import com.datadog.android.v2.api.Request
@@ -13,14 +13,12 @@ import com.datadog.android.v2.api.context.DatadogContext
 import java.util.Locale
 import java.util.UUID
 
-// TODO RUMM-3002. Probably public temporary? Public for now, because need to share
-//  between Logs and WebView Logs.
 /**
  * Request factory for the Logs feature.
  * @param endpointUrl URL of the Logs intake.
  */
-class LogsRequestFactory(
-    val endpointUrl: String
+internal class LogsRequestFactory(
+    internal val endpointUrl: String
 ) : RequestFactory {
 
     /** @inheritdoc */

--- a/library/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsFeatureBuilderTest.kt
+++ b/library/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsFeatureBuilderTest.kt
@@ -10,9 +10,9 @@ import com.datadog.android.DatadogEndpoint
 import com.datadog.android.DatadogSite
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.NoOpEventMapper
+import com.datadog.android.log.internal.net.LogsRequestFactory
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.log.net.LogsRequestFactory
 import com.nhaarman.mockitokotlin2.mock
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery

--- a/library/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsFeatureTest.kt
+++ b/library/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsFeatureTest.kt
@@ -10,6 +10,7 @@ import android.content.Context
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.MapperSerializer
 import com.datadog.android.log.internal.domain.event.LogEventMapperWrapper
+import com.datadog.android.log.internal.net.LogsRequestFactory
 import com.datadog.android.log.internal.storage.LogsDataWriter
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.config.InternalLoggerTestConfiguration
@@ -25,13 +26,11 @@ import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.NetworkInfo
 import com.datadog.android.v2.api.context.UserInfo
 import com.datadog.android.v2.core.storage.DataWriter
-import com.datadog.android.v2.log.net.LogsRequestFactory
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.forge.aThrowable
 import com.datadog.tools.unit.forge.exhaustiveAttributes
-import com.datadog.tools.unit.getFieldValue
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doAnswer

--- a/library/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/net/LogsRequestFactoryTest.kt
+++ b/library/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/net/LogsRequestFactoryTest.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.v2.log.net
+package com.datadog.android.log.internal.net
 
 import com.datadog.android.core.internal.utils.join
 import com.datadog.android.utils.forge.Configurator


### PR DESCRIPTION
### What does this PR do?

Since WebView Logs doesn't use `LogsRequestFactory` explicitly now, we can move this class to the Logs module and make it internal.

Also this PR updates coverage for nightly tests.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

