### PR TITLE
Randomize SDK initialization sequence (feature-wise) for instrumented tests

### DIFF
--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ResourceTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ResourceTrackingTest.kt
@@ -20,7 +20,6 @@ import com.datadog.android.sdk.utils.exhaustiveAttributes
 import com.datadog.android.sdk.utils.isRumUrl
 import com.datadog.tools.unit.ConditionWatcher
 import com.google.gson.JsonObject
-import fr.xgouchet.elmyr.junit4.ForgeRule
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.Response
@@ -42,15 +41,12 @@ internal class ResourceTrackingTest {
         trackingConsent = TrackingConsent.GRANTED
     )
 
-    @get:Rule
-    val forge = ForgeRule()
-
     private lateinit var okHttpClient: OkHttpClient
     private lateinit var extraAttributes: Map<String, Any?>
 
     @Before
     fun setUp() {
-        extraAttributes = forge.exhaustiveAttributes()
+        extraAttributes = mockServerRule.forge.exhaustiveAttributes()
 
         okHttpClient = OkHttpClient.Builder()
             .addInterceptor(

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -35,6 +35,7 @@ import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.io.File
+import java.util.Random
 import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.experimental.inv
 
@@ -59,14 +60,16 @@ internal class EncryptionTest {
         val credentials = createCredentials()
 
         Datadog.initialize(targetContext, credentials, configuration, TrackingConsent.PENDING)
-        Datadog.registerFeature(
-            RumFeature.Builder(applicationId = forge.anAlphaNumericalString()).build()
+        val features = mutableListOf(
+            RumFeature.Builder(applicationId = forge.anAlphaNumericalString()).build(),
+            LogsFeature.Builder().build(),
+            TracingFeature.Builder().build(),
+            SessionReplayFeature(SessionReplayConfiguration.Builder().build())
         )
-        Datadog.registerFeature(LogsFeature.Builder().build())
-        Datadog.registerFeature(TracingFeature.Builder().build())
 
-        val sessionReplayConfig = SessionReplayConfiguration.Builder().build()
-        Datadog.registerFeature(SessionReplayFeature(sessionReplayConfig))
+        features.shuffled(Random(forge.seed)).forEach {
+            Datadog.registerFeature(it)
+        }
 
         val rumMonitor = RumMonitor.Builder().build()
         GlobalRum.registerIfAbsent(rumMonitor)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/utils/ExtraIntentExtensions.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/utils/ExtraIntentExtensions.kt
@@ -29,3 +29,5 @@ fun Intent.addTrackingConsent(consent: TrackingConsent) {
     }
     this.putExtra(TRACKING_CONSENT_KEY, consentToInt)
 }
+
+fun Intent.addForgeSeed(seed: Long) = this.putExtra(FORGE_SEED_KEY, seed)

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/telemetry/TelemetryPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/telemetry/TelemetryPlaygroundActivity.kt
@@ -17,6 +17,7 @@ import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.sdk.integration.R
 import com.datadog.android.sdk.integration.RuntimeConfig
+import com.datadog.android.sdk.utils.getForgeSeed
 import com.datadog.android.sdk.utils.getTrackingConsent
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryException
@@ -32,7 +33,7 @@ import java.lang.RuntimeException
 @Suppress("DEPRECATION") // TODO RUMM-3103 remove deprecated references
 internal class TelemetryPlaygroundActivity : AppCompatActivity(R.layout.main_activity_layout) {
 
-    private val forge = Forge()
+    private val forge by lazy { Forge().apply { seed = intent.getForgeSeed() } }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/utils/IntentExtensions.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/utils/IntentExtensions.kt
@@ -21,3 +21,13 @@ internal fun Intent.getTrackingConsent(): TrackingConsent {
         else -> TrackingConsent.NOT_GRANTED
     }
 }
+
+internal const val FORGE_SEED_KEY = "forge_seed"
+
+@Suppress("CheckInternal")
+internal fun Intent.getForgeSeed(): Long {
+    check(hasExtra(FORGE_SEED_KEY)) {
+        "$FORGE_SEED_KEY value should be provided."
+    }
+    return getLongExtra(FORGE_SEED_KEY, -1)
+}

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash/JvmCrashHandlerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash/JvmCrashHandlerE2ETests.kt
@@ -17,6 +17,7 @@ import com.datadog.android.nightly.services.JvmCrashService
 import com.datadog.android.nightly.services.RumDisabledCrashService
 import com.datadog.android.nightly.services.RumEnabledCrashService
 import com.datadog.android.nightly.utils.initializeSdk
+import fr.xgouchet.elmyr.junit4.ForgeRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -26,6 +27,9 @@ import org.junit.runner.RunWith
 class JvmCrashHandlerE2ETests {
 
     // region Tests
+
+    @get:Rule
+    val forgeRule = ForgeRule()
 
     @get:Rule
     val nightlyTestRule = NightlyTestRule()
@@ -44,7 +48,10 @@ class JvmCrashHandlerE2ETests {
         // measure to prevent sending an event twice from 2 different process. For this reason
         // we are using a NoOpOkHttpUploader in case the process is not the app main process.
         val testMethodName = "crash_reports_rum_enabled"
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forgeRule.seed
+        )
         startService(
             testMethodName,
             RumEnabledCrashService::class.java
@@ -60,7 +67,10 @@ class JvmCrashHandlerE2ETests {
     @Test
     fun crash_reports_rum_disabled() {
         val testMethodName = "crash_reports_rum_disabled"
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forgeRule.seed
+        )
         startService(
             testMethodName,
             RumDisabledCrashService::class.java
@@ -76,7 +86,10 @@ class JvmCrashHandlerE2ETests {
     @Test
     fun crash_reports_feature_disabled() {
         val testMethodName = "crash_reports_feature_disabled"
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forgeRule.seed
+        )
         startService(
             testMethodName,
             CrashHandlerDisabledCrashService::class.java

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash/NdkCrashHandlerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/crash/NdkCrashHandlerE2ETests.kt
@@ -20,6 +20,7 @@ import com.datadog.android.nightly.services.RumEncryptionEnabledNdkCrashService
 import com.datadog.android.nightly.utils.NeverUseThatEncryption
 import com.datadog.android.nightly.utils.initializeSdk
 import com.datadog.android.nightly.utils.stopSdk
+import fr.xgouchet.elmyr.junit4.ForgeRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -29,6 +30,9 @@ import org.junit.runner.RunWith
 class NdkCrashHandlerE2ETests {
 
     // region Tests
+
+    @get:Rule
+    val forgeRule = ForgeRule()
 
     @get:Rule
     val nightlyTestRule = NightlyTestRule()
@@ -46,7 +50,10 @@ class NdkCrashHandlerE2ETests {
         // measure to prevent sending an event twice from 2 different process. For this reason
         // we are using a NoOpOkHttpUploader in case the process is not the app main process.
         val testMethodName = "ndk_crash_reports_rum_enabled"
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forgeRule.seed
+        )
         startService(
             testMethodName,
             RumEnabledNdkCrashService::class.java
@@ -55,7 +62,10 @@ class NdkCrashHandlerE2ETests {
         stopService(RumEnabledNdkCrashService::class.java)
         // we stop and initialize the SDK again to handle the preserved ndk crash
         stopSdk()
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forgeRule.seed
+        )
         waitForProcessToIdle()
     }
 
@@ -70,7 +80,10 @@ class NdkCrashHandlerE2ETests {
     @Test
     fun ndk_crash_reports_rum_enabled_with_encryption() {
         val testMethodName = "ndk_crash_reports_rum_enabled_with_encryption"
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forgeRule.seed
+        )
         startService(
             testMethodName,
             RumEncryptionEnabledNdkCrashService::class.java
@@ -81,6 +94,7 @@ class NdkCrashHandlerE2ETests {
         stopSdk()
         initializeSdk(
             InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forgeRule.seed,
             // need that to be able to read encrypted data written by NDK crash service
             config = Configuration
                 .Builder(
@@ -98,7 +112,10 @@ class NdkCrashHandlerE2ETests {
     @Test
     fun ndk_crash_reports_feature_disabled() {
         val testMethodName = "ndk_crash_reports_feature_disabled"
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forgeRule.seed
+        )
         startService(
             testMethodName,
             NdkHandlerDisabledNdkCrashService::class.java
@@ -107,7 +124,10 @@ class NdkCrashHandlerE2ETests {
         stopService(NdkHandlerDisabledNdkCrashService::class.java)
         // we stop and initialize the SDK again to handle the preserved ndk crash
         stopSdk()
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forgeRule.seed
+        )
         waitForProcessToIdle()
     }
 

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/GdprLogsE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/GdprLogsE2ETests.kt
@@ -44,6 +44,7 @@ class GdprLogsE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.PENDING
             )
         }
@@ -65,6 +66,7 @@ class GdprLogsE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.GRANTED
             )
         }
@@ -86,6 +88,7 @@ class GdprLogsE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.NOT_GRANTED
             )
         }
@@ -104,6 +107,7 @@ class GdprLogsE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.PENDING
             )
         }
@@ -125,6 +129,7 @@ class GdprLogsE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.PENDING
             )
         }
@@ -146,6 +151,7 @@ class GdprLogsE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.GRANTED
             )
         }
@@ -167,6 +173,7 @@ class GdprLogsE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.NOT_GRANTED
             )
         }
@@ -188,6 +195,7 @@ class GdprLogsE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.NOT_GRANTED
             )
         }
