### PR TITLE
RUMM-3196: Remove SDK instance provider in favour of SdkReference usage

### DIFF
--- a/dd-sdk-android-glide/apiSurface
+++ b/dd-sdk-android-glide/apiSurface
@@ -1,8 +1,8 @@
 open class com.datadog.android.glide.DatadogGlideModule : com.bumptech.glide.module.AppGlideModule
-  constructor(() -> com.datadog.android.v2.api.SdkCore = { Datadog.getInstance() }, List<String> = emptyList(), Float = DEFAULT_SAMPLING_RATE)
+  constructor(String? = null, List<String> = emptyList(), Float = DEFAULT_SAMPLING_RATE)
   override fun registerComponents(android.content.Context, com.bumptech.glide.Glide, com.bumptech.glide.Registry)
   override fun applyOptions(android.content.Context, com.bumptech.glide.GlideBuilder)
   open fun getClientBuilder(): okhttp3.OkHttpClient.Builder
 class com.datadog.android.glide.DatadogRUMUncaughtThrowableStrategy : com.bumptech.glide.load.engine.executor.GlideExecutor.UncaughtThrowableStrategy
-  constructor(String, com.datadog.android.v2.api.SdkCore)
+  constructor(String, String? = null)
   override fun handle(Throwable?)

--- a/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/DatadogGlideModuleTest.kt
+++ b/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/DatadogGlideModuleTest.kt
@@ -31,11 +31,8 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.argumentCaptor
-import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.InputStream
 import java.util.concurrent.ExecutorService
