### PR TITLE
RUMM-3089: Use message bus to report configuration telemetry from the core

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -69,6 +69,7 @@ import com.datadog.android.rum.tracking.NoOpViewTrackingStrategy
 import com.datadog.android.rum.tracking.TrackingStrategy
 import com.datadog.android.rum.tracking.ViewAttributesProvider
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
+import com.datadog.android.telemetry.internal.TelemetryCoreConfiguration
 import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 import com.datadog.android.v2.api.EnvironmentProvider
 import com.datadog.android.v2.api.Feature
@@ -247,6 +248,7 @@ internal class RumFeature(
             }
             "telemetry_error" -> logTelemetryError(event)
             "telemetry_debug" -> logTelemetryDebug(event)
+            "telemetry_configuration" -> logTelemetryConfiguration(event)
             else -> {
                 internalLogger.log(
                     InternalLogger.Level.WARN,
@@ -455,6 +457,13 @@ internal class RumFeature(
             return
         }
         telemetry.debug(message)
+    }
+
+    private fun logTelemetryConfiguration(event: Map<*, *>) {
+        TelemetryCoreConfiguration.fromEvent(event)?.let {
+            (GlobalRum.get() as? AdvancedRumMonitor)
+                ?.sendConfigurationTelemetryEvent(it)
+        }
     }
 
     // endregion

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumPerformanceMetric
@@ -15,6 +14,7 @@ import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.telemetry.internal.TelemetryCoreConfiguration
 import com.datadog.android.telemetry.internal.TelemetryType
 
 internal sealed class RumRawEvent {
@@ -201,7 +201,7 @@ internal sealed class RumRawEvent {
         val message: String,
         val stack: String?,
         val kind: String?,
-        val configuration: Configuration?,
+        val coreConfiguration: TelemetryCoreConfiguration?,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -6,12 +6,12 @@
 
 package com.datadog.android.rum.internal.monitor
 
-import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.internal.debug.RumDebugListener
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.telemetry.internal.TelemetryCoreConfiguration
 import com.datadog.tools.annotation.NoOpImplementation
 
 /**
@@ -48,7 +48,7 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
     fun sendErrorTelemetryEvent(message: String, stack: String?, kind: String?)
 
     @Suppress("FunctionMaxLength")
-    fun sendConfigurationTelemetryEvent(configuration: Configuration)
+    fun sendConfigurationTelemetryEvent(coreConfiguration: TelemetryCoreConfiguration)
 
     fun updatePerformanceMetric(metric: RumPerformanceMetric, value: Double)
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.rum.internal.monitor
 
 import android.os.Handler
-import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.core.internal.utils.loggableStackTrace
@@ -33,6 +32,7 @@ import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.telemetry.internal.TelemetryCoreConfiguration
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
 import com.datadog.android.telemetry.internal.TelemetryType
 import com.datadog.android.v2.api.InternalLogger
@@ -350,9 +350,9 @@ internal class DatadogRumMonitor(
     }
 
     @Suppress("FunctionMaxLength")
-    override fun sendConfigurationTelemetryEvent(configuration: Configuration) {
+    override fun sendConfigurationTelemetryEvent(coreConfiguration: TelemetryCoreConfiguration) {
         handleEvent(
-            RumRawEvent.SendTelemetry(TelemetryType.CONFIGURATION, "", null, null, configuration)
+            RumRawEvent.SendTelemetry(TelemetryType.CONFIGURATION, "", null, null, coreConfiguration)
         )
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryCoreConfiguration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryCoreConfiguration.kt
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.internal
+
+import com.datadog.android.core.internal.utils.internalLogger
+import com.datadog.android.v2.api.InternalLogger
+
+internal data class TelemetryCoreConfiguration(
+    val trackErrors: Boolean,
+    // batchSize.windowDurationMs
+    val batchSize: Long,
+    // uploadFrequency.baseStepMs
+    val batchUploadFrequency: Long,
+    val useProxy: Boolean,
+    val useLocalEncryption: Boolean
+) {
+    companion object {
+        fun fromEvent(event: Map<*, *>): TelemetryCoreConfiguration? {
+            val trackErrors = event["track_errors"] as? Boolean
+            val batchSize = event["batch_size"] as? Long
+            val batchUploadFrequency = event["batch_upload_frequency"] as? Long
+            val useProxy = event["use_proxy"] as? Boolean
+            val useLocalEncryption = event["use_local_encryption"] as? Boolean
+
+            @Suppress("ComplexCondition")
+            if (trackErrors == null || batchSize == null || batchUploadFrequency == null ||
+                useProxy == null || useLocalEncryption == null
+            ) {
+                // TODO RUMM-3088 Do an intelligent reporting when message values are missing/have
+                //  wrong type, reporting the parameter name and what is exactly wrong
+                // this applies to all messages going through the message bus
+                internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.USER,
+                    "One of the mandatory parameters for core configuration telemetry" +
+                        " reporting is either missing or have a wrong type."
+                )
+                return null
+            }
+
+            return TelemetryCoreConfiguration(
+                trackErrors = trackErrors,
+                batchSize = batchSize,
+                batchUploadFrequency = batchUploadFrequency,
+                useProxy = useProxy,
+                useLocalEncryption = useLocalEncryption
+            )
+        }
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.rum.internal.monitor
 
 import android.os.Handler
-import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumActionType
@@ -30,6 +29,7 @@ import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.telemetry.internal.TelemetryCoreConfiguration
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
 import com.datadog.android.telemetry.internal.TelemetryType
 import com.datadog.android.utils.forge.Configurator
@@ -1410,7 +1410,7 @@ internal class DatadogRumMonitorTest {
             assertThat(lastValue.type).isEqualTo(TelemetryType.DEBUG)
             assertThat(lastValue.stack).isNull()
             assertThat(lastValue.kind).isNull()
-            assertThat(lastValue.configuration).isNull()
+            assertThat(lastValue.coreConfiguration).isNull()
         }
     }
 
@@ -1433,7 +1433,7 @@ internal class DatadogRumMonitorTest {
             assertThat(lastValue.type).isEqualTo(TelemetryType.ERROR)
             assertThat(lastValue.stack).isEqualTo(stackTrace)
             assertThat(lastValue.kind).isEqualTo(kind)
-            assertThat(lastValue.configuration).isNull()
+            assertThat(lastValue.coreConfiguration).isNull()
         }
     }
 
@@ -1456,16 +1456,16 @@ internal class DatadogRumMonitorTest {
             assertThat(lastValue.type).isEqualTo(TelemetryType.ERROR)
             assertThat(lastValue.stack).isEqualTo(throwable?.loggableStackTrace())
             assertThat(lastValue.kind).isEqualTo(throwable?.javaClass?.canonicalName)
-            assertThat(lastValue.configuration).isNull()
+            assertThat(lastValue.coreConfiguration).isNull()
         }
     }
 
     @Test
     fun `M handle configuration telemetry event W sendConfigurationTelemetryEvent()`(
-        @Forgery configuration: Configuration
+        @Forgery fakeConfiguration: TelemetryCoreConfiguration
     ) {
         // When
-        testedMonitor.sendConfigurationTelemetryEvent(configuration)
+        testedMonitor.sendConfigurationTelemetryEvent(fakeConfiguration)
 
         // Then
         argumentCaptor<RumRawEvent.SendTelemetry> {
@@ -1477,7 +1477,7 @@ internal class DatadogRumMonitorTest {
             assertThat(lastValue.type).isEqualTo(TelemetryType.CONFIGURATION)
             assertThat(lastValue.stack).isNull()
             assertThat(lastValue.kind).isNull()
-            assertThat(lastValue.configuration).isSameAs(configuration)
+            assertThat(lastValue.coreConfiguration).isSameAs(fakeConfiguration)
         }
     }
 
@@ -1496,7 +1496,7 @@ internal class DatadogRumMonitorTest {
             assertThat(lastValue.type).isEqualTo(TelemetryType.INTERCEPTOR_SETUP)
             assertThat(lastValue.stack).isNull()
             assertThat(lastValue.kind).isNull()
-            assertThat(lastValue.configuration).isNull()
+            assertThat(lastValue.coreConfiguration).isNull()
         }
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryCoreConfigurationTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryCoreConfigurationTest.kt
@@ -1,0 +1,69 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.internal
+
+import fr.xgouchet.elmyr.annotation.AdvancedForgery
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.MapForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+internal class TelemetryCoreConfigurationTest {
+
+    @Test
+    fun `𝕄 create TelemetryCoreConfiguration 𝕎 fromEvent()`(
+        @BoolForgery trackErrors: Boolean,
+        @BoolForgery useProxy: Boolean,
+        @BoolForgery useLocalEncryption: Boolean,
+        @LongForgery(min = 0L) batchSize: Long,
+        @LongForgery(min = 0L) batchUploadFrequency: Long
+    ) {
+        // Given
+        val event = mapOf(
+            "type" to "telemetry_configuration",
+            "track_errors" to trackErrors,
+            "batch_size" to batchSize,
+            "batch_upload_frequency" to batchUploadFrequency,
+            "use_proxy" to useProxy,
+            "use_local_encryption" to useLocalEncryption
+        )
+
+        // When
+        val coreConfig = TelemetryCoreConfiguration.fromEvent(event)
+
+        // Then
+        assertThat(coreConfig).isNotNull
+        assertThat(coreConfig!!.trackErrors).isEqualTo(trackErrors)
+        assertThat(coreConfig.batchSize).isEqualTo(batchSize)
+        assertThat(coreConfig.batchUploadFrequency).isEqualTo(batchUploadFrequency)
+        assertThat(coreConfig.useProxy).isEqualTo(useProxy)
+        assertThat(coreConfig.useLocalEncryption).isEqualTo(useLocalEncryption)
+    }
+
+    @Test
+    fun `𝕄 return null 𝕎 fromEvent() { malformed message }`(
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHABETICAL)])
+        ) fakeEvent: Map<String, String>
+    ) {
+        // When
+        val coreConfig = TelemetryCoreConfiguration.fromEvent(fakeEvent)
+
+        // Then
+        assertThat(coreConfig).isNull()
+    }
+}

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -47,6 +47,7 @@ internal class Configurator :
         forge.addFactory(ResourceTimingForgeryFactory())
         forge.addFactory(ViewEventForgeryFactory())
         forge.addFactory(VitalInfoForgeryFactory())
+        forge.addFactory(TelemetryCoreConfigurationForgeryFactory())
 
         // Telemetry
         forge.addFactory(TelemetryDebugEventForgeryFactory())

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/TelemetryCoreConfigurationForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/TelemetryCoreConfigurationForgeryFactory.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.telemetry.internal.TelemetryCoreConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class TelemetryCoreConfigurationForgeryFactory :
+    ForgeryFactory<TelemetryCoreConfiguration> {
+    override fun getForgery(forge: Forge): TelemetryCoreConfiguration {
+        return TelemetryCoreConfiguration(
+            trackErrors = forge.aBool(),
+            batchSize = forge.aPositiveLong(),
+            batchUploadFrequency = forge.aPositiveLong(),
+            useProxy = forge.aBool(),
+            useLocalEncryption = forge.aBool()
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

RUM is going to be extracted into the dedicated module, so we cannot use `GlobalRum` from the core.

This change makes the use of message bus in order to submit configuration to the telemetry and also reads RUM-related configuration from `RumFeature.Configuration` now instead of `Configuration.Feature.RUM`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

