### PR TITLE
RUMM-3197: Lazy usage of SDK instance in the OkHttp instrumentation

### DIFF
--- a/dd-sdk-android-glide/src/main/kotlin/com/datadog/android/glide/DatadogGlideModule.kt
+++ b/dd-sdk-android-glide/src/main/kotlin/com/datadog/android/glide/DatadogGlideModule.kt
@@ -43,6 +43,7 @@ import java.io.InputStream
  */
 open class DatadogGlideModule
 @JvmOverloads constructor(
+    // TODO RUMM-3196 Maybe change provider to the instance name?
     private val sdkCoreProvider: () -> SdkCore = { Datadog.getInstance() },
     private val firstPartyHosts: List<String> = emptyList(),
     private val samplingRate: Float = DEFAULT_SAMPLING_RATE
@@ -85,10 +86,10 @@ open class DatadogGlideModule
         val builder = OkHttpClient.Builder()
 
         val sdkCore = sdkCoreProvider.invoke()
-        builder.eventListenerFactory(DatadogEventListener.Factory(sdkCore))
+        builder.eventListenerFactory(DatadogEventListener.Factory(sdkCore.name))
         builder.addInterceptor(
             DatadogInterceptor(
-                sdkCore,
+                sdkCore.name,
                 firstPartyHosts,
                 traceSamplingRate = samplingRate
             )

--- a/dd-sdk-android-okhttp/apiSurface
+++ b/dd-sdk-android-okhttp/apiSurface
@@ -13,22 +13,23 @@ class com.datadog.android.okhttp.DatadogEventListener : okhttp3.EventListener
   override fun callEnd(okhttp3.Call)
   override fun callFailed(okhttp3.Call, java.io.IOException)
   class Factory : okhttp3.EventListener.Factory
-    constructor(com.datadog.android.v2.api.SdkCore)
+    constructor(String? = null)
     override fun create(okhttp3.Call): okhttp3.EventListener
 open class com.datadog.android.okhttp.DatadogInterceptor : com.datadog.android.okhttp.trace.TracingInterceptor
-  constructor(com.datadog.android.v2.api.SdkCore, Map<String, Set<com.datadog.android.trace.TracingHeaderType>>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-  constructor(com.datadog.android.v2.api.SdkCore, List<String>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-  constructor(com.datadog.android.v2.api.SdkCore, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+  constructor(String? = null, Map<String, Set<com.datadog.android.trace.TracingHeaderType>>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+  constructor(String? = null, List<String>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+  constructor(String? = null, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
-  override fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
+  override fun onRequestIntercepted(com.datadog.android.v2.api.SdkCore, okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
   override fun canSendSpan(): Boolean
+  override fun onSdkInstanceReady(com.datadog.android.v2.api.SdkCore)
 class com.datadog.android.okhttp.rum.RumInterceptor : com.datadog.android.okhttp.DatadogInterceptor
-  constructor(com.datadog.android.v2.api.SdkCore, List<String> = emptyList(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+  constructor(String? = null, List<String> = emptyList(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
 interface com.datadog.android.okhttp.trace.TracedRequestListener
   fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span, okhttp3.Response?, Throwable?)
 open class com.datadog.android.okhttp.trace.TracingInterceptor : okhttp3.Interceptor
-  constructor(com.datadog.android.v2.api.SdkCore, List<String>, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-  constructor(com.datadog.android.v2.api.SdkCore, Map<String, Set<com.datadog.android.trace.TracingHeaderType>>, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-  constructor(com.datadog.android.v2.api.SdkCore, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+  constructor(String? = null, List<String>, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+  constructor(String? = null, Map<String, Set<com.datadog.android.trace.TracingHeaderType>>, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+  constructor(String? = null, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
-  protected open fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
+  protected open fun onRequestIntercepted(com.datadog.android.v2.api.SdkCore, okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)

--- a/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/rum/RumInterceptor.kt
+++ b/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/rum/RumInterceptor.kt
@@ -12,7 +12,6 @@ import com.datadog.android.okhttp.DatadogInterceptor
 import com.datadog.android.rum.RumFeature
 import com.datadog.android.rum.RumResourceAttributesProvider
 import com.datadog.android.rum.tracking.ViewTrackingStrategy
-import com.datadog.android.v2.api.SdkCore
 import okhttp3.Interceptor
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -33,11 +32,12 @@ import okhttp3.Request
  * To use:
  * ```
  *   OkHttpClient client = new OkHttpClient.Builder()
- *       .addInterceptor(new RumInterceptor(sdkCore))
+ *       .addInterceptor(new RumInterceptor())
  *       .build();
  * ```
  *
- * @param sdkCore SDK instance to bind to.
+ * @param sdkInstanceName SDK instance name to bind to, or null to check the default instance.
+ * Instrumentation won't be working until SDK instance is ready.
  * @param firstPartyHosts the list of first party hosts.
  * Requests made to a URL with any one of these hosts (or any subdomain) will:
  * - be considered a first party RUM Resource and categorised as such in your RUM dashboard;
@@ -52,13 +52,13 @@ import okhttp3.Request
  * be kept, `100.0` means all traces will be kept (default value is `20.0`).
  */
 class RumInterceptor(
-    sdkCore: SdkCore,
+    sdkInstanceName: String? = null,
     firstPartyHosts: List<String> = emptyList(),
     rumResourceAttributesProvider: RumResourceAttributesProvider =
         NoOpRumResourceAttributesProvider(),
     @FloatRange(from = 0.0, to = 100.0) traceSamplingRate: Float = DEFAULT_TRACE_SAMPLING_RATE
 ) : DatadogInterceptor(
-    sdkCore,
+    sdkInstanceName,
     firstPartyHosts,
     rumResourceAttributesProvider = rumResourceAttributesProvider,
     traceSamplingRate = traceSamplingRate

--- a/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/utils/SdkReference.kt
+++ b/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/utils/SdkReference.kt
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp.utils
+
+import com.datadog.android.Datadog
+import com.datadog.android.v2.api.SdkCore
+import java.util.concurrent.atomic.AtomicReference
+
+internal class SdkReference(
+    private val sdkInstanceName: String? = null,
+    private val onSdkInstanceCaptured: (SdkCore) -> Unit = {}
+) {
+
+    private val reference = AtomicReference<SdkCore>(null)
+
+    fun get(): SdkCore? {
+        val current = reference.get()
+        // TODO RUMM-3195 Check if instance is stopped and remove it?
+        @Suppress("IfThenToElvis") // less readable
+        return if (current == null) {
+            if (Datadog.isInitialized(sdkInstanceName)) {
+                val sdkCore = Datadog.getInstance(sdkInstanceName)
+                if (reference.compareAndSet(null, sdkCore)) {
+                    onSdkInstanceCaptured(sdkCore)
+                }
+                sdkCore
+            } else {
+                null
+            }
+        } else {
+            current
+        }
+    }
+}

--- a/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
+++ b/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
@@ -11,6 +11,7 @@ import com.datadog.android.okhttp.trace.TracingInterceptorTest
 import com.datadog.android.rum.RumResourceAttributesProvider
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.v2.api.InternalLogger
+import com.datadog.android.v2.api.SdkCore
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.forge.BaseConfigurator
 import com.nhaarman.mockitokotlin2.any
@@ -48,13 +49,12 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
 
     override fun instantiateTestedInterceptor(
         tracedHosts: Map<String, Set<TracingHeaderType>>,
-        factory: (Set<TracingHeaderType>) -> Tracer
+        factory: (SdkCore, Set<TracingHeaderType>) -> Tracer
     ): TracingInterceptor {
         return DatadogInterceptor(
-            sdkCore = rumMonitor.mockSdkCore,
+            sdkInstanceName = null,
             tracedHosts = tracedHosts,
             tracedRequestListener = mockRequestListener,
-            firstPartyHostResolver = mockResolver,
             rumResourceAttributesProvider = mockRumAttributesProvider,
             traceSampler = mockTraceSampler,
             localTracerFactory = factory

--- a/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -150,16 +150,16 @@ internal class DatadogInterceptorWithoutTracesTest {
         fakeMediaType = MediaType.parse(mediaType)
         fakeRequest = forgeRequest(forge)
         testedInterceptor = DatadogInterceptor(
-            sdkCore = rumMonitor.mockSdkCore,
+            sdkInstanceName = null,
             tracedHosts = emptyMap(),
             tracedRequestListener = mockRequestListener,
-            firstPartyHostResolver = mockResolver,
             rumResourceAttributesProvider = mockRumAttributesProvider,
             traceSampler = mockTraceSampler
-        ) { mockLocalTracer }
+        ) { _, _ -> mockLocalTracer }
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mock()
         whenever(rumMonitor.mockSdkCore._internalLogger) doReturn mockInternalLogger
+        whenever(rumMonitor.mockSdkCore.firstPartyHostResolver) doReturn mockResolver
 
         fakeResourceAttributes = forge.exhaustiveAttributes()
 
@@ -356,13 +356,13 @@ internal class DatadogInterceptorWithoutTracesTest {
     // endregion
 
     companion object {
-        val rumMonitor = GlobalRumMonitorTestConfiguration()
         val datadogCore = DatadogSingletonTestConfiguration()
+        val rumMonitor = GlobalRumMonitorTestConfiguration(datadogCore)
 
         @TestConfigurationsProvider
         @JvmStatic
         fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(rumMonitor, datadogCore)
+            return listOf(datadogCore, rumMonitor)
         }
     }
 }

--- a/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/rum/RumInterceptorTest.kt
+++ b/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/rum/RumInterceptorTest.kt
@@ -10,14 +10,8 @@ import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.okhttp.trace.NoOpTracedRequestListener
 import com.datadog.android.okhttp.trace.TracingInterceptor
 import com.datadog.android.okhttp.trace.TracingInterceptorNotSendingSpanTest
-import com.datadog.android.okhttp.utils.config.GlobalRumMonitorTestConfiguration
-import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
-import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.forge.BaseConfigurator
-import com.nhaarman.mockitokotlin2.doReturn
-import com.nhaarman.mockitokotlin2.mock
-import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -39,11 +33,8 @@ internal class RumInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
     @Test
     fun `M instantiate with default values W init()`() {
-        // Given
-        whenever(rumMonitor.mockSdkCore.firstPartyHostResolver) doReturn mock()
-
         // When
-        val interceptor = RumInterceptor(rumMonitor.mockSdkCore)
+        val interceptor = RumInterceptor()
 
         // Then
         assertThat(interceptor.tracedHosts).isEmpty()
@@ -56,15 +47,5 @@ internal class RumInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val traceSampler = interceptor.traceSampler as RateBasedSampler
         assertThat(traceSampler.getSamplingRate())
             .isEqualTo(TracingInterceptor.DEFAULT_TRACE_SAMPLING_RATE / 100)
-    }
-
-    companion object {
-        val rumMonitor = GlobalRumMonitorTestConfiguration()
-
-        @TestConfigurationsProvider
-        @JvmStatic
-        fun getTestConfigurations(): List<TestConfiguration> {
-            return listOf(rumMonitor)
-        }
     }
 }

--- a/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/SdkReferenceTest.kt
+++ b/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/SdkReferenceTest.kt
@@ -1,0 +1,84 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp.utils
+
+import com.datadog.android.okhttp.utils.config.DatadogSingletonTestConfiguration
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+internal class SdkReferenceTest {
+
+    @Test
+    fun `𝕄 return SDK instance 𝕎 get() {instance exists}`() {
+        // Given
+        val testedReference = SdkReference(null)
+
+        // When
+        val sdkCore = testedReference.get()
+
+        // Then
+        assertThat(sdkCore).isSameAs(datadogCore.mockInstance)
+    }
+
+    @Test
+    fun `𝕄 return null 𝕎 get() {instance doesn't exist}`(
+        @StringForgery fakeInstanceName: String
+    ) {
+        // Given
+        val emptyReference = SdkReference(fakeInstanceName)
+
+        // When
+        val sdkCore = emptyReference.get()
+
+        // Then
+        assertThat(sdkCore).isNull()
+    }
+
+    @Test
+    fun `𝕄 call onSdkInstanceCaptured once 𝕎 get() { multiple threads }`(
+        @IntForgery(min = 2, max = 10) threadCount: Int
+    ) {
+        // Given
+        var callsCount = 0
+        val testedReference = SdkReference(null) {
+            callsCount++
+        }
+
+        // When
+        val threads = buildList(threadCount) { add(Thread { testedReference.get() }) }
+        threads.forEach { it.start() }
+        threads.forEach { it.join() }
+
+        // Then
+        assertThat(callsCount).isEqualTo(1)
+    }
+
+    companion object {
+
+        val datadogCore = DatadogSingletonTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(datadogCore)
+        }
+    }
+}

--- a/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/config/DatadogSingletonTestConfiguration.kt
+++ b/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/config/DatadogSingletonTestConfiguration.kt
@@ -8,12 +8,13 @@ package com.datadog.android.okhttp.utils.config
 
 import com.datadog.android.Datadog
 import com.datadog.android.v2.api.SdkCore
+import com.datadog.android.v2.core.InternalSdkCore
 import com.datadog.tools.unit.extensions.config.MockTestConfiguration
 import fr.xgouchet.elmyr.Forge
 
 // TODO RUMM-2949 Share forgeries/test configurations between modules
 internal class DatadogSingletonTestConfiguration :
-    MockTestConfiguration<SdkCore>(SdkCore::class.java) {
+    MockTestConfiguration<InternalSdkCore>(InternalSdkCore::class.java) {
 
     override fun setUp(forge: Forge) {
         super.setUp(forge)

--- a/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/config/GlobalRumMonitorTestConfiguration.kt
+++ b/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/config/GlobalRumMonitorTestConfiguration.kt
@@ -15,14 +15,15 @@ import com.nhaarman.mockitokotlin2.mock
 import fr.xgouchet.elmyr.Forge
 
 // TODO RUMM-2949 Share forgeries/test configurations between modules
-internal class GlobalRumMonitorTestConfiguration :
-    MockTestConfiguration<FakeRumMonitor>(FakeRumMonitor::class.java) {
+internal class GlobalRumMonitorTestConfiguration(
+    private val datadogSingletonTestConfiguration: DatadogSingletonTestConfiguration? = null
+) : MockTestConfiguration<FakeRumMonitor>(FakeRumMonitor::class.java) {
 
     lateinit var mockSdkCore: InternalSdkCore
 
     override fun setUp(forge: Forge) {
         super.setUp(forge)
-        mockSdkCore = mock()
+        mockSdkCore = datadogSingletonTestConfiguration?.mockInstance ?: mock()
         GlobalRum.registerIfAbsent(mockSdkCore, mockInstance)
     }
 

--- a/dd-sdk-android/apiSurface
+++ b/dd-sdk-android/apiSurface
@@ -2,7 +2,10 @@ object com.datadog.android.Datadog
   fun initialize(String?, android.content.Context, com.datadog.android.core.configuration.Credentials, com.datadog.android.core.configuration.Configuration, com.datadog.android.privacy.TrackingConsent): com.datadog.android.v2.api.SdkCore?
   fun initialize(android.content.Context, com.datadog.android.core.configuration.Credentials, com.datadog.android.core.configuration.Configuration, com.datadog.android.privacy.TrackingConsent): com.datadog.android.v2.api.SdkCore?
   fun getInstance(String? = null): com.datadog.android.v2.api.SdkCore
+  fun isInitialized(String? = null): Boolean
   fun stopInstance(String? = null)
+  fun setVerbosity(Int)
+  fun getVerbosity(): Int
   fun _internalProxy(String? = null): _InternalProxy
 object com.datadog.android.DatadogEndpoint
   DEPRECATED const val LOGS_US1: String
@@ -88,7 +91,6 @@ class com.datadog.android.core.constraints.DatadogDataConstraints : DataConstrai
   override fun validateTags(List<String>): List<String>
   override fun <T: Any?> validateAttributes(Map<String, T>, String?, String?, Set<String>): MutableMap<String, T>
   override fun validateTimings(Map<String, Long>): MutableMap<String, Long>
-  companion object 
 class com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver : FirstPartyHostHeaderTypeResolver
   constructor(Map<String, Set<com.datadog.android.trace.TracingHeaderType>>)
   override fun isFirstPartyUrl(okhttp3.HttpUrl): Boolean
@@ -276,8 +278,6 @@ interface com.datadog.android.v2.api.SdkCore
   val _internalLogger: InternalLogger
   fun registerFeature(Feature)
   fun getFeature(String): FeatureScope?
-  fun setVerbosity(Int)
-  fun getVerbosity(): Int
   fun setTrackingConsent(com.datadog.android.privacy.TrackingConsent)
   fun setUserInfo(com.datadog.android.v2.api.context.UserInfo)
   fun addUserProperties(Map<String, Any?>)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/constraints/DatadogDataConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/constraints/DatadogDataConstraints.kt
@@ -196,7 +196,7 @@ class DatadogDataConstraints(val internalLogger: InternalLogger) : DataConstrain
 
     // endregion
 
-    companion object {
+    internal companion object {
 
         private const val MAX_TAG_LENGTH = 200
         private const val MAX_TAG_COUNT = 100

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/SdkCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/SdkCore.kt
@@ -58,30 +58,6 @@ interface SdkCore {
     fun getFeature(featureName: String): FeatureScope?
 
     /**
-     * Sets the verbosity of this instance of the Datadog SDK.
-     *
-     * Messages with a priority level equal or above the given level will be sent to Android's
-     * Logcat.
-     *
-     * @param level one of the Android [android.util.Log] constants
-     * ([android.util.Log.VERBOSE], [android.util.Log.DEBUG], [android.util.Log.INFO],
-     * [android.util.Log.WARN], [android.util.Log.ERROR], [android.util.Log.ASSERT]).
-     */
-    fun setVerbosity(level: Int)
-
-    /**
-     * Gets the verbosity of this instance of the Datadog SDK.
-     *
-     * Messages with a priority level equal or above the given level will be sent to Android's
-     * Logcat.
-     *
-     * @returns level one of the Android [android.util.Log] constants
-     * ([android.util.Log.VERBOSE], [android.util.Log.DEBUG], [android.util.Log.INFO],
-     * [android.util.Log.WARN], [android.util.Log.ERROR], [android.util.Log.ASSERT]).
-     */
-    fun getVerbosity(): Int
-
-    /**
      * Sets the tracking consent regarding the data collection for this instance of the Datadog SDK.
      *
      * @param consent which can take one of the values

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -62,8 +62,6 @@ internal class DatadogCore(
     internalLoggerProvider: (SdkCore) -> InternalLogger = { SdkInternalLogger(it) }
 ) : InternalSdkCore {
 
-    internal var libraryVerbosity = Int.MAX_VALUE
-
     internal lateinit var coreFeature: CoreFeature
 
     internal val features: MutableMap<String, SdkFeature> = mutableMapOf()
@@ -158,16 +156,6 @@ internal class DatadogCore(
     /** @inheritDoc */
     override fun getFeature(featureName: String): FeatureScope? {
         return features[featureName]
-    }
-
-    /** @inheritDoc */
-    override fun setVerbosity(level: Int) {
-        libraryVerbosity = level
-    }
-
-    /** @inheritDoc */
-    override fun getVerbosity(): Int {
-        return libraryVerbosity
     }
 
     /** @inheritDoc */
@@ -312,7 +300,7 @@ internal class DatadogCore(
         var mutableConfig = configuration
         if (isDebug and configuration.coreConfig.enableDeveloperModeWhenDebuggable) {
             mutableConfig = modifyConfigurationForDeveloperDebug(configuration)
-            setVerbosity(Log.VERBOSE)
+            Datadog.setVerbosity(Log.VERBOSE)
         }
 
         // always initialize Core Features first

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/NoOpSdkCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/NoOpSdkCore.kt
@@ -47,10 +47,6 @@ internal class NoOpSdkCore : SdkCore {
 
     override fun getFeature(featureName: String): FeatureScope? = null
 
-    override fun setVerbosity(level: Int) = Unit
-
-    override fun getVerbosity(): Int = 0
-
     override fun setTrackingConsent(consent: TrackingConsent) = Unit
 
     override fun setUserInfo(userInfo: UserInfo) = Unit

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/SdkInternalLogger.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/SdkInternalLogger.kt
@@ -8,6 +8,7 @@ package com.datadog.android.v2.core
 
 import android.util.Log
 import com.datadog.android.BuildConfig
+import com.datadog.android.Datadog
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.api.SdkCore
@@ -16,7 +17,7 @@ internal class SdkInternalLogger(
     private val sdkCore: SdkCore?,
     devLogHandlerFactory: () -> LogcatLogHandler = {
         LogcatLogHandler(DEV_LOG_TAG) { level ->
-            level >= (sdkCore?.getVerbosity() ?: Log.VERBOSE)
+            level >= Datadog.getVerbosity()
         }
     },
     sdkLogHandlerFactory: () -> LogcatLogHandler? = {
@@ -30,7 +31,7 @@ internal class SdkInternalLogger(
 
     /**
      * Global Dev Logger. This logger is meant for user's debugging purposes.
-     * Logcat logs are conditioned by the [DatadogCore.libraryVerbosity].
+     * Logcat logs are conditioned by the [Datadog.libraryVerbosity].
      * No Datadog logs should be sent.
      */
     internal val devLogger = devLogHandlerFactory.invoke()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreInitializationTest.kt
@@ -193,6 +193,7 @@ internal class DatadogCoreInitializationTest {
         @IntForgery fakeFlags: Int
     ) {
         // Given
+        Datadog.setVerbosity(Int.MAX_VALUE)
         appContext.fakeAppInfo.flags = fakeFlags and ApplicationInfo.FLAG_DEBUGGABLE.inv()
         val configuration = Configuration.Builder(
             crashReportsEnabled = true
@@ -211,7 +212,7 @@ internal class DatadogCoreInitializationTest {
         }
 
         // Then
-        assertThat(testedCore.libraryVerbosity)
+        assertThat(Datadog.libraryVerbosity)
             .isEqualTo(Int.MAX_VALUE)
     }
 
@@ -238,7 +239,7 @@ internal class DatadogCoreInitializationTest {
         }
 
         // Then
-        assertThat(testedCore.libraryVerbosity)
+        assertThat(Datadog.libraryVerbosity)
             .isEqualTo(Log.VERBOSE)
     }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
@@ -41,7 +41,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.AdvancedForgery
 import fr.xgouchet.elmyr.annotation.Forgery
-import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.MapForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -193,18 +192,6 @@ internal class DatadogCoreTest {
 
         // Then
         verify(mockUserInfoProvider).setUserInfo(userInfo)
-    }
-
-    @Test
-    fun `𝕄 set and get lib verbosity 𝕎 setVerbosity() + getVerbosity()`(
-        @IntForgery level: Int
-    ) {
-        // When
-        testedCore.setVerbosity(level)
-        val result = testedCore.getVerbosity()
-
-        // Then
-        assertThat(result).isEqualTo(level)
     }
 
     @Test

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/SdkInternalLoggerTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/SdkInternalLoggerTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.v2.core
 
 import android.util.Log
+import com.datadog.android.Datadog
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureScope
@@ -95,7 +96,7 @@ internal class SdkInternalLoggerTest {
         @IntForgery(min = Log.VERBOSE, max = (Log.ASSERT + 1)) sdkVerbosity: Int
     ) {
         // Given
-        whenever(mockSdkCore.getVerbosity()) doReturn sdkVerbosity
+        Datadog.setVerbosity(sdkVerbosity)
 
         // When
         testedInternalLogger = SdkInternalLogger(

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ResourceTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/ResourceTrackingTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.sdk.integration.rum
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
-import com.datadog.android.Datadog
 import com.datadog.android.okhttp.rum.RumInterceptor
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.RumResourceAttributesProvider
@@ -52,7 +51,6 @@ internal class ResourceTrackingTest {
         okHttpClient = OkHttpClient.Builder()
             .addInterceptor(
                 RumInterceptor(
-                    Datadog.getInstance(),
                     rumResourceAttributesProvider = object : RumResourceAttributesProvider {
                         override fun onProvideAttributes(
                             request: Request,

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -56,9 +56,9 @@ internal class EncryptionTest {
         val configuration = createSdkConfiguration()
         val credentials = createCredentials()
 
+        Datadog.setVerbosity(Log.VERBOSE)
         val sdkCore = Datadog.initialize(targetContext, credentials, configuration, TrackingConsent.PENDING)
         checkNotNull(sdkCore)
-        sdkCore.setVerbosity(Log.VERBOSE)
         val features = mutableListOf(
             RumFeature.Builder(applicationId = forge.anAlphaNumericalString()).build(),
             LogsFeature.Builder().build(),

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/log/ActivityLifecycleLogs.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/log/ActivityLifecycleLogs.kt
@@ -37,9 +37,9 @@ internal class ActivityLifecycleLogs : AppCompatActivity() {
         val config = RuntimeConfig.configBuilder().build()
         val trackingConsent = intent.getTrackingConsent()
 
+        Datadog.setVerbosity(Log.VERBOSE)
         val sdkCore = Datadog.initialize(this, credentials, config, trackingConsent)
         checkNotNull(sdkCore)
-        sdkCore.setVerbosity(Log.VERBOSE)
         val features = mutableListOf(
             RuntimeConfig.logsFeatureBuilder().build(),
             RuntimeConfig.tracingFeatureBuilder().build()

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingPlaygroundActivity.kt
@@ -31,9 +31,9 @@ internal class ActivityTrackingPlaygroundActivity : AppCompatActivity() {
         val config = RuntimeConfig.configBuilder().build()
         val trackingConsent = intent.getTrackingConsent()
 
+        Datadog.setVerbosity(Log.VERBOSE)
         val sdkCore = Datadog.initialize(this, credentials, config, trackingConsent)
         checkNotNull(sdkCore)
-        sdkCore.setVerbosity(Log.VERBOSE)
 
         sdkCore.registerFeature(
             RuntimeConfig.rumFeatureBuilder()

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingPlaygroundActivity.kt
@@ -34,9 +34,9 @@ internal class FragmentTrackingPlaygroundActivity : AppCompatActivity() {
             .build()
         val trackingConsent = intent.getTrackingConsent()
 
+        Datadog.setVerbosity(Log.VERBOSE)
         val sdkCore = Datadog.initialize(this, credentials, config, trackingConsent)
         checkNotNull(sdkCore)
-        sdkCore.setVerbosity(Log.VERBOSE)
 
         sdkCore.registerFeature(
             RuntimeConfig.rumFeatureBuilder()

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplayPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplayPlaygroundActivity.kt
@@ -38,9 +38,9 @@ internal class SessionReplayPlaygroundActivity : AppCompatActivity() {
         val credentials = RuntimeConfig.credentials()
         val config = RuntimeConfig.configBuilder().build()
         val trackingConsent = intent.getTrackingConsent()
+        Datadog.setVerbosity(Log.VERBOSE)
         val sdkCore = Datadog.initialize(this, credentials, config, trackingConsent)
         checkNotNull(sdkCore)
-        sdkCore.setVerbosity(Log.VERBOSE)
         val features = mutableListOf(
             // we will use a large long task threshold to make sure we will not have LongTask events
             // noise in our integration tests.

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/telemetry/TelemetryPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/telemetry/TelemetryPlaygroundActivity.kt
@@ -44,9 +44,9 @@ internal class TelemetryPlaygroundActivity : AppCompatActivity(R.layout.main_act
 
         val trackingConsent = intent.getTrackingConsent()
 
+        Datadog.setVerbosity(Log.VERBOSE)
         val sdkCore = Datadog.initialize(this, credentials, config, trackingConsent)
         checkNotNull(sdkCore)
-        sdkCore.setVerbosity(Log.VERBOSE)
 
         sdkCore.registerFeature(
             // we will use a large long task threshold to make sure we will not have LongTask events

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/trace/ActivityLifecycleTrace.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/trace/ActivityLifecycleTrace.kt
@@ -42,9 +42,9 @@ internal class ActivityLifecycleTrace : AppCompatActivity() {
         val config = RuntimeConfig.configBuilder().build()
         val trackingConsent = intent.getTrackingConsent()
 
+        Datadog.setVerbosity(Log.VERBOSE)
         val sdkCore = Datadog.initialize(this, credentials, config, trackingConsent)
         checkNotNull(sdkCore)
-        sdkCore.setVerbosity(Log.VERBOSE)
         mutableListOf<Feature>(
             RuntimeConfig.logsFeatureBuilder().build(),
             RuntimeConfig.tracingFeatureBuilder().build()

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumResourceTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumResourceTrackingE2ETests.kt
@@ -41,7 +41,7 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(com.datadog.android.v2.api.SdkCore, List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(String? = null, List<String> = emptyList(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      */
     @Test
     fun rum_resource_tracking() {
@@ -64,8 +64,8 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(com.datadog.android.v2.api.SdkCore, List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-     * apiMethodSignature: com.datadog.android.okhttp.trace.DatadogInterceptor#constructor((com.datadog.android.v2.api.SdkCore, List<String>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(String? = null, List<String> = emptyList(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.DatadogInterceptor#constructor(String? = null, List<String>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      */
     @Test
     fun rum_resource_tracking_with_custom_attributes() {
@@ -88,9 +88,9 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.okhttp.trace.TracingInterceptor#constructor(com.datadog.android.v2.api.SdkCore, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-     * apiMethodSignature: com.datadog.android.okhttp.trace.DatadogInterceptor#constructor(com.datadog.android.v2.api.SdkCore, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(com.datadog.android.v2.api.SdkCore, List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.trace.TracingInterceptor#constructor(String? = null, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.DatadogInterceptor#constructor(String? = null, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(String? = null, List<String> = emptyList(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setFirstPartyHosts(List<String>): Builder
      */
     @Test
@@ -120,9 +120,9 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.okhttp.trace.TracingInterceptor#constructor(com.datadog.android.v2.api.SdkCore, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-     * apiMethodSignature: com.datadog.android.okhttp.trace.DatadogInterceptor#constructor(com.datadog.android.v2.api.SdkCore, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(com.datadog.android.v2.api.SdkCore, List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.trace.TracingInterceptor#constructor(String? = null, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.DatadogInterceptor#constructor(String? = null, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(String? = null, List<String> = emptyList(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setFirstPartyHostsWithHeaderType(Map<String, Set<com.datadog.android.trace.TracingHeaderType>>): Builder
      */
     @Test
@@ -159,8 +159,8 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(com.datadog.android.v2.api.SdkCore, List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-     * apiMethodSignature: com.datadog.android.okhttp.trace.TracingInterceptor#constructor(com.datadog.android.v2.api.SdkCore, List<String>, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(String? = null, List<String> = emptyList(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.trace.TracingInterceptor#constructor(String? = null, List<String>, TracedRequestListener = NoOpTracedRequestListener(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      */
     @Test
     fun rum_resource_tracking_with_network_interceptor() {
@@ -186,8 +186,8 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(com.datadog.android.v2.api.SdkCore, List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
-     * apiMethodSignature: com.datadog.android.okhttp.trace.DatadogInterceptor#constructor(com.datadog.android.v2.api.SdkCore, List<String>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(String? = null, List<String> = emptyList(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.DatadogInterceptor#constructor(String? = null, List<String>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setFirstPartyHosts(List<String>): Builder
      */
     @Test
@@ -214,7 +214,7 @@ internal class RumResourceTrackingE2ETests {
     /**
      * apiMethodSignature: com.datadog.android.rum.RumFeature$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
      * apiMethodSignature: com.datadog.android.rum.tracking.ActivityViewTrackingStrategy#constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities())
-     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(com.datadog.android.v2.api.SdkCore, List<String> = emptyList(), RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
+     * apiMethodSignature: com.datadog.android.okhttp.rum.RumInterceptor#constructor(String? = null, List<String> = emptyList(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), Float = DEFAULT_TRACE_SAMPLING_RATE)
      */
     @Test
     fun rum_resource_tracking_trace_sampling_75_percent() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -102,6 +102,7 @@ fun initializeSdk(
     tracerProvider: (SdkCore) -> Tracer = { createDefaultAndroidTracer(it) },
     rumMonitorProvider: (SdkCore) -> RumMonitor = { createDefaultRumMonitor(it) }
 ): SdkCore {
+    Datadog.setVerbosity(Log.VERBOSE)
     val sdkCore = Datadog.initialize(
         targetContext,
         createDatadogCredentials(),
@@ -109,7 +110,6 @@ fun initializeSdk(
         consent
     )
     checkNotNull(sdkCore)
-    sdkCore.setVerbosity(Log.VERBOSE)
     mutableListOf(
         rumFeatureProvider(
             RumFeature.Builder(BuildConfig.NIGHTLY_TESTS_RUM_APP_ID)

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingActivity.kt
@@ -8,7 +8,6 @@ package com.datadog.android.nightly.activities
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.datadog.android.Datadog
 import com.datadog.android.nightly.R
 import com.datadog.android.okhttp.rum.RumInterceptor
 import okhttp3.Call
@@ -22,16 +21,14 @@ import java.util.concurrent.TimeUnit
 
 internal open class ResourceTrackingActivity : AppCompatActivity() {
 
-    open val okHttpClient: OkHttpClient by lazy {
-        OkHttpClient.Builder()
-            .addInterceptor(
-                RumInterceptor(
-                    Datadog.getInstance(),
-                    traceSamplingRate = HUNDRED_PERCENT
-                )
+    open val okHttpClient: OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(
+            RumInterceptor(
+                traceSamplingRate = HUNDRED_PERCENT
             )
-            .build()
-    }
+        )
+        .build()
+
     open val randomUrl: String = RANDOM_URL
     private val countDownLatch = CountDownLatch(1)
 

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingCustomAttributesActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingCustomAttributesActivity.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.nightly.activities
 
-import com.datadog.android.Datadog
 import com.datadog.android.nightly.SPECIAL_INT_ATTRIBUTE_NAME
 import com.datadog.android.nightly.SPECIAL_NULL_ATTRIBUTE_NAME
 import com.datadog.android.nightly.SPECIAL_STRING_ATTRIBUTE_NAME
@@ -18,28 +17,25 @@ import okhttp3.Response
 
 internal class ResourceTrackingCustomAttributesActivity : ResourceTrackingActivity() {
 
-    override val okHttpClient: OkHttpClient by lazy {
-        OkHttpClient.Builder()
-            .addInterceptor(
-                RumInterceptor(
-                    Datadog.getInstance(),
-                    rumResourceAttributesProvider = object :
-                        RumResourceAttributesProvider {
-                        override fun onProvideAttributes(
-                            request: Request,
-                            response: Response?,
-                            throwable: Throwable?
-                        ): Map<String, Any?> {
-                            return mapOf(
-                                SPECIAL_STRING_ATTRIBUTE_NAME to "custom_string_value",
-                                SPECIAL_INT_ATTRIBUTE_NAME to 2,
-                                SPECIAL_NULL_ATTRIBUTE_NAME to null
-                            )
-                        }
-                    },
-                    traceSamplingRate = HUNDRED_PERCENT
-                )
+    override val okHttpClient: OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(
+            RumInterceptor(
+                rumResourceAttributesProvider = object :
+                    RumResourceAttributesProvider {
+                    override fun onProvideAttributes(
+                        request: Request,
+                        response: Response?,
+                        throwable: Throwable?
+                    ): Map<String, Any?> {
+                        return mapOf(
+                            SPECIAL_STRING_ATTRIBUTE_NAME to "custom_string_value",
+                            SPECIAL_INT_ATTRIBUTE_NAME to 2,
+                            SPECIAL_NULL_ATTRIBUTE_NAME to null
+                        )
+                    }
+                },
+                traceSamplingRate = HUNDRED_PERCENT
             )
-            .build()
-    }
+        )
+        .build()
 }

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingCustomSpanAttributesActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingCustomSpanAttributesActivity.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.nightly.activities
 
-import com.datadog.android.Datadog
 import com.datadog.android.okhttp.rum.RumInterceptor
 import com.datadog.android.okhttp.trace.TracedRequestListener
 import com.datadog.android.okhttp.trace.TracingInterceptor
@@ -17,18 +16,15 @@ import okhttp3.Response
 
 internal class ResourceTrackingCustomSpanAttributesActivity : ResourceTrackingActivity() {
     override val okHttpClient: OkHttpClient by lazy {
-        val sdkCore = Datadog.getInstance()
         val builder = OkHttpClient.Builder()
         builder.addInterceptor(
             RumInterceptor(
-                sdkCore,
                 traceSamplingRate = HUNDRED_PERCENT
             )
         )
         builder.addNetworkInterceptor(
             TracingInterceptor(
-                sdkCore,
-                listOf(HOST),
+                tracedHosts = listOf(HOST),
                 tracedRequestListener = object : TracedRequestListener {
                     override fun onRequestIntercepted(
                         request: Request,

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingNetworkInterceptorActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingNetworkInterceptorActivity.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.nightly.activities
 
-import com.datadog.android.Datadog
 import com.datadog.android.nightly.server.LocalServer
 import com.datadog.android.okhttp.rum.RumInterceptor
 import com.datadog.android.okhttp.trace.TracingInterceptor
@@ -16,20 +15,15 @@ internal class ResourceTrackingNetworkInterceptorActivity : ResourceTrackingActi
 
     private val localServer: LocalServer by lazy { LocalServer() }
 
-    override val okHttpClient: OkHttpClient by lazy {
-        OkHttpClient.Builder()
-            .addInterceptor(
-                RumInterceptor(Datadog.getInstance(), traceSamplingRate = HUNDRED_PERCENT)
+    override val okHttpClient: OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(RumInterceptor(traceSamplingRate = HUNDRED_PERCENT))
+        .addNetworkInterceptor(
+            TracingInterceptor(
+                tracedHosts = listOf(HOST, LocalServer.HOST),
+                traceSamplingRate = HUNDRED_PERCENT
             )
-            .addNetworkInterceptor(
-                TracingInterceptor(
-                    Datadog.getInstance(),
-                    listOf(HOST, LocalServer.HOST),
-                    traceSamplingRate = HUNDRED_PERCENT
-                )
-            )
-            .build()
-    }
+        )
+        .build()
 
     override val randomUrl: String by lazy {
         localServer.getUrl()

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingTraceSamplingActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ResourceTrackingTraceSamplingActivity.kt
@@ -8,7 +8,6 @@ package com.datadog.android.nightly.activities
 
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
-import com.datadog.android.Datadog
 import com.datadog.android.nightly.R
 import com.datadog.android.nightly.server.LocalServer
 import com.datadog.android.okhttp.rum.RumInterceptor
@@ -30,18 +29,15 @@ internal class ResourceTrackingTraceSamplingActivity : AppCompatActivity() {
 
     private val forge = Forge()
 
-    private val okHttpClient: OkHttpClient by lazy {
-        OkHttpClient.Builder()
-            .addInterceptor(
-                RumInterceptor(
-                    Datadog.getInstance(),
-                    listOf(LocalServer.HOST),
-                    // 75% of the RUM resources sent should have traces included
-                    traceSamplingRate = 75f
-                )
+    private val okHttpClient: OkHttpClient = OkHttpClient.Builder()
+        .addInterceptor(
+            RumInterceptor(
+                firstPartyHosts = listOf(LocalServer.HOST),
+                // 75% of the RUM resources sent should have traces included
+                traceSamplingRate = 75f
             )
-            .build()
-    }
+        )
+        .build()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/JvmCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/JvmCrashService.kt
@@ -69,6 +69,7 @@ internal open class JvmCrashService : CrashService() {
         val configBuilder = Configuration.Builder(
             crashReportsEnabled = crashReportsEnabled
         )
+        Datadog.setVerbosity(Log.VERBOSE)
         val sdkCore = Datadog.initialize(
             this,
             getCredentials(),
@@ -76,7 +77,6 @@ internal open class JvmCrashService : CrashService() {
             TrackingConsent.GRANTED
         )
         checkNotNull(sdkCore)
-        sdkCore.setVerbosity(Log.VERBOSE)
         if (rumEnabled) {
             sdkCore.registerFeature(
                 RumFeature.Builder(rumApplicationId)

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/NdkCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/NdkCrashService.kt
@@ -78,6 +78,7 @@ internal open class NdkCrashService : CrashService() {
         if (encryptionEnabled) {
             configBuilder.setEncryption(NeverUseThatEncryption())
         }
+        Datadog.setVerbosity(Log.VERBOSE)
         val sdkCore = Datadog.initialize(
             this,
             getCredentials(),
@@ -85,7 +86,6 @@ internal open class NdkCrashService : CrashService() {
             TrackingConsent.GRANTED
         )
         checkNotNull(sdkCore)
-        sdkCore.setVerbosity(Log.VERBOSE)
         if (rumEnabled) {
             sdkCore.registerFeature(
                 RumFeature.Builder(rumApplicationId)

--- a/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandler.kt
+++ b/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandler.kt
@@ -23,6 +23,7 @@ import java.util.Locale
  * For more information [https://www.sqlite.org/howtocorrupt.html]
  */
 class DatadogDatabaseErrorHandler(
+    // TODO RUMM-3196 Maybe change provider to the instance name?
     internal val sdkCoreProvider: () -> SdkCore,
     internal val defaultErrorHandler: DatabaseErrorHandler = DefaultDatabaseErrorHandler()
 ) : DatabaseErrorHandler {

--- a/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AbstractGesturesListenerTest.kt
+++ b/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/AbstractGesturesListenerTest.kt
@@ -66,13 +66,13 @@ internal abstract class AbstractGesturesListenerTest {
 
     @BeforeEach
     open fun `set up`() {
-        Datadog.getInstance().setVerbosity(Log.VERBOSE)
+        Datadog.setVerbosity(Log.VERBOSE)
         whenever(mockAppContext.resources).thenReturn(mockResources)
     }
 
     @AfterEach
     fun `tear down`() {
-        Datadog.getInstance().setVerbosity(Integer.MAX_VALUE)
+        Datadog.setVerbosity(Integer.MAX_VALUE)
     }
 
     // endregion

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -110,13 +110,13 @@ class SampleApplication : Application() {
     private fun initializeDatadog() {
         val preferences = Preferences.defaultPreferences(this)
 
+        Datadog.setVerbosity(Log.VERBOSE)
         sdkCore = Datadog.initialize(
             this,
             createDatadogCredentials(),
             createDatadogConfiguration(),
             preferences.getTrackingConsent()
         ) ?: return
-        sdkCore.setVerbosity(Log.VERBOSE)
 
         val rumFeature = createRumFeature()
         sdkCore.registerFeature(rumFeature)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -43,7 +43,6 @@ import com.datadog.android.sessionreplay.material.MaterialExtensionSupport
 import com.datadog.android.timber.DatadogTree
 import com.datadog.android.trace.AndroidTracer
 import com.datadog.android.trace.TracingFeature
-import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.UserInfo
 import com.facebook.stetho.Stetho
 import com.google.gson.GsonBuilder
@@ -63,33 +62,25 @@ import timber.log.Timber
 @Suppress("MagicNumber")
 class SampleApplication : Application() {
 
-    private lateinit var sdkCore: SdkCore
-
     private val tracedHosts = listOf(
         "datadoghq.com",
         "127.0.0.1"
     )
 
-    // TODO RUMM-0000 lazy is needed here, because without it global first party host resolver is
-    //  not available yet at the interceptor construction time
-    private val okHttpClient by lazy {
-        OkHttpClient.Builder()
-            .addInterceptor(RumInterceptor(sdkCore, traceSamplingRate = 100f))
-            .addNetworkInterceptor(TracingInterceptor(sdkCore, traceSamplingRate = 100f))
-            .eventListenerFactory(DatadogEventListener.Factory(sdkCore))
-            .build()
-    }
+    private val okHttpClient = OkHttpClient.Builder()
+        .addInterceptor(RumInterceptor(traceSamplingRate = 100f))
+        .addNetworkInterceptor(TracingInterceptor(traceSamplingRate = 100f))
+        .eventListenerFactory(DatadogEventListener.Factory())
+        .build()
 
-    private val retrofitClient by lazy {
-        Retrofit.Builder()
-            .baseUrl("https://api.datadoghq.com/api/v2/")
-            .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
-            .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
-            .client(okHttpClient)
-            .build()
-    }
+    private val retrofitClient = Retrofit.Builder()
+        .baseUrl("https://api.datadoghq.com/api/v2/")
+        .addConverterFactory(GsonConverterFactory.create(GsonBuilder().setLenient().create()))
+        .addCallAdapterFactory(RxJava3CallAdapterFactory.createSynchronous())
+        .client(okHttpClient)
+        .build()
 
-    private val retrofitBaseDataSource by lazy { retrofitClient.create(RemoteDataSource::class.java) }
+    private val retrofitBaseDataSource = retrofitClient.create(RemoteDataSource::class.java)
 
     override fun onCreate() {
         super.onCreate()
@@ -111,7 +102,7 @@ class SampleApplication : Application() {
         val preferences = Preferences.defaultPreferences(this)
 
         Datadog.setVerbosity(Log.VERBOSE)
-        sdkCore = Datadog.initialize(
+        val sdkCore = Datadog.initialize(
             this,
             createDatadogCredentials(),
             createDatadogConfiguration(),


### PR DESCRIPTION
### What does this PR do?

This PR makes changes to the OkHttp instrumentation in a way that SDK instance is queried lazily now, when the actual call is made. This is needed to support the cases when OkHttp client is initialized before the SDK (for the remote config fetch, for example) and since it is immutable and can be used in the DI graph, re-building it is not an easy and convenient thing.

The goal is achieved by explicitly passing down the SDK instance in the `DatadogInterceptor`, `TracingInterceptor`, `RumInterceptor`, `DatadogEventListener` classes, which is taken from `SdkReference` class - it tries to acquire the SDK instance when it is available and does it only once (to avoid the possible thread bottleneck during the sync lock in the `getInstance` calls).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

