### PR TITLE
Add more internal logs to the cases when SDK core instance is missing

### DIFF
--- a/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumFeature.kt
+++ b/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumFeature.kt
@@ -290,6 +290,14 @@ class RumFeature internal constructor(
     // region Internal
 
     private fun enableDebugging() {
+        if (!initialized.get()) {
+            InternalLogger.UNBOUND.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.USER,
+                "$RUM_FEATURE_NOT_YET_INITIALIZED Cannot enable RUM debugging."
+            )
+            return
+        }
         val context = appContext
         if (context is Application) {
             debugActivityLifecycleListener = UiRumDebugListener(sdkCore)
@@ -831,6 +839,9 @@ class RumFeature internal constructor(
             " event, but mandatory message field is either missing or has a wrong type."
         internal const val DEVELOPER_MODE_SAMPLE_RATE_CHANGED_MESSAGE =
             "Developer mode enabled, setting RUM sample rate to 100%."
+        internal const val RUM_FEATURE_NOT_YET_INITIALIZED =
+            "RUM feature is not initialized yet, you need to register it with a" +
+                " SDK instance by calling SdkCore#registerFeature method."
 
         private fun provideUserTrackingStrategy(
             touchTargetExtraAttributesProviders: Array<ViewAttributesProvider>,

--- a/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
+++ b/library/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
@@ -11,6 +11,7 @@ import android.app.Application
 import android.content.Context
 import android.content.Intent
 import android.os.Bundle
+import com.datadog.android.rum.RumFeature
 import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.api.SdkCore
 
@@ -150,6 +151,12 @@ abstract class ActivityLifecycleTrackingStrategy :
         return if (this::sdkCore.isInitialized) {
             block(sdkCore)
         } else {
+            InternalLogger.UNBOUND.log(
+                InternalLogger.Level.INFO,
+                InternalLogger.Target.USER,
+                RumFeature.RUM_FEATURE_NOT_YET_INITIALIZED +
+                    " Cannot provide SDK instance for view tracking."
+            )
             null
         }
     }

--- a/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumFeatureTest.kt
+++ b/library/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumFeatureTest.kt
@@ -709,6 +709,15 @@ internal class RumFeatureTest {
     }
 
     @Test
+    fun `𝕄 enable RUM debugging 𝕎 enableRumDebugging(true){RUM feature is not yet initialized}`() {
+        // When
+        testedFeature.enableRumDebugging(true)
+
+        // Then
+        assertThat(testedFeature.debugActivityLifecycleListener).isNull()
+    }
+
+    @Test
     fun `𝕄 disable RUM debugging 𝕎 enableRumDebugging(false)`() {
         // Given
         testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)


### PR DESCRIPTION
### What does this PR do?

This PR adds more logs to the cases when SDK instance is missing:

* For `enableRumDebugging` it has `warn` level, because it is the user who controlling the call.
* For view tracking strategy it is `info`, because it is us who control the call.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

