### PR TITLE
REPLAY-1447 Introduce the ExtensionSupport public API

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitor.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitor.kt
@@ -450,7 +450,8 @@ class KotlinFileVisitor {
             val generics = userType.firstChildNodeOrNull("typeArguments")
                 ?.childrenNodes("typeProjection")
                 ?.joinToString(", ", prefix = "<", postfix = ">") {
-                    it.firstChildNode("type").typeName()
+                    it.firstChildNodeOrNull("type")?.typeName()
+                        ?: it.firstChildTerminalOrNull("MULT")?.text.toString()
                 } ?: ""
             if (aggr.isEmpty()) {
                 (imports[typeName] ?: typeName) + generics

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitorTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/apisurface/KotlinFileVisitorTest.kt
@@ -467,6 +467,29 @@ internal class KotlinFileVisitorTest {
     }
 
     @Test
+    fun `describes wildcard generics in functions`() {
+        tempFile.writeText(
+            """
+            package foo.bar
+            import java.io.IOException
+            class Spam {
+                fun <K, V> doSomethingElse(map : Map<*, *>) : Pair<List<*>, List<*>> {
+                    TODO()
+                }
+            }
+            """.trimIndent()
+        )
+
+        testedVisitor.visitFile(tempFile)
+
+        assertEquals(
+            "class foo.bar.Spam\n" +
+                "  fun <K, V> doSomethingElse(Map<*, *>): Pair<List<*>, List<*>>\n",
+            testedVisitor.description.toString()
+        )
+    }
+
+    @Test
     fun `describes parent class and interfaces in class types`() {
         tempFile.writeText(
             """

--- a/library/dd-sdk-android-session-replay/apiSurface
+++ b/library/dd-sdk-android-session-replay/apiSurface
@@ -1,5 +1,8 @@
+interface com.datadog.android.sessionreplay.ExtensionSupport
+  fun getCustomViewMappers(): Map<SessionReplayPrivacy, Map<Class<*>, com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper<android.view.View, *>>>
 data class com.datadog.android.sessionreplay.SessionReplayConfiguration
   class Builder
+    fun addExtensionSupport(ExtensionSupport): Builder
     fun useSite(com.datadog.android.DatadogSite): Builder
     fun useCustomEndpoint(String): Builder
     fun setPrivacy(SessionReplayPrivacy): Builder
@@ -17,6 +20,13 @@ class com.datadog.android.sessionreplay.SessionReplayFeature : com.datadog.andro
 enum com.datadog.android.sessionreplay.SessionReplayPrivacy
   - ALLOW_ALL
   - MASK_ALL
+data class com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
+  constructor(Long, Long, Long, Long)
+data class com.datadog.android.sessionreplay.internal.recorder.SystemInformation
+  constructor(GlobalBounds, Int = Configuration.ORIENTATION_UNDEFINED, Float, String? = null)
+typealias MapperCondition = (android.view.View) -> Boolean
+interface com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper<T: android.view.View, S: com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
+  fun map(T, com.datadog.android.sessionreplay.internal.recorder.SystemInformation): List<S>
 data class com.datadog.android.sessionreplay.model.MobileSegment
   constructor(Application, Session, View, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long? = null, kotlin.Boolean? = null, Source, kotlin.collections.List<MobileRecord>)
   fun toJson(): com.google.gson.JsonElement

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ExtensionSupport.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ExtensionSupport.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+import android.view.View
+import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
+
+/**
+ * In case you need to provide different configuration for a specific Android UI framework that
+ * is not supported by our SR instrumentation layer (e.g Material elements)
+ * you can implement this class.
+ * @see [SessionReplayConfiguration.Builder.addExtensionSupport]
+ */
+interface ExtensionSupport {
+    /**
+     * Use this method if you want to apply a custom [WireframeMapper] for a specific [View] type
+     * and for a specific [SessionReplayPrivacy].
+     * @return the [View] type to custom [WireframeMapper] map grouped by [SessionReplayPrivacy].
+     */
+    fun getCustomViewMappers(): Map<SessionReplayPrivacy, Map<Class<*>, WireframeMapper<View, *>>>
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/NoOpExtensionSupport.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/NoOpExtensionSupport.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+import android.view.View
+import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
+
+internal class NoOpExtensionSupport : ExtensionSupport {
+    override fun getCustomViewMappers():
+        Map<SessionReplayPrivacy, Map<Class<*>, WireframeMapper<View, *>>> {
+        return emptyMap()
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayFeature.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayFeature.kt
@@ -47,11 +47,12 @@ class SessionReplayFeature internal constructor(
         configuration,
         { sdkCore, recordWriter ->
             SessionReplayLifecycleCallback(
-                SessionReplayRumContextProvider(sdkCore),
-                configuration.privacy,
-                recordWriter,
-                SessionReplayTimeProvider(sdkCore),
-                SessionReplayRecordCallback(sdkCore)
+                rumContextProvider = SessionReplayRumContextProvider(sdkCore),
+                privacy = configuration.privacy,
+                recordWriter = recordWriter,
+                timeProvider = SessionReplayTimeProvider(sdkCore),
+                recordCallback = SessionReplayRecordCallback(sdkCore),
+                customMappers = configuration.customMappers()
             )
         }
     )

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
@@ -6,9 +6,11 @@
 
 package com.datadog.android.sessionreplay
 
+import android.view.View
 import com.datadog.android.sessionreplay.internal.recorder.mapper.AllowAllWireframeMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.GenericWireframeMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllWireframeMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
 
 /**
  * Defines the Session Replay privacy policy when recording the sessions.
@@ -27,10 +29,10 @@ enum class SessionReplayPrivacy {
      **/
     MASK_ALL;
 
-    internal fun mapper(): GenericWireframeMapper {
+    internal fun mapper(customMappers: Map<Class<*>, WireframeMapper<View, *>>): GenericWireframeMapper {
         return when (this) {
-            ALLOW_ALL -> AllowAllWireframeMapper()
-            MASK_ALL -> MaskAllWireframeMapper()
+            ALLOW_ALL -> AllowAllWireframeMapper(customMappers = customMappers)
+            MASK_ALL -> MaskAllWireframeMapper(customMappers = customMappers)
         }
     }
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayLifecycleCallback.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayLifecycleCallback.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal
 import android.app.Activity
 import android.app.Application
 import android.os.Bundle
+import android.view.View
 import androidx.fragment.app.FragmentActivity
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.processor.RecordedDataProcessor
@@ -16,6 +17,7 @@ import com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer
 import com.datadog.android.sessionreplay.internal.recorder.ViewOnDrawInterceptor
 import com.datadog.android.sessionreplay.internal.recorder.WindowCallbackInterceptor
 import com.datadog.android.sessionreplay.internal.recorder.callback.RecorderFragmentLifecycleCallback
+import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
 import com.datadog.android.sessionreplay.internal.utils.RumContextProvider
 import com.datadog.android.sessionreplay.internal.utils.TimeProvider
 import java.util.concurrent.LinkedBlockingDeque
@@ -30,7 +32,8 @@ internal class SessionReplayLifecycleCallback(
     privacy: SessionReplayPrivacy,
     recordWriter: RecordWriter,
     timeProvider: TimeProvider,
-    recordCallback: RecordCallback = NoOpRecordCallback()
+    recordCallback: RecordCallback = NoOpRecordCallback(),
+    customMappers: Map<Class<*>, WireframeMapper<View, *>> = emptyMap()
 ) : LifecycleCallback {
 
     @Suppress("UnsafeThirdPartyFunctionCall") // workQueue can't be null
@@ -48,7 +51,10 @@ internal class SessionReplayLifecycleCallback(
         recordWriter,
         recordCallback
     )
-    internal var viewOnDrawInterceptor = ViewOnDrawInterceptor(processor, SnapshotProducer(privacy.mapper()))
+    internal var viewOnDrawInterceptor = ViewOnDrawInterceptor(
+        processor,
+        SnapshotProducer(privacy.mapper(customMappers))
+    )
 
     internal var windowCallbackInterceptor =
         WindowCallbackInterceptor(processor, viewOnDrawInterceptor, timeProvider)

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/GlobalBounds.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/GlobalBounds.kt
@@ -6,7 +6,18 @@
 
 package com.datadog.android.sessionreplay.internal.recorder
 
-internal data class GlobalBounds(
+/**
+ * Defines the dimension and positions in Global coordinates for a geometry. By Global we mean that
+ * the View position will not be relative to its parent but to the Device screen.
+ * These dimensions are already normalized according with the current device screen density.
+ * Example: if a device has a DPI = 2, the value of the dimension or position is divided by 2 to get
+ * a normalized value.
+ * @param x as the position on X axis
+ * @param y as the position on Y axis
+ * @param width as the width
+ * @param height as the height
+ */
+data class GlobalBounds(
     val x: Long,
     val y: Long,
     val width: Long,

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SystemInformation.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SystemInformation.kt
@@ -8,7 +8,14 @@ package com.datadog.android.sessionreplay.internal.recorder
 
 import android.content.res.Configuration
 
-internal data class SystemInformation(
+/**
+ * Provides information about the current system.
+ * @param screenBounds as screen bounds in Global coordinates
+ * @param screenOrientation as current screen orientation
+ * @param screenDensity current screen density
+ * @param themeColor application theme color
+ */
+data class SystemInformation(
     val screenBounds: GlobalBounds,
     val screenOrientation: Int = Configuration.ORIENTATION_UNDEFINED,
     val screenDensity: Float,

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AllowAllWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AllowAllWireframeMapper.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
+import android.view.View
+
 internal open class AllowAllWireframeMapper(
     viewWireframeMapper: ViewWireframeMapper = ViewWireframeMapper(),
     imageMapper: ViewScreenshotWireframeMapper = ViewScreenshotWireframeMapper(viewWireframeMapper),
@@ -18,7 +20,8 @@ internal open class AllowAllWireframeMapper(
         DecorViewMapper(viewWireframeMapper),
     checkBoxMapper: CheckBoxMapper = CheckBoxMapper(textMapper),
     radioButtonMapper: RadioButtonMapper = RadioButtonMapper(textMapper),
-    switchCompatMapper: SwitchCompatMapper = SwitchCompatMapper(textMapper)
+    switchCompatMapper: SwitchCompatMapper = SwitchCompatMapper(textMapper),
+    customMappers: Map<Class<*>, WireframeMapper<View, *>> = emptyMap()
 ) : GenericWireframeMapper(
     viewWireframeMapper,
     imageMapper,
@@ -29,5 +32,6 @@ internal open class AllowAllWireframeMapper(
     decorViewMapper,
     checkBoxMapper,
     radioButtonMapper,
-    switchCompatMapper
+    switchCompatMapper,
+    customMappers
 )

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/GenericWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/GenericWireframeMapper.kt
@@ -17,60 +17,95 @@ import android.widget.TextView
 import androidx.appcompat.widget.SwitchCompat
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.model.MobileSegment
+import java.util.LinkedList
+
+typealias MapperCondition = (View) -> Boolean
 
 internal abstract class GenericWireframeMapper(
-    private val viewWireframeMapper: ViewWireframeMapper,
+    viewWireframeMapper: ViewWireframeMapper,
     internal val imageMapper: ViewScreenshotWireframeMapper,
-    private val textMapper: TextWireframeMapper,
-    private val buttonMapper: ButtonMapper,
-    private val editTextViewMapper: EditTextViewMapper,
-    private val checkedTextViewMapper: CheckedTextViewMapper,
-    private val decorViewMapper: DecorViewMapper,
-    private val checkBoxMapper: CheckBoxMapper,
-    private val radioButtonMapper: RadioButtonMapper,
-    private val switchCompatMapper: SwitchCompatMapper
+    textMapper: TextWireframeMapper,
+    buttonMapper: ButtonMapper,
+    editTextViewMapper: EditTextViewMapper,
+    checkedTextViewMapper: CheckedTextViewMapper,
+    decorViewMapper: DecorViewMapper,
+    checkBoxMapper: CheckBoxMapper,
+    radioButtonMapper: RadioButtonMapper,
+    switchCompatMapper: SwitchCompatMapper,
+    customMappers: Map<Class<*>, WireframeMapper<View, *>>
 ) : WireframeMapper<View, MobileSegment.Wireframe> {
+
+    private val mappers: LinkedList<Pair<MapperCondition, WireframeMapper<View, *>>> = LinkedList()
+
+    init {
+        // Make sure you add the custom mappers first in the list. The order matters !!!
+
+        customMappers.entries.forEach {
+            mappers.add(defaultTypeCheckCondition(it.key) to it.value)
+        }
+        mappers.add(
+            defaultTypeCheckCondition(SwitchCompat::class.java) to
+                switchCompatMapper.toGenericMapper()
+        )
+        mappers.add(
+            defaultTypeCheckCondition(RadioButton::class.java) to
+                radioButtonMapper.toGenericMapper()
+        )
+        mappers.add(
+            defaultTypeCheckCondition(CheckBox::class.java) to
+                checkBoxMapper.toGenericMapper()
+        )
+        mappers.add(
+            defaultTypeCheckCondition(CheckedTextView::class.java) to
+                checkedTextViewMapper.toGenericMapper()
+        )
+        mappers.add(
+            defaultTypeCheckCondition(Button::class.java) to
+                buttonMapper.toGenericMapper()
+        )
+        mappers.add(
+            defaultTypeCheckCondition(EditText::class.java) to
+                editTextViewMapper.toGenericMapper()
+        )
+        mappers.add(
+            defaultTypeCheckCondition(TextView::class.java) to
+                textMapper.toGenericMapper()
+        )
+        mappers.add(
+            defaultTypeCheckCondition(ImageView::class.java) to
+                imageMapper.toGenericMapper()
+        )
+        mappers.add(
+            decorViewCheckCondition() to
+                decorViewMapper.toGenericMapper()
+        )
+        mappers.add(
+            { _: View -> true } to
+                viewWireframeMapper.toGenericMapper()
+        )
+    }
 
     override fun map(view: View, systemInformation: SystemInformation):
         List<MobileSegment.Wireframe> {
-        return when {
-            SwitchCompat::class.java.isAssignableFrom(view::class.java) -> {
-                switchCompatMapper.map(view as SwitchCompat, systemInformation)
-            }
-            RadioButton::class.java.isAssignableFrom(view::class.java) -> {
-                radioButtonMapper.map(view as RadioButton, systemInformation)
-            }
-            CheckBox::class.java.isAssignableFrom(view::class.java) -> {
-                checkBoxMapper.map(view as CheckBox, systemInformation)
-            }
-            CheckedTextView::class.java.isAssignableFrom(view::class.java) -> {
-                checkedTextViewMapper.map(
-                    view as CheckedTextView,
-                    systemInformation
-                )
-            }
-            Button::class.java.isAssignableFrom(view::class.java) -> {
-                buttonMapper.map(view as Button, systemInformation)
-            }
-            EditText::class.java.isAssignableFrom(view::class.java) -> {
-                editTextViewMapper.map(view as EditText, systemInformation)
-            }
-            TextView::class.java.isAssignableFrom(view::class.java) -> {
-                textMapper.map(view as TextView, systemInformation)
-            }
-            ImageView::class.java.isAssignableFrom(view::class.java) -> {
-                imageMapper.map(view as ImageView, systemInformation)
-            }
-            else -> {
-                val viewParent = view.parent
-                if (viewParent == null ||
-                    !View::class.java.isAssignableFrom(viewParent::class.java)
-                ) {
-                    decorViewMapper.map(view, systemInformation)
-                } else {
-                    viewWireframeMapper.map(view, systemInformation)
-                }
-            }
+        return mappers.firstOrNull {
+            it.first(view)
+        }?.second?.map(view, systemInformation) ?: emptyList()
+    }
+
+    private fun defaultTypeCheckCondition(type: Class<*>): MapperCondition {
+        return {
+            type.isAssignableFrom(it::class.java)
         }
+    }
+    private fun decorViewCheckCondition(): MapperCondition {
+        return {
+            val viewParent = it.parent
+            viewParent == null || !View::class.java.isAssignableFrom(viewParent::class.java)
+        }
+    }
+
+    @Suppress("UNCHECKED_CAST")
+    private fun WireframeMapper<*, *>.toGenericMapper(): WireframeMapper<View, *> {
+        return this as WireframeMapper<View, *>
     }
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllWireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllWireframeMapper.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
+import android.view.View
+
 internal class MaskAllWireframeMapper(
     viewWireframeMapper: ViewWireframeMapper = ViewWireframeMapper(),
     imageMapper: ViewScreenshotWireframeMapper = ViewScreenshotWireframeMapper(viewWireframeMapper),
@@ -19,7 +21,8 @@ internal class MaskAllWireframeMapper(
     checkBoxWireframeMapper: MaskAllCheckBoxMapper =
         MaskAllCheckBoxMapper(textMapper),
     radioButtonMapper: MaskAllRadioButtonMapper = MaskAllRadioButtonMapper(textMapper),
-    switchCompatMapper: SwitchCompatMapper = SwitchCompatMapper(textMapper)
+    switchCompatMapper: SwitchCompatMapper = SwitchCompatMapper(textMapper),
+    customMappers: Map<Class<*>, WireframeMapper<View, *>> = emptyMap()
 ) : GenericWireframeMapper(
     viewWireframeMapper,
     imageMapper,
@@ -30,5 +33,6 @@ internal class MaskAllWireframeMapper(
     decorViewMapper,
     checkBoxWireframeMapper,
     radioButtonMapper,
-    switchCompatMapper
+    switchCompatMapper,
+    customMappers
 )

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper.kt
@@ -10,6 +10,20 @@ import android.view.View
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.model.MobileSegment
 
-internal interface WireframeMapper<T : View, S : MobileSegment.Wireframe> {
+/**
+ * Maps a View to a [List] of [MobileSegment.Wireframe].
+ * This is mainly used internally by the SDK but if you want to provide a different
+ * Session Replay representation for a specific View type you can implement this on your end.
+ */
+interface WireframeMapper<in T : View, out S : MobileSegment.Wireframe> {
+
+    /**
+     * Maps a [View] to a [List<Wireframe>] in order to be rendered in the Session Replay player.
+     * @param view as the [View] instance that will be mapped
+     * @param systemInformation in which we provide useful information regarding the current
+     * system state.
+     * @see MobileSegment.Wireframe
+     * @see SystemInformation
+     */
     fun map(view: T, systemInformation: SystemInformation): List<S>
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay
 import com.datadog.android.DatadogEndpoint
 import com.datadog.android.DatadogSite
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.nhaarman.mockitokotlin2.mock
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -40,6 +41,7 @@ internal class SessionReplayConfigurationBuilderTest {
         // Then
         assertThat(config.endpointUrl).isEqualTo(DatadogEndpoint.SESSION_REPLAY_US1)
         assertThat(config.privacy).isEqualTo(SessionReplayPrivacy.MASK_ALL)
+        assertThat(config.extensionSupport).isInstanceOf(NoOpExtensionSupport::class.java)
     }
 
     @Test
@@ -73,5 +75,17 @@ internal class SessionReplayConfigurationBuilderTest {
 
         // Then
         assertThat(config.privacy).isEqualTo(fakePrivacy)
+    }
+
+    @Test
+    fun `𝕄 use the given extension support 𝕎 addExtensionSupport`() {
+        // Given
+        val mockExtensionSupport: ExtensionSupport = mock()
+
+        // When
+        val config = testedBuilder.addExtensionSupport(mockExtensionSupport).build()
+
+        // Then
+        assertThat(config.extensionSupport).isEqualTo(mockExtensionSupport)
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationTest.kt
@@ -1,0 +1,101 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+import android.view.View
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(value = ForgeConfigurator::class)
+internal class SessionReplayConfigurationTest {
+
+    lateinit var testSessionReplayConfiguration: SessionReplayConfiguration
+
+    @StringForgery
+    lateinit var fakeEndpoint: String
+    lateinit var fakePrivacy: SessionReplayPrivacy
+
+    @Mock
+    lateinit var mockExtensionSupport: ExtensionSupport
+    lateinit var fakeCustomMappers: Map<SessionReplayPrivacy, Map<Class<*>, WireframeMapper<View, *>>>
+    lateinit var fakeAllowAllCustomMappers: Map<Class<*>, WireframeMapper<View, *>>
+    lateinit var fakeMaskAllCustomMappers: Map<Class<*>, WireframeMapper<View, *>>
+
+    @BeforeEach
+    fun `set up`() {
+        fakeAllowAllCustomMappers = mapOf(Any::class.java to mock())
+        fakeMaskAllCustomMappers = mapOf(Any::class.java to mock())
+        fakeCustomMappers = mapOf(
+            SessionReplayPrivacy.ALLOW_ALL to fakeAllowAllCustomMappers,
+            SessionReplayPrivacy.MASK_ALL to fakeMaskAllCustomMappers
+        )
+        whenever(mockExtensionSupport.getCustomViewMappers()).thenReturn(fakeCustomMappers)
+    }
+
+    @Test
+    fun `M resolve the correct custom Mappers W customMappers { ALLOW_ALL }`() {
+        // Given
+        testSessionReplayConfiguration = SessionReplayConfiguration(
+            fakeEndpoint,
+            SessionReplayPrivacy.ALLOW_ALL,
+            mockExtensionSupport
+        )
+
+        // Then
+        assertThat(testSessionReplayConfiguration.customMappers())
+            .isEqualTo(fakeAllowAllCustomMappers)
+    }
+
+    @Test
+    fun `M resolve the correct custom Mappers W customMappers { MASK_ALL }`() {
+        // Given
+        testSessionReplayConfiguration = SessionReplayConfiguration(
+            fakeEndpoint,
+            SessionReplayPrivacy.MASK_ALL,
+            mockExtensionSupport
+        )
+
+        // Then
+        assertThat(testSessionReplayConfiguration.customMappers())
+            .isEqualTo(fakeMaskAllCustomMappers)
+    }
+
+    @Test
+    fun `M return empty map W customMappers { no mappers provided }`(forge: Forge) {
+        // Given
+        val fakePrivacy = forge.aValueFrom(SessionReplayPrivacy::class.java)
+        whenever(mockExtensionSupport.getCustomViewMappers()).thenReturn(emptyMap())
+        testSessionReplayConfiguration = SessionReplayConfiguration(
+            fakeEndpoint,
+            fakePrivacy,
+            mockExtensionSupport
+        )
+
+        // Then
+        assertThat(testSessionReplayConfiguration.customMappers()).isEmpty()
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay
 
 import com.datadog.android.sessionreplay.internal.recorder.mapper.AllowAllWireframeMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllWireframeMapper
+import com.nhaarman.mockitokotlin2.mock
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -15,13 +16,13 @@ internal class SessionReplayPrivacyTest {
 
     @Test
     fun `M return the AllowAll mapper W rule(ALLOW_ALL)`() {
-        assertThat(SessionReplayPrivacy.ALLOW_ALL.mapper())
+        assertThat(SessionReplayPrivacy.ALLOW_ALL.mapper(mock()))
             .isInstanceOf(AllowAllWireframeMapper::class.java)
     }
 
     @Test
     fun `M return the MASK_ALL mapper W rule(MASK_ALL)`() {
-        assertThat(SessionReplayPrivacy.MASK_ALL.mapper())
+        assertThat(SessionReplayPrivacy.MASK_ALL.mapper(mock()))
             .isInstanceOf(MaskAllWireframeMapper::class.java)
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sessionreplay.forge
 
+import com.datadog.android.sessionreplay.NoOpExtensionSupport
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import fr.xgouchet.elmyr.Forge
@@ -16,7 +17,8 @@ internal class SessionReplayConfigurationForgeryFactory :
     override fun getForgery(forge: Forge): SessionReplayConfiguration {
         return SessionReplayConfiguration(
             endpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
-            privacy = forge.aValueFrom(SessionReplayPrivacy::class.java)
+            privacy = forge.aValueFrom(SessionReplayPrivacy::class.java),
+            extensionSupport = NoOpExtensionSupport()
         )
     }
 }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptorTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptorTest.kt
@@ -77,6 +77,25 @@ internal class ViewOnDrawInterceptorTest {
     }
 
     @Test
+    fun `M force onDraw on the listener when registered()`() {
+        // Given
+        val mockOnDrawListener = mock<ViewTreeObserver.OnDrawListener>()
+        testedInterceptor = ViewOnDrawInterceptor(
+            mockProcessor,
+            mockSnapshotProducer
+        ) { _, _ -> mockOnDrawListener }
+
+        // When
+        testedInterceptor.intercept(fakeDecorViews, mockActivity)
+
+        // Then
+        fakeDecorViews.forEach {
+            verify(it.viewTreeObserver).addOnDrawListener(mockOnDrawListener)
+        }
+        verify(mockOnDrawListener).onDraw()
+    }
+
+    @Test
     fun `M register one single listener instance W intercept()`() {
         // When
         testedInterceptor.intercept(fakeDecorViews, mockActivity)

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AllowAllWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/AllowAllWireframeMapperTest.kt
@@ -38,7 +38,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class AllowAllWireframeMapperTest : BaseWireframeMapperTest() {
+internal class AllowAllWireframeMapperTest : BaseGenericWireframeMapperTest() {
     @Mock
     lateinit var mockViewWireframeMapper: ViewWireframeMapper
 
@@ -92,7 +92,8 @@ internal class AllowAllWireframeMapperTest : BaseWireframeMapperTest() {
     lateinit var testedAllowAllWireframeMapper: AllowAllWireframeMapper
 
     @BeforeEach
-    fun `set up`(forge: Forge) {
+    override fun `set up`(forge: Forge) {
+        super.`set up`(forge)
         mockShapeWireframes = forge.aList { mock() }
         mockImageWireframes = forge.aList { mock() }
         mockButtonWireframes = forge.aList { mock() }
@@ -114,8 +115,39 @@ internal class AllowAllWireframeMapperTest : BaseWireframeMapperTest() {
             mockDecorViewMapper,
             mockCheckBoxMapper,
             mockRadioButtonMapper,
-            mockSwitchCompatMapper
+            mockSwitchCompatMapper,
+            mockCustomMappers
         )
+    }
+
+    @Test
+    fun `M resolve first from customMappers W map { customMappers provided }`(forge: Forge) {
+        // Given
+        mockCustomMappers = mockCustomMappedToData.associate {
+            val mockWireframeMapper = mock<WireframeMapper<View, *>>()
+            whenever(mockWireframeMapper.map(it.first, fakeSystemInformation)).thenReturn(it.second)
+            it.first::class.java to mockWireframeMapper
+        }
+        val fakeCustomMappedIndex = forge.anInt(min = 0, max = mockCustomMappedToData.size)
+        val mockCustomMappedView = mockCustomMappedToData[fakeCustomMappedIndex].first
+        val expectedWireframeData = mockCustomMappedToData[fakeCustomMappedIndex].second
+        testedAllowAllWireframeMapper = AllowAllWireframeMapper(
+            mockViewWireframeMapper,
+            mockImageWireframeMapper,
+            mockTextWireframeMapper,
+            mockButtonMapper,
+            mockEditTextViewMapper,
+            mockCheckedTextViewMapper,
+            mockDecorViewMapper,
+            mockCheckBoxMapper,
+            mockRadioButtonMapper,
+            mockSwitchCompatMapper,
+            mockCustomMappers
+        )
+
+        // Then
+        assertThat(testedAllowAllWireframeMapper.map(mockCustomMappedView, fakeSystemInformation))
+            .isEqualTo(expectedWireframeData)
     }
 
     @Test

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseGenericWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseGenericWireframeMapperTest.kt
@@ -1,0 +1,35 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.mapper
+
+import android.view.View
+import android.widget.Button
+import android.widget.CheckBox
+import android.widget.ProgressBar
+import android.widget.Switch
+import androidx.appcompat.widget.SwitchCompat
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.nhaarman.mockitokotlin2.mock
+import fr.xgouchet.elmyr.Forge
+
+internal open class BaseGenericWireframeMapperTest : BaseWireframeMapperTest() {
+
+    lateinit var mockCustomMappers: Map<Class<*>, WireframeMapper<View, *>>
+
+    lateinit var mockCustomMappedToData: List<Pair<View, List<MobileSegment.Wireframe>>>
+
+    open fun `set up`(forge: Forge) {
+        mockCustomMappedToData = listOf(
+            mock<ProgressBar>() to forge.aList { getForgery() },
+            mock<CheckBox>() to forge.aList { getForgery() },
+            mock<Switch>() to forge.aList { getForgery() },
+            mock<SwitchCompat>() to forge.aList { getForgery() },
+            mock<Button>() to forge.aList { getForgery() }
+        )
+        mockCustomMappers = emptyMap()
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllWireframeMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllWireframeMapperTest.kt
@@ -38,7 +38,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllWireframeMapperTest : BaseWireframeMapperTest() {
+internal class MaskAllWireframeMapperTest : BaseGenericWireframeMapperTest() {
 
     @Mock
     lateinit var mockViewWireframeMapper: ViewWireframeMapper
@@ -93,7 +93,8 @@ internal class MaskAllWireframeMapperTest : BaseWireframeMapperTest() {
     lateinit var testedMaskAllWireframeMapper: MaskAllWireframeMapper
 
     @BeforeEach
-    fun `set up`(forge: Forge) {
+    override fun `set up`(forge: Forge) {
+        super.`set up`(forge)
         mockShapeWireframes = forge.aList { mock() }
         mockImageWireframes = forge.aList { mock() }
         mockButtonWireframes = forge.aList { mock() }
@@ -115,8 +116,39 @@ internal class MaskAllWireframeMapperTest : BaseWireframeMapperTest() {
             mockDecorViewMapper,
             mockCheckBoxWireframeMapper,
             mockRadioButtonMapper,
-            mockSwitchCompatMapper
+            mockSwitchCompatMapper,
+            mockCustomMappers
         )
+    }
+
+    @Test
+    fun `M resolve first from customMappers W map { customMappers provided }`(forge: Forge) {
+        // Given
+        mockCustomMappers = mockCustomMappedToData.associate {
+            val mockWireframeMapper = mock<WireframeMapper<View, *>>()
+            whenever(mockWireframeMapper.map(it.first, fakeSystemInformation)).thenReturn(it.second)
+            it.first::class.java to mockWireframeMapper
+        }
+        val fakeCustomMappedIndex = forge.anInt(min = 0, max = mockCustomMappedToData.size)
+        val mockCustomMappedView = mockCustomMappedToData[fakeCustomMappedIndex].first
+        val expectedWireframeData = mockCustomMappedToData[fakeCustomMappedIndex].second
+        testedMaskAllWireframeMapper = MaskAllWireframeMapper(
+            mockViewWireframeMapper,
+            mockImageWireframeMapper,
+            mockMaskAllTextViewMapper,
+            mockButtonMapper,
+            mockEditTextViewMapper,
+            mockCheckedTextViewWireframeMapper,
+            mockDecorViewMapper,
+            mockCheckBoxWireframeMapper,
+            mockRadioButtonMapper,
+            mockSwitchCompatMapper,
+            mockCustomMappers
+        )
+
+        // Then
+        assertThat(testedMaskAllWireframeMapper.map(mockCustomMappedView, fakeSystemInformation))
+            .isEqualTo(expectedWireframeData)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

In this PR we are introducing a new capability in the SR Public API which will allow users to provide an `ExtensionSupport` implementation to support UI frameworks different than the default ones (e.g. Material). For now the `ExtensionSupport` has only one method/property -> ` getCustomViewMappers(): Map<Class<*>, WireframeMapper<View, *>>` which could be used to specify a custom `WireframeMapper` for a specific `View` type that is not supported by default by the core SR sdk. 
This method will be leveraged in the next PR to provide a `SliderWireframeMapper` for the Material `Slider` component.

Please note that a fix was added for the `ApiSurfaceGenerator` in order to support wildcard generics in functions.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

