### PR TITLE
RUMM-3009: Leave useSite configuration only in the core

### DIFF
--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -297,7 +297,7 @@ interface com.datadog.android.v2.api.StorageBackedFeature : Feature
 data class com.datadog.android.v2.api.context.CarrierInfo
   constructor(String?, String?)
 data class com.datadog.android.v2.api.context.DatadogContext
-  constructor(String, String, String, String, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, com.datadog.android.privacy.TrackingConsent, Map<String, Map<String, Any?>>)
+  constructor(com.datadog.android.DatadogSite, String, String, String, String, String, String, String, TimeInfo, ProcessInfo, NetworkInfo, DeviceInfo, UserInfo, com.datadog.android.privacy.TrackingConsent, Map<String, Map<String, Any?>>)
 data class com.datadog.android.v2.api.context.DeviceInfo
   constructor(String, String, String, DeviceType, String, String, String, String, String)
 enum com.datadog.android.v2.api.context.DeviceType

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/RequestFactory.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/RequestFactory.kt
@@ -13,7 +13,6 @@ import com.datadog.android.v2.api.context.DatadogContext
  */
 fun interface RequestFactory {
 
-    // TODO RUMM-2298 Support 1:many relationship between batch and requests
     /**
      * Creates a request for the given batch.
      * @param context Datadog SDK context.

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/context/DatadogContext.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/context/DatadogContext.kt
@@ -6,10 +6,12 @@
 
 package com.datadog.android.v2.api.context
 
+import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 
 /**
  * Contains system information, as well as user-specific and feature specific context info.
+ * @property site [Datadog Site](https://docs.datadoghq.com/getting_started/site/) for data uploads.
  * @property clientToken the client token allowing for data uploads to
  * [Datadog Site](https://docs.datadoghq.com/getting_started/site/).
  * @property service the name of the service that data is generated from. Used for
@@ -32,6 +34,7 @@ import com.datadog.android.privacy.TrackingConsent
  * the parent SDK instance
  */
 data class DatadogContext(
+    val site: DatadogSite,
     val clientToken: String,
     val service: String,
     val env: String,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/DatadogContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/DatadogContextProvider.kt
@@ -19,6 +19,7 @@ internal class DatadogContextProvider(val coreFeature: CoreFeature) : ContextPro
             // IMPORTANT All properties should be immutable and be frozen at the state
             // of the context construction moment
             return DatadogContext(
+                site = coreFeature.site,
                 clientToken = coreFeature.clientToken,
                 service = coreFeature.serviceName,
                 env = coreFeature.envName,

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/NoOpContextProvider.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/NoOpContextProvider.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.v2.core.internal
 
+import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.DeviceInfo
@@ -19,6 +20,7 @@ internal class NoOpContextProvider : ContextProvider {
     // TODO RUMM-0000 this one is quite ugly. Should return type be nullable?
     override val context: DatadogContext
         get() = DatadogContext(
+            site = DatadogSite.US1,
             clientToken = "",
             service = "",
             env = "",

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.utils.forge
 
+import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.tools.unit.forge.exhaustiveAttributes
@@ -17,6 +18,7 @@ class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
 
     override fun getForgery(forge: Forge): DatadogContext {
         return DatadogContext(
+            site = forge.aValueFrom(DatadogSite::class.java),
             clientToken = forge.anHexadecimalString().lowercase(Locale.US),
             service = forge.anAlphabeticalString(),
             version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/DatadogContextProviderTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/internal/DatadogContextProviderTest.kt
@@ -95,6 +95,7 @@ internal class DatadogContextProviderTest {
         val context = testedProvider.context
 
         // Then
+        assertThat(context.site).isEqualTo(coreFeature.mockInstance.site)
         assertThat(context.env).isEqualTo(coreFeature.mockInstance.envName)
         assertThat(context.clientToken).isEqualTo(coreFeature.mockInstance.clientToken)
         assertThat(context.service).isEqualTo(coreFeature.mockInstance.serviceName)

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -22,7 +22,6 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.event.MapperSerializer<T#constructor(EventMapper<T>, com.datadog.android.core.persistence.Serializer<T>)
  * apiMethodSignature: com.datadog.android.sessionreplay.SessionReplayConfiguration$Builder#fun setPrivacy(com.datadog.android.sessionreplay.SessionReplayPrivacy): Builder
  * apiMethodSignature: com.datadog.android.sessionreplay.SessionReplayConfiguration$Builder#fun useCustomEndpoint(String): Builder
- * apiMethodSignature: com.datadog.android.sessionreplay.SessionReplayConfiguration$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
  * apiMethodSignature: com.datadog.android.rum.RumMonitor$Builder#fun setSessionListener(RumSessionListener): Builder
  * apiMethodSignature: com.datadog.android.log.Logger#fun log(Int, String, Throwable? = null, Map<String, Any?> = emptyMap())
  * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setLogcatLogsEnabled(Boolean): Builder
@@ -36,11 +35,8 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#fun startTracking()
  * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#fun stopTracking()
  * apiMethodSignature: com.datadog.android.log.LogsFeature$Builder#fun useCustomEndpoint(String): Builder
- * apiMethodSignature: com.datadog.android.log.LogsFeature$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
  * apiMethodSignature: com.datadog.android.trace.TracingFeature$Builder#fun useCustomEndpoint(String): Builder
- * apiMethodSignature: com.datadog.android.trace.TracingFeature$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
  * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useCustomEndpoint(String): Builder
- * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
  * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun sampleTelemetry(Float): Builder
  * apiMethodSignature: fun Any?.toJsonElement(): com.google.gson.JsonElement
  * apiMethodSignature: fun Collection<ByteArray>.join(ByteArray, ByteArray = ByteArray(0), ByteArray = ByteArray(0)): ByteArray

--- a/library/dd-sdk-android-logs/apiSurface
+++ b/library/dd-sdk-android-logs/apiSurface
@@ -33,7 +33,6 @@ class com.datadog.android.log.LogsFeature : com.datadog.android.v2.api.StorageBa
   override fun onStop()
   override fun onReceive(Any)
   class Builder
-    fun useSite(com.datadog.android.DatadogSite): Builder
     fun useCustomEndpoint(String): Builder
     fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
     fun build(): LogsFeature

--- a/library/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/LogsFeature.kt
+++ b/library/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/LogsFeature.kt
@@ -9,7 +9,6 @@ package com.datadog.android.log
 import android.content.Context
 import android.util.Log
 import androidx.annotation.AnyThread
-import com.datadog.android.DatadogSite
 import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.MapperSerializer
@@ -40,7 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Logs feature class, which needs to be registered with Datadog SDK instance.
  */
 class LogsFeature internal constructor(
-    endpointUrl: String,
+    customEndpointUrl: String?,
     internal val eventMapper: EventMapper<LogEvent>
 ) : StorageBackedFeature, FeatureEventReceiver {
 
@@ -67,7 +66,7 @@ class LogsFeature internal constructor(
         initialized.set(true)
     }
 
-    override val requestFactory: RequestFactory = LogsRequestFactory(endpointUrl)
+    override val requestFactory: RequestFactory = LogsRequestFactory(customEndpointUrl)
     override val storageConfiguration: FeatureStorageConfiguration =
         FeatureStorageConfiguration.DEFAULT
 
@@ -275,22 +274,14 @@ class LogsFeature internal constructor(
      * A Builder class for a [LogsFeature].
      */
     class Builder {
-        private var endpointUrl = DatadogSite.US1.intakeEndpoint
+        private var customEndpointUrl: String? = null
         private var logsEventMapper: EventMapper<LogEvent> = NoOpEventMapper()
-
-        /**
-         * Let the Logs feature target your preferred Datadog's site.
-         */
-        fun useSite(site: DatadogSite): Builder {
-            endpointUrl = site.intakeEndpoint
-            return this
-        }
 
         /**
          * Let the Logs feature target a custom server.
          */
         fun useCustomEndpoint(endpoint: String): Builder {
-            endpointUrl = endpoint
+            customEndpointUrl = endpoint
             return this
         }
 
@@ -311,7 +302,7 @@ class LogsFeature internal constructor(
          */
         fun build(): LogsFeature {
             return LogsFeature(
-                endpointUrl = endpointUrl,
+                customEndpointUrl = customEndpointUrl,
                 eventMapper = logsEventMapper
             )
         }

--- a/library/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/net/LogsRequestFactory.kt
+++ b/library/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/net/LogsRequestFactory.kt
@@ -15,10 +15,10 @@ import java.util.UUID
 
 /**
  * Request factory for the Logs feature.
- * @param endpointUrl URL of the Logs intake.
+ * @param customEndpointUrl URL of the Logs intake.
  */
 internal class LogsRequestFactory(
-    internal val endpointUrl: String
+    internal val customEndpointUrl: String?
 ) : RequestFactory {
 
     /** @inheritdoc */
@@ -32,7 +32,7 @@ internal class LogsRequestFactory(
         return Request(
             id = requestId,
             description = "Logs Request",
-            url = buildUrl(context.source),
+            url = buildUrl(context.source, context),
             headers = buildHeaders(
                 requestId,
                 context.clientToken,
@@ -48,9 +48,14 @@ internal class LogsRequestFactory(
         )
     }
 
-    private fun buildUrl(source: String): String {
+    private fun buildUrl(source: String, context: DatadogContext): String {
         return "%s/api/v2/logs?%s=%s"
-            .format(Locale.US, endpointUrl, RequestFactory.QUERY_PARAM_SOURCE, source)
+            .format(
+                Locale.US,
+                customEndpointUrl ?: context.site.intakeEndpoint,
+                RequestFactory.QUERY_PARAM_SOURCE,
+                source
+            )
     }
 
     private fun buildHeaders(

--- a/library/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsFeatureBuilderTest.kt
+++ b/library/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsFeatureBuilderTest.kt
@@ -6,14 +6,12 @@
 
 package com.datadog.android.log
 
-import com.datadog.android.DatadogSite
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.NoOpEventMapper
 import com.datadog.android.log.internal.net.LogsRequestFactory
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.forge.Configurator
 import com.nhaarman.mockitokotlin2.mock
-import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -38,24 +36,10 @@ internal class LogsFeatureBuilderTest {
         // Then
         val requestFactory = config.requestFactory
         assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
-        assertThat((requestFactory as LogsRequestFactory).endpointUrl)
-            .isEqualTo(DatadogSite.US1.intakeEndpoint)
+        assertThat((requestFactory as LogsRequestFactory).customEndpointUrl)
+            .isNull()
 
         assertThat(config.eventMapper).isInstanceOf(NoOpEventMapper::class.java)
-    }
-
-    @Test
-    fun `𝕄 build feature with custom site 𝕎 useSite() and build()`(
-        @Forgery site: DatadogSite
-    ) {
-        // When
-        val config = testedBuilder.useSite(site).build()
-
-        // Then
-        val requestFactory = config.requestFactory
-        assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
-        assertThat((requestFactory as LogsRequestFactory).endpointUrl)
-            .isEqualTo(site.intakeEndpoint)
     }
 
     @Test
@@ -68,7 +52,7 @@ internal class LogsFeatureBuilderTest {
         // Then
         val requestFactory = config.requestFactory
         assertThat(requestFactory).isInstanceOf(LogsRequestFactory::class.java)
-        assertThat((requestFactory as LogsRequestFactory).endpointUrl)
+        assertThat((requestFactory as LogsRequestFactory).customEndpointUrl)
             .isEqualTo(logsEndpointUrl)
     }
 

--- a/library/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
+++ b/library/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.utils.forge
 
 import android.app.ActivityManager
+import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.DeviceInfo
@@ -23,6 +24,7 @@ internal class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
 
     override fun getForgery(forge: Forge): DatadogContext {
         return DatadogContext(
+            site = forge.aValueFrom(DatadogSite::class.java),
             clientToken = forge.anHexadecimalString().lowercase(Locale.US),
             service = forge.anAlphabeticalString(),
             version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),

--- a/library/dd-sdk-android-rum/apiSurface
+++ b/library/dd-sdk-android-rum/apiSurface
@@ -80,7 +80,6 @@ class com.datadog.android.rum.RumFeature : com.datadog.android.v2.api.StorageBac
     fun trackBackgroundRumEvents(Boolean): Builder
     fun trackFrustrations(Boolean): Builder
     fun setVitalsUpdateFrequency(com.datadog.android.rum.configuration.VitalsUpdateFrequency): Builder
-    fun useSite(com.datadog.android.DatadogSite): Builder
     fun useCustomEndpoint(String): Builder
     fun setAdditionalConfiguration(Map<String, Any>): Builder
     fun build(): RumFeature

--- a/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumFeature.kt
+++ b/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumFeature.kt
@@ -13,7 +13,6 @@ import android.os.Handler
 import android.os.Looper
 import android.view.Choreographer
 import androidx.annotation.FloatRange
-import com.datadog.android.DatadogSite
 import com.datadog.android.core.internal.thread.LoggingScheduledThreadPoolExecutor
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.core.internal.utils.internalLogger
@@ -159,7 +158,7 @@ class RumFeature internal constructor(
         initialized.set(true)
     }
 
-    override val requestFactory: RequestFactory = RumRequestFactory(configuration.endpointUrl)
+    override val requestFactory: RequestFactory = RumRequestFactory(configuration.customEndpointUrl)
     override val storageConfiguration: FeatureStorageConfiguration =
         FeatureStorageConfiguration.DEFAULT
 
@@ -681,18 +680,10 @@ class RumFeature internal constructor(
         }
 
         /**
-         * Let the RUM feature target your preferred Datadog's site.
-         */
-        fun useSite(site: DatadogSite): Builder {
-            rumConfig = rumConfig.copy(endpointUrl = site.intakeEndpoint)
-            return this
-        }
-
-        /**
          * Let the RUM feature target a custom server.
          */
         fun useCustomEndpoint(endpoint: String): Builder {
-            rumConfig = rumConfig.copy(endpointUrl = endpoint)
+            rumConfig = rumConfig.copy(customEndpointUrl = endpoint)
             return this
         }
 
@@ -738,7 +729,7 @@ class RumFeature internal constructor(
     }
 
     internal data class Configuration(
-        val endpointUrl: String,
+        val customEndpointUrl: String?,
         val samplingRate: Float,
         val telemetrySamplingRate: Float,
         val telemetryConfigurationSamplingRate: Float,
@@ -762,7 +753,7 @@ class RumFeature internal constructor(
             "_dd.telemetry.configuration_sample_rate"
 
         internal val DEFAULT_RUM_CONFIG = Configuration(
-            endpointUrl = DatadogSite.US1.intakeEndpoint,
+            customEndpointUrl = null,
             samplingRate = DEFAULT_SAMPLING_RATE,
             telemetrySamplingRate = DEFAULT_TELEMETRY_SAMPLING_RATE,
             telemetryConfigurationSamplingRate = DEFAULT_TELEMETRY_CONFIGURATION_SAMPLING_RATE,

--- a/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumRequestFactory.kt
+++ b/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/net/RumRequestFactory.kt
@@ -15,7 +15,7 @@ import java.util.Locale
 import java.util.UUID
 
 internal class RumRequestFactory(
-    private val endpointUrl: String
+    private val customEndpointUrl: String?
 ) : RequestFactory {
 
     override fun create(
@@ -54,7 +54,10 @@ internal class RumRequestFactory(
             )
         )
 
-        val intakeUrl = "%s/api/v2/rum".format(Locale.US, endpointUrl)
+        val intakeUrl = "%s/api/v2/rum".format(
+            Locale.US,
+            customEndpointUrl ?: context.site.intakeEndpoint
+        )
 
         return intakeUrl + queryParams.map { "${it.key}=${it.value}" }
             .joinToString("&", prefix = "?")

--- a/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumFeatureBuilderTest.kt
+++ b/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumFeatureBuilderTest.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.rum
 
 import android.os.Build
-import com.datadog.android.DatadogSite
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.NoOpEventMapper
 import com.datadog.android.rum.assertj.ConfigurationRumAssert
@@ -77,7 +76,7 @@ internal class RumFeatureBuilderTest {
         // Then
         assertThat(rumFeature.configuration).isEqualTo(
             RumFeature.Configuration(
-                endpointUrl = DatadogSite.US1.intakeEndpoint,
+                customEndpointUrl = null,
                 samplingRate = RumFeature.DEFAULT_SAMPLING_RATE,
                 telemetrySamplingRate = RumFeature.DEFAULT_TELEMETRY_SAMPLING_RATE,
                 telemetryConfigurationSamplingRate = RumFeature.DEFAULT_TELEMETRY_CONFIGURATION_SAMPLING_RATE,
@@ -108,19 +107,6 @@ internal class RumFeatureBuilderTest {
     }
 
     @Test
-    fun `𝕄 build config with custom site 𝕎 useSite() and build()`(
-        @Forgery site: DatadogSite
-    ) {
-        // When
-        val rumFeature = testedBuilder.useSite(site).build()
-
-        // Then
-        assertThat(rumFeature.configuration).isEqualTo(
-            RumFeature.DEFAULT_RUM_CONFIG.copy(endpointUrl = site.intakeEndpoint)
-        )
-    }
-
-    @Test
     fun `𝕄 build config with custom endpoint 𝕎 useCustomEndpoint() and build()`(
         @StringForgery(regex = "https://[a-z]+\\.com") rumUrl: String
     ) {
@@ -131,7 +117,7 @@ internal class RumFeatureBuilderTest {
 
         // Then
         assertThat(rumFeature.configuration).isEqualTo(
-            RumFeature.DEFAULT_RUM_CONFIG.copy(endpointUrl = rumUrl)
+            RumFeature.DEFAULT_RUM_CONFIG.copy(customEndpointUrl = rumUrl)
         )
     }
 

--- a/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/RumRequestFactoryTest.kt
+++ b/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/net/RumRequestFactoryTest.kt
@@ -38,13 +38,10 @@ internal class RumRequestFactoryTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
-    @StringForgery(regex = "https://[a-z]+\\.com")
-    lateinit var fakeEndpoint: String
-
     @BeforeEach
     fun `set up`() {
         testedFactory = RumRequestFactory(
-            endpointUrl = fakeEndpoint
+            customEndpointUrl = null
         )
     }
 
@@ -56,6 +53,42 @@ internal class RumRequestFactoryTest {
         forge: Forge
     ) {
         // Given
+        val batchData = batchData.map { it.toByteArray() }
+        val batchMetadata = forge.aNullable { batchMetadata.toByteArray() }
+
+        // When
+        val request = testedFactory.create(fakeDatadogContext, batchData, batchMetadata)
+
+        // Then
+        assertThat(request.url).isEqualTo(expectedUrl(fakeDatadogContext.site.intakeEndpoint))
+        assertThat(request.contentType).isEqualTo(RequestFactory.CONTENT_TYPE_TEXT_UTF8)
+        assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
+            mapOf(
+                RequestFactory.HEADER_API_KEY to fakeDatadogContext.clientToken,
+                RequestFactory.HEADER_EVP_ORIGIN to fakeDatadogContext.source,
+                RequestFactory.HEADER_EVP_ORIGIN_VERSION to fakeDatadogContext.sdkVersion
+            )
+        )
+        assertThat(request.headers[RequestFactory.HEADER_REQUEST_ID]).isNotEmpty()
+        assertThat(request.id).isEqualTo(request.headers[RequestFactory.HEADER_REQUEST_ID])
+        assertThat(request.description).isEqualTo("RUM Request")
+        assertThat(request.body).isEqualTo(
+            batchData.join(
+                separator = "\n".toByteArray()
+            )
+        )
+    }
+
+    @Suppress("NAME_SHADOWING")
+    @Test
+    fun `𝕄 create a proper request 𝕎 create() { custom endpoint }`(
+        @StringForgery(regex = "https://[a-z]+\\.com") fakeEndpoint: String,
+        @StringForgery batchData: List<String>,
+        @StringForgery batchMetadata: String,
+        forge: Forge
+    ) {
+        // Given
+        testedFactory = RumRequestFactory(customEndpointUrl = fakeEndpoint)
         val batchData = batchData.map { it.toByteArray() }
         val batchMetadata = forge.aNullable { batchMetadata.toByteArray() }
 

--- a/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -20,7 +20,7 @@ internal class ConfigurationRumForgeryFactory :
     ForgeryFactory<RumFeature.Configuration> {
     override fun getForgery(forge: Forge): RumFeature.Configuration {
         return RumFeature.Configuration(
-            endpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
+            customEndpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
             samplingRate = forge.aFloat(0f, 100f),
             telemetrySamplingRate = forge.aFloat(0f, 100f),
             telemetryConfigurationSamplingRate = forge.aFloat(0f, 100f),

--- a/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/DatadogContextForgeryFactory.kt
+++ b/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/DatadogContextForgeryFactory.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.utils.forge
 
+import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.tools.unit.forge.exhaustiveAttributes
@@ -18,6 +19,7 @@ internal class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
 
     override fun getForgery(forge: Forge): DatadogContext {
         return DatadogContext(
+            site = forge.aValueFrom(DatadogSite::class.java),
             clientToken = forge.anHexadecimalString().lowercase(Locale.US),
             service = forge.anAlphabeticalString(),
             version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),

--- a/library/dd-sdk-android-session-replay/apiSurface
+++ b/library/dd-sdk-android-session-replay/apiSurface
@@ -1,6 +1,5 @@
 data class com.datadog.android.sessionreplay.SessionReplayConfiguration
   class Builder
-    fun useSite(com.datadog.android.DatadogSite): Builder
     fun useCustomEndpoint(String): Builder
     fun setPrivacy(SessionReplayPrivacy): Builder
     fun build(): SessionReplayConfiguration

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.sessionreplay
 
-import com.datadog.android.DatadogSite
 import com.datadog.android.core.configuration.Configuration
 
 /**
@@ -14,7 +13,7 @@ import com.datadog.android.core.configuration.Configuration
  */
 data class SessionReplayConfiguration
 internal constructor(
-    internal val endpointUrl: String,
+    internal val customEndpointUrl: String?,
     internal val privacy: SessionReplayPrivacy
 ) {
 
@@ -22,22 +21,14 @@ internal constructor(
      * A Builder class for a [SessionReplayConfiguration].
      */
     class Builder {
-        private var endpointUrl = DatadogSite.US1.intakeEndpoint
+        private var customEndpointUrl: String? = null
         private var privacy = SessionReplayPrivacy.MASK_ALL
-
-        /**
-         * Let the Session Replay target your preferred Datadog's site.
-         */
-        fun useSite(site: DatadogSite): Builder {
-            endpointUrl = site.intakeEndpoint
-            return this
-        }
 
         /**
          * Let the Session Replay target a custom server.
          */
         fun useCustomEndpoint(endpoint: String): Builder {
-            endpointUrl = endpoint
+            customEndpointUrl = endpoint
             return this
         }
 
@@ -57,7 +48,7 @@ internal constructor(
          */
         fun build(): SessionReplayConfiguration {
             return SessionReplayConfiguration(
-                endpointUrl = endpointUrl,
+                customEndpointUrl = customEndpointUrl,
                 privacy = privacy
             )
         }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayFeature.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayFeature.kt
@@ -83,7 +83,7 @@ class SessionReplayFeature internal constructor(
     }
 
     override val requestFactory: RequestFactory =
-        SessionReplayRequestFactory(configuration.endpointUrl)
+        SessionReplayRequestFactory(configuration.customEndpointUrl)
 
     override val storageConfiguration: FeatureStorageConfiguration =
         FeatureStorageConfiguration.DEFAULT

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactory.kt
@@ -18,19 +18,10 @@ import java.util.Locale
 import java.util.UUID
 
 internal class SessionReplayRequestFactory(
-    private val endpoint: String,
+    private val customEndpointUrl: String?,
     private val batchToSegmentsMapper: BatchesToSegmentsMapper = BatchesToSegmentsMapper(),
     private val requestBodyFactory: RequestBodyFactory = RequestBodyFactory()
 ) : RequestFactory {
-
-    private val intakeUrl by lazy {
-        String.format(
-            Locale.US,
-            UPLOAD_URL,
-            endpoint,
-            "replay"
-        )
-    }
 
     override fun create(
         context: DatadogContext,
@@ -68,6 +59,12 @@ internal class SessionReplayRequestFactory(
 
     private fun buildUrl(datadogContext: DatadogContext): String {
         val queryParams = buildQueryParameters(datadogContext)
+        val intakeUrl = String.format(
+            Locale.US,
+            UPLOAD_URL,
+            customEndpointUrl ?: datadogContext.site.intakeEndpoint,
+            "replay"
+        )
         return intakeUrl + queryParams.map { "${it.key}=${it.value}" }
             .joinToString("&", prefix = "?")
     }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.sessionreplay
 
-import com.datadog.android.DatadogSite
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -37,19 +36,8 @@ internal class SessionReplayConfigurationBuilderTest {
         val config = testedBuilder.build()
 
         // Then
-        assertThat(config.endpointUrl).isEqualTo(DatadogSite.US1.intakeEndpoint)
+        assertThat(config.customEndpointUrl).isEqualTo(null)
         assertThat(config.privacy).isEqualTo(SessionReplayPrivacy.MASK_ALL)
-    }
-
-    @Test
-    fun `𝕄 build config with custom site 𝕎 useSite() and build()`(
-        @Forgery site: DatadogSite
-    ) {
-        // When
-        val config = testedBuilder.useSite(site).build()
-
-        // Then
-        assertThat(config.endpointUrl).isEqualTo(site.intakeEndpoint)
     }
 
     @Test
@@ -60,7 +48,7 @@ internal class SessionReplayConfigurationBuilderTest {
         val config = testedBuilder.useCustomEndpoint(sessionReplayUrl).build()
 
         // Then
-        assertThat(config.endpointUrl).isEqualTo(sessionReplayUrl)
+        assertThat(config.customEndpointUrl).isEqualTo(sessionReplayUrl)
     }
 
     @Test

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/DatadogContextForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/DatadogContextForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.forge
 
 import android.app.ActivityManager
+import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.DeviceInfo
@@ -24,6 +25,7 @@ internal class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
 
     override fun getForgery(forge: Forge): DatadogContext {
         return DatadogContext(
+            site = forge.aValueFrom(DatadogSite::class.java),
             clientToken = forge.anHexadecimalString().lowercase(Locale.US),
             service = forge.anAlphabeticalString(),
             version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
@@ -15,7 +15,7 @@ internal class SessionReplayConfigurationForgeryFactory :
     ForgeryFactory<SessionReplayConfiguration> {
     override fun getForgery(forge: Forge): SessionReplayConfiguration {
         return SessionReplayConfiguration(
-            endpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
+            customEndpointUrl = forge.aStringMatching("http(s?)://[a-z]+\\.com/\\w+"),
             privacy = forge.aValueFrom(SessionReplayPrivacy::class.java)
         )
     }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactoryTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactoryTest.kt
@@ -56,9 +56,6 @@ internal class SessionReplayRequestFactoryTest {
     @Mock
     lateinit var mockRequestBodyFactory: RequestBodyFactory
 
-    @StringForgery(regex = "https://[a-z]+\\.com")
-    lateinit var fakeEndpoint: String
-
     @Forgery
     lateinit var fakeSegment: MobileSegment
 
@@ -98,7 +95,7 @@ internal class SessionReplayRequestFactoryTest {
         whenever(mockBatchesToSegmentsMapper.map(fakeBatchData))
             .thenReturn(Pair(fakeSegment, fakeSerializedSegment))
         testedRequestFactory = SessionReplayRequestFactory(
-            fakeEndpoint,
+            customEndpointUrl = null,
             mockBatchesToSegmentsMapper,
             mockRequestBodyFactory
         )
@@ -109,6 +106,38 @@ internal class SessionReplayRequestFactoryTest {
     @Test
     fun `M return a valid Request W create`() {
         // When
+        val request = testedRequestFactory.create(
+            fakeDatadogContext,
+            fakeBatchData,
+            fakeBatchMetadata
+        )
+
+        // Then
+        assertThat(request.url).isEqualTo(expectedUrl(fakeDatadogContext.site.intakeEndpoint))
+        assertThat(request.contentType).isEqualTo(fakeMediaType.toString())
+        assertThat(request.headers.minus(RequestFactory.HEADER_REQUEST_ID)).isEqualTo(
+            mapOf(
+                RequestFactory.HEADER_API_KEY to fakeDatadogContext.clientToken,
+                RequestFactory.HEADER_EVP_ORIGIN to fakeDatadogContext.source,
+                RequestFactory.HEADER_EVP_ORIGIN_VERSION to fakeDatadogContext.sdkVersion
+            )
+        )
+        assertThat(request.headers[RequestFactory.HEADER_REQUEST_ID]).isNotEmpty
+        assertThat(request.id).isEqualTo(request.headers[RequestFactory.HEADER_REQUEST_ID])
+        assertThat(request.description).isEqualTo("Session Replay Segment Upload Request")
+        assertThat(request.body).isEqualTo(mockRequestBody.toByteArray())
+    }
+
+    @Test
+    fun `M return a valid Request W create { custom endpoint }`(
+        @StringForgery(regex = "https://[a-z]+\\.com") fakeEndpoint: String
+    ) {
+        // When
+        testedRequestFactory = SessionReplayRequestFactory(
+            customEndpointUrl = fakeEndpoint,
+            mockBatchesToSegmentsMapper,
+            mockRequestBodyFactory
+        )
         val request = testedRequestFactory.create(
             fakeDatadogContext,
             fakeBatchData,

--- a/library/dd-sdk-android-trace/apiSurface
+++ b/library/dd-sdk-android-trace/apiSurface
@@ -18,7 +18,6 @@ class com.datadog.android.trace.TracingFeature : com.datadog.android.v2.api.Stor
   override val storageConfiguration: com.datadog.android.v2.api.FeatureStorageConfiguration
   override fun onStop()
   class Builder
-    fun useSite(com.datadog.android.DatadogSite): Builder
     fun useCustomEndpoint(String): Builder
     fun setSpanEventMapper(com.datadog.android.trace.internal.domain.event.SpanEventMapper): Builder
     fun build(): TracingFeature

--- a/library/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TracingFeature.kt
+++ b/library/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TracingFeature.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.trace
 
 import android.content.Context
-import com.datadog.android.DatadogSite
 import com.datadog.android.core.internal.utils.internalLogger
 import com.datadog.android.trace.internal.data.NoOpWriter
 import com.datadog.android.trace.internal.data.TraceWriter
@@ -29,7 +28,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Tracing feature class, which needs to be registered with Datadog SDK instance.
  */
 class TracingFeature internal constructor(
-    endpointUrl: String,
+    customEndpointUrl: String?,
     internal val spanEventMapper: SpanEventMapper
 ) : StorageBackedFeature {
 
@@ -48,7 +47,7 @@ class TracingFeature internal constructor(
         initialized.set(true)
     }
 
-    override val requestFactory: RequestFactory = TracesRequestFactory(endpointUrl)
+    override val requestFactory: RequestFactory = TracesRequestFactory(customEndpointUrl)
     override val storageConfiguration: FeatureStorageConfiguration =
         FeatureStorageConfiguration.DEFAULT
 
@@ -75,22 +74,14 @@ class TracingFeature internal constructor(
      * A Builder class for a [TracingFeature].
      */
     class Builder {
-        private var endpointUrl = DatadogSite.US1.intakeEndpoint
+        private var customEndpointUrl: String? = null
         private var spanEventMapper: SpanEventMapper = NoOpSpanEventMapper()
-
-        /**
-         * Let the Tracing feature target your preferred Datadog's site.
-         */
-        fun useSite(site: DatadogSite): Builder {
-            endpointUrl = site.intakeEndpoint
-            return this
-        }
 
         /**
          * Let the Tracing feature target a custom server.
          */
         fun useCustomEndpoint(endpoint: String): Builder {
-            endpointUrl = endpoint
+            customEndpointUrl = endpoint
             return this
         }
 
@@ -111,7 +102,7 @@ class TracingFeature internal constructor(
          */
         fun build(): TracingFeature {
             return TracingFeature(
-                endpointUrl = endpointUrl,
+                customEndpointUrl = customEndpointUrl,
                 spanEventMapper = spanEventMapper
             )
         }

--- a/library/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/TracesRequestFactory.kt
+++ b/library/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/net/TracesRequestFactory.kt
@@ -14,7 +14,7 @@ import java.util.Locale
 import java.util.UUID
 
 internal class TracesRequestFactory(
-    internal val endpointUrl: String
+    internal val customEndpointUrl: String?
 ) : RequestFactory {
 
     override fun create(
@@ -27,7 +27,10 @@ internal class TracesRequestFactory(
         return Request(
             id = requestId,
             description = "Traces Request",
-            url = "%s/api/v2/spans".format(Locale.US, endpointUrl),
+            url = "%s/api/v2/spans".format(
+                Locale.US,
+                customEndpointUrl ?: context.site.intakeEndpoint
+            ),
             headers = buildHeaders(
                 requestId,
                 context.clientToken,

--- a/library/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TracingFeatureBuilderTest.kt
+++ b/library/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TracingFeatureBuilderTest.kt
@@ -6,13 +6,11 @@
 
 package com.datadog.android.trace
 
-import com.datadog.android.DatadogSite
 import com.datadog.android.trace.internal.domain.event.NoOpSpanEventMapper
 import com.datadog.android.trace.internal.domain.event.SpanEventMapper
 import com.datadog.android.trace.internal.net.TracesRequestFactory
 import com.datadog.android.utils.forge.Configurator
 import com.nhaarman.mockitokotlin2.mock
-import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -37,24 +35,10 @@ internal class TracingFeatureBuilderTest {
         // Then
         val requestFactory = config.requestFactory
         assertThat(requestFactory).isInstanceOf(TracesRequestFactory::class.java)
-        assertThat((requestFactory as TracesRequestFactory).endpointUrl)
-            .isEqualTo(DatadogSite.US1.intakeEndpoint)
+        assertThat((requestFactory as TracesRequestFactory).customEndpointUrl)
+            .isNull()
 
         assertThat(config.spanEventMapper).isInstanceOf(NoOpSpanEventMapper::class.java)
-    }
-
-    @Test
-    fun `𝕄 build feature with custom site 𝕎 useSite() and build()`(
-        @Forgery site: DatadogSite
-    ) {
-        // When
-        val config = testedBuilder.useSite(site).build()
-
-        // Then
-        val requestFactory = config.requestFactory
-        assertThat(requestFactory).isInstanceOf(TracesRequestFactory::class.java)
-        assertThat((requestFactory as TracesRequestFactory).endpointUrl)
-            .isEqualTo(site.intakeEndpoint)
     }
 
     @Test
@@ -67,7 +51,7 @@ internal class TracingFeatureBuilderTest {
         // Then
         val requestFactory = config.requestFactory
         assertThat(requestFactory).isInstanceOf(TracesRequestFactory::class.java)
-        assertThat((requestFactory as TracesRequestFactory).endpointUrl)
+        assertThat((requestFactory as TracesRequestFactory).customEndpointUrl)
             .isEqualTo(tracesEndpointUrl)
     }
 

--- a/library/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
+++ b/library/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.utils.forge
 
 import android.app.ActivityManager
+import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.DeviceInfo
@@ -23,6 +24,7 @@ internal class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
 
     override fun getForgery(forge: Forge): DatadogContext {
         return DatadogContext(
+            site = forge.aValueFrom(DatadogSite::class.java),
             clientToken = forge.anHexadecimalString().lowercase(Locale.US),
             service = forge.anAlphabeticalString(),
             version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),

--- a/library/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
+++ b/library/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/DatadogContextForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.utils.forge
 
 import android.app.ActivityManager
+import com.datadog.android.DatadogSite
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.v2.api.context.DatadogContext
 import com.datadog.android.v2.api.context.DeviceInfo
@@ -23,6 +24,7 @@ internal class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
 
     override fun getForgery(forge: Forge): DatadogContext {
         return DatadogContext(
+            site = forge.aValueFrom(DatadogSite::class.java),
             clientToken = forge.anHexadecimalString().lowercase(Locale.US),
             service = forge.anAlphabeticalString(),
             version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -121,7 +121,6 @@ class SampleApplication : Application() {
 
         val sessionReplayConfig = SessionReplayConfiguration.Builder()
             .apply {
-                useSite(DatadogSite.valueOf(BuildConfig.DD_SITE_NAME))
                 if (BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL.isNotBlank()) {
                     useCustomEndpoint(BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL)
                 }
@@ -132,7 +131,6 @@ class SampleApplication : Application() {
         Datadog.registerFeature(sessionReplayFeature)
 
         val logsFeature = LogsFeature.Builder().apply {
-            useSite(DatadogSite.valueOf(BuildConfig.DD_SITE_NAME))
             if (BuildConfig.DD_OVERRIDE_LOGS_URL.isNotBlank()) {
                 useCustomEndpoint(BuildConfig.DD_OVERRIDE_LOGS_URL)
             }
@@ -140,7 +138,6 @@ class SampleApplication : Application() {
         Datadog.registerFeature(logsFeature)
 
         val tracingFeature = TracingFeature.Builder().apply {
-            useSite(DatadogSite.valueOf(BuildConfig.DD_SITE_NAME))
             if (BuildConfig.DD_OVERRIDE_TRACES_URL.isNotBlank()) {
                 useCustomEndpoint(BuildConfig.DD_OVERRIDE_TRACES_URL)
             }
@@ -179,7 +176,6 @@ class SampleApplication : Application() {
 
     private fun createRumFeature(): RumFeature {
         return RumFeature.Builder(BuildConfig.DD_RUM_APPLICATION_ID)
-            .useSite(DatadogSite.valueOf(BuildConfig.DD_SITE_NAME))
             .apply {
                 if (BuildConfig.DD_OVERRIDE_RUM_URL.isNotBlank()) {
                     useCustomEndpoint(BuildConfig.DD_OVERRIDE_RUM_URL)


### PR DESCRIPTION
### What does this PR do?

Before this change we had `useSite` configuration options for every feature, but it makes setup more verbose and unlikely it can be the case when different features are using different sites (especially considering that `clientToken` is site-specific and is defined only in the core configuration).

To address that we are bringing back `DatadogContext#site` property and request factories will use it unless custom URL is given.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

