### PR TITLE
REPLAY-1444 Do not apply textSize correction to check and radio marks

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableCompoundButtonMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableCompoundButtonMapper.kt
@@ -38,12 +38,7 @@ internal abstract class CheckableCompoundButtonMapper<T : CompoundButton>(
         }
         // minus the padding
         checkBoxHeight -= MIN_PADDING_IN_PX * 2
-        val textSize = view.textSize.toLong()
-        // to solve the current font issues on the player side we lower the original font
-        // size with 1 unit. We will need to normalize the current checkbox size
-        // to this new size
-        checkBoxHeight = (checkBoxHeight * (textSize - 1) / textSize)
-            .densityNormalized(pixelsDensity)
+        checkBoxHeight = checkBoxHeight.densityNormalized(pixelsDensity)
         return GlobalBounds(
             x = viewGlobalBounds.x + MIN_PADDING_IN_PX.densityNormalized(pixelsDensity),
             y = viewGlobalBounds.y + (viewGlobalBounds.height - checkBoxHeight) / 2,

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckedTextViewMapper.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckedTextViewMapper.kt
@@ -50,11 +50,7 @@ internal open class CheckedTextViewMapper(
             val height = checkMarkDrawable.intrinsicHeight -
                 view.totalPaddingTop -
                 view.totalPaddingBottom
-            // to solve the current font issues on the player side we lower the original font
-            // size with 1 unit. We will need to normalize the current checkbox size
-            // to this new size
-            checkBoxHeight = (height * (view.textSize - 1) / view.textSize)
-                .toLong().densityNormalized(pixelsDensity)
+            checkBoxHeight = height.toLong().densityNormalized(pixelsDensity)
         }
 
         return GlobalBounds(

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckBoxMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckBoxMapperTest.kt
@@ -283,9 +283,8 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
 
     private fun resolveCheckBoxSize(checkBoxSize: Long): Long {
         val density = fakeSystemInformation.screenDensity
-        val textSize = fakeTextSize.toLong()
         val size = checkBoxSize - 2 * CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
-        return (size * (textSize - 1) / textSize).densityNormalized(density)
+        return size.densityNormalized(density)
     }
 
     // endregion

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckedTextViewMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckedTextViewMapperTest.kt
@@ -358,8 +358,7 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
 
     private fun resolveCheckBoxSize(): Long {
         val size = fakeCheckMarkHeight - fakePaddingBottom - fakePaddingTop
-        return (size * (fakeTextSize - 1) / fakeTextSize).toLong()
-            .densityNormalized(fakeSystemInformation.screenDensity)
+        return size.toLong().densityNormalized(fakeSystemInformation.screenDensity)
     }
 
     // endregion

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseRadioButtonMapperTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseRadioButtonMapperTest.kt
@@ -292,9 +292,8 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
 
     private fun resolveRadioBoxSize(radioSize: Long): Long {
         val density = fakeSystemInformation.screenDensity
-        val textSize = fakeTextSize.toLong()
         val size = radioSize - 2 * CheckableCompoundButtonMapper.MIN_PADDING_IN_PX
-        return (size * (textSize - 1) / textSize).densityNormalized(density)
+        return size.densityNormalized(density)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

In the HTML player we use a quick hack in order to avoid text fields wrapping due to the missing ROBOTO fonts. This workaround consists in decreasing the font size the for all the `TextWireframes` to `size-1`. Once we started providing mappers for `CheckBoxes` or `RadioButtons` I thought that I should align to this correction also for the check marks but then I realized this is not needed. In this PR we are removing this correction.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

