### PR TITLE
Remove redundant Glide compiler reference from Glide module

### DIFF
--- a/dd-sdk-android-glide/build.gradle.kts
+++ b/dd-sdk-android-glide/build.gradle.kts
@@ -16,7 +16,6 @@ plugins {
     // Build
     id("com.android.library")
     kotlin("android")
-    kotlin("kapt")
 
     // Publish
     `maven-publish`
@@ -79,8 +78,6 @@ dependencies {
     implementation(libs.kotlin)
     implementation(libs.okHttp)
     implementation(libs.bundles.glide)
-
-    kapt(libs.glideCompiler)
 
     testImplementation(project(":tools:unit"))
     testImplementation(libs.bundles.jUnit5)


### PR DESCRIPTION
### What does this PR do?

This PR removes the reference both to Glide compiler and KAPT from Glide module, because they are not needed - this module doesn't use `GlideModule` or `GlideExtension` annotations, they are used in the sample app directly only.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

