### PR TITLE
RUMM-3305: Ignore adding custom timings and feature flags for the stopped view

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -85,7 +85,7 @@ internal class RumViewManagerScope(
 
     // region Internal
 
-    fun isViewManagerComplete(): Boolean {
+    private fun isViewManagerComplete(): Boolean {
         return stopped && childrenScopes.isEmpty()
     }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -106,7 +106,7 @@ internal open class RumViewScope(
     private var version: Long = 1
     private var loadingTime: Long? = null
     private var loadingType: ViewEvent.LoadingType? = null
-    private val customTimings: MutableMap<String, Long> = mutableMapOf()
+    internal val customTimings: MutableMap<String, Long> = mutableMapOf()
     internal val featureFlags: MutableMap<String, Any?> = mutableMapOf()
 
     internal var stopped: Boolean = false
@@ -467,6 +467,8 @@ internal open class RumViewScope(
         event: RumRawEvent.AddCustomTiming,
         writer: DataWriter<Any>
     ) {
+        if (stopped) return
+
         customTimings[event.name] = max(event.eventTime.nanoTime - startedNanos, 1L)
         sendViewUpdate(event, writer)
     }
@@ -988,6 +990,8 @@ internal open class RumViewScope(
         event: RumRawEvent.AddFeatureFlagEvaluation,
         writer: DataWriter<Any>
     ) {
+        if (stopped) return
+
         featureFlags[event.name] = event.value
         sendViewUpdate(event, writer)
         sendViewChanged()

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -5563,6 +5563,25 @@ internal class RumViewScopeTest {
         verifyNoMoreInteractions(mockWriter)
     }
 
+    @Test
+    fun `𝕄 not add custom timing 𝕎 handleEvent(AddCustomTiming) on stopped view`(
+        forge: Forge
+    ) {
+        // Given
+        testedScope.stopped = true
+        val fakeTimingKey = forge.anAlphabeticalString()
+
+        // When
+        testedScope.handleEvent(
+            RumRawEvent.AddCustomTiming(fakeTimingKey),
+            mockWriter
+        )
+
+        // Then
+        assertThat(testedScope.customTimings).isEmpty()
+        verifyNoInteractions(mockWriter)
+    }
+
     // endregion
 
     // region Vitals
@@ -6902,6 +6921,28 @@ internal class RumViewScopeTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture())
             assertThat(lastValue).hasFeatureFlag(flagName, flagValue)
         }
+    }
+
+    @Test
+    fun `M not add feature flag W handleEvent(AddFeatureFlagEvaluation) on stopped view`(
+        @StringForgery flagName: String,
+        @StringForgery flagValue: String
+    ) {
+        // GIVEN
+        testedScope.stopped = true
+
+        // WHEN
+        testedScope.handleEvent(
+            RumRawEvent.AddFeatureFlagEvaluation(
+                name = flagName,
+                value = flagValue
+            ),
+            mockWriter
+        )
+
+        // THEN
+        assertThat(testedScope.featureFlags).isEmpty()
+        verifyNoInteractions(mockWriter)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This change fixes https://github.com/DataDog/dd-sdk-android/issues/1432: `RumViewScope` was accepting custom timings and feature flags in the `stopped` state, allowing them to be added to the multiple views at the same time (because we keep some views in `RumViewManagerScope` until their child events complete).

This PR adds the necessary check requiring the view to be active to add such information, and this aligns with the logic in the iOS SDK for the [custom timings](https://github.com/DataDog/dd-sdk-ios/blob/92ee37cf420bb0a8262b60ab8e5e837a620327f1/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift#L191) and [feature flags](https://github.com/DataDog/dd-sdk-ios/blob/92ee37cf420bb0a8262b60ab8e5e837a620327f1/Sources/Datadog/RUM/RUMMonitor/Scopes/RUMViewScope.swift#L223).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

