### PR TITLE
RUMM-2995: Handle NDK crashes considering the dynamic feature registration

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/ndk/NdkCrashHandler.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/ndk/NdkCrashHandler.kt
@@ -13,5 +13,10 @@ import com.datadog.tools.annotation.NoOpImplementation
 internal interface NdkCrashHandler {
     fun prepareData()
 
-    fun handleNdkCrash(sdkCore: SdkCore)
+    fun handleNdkCrash(sdkCore: SdkCore, reportTarget: ReportTarget)
+
+    enum class ReportTarget {
+        RUM,
+        LOGS
+    }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataUploader.kt
@@ -12,7 +12,6 @@ import com.datadog.tools.annotation.NoOpImplementation
 
 @NoOpImplementation
 internal interface DataUploader {
-    // TODO RUMM-2298 Support 1:many relationship between batch and requests
     fun upload(
         context: DatadogContext,
         batch: List<ByteArray>,


### PR DESCRIPTION
### What does this PR do?

This update brings back NDK crash submission, which was not working during the dynamic nature of feature registration.

Now we will check what is the feature registered via `registerFeature` call, and if it is RUM or Logs, then we will proceed with the crash data submission to the relevant channel.

Also this PR makes a bit of change in the data preparation flow - now deserialization happens at the `prepareData` call (it was handled only in `handleNdkCrash` before), which should be fine, because deserializers are simple and everything needed should be ready by the time deserialization is performed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

