### PR TITLE
RUMM-3085: Remove explicit references to the telemetry from core module

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -10,7 +10,6 @@ import android.content.Context
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.Credentials
 import com.datadog.android.core.internal.utils.internalLogger
-import com.datadog.android.core.internal.utils.telemetry
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.internal.RumFeature
@@ -244,10 +243,10 @@ object Datadog {
      *
      * @see _InternalProxy
      */
-    @Suppress("ObjectPropertyNaming")
+    @Suppress("ObjectPropertyName", "ObjectPropertyNaming")
     val _internal: _InternalProxy by lazy {
         _InternalProxy(
-            telemetry,
+            globalSdkCore,
             (globalSdkCore as? DatadogCore)?.coreFeature
         )
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapperTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/WindowCallbackWrapperTest.kt
@@ -18,7 +18,9 @@ import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.tracking.InteractionPredicate
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import com.datadog.android.utils.config.GlobalRumMonitorTestConfiguration
+import com.datadog.android.utils.config.InternalLoggerTestConfiguration
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.v2.api.InternalLogger
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
@@ -368,10 +370,16 @@ internal class WindowCallbackWrapperTest {
         testedWrapper.dispatchKeyEvent(null)
 
         // Then
-        verify(rumMonitor.mockInstance).sendErrorTelemetryEvent(
-            "Received KeyEvent=null",
-            null
-        )
+        verify(logger.mockInternalLogger)
+            .log(
+                InternalLogger.Level.ERROR,
+                targets = listOf(
+                    InternalLogger.Target.MAINTAINER,
+                    InternalLogger.Target.TELEMETRY
+                ),
+                "Received KeyEvent=null",
+                null
+            )
         verifyNoMoreInteractions(rumMonitor.mockInstance)
     }
 
@@ -651,11 +659,12 @@ internal class WindowCallbackWrapperTest {
 
     companion object {
         val rumMonitor = GlobalRumMonitorTestConfiguration()
+        val logger = InternalLoggerTestConfiguration()
 
         @TestConfigurationsProvider
         @JvmStatic
         fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(rumMonitor)
+            return listOf(rumMonitor, logger)
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Since telemetry is depending on the RUM feature, which will move to its own module and is not guaranteed to be enabled, this change switches to the usage of message bus to send telemetry to RUM.

**NOTE**: This doesn't touch configuration telemetry, this one will be handled later.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

