### PR TITLE
MTG-13 update static analysis dependency

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -63,7 +63,7 @@ static-analysis:
     DETEKT_CUSTOM_RULES_JAR_PATH: "tools/detekt/build/libs/detekt.jar"
     DETEKT_CUSTOM_RULES_YML_PATH: "detekt_custom.yml"
   trigger:
-    include: "https://gitlab-templates.ddbuild.io/mobile/v12509514-f43ceb02/static-analysis.yml"
+    include: "https://gitlab-templates.ddbuild.io/mobile/v13971524-c0282e65/static-analysis.yml"
     strategy: depend
 
 analysis:android-lint:
@@ -89,14 +89,6 @@ analysis:nightly-tests-coverage:
   timeout: 30m
   script:
     - GRADLE_OPTS="-Xmx2560m" ./gradlew checkNightlyTestsCoverage --stacktrace --no-daemon
-
-analysis:woke:
-  tags: [ "runner:main" ]
-  image: $CI_IMAGE_DOCKER
-  stage: analysis
-  timeout: 30m
-  script:
-    - /usr/bin/woke --exit-1-on-failure
 
 # TESTS
 


### PR DESCRIPTION
### What does this PR do?

Update the static analysis dependency to us the shared woke step