### PR TITLE
Fix telemetry sampling internal configuration for Flutter

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -287,10 +287,10 @@ internal class DatadogCore(
 
         // Special case -- needs to apply to the RUM config before initializing it.
         mutableConfig.additionalConfig[Datadog.DD_TELEMETRY_CONFIG_SAMPLE_RATE_TAG]?. let {
-            if (it is Float && mutableConfig.rumConfig != null) {
+            if (it is Number && mutableConfig.rumConfig != null) {
                 mutableConfig = mutableConfig.copy(
                     rumConfig = mutableConfig.rumConfig?.copy(
-                        telemetryConfigurationSamplingRate = it
+                        telemetryConfigurationSamplingRate = it.toFloat()
                     )
                 )
             }


### PR DESCRIPTION
### What does this PR do?

Flutter sends the telemetry configuration sample rate as a Double, not a Float. Use Number instead.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

