### PR TITLE
RUMM-1391 Refactor the SR ViewMapper implementations

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckBoxMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckBoxMapper.kt
@@ -13,10 +13,9 @@ import com.datadog.android.sessionreplay.internal.utils.StringUtils
 internal open class CheckBoxMapper(
     textWireframeMapper: TextWireframeMapper,
     stringUtils: StringUtils = StringUtils,
-    uniqueIdentifierGenerator: UniqueIdentifierResolver =
-        UniqueIdentifierResolver,
+    uniqueIdentifierGenerator: UniqueIdentifierResolver = UniqueIdentifierResolver,
     viewUtils: ViewUtils = ViewUtils()
-) : CompoundButtonMapper<CheckBox>(
+) : CheckableCompoundButtonMapper<CheckBox>(
     textWireframeMapper,
     stringUtils,
     uniqueIdentifierGenerator,

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableCompoundButtonMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableCompoundButtonMapper.kt
@@ -9,36 +9,27 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 import android.os.Build
 import android.widget.CompoundButton
 import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
-import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.internal.recorder.ViewUtils
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.internal.utils.StringUtils
-import com.datadog.android.sessionreplay.model.MobileSegment
 
-internal abstract class CompoundButtonMapper<T : CompoundButton>(
-    private val textWireframeMapper: TextWireframeMapper,
-    private val stringUtils: StringUtils = StringUtils,
+internal abstract class CheckableCompoundButtonMapper<T : CompoundButton>(
+    textWireframeMapper: TextWireframeMapper,
+    stringUtils: StringUtils = StringUtils,
     uniqueIdentifierGenerator: UniqueIdentifierResolver = UniqueIdentifierResolver,
     viewUtils: ViewUtils = ViewUtils()
-) :
-    CheckableWireframeMapper<T>(uniqueIdentifierGenerator, viewUtils) {
+) : CheckableTextViewMapper<T>(
+    textWireframeMapper,
+    stringUtils,
+    uniqueIdentifierGenerator,
+    viewUtils
+) {
 
-    override fun map(view: T, systemInformation: SystemInformation):
-        List<MobileSegment.Wireframe> {
-        val mainWireframeList = textWireframeMapper.map(view, systemInformation)
-        resolveCheckableWireframe(view, systemInformation.screenDensity)?.let { wireframe ->
-            return mainWireframeList + wireframe
-        }
-        return mainWireframeList
-    }
-
-    override fun resolveCheckableColor(view: T): String {
-        return stringUtils.formatColorAndAlphaAsHexa(view.currentTextColor, OPAQUE_ALPHA_VALUE)
-    }
+    // region CheckableTextViewMapper
 
     override fun resolveCheckableBounds(view: T, pixelsDensity: Float): GlobalBounds {
         val viewGlobalBounds = resolveViewGlobalBounds(view, pixelsDensity)
-        var checkBoxHeight = DEFAULT_CHECKBOX_HEIGHT_IN_PX
+        var checkBoxHeight = DEFAULT_CHECKABLE_HEIGHT_IN_PX
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             view.buttonDrawable?.let {
                 checkBoxHeight = it.intrinsicHeight.toLong()
@@ -60,8 +51,10 @@ internal abstract class CompoundButtonMapper<T : CompoundButton>(
         )
     }
 
+    // endregion
+
     companion object {
         internal const val MIN_PADDING_IN_PX = 20L
-        internal const val DEFAULT_CHECKBOX_HEIGHT_IN_PX = 84L
+        internal const val DEFAULT_CHECKABLE_HEIGHT_IN_PX = 84L
     }
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
@@ -1,0 +1,122 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.mapper
+
+import android.widget.Checkable
+import android.widget.TextView
+import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
+import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
+import com.datadog.android.sessionreplay.internal.recorder.ViewUtils
+import com.datadog.android.sessionreplay.internal.utils.StringUtils
+import com.datadog.android.sessionreplay.model.MobileSegment
+
+internal abstract class CheckableTextViewMapper<T>(
+    private val textWireframeMapper: TextWireframeMapper,
+    private val stringUtils: StringUtils = StringUtils,
+    private val uniqueIdentifierGenerator: UniqueIdentifierResolver,
+    viewUtils: ViewUtils = ViewUtils()
+) : CheckableWireframeMapper<T>(viewUtils) where T : TextView, T : Checkable {
+
+    // region CheckableWireframeMapper
+
+    override fun resolveMainWireframes(view: T, systemInformation: SystemInformation):
+        List<MobileSegment.Wireframe> {
+        return textWireframeMapper.map(view, systemInformation)
+    }
+
+    override fun resolveCheckedCheckable(view: T, systemInformation: SystemInformation):
+        List<MobileSegment.Wireframe>? {
+        val checkableId = uniqueIdentifierGenerator.resolveChildUniqueIdentifier(
+            view,
+            CHECKABLE_KEY_NAME
+        ) ?: return null
+        val checkBoxColor = resolveCheckableColor(view)
+        val checkBoxBounds = resolveCheckableBounds(view, systemInformation.screenDensity)
+        val shapeStyle = resolveCheckedShapeStyle(view, checkBoxColor)
+        val shapeBorder = resolveCheckedShapeBorder(view, checkBoxColor)
+        return listOf(
+            MobileSegment.Wireframe.ShapeWireframe(
+                id = checkableId,
+                x = checkBoxBounds.x,
+                y = checkBoxBounds.y,
+                width = checkBoxBounds.width,
+                height = checkBoxBounds.height,
+                border = shapeBorder,
+                shapeStyle = shapeStyle
+            )
+        )
+    }
+
+    override fun resolveNotCheckedCheckable(view: T, systemInformation: SystemInformation):
+        List<MobileSegment.Wireframe>? {
+        val checkableId = uniqueIdentifierGenerator.resolveChildUniqueIdentifier(
+            view,
+            CHECKABLE_KEY_NAME
+        ) ?: return null
+        val checkBoxColor = resolveCheckableColor(view)
+        val checkBoxBounds = resolveCheckableBounds(view, systemInformation.screenDensity)
+        val shapeBorder = resolveNotCheckedShapeBorder(view, checkBoxColor)
+        val shapeStyle = resolveNotCheckedShapeStyle(view, checkBoxColor)
+        return listOf(
+            MobileSegment.Wireframe.ShapeWireframe(
+                id = checkableId,
+                x = checkBoxBounds.x,
+                y = checkBoxBounds.y,
+                width = checkBoxBounds.width,
+                height = checkBoxBounds.height,
+                border = shapeBorder,
+                shapeStyle = shapeStyle
+            )
+        )
+    }
+
+    // endregion
+
+    // region CheckableTextViewMapper
+
+    abstract fun resolveCheckableBounds(view: T, pixelsDensity: Float): GlobalBounds
+
+    protected open fun resolveCheckableColor(view: T): String {
+        return stringUtils.formatColorAndAlphaAsHexa(view.currentTextColor, OPAQUE_ALPHA_VALUE)
+    }
+
+    protected open fun resolveCheckedShapeStyle(view: T, checkBoxColor: String):
+        MobileSegment.ShapeStyle? {
+        return MobileSegment.ShapeStyle(
+            backgroundColor = checkBoxColor,
+            view.alpha
+        )
+    }
+
+    protected open fun resolveCheckedShapeBorder(view: T, checkBoxColor: String):
+        MobileSegment.ShapeBorder? {
+        return MobileSegment.ShapeBorder(
+            color = checkBoxColor,
+            width = CHECKABLE_BORDER_WIDTH
+        )
+    }
+
+    protected open fun resolveNotCheckedShapeStyle(view: T, checkBoxColor: String):
+        MobileSegment.ShapeStyle? {
+        return null
+    }
+
+    protected open fun resolveNotCheckedShapeBorder(view: T, checkBoxColor: String):
+        MobileSegment.ShapeBorder? {
+        return MobileSegment.ShapeBorder(
+            color = checkBoxColor,
+            width = CHECKABLE_BORDER_WIDTH
+        )
+    }
+
+    // endregion
+
+    companion object {
+        internal const val CHECKABLE_KEY_NAME = "checkable"
+        internal const val CHECKABLE_BORDER_WIDTH = 1L
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
@@ -6,69 +6,34 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
+import android.view.View
 import android.widget.Checkable
-import android.widget.TextView
-import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
+import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.internal.recorder.ViewUtils
 import com.datadog.android.sessionreplay.model.MobileSegment
 
-internal abstract class CheckableWireframeMapper<T>(
-    private val uniqueIdentifierGenerator: UniqueIdentifierResolver,
-    viewUtils: ViewUtils
-) : BaseWireframeMapper<T, MobileSegment.Wireframe>(viewUtils = viewUtils)
-        where T : TextView, T : Checkable {
+internal abstract class CheckableWireframeMapper<T>(viewUtils: ViewUtils) :
+    BaseWireframeMapper<T, MobileSegment.Wireframe>(viewUtils = viewUtils)
+        where T : View, T : Checkable {
 
-    internal fun resolveCheckableWireframe(view: T, pixelDensity: Float):
-        MobileSegment.Wireframe? {
-        val checkboxId = uniqueIdentifierGenerator.resolveChildUniqueIdentifier(
-            view,
-            CHECKBOX_KEY_NAME
-        )
-        return if (checkboxId != null) {
-            val checkBoxColor = resolveCheckableColor(view)
-            val checkBoxBounds = resolveCheckableBounds(view, pixelDensity)
-            val shapeStyle = resolveCheckableShapeStyle(view, checkBoxColor)
-            val shapeBorder = resolveCheckableShapeBorder(view, checkBoxColor)
-            MobileSegment.Wireframe.ShapeWireframe(
-                id = checkboxId,
-                x = checkBoxBounds.x,
-                y = checkBoxBounds.y,
-                width = checkBoxBounds.width,
-                height = checkBoxBounds.height,
-                border = shapeBorder,
-                shapeStyle = shapeStyle
-            )
+    override fun map(view: T, systemInformation: SystemInformation): List<MobileSegment.Wireframe> {
+        val mainWireframes = resolveMainWireframes(view, systemInformation)
+        val checkableWireframes = if (view.isChecked) {
+            resolveCheckedCheckable(view, systemInformation)
         } else {
-            null
+            resolveNotCheckedCheckable(view, systemInformation)
         }
-    }
-
-    internal open fun resolveCheckableShapeStyle(view: T, checkBoxColor: String):
-        MobileSegment.ShapeStyle? {
-        return if (view.isChecked) {
-            MobileSegment.ShapeStyle(
-                backgroundColor = checkBoxColor,
-                view.alpha
-            )
-        } else {
-            null
+        checkableWireframes?.let { wireframes ->
+            return mainWireframes + wireframes
         }
+        return mainWireframes
     }
 
-    internal open fun resolveCheckableShapeBorder(view: T, checkBoxColor: String):
-        MobileSegment.ShapeBorder? {
-        return MobileSegment.ShapeBorder(
-            color = checkBoxColor,
-            width = CHECKBOX_BORDER_WIDTH
-        )
-    }
+    abstract fun resolveMainWireframes(view: T, systemInformation: SystemInformation):
+        List<MobileSegment.Wireframe>
 
-    internal abstract fun resolveCheckableColor(view: T): String
-
-    internal abstract fun resolveCheckableBounds(view: T, pixelsDensity: Float): GlobalBounds
-
-    companion object {
-        internal const val CHECKBOX_KEY_NAME = "checkbox"
-        internal const val CHECKBOX_BORDER_WIDTH = 1L
-    }
+    abstract fun resolveNotCheckedCheckable(view: T, systemInformation: SystemInformation):
+        List<MobileSegment.Wireframe>?
+    abstract fun resolveCheckedCheckable(view: T, systemInformation: SystemInformation):
+        List<MobileSegment.Wireframe>?
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckedTextViewMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckedTextViewMapper.kt
@@ -9,28 +9,23 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 import android.os.Build
 import android.widget.CheckedTextView
 import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
-import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.internal.recorder.ViewUtils
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.internal.utils.StringUtils
-import com.datadog.android.sessionreplay.model.MobileSegment
 
 internal open class CheckedTextViewMapper(
-    private val textWireframeMapper: TextWireframeMapper,
+    textWireframeMapper: TextWireframeMapper,
     private val stringUtils: StringUtils = StringUtils,
-    uniqueIdentifierGenerator: UniqueIdentifierResolver =
-        UniqueIdentifierResolver,
+    uniqueIdentifierGenerator: UniqueIdentifierResolver = UniqueIdentifierResolver,
     viewUtils: ViewUtils = ViewUtils()
-) : CheckableWireframeMapper<CheckedTextView>(uniqueIdentifierGenerator, viewUtils) {
+) : CheckableTextViewMapper<CheckedTextView>(
+    textWireframeMapper,
+    stringUtils,
+    uniqueIdentifierGenerator,
+    viewUtils
+) {
 
-    override fun map(view: CheckedTextView, systemInformation: SystemInformation):
-        List<MobileSegment.Wireframe> {
-        val mainWireframeList = textWireframeMapper.map(view, systemInformation)
-        resolveCheckableWireframe(view, systemInformation.screenDensity)?.let { wireframe ->
-            return mainWireframeList + wireframe
-        }
-        return mainWireframeList
-    }
+    // region CheckableTextViewMapper
 
     override fun resolveCheckableColor(view: CheckedTextView): String {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
@@ -69,4 +64,6 @@ internal open class CheckedTextViewMapper(
 
         )
     }
+
+    // endregion
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllCheckBoxMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllCheckBoxMapper.kt
@@ -14,12 +14,11 @@ import com.datadog.android.sessionreplay.model.MobileSegment
 internal class MaskAllCheckBoxMapper(
     textWireframeMapper: TextWireframeMapper,
     stringUtils: StringUtils = StringUtils,
-    uniqueIdentifierGenerator: UniqueIdentifierResolver =
-        UniqueIdentifierResolver,
+    uniqueIdentifierGenerator: UniqueIdentifierResolver = UniqueIdentifierResolver,
     viewUtils: ViewUtils = ViewUtils()
 ) : CheckBoxMapper(textWireframeMapper, stringUtils, uniqueIdentifierGenerator, viewUtils) {
 
-    override fun resolveCheckableShapeStyle(view: CheckBox, checkBoxColor: String):
+    override fun resolveCheckedShapeStyle(view: CheckBox, checkBoxColor: String):
         MobileSegment.ShapeStyle? {
         // in case the MASK_ALL rule is applied we do not want to show the selection in the
         // checkbox related wireframe and in order to achieve that we need to provide

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllCheckedTextViewMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllCheckedTextViewMapper.kt
@@ -24,7 +24,7 @@ internal class MaskAllCheckedTextViewMapper(
     viewUtils
 ) {
 
-    override fun resolveCheckableShapeStyle(view: CheckedTextView, checkBoxColor: String):
+    override fun resolveCheckedShapeStyle(view: CheckedTextView, checkBoxColor: String):
         MobileSegment.ShapeStyle? {
         // in case the MASK_ALL rule is applied we do not want to show the selection in the
         // checkbox related wireframe and in order to achieve that we need to provide

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllRadioButtonMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllRadioButtonMapper.kt
@@ -23,8 +23,8 @@ internal class MaskAllRadioButtonMapper(
     viewUtils
 ) {
 
-    override fun resolveCheckableShapeStyle(view: RadioButton, checkBoxColor: String):
-        MobileSegment.ShapeStyle? {
+    override fun resolveCheckedShapeStyle(view: RadioButton, checkBoxColor: String):
+        MobileSegment.ShapeStyle {
         return MobileSegment.ShapeStyle(
             backgroundColor = null,
             view.alpha,

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/RadioButtonMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/RadioButtonMapper.kt
@@ -14,32 +14,36 @@ import com.datadog.android.sessionreplay.model.MobileSegment
 internal open class RadioButtonMapper(
     textWireframeMapper: TextWireframeMapper,
     stringUtils: StringUtils = StringUtils,
-    uniqueIdentifierGenerator: UniqueIdentifierResolver =
-        UniqueIdentifierResolver,
+    uniqueIdentifierGenerator: UniqueIdentifierResolver = UniqueIdentifierResolver,
     viewUtils: ViewUtils = ViewUtils()
-) : CompoundButtonMapper<RadioButton>(
+) : CheckableCompoundButtonMapper<RadioButton>(
     textWireframeMapper,
     stringUtils,
     uniqueIdentifierGenerator,
     viewUtils
 ) {
 
-    override fun resolveCheckableShapeStyle(view: RadioButton, checkBoxColor: String):
+    // region CheckableTextViewMapper
+
+    override fun resolveCheckedShapeStyle(view: RadioButton, checkBoxColor: String):
         MobileSegment.ShapeStyle? {
-        return if (view.isChecked) {
-            MobileSegment.ShapeStyle(
-                backgroundColor = checkBoxColor,
-                view.alpha,
-                cornerRadius = CORNER_RADIUS
-            )
-        } else {
-            MobileSegment.ShapeStyle(
-                backgroundColor = null,
-                view.alpha,
-                cornerRadius = CORNER_RADIUS
-            )
-        }
+        return MobileSegment.ShapeStyle(
+            backgroundColor = checkBoxColor,
+            view.alpha,
+            cornerRadius = CORNER_RADIUS
+        )
     }
+
+    override fun resolveNotCheckedShapeStyle(view: RadioButton, checkBoxColor: String):
+        MobileSegment.ShapeStyle? {
+        return MobileSegment.ShapeStyle(
+            backgroundColor = null,
+            view.alpha,
+            cornerRadius = CORNER_RADIUS
+        )
+    }
+
+    // endregion
 
     companion object {
         internal const val CORNER_RADIUS = 10

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapper.kt
@@ -16,7 +16,8 @@ internal class ViewWireframeMapper :
     override fun map(view: View, systemInformation: SystemInformation):
         List<MobileSegment.Wireframe.ShapeWireframe> {
         val viewGlobalBounds = resolveViewGlobalBounds(view, systemInformation.screenDensity)
-        val styleBorderPair = view.background?.resolveShapeStyleAndBorder(view.alpha)
+        val (shapeStyle, border) = view.background?.resolveShapeStyleAndBorder(view.alpha)
+            ?: (null to null)
         return listOf(
             MobileSegment.Wireframe.ShapeWireframe(
                 resolveViewId(view),
@@ -24,8 +25,8 @@ internal class ViewWireframeMapper :
                 viewGlobalBounds.y,
                 viewGlobalBounds.width,
                 viewGlobalBounds.height,
-                shapeStyle = styleBorderPair?.first,
-                border = styleBorderPair?.second
+                shapeStyle = shapeStyle,
+                border = border
             )
         )
     }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckBoxMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckBoxMapperTest.kt
@@ -72,7 +72,7 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
     @FloatForgery(min = 1f, max = 100f)
     var fakeTextSize: Float = 1f
 
-    @IntForgery(min = CompoundButtonMapper.DEFAULT_CHECKBOX_HEIGHT_IN_PX.toInt(), max = 100)
+    @IntForgery(min = CheckableCompoundButtonMapper.DEFAULT_CHECKABLE_HEIGHT_IN_PX.toInt(), max = 100)
     var fakeIntrinsicDrawableHeight = 1
 
     @BeforeEach
@@ -84,7 +84,7 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
         whenever(
             mockUniqueIdentifierResolver.resolveChildUniqueIdentifier(
                 mockCheckBox,
-                CheckableWireframeMapper.CHECKBOX_KEY_NAME
+                CheckableTextViewMapper.CHECKABLE_KEY_NAME
             )
         ).thenReturn(fakeGeneratedIdentifier)
         whenever(mockTextWireframeMapper.map(mockCheckBox, fakeSystemInformation))
@@ -127,14 +127,14 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
             resolveCheckBoxSize(fakeIntrinsicDrawableHeight.toLong())
         val expectedCheckBoxWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeGeneratedIdentifier,
-            x = fakeViewGlobalBounds.x + CompoundButtonMapper.MIN_PADDING_IN_PX
+            x = fakeViewGlobalBounds.x + CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
                 .densityNormalized(fakeSystemInformation.screenDensity),
             y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - checkBoxSize) / 2,
             width = checkBoxSize,
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedCheckBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = expectedCheckedShapeStyle(expectedCheckBoxColor)
         )
@@ -166,14 +166,14 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
             resolveCheckBoxSize(fakeIntrinsicDrawableHeight.toLong())
         val expectedCheckBoxWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeGeneratedIdentifier,
-            x = fakeViewGlobalBounds.x + CompoundButtonMapper.MIN_PADDING_IN_PX
+            x = fakeViewGlobalBounds.x + CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
                 .densityNormalized(fakeSystemInformation.screenDensity),
             y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - checkBoxSize) / 2,
             width = checkBoxSize,
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedCheckBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = null
         )
@@ -197,17 +197,17 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
             OPAQUE_ALPHA_VALUE
         )
         val checkBoxSize =
-            resolveCheckBoxSize(CompoundButtonMapper.DEFAULT_CHECKBOX_HEIGHT_IN_PX)
+            resolveCheckBoxSize(CheckableCompoundButtonMapper.DEFAULT_CHECKABLE_HEIGHT_IN_PX)
         val expectedCheckBoxWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeGeneratedIdentifier,
-            x = fakeViewGlobalBounds.x + CompoundButtonMapper.MIN_PADDING_IN_PX
+            x = fakeViewGlobalBounds.x + CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
                 .densityNormalized(fakeSystemInformation.screenDensity),
             y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - checkBoxSize) / 2,
             width = checkBoxSize,
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedCheckBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = expectedCheckedShapeStyle(expectedCheckBoxColor)
         )
@@ -231,17 +231,17 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
             OPAQUE_ALPHA_VALUE
         )
         val checkBoxSize =
-            resolveCheckBoxSize(CompoundButtonMapper.DEFAULT_CHECKBOX_HEIGHT_IN_PX)
+            resolveCheckBoxSize(CheckableCompoundButtonMapper.DEFAULT_CHECKABLE_HEIGHT_IN_PX)
         val expectedCheckBoxWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeGeneratedIdentifier,
-            x = fakeViewGlobalBounds.x + CompoundButtonMapper.MIN_PADDING_IN_PX
+            x = fakeViewGlobalBounds.x + CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
                 .densityNormalized(fakeSystemInformation.screenDensity),
             y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - checkBoxSize) / 2,
             width = checkBoxSize,
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedCheckBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = null
         )
@@ -262,7 +262,7 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
         whenever(
             mockUniqueIdentifierResolver.resolveChildUniqueIdentifier(
                 mockCheckBox,
-                CheckableWireframeMapper.CHECKBOX_KEY_NAME
+                CheckableTextViewMapper.CHECKABLE_KEY_NAME
             )
         ).thenReturn(null)
 
@@ -283,7 +283,7 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
     private fun resolveCheckBoxSize(checkBoxSize: Long): Long {
         val density = fakeSystemInformation.screenDensity
         val textSize = fakeTextSize.toLong()
-        val size = checkBoxSize - 2 * CompoundButtonMapper.MIN_PADDING_IN_PX
+        val size = checkBoxSize - 2 * CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
         return (size * (textSize - 1) / textSize).densityNormalized(density)
     }
 

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckedTextViewMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckedTextViewMapperTest.kt
@@ -109,7 +109,7 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         whenever(
             mockUniqueIdentifierResolver.resolveChildUniqueIdentifier(
                 mockCheckedTextView,
-                CheckableWireframeMapper.CHECKBOX_KEY_NAME
+                CheckableTextViewMapper.CHECKABLE_KEY_NAME
             )
         ).thenReturn(fakeGeneratedIdentifier)
         whenever(mockTextWireframeMapper.map(mockCheckedTextView, fakeSystemInformation))
@@ -153,7 +153,7 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedCheckBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = expectedCheckedShapeStyle(expectedCheckBoxColor)
         )
@@ -186,7 +186,7 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedCheckBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = null
         )
@@ -219,7 +219,7 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
             height = 0,
             border = MobileSegment.ShapeBorder(
                 color = expectedCheckBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = null
         )
@@ -253,7 +253,7 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedCheckBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             )
         )
 
@@ -286,7 +286,7 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedCheckBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             )
         )
 
@@ -317,7 +317,7 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedCheckBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             )
         )
 
@@ -337,7 +337,7 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         whenever(
             mockUniqueIdentifierResolver.resolveChildUniqueIdentifier(
                 mockCheckedTextView,
-                CheckableWireframeMapper.CHECKBOX_KEY_NAME
+                CheckableTextViewMapper.CHECKABLE_KEY_NAME
             )
         ).thenReturn(null)
 

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseRadioButtonMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseRadioButtonMapperTest.kt
@@ -72,7 +72,7 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
     @FloatForgery(min = 1f, max = 100f)
     var fakeTextSize: Float = 1f
 
-    @IntForgery(min = CompoundButtonMapper.DEFAULT_CHECKBOX_HEIGHT_IN_PX.toInt(), max = 100)
+    @IntForgery(min = CheckableCompoundButtonMapper.DEFAULT_CHECKABLE_HEIGHT_IN_PX.toInt(), max = 100)
     var fakeIntrinsicDrawableHeight = 1
 
     @BeforeEach
@@ -84,7 +84,7 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
         whenever(
             mockUniqueIdentifierResolver.resolveChildUniqueIdentifier(
                 mockRadioButton,
-                CheckableWireframeMapper.CHECKBOX_KEY_NAME
+                CheckableTextViewMapper.CHECKABLE_KEY_NAME
             )
         ).thenReturn(fakeGeneratedIdentifier)
         whenever(mockTextWireframeMapper.map(mockRadioButton, fakeSystemInformation))
@@ -136,14 +136,14 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
             resolveRadioBoxSize(fakeIntrinsicDrawableHeight.toLong())
         val expectedCheckBoxWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeGeneratedIdentifier,
-            x = fakeViewGlobalBounds.x + CompoundButtonMapper.MIN_PADDING_IN_PX
+            x = fakeViewGlobalBounds.x + CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
                 .densityNormalized(fakeSystemInformation.screenDensity),
             y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - checkBoxSize) / 2,
             width = checkBoxSize,
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedRadioBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = expectedCheckedShapeStyle(expectedRadioBoxColor)
         )
@@ -175,14 +175,14 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
             resolveRadioBoxSize(fakeIntrinsicDrawableHeight.toLong())
         val expectedCheckBoxWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeGeneratedIdentifier,
-            x = fakeViewGlobalBounds.x + CompoundButtonMapper.MIN_PADDING_IN_PX
+            x = fakeViewGlobalBounds.x + CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
                 .densityNormalized(fakeSystemInformation.screenDensity),
             y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - checkBoxSize) / 2,
             width = checkBoxSize,
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedRadioBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = expectedNotCheckedShapeStyle(expectedRadioBoxColor)
         )
