### PR TITLE
Add internal telemetry configuration sampling rate

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -256,6 +256,7 @@ object Datadog {
     internal const val DD_SOURCE_TAG = "_dd.source"
     internal const val DD_SDK_VERSION_TAG = "_dd.sdk_version"
     internal const val DD_APP_VERSION_TAG = "_dd.version"
+    internal const val DD_TELEMETRY_CONFIG_SAMPLE_RATE_TAG = "_dd.telemetry.configuration_sample_rate"
 
     // endregion
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -107,6 +107,7 @@ internal constructor(
             override val plugins: List<DatadogPlugin>,
             val samplingRate: Float,
             val telemetrySamplingRate: Float,
+            val telemetryConfigurationSamplingRate: Float,
             val userActionTrackingStrategy: UserActionTrackingStrategy?,
             val viewTrackingStrategy: ViewTrackingStrategy?,
             val longTaskTrackingStrategy: TrackingStrategy?,
@@ -693,6 +694,7 @@ internal constructor(
     internal companion object {
         internal const val DEFAULT_SAMPLING_RATE: Float = 100f
         internal const val DEFAULT_TELEMETRY_SAMPLING_RATE: Float = 20f
+        internal const val DEFAULT_TELEMETRY_CONFIGURATION_SAMPLING_RATE: Float = 20f
         internal const val DEFAULT_LONG_TASK_THRESHOLD_MS = 100L
         internal const val PLUGINS_DEPRECATED_WARN_MESSAGE =
             "Datadog Plugins will be removed in SDK v2.0.0. You will then need to" +
@@ -729,6 +731,7 @@ internal constructor(
             plugins = emptyList(),
             samplingRate = DEFAULT_SAMPLING_RATE,
             telemetrySamplingRate = DEFAULT_TELEMETRY_SAMPLING_RATE,
+            telemetryConfigurationSamplingRate = DEFAULT_TELEMETRY_CONFIGURATION_SAMPLING_RATE,
             userActionTrackingStrategy = provideUserTrackingStrategy(
                 emptyArray(),
                 NoOpInteractionPredicate()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -325,7 +325,10 @@ interface RumMonitor {
                     handler = Handler(Looper.getMainLooper()),
                     telemetryEventHandler = TelemetryEventHandler(
                         sdkCore = datadogCore,
-                        eventSampler = RateBasedSampler(rumFeature.telemetrySamplingRate.percent())
+                        eventSampler = RateBasedSampler(rumFeature.telemetrySamplingRate.percent()),
+                        configurationExtraSampler = RateBasedSampler(
+                            rumFeature.telemetryConfigurationSamplingRate.percent()
+                        )
                     ),
                     firstPartyHostHeaderTypeResolver = coreFeature.firstPartyHostHeaderTypeResolver,
                     cpuVitalMonitor = rumFeature.cpuVitalMonitor,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -71,6 +71,7 @@ internal class RumFeature(
 
     internal var samplingRate: Float = 0f
     internal var telemetrySamplingRate: Float = 0f
+    internal var telemetryConfigurationSamplingRate: Float = 0f
     internal var backgroundEventTracking: Boolean = false
     internal var trackFrustrations: Boolean = false
 
@@ -99,6 +100,7 @@ internal class RumFeature(
 
         samplingRate = configuration.samplingRate
         telemetrySamplingRate = configuration.telemetrySamplingRate
+        telemetryConfigurationSamplingRate = configuration.telemetryConfigurationSamplingRate
         backgroundEventTracking = configuration.backgroundEventTracking
         trackFrustrations = configuration.trackFrustrations
         rumEventMapper = configuration.rumEventMapper

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -285,6 +285,17 @@ internal class DatadogCore(
             setVerbosity(Log.VERBOSE)
         }
 
+        // Special case -- needs to apply to the RUM config before initializing it.
+        mutableConfig.additionalConfig[Datadog.DD_TELEMETRY_CONFIG_SAMPLE_RATE_TAG]?. let {
+            if (it is Float && mutableConfig.rumConfig != null) {
+                mutableConfig = mutableConfig.copy(
+                    rumConfig = mutableConfig.rumConfig?.copy(
+                        telemetryConfigurationSamplingRate = it
+                    )
+                )
+            }
+        }
+
         // always initialize Core Features first
         coreFeature = CoreFeature()
         coreFeature.initialize(

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -144,6 +144,7 @@ internal class ConfigurationBuilderTest {
                 plugins = emptyList(),
                 samplingRate = Configuration.DEFAULT_SAMPLING_RATE,
                 telemetrySamplingRate = Configuration.DEFAULT_TELEMETRY_SAMPLING_RATE,
+                telemetryConfigurationSamplingRate = Configuration.DEFAULT_TELEMETRY_CONFIGURATION_SAMPLING_RATE,
                 userActionTrackingStrategy = UserActionTrackingStrategyLegacy(
                     DatadogGesturesTracker(
                         arrayOf(JetpackViewAttributesProvider()),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -24,6 +24,7 @@ internal class ConfigurationRumForgeryFactory :
             plugins = forge.aList { mock() },
             samplingRate = forge.aFloat(0f, 100f),
             telemetrySamplingRate = forge.aFloat(0f, 100f),
+            telemetryConfigurationSamplingRate = forge.aFloat(0f, 100f),
             userActionTrackingStrategy = mock(),
             viewTrackingStrategy = forge.anElementFrom(
                 ActivityViewTrackingStrategy(forge.aBool(), mock()),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
@@ -38,6 +38,7 @@ import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -587,6 +588,28 @@ internal class DatadogCoreInitializationTest {
         assertThat(testedCore.coreFeature.packageVersionProvider.version).isEqualTo(
             appContext.fakeVersionName
         )
+    }
+
+    @Test
+    fun `𝕄 apply configuration telemety sample rate W applyAdditionalConfig(confic) { with sample rate }`(
+        @FloatForgery(0.0f, 100.0f) sampleRate: Float
+    ) {
+        // Given
+        val configuration = Configuration.Builder(
+            logsEnabled = true,
+            tracesEnabled = true,
+            crashReportsEnabled = true,
+            rumEnabled = true
+        )
+            .setAdditionalConfiguration(mapOf(Datadog.DD_TELEMETRY_CONFIG_SAMPLE_RATE_TAG to sampleRate))
+            .build()
+
+        // When
+        testedCore =
+            DatadogCore(appContext.mockInstance, fakeCredentials, configuration, fakeInstanceId)
+
+        // Then
+        assertThat(testedCore.rumFeature?.telemetryConfigurationSamplingRate).isEqualTo(sampleRate)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Add a property that can be supplied through additionalConfiguration which sets the extra sample rate for configuration telemetry. This serves as a way for the cross platform SDKs to modify whether telemetry gets sent in order to test our own telemetry logic.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

