### PR TITLE
RUMM-2986 update sdk instance id hash to use only instance name and datacenter

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -36,7 +36,8 @@ object Datadog {
 
     /**
      * Initializes a named instance of the Datadog SDK.
-     * @param instanceName the name of the instance (or null to initialize the default instance)
+     * @param instanceName the name of the instance (or null to initialize the default instance).
+     * Note that the instance name should be stable across builds.
      * @param context your application context
      * @param credentials your organization credentials
      * @param configuration the configuration for the SDK library
@@ -70,7 +71,7 @@ object Datadog {
             }
 
             val sdkInstanceId = hashGenerator.generate(
-                "${credentials.clientToken}${configuration.coreConfig.site.siteName}"
+                "$instanceName/${configuration.coreConfig.site.siteName}"
             )
 
             if (sdkInstanceId == null) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/SdkCoreRegistry.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/SdkCoreRegistry.kt
@@ -69,6 +69,6 @@ internal class SdkCoreRegistry(
     // endregion
 
     companion object {
-        const val DEFAULT_INSTANCE_NAME = "main"
+        const val DEFAULT_INSTANCE_NAME = "_dd.sdk_core.default"
     }
 }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -203,7 +203,7 @@ internal class DatadogTest {
         val mockHashGenerator: HashGenerator = mock()
         whenever(
             mockHashGenerator.generate(
-                fakeCredentials.clientToken + fakeConfiguration.coreConfig.site.siteName
+                "null/${fakeConfiguration.coreConfig.site.siteName}"
             )
         ) doReturn fakeHash
         Datadog.hashGenerator = mockHashGenerator
@@ -223,7 +223,7 @@ internal class DatadogTest {
 
     @Test
     fun `𝕄 create instance ID 𝕎 initialize(name)`(
-        @StringForgery name: String,
+        @StringForgery instanceName: String,
         @Forgery fakeCredentials: Credentials,
         @Forgery fakeConfiguration: Configuration,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) fakeHash: String
@@ -232,14 +232,14 @@ internal class DatadogTest {
         val mockHashGenerator: HashGenerator = mock()
         whenever(
             mockHashGenerator.generate(
-                fakeCredentials.clientToken + fakeConfiguration.coreConfig.site.siteName
+                "$instanceName/${fakeConfiguration.coreConfig.site.siteName}"
             )
         ) doReturn fakeHash
         Datadog.hashGenerator = mockHashGenerator
 
         // When
         val instance = Datadog.initialize(
-            name,
+            instanceName,
             appContext.mockInstance,
             fakeCredentials,
             fakeConfiguration,
@@ -261,7 +261,7 @@ internal class DatadogTest {
         val mockHashGenerator: HashGenerator = mock()
         whenever(
             mockHashGenerator.generate(
-                fakeCredentials.clientToken + fakeConfiguration.coreConfig.site.siteName
+                "null/${fakeConfiguration.coreConfig.site.siteName}"
             )
         ) doReturn fakeHash
         Datadog.hashGenerator = mockHashGenerator
@@ -281,7 +281,7 @@ internal class DatadogTest {
 
     @Test
     fun `𝕄 set tracking consent 𝕎 initialize(name)`(
-        @StringForgery name: String,
+        @StringForgery instanceName: String,
         @Forgery fakeCredentials: Credentials,
         @Forgery fakeConfiguration: Configuration,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) fakeHash: String
@@ -290,14 +290,14 @@ internal class DatadogTest {
         val mockHashGenerator: HashGenerator = mock()
         whenever(
             mockHashGenerator.generate(
-                fakeCredentials.clientToken + fakeConfiguration.coreConfig.site.siteName
+                "$instanceName/${fakeConfiguration.coreConfig.site.siteName}"
             )
         ) doReturn fakeHash
         Datadog.hashGenerator = mockHashGenerator
 
         // When
         val instance = Datadog.initialize(
-            name,
+            instanceName,
             appContext.mockInstance,
             fakeCredentials,
             fakeConfiguration,


### PR DESCRIPTION
### What does this PR do?

Remove the usage of the Client token in the instance id. This allows an application to rotate their token and still send previous data.