@@ -73,14 +70,11 @@ internal class DatadogGlideModuleTest {
 
     @BeforeEach
     fun `set up`() {
-        testedModule = DatadogGlideModule({ mockSdkCore }, listOf(fakeHost))
+        testedModule = DatadogGlideModule(firstPartyHosts = listOf(fakeHost))
     }
 
     @Test
     fun `registers a custom OkHttpLoader`() {
-        // Given
-        whenever(mockSdkCore.firstPartyHostResolver) doReturn mock()
-
         // When
         testedModule.registerComponents(mockContext, mockGlide, mockRegistry)
 

--- a/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/DatadogRUMUncaughtThrowableStrategyTest.kt
+++ b/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/DatadogRUMUncaughtThrowableStrategyTest.kt
@@ -6,10 +6,13 @@
 
 package com.datadog.android.glide
 
+import com.datadog.android.glide.utils.config.DatadogSingletonTestConfiguration
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
-import com.datadog.android.v2.api.SdkCore
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.AfterEach
@@ -28,7 +31,8 @@ import java.lang.RuntimeException
 @Extensions(
     ExtendWith(
         MockitoExtension::class,
-        ForgeExtension::class
+        ForgeExtension::class,
+        TestConfigurationExtension::class
     )
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
@@ -39,17 +43,14 @@ internal class DatadogRUMUncaughtThrowableStrategyTest {
     @Mock
     lateinit var mockRumMonitor: RumMonitor
 
-    @Mock
-    lateinit var mockSdkCore: SdkCore
-
     @StringForgery
     lateinit var fakeName: String
 
     @BeforeEach
     fun `set up`() {
-        GlobalRum.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRum.registerIfAbsent(datadog.mockInstance, mockRumMonitor)
 
-        testedStrategy = DatadogRUMUncaughtThrowableStrategy(fakeName, mockSdkCore)
+        testedStrategy = DatadogRUMUncaughtThrowableStrategy(fakeName)
     }
 
     @AfterEach
@@ -77,5 +78,15 @@ internal class DatadogRUMUncaughtThrowableStrategyTest {
         testedStrategy.handle(null)
 
         verifyNoInteractions(mockRumMonitor)
+    }
+
+    companion object {
+        val datadog = DatadogSingletonTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(datadog)
+        }
     }
 }

--- a/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/utils/config/DatadogSingletonTestConfiguration.kt
+++ b/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/utils/config/DatadogSingletonTestConfiguration.kt
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.glide.utils.config
+
+import com.datadog.android.Datadog
+import com.datadog.android.v2.api.SdkCore
+import com.datadog.android.v2.core.InternalSdkCore
+import com.datadog.tools.unit.extensions.config.MockTestConfiguration
+import fr.xgouchet.elmyr.Forge
+
+// TODO RUMM-2949 Share forgeries/test configurations between modules
+internal class DatadogSingletonTestConfiguration :
+    MockTestConfiguration<InternalSdkCore>(InternalSdkCore::class.java) {
+
+    override fun setUp(forge: Forge) {
+        super.setUp(forge)
+
+        val registry = registryField.get(null)
+        registryRegisterMethod.invoke(registry, null, mockInstance)
+    }
+
+    override fun tearDown(forge: Forge) {
+        val registry = registryField.get(null)
+        registryClearMethod.invoke(registry)
+        super.tearDown(forge)
+    }
+
+    companion object {
+        private val registryField = Datadog::class.java.getDeclaredField("registry").apply {
+            isAccessible = true
+        }
+        private val registryRegisterMethod = registryField.type.getMethod(
+            "register",
+            String::class.java,
+            SdkCore::class.java
+        )
+        private val registryClearMethod = registryField.type.getMethod("clear")
+    }
+}

--- a/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -64,7 +64,7 @@ import java.util.concurrent.atomic.AtomicReference
 @Suppress("TooManyFunctions", "StringLiteralDuplication")
 open class TracingInterceptor
 internal constructor(
-    sdkInstanceName: String?,
+    private val sdkInstanceName: String?,
     internal val tracedHosts: Map<String, Set<TracingHeaderType>>,
     internal val tracedRequestListener: TracedRequestListener,
     internal val traceOrigin: String?,
@@ -188,10 +188,15 @@ internal constructor(
     override fun intercept(chain: Interceptor.Chain): Response {
         val sdkCore = sdkCoreReference.get()
         if (sdkCore == null) {
+            val prefix = if (sdkInstanceName == null) {
+                "Default SDK instance"
+            } else {
+                "SDK instance with name=$sdkInstanceName"
+            }
             InternalLogger.UNBOUND.log(
                 InternalLogger.Level.INFO,
                 InternalLogger.Target.USER,
-                "SDK instance for OkHttp instrumentation is not provided, skipping" +
+                "$prefix for OkHttp instrumentation is found, skipping" +
                     " tracking of request with url=${chain.request().url()}"
             )
             return chain.proceed(chain.request())

--- a/library/dd-sdk-android-rum/apiSurface
+++ b/library/dd-sdk-android-rum/apiSurface
@@ -246,7 +246,7 @@ interface com.datadog.android.rum.tracking.ViewAttributesProvider
   fun extractAttributes(android.view.View, MutableMap<String, Any?>)
 interface com.datadog.android.rum.tracking.ViewTrackingStrategy : TrackingStrategy
 class com.datadog.android.sqlite.DatadogDatabaseErrorHandler : android.database.DatabaseErrorHandler
-  constructor(() -> com.datadog.android.v2.api.SdkCore, android.database.DatabaseErrorHandler = DefaultDatabaseErrorHandler())
+  constructor(String? = null, android.database.DatabaseErrorHandler = DefaultDatabaseErrorHandler())
   override fun onCorruption(android.database.sqlite.SQLiteDatabase)
 data class com.datadog.android.rum.model.ActionChildProperties
   constructor(Action? = null)

--- a/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandler.kt
+++ b/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandler.kt
@@ -9,10 +9,11 @@ package com.datadog.android.sqlite
 import android.database.DatabaseErrorHandler
 import android.database.DefaultDatabaseErrorHandler
 import android.database.sqlite.SQLiteDatabase
+import com.datadog.android.SdkReference
 import com.datadog.android.rum.GlobalRum
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
-import com.datadog.android.v2.api.SdkCore
+import com.datadog.android.v2.api.InternalLogger
 import java.util.Locale
 
 /**
@@ -21,26 +22,46 @@ import java.util.Locale
  *
  * It will automatically send RUM Error events whenever a Database corruption was signaled.
  * For more information [https://www.sqlite.org/howtocorrupt.html]
+ *
+ * @param sdkInstanceName the SDK instance name to bind to, or null to check the default instance.
+ * Instrumentation won't be working until SDK instance is ready.
+ * @param defaultErrorHandler the corruption error handler, by default it is [DefaultDatabaseErrorHandler].
  */
 class DatadogDatabaseErrorHandler(
-    // TODO RUMM-3196 Maybe change provider to the instance name?
-    internal val sdkCoreProvider: () -> SdkCore,
+    private val sdkInstanceName: String? = null,
     internal val defaultErrorHandler: DatabaseErrorHandler = DefaultDatabaseErrorHandler()
 ) : DatabaseErrorHandler {
+
+    private val sdkReference = SdkReference(sdkInstanceName)
 
     /** @inheritDoc */
     override fun onCorruption(dbObj: SQLiteDatabase) {
         defaultErrorHandler.onCorruption(dbObj)
-        GlobalRum.get(sdkCoreProvider.invoke())
-            .addError(
-                String.format(Locale.US, DATABASE_CORRUPTION_ERROR_MESSAGE, dbObj.path),
-                RumErrorSource.SOURCE,
-                null,
-                mapOf(
-                    RumAttributes.ERROR_DATABASE_PATH to dbObj.path,
-                    RumAttributes.ERROR_DATABASE_VERSION to dbObj.version
+        val sdkCore = sdkReference.get()
+        if (sdkCore != null) {
+            GlobalRum.get(sdkCore)
+                .addError(
+                    String.format(Locale.US, DATABASE_CORRUPTION_ERROR_MESSAGE, dbObj.path),
+                    RumErrorSource.SOURCE,
+                    null,
+                    mapOf(
+                        RumAttributes.ERROR_DATABASE_PATH to dbObj.path,
+                        RumAttributes.ERROR_DATABASE_VERSION to dbObj.version
+                    )
                 )
+        } else {
+            val prefix = if (sdkInstanceName == null) {
+                "Default SDK instance"
+            } else {
+                "SDK instance with name=$sdkInstanceName"
+            }
+            InternalLogger.UNBOUND.log(
+                InternalLogger.Level.INFO,
+                InternalLogger.Target.USER,
+                "$prefix is not found, skipping" +
+                    " reporting the corruption of sqlite database: %s"
             )
+        }
     }
 
     internal companion object {

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/data/db/sqlite/DatadogSqliteHelper.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/data/db/sqlite/DatadogSqliteHelper.kt
@@ -10,7 +10,6 @@ import android.content.Context
 import android.database.sqlite.SQLiteDatabase
 import android.database.sqlite.SQLiteOpenHelper
 import android.provider.BaseColumns
-import com.datadog.android.Datadog
 import com.datadog.android.sample.data.db.DatadogDbContract
 import com.datadog.android.sqlite.DatadogDatabaseErrorHandler
 
@@ -20,7 +19,7 @@ internal class DatadogSqliteHelper(context: Context) :
         DatadogDbContract.DB_NAME,
         null,
         DatadogDbContract.DB_VERSION,
-        DatadogDatabaseErrorHandler({ Datadog.getInstance() })
+        DatadogDatabaseErrorHandler()
     ) {
 
     override fun onCreate(db: SQLiteDatabase) {


### PR DESCRIPTION
### What does this PR do?

This PR removes SDK provider for the classes which may be created before SDK initialized in favour of the SDK instance name + `SdkReference` usage, so that SDK can be resolved lazily.

`DatadogRUMUncaughtThrowableStrategy` requires lazy resolution as well, because `AppGlideModule#applyOptions` is called once and this call may happen before Datadog SDK is actually initialized.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

