### PR TITLE
Fix stopped RUMViewManager from being able to start new views.

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -47,7 +47,8 @@ internal class RumViewManagerScope(
 
     @WorkerThread
     override fun handleEvent(event: RumRawEvent, writer: DataWriter<Any>): RumScope? {
-        if (!applicationDisplayed && event !is RumRawEvent.StopSession) {
+        val canDisplayApplication = !stopped && event !is RumRawEvent.StopSession
+        if (!applicationDisplayed && canDisplayApplication) {
             val isForegroundProcess = CoreFeature.processImportance ==
                 ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
             if (isForegroundProcess) {
@@ -57,7 +58,7 @@ internal class RumViewManagerScope(
 
         delegateToChildren(event, writer)
 
-        if (event is RumRawEvent.StartView) {
+        if (event is RumRawEvent.StartView && !stopped) {
             startForegroundView(event)
         } else if (event is RumRawEvent.StopSession) {
             stopped = true

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -790,6 +790,37 @@ internal class RumViewManagerScopeTest {
         assertThat(testedScope.childrenScopes).isEmpty()
     }
 
+    @Test
+    fun `M not start a new view W stopped { application not displayed }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.handleEvent(RumRawEvent.StopSession(), mockWriter)
+        val fakeEvent = forge.startViewEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).isEmpty()
+    }
+
+    @Test
+    fun `M not start a new view W stopped { application displayed }`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.applicationDisplayed = true
+        testedScope.handleEvent(RumRawEvent.StopSession(), mockWriter)
+        val fakeEvent = forge.startViewEvent()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.childrenScopes).isEmpty()
+    }
+
     // endregion
 
     private fun resolveExpectedTimestamp(timestamp: Long): Long {


### PR DESCRIPTION
### What does this PR do?

Stopping a session leaves the session in the list of child scopes until the session is done with all of its work (Resources and user actions are stopped).  If a StartView event happens while that session is stopped but still processing events, it was incorrectly being created in the stopped ViewManagerScope.

### Additional Notes

I double checked Resources and Actions in the ViewScope and those should be safe, as they are only created if the view is active (and stopping the session stops the active view)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