@@ -209,6 +217,7 @@ class GdprLogsE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.GRANTED
             )
         }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerBuilderE2ETests.kt
@@ -40,7 +40,10 @@ class LoggerBuilderE2ETests {
 
     @Before
     fun setUp() {
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forge.seed
+        )
     }
 
     /**
@@ -183,7 +186,8 @@ class LoggerBuilderE2ETests {
     fun logs_logger_builder_set_service_name() {
         val testMethodName = "logs_logger_builder_set_service_name"
         measureLoggerInitialize {
-            logger = Logger.Builder(Datadog.globalSdkCore).setServiceName(CUSTOM_SERVICE_NAME).build()
+            logger =
+                Logger.Builder(Datadog.globalSdkCore).setServiceName(CUSTOM_SERVICE_NAME).build()
         }
         logger.sendRandomLog(testMethodName, forge)
     }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
@@ -65,7 +65,10 @@ class LoggerE2ETests {
      */
     @Before
     fun setUp() {
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forge.seed
+        )
         logger = Logger.Builder(Datadog.globalSdkCore)
             .setLoggerName(LOGGER_NAME)
             .build()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
@@ -49,6 +49,7 @@ class LogsConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 defaultConfigurationBuilder(
                     crashReportsEnabled = true
@@ -70,6 +71,7 @@ class LogsConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 defaultConfigurationBuilder(
                     crashReportsEnabled = true
@@ -91,6 +93,7 @@ class LogsConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 defaultConfigurationBuilder(
                     crashReportsEnabled = true
@@ -113,6 +116,7 @@ class LogsConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 defaultConfigurationBuilder(
                     crashReportsEnabled = true
@@ -148,6 +152,7 @@ class LogsConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 defaultConfigurationBuilder(
                     crashReportsEnabled = true
@@ -184,6 +189,7 @@ class LogsConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 Configuration
                     .Builder(

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/GdprRumE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/GdprRumE2ETests.kt
@@ -40,6 +40,7 @@ class GdprRumE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.PENDING
             )
         }
@@ -55,6 +56,7 @@ class GdprRumE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.GRANTED
             )
         }
@@ -70,6 +72,7 @@ class GdprRumE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.NOT_GRANTED
             )
         }
