### PR TITLE
RUMM-3250: Keep bytecode produced compatible with Java 11

### DIFF
--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -79,7 +79,8 @@ gradlePlugin {
 }
 
 tasks.withType<KotlinCompile>().configureEach {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_17.toString()
+    // TODO RUMM-3263 Switch to Java 17 bytecode
+    kotlinOptions.jvmTarget = JavaVersion.VERSION_11.toString()
 }
 
 tasks {

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -6,8 +6,10 @@
 
 package com.datadog.gradle.config
 
+import com.android.build.api.dsl.CompileOptions
 import com.android.build.api.dsl.LibraryDefaultConfig
 import com.datadog.gradle.utils.Version
+import org.gradle.api.JavaVersion
 
 object AndroidConfig {
 
@@ -20,6 +22,12 @@ object AndroidConfig {
     const val BUILD_TOOLS_VERSION = "33.0.0"
 
     val VERSION = Version(1, 20, 0, Version.Type.Snapshot)
+}
+
+// TODO RUMM-3263 Switch to Java 17 bytecode
+fun CompileOptions.java11() {
+    sourceCompatibility = JavaVersion.VERSION_11
+    targetCompatibility = JavaVersion.VERSION_11
 }
 
 @Suppress("UnstableApiUsage")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
@@ -15,7 +15,8 @@ import java.io.File
 fun Project.kotlinConfig(evaluateWarningsAsErrors: Boolean = true) {
     taskConfig<KotlinCompile> {
         kotlinOptions {
-            jvmTarget = JavaVersion.VERSION_17.toString()
+            // TODO RUMM-3263 Switch to Java 17 bytecode
+            jvmTarget = JavaVersion.VERSION_11.toString()
             allWarningsAsErrors = evaluateWarningsAsErrors
             apiVersion = "1.6"
             languageVersion = "1.6"

--- a/dd-sdk-android-coil/build.gradle.kts
+++ b/dd-sdk-android-coil/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -54,8 +55,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/dd-sdk-android-compose/build.gradle.kts
+++ b/dd-sdk-android-compose/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -66,8 +67,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/dd-sdk-android-fresco/build.gradle.kts
+++ b/dd-sdk-android-fresco/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -54,8 +55,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/dd-sdk-android-glide/build.gradle.kts
+++ b/dd-sdk-android-glide/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -55,8 +56,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/dd-sdk-android-ktx/build.gradle.kts
+++ b/dd-sdk-android-ktx/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -54,8 +55,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/dd-sdk-android-ndk/build.gradle.kts
+++ b/dd-sdk-android-ndk/build.gradle.kts
@@ -7,6 +7,7 @@
 import com.datadog.gradle.Dependencies
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -62,8 +63,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/dd-sdk-android-rx/build.gradle.kts
+++ b/dd-sdk-android-rx/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -54,8 +55,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/dd-sdk-android-sqldelight/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -54,8 +55,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/dd-sdk-android-timber/build.gradle.kts
+++ b/dd-sdk-android-timber/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -54,8 +55,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/dd-sdk-android-tv/build.gradle.kts
+++ b/dd-sdk-android-tv/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -54,8 +55,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/dd-sdk-android/build.gradle.kts
+++ b/dd-sdk-android/build.gradle.kts
@@ -8,6 +8,7 @@ import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.BuildConfigPropertiesKeys
 import com.datadog.gradle.config.GradlePropertiesKeys
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -72,8 +73,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -5,8 +5,8 @@
  */
 
 import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.kotlinConfig
-import org.gradle.api.JavaVersion
 
 plugins {
     id("com.android.application")
@@ -48,8 +48,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     packagingOptions {

--- a/instrumented/nightly-tests/build.gradle.kts
+++ b/instrumented/nightly-tests/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.datadog.gradle.Dependencies
 import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.kotlinConfig
-import org.gradle.api.JavaVersion
 
 plugins {
     id("com.android.application")
@@ -54,8 +54,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     packagingOptions {

--- a/library/dd-sdk-android-session-replay/build.gradle.kts
+++ b/library/dd-sdk-android-session-replay/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -55,8 +56,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     testOptions {

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -8,6 +8,7 @@ import com.datadog.gradle.Dependencies
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.configureFlavorForSampleApp
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -90,8 +91,7 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     packagingOptions {

--- a/tools/unit/build.gradle.kts
+++ b/tools/unit/build.gradle.kts
@@ -6,6 +6,7 @@
 
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 
@@ -28,8 +29,7 @@ android {
     namespace = "com.datadog.tools.unit"
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_17
-        targetCompatibility = JavaVersion.VERSION_17
+        java11()
     }
 
     sourceSets.named("main") {


### PR DESCRIPTION
### What does this PR do?

Rolling back some changes done in https://github.com/DataDog/dd-sdk-android/pull/1406: we need to keep bytecode produced at the Java 11 level, because `aar` files are distributed non-dexed (meaning they carry simple `.class` jvm files), so old AGP versions may be not able to handle bytecode produced by Java 17.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

