### PR TITLE
REPLAY-1612 Use default TabWireframeMapper for MASK_USER_INPUT privacy option

### DIFF
--- a/library/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupport.kt
+++ b/library/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupport.kt
@@ -26,8 +26,6 @@ class MaterialExtensionSupport : ExtensionSupport {
         val allowAllSliderMapper = SliderWireframeMapper() as WireframeMapper<View, *>
         val maskAllTabWireframeMapper = MaskAllTabWireframeMapper() as WireframeMapper<View, *>
         val allowAllTabWireframeMapper = TabWireframeMapper() as WireframeMapper<View, *>
-        val maskUserInputTabWireframeMapper =
-            MaskInputTabWireframeMapper() as WireframeMapper<View, *>
         return mapOf(
             SessionReplayPrivacy.ALLOW_ALL to mapOf(
                 Slider::class.java to allowAllSliderMapper,
@@ -39,7 +37,7 @@ class MaterialExtensionSupport : ExtensionSupport {
             ),
             SessionReplayPrivacy.MASK_USER_INPUT to mapOf(
                 Slider::class.java to maskUserInputSliderMapper,
-                TabLayout.TabView::class.java to maskUserInputTabWireframeMapper
+                TabLayout.TabView::class.java to allowAllTabWireframeMapper
             )
         )
     }

--- a/library/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupportTest.kt
+++ b/library/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupportTest.kt
@@ -85,13 +85,13 @@ class MaterialExtensionSupportTest {
     }
 
     @Test
-    fun `M return a MaskInputTabMapper W getCustomViewMappers() { MASK_USER_INPUT  }`() {
+    fun `M return a TabWireframeMapper W getCustomViewMappers() { MASK_USER_INPUT  }`() {
         // When
         val customMappers = testedMaterialExtensionSupport.getCustomViewMappers()
 
         // Then
         assertThat(customMappers.entries.size).isEqualTo(3)
         assertThat(customMappers[SessionReplayPrivacy.MASK_USER_INPUT]?.get(TabView::class.java))
-            .isInstanceOf(MaskInputTabWireframeMapper::class.java)
+            .isInstanceOf(TabWireframeMapper::class.java)
     }
 }


### PR DESCRIPTION
…y option

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

