### PR TITLE
Pass register call to bundled strategies in case of MixedViewTrackingStrategy

### DIFF
--- a/library/dd-sdk-android-rum/apiSurface
+++ b/library/dd-sdk-android-rum/apiSurface
@@ -223,6 +223,8 @@ interface com.datadog.android.rum.tracking.InteractionPredicate
   fun getTargetName(Any): String?
 class com.datadog.android.rum.tracking.MixedViewTrackingStrategy : ActivityLifecycleTrackingStrategy, ViewTrackingStrategy
   constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities(), ComponentPredicate<androidx.fragment.app.Fragment> = AcceptAllSupportFragments(), ComponentPredicate<android.app.Fragment> = AcceptAllDefaultFragment())
+  override fun register(com.datadog.android.v2.api.SdkCore, android.content.Context)
+  override fun unregister(android.content.Context?)
   override fun onActivityCreated(android.app.Activity, android.os.Bundle?)
   override fun onActivityStarted(android.app.Activity)
   override fun onActivityResumed(android.app.Activity)

--- a/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/MixedViewTrackingStrategy.kt
+++ b/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/MixedViewTrackingStrategy.kt
@@ -7,8 +7,10 @@
 package com.datadog.android.rum.tracking
 
 import android.app.Activity
+import android.content.Context
 import android.os.Bundle
 import androidx.fragment.app.Fragment
+import com.datadog.android.v2.api.SdkCore
 
 /**
  * A [ViewTrackingStrategy] that will track [Activity] and [Fragment] as RUM View Events.
@@ -46,6 +48,18 @@ class MixedViewTrackingStrategy internal constructor(
             defaultFragmentComponentPredicate
         )
     )
+
+    override fun register(sdkCore: SdkCore, context: Context) {
+        super.register(sdkCore, context)
+        activityViewTrackingStrategy.register(sdkCore, context)
+        fragmentViewTrackingStrategy.register(sdkCore, context)
+    }
+
+    override fun unregister(context: Context?) {
+        activityViewTrackingStrategy.unregister(context)
+        fragmentViewTrackingStrategy.unregister(context)
+        super.unregister(context)
+    }
 
     // region ActivityLifecycleTrackingStrategy
 

--- a/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/MixedViewTrackingStrategyTest.kt
+++ b/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/MixedViewTrackingStrategyTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
 import com.datadog.android.rum.tracking.MixedViewTrackingStrategy
 import com.datadog.android.rum.tracking.StubComponentPredicate
 import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.android.v2.api.SdkCore
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -23,6 +24,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.inOrder
+import org.mockito.kotlin.verify
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -43,6 +45,9 @@ internal class MixedViewTrackingStrategyTest :
     @Mock
     lateinit var mockBundle: Bundle
 
+    @Mock
+    lateinit var mockSdkCore: SdkCore
+
     // region tests
 
     @BeforeEach
@@ -56,7 +61,27 @@ internal class MixedViewTrackingStrategyTest :
     }
 
     @Test
-    fun `when created will delegate to the bundled strategies`() {
+    fun `when registered will delegate to the bundled strategies`() {
+        // Whenever
+        testedStrategy.register(mockSdkCore, mockAppContext)
+
+        // Then
+        verify(mockActivityViewTrackingStrategy).register(mockSdkCore, mockAppContext)
+        verify(mockFragmentViewTrackingStrategy).register(mockSdkCore, mockAppContext)
+    }
+
+    @Test
+    fun `when unregistered will delegate to the bundled strategies`() {
+        // Whenever
+        testedStrategy.unregister(mockAppContext)
+
+        // Then
+        verify(mockActivityViewTrackingStrategy).unregister(mockAppContext)
+        verify(mockFragmentViewTrackingStrategy).unregister(mockAppContext)
+    }
+
+    @Test
+    fun `when activity created will delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityCreated(mockActivity, mockBundle)
 
@@ -68,7 +93,7 @@ internal class MixedViewTrackingStrategyTest :
     }
 
     @Test
-    fun `when destroyed will delegate to the bundled strategies`() {
+    fun `when activity destroyed will delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityDestroyed(mockActivity)
 
@@ -80,7 +105,7 @@ internal class MixedViewTrackingStrategyTest :
     }
 
     @Test
-    fun `when started will delegate to the bundled strategies`() {
+    fun `when activity started will delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityStarted(mockActivity)
 
@@ -92,7 +117,7 @@ internal class MixedViewTrackingStrategyTest :
     }
 
     @Test
-    fun `when stopped will delegate to the bundled strategies`() {
+    fun `when activity stopped will delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityStopped(mockActivity)
 
@@ -104,7 +129,7 @@ internal class MixedViewTrackingStrategyTest :
     }
 
     @Test
-    fun `when resumed will delegate to the bundled strategies`() {
+    fun `when activity resumed will delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityResumed(mockActivity)
 
@@ -116,7 +141,7 @@ internal class MixedViewTrackingStrategyTest :
     }
 
     @Test
-    fun `when paused will delegate to the bundled strategies`() {
+    fun `when activity paused will delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityPaused(mockActivity)
 


### PR DESCRIPTION
### What does this PR do?

Bugfix: we need to pass `register` call to the bundled strategies in case of `MixedViewTrackingStrategy`, otherwise they are effectively not initialized properly.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

