### PR TITLE
RUMM-3094 fix unreliable plugged battery info

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
@@ -87,10 +87,11 @@ internal class BroadcastReceiverSystemInfoProvider(
         val scale = intent.getIntExtra(BatteryManager.EXTRA_SCALE, DEFAULT_BATTERY_SCALE)
         val pluggedStatus = intent.getIntExtra(BatteryManager.EXTRA_PLUGGED, BATTERY_UNPLUGGED)
         val batteryStatus = SystemInfo.BatteryStatus.fromAndroidStatus(status)
+        val batteryPresent = intent.getBooleanExtra(BatteryManager.EXTRA_PRESENT, true)
 
         @Suppress("UnsafeThirdPartyFunctionCall") // Not a NaN here
         val batteryLevel = ((level * DEFAULT_BATTERY_SCALE.toFloat()) / scale).roundToInt()
-        val onExternalPowerSource = pluggedStatus in PLUGGED_IN_STATUS_VALUES
+        val onExternalPowerSource = pluggedStatus in PLUGGED_IN_STATUS_VALUES || !batteryPresent
         val batteryFullOrCharging = batteryStatus in batteryFullOrChargingStatus
         systemInfo = systemInfo.copy(
             batteryFullOrCharging = batteryFullOrCharging,

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProviderTest.kt
@@ -138,6 +138,8 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_LEVEL), any()))
             .doReturn(scaledLevel)
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_SCALE), any())) doReturn scale
+        whenever(batteryIntent.getBooleanExtra(eq(BatteryManager.EXTRA_PRESENT), any()))
+            .doReturn(true)
         whenever(batteryIntent.action) doReturn Intent.ACTION_BATTERY_CHANGED
         val powerSaveModeIntent: Intent = mock()
         whenever(mockPowerMgr.isPowerSaveMode) doReturn powerSaveMode
@@ -175,6 +177,8 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_LEVEL), any()))
             .doReturn(scaledLevel)
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_SCALE), any())) doReturn scale
+        whenever(batteryIntent.getBooleanExtra(eq(BatteryManager.EXTRA_PRESENT), any()))
+            .doReturn(true)
         whenever(batteryIntent.action) doReturn Intent.ACTION_BATTERY_CHANGED
 
         val powerSaveModeIntent: Intent = mock()
@@ -200,6 +204,9 @@ internal class BroadcastReceiverSystemInfoProviderTest {
         // Given
         whenever(mockIntent.getIntExtra(any(), any())) doAnswer {
             it.arguments[1] as Int
+        }
+        whenever(mockIntent.getBooleanExtra(any(), any())) doAnswer {
+            it.arguments[1] as Boolean
         }
         whenever(mockIntent.action) doReturn Intent.ACTION_BATTERY_CHANGED
 
@@ -227,6 +234,8 @@ internal class BroadcastReceiverSystemInfoProviderTest {
             .doReturn(status.androidStatus())
         whenever(mockIntent.getIntExtra(eq(BatteryManager.EXTRA_LEVEL), any())) doReturn scaledLevel
         whenever(mockIntent.getIntExtra(eq(BatteryManager.EXTRA_SCALE), any())) doReturn scale
+        whenever(mockIntent.getBooleanExtra(eq(BatteryManager.EXTRA_PRESENT), any()))
+            .doReturn(true)
         whenever(mockIntent.action) doReturn Intent.ACTION_BATTERY_CHANGED
 
         // When
@@ -443,6 +452,46 @@ internal class BroadcastReceiverSystemInfoProviderTest {
             scaledLevel
         whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_PLUGGED), any()))
             .doReturn(0)
+        whenever(batteryIntent.getBooleanExtra(eq(BatteryManager.EXTRA_PRESENT), any()))
+            .doReturn(true)
+        whenever(batteryIntent.action) doReturn Intent.ACTION_BATTERY_CHANGED
+
+        // When
+        testedProvider.onReceive(mockContext, batteryIntent)
+        val systemInfo = testedProvider.getLatestSystemInfo()
+
+        // Then
+        assertThat(systemInfo).hasOnExternalPowerSource(false)
+    }
+
+    @Test
+    fun `M set onExternalPowerSource to true W onReceive { battery absent }`() {
+        // Given
+        val batteryIntent: Intent = mock()
+        whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_SCALE), any())) doReturn 100
+        whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_LEVEL), any())) doReturn 0
+        whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_PLUGGED), any())) doReturn 0
+        whenever(batteryIntent.getBooleanExtra(eq(BatteryManager.EXTRA_PRESENT), any()))
+            .doReturn(false)
+        whenever(batteryIntent.action) doReturn Intent.ACTION_BATTERY_CHANGED
+
+        // When
+        testedProvider.onReceive(mockContext, batteryIntent)
+        val systemInfo = testedProvider.getLatestSystemInfo()
+
+        // Then
+        assertThat(systemInfo).hasOnExternalPowerSource(true)
+    }
+
+    @Test
+    fun `M set onExternalPowerSource to false W onReceive { battery present }`() {
+        // Given
+        val batteryIntent: Intent = mock()
+        whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_SCALE), any())) doReturn 100
+        whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_LEVEL), any())) doReturn 0
+        whenever(batteryIntent.getIntExtra(eq(BatteryManager.EXTRA_PLUGGED), any())) doReturn 0
+        whenever(batteryIntent.getBooleanExtra(eq(BatteryManager.EXTRA_PRESENT), any()))
+            .doReturn(true)
         whenever(batteryIntent.action) doReturn Intent.ACTION_BATTERY_CHANGED
 
         // When


### PR DESCRIPTION
### What does this PR do?

On some devices (e.g. Fire TV on OS 7.6.2.4), the `BatteryManager.EXTRA_PLUGGED` returns `0`, when the device is clearly plugged. Because we only upload tracked data when the device as enough power (battery > 10% or device is plugged), the device doesn't upload anything on those devices. 

The fix relies on the `BatteryManager.EXTRA_PRESENT` that tells if a battery is present on the device. We can then assume that if the battery is not present, and the device is alive running the app, that it has another power source.