### PR TITLE
Force new session at sdk initialization

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -204,6 +204,10 @@ internal sealed class RumRawEvent {
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
+    internal data class SdkInit(
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
     internal data class WebViewEvent(override val eventTime: Time = Time()) : RumRawEvent()
 
     internal data class SendTelemetry(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -146,7 +146,9 @@ internal class RumSessionScope(
         val isInteraction = (event is RumRawEvent.StartView) || (event is RumRawEvent.StartAction)
         val isBackgroundEvent = (event.javaClass in RumViewManagerScope.validBackgroundEventTypes)
 
-        if (isInteraction) {
+        if (event is RumRawEvent.SdkInit && isNewSession) {
+            renewSession(nanoTime)
+        } else if (isInteraction) {
             if (isNewSession || isExpired || isTimedOut) {
                 renewSession(nanoTime)
             }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -64,7 +64,8 @@ internal class DatadogRumMonitor(
     frameRateVitalMonitor: VitalMonitor,
     sessionListener: RumSessionListener?,
     contextProvider: ContextProvider,
-    private val executorService: ExecutorService = Executors.newSingleThreadExecutor()
+    private val executorService: ExecutorService = Executors.newSingleThreadExecutor(),
+    sendSdkInit: Boolean = true
 ) : RumMonitor, AdvancedRumMonitor {
 
     internal var rootScope: RumScope = RumApplicationScope(
@@ -95,6 +96,9 @@ internal class DatadogRumMonitor(
 
     init {
         handler.postDelayed(keepAliveRunnable, KEEP_ALIVE_MS)
+        if (sendSdkInit) {
+            sendSdkInitEvent()
+        }
     }
 
     // region RumMonitor
@@ -505,6 +509,12 @@ internal class DatadogRumMonitor(
             "flutter" -> RumErrorSourceType.FLUTTER
             else -> RumErrorSourceType.ANDROID
         }
+    }
+
+    private fun sendSdkInitEvent() {
+        handleEvent(
+            RumRawEvent.SdkInit()
+        )
     }
 
     // endregion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -284,6 +284,23 @@ internal class RumSessionScopeTest {
     }
 
     @Test
+    fun `𝕄 create new session context 𝕎 handleEvent(sdkInit)+getRumContext() {sampling = 100}`() {
+        // Given
+        initializeTestedScope(100f)
+
+        // When
+        val result = testedScope.handleEvent(RumRawEvent.SdkInit(), mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.sessionId).isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
+        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
+        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
+    }
+
+    @Test
     fun `𝕄 create new session context 𝕎 handleEvent(view)+getRumContext() {sampling = 100}`(
         forge: Forge
     ) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -159,7 +159,8 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockContextProvider
+            mockContextProvider,
+            sendSdkInit = false
         )
         testedMonitor.rootScope = mockScope
     }
@@ -1131,6 +1132,39 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
+    fun `M delegate SdkInit event to rootScope W init()`() {
+        // When
+        testedMonitor = DatadogRumMonitor(
+            fakeApplicationId,
+            mockSdkCore,
+            fakeSamplingRate,
+            fakeBackgroundTrackingEnabled,
+            fakeTrackFrustrations,
+            mockWriter,
+            mockHandler,
+            mockTelemetryEventHandler,
+            mockResolver,
+            mockCpuVitalMonitor,
+            mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
+            mockSessionListener,
+            mockContextProvider,
+            sendSdkInit = true
+        )
+        testedMonitor.rootScope = mockScope
+
+        Thread.sleep(PROCESSING_DELAY)
+
+        // Then
+        verify(mockScope).handleEvent(
+            argThat { this is RumRawEvent.SdkInit },
+            same(mockWriter)
+        )
+
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
     fun `delays keep alive runnable on other event`() {
         val mockEvent: RumRawEvent = mock()
         val runnable = testedMonitor.keepAliveRunnable
@@ -1258,7 +1292,8 @@ internal class DatadogRumMonitorTest {
             mockFrameRateVitalMonitor,
             mockSessionListener,
             mockContextProvider,
-            mockExecutorService
+            mockExecutorService,
+            false
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)
 
@@ -1570,7 +1605,8 @@ internal class DatadogRumMonitorTest {
             mockFrameRateVitalMonitor,
             mockSessionListener,
             mockContextProvider,
-            executorService = mockExecutorService
+            executorService = mockExecutorService,
+            false
         )
 
         var isMethodOccupied = false


### PR DESCRIPTION
Introduces the SdkInit event at the initialization of RumMonitor in order to make sure a session is started before the first RUM interaction. 
This makes it so that logs and traces are correctly correlated to a valid session if they occur before the first view or action takes place.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

