### PR TITLE
Use SDK-bound internal logger in GlobalRum

### DIFF
--- a/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/GlobalRum.kt
+++ b/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/GlobalRum.kt
@@ -24,7 +24,7 @@ import java.util.concurrent.Callable
  */
 object GlobalRum {
 
-    internal val registeredMonitors: MutableMap<SdkCore, RumMonitor> = mutableMapOf()
+    private val registeredMonitors: MutableMap<SdkCore, RumMonitor> = mutableMapOf()
 
     /**
      * Identify whether a [RumMonitor] has previously been registered for the given SDK instance.
@@ -79,7 +79,7 @@ object GlobalRum {
     fun registerIfAbsent(sdkCore: SdkCore, provider: Callable<RumMonitor>): Boolean {
         return synchronized(registeredMonitors) {
             if (registeredMonitors.containsKey(sdkCore)) {
-                InternalLogger.UNBOUND.log(
+                sdkCore._internalLogger.log(
                     InternalLogger.Level.WARN,
                     InternalLogger.Target.USER,
                     "A RumMonitor has already been registered for this SDK instance"

--- a/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/GlobalRumTest.kt
+++ b/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/GlobalRumTest.kt
@@ -9,7 +9,9 @@ package com.datadog.android.rum
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn
 import com.datadog.tools.unit.extensions.ProhibitLeavingStaticMocksExtension
+import com.nhaarman.mockitokotlin2.doReturn
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -40,6 +42,7 @@ internal class GlobalRumTest {
 
     @BeforeEach
     fun `set up`() {
+        whenever(mockSdkCore._internalLogger) doReturn mock()
         fakeRumMonitorProvider = Callable<RumMonitor> { mockRumMonitor }
     }
 


### PR DESCRIPTION
### What does this PR do?

Small change that removes the usage of `InternalLogger.UNBOUND` in `GlobalRum` class.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

