### PR TITLE
Add extra error output in case of a failed upload

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploader.kt
@@ -56,6 +56,12 @@ internal class DataOkHttpUploader(
                 "Unable to upload batch data.",
                 e
             )
+            internalLogger.log(
+                InternalLogger.Level.DEBUG,
+                InternalLogger.Target.USER,
+                "Unable to upload batch data.",
+                e
+            )
             UploadStatus.NETWORK_ERROR
         }
 


### PR DESCRIPTION
### What does this PR do?

We currently send failed upload information to the maintainer logger, but not to the user console. I've added a line at the `verbose` level for users to help diagnose network errors.

### Motivation

I am trying to diagnose an error on batch upload and can't seem to get enough information to figure out what's happening. Hoping this will help in the future.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