@@ -85,6 +88,7 @@ class GdprRumE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.PENDING
             )
         }
@@ -103,6 +107,7 @@ class GdprRumE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.PENDING
             )
         }
@@ -121,6 +126,7 @@ class GdprRumE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.GRANTED
             )
         }
@@ -139,6 +145,7 @@ class GdprRumE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.GRANTED
             )
         }
@@ -157,6 +164,7 @@ class GdprRumE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.NOT_GRANTED
             )
         }
@@ -175,6 +183,7 @@ class GdprRumE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.NOT_GRANTED
             )
         }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/GlobalRumE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/GlobalRumE2ETests.kt
@@ -52,7 +52,7 @@ class GlobalRumE2ETests {
      */
     @Before
     fun setUp() {
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext, forgeSeed = forge.seed)
     }
 
     // region View

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumConfigE2ETests.kt
@@ -74,6 +74,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 defaultConfigurationBuilder().build()
             )
@@ -90,6 +91,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 defaultConfigurationBuilder()
                     .setBatchSize(forge.aValueFrom(BatchSize::class.java))
@@ -108,6 +110,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     null
@@ -133,6 +136,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumViewEventMapper(
@@ -170,6 +174,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumViewEventMapper(
@@ -209,6 +214,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumResourceEventMapper(
@@ -237,6 +243,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumResourceEventMapper(
@@ -265,6 +272,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumResourceEventMapper(
@@ -298,6 +306,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumActionEventMapper(
@@ -326,6 +335,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumActionEventMapper(
@@ -354,6 +364,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumActionEventMapper(
@@ -387,6 +398,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumErrorEventMapper(
@@ -415,6 +427,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumErrorEventMapper(
@@ -443,6 +456,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumErrorEventMapper(
@@ -477,6 +491,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumLongTaskEventMapper(
@@ -506,6 +521,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumLongTaskEventMapper(
@@ -535,6 +551,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.setRumLongTaskEventMapper(
@@ -568,6 +585,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.sampleRumSessions(100f).build()
@@ -590,6 +608,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.sampleRumSessions(0f).build()
@@ -613,6 +632,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 rumFeatureProvider = {
                     it.sampleRumSessions(75f).build()
@@ -644,6 +664,7 @@ class RumConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 TrackingConsent.GRANTED,
                 Configuration.Builder(
                     crashReportsEnabled = true
@@ -681,6 +702,7 @@ class RumConfigE2ETests {
                 ).build()
                 initializeSdk(
                     InstrumentationRegistry.getInstrumentation().targetContext,
+                    forgeSeed = forge.seed,
                     rumFeatureProvider = {
                         it.useViewTrackingStrategy(strategy)
                             .setVitalsUpdateFrequency(VitalsUpdateFrequency.NEVER).build()
@@ -731,6 +753,7 @@ class RumConfigE2ETests {
                 ).build()
                 initializeSdk(
                     InstrumentationRegistry.getInstrumentation().targetContext,
+                    forgeSeed = forge.seed,
                     rumFeatureProvider = {
                         it.useViewTrackingStrategy(strategy).setVitalsUpdateFrequency(fakeFrequency)
                             .build()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBackgroundE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBackgroundE2ETests.kt
@@ -57,6 +57,7 @@ class RumMonitorBackgroundE2ETests {
     fun setUp() {
         initializeSdk(
             InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forge.seed,
             rumFeatureProvider = {
                 it.trackBackgroundRumEvents(true)
                     .trackFrustrations(true)

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBuilderE2ETests.kt
@@ -40,6 +40,7 @@ class RumMonitorBuilderE2ETests {
 
         initializeSdk(
             InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forge.seed,
             rumMonitorProvider = {
                 measureRumMonitorInitialize {
                     RumMonitor.Builder().build()
@@ -59,6 +60,7 @@ class RumMonitorBuilderE2ETests {
         val testMethodName = "rum_rummonitor_builder_sample_all_out"
         initializeSdk(
             InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forge.seed,
             rumMonitorProvider = {
                 measureRumMonitorInitialize {
                     RumMonitor.Builder().sampleRumSessions(0f).build()
@@ -78,6 +80,7 @@ class RumMonitorBuilderE2ETests {
         val eventsNumber = 100
         initializeSdk(
             InstrumentationRegistry.getInstrumentation().targetContext,
+            forgeSeed = forge.seed,
             rumMonitorProvider = {
                 measureRumMonitorInitialize {
                     RumMonitor.Builder().sampleRumSessions(75f).build()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
@@ -57,7 +57,7 @@ class RumMonitorE2ETests {
      */
     @Before
     fun setUp() {
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext, forgeSeed = forge.seed)
     }
 
     // region View

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumResourceTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumResourceTrackingE2ETests.kt
@@ -23,6 +23,7 @@ import com.datadog.android.nightly.utils.initializeSdk
 import com.datadog.android.nightly.utils.measureSdkInitialize
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.trace.TracingHeaderType
+import fr.xgouchet.elmyr.junit4.ForgeRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -34,6 +35,9 @@ internal class RumResourceTrackingE2ETests {
     @get:Rule
     val nightlyTestRule = NightlyTestRule()
 
+    @get:Rule
+    val forge = ForgeRule()
+
     /**
      * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
@@ -44,6 +48,7 @@ internal class RumResourceTrackingE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
                         .build()
@@ -67,6 +72,7 @@ internal class RumResourceTrackingE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
                         .build()
@@ -101,6 +107,7 @@ internal class RumResourceTrackingE2ETests {
                 .build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(ActivityViewTrackingStrategy(true)).build()
                 },
@@ -138,6 +145,7 @@ internal class RumResourceTrackingE2ETests {
                 .build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
                         .build()
@@ -162,6 +170,7 @@ internal class RumResourceTrackingE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
                         .build()
@@ -189,6 +198,7 @@ internal class RumResourceTrackingE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
                         .build()
@@ -214,6 +224,7 @@ internal class RumResourceTrackingE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
                         .build()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumUserInteractionTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumUserInteractionTrackingE2ETests.kt
@@ -21,6 +21,7 @@ import com.datadog.android.nightly.utils.defaultConfigurationBuilder
 import com.datadog.android.nightly.utils.initializeSdk
 import com.datadog.android.nightly.utils.measureSdkInitialize
 import com.datadog.android.rum.tracking.InteractionPredicate
+import fr.xgouchet.elmyr.junit4.ForgeRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -32,6 +33,9 @@ internal class RumUserInteractionTrackingE2ETests {
     @get:Rule
     val nightlyTestRule = NightlyTestRule()
 
+    @get:Rule
+    val forge = ForgeRule()
+
     /**
      * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun trackInteractions(Array<com.datadog.android.rum.tracking.ViewAttributesProvider> = emptyArray(), com.datadog.android.rum.tracking.InteractionPredicate = NoOpInteractionPredicate()): Builder
      */
@@ -40,6 +44,7 @@ internal class RumUserInteractionTrackingE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.trackInteractions().build()
                 },
@@ -61,6 +66,7 @@ internal class RumUserInteractionTrackingE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.trackInteractions(
                         interactionPredicate = object : InteractionPredicate {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumViewTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumViewTrackingE2ETests.kt
@@ -28,6 +28,7 @@ import com.datadog.android.rum.tracking.ComponentPredicate
 import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
 import com.datadog.android.rum.tracking.MixedViewTrackingStrategy
 import com.datadog.android.rum.tracking.NavigationViewTrackingStrategy
+import fr.xgouchet.elmyr.junit4.ForgeRule
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -38,6 +39,9 @@ internal class RumViewTrackingE2ETests {
 
     @get:Rule
     val nightlyTestRule = NightlyTestRule()
+
+    @get:Rule
+    val forge = ForgeRule()
 
     /**
      * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
@@ -51,6 +55,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
                         .build()
@@ -73,6 +78,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(
                         ActivityViewTrackingStrategy(
@@ -107,6 +113,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(
                         ActivityViewTrackingStrategy(
@@ -141,6 +148,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(FragmentViewTrackingStrategy(true))
                         .build()
@@ -163,6 +171,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(
                         FragmentViewTrackingStrategy(
@@ -198,6 +207,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(
                         FragmentViewTrackingStrategy(
@@ -233,6 +243,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(
                         NavigationViewTrackingStrategy(
@@ -260,6 +271,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(
                         NavigationViewTrackingStrategy(
@@ -295,6 +307,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(
                         NavigationViewTrackingStrategy(
@@ -330,6 +343,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(MixedViewTrackingStrategy(true))
                         .build()
@@ -352,6 +366,7 @@ internal class RumViewTrackingE2ETests {
             ).build()
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 rumFeatureProvider = {
                     it.useViewTrackingStrategy(MixedViewTrackingStrategy(true))
                         .build()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/GdprSpanE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/GdprSpanE2ETests.kt
@@ -42,6 +42,7 @@ class GdprSpanE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.PENDING
             )
         }
@@ -61,6 +62,7 @@ class GdprSpanE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.GRANTED
             )
         }
@@ -80,6 +82,7 @@ class GdprSpanE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.NOT_GRANTED
             )
         }
@@ -99,6 +102,7 @@ class GdprSpanE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.PENDING
             )
         }
@@ -121,6 +125,7 @@ class GdprSpanE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.PENDING
             )
         }
@@ -143,6 +148,7 @@ class GdprSpanE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.GRANTED
             )
         }
@@ -165,6 +171,7 @@ class GdprSpanE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.NOT_GRANTED
             )
         }
@@ -187,6 +194,7 @@ class GdprSpanE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.NOT_GRANTED
             )
         }
@@ -209,6 +217,7 @@ class GdprSpanE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 consent = TrackingConsent.GRANTED
             )
         }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanBuilderE2ETests.kt
@@ -12,6 +12,7 @@ import androidx.test.platform.app.InstrumentationRegistry
 import com.datadog.android.nightly.rules.NightlyTestRule
 import com.datadog.android.nightly.utils.initializeSdk
 import com.datadog.android.nightly.utils.measure
+import fr.xgouchet.elmyr.junit4.ForgeRule
 import io.opentracing.Span
 import io.opentracing.util.GlobalTracer
 import org.junit.Before
@@ -26,6 +27,9 @@ class SpanBuilderE2ETests {
     @get:Rule
     val nightlyTestRule = NightlyTestRule()
 
+    @get:Rule
+    val forge = ForgeRule()
+
     /**
      * apiMethodSignature: com.datadog.android.Datadog#fun initialize(android.content.Context, com.datadog.android.core.configuration.Credentials, com.datadog.android.core.configuration.Configuration, com.datadog.android.privacy.TrackingConsent)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun build(): Configuration
@@ -35,7 +39,7 @@ class SpanBuilderE2ETests {
      */
     @Before
     fun setUp() {
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext, forgeSeed = forge.seed)
     }
 
     /**

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
@@ -54,6 +54,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 config = defaultConfigurationBuilder(
                     crashReportsEnabled = true
                 ).build()
@@ -75,6 +76,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 config = defaultConfigurationBuilder(
                     crashReportsEnabled = true
                 ).setBatchSize(forge.aValueFrom(BatchSize::class.java)).build()
@@ -96,6 +98,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 config = defaultConfigurationBuilder(
                     crashReportsEnabled = true
                 ).build(),
@@ -119,6 +122,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 config = defaultConfigurationBuilder(
                     crashReportsEnabled = true
                 ).build(),
@@ -155,6 +159,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 tracerProvider = { AndroidTracer.Builder().setBundleWithRumEnabled(true).build() }
             )
         }
@@ -188,6 +193,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 tracerProvider = { AndroidTracer.Builder().setBundleWithRumEnabled(false).build() }
             )
         }
@@ -218,6 +224,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 tracerProvider = {
                     AndroidTracer.Builder().setPartialFlushThreshold(partialFlushThreshold).build()
                 }
@@ -245,6 +252,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 tracerProvider = {
                     AndroidTracer.Builder().setPartialFlushThreshold(partialFlushThreshold).build()
                 }
@@ -271,6 +279,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 tracerProvider = {
                     AndroidTracer.Builder()
                         .addGlobalTag(
@@ -297,6 +306,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 tracerProvider = {
                     AndroidTracer.Builder()
                         .setServiceName("service-$testMethodName")
@@ -320,6 +330,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 tracerProvider = {
                     AndroidTracer.Builder()
                         .setTracingHeaderTypes(setOf(TracingHeaderType.TRACECONTEXT))
@@ -341,7 +352,7 @@ class SpanConfigE2ETests {
     fun trace_config_set_user_info() {
         val testMethodName = "trace_config_set_user_info"
         measureSdkInitialize {
-            initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+            initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext, forgeSeed = forge.seed)
         }
 
         val userId = "some-id-${forge.anAlphaNumericalString()}"
@@ -377,6 +388,7 @@ class SpanConfigE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 config = Configuration
                     .Builder(
                         crashReportsEnabled = true

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanE2ETests.kt
@@ -44,7 +44,7 @@ class SpanE2ETests {
      */
     @Before
     fun setUp() {
-        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext)
+        initializeSdk(InstrumentationRegistry.getInstrumentation().targetContext, forgeSeed = forge.seed)
     }
 
     /**

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
@@ -21,6 +21,7 @@ import com.datadog.android.nightly.rules.NightlyTestRule
 import com.datadog.android.nightly.utils.defaultConfigurationBuilder
 import com.datadog.android.nightly.utils.initializeSdk
 import com.datadog.android.nightly.utils.measureSdkInitialize
+import fr.xgouchet.elmyr.junit4.ForgeRule
 import org.junit.After
 import org.junit.Rule
 import org.junit.Test
@@ -32,6 +33,9 @@ internal class WebViewTrackingE2ETests {
 
     @get:Rule
     val nightlyTestRule = NightlyTestRule()
+
+    @get:Rule
+    val forge = ForgeRule()
 
     @After
     fun tearDown() {
@@ -155,6 +159,7 @@ internal class WebViewTrackingE2ETests {
         measureSdkInitialize {
             initializeSdk(
                 InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
                 config = config
             )
         }


### PR DESCRIPTION
### What does this PR do?

Features can be registered at any time (using `Datadog#registerFeature` API) and to check that any order works, we are adding some randomization to the order they are registered.

So far it only makes features be registered before Logger/Tracer/RUM monitor are registered.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

