### PR TITLE
RUMM-3081 prevent reporting invalid cpu ticks per seconds 

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/assertj/ViewEventAssert.kt
@@ -325,10 +325,12 @@ internal class ViewEventAssert(actual: ViewEvent) :
             )
             .isEqualTo(expectedTicks)
 
-        val expectedTicksPerSeconds = if (expectedTicks != null) {
-            (expectedTicks * ONE_SECOND_NS) / actual.view.timeSpent
-        } else {
+        val expectedTicksPerSeconds = if (expectedTicks == null) {
             null
+        } else if (actual.view.timeSpent < ONE_SECOND_NS) {
+            null
+        } else {
+            (expectedTicks * ONE_SECOND_NS) / actual.view.timeSpent
         }
         assertThat(actual.view.cpuTicksPerSecond)
             .overridingErrorMessage(


### PR DESCRIPTION
When a view has a short lifespan (less than one second), the estimation of ticks per seconds can go through the roof.

We limit the computation of ticks per second to views spanning longer than 1 seconds to avoid erroneous values