@@ -206,17 +206,17 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
             OPAQUE_ALPHA_VALUE
         )
         val checkBoxSize =
-            resolveRadioBoxSize(CompoundButtonMapper.DEFAULT_CHECKBOX_HEIGHT_IN_PX)
+            resolveRadioBoxSize(CheckableCompoundButtonMapper.DEFAULT_CHECKABLE_HEIGHT_IN_PX)
         val expectedCheckBoxWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeGeneratedIdentifier,
-            x = fakeViewGlobalBounds.x + CompoundButtonMapper.MIN_PADDING_IN_PX
+            x = fakeViewGlobalBounds.x + CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
                 .densityNormalized(fakeSystemInformation.screenDensity),
             y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - checkBoxSize) / 2,
             width = checkBoxSize,
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedRadioBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = expectedCheckedShapeStyle(expectedRadioBoxColor)
         )
@@ -240,17 +240,17 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
             OPAQUE_ALPHA_VALUE
         )
         val checkBoxSize =
-            resolveRadioBoxSize(CompoundButtonMapper.DEFAULT_CHECKBOX_HEIGHT_IN_PX)
+            resolveRadioBoxSize(CheckableCompoundButtonMapper.DEFAULT_CHECKABLE_HEIGHT_IN_PX)
         val expectedCheckBoxWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeGeneratedIdentifier,
