### PR TITLE
Remove MaxPermSize JVM option for the compatibility with Java 17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-Present Datadog, Inc.
 #
-org.gradle.jvmargs=-Xmx2560m -XX:MaxPermSize=512m
+org.gradle.jvmargs=-Xmx2560m
 android.useAndroidX=true
 android.disableAutomaticComponentCreation=true
 # Leave the next line blank for CI


### PR DESCRIPTION
### What does this PR do?

As a result of changes being made in https://github.com/DataDog/dd-sdk-android/pull/1406, Bitrise is now using Java 17, so need to remove unsupported JVM option.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

