### PR TITLE
Fix timing of ApplicationLaunch view and application_start events

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -148,6 +148,9 @@ internal class RumSessionScope(
         sessionState = if (keepSession) State.TRACKED else State.NOT_TRACKED
         sessionId = UUID.randomUUID().toString()
         sessionStartNs.set(nanoTime)
+        sdkCore.updateFeatureContext(RumFeature.RUM_FEATURE_NAME) {
+            it.putAll(getRumContext().toMap())
+        }
         sessionListener?.onSessionStarted(sessionId, !keepSession)
         sdkCore.getFeature(SESSION_REPLAY_FEATURE_NAME)?.sendEvent(
             mapOf(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -91,9 +91,10 @@ internal class RumViewManagerScope(
             nanoTime = processStartTime
         )
         val viewScope = createAppLaunchViewScope(applicationLaunchViewTime)
+        val startupTime = event.eventTime.nanoTime - processStartTime
         applicationDisplayed = true
         viewScope.handleEvent(
-            RumRawEvent.ApplicationStarted(event.eventTime, processStartTime),
+            RumRawEvent.ApplicationStarted(applicationLaunchViewTime, startupTime),
             writer
         )
         childrenScopes.add(viewScope)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -78,8 +78,13 @@ internal class RumViewManagerScope(
     @WorkerThread
     private fun startApplicationLaunchView(event: RumRawEvent, writer: DataWriter<Any>) {
         val applicationLaunchViewTimeNs = appStartTimeProvider.appStartTimeNs
+        // appStartTimeNs is based on elapsed system time. Timestamp needs to be currentMs.
+        // Figure out the difference then apply that to the applicationLaunchView to get the
+        // timestamp
+        val timestamp = (event.eventTime.timestamp - TimeUnit.NANOSECONDS.toMillis(event.eventTime.nanoTime)) +
+            TimeUnit.NANOSECONDS.toMillis(applicationLaunchViewTimeNs)
         val applicationLaunchViewTime = Time(
-            timestamp = TimeUnit.NANOSECONDS.toMillis(applicationLaunchViewTimeNs),
+            timestamp = timestamp,
             nanoTime = applicationLaunchViewTimeNs
         )
         val viewScope = createAppLaunchViewScope(applicationLaunchViewTime)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -839,7 +839,7 @@ internal open class RumViewScope(
                         crash = ActionEvent.Crash(0),
                         longTask = ActionEvent.LongTask(0),
                         resource = ActionEvent.Resource(0),
-                        loadingTime = getStartupTime(event)
+                        loadingTime = event.applicationStartupNanos
                     ),
                     view = ActionEvent.View(
                         id = rumContext.viewId.orEmpty(),
@@ -887,12 +887,6 @@ internal open class RumViewScope(
                 @Suppress("ThreadSafety") // called in a worker thread context
                 writer.write(eventBatchWriter, actionEvent)
             }
-    }
-
-    private fun getStartupTime(event: RumRawEvent.ApplicationStarted): Long {
-        val now = event.eventTime.nanoTime
-        val startupTime = event.applicationStartupNanos
-        return max(now - startupTime, 1L)
     }
 
     @Suppress("LongMethod")

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -517,17 +517,18 @@ internal class RumViewManagerScopeTest {
         testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
-        val appStartTimeMs = (
-            fakeEvent.eventTime.timestamp -
-                TimeUnit.NANOSECONDS.toMillis(fakeEvent.eventTime.nanoTime)
+        val timestampNs = (
+            TimeUnit.MILLISECONDS.toNanos(fakeEvent.eventTime.timestamp) -
+                fakeEvent.eventTime.nanoTime
             ) +
-            TimeUnit.NANOSECONDS.toMillis(appStartTimeNs)
+            appStartTimeNs
+        val timestampMs = TimeUnit.NANOSECONDS.toMillis((timestampNs))
         val scopeCount = if (fakeEvent is RumRawEvent.StartView) 2 else 1
         assertThat(testedScope.childrenScopes).hasSize(scopeCount)
         assertThat(testedScope.childrenScopes[0])
             .isInstanceOfSatisfying(RumViewScope::class.java) {
                 assertThat(it.eventTimestamp)
-                    .isEqualTo(resolveExpectedTimestamp(appStartTimeMs))
+                    .isEqualTo(resolveExpectedTimestamp(timestampMs))
                 assertThat(it.keyRef.get()).isEqualTo(RumViewManagerScope.RUM_APP_LAUNCH_VIEW_URL)
                 assertThat(it.name).isEqualTo(RumViewManagerScope.RUM_APP_LAUNCH_VIEW_NAME)
                 assertThat(it.cpuVitalMonitor).isInstanceOf(NoOpVitalMonitor::class.java)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -517,7 +517,11 @@ internal class RumViewManagerScopeTest {
         testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
-        val appStartTimeMs = TimeUnit.NANOSECONDS.toMillis(appStartTimeNs)
+        val appStartTimeMs = (
+            fakeEvent.eventTime.timestamp -
+                TimeUnit.NANOSECONDS.toMillis(fakeEvent.eventTime.nanoTime)
+            ) +
+            TimeUnit.NANOSECONDS.toMillis(appStartTimeNs)
         val scopeCount = if (fakeEvent is RumRawEvent.StartView) 2 else 1
         assertThat(testedScope.childrenScopes).hasSize(scopeCount)
         assertThat(testedScope.childrenScopes[0])
@@ -647,7 +651,11 @@ internal class RumViewManagerScopeTest {
         testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
-        val appStartTimeMs = TimeUnit.NANOSECONDS.toMillis(appStartTimeNs)
+        val appStartTimeMs = (
+            fakeEvent.eventTime.timestamp -
+                TimeUnit.NANOSECONDS.toMillis(fakeEvent.eventTime.nanoTime)
+            ) +
+            TimeUnit.NANOSECONDS.toMillis(appStartTimeNs)
         argumentCaptor<ActionEvent> {
             verify(mockWriter, atLeastOnce()).write(eq(mockEventBatchWriter), capture())
             assertThat(firstValue.action.type).isEqualTo(ActionEvent.ActionEventActionType.APPLICATION_START)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -652,16 +652,18 @@ internal class RumViewManagerScopeTest {
         testedScope.handleEvent(fakeEvent, mockWriter)
 
         // Then
-        val appStartTimeMs = (
-            fakeEvent.eventTime.timestamp -
-                TimeUnit.NANOSECONDS.toMillis(fakeEvent.eventTime.nanoTime)
-            ) +
-            TimeUnit.NANOSECONDS.toMillis(appStartTimeNs)
+        val appStartTimestamp = TimeUnit.NANOSECONDS.toMillis(
+            (
+                TimeUnit.MILLISECONDS.toNanos(fakeEvent.eventTime.timestamp) -
+                    fakeEvent.eventTime.nanoTime
+                ) +
+                appStartTimeNs
+        )
         argumentCaptor<ActionEvent> {
             verify(mockWriter, atLeastOnce()).write(eq(mockEventBatchWriter), capture())
             assertThat(firstValue.action.type).isEqualTo(ActionEvent.ActionEventActionType.APPLICATION_START)
             // Application start event occurse at the start time
-            assertThat(firstValue.date).isEqualTo(resolveExpectedTimestamp(appStartTimeMs))
+            assertThat(firstValue.date).isEqualTo(resolveExpectedTimestamp(appStartTimestamp))
 
             // Duration lasts until the first event is sent to RUM (whatever that is)
             val loadingTime = fakeEvent.eventTime.nanoTime - appStartTimeNs

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -2270,8 +2270,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         val eventTime = Time()
-        val startedNanos = eventTime.nanoTime - duration
-        fakeEvent = RumRawEvent.ApplicationStarted(eventTime, startedNanos)
+        fakeEvent = RumRawEvent.ApplicationStarted(eventTime, duration)
         val attributes = forgeGlobalAttributes(forge, fakeAttributes)
         GlobalRum.globalAttributes.putAll(attributes)
 
@@ -2667,8 +2666,7 @@ internal class RumViewScopeTest {
         // Given
         testedScope.stopped = true
         val eventTime = Time()
-        val startedNanos = eventTime.nanoTime - duration
-        fakeEvent = RumRawEvent.ApplicationStarted(eventTime, startedNanos)
+        fakeEvent = RumRawEvent.ApplicationStarted(eventTime, duration)
         val fakeActionSent = RumRawEvent.ActionSent(testedScope.viewId, frustrationCount)
 
         // When
@@ -2724,8 +2722,7 @@ internal class RumViewScopeTest {
         // Given
         testedScope.stopped = true
         val eventTime = Time()
-        val startedNanos = eventTime.nanoTime - duration
-        fakeEvent = RumRawEvent.ApplicationStarted(eventTime, startedNanos)
+        fakeEvent = RumRawEvent.ApplicationStarted(eventTime, duration)
         val fakeActionSent = RumRawEvent.ActionDropped(testedScope.viewId)
 
         // When
@@ -3243,8 +3240,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         val eventTime = Time()
-        val startedNanos = eventTime.nanoTime - duration
-        fakeEvent = RumRawEvent.ApplicationStarted(eventTime, startedNanos)
+        fakeEvent = RumRawEvent.ApplicationStarted(eventTime, duration)
         testedScope.activeActionScope = null
         testedScope.pendingActionCount = 0
 
@@ -6758,8 +6754,7 @@ internal class RumViewScopeTest {
     ) {
         // Given
         val eventTime = Time()
-        val startedNanos = eventTime.nanoTime - duration
-        fakeEvent = RumRawEvent.ApplicationStarted(eventTime, startedNanos)
+        fakeEvent = RumRawEvent.ApplicationStarted(eventTime, duration)
         val attributes = forgeGlobalAttributes(forge, fakeAttributes)
         GlobalRum.globalAttributes.putAll(attributes)
         whenever(mockViewUpdatePredicate.canUpdateView(any(), any())).thenReturn(false)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingTest.kt
@@ -28,7 +28,6 @@ internal abstract class ActivityTrackingTest :
         )
 
         instrumentation.waitForIdleSync()
-        Thread.sleep(1000) // Just chill for a second
 
         expectedEvents.add(ExpectedApplicationStartActionEvent())
         expectedEvents.add(

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingTest.kt
@@ -28,6 +28,7 @@ internal abstract class ActivityTrackingTest :
         )
 
         instrumentation.waitForIdleSync()
+        Thread.sleep(1000) // Just chill for a second
 
         expectedEvents.add(ExpectedApplicationStartActionEvent())
         expectedEvents.add(


### PR DESCRIPTION
### What does this PR do?

Fix the timing of ApplicaitonLaunch vie and application_start events. The events were incorrectly using the nano time for their timestamp instead of using an ms timestamp. We use the difference between the triggering event's timestamp and nano time to determine how far apart they are, and add that to the application start time.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