-            x = fakeViewGlobalBounds.x + CompoundButtonMapper.MIN_PADDING_IN_PX
+            x = fakeViewGlobalBounds.x + CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
                 .densityNormalized(fakeSystemInformation.screenDensity),
             y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - checkBoxSize) / 2,
             width = checkBoxSize,
             height = checkBoxSize,
             border = MobileSegment.ShapeBorder(
                 color = expectedRadioBoxColor,
-                width = CheckableWireframeMapper.CHECKBOX_BORDER_WIDTH
+                width = CheckableTextViewMapper.CHECKABLE_BORDER_WIDTH
             ),
             shapeStyle = expectedNotCheckedShapeStyle(expectedRadioBoxColor)
         )
@@ -271,7 +271,7 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
         whenever(
             mockUniqueIdentifierResolver.resolveChildUniqueIdentifier(
                 mockRadioButton,
-                CheckableWireframeMapper.CHECKBOX_KEY_NAME
+                CheckableTextViewMapper.CHECKABLE_KEY_NAME
             )
         ).thenReturn(null)
 
@@ -292,7 +292,7 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
     private fun resolveRadioBoxSize(radioSize: Long): Long {
         val density = fakeSystemInformation.screenDensity
         val textSize = fakeTextSize.toLong()
-        val size = radioSize - 2 * CompoundButtonMapper.MIN_PADDING_IN_PX
+        val size = radioSize - 2 * CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
         return (size * (textSize - 1) / textSize).densityNormalized(density)
     }
 


### PR DESCRIPTION
### What does this PR do?

We needed to refactor and clean a bit the `WireframeMapper` architecture to make it more scalable for future implementations.
We will now have an abstract `CheckableWireframeMapper` which can be extended by any `Mapper` that maps a `View` with a checked state.
Further on we introduced the `CheckableTextViewMapper` which extends the `CheckableWireframeMapper` and offers a simple implementation of a checkable `TextView`. This is extended by the `CheckedTextViewMapper` and the `CheckableCompoundButtonMapper`. Later on we will introduce the `SwitchViewMapper` which will extend the `CheckableWireframeMapper` and will offer a different representation of the `checkable` widget by using a list of `ShapeWireframe`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

