### PR TITLE
RUMM-3080: Remove explicit reference to RUM feature from DatadogCore

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.core.internal.utils.telemetry
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.InternalLogger
@@ -219,7 +220,8 @@ object Datadog {
      */
     @JvmStatic
     fun enableRumDebugging(enable: Boolean) {
-        val rumFeature = (globalSdkCore as? DatadogCore)?.rumFeature
+        val rumFeature = globalSdkCore.getFeature(Feature.RUM_FEATURE_NAME)
+            ?.unwrap<RumFeature>()
         if (enable) {
             rumFeature?.enableDebugging()
         } else {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -15,8 +15,10 @@ import com.datadog.android.Datadog
 import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.core.internal.utils.percent
 import com.datadog.android.core.sampling.RateBasedSampler
+import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
+import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.core.DatadogCore
 import com.datadog.tools.annotation.NoOpImplementation
@@ -288,7 +290,8 @@ interface RumMonitor {
             val datadogCore = Datadog.globalSdkCore as? DatadogCore
             val coreFeature = datadogCore?.coreFeature
             val contextProvider = datadogCore?.contextProvider
-            val rumFeature = datadogCore?.rumFeature
+            val rumFeature = datadogCore?.getFeature(Feature.RUM_FEATURE_NAME)
+                ?.unwrap<RumFeature>()
             val rumApplicationId = coreFeature?.rumApplicationId
             return if (rumFeature == null || coreFeature == null || contextProvider == null) {
                 internalLogger.log(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategy.kt
@@ -12,13 +12,14 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import com.datadog.android.Datadog
 import com.datadog.android.rum.GlobalRum
+import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.NoOpAdvancedRumMonitor
 import com.datadog.android.rum.internal.tracking.AndroidXFragmentLifecycleCallbacks
 import com.datadog.android.rum.internal.tracking.FragmentLifecycleCallbacks
 import com.datadog.android.rum.internal.tracking.NoOpFragmentLifecycleCallbacks
 import com.datadog.android.rum.internal.tracking.OreoFragmentLifecycleCallbacks
-import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.api.Feature
 
 /**
  * A [ViewTrackingStrategy] that will track [Fragment]s as RUM Views.
@@ -46,7 +47,9 @@ class FragmentViewTrackingStrategy @JvmOverloads constructor(
 
     private val androidXLifecycleCallbacks: FragmentLifecycleCallbacks<FragmentActivity>
         by lazy {
-            val rumFeature = (Datadog.globalSdkCore as? DatadogCore)?.rumFeature
+            val rumFeature = Datadog.globalSdkCore
+                .getFeature(Feature.RUM_FEATURE_NAME)
+                ?.unwrap<RumFeature>()
             if (rumFeature != null) {
                 AndroidXFragmentLifecycleCallbacks(
                     argumentsProvider = {
@@ -64,7 +67,9 @@ class FragmentViewTrackingStrategy @JvmOverloads constructor(
         }
     private val oreoLifecycleCallbacks: FragmentLifecycleCallbacks<Activity>
         by lazy {
-            val rumFeature = (Datadog.globalSdkCore as? DatadogCore)?.rumFeature
+            val rumFeature = Datadog.globalSdkCore
+                .getFeature(Feature.RUM_FEATURE_NAME)
+                ?.unwrap<RumFeature>()
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && rumFeature != null) {
                 OreoFragmentLifecycleCallbacks(
                     argumentsProvider = {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
@@ -25,7 +25,7 @@ import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.NoOpAdvancedRumMonitor
 import com.datadog.android.rum.internal.tracking.AndroidXFragmentLifecycleCallbacks
 import com.datadog.android.rum.model.ViewEvent
-import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.api.Feature
 import java.lang.IllegalStateException
 import java.util.WeakHashMap
 
@@ -115,7 +115,9 @@ class NavigationViewTrackingStrategy(
      */
     fun startTracking() {
         val activity = startedActivity ?: return
-        val rumFeature = (Datadog.globalSdkCore as? DatadogCore)?.rumFeature ?: return
+        val rumFeature = Datadog.globalSdkCore
+            .getFeature(Feature.RUM_FEATURE_NAME)
+            ?.unwrap<RumFeature>() ?: return
         activity.findNavControllerOrNull(navigationViewId)?.let {
             if (FragmentActivity::class.java.isAssignableFrom(activity::class.java)) {
                 val navControllerFragmentCallbacks = NavControllerFragmentLifecycleCallbacks(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -60,8 +60,6 @@ internal class DatadogCore(
 
     internal val features: MutableMap<String, SdkFeature> = mutableMapOf()
 
-    internal var rumFeature: RumFeature? = null
-
     // TODO RUMM-0000 handle context
     internal val contextProvider: ContextProvider?
         get() {
@@ -170,10 +168,6 @@ internal class DatadogCore(
     override fun stop() {
         features.forEach {
             it.value.stop()
-            // TODO RUMM-0000 Temporary thing
-            when (it.key) {
-                Feature.RUM_FEATURE_NAME -> rumFeature = null
-            }
         }
         features.clear()
 
@@ -304,7 +298,6 @@ internal class DatadogCore(
                 )
             }
             val rumFeature = RumFeature(configuration, coreFeature)
-            this.rumFeature = rumFeature
             registerFeature(rumFeature)
         }
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -12,6 +12,7 @@ import android.net.ConnectivityManager
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.internal.CoreFeature
+import com.datadog.android.core.internal.SdkFeature
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
@@ -20,6 +21,7 @@ import com.datadog.android.utils.config.InternalLoggerTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
 import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.api.context.UserInfo
 import com.datadog.android.v2.core.DatadogCore
@@ -280,11 +282,14 @@ internal class DatadogTest {
         )
             .build()
         val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
         val mockRumFeature = mock<RumFeature>()
+        val mockSdkFeature = mock<SdkFeature>()
+        whenever(mockSdkFeature.unwrap<RumFeature>()) doReturn mockRumFeature
+        (Datadog.globalSdkCore as DatadogCore).features +=
+            Feature.RUM_FEATURE_NAME to mockSdkFeature
 
         // When
-        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
-        (Datadog.globalSdkCore as DatadogCore).rumFeature = mockRumFeature
         Datadog.enableRumDebugging(true)
 
         // Then
@@ -300,11 +305,14 @@ internal class DatadogTest {
         )
             .build()
         val credentials = Credentials(fakeToken, fakeEnvName, fakeVariant, null, null)
+        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
         val mockRumFeature = mock<RumFeature>()
+        val mockSdkFeature = mock<SdkFeature>()
+        whenever(mockSdkFeature.unwrap<RumFeature>()) doReturn mockRumFeature
+        (Datadog.globalSdkCore as DatadogCore).features +=
+            Feature.RUM_FEATURE_NAME to mockSdkFeature
 
         // When
-        Datadog.initialize(appContext.mockInstance, credentials, config, TrackingConsent.GRANTED)
-        (Datadog.globalSdkCore as DatadogCore).rumFeature = mockRumFeature
         Datadog.enableRumDebugging(false)
 
         // Then

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/RumMonitorBuilderTest.kt
@@ -20,6 +20,8 @@ import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.CoreFeatureTestConfiguration
 import com.datadog.android.utils.config.InternalLoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.Feature
+import com.datadog.android.v2.api.FeatureScope
 import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.core.DatadogCore
 import com.datadog.android.v2.core.NoOpSdkCore
@@ -71,7 +73,9 @@ internal class RumMonitorBuilderTest {
 
         rumFeature = RumFeature(fakeConfig, coreFeature.mockInstance)
         rumFeature.onInitialize(mockSdkCore, appContext.mockInstance, mock())
-        whenever(mockSdkCore.rumFeature) doReturn rumFeature
+        val mockRumFeatureScope = mock<FeatureScope>()
+        whenever(mockRumFeatureScope.unwrap<RumFeature>()) doReturn rumFeature
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
 
         Datadog.globalSdkCore = mockSdkCore
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
@@ -20,7 +20,9 @@ import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.tracking.OreoFragmentLifecycleCallbacks
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.api.Feature
+import com.datadog.android.v2.api.FeatureScope
+import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.tools.unit.ObjectTest
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -92,8 +94,10 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         whenever(mockActivity.fragmentManager)
             .thenReturn(mockDefaultFragmentManager)
 
-        val mockCore = mock<DatadogCore>()
-        whenever(mockCore.rumFeature) doReturn mock<RumFeature>()
+        val mockCore = mock<SdkCore>()
+        val mockRumFeatureScope = mock<FeatureScope>()
+        whenever(mockRumFeatureScope.unwrap<RumFeature>()) doReturn mock()
+        whenever(mockCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         Datadog.globalSdkCore = mockCore
 
         testedStrategy = FragmentViewTrackingStrategy(true)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -27,7 +27,9 @@ import com.datadog.android.rum.internal.tracking.ViewLoadingTimer
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.core.DatadogCore
+import com.datadog.android.v2.api.Feature
+import com.datadog.android.v2.api.FeatureScope
+import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.core.NoOpSdkCore
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -112,8 +114,10 @@ internal class NavigationViewTrackingStrategyTest {
         whenever(mockNavView.getTag(R.id.nav_controller_view_tag)) doReturn mockNavController
         mockNavDestination = mockNavDestination(forge, fakeDestinationName)
 
-        val mockCore = mock<DatadogCore>()
-        whenever(mockCore.rumFeature) doReturn mock<RumFeature>()
+        val mockCore = mock<SdkCore>()
+        val mockRumFeatureScope = mock<FeatureScope>()
+        whenever(mockRumFeatureScope.unwrap<RumFeature>()) doReturn mock()
+        whenever(mockCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         Datadog.globalSdkCore = mockCore
 
         testedStrategy = NavigationViewTrackingStrategy(fakeNavViewId, true, mockPredicate)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
@@ -116,11 +116,10 @@ internal class DatadogCoreInitializationTest {
                 it.isNull()
             }
         }
+
         if (rumEnabled) {
-            assertThat(testedCore.rumFeature!!.initialized.get()).isTrue()
             assertThat(testedCore.getFeature(Feature.RUM_FEATURE_NAME)).isNotNull
         } else {
-            assertThat(testedCore.rumFeature).isNull()
             assertThat(testedCore.getFeature(Feature.RUM_FEATURE_NAME)).isNull()
         }
     }
@@ -140,7 +139,6 @@ internal class DatadogCoreInitializationTest {
 
         // Then
         assertThat(testedCore.coreFeature.initialized.get()).isTrue()
-        assertThat(testedCore.rumFeature!!.initialized.get()).isTrue()
         verify(logger.mockInternalLogger).log(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
@@ -163,7 +161,6 @@ internal class DatadogCoreInitializationTest {
 
         // Then
         assertThat(testedCore.coreFeature.initialized.get()).isTrue()
-        assertThat(testedCore.rumFeature).isNull()
         verify(logger.mockInternalLogger, never())
             .log(
                 any(),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
@@ -17,13 +17,11 @@ import com.datadog.android.core.internal.time.NoOpTimeProvider
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.internal.user.MutableUserInfoProvider
 import com.datadog.android.privacy.TrackingConsent
-import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.InternalLoggerTestConfiguration
 import com.datadog.android.utils.config.MainLooperTestConfiguration
 import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureEventReceiver
 import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.api.context.TimeInfo
@@ -432,19 +430,15 @@ internal class DatadogCoreTest {
     }
 
     @Test
-    fun `𝕄 stop all features 𝕎 stop()`() {
+    fun `𝕄 stop all features 𝕎 stop()`(
+        @StringForgery fakeFeatureNames: List<String>
+    ) {
         // Given
         val mockCoreFeature = mock<CoreFeature>()
         whenever(mockCoreFeature.initialized).thenReturn(mock())
         testedCore.coreFeature = mockCoreFeature
-        val mockRumFeature = mock<RumFeature>()
-        testedCore.rumFeature = mockRumFeature
 
-        val sdkFeatureMocks = listOf(
-            Feature.RUM_FEATURE_NAME,
-            Feature.TRACING_FEATURE_NAME,
-            Feature.LOGS_FEATURE_NAME
-        ).map {
+        val sdkFeatureMocks = fakeFeatureNames.map {
             it to mock<SdkFeature>()
         }
 
@@ -459,7 +453,6 @@ internal class DatadogCoreTest {
             verify(it.second).stop()
         }
 
-        assertThat(testedCore.rumFeature).isNull()
         assertThat(testedCore.contextProvider).isNull()
 
         assertThat(testedCore.features).isEmpty()


### PR DESCRIPTION
### What does this PR do?

This change removes explicit reference to RUM feature from `DatadogCore` by switching to the `FeatureScope#unwrap` usage.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

