### PR TITLE
RUMM-3082: Remove CoreFeature usage from RumMonitor/DatadogRumMonitor

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -539,6 +539,8 @@ data class com.datadog.android.v2.api.context.TimeInfo
   constructor(Long, Long, Long, Long)
 data class com.datadog.android.v2.api.context.UserInfo
   constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, Map<kotlin.String, kotlin.Any?> = emptyMap())
+interface com.datadog.android.v2.core.InternalSdkCore : com.datadog.android.v2.api.SdkCore
+  val networkInfo: com.datadog.android.v2.api.context.NetworkInfo
 interface com.datadog.android.v2.core.storage.DataWriter<T>
   fun write(com.datadog.android.v2.api.EventBatchWriter, T): Boolean
 class com.datadog.tools.annotation.NoOpImplementation

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -90,15 +90,18 @@ import com.datadog.android.core.configuration.Configuration as LegacyConfigurati
 
 @Suppress("TooManyFunctions")
 internal class RumFeature(
+    internal val applicationId: String,
     internal val configuration: Configuration,
     private val coreFeature: CoreFeature,
     private val ndkCrashEventHandler: NdkCrashEventHandler = DatadogNdkCrashEventHandler()
 ) : StorageBackedFeature, FeatureEventReceiver {
 
     constructor(
+        applicationId: String,
         configuration: LegacyConfiguration.Feature.RUM,
         coreFeature: CoreFeature
     ) : this(
+        applicationId,
         Configuration(
             endpointUrl = configuration.endpointUrl,
             samplingRate = configuration.samplingRate,
@@ -421,8 +424,10 @@ internal class RumFeature(
 
     /**
      * A Builder class for a [RumFeature].
+     *
+     * @param applicationId your applicationId for RUM events
      */
-    class Builder {
+    class Builder(private val applicationId: String) {
 
         private var rumConfig = DEFAULT_RUM_CONFIG
 
@@ -655,6 +660,7 @@ internal class RumFeature(
          */
         fun build(coreFeature: CoreFeature): RumFeature {
             return RumFeature(
+                applicationId = applicationId,
                 configuration = rumConfig,
                 coreFeature = coreFeature
             )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -14,8 +14,7 @@ import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.v2.api.Feature
-import com.datadog.android.v2.api.SdkCore
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import java.lang.ref.WeakReference
 import java.util.UUID
@@ -24,7 +23,7 @@ import kotlin.math.max
 
 internal class RumActionScope(
     val parentScope: RumScope,
-    private val sdkCore: SdkCore,
+    private val sdkCore: InternalSdkCore,
     val waitForStop: Boolean,
     eventTime: Time,
     initialType: RumActionType,
@@ -33,7 +32,6 @@ internal class RumActionScope(
     serverTimeOffsetInMs: Long,
     inactivityThresholdMs: Long = ACTION_INACTIVITY_MS,
     maxDurationMs: Long = ACTION_MAX_DURATION_MS,
-    contextProvider: ContextProvider,
     private val featuresContextResolver: FeaturesContextResolver = FeaturesContextResolver(),
     private val trackFrustrations: Boolean
 ) : RumScope {
@@ -47,7 +45,7 @@ internal class RumActionScope(
     internal var name: String = initialName
     private val startedNanos: Long = eventTime.nanoTime
     private var lastInteractionNanos: Long = startedNanos
-    private val networkInfo = contextProvider.context.networkInfo
+    private val networkInfo = sdkCore.networkInfo
 
     internal val attributes: MutableMap<String, Any?> = initialAttributes.toMutableMap().apply {
         putAll(GlobalRum.globalAttributes)
@@ -293,10 +291,9 @@ internal class RumActionScope(
         @Suppress("LongParameterList")
         fun fromEvent(
             parentScope: RumScope,
-            sdkCore: SdkCore,
+            sdkCore: InternalSdkCore,
             event: RumRawEvent.StartAction,
             timestampOffset: Long,
-            contextProvider: ContextProvider,
             featuresContextResolver: FeaturesContextResolver,
             trackFrustrations: Boolean
         ): RumScope {
@@ -309,7 +306,6 @@ internal class RumActionScope(
                 event.name,
                 event.attributes,
                 timestampOffset,
-                contextProvider = contextProvider,
                 featuresContextResolver = featuresContextResolver,
                 trackFrustrations = trackFrustrations
             )

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -7,27 +7,25 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.vitals.VitalMonitor
-import com.datadog.android.v2.api.SdkCore
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 
 @Suppress("LongParameterList")
 internal class RumApplicationScope(
     applicationId: String,
-    sdkCore: SdkCore,
+    sdkCore: InternalSdkCore,
     internal val samplingRate: Float,
     internal val backgroundTrackingEnabled: Boolean,
     internal val trackFrustrations: Boolean,
-    firstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver,
+    firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
     cpuVitalMonitor: VitalMonitor,
     memoryVitalMonitor: VitalMonitor,
     frameRateVitalMonitor: VitalMonitor,
-    sessionListener: RumSessionListener?,
-    contextProvider: ContextProvider
+    sessionListener: RumSessionListener?
 ) : RumScope {
 
     private val rumContext = RumContext(applicationId = applicationId)
@@ -41,8 +39,7 @@ internal class RumApplicationScope(
         cpuVitalMonitor,
         memoryVitalMonitor,
         frameRateVitalMonitor,
-        sessionListener,
-        contextProvider
+        sessionListener
     )
 
     // region RumScope

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRum
@@ -22,8 +22,7 @@ import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.InternalLogger
-import com.datadog.android.v2.api.SdkCore
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import java.net.MalformedURLException
 import java.net.URL
@@ -33,15 +32,14 @@ import java.util.UUID
 @Suppress("LongParameterList")
 internal class RumResourceScope(
     internal val parentScope: RumScope,
-    internal val sdkCore: SdkCore,
+    internal val sdkCore: InternalSdkCore,
     internal val url: String,
     internal val method: String,
     internal val key: String,
     eventTime: Time,
     initialAttributes: Map<String, Any?>,
     serverTimeOffsetInMs: Long,
-    internal val firstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver,
-    contextProvider: ContextProvider,
+    internal val firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
     private val featuresContextResolver: FeaturesContextResolver
 ) : RumScope {
 
@@ -54,7 +52,7 @@ internal class RumResourceScope(
 
     internal val eventTimestamp = eventTime.timestamp + serverTimeOffsetInMs
     private val startedNanos: Long = eventTime.nanoTime
-    private val networkInfo = contextProvider.context.networkInfo
+    private val networkInfo = sdkCore.networkInfo
 
     private var sent = false
     private var waitForTiming = false
@@ -401,11 +399,10 @@ internal class RumResourceScope(
         @Suppress("LongParameterList")
         fun fromEvent(
             parentScope: RumScope,
-            sdkCore: SdkCore,
+            sdkCore: InternalSdkCore,
             event: RumRawEvent.StartResource,
-            firstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver,
+            firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
             timestampOffset: Long,
-            contextProvider: ContextProvider,
             featuresContextResolver: FeaturesContextResolver
         ): RumScope {
             return RumResourceScope(
@@ -418,7 +415,6 @@ internal class RumResourceScope(
                 event.attributes,
                 timestampOffset,
                 firstPartyHostHeaderTypeResolver,
-                contextProvider,
                 featuresContextResolver
             )
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
 import com.datadog.android.core.internal.utils.percent
@@ -15,8 +15,7 @@ import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.v2.api.Feature
-import com.datadog.android.v2.api.SdkCore
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import com.datadog.android.v2.core.storage.NoOpDataWriter
 import java.security.SecureRandom
@@ -27,16 +26,15 @@ import java.util.concurrent.atomic.AtomicLong
 @Suppress("LongParameterList")
 internal class RumSessionScope(
     private val parentScope: RumScope,
-    private val sdkCore: SdkCore,
+    private val sdkCore: InternalSdkCore,
     internal val samplingRate: Float,
     internal val backgroundTrackingEnabled: Boolean,
     internal val trackFrustrations: Boolean,
-    internal val firstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver,
+    internal val firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
     cpuVitalMonitor: VitalMonitor,
     memoryVitalMonitor: VitalMonitor,
     frameRateVitalMonitor: VitalMonitor,
     internal val sessionListener: RumSessionListener?,
-    contextProvider: ContextProvider,
     buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider(),
     private val sessionInactivityNanos: Long = DEFAULT_SESSION_INACTIVITY_NS,
     private val sessionMaxDurationNanos: Long = DEFAULT_SESSION_MAX_DURATION_NS
@@ -61,8 +59,7 @@ internal class RumSessionScope(
         cpuVitalMonitor,
         memoryVitalMonitor,
         frameRateVitalMonitor,
-        buildSdkVersionProvider,
-        contextProvider
+        buildSdkVersionProvider
     )
 
     init {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -14,7 +14,7 @@ import android.os.SystemClock
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import com.datadog.android.core.internal.CoreFeature
-import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.core.internal.system.DefaultBuildSdkVersionProvider
 import com.datadog.android.core.internal.utils.internalLogger
@@ -24,22 +24,20 @@ import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.v2.api.InternalLogger
-import com.datadog.android.v2.api.SdkCore
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import java.util.concurrent.TimeUnit
 
 internal class RumViewManagerScope(
     private val parentScope: RumScope,
-    private val sdkCore: SdkCore,
+    private val sdkCore: InternalSdkCore,
     private val backgroundTrackingEnabled: Boolean,
     private val trackFrustrations: Boolean,
-    internal val firstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver,
+    internal val firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
     private val cpuVitalMonitor: VitalMonitor,
     private val memoryVitalMonitor: VitalMonitor,
     private val frameRateVitalMonitor: VitalMonitor,
-    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider(),
-    private val contextProvider: ContextProvider
+    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider()
 ) : RumScope {
 
     internal val childrenScopes = mutableListOf<RumScope>()
@@ -110,7 +108,6 @@ internal class RumViewManagerScope(
             cpuVitalMonitor,
             memoryVitalMonitor,
             frameRateVitalMonitor,
-            contextProvider,
             trackFrustrations
         )
         onViewDisplayed(event, viewScope, writer)
@@ -179,7 +176,6 @@ internal class RumViewManagerScope(
             NoOpVitalMonitor(),
             NoOpVitalMonitor(),
             type = RumViewScope.RumViewType.BACKGROUND,
-            contextProvider = contextProvider,
             trackFrustrations = trackFrustrations
         )
     }
@@ -197,7 +193,6 @@ internal class RumViewManagerScope(
             NoOpVitalMonitor(),
             NoOpVitalMonitor(),
             type = RumViewScope.RumViewType.APPLICATION_LAUNCH,
-            contextProvider = contextProvider,
             trackFrustrations = trackFrustrations
         )
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import androidx.annotation.WorkerThread
-import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.internal.utils.resolveViewUrl
@@ -28,8 +28,7 @@ import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.InternalLogger
-import com.datadog.android.v2.api.SdkCore
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import java.lang.ref.Reference
 import java.lang.ref.WeakReference
@@ -42,16 +41,15 @@ import kotlin.math.min
 @Suppress("TooManyFunctions", "LargeClass", "LongParameterList")
 internal open class RumViewScope(
     private val parentScope: RumScope,
-    private val sdkCore: SdkCore,
+    private val sdkCore: InternalSdkCore,
     key: Any,
     internal val name: String,
     eventTime: Time,
     initialAttributes: Map<String, Any?>,
-    internal val firstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver,
+    internal val firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
     internal val cpuVitalMonitor: VitalMonitor,
     internal val memoryVitalMonitor: VitalMonitor,
     internal val frameRateVitalMonitor: VitalMonitor,
-    private val contextProvider: ContextProvider,
     private val viewUpdatePredicate: ViewUpdatePredicate = DefaultViewUpdatePredicate(),
     private val featuresContextResolver: FeaturesContextResolver = FeaturesContextResolver(),
     internal val type: RumViewType = RumViewType.FOREGROUND,
@@ -292,7 +290,6 @@ internal open class RumViewScope(
                     sdkCore,
                     event,
                     serverTimeOffsetInMs,
-                    contextProvider,
                     featuresContextResolver,
                     trackFrustrations
                 )
@@ -315,7 +312,6 @@ internal open class RumViewScope(
                 sdkCore,
                 event,
                 serverTimeOffsetInMs,
-                contextProvider,
                 featuresContextResolver,
                 trackFrustrations
             )
@@ -340,7 +336,6 @@ internal open class RumViewScope(
             updatedEvent,
             firstPartyHostHeaderTypeResolver,
             serverTimeOffsetInMs,
-            contextProvider,
             featuresContextResolver
         )
         pendingResourceCount++
@@ -1001,13 +996,12 @@ internal open class RumViewScope(
 
         internal fun fromEvent(
             parentScope: RumScope,
-            sdkCore: SdkCore,
+            sdkCore: InternalSdkCore,
             event: RumRawEvent.StartView,
-            firstPartyHostHeaderTypeResolver: DefaultFirstPartyHostHeaderTypeResolver,
+            firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
             cpuVitalMonitor: VitalMonitor,
             memoryVitalMonitor: VitalMonitor,
             frameRateVitalMonitor: VitalMonitor,
-            contextProvider: ContextProvider,
             trackFrustrations: Boolean
         ): RumViewScope {
             return RumViewScope(
@@ -1021,7 +1015,6 @@ internal open class RumViewScope(
                 cpuVitalMonitor,
                 memoryVitalMonitor,
                 frameRateVitalMonitor,
-                contextProvider,
                 trackFrustrations = trackFrustrations
             )
         }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/InternalSdkCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/InternalSdkCore.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.v2.core
+
+import com.datadog.android.v2.api.SdkCore
+import com.datadog.android.v2.api.context.NetworkInfo
+
+/**
+ * FOR INTERNAL USAGE ONLY. THIS INTERFACE CONTENT MAY CHANGE WITHOUT NOTICE.
+ */
+interface InternalSdkCore : SdkCore {
+
+    /**
+     * Returns current state of network connection.
+     */
+    val networkInfo: NetworkInfo
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureBuilderTest.kt
@@ -44,6 +44,7 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -52,6 +53,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
+import java.util.UUID
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -62,10 +64,18 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(Configurator::class)
 internal class RumFeatureBuilderTest {
 
-    private val testedBuilder = RumFeature.Builder()
+    private lateinit var testedBuilder: RumFeature.Builder
 
     @Mock
     lateinit var mockCoreFeature: CoreFeature
+
+    @Forgery
+    lateinit var fakeApplicationId: UUID
+
+    @BeforeEach
+    fun `set up`() {
+        testedBuilder = RumFeature.Builder(fakeApplicationId.toString())
+    }
 
     @Test
     fun `𝕄 use sensible defaults 𝕎 build()`() {
@@ -92,6 +102,15 @@ internal class RumFeatureBuilderTest {
                 vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE
             )
         )
+    }
+
+    @Test
+    fun `𝕄 use applicationId provided 𝕎 build()`() {
+        // When
+        val rumFeature = testedBuilder.build(mockCoreFeature)
+
+        // Then
+        assertThat(rumFeature.applicationId).isEqualTo(fakeApplicationId.toString())
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -65,6 +65,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
 import java.util.Locale
+import java.util.UUID
 import java.util.concurrent.ScheduledThreadPoolExecutor
 
 @Extensions(
@@ -79,6 +80,9 @@ internal class RumFeatureTest {
     private lateinit var testedFeature: RumFeature
 
     @Forgery
+    lateinit var fakeApplicationId: UUID
+
+    @Forgery
     lateinit var fakeConfiguration: RumFeature.Configuration
 
     @Mock
@@ -91,12 +95,17 @@ internal class RumFeatureTest {
     lateinit var mockNdkCrashEventHandler: NdkCrashEventHandler
 
     @BeforeEach
-    fun `set up RUM`() {
+    fun `set up`() {
         doNothing().whenever(mockChoreographer).postFrameCallback(any())
         mockChoreographerInstance(mockChoreographer)
 
         testedFeature =
-            RumFeature(fakeConfiguration, coreFeature.mockInstance, mockNdkCrashEventHandler)
+            RumFeature(
+                fakeApplicationId.toString(),
+                fakeConfiguration,
+                coreFeature.mockInstance,
+                mockNdkCrashEventHandler
+            )
     }
 
     @Test
@@ -139,12 +148,19 @@ internal class RumFeatureTest {
     }
 
     @Test
-    fun `𝕄 store and register viewTrackingStrategy 𝕎 initialize()`() {
+    fun `𝕄 store and register viewTrackingStrategy 𝕎 initialize()`(
+        @Forgery fakeApplicationId: UUID
+    ) {
         // Given
         val mockViewTrackingStrategy = mock<ViewTrackingStrategy>()
         fakeConfiguration =
             fakeConfiguration.copy(viewTrackingStrategy = mockViewTrackingStrategy)
-        testedFeature = RumFeature(fakeConfiguration, coreFeature.mockInstance, mockNdkCrashEventHandler)
+        testedFeature = RumFeature(
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            coreFeature.mockInstance,
+            mockNdkCrashEventHandler
+        )
 
         // When
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance, mock())
@@ -182,6 +198,7 @@ internal class RumFeatureTest {
     fun `𝕄 use noop viewTrackingStrategy 𝕎 initialize()`() {
         // Given
         testedFeature = RumFeature(
+            fakeApplicationId.toString(),
             fakeConfiguration.copy(viewTrackingStrategy = null),
             coreFeature.mockInstance,
             mockNdkCrashEventHandler
@@ -199,7 +216,12 @@ internal class RumFeatureTest {
     fun `𝕄 use noop userActionTrackingStrategy 𝕎 initialize()`() {
         // Given
         fakeConfiguration = fakeConfiguration.copy(userActionTrackingStrategy = null)
-        testedFeature = RumFeature(fakeConfiguration, coreFeature.mockInstance, mockNdkCrashEventHandler)
+        testedFeature = RumFeature(
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            coreFeature.mockInstance,
+            mockNdkCrashEventHandler
+        )
 
         // When
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance, mock())
@@ -213,7 +235,12 @@ internal class RumFeatureTest {
     fun `𝕄 use noop longTaskTrackingStrategy 𝕎 initialize()`() {
         // Given
         fakeConfiguration = fakeConfiguration.copy(longTaskTrackingStrategy = null)
-        testedFeature = RumFeature(fakeConfiguration, coreFeature.mockInstance, mockNdkCrashEventHandler)
+        testedFeature = RumFeature(
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            coreFeature.mockInstance,
+            mockNdkCrashEventHandler
+        )
 
         // When
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance, mock())
@@ -239,7 +266,12 @@ internal class RumFeatureTest {
     ) {
         // Given
         fakeConfiguration = fakeConfiguration.copy(vitalsMonitorUpdateFrequency = fakeFrequency)
-        testedFeature = RumFeature(fakeConfiguration, coreFeature.mockInstance, mockNdkCrashEventHandler)
+        testedFeature = RumFeature(
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            coreFeature.mockInstance,
+            mockNdkCrashEventHandler
+        )
 
         // When
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance, mock())
@@ -263,7 +295,12 @@ internal class RumFeatureTest {
         fakeConfiguration = fakeConfiguration.copy(
             vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.NEVER
         )
-        testedFeature = RumFeature(fakeConfiguration, coreFeature.mockInstance, mockNdkCrashEventHandler)
+        testedFeature = RumFeature(
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            coreFeature.mockInstance,
+            mockNdkCrashEventHandler
+        )
 
         // When
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance, mock())
@@ -288,7 +325,12 @@ internal class RumFeatureTest {
         // Given
         doThrow(IllegalStateException(message)).whenever(mockChoreographer).postFrameCallback(any())
         fakeConfiguration = fakeConfiguration.copy(vitalsMonitorUpdateFrequency = fakeFrequency)
-        testedFeature = RumFeature(fakeConfiguration, coreFeature.mockInstance, mockNdkCrashEventHandler)
+        testedFeature = RumFeature(
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            coreFeature.mockInstance,
+            mockNdkCrashEventHandler
+        )
 
         // When
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance, mock())
@@ -309,7 +351,12 @@ internal class RumFeatureTest {
         fakeConfiguration = fakeConfiguration.copy(
             vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.NEVER
         )
-        testedFeature = RumFeature(fakeConfiguration, coreFeature.mockInstance, mockNdkCrashEventHandler)
+        testedFeature = RumFeature(
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            coreFeature.mockInstance,
+            mockNdkCrashEventHandler
+        )
 
         // When
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance, mock())
@@ -397,7 +444,12 @@ internal class RumFeatureTest {
         fakeConfiguration = fakeConfiguration.copy(
             vitalsMonitorUpdateFrequency = fakeFrequency
         )
-        testedFeature = RumFeature(fakeConfiguration, coreFeature.mockInstance, mockNdkCrashEventHandler)
+        testedFeature = RumFeature(
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            coreFeature.mockInstance,
+            mockNdkCrashEventHandler
+        )
 
         // When
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance, mock())
@@ -413,7 +465,12 @@ internal class RumFeatureTest {
         fakeConfiguration = fakeConfiguration.copy(
             vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.NEVER
         )
-        testedFeature = RumFeature(fakeConfiguration, coreFeature.mockInstance, mockNdkCrashEventHandler)
+        testedFeature = RumFeature(
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            coreFeature.mockInstance,
+            mockNdkCrashEventHandler
+        )
 
         // When
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance, mock())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -20,9 +20,9 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.EventBatchWriter
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureScope
-import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.DatadogContext
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.api.context.NetworkInfo
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -76,10 +76,7 @@ internal class RumActionScopeTest {
     lateinit var mockWriter: DataWriter<Any>
 
     @Mock
-    lateinit var mockContextProvider: ContextProvider
-
-    @Mock
-    lateinit var mockSdkCore: SdkCore
+    lateinit var mockSdkCore: InternalSdkCore
 
     @Mock
     lateinit var mockRumFeatureScope: FeatureScope
@@ -99,7 +96,7 @@ internal class RumActionScopeTest {
     lateinit var fakeParentContext: RumContext
 
     @Forgery
-    lateinit var fakeDatadogContextAtScopeStart: DatadogContext
+    lateinit var fakeNetworkInfoAtScopeStart: NetworkInfo
 
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
@@ -144,7 +141,7 @@ internal class RumActionScopeTest {
         fakeAttributes = forge.exhaustiveAttributes()
         fakeKey = forge.anAsciiString().toByteArray()
 
-        whenever(mockContextProvider.context) doReturn fakeDatadogContextAtScopeStart
+        whenever(mockSdkCore.networkInfo) doReturn fakeNetworkInfoAtScopeStart
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
@@ -169,7 +166,6 @@ internal class RumActionScopeTest {
             fakeServerOffset,
             TEST_INACTIVITY_MS,
             TEST_MAX_DURATION_MS,
-            mockContextProvider,
             mockFeaturesContextResolver,
             true
         )
@@ -252,7 +248,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -356,7 +352,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -437,7 +433,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -573,7 +569,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -642,7 +638,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -698,7 +694,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -764,7 +760,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -824,7 +820,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -881,7 +877,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -937,7 +933,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -998,7 +994,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1061,7 +1057,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1116,7 +1112,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1171,7 +1167,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1231,7 +1227,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1293,7 +1289,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1326,7 +1322,6 @@ internal class RumActionScopeTest {
             fakeServerOffset,
             TEST_INACTIVITY_MS,
             TEST_MAX_DURATION_MS,
-            mockContextProvider,
             mockFeaturesContextResolver,
             fakeTrackFrustrations
         )
@@ -1371,7 +1366,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1433,7 +1428,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1486,7 +1481,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1542,7 +1537,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1602,7 +1597,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1663,7 +1658,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1715,7 +1710,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1774,7 +1769,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1831,7 +1826,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1886,7 +1881,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1941,7 +1936,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1998,7 +1993,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -2085,7 +2080,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -2137,7 +2132,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -2189,7 +2184,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -2241,7 +2236,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -2270,7 +2265,6 @@ internal class RumActionScopeTest {
             fakeServerOffset,
             TEST_INACTIVITY_MS,
             TEST_MAX_DURATION_MS,
-            mockContextProvider,
             trackFrustrations = false
         )
 
@@ -2328,7 +2322,7 @@ internal class RumActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -6,12 +6,11 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.SdkCore
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import com.datadog.tools.unit.setFieldValue
 import com.nhaarman.mockitokotlin2.verify
@@ -51,7 +50,7 @@ internal class RumApplicationScopeTest {
     lateinit var mockWriter: DataWriter<Any>
 
     @Mock
-    lateinit var mockResolver: DefaultFirstPartyHostHeaderTypeResolver
+    lateinit var mockResolver: FirstPartyHostHeaderTypeResolver
 
     @Mock
     lateinit var mockCpuVitalMonitor: VitalMonitor
@@ -66,10 +65,7 @@ internal class RumApplicationScopeTest {
     lateinit var mockSessionListener: RumSessionListener
 
     @Mock
-    lateinit var mockContextProvider: ContextProvider
-
-    @Mock
-    lateinit var mockSdkCore: SdkCore
+    lateinit var mockSdkCore: InternalSdkCore
 
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
@@ -95,8 +91,7 @@ internal class RumApplicationScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockContextProvider
+            mockSessionListener
         )
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -19,9 +19,9 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.EventBatchWriter
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureScope
-import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.DatadogContext
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.api.context.NetworkInfo
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -74,13 +74,10 @@ internal class RumContinuousActionScopeTest {
     lateinit var mockParentScope: RumScope
 
     @Mock
-    lateinit var mockContextProvider: ContextProvider
-
-    @Mock
     lateinit var mockWriter: DataWriter<Any>
 
     @Mock
-    lateinit var mockSdkCore: SdkCore
+    lateinit var mockSdkCore: InternalSdkCore
 
     @Mock
     lateinit var mockRumFeatureScope: FeatureScope
@@ -101,7 +98,7 @@ internal class RumContinuousActionScopeTest {
     lateinit var fakeParentContext: RumContext
 
     @Forgery
-    lateinit var fakeDatadogContextAtScopeStart: DatadogContext
+    lateinit var fakeNetworkInfoAtScopeStart: NetworkInfo
 
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
@@ -136,7 +133,7 @@ internal class RumContinuousActionScopeTest {
         fakeKey = forge.anAsciiString().toByteArray()
 
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
-        whenever(mockContextProvider.context) doReturn fakeDatadogContextAtScopeStart
+        whenever(mockSdkCore.networkInfo) doReturn fakeNetworkInfoAtScopeStart
 
         whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
         whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
@@ -155,8 +152,7 @@ internal class RumContinuousActionScopeTest {
             fakeServerOffset,
             TEST_INACTIVITY_MS,
             TEST_MAX_DURATION_MS,
-            trackFrustrations = true,
-            contextProvider = mockContextProvider
+            trackFrustrations = true
         )
     }
 
@@ -253,7 +249,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -316,7 +312,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -378,7 +374,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -443,7 +439,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -522,7 +518,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -605,7 +601,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -670,7 +666,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -743,7 +739,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -809,7 +805,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -882,7 +878,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -932,7 +928,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -986,7 +982,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1040,7 +1036,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1099,7 +1095,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1160,7 +1156,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1212,7 +1208,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1246,8 +1242,7 @@ internal class RumContinuousActionScopeTest {
             fakeServerOffset,
             TEST_INACTIVITY_MS,
             TEST_MAX_DURATION_MS,
-            trackFrustrations = fakeTrackFrustrations,
-            contextProvider = mockContextProvider
+            trackFrustrations = fakeTrackFrustrations
         )
         fakeGlobalAttributes.keys.forEach { GlobalRum.globalAttributes.remove(it) }
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap())
@@ -1291,7 +1286,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1355,7 +1350,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1413,7 +1408,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1475,7 +1470,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1538,7 +1533,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1594,7 +1589,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1654,7 +1649,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1710,7 +1705,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1833,7 +1828,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1893,7 +1888,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }
@@ -1947,7 +1942,7 @@ internal class RumContinuousActionScopeTest {
                         fakeDatadogContext.deviceInfo.osVersion,
                         fakeDatadogContext.deviceInfo.osMajorVersion
                     )
-                    hasConnectivityInfo(fakeDatadogContextAtScopeStart.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasServiceName(fakeDatadogContext.service)
                     hasVersion(fakeDatadogContext.version)
                 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumAttributes
@@ -28,9 +28,9 @@ import com.datadog.android.v2.api.EventBatchWriter
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureScope
 import com.datadog.android.v2.api.InternalLogger
-import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.DatadogContext
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.api.context.NetworkInfo
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -91,13 +91,10 @@ internal class RumResourceScopeTest {
     lateinit var mockWriter: DataWriter<Any>
 
     @Mock
-    lateinit var mockResolver: DefaultFirstPartyHostHeaderTypeResolver
+    lateinit var mockResolver: FirstPartyHostHeaderTypeResolver
 
     @Mock
-    lateinit var mockContextProvider: ContextProvider
-
-    @Mock
-    lateinit var mockSdkCore: SdkCore
+    lateinit var mockSdkCore: InternalSdkCore
 
     @Mock
     lateinit var mockRumFeatureScope: FeatureScope
@@ -116,6 +113,9 @@ internal class RumResourceScopeTest {
 
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
+
+    @Forgery
+    lateinit var fakeNetworkInfoAtScopeStart: NetworkInfo
 
     var fakeServerOffset: Long = 0L
 
@@ -167,7 +167,7 @@ internal class RumResourceScopeTest {
         fakeMethod = forge.anElementFrom("PUT", "POST", "GET", "DELETE")
         mockEvent = mockEvent()
 
-        whenever(mockContextProvider.context) doReturn fakeDatadogContext
+        whenever(mockSdkCore.networkInfo) doReturn fakeNetworkInfoAtScopeStart
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
         doAnswer { false }.whenever(mockResolver).isFirstPartyUrl(any<String>())
         whenever(
@@ -192,7 +192,6 @@ internal class RumResourceScopeTest {
             fakeAttributes,
             fakeServerOffset,
             mockResolver,
-            mockContextProvider,
             mockFeaturesContextResolver
         )
     }
@@ -252,7 +251,7 @@ internal class RumResourceScopeTest {
                     hasStatusCode(statusCode)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -318,7 +317,7 @@ internal class RumResourceScopeTest {
                     hasStatusCode(statusCode)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -372,7 +371,6 @@ internal class RumResourceScopeTest {
             fakeAttributes,
             fakeServerOffset,
             mockResolver,
-            mockContextProvider,
             mockFeaturesContextResolver
         )
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(brokenUrl)
@@ -399,7 +397,7 @@ internal class RumResourceScopeTest {
                     hasStatusCode(statusCode)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -472,7 +470,7 @@ internal class RumResourceScopeTest {
                     hasStatusCode(statusCode)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -539,7 +537,7 @@ internal class RumResourceScopeTest {
                     hasStatusCode(statusCode)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -597,7 +595,7 @@ internal class RumResourceScopeTest {
                     hasStatusCode(statusCode)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -650,7 +648,7 @@ internal class RumResourceScopeTest {
                     hasKind(kind)
                     hasStatusCode(statusCode)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -746,7 +744,6 @@ internal class RumResourceScopeTest {
             fakeAttributes,
             fakeServerOffset,
             mockResolver,
-            mockContextProvider,
             mockFeaturesContextResolver
         )
         fakeGlobalAttributes.keys.forEach { GlobalRum.removeAttribute(it) }
@@ -769,7 +766,7 @@ internal class RumResourceScopeTest {
                     hasStatusCode(statusCode)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -837,7 +834,7 @@ internal class RumResourceScopeTest {
                     hasStatusCode(statusCode)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -906,7 +903,7 @@ internal class RumResourceScopeTest {
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasTiming(timing)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -976,7 +973,7 @@ internal class RumResourceScopeTest {
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasNoTiming()
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1048,7 +1045,7 @@ internal class RumResourceScopeTest {
                     isCrash(false)
                     hasResource(fakeUrl, fakeMethod, 0L)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1119,7 +1116,7 @@ internal class RumResourceScopeTest {
                     isCrash(false)
                     hasResource(fakeUrl, fakeMethod, 0L)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1169,7 +1166,6 @@ internal class RumResourceScopeTest {
             fakeAttributes,
             fakeServerOffset,
             mockResolver,
-            mockContextProvider,
             mockFeaturesContextResolver
         )
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(brokenUrl)
@@ -1202,7 +1198,7 @@ internal class RumResourceScopeTest {
                     isCrash(false)
                     hasResource(brokenUrl, fakeMethod, 0L)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1256,7 +1252,6 @@ internal class RumResourceScopeTest {
             fakeAttributes,
             fakeServerOffset,
             mockResolver,
-            mockContextProvider,
             mockFeaturesContextResolver
         )
         doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(brokenUrl)
@@ -1290,7 +1285,7 @@ internal class RumResourceScopeTest {
                     isCrash(false)
                     hasResource(brokenUrl, fakeMethod, 0L)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1362,7 +1357,7 @@ internal class RumResourceScopeTest {
                     isCrash(false)
                     hasResource(fakeUrl, fakeMethod, 0L)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1436,7 +1431,7 @@ internal class RumResourceScopeTest {
                     isCrash(false)
                     hasResource(fakeUrl, fakeMethod, 0L)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1508,7 +1503,7 @@ internal class RumResourceScopeTest {
                     isCrash(false)
                     hasResource(fakeUrl, fakeMethod, 0L)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1582,7 +1577,7 @@ internal class RumResourceScopeTest {
                     isCrash(false)
                     hasResource(fakeUrl, fakeMethod, 0L)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1659,7 +1654,7 @@ internal class RumResourceScopeTest {
                     isCrash(false)
                     hasResource(fakeUrl, fakeMethod, statusCode)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1739,7 +1734,7 @@ internal class RumResourceScopeTest {
                     isCrash(false)
                     hasResource(fakeUrl, fakeMethod, statusCode)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1896,7 +1891,7 @@ internal class RumResourceScopeTest {
                     hasStatusCode(statusCode)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -1960,7 +1955,7 @@ internal class RumResourceScopeTest {
                     hasStatusCode(statusCode)
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -2026,7 +2021,7 @@ internal class RumResourceScopeTest {
                     hasDurationGreaterThan(TimeUnit.MILLISECONDS.toNanos(RESOURCE_DURATION_MS))
                     hasTiming(timing)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -2141,7 +2136,7 @@ internal class RumResourceScopeTest {
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
@@ -2205,7 +2200,7 @@ internal class RumResourceScopeTest {
                     hasUrl(fakeUrl)
                     hasMethod(fakeMethod)
                     hasUserInfo(fakeDatadogContext.userInfo)
-                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasConnectivityInfo(fakeNetworkInfoAtScopeStart)
                     hasView(fakeParentContext)
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
@@ -15,8 +15,7 @@ import com.datadog.android.utils.config.InternalLoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureScope
-import com.datadog.android.v2.api.SdkCore
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import com.datadog.android.v2.core.storage.NoOpDataWriter
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
@@ -73,7 +72,7 @@ internal class RumSessionScopeTest {
     lateinit var mockWriter: DataWriter<Any>
 
     @Mock
-    lateinit var mockResolver: DefaultFirstPartyHostHeaderTypeResolver
+    lateinit var mockResolver: FirstPartyHostHeaderTypeResolver
 
     @Mock
     lateinit var mockCpuVitalMonitor: VitalMonitor
@@ -91,10 +90,7 @@ internal class RumSessionScopeTest {
     lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
 
     @Mock
-    lateinit var mockContextProvider: ContextProvider
-
-    @Mock
-    lateinit var mockSdkCore: SdkCore
+    lateinit var mockSdkCore: InternalSdkCore
 
     @Forgery
     lateinit var fakeParentContext: RumContext
@@ -998,7 +994,6 @@ internal class RumSessionScopeTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockContextProvider,
             mockBuildSdkVersionProvider,
             TEST_INACTIVITY_NS,
             TEST_MAX_DURATION_NS

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -9,7 +9,7 @@ package com.datadog.android.rum.internal.domain.scope
 import android.app.ActivityManager.RunningAppProcessInfo
 import android.os.Build
 import com.datadog.android.core.internal.CoreFeature
-import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.internal.RumFeature
@@ -21,10 +21,9 @@ import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.utils.config.InternalLoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.InternalLogger
-import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.TimeInfo
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -77,7 +76,7 @@ internal class RumViewManagerScopeTest {
     lateinit var mockWriter: DataWriter<Any>
 
     @Mock
-    lateinit var mockResolver: DefaultFirstPartyHostHeaderTypeResolver
+    lateinit var mockResolver: FirstPartyHostHeaderTypeResolver
 
     @Mock
     lateinit var mockCpuVitalMonitor: VitalMonitor
@@ -89,13 +88,10 @@ internal class RumViewManagerScopeTest {
     lateinit var mockFrameRateVitalMonitor: VitalMonitor
 
     @Mock
-    lateinit var mockContextProvider: ContextProvider
-
-    @Mock
     lateinit var mockBuildSdkVersionProvider: BuildSdkVersionProvider
 
     @Mock
-    lateinit var mockSdkCore: SdkCore
+    lateinit var mockSdkCore: InternalSdkCore
 
     @Forgery
     lateinit var fakeParentContext: RumContext
@@ -111,7 +107,6 @@ internal class RumViewManagerScopeTest {
 
     @BeforeEach
     fun `set up`() {
-        whenever(mockContextProvider.context) doReturn fakeDatadogContext
         whenever(mockSdkCore.time) doReturn fakeTime
 
         whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
@@ -128,8 +123,7 @@ internal class RumViewManagerScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockBuildSdkVersionProvider,
-            mockContextProvider
+            mockBuildSdkVersionProvider
         )
     }
 
@@ -391,8 +385,7 @@ internal class RumViewManagerScopeTest {
             firstPartyHostHeaderTypeResolver = mockResolver,
             cpuVitalMonitor = mockCpuVitalMonitor,
             memoryVitalMonitor = mockMemoryVitalMonitor,
-            frameRateVitalMonitor = mockFrameRateVitalMonitor,
-            contextProvider = mockContextProvider
+            frameRateVitalMonitor = mockFrameRateVitalMonitor
         )
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.validBackgroundEvent()
@@ -418,8 +411,7 @@ internal class RumViewManagerScopeTest {
             cpuVitalMonitor = mockCpuVitalMonitor,
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
-            buildSdkVersionProvider = mockBuildSdkVersionProvider,
-            contextProvider = mockContextProvider
+            buildSdkVersionProvider = mockBuildSdkVersionProvider
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true
@@ -448,8 +440,7 @@ internal class RumViewManagerScopeTest {
             cpuVitalMonitor = mockCpuVitalMonitor,
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
-            buildSdkVersionProvider = mockBuildSdkVersionProvider,
-            contextProvider = mockContextProvider
+            buildSdkVersionProvider = mockBuildSdkVersionProvider
         )
         testedScope.applicationDisplayed = true
         val fakeEvent = forge.validBackgroundEvent()
@@ -538,8 +529,7 @@ internal class RumViewManagerScopeTest {
             firstPartyHostHeaderTypeResolver = mockResolver,
             cpuVitalMonitor = mockCpuVitalMonitor,
             memoryVitalMonitor = mockMemoryVitalMonitor,
-            frameRateVitalMonitor = mockFrameRateVitalMonitor,
-            contextProvider = mockContextProvider
+            frameRateVitalMonitor = mockFrameRateVitalMonitor
         )
         testedScope.applicationDisplayed = false
         val fakeEvent = forge.validAppLaunchEvent()
@@ -580,8 +570,7 @@ internal class RumViewManagerScopeTest {
             cpuVitalMonitor = mockCpuVitalMonitor,
             memoryVitalMonitor = mockMemoryVitalMonitor,
             frameRateVitalMonitor = mockFrameRateVitalMonitor,
-            buildSdkVersionProvider = mockBuildSdkVersionProvider,
-            contextProvider = mockContextProvider
+            buildSdkVersionProvider = mockBuildSdkVersionProvider
         )
         testedScope.childrenScopes.add(mockChildScope)
         whenever(mockChildScope.isActive()) doReturn true

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -8,7 +8,7 @@ package com.datadog.android.rum.internal.monitor
 
 import android.os.Handler
 import com.datadog.android.core.configuration.Configuration
-import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
@@ -33,8 +33,7 @@ import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
 import com.datadog.android.telemetry.internal.TelemetryType
 import com.datadog.android.utils.forge.Configurator
-import com.datadog.android.v2.api.SdkCore
-import com.datadog.android.v2.core.internal.ContextProvider
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.android.v2.core.storage.DataWriter
 import com.datadog.tools.unit.forge.aThrowable
 import com.datadog.tools.unit.forge.exhaustiveAttributes
@@ -102,7 +101,7 @@ internal class DatadogRumMonitorTest {
     lateinit var mockHandler: Handler
 
     @Mock
-    lateinit var mockResolver: DefaultFirstPartyHostHeaderTypeResolver
+    lateinit var mockResolver: FirstPartyHostHeaderTypeResolver
 
     @Mock
     lateinit var mockCpuVitalMonitor: VitalMonitor
@@ -120,10 +119,7 @@ internal class DatadogRumMonitorTest {
     lateinit var mockTelemetryEventHandler: TelemetryEventHandler
 
     @Mock
-    lateinit var mockContextProvider: ContextProvider
-
-    @Mock
-    lateinit var mockSdkCore: SdkCore
+    lateinit var mockSdkCore: InternalSdkCore
 
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
@@ -158,8 +154,7 @@ internal class DatadogRumMonitorTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockContextProvider
+            mockSessionListener
         )
         testedMonitor.rootScope = mockScope
     }
@@ -179,8 +174,7 @@ internal class DatadogRumMonitorTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockContextProvider
+            mockSessionListener
         )
 
         val rootScope = testedMonitor.rootScope
@@ -1180,7 +1174,6 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockContextProvider,
             mockExecutor
         )
 
@@ -1225,7 +1218,6 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockContextProvider,
             mockExecutorService
         )
 
@@ -1257,7 +1249,6 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockContextProvider,
             mockExecutorService
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)
@@ -1569,7 +1560,6 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockContextProvider,
             executorService = mockExecutorService
         )
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.SdkFeature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.core.internal.time.NoOpTimeProvider
 import com.datadog.android.core.internal.time.TimeProvider
@@ -24,6 +25,7 @@ import com.datadog.android.utils.extension.mockChoreographerInstance
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.FeatureEventReceiver
 import com.datadog.android.v2.api.InternalLogger
+import com.datadog.android.v2.api.context.NetworkInfo
 import com.datadog.android.v2.api.context.TimeInfo
 import com.datadog.android.v2.api.context.UserInfo
 import com.datadog.android.v2.core.internal.ContextProvider
@@ -382,6 +384,23 @@ internal class DatadogCoreTest {
 
         // Then
         assertThat(resolver).isSameAs(mockResolver)
+    }
+
+    @Test
+    fun `𝕄 provide network info 𝕎 networkInfo()`(
+        @Forgery fakeNetworkInfo: NetworkInfo
+    ) {
+        // Given
+        testedCore.coreFeature = mock()
+        val mockNetworkInfoProvider = mock<NetworkInfoProvider>()
+        whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
+        whenever(testedCore.coreFeature.networkInfoProvider) doReturn mockNetworkInfoProvider
+
+        // When
+        val networkInfo = testedCore.networkInfo
+
+        // Then
+        assertThat(networkInfo).isSameAs(fakeNetworkInfo)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This change removes references to `CoreFeature` (which will stay as internal) from the `RumMonitor` and `DatadogRumMonitor` (meaning from `RumViewScope`, `RumActionScope`, etc.).

This is mostly achieved by the properties of `SdkCore`. But for the action/resource scopes we need to know the network info at the scope start, and since I don't think we should expose `networkInfo` in the `SdkCore` (quite specific property), it is exposed in the `AdvancedSdkCore` instead. Later however, we may promote this property to the `SdkCore`.

Expecting SDK instance to implement `AdvancedSdkCore` is not an issue, because it is not created outside anyway and managed by us.

Also `RumFeature.Builder` now requires `applicationId` explicitly, this will allow later to remove `rumApplicationId` from `Credentials` object.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

