### PR TITLE
RUMM-3313: Set last interaction time by SdkInit event

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -31,7 +31,7 @@ internal class RumSessionScope(
     internal val samplingRate: Float,
     internal val backgroundTrackingEnabled: Boolean,
     internal val trackFrustrations: Boolean,
-    internal val viewChangedListener: RumViewChangedListener?,
+    viewChangedListener: RumViewChangedListener?,
     internal val firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
     cpuVitalMonitor: VitalMonitor,
     memoryVitalMonitor: VitalMonitor,
@@ -148,6 +148,8 @@ internal class RumSessionScope(
 
         if (event is RumRawEvent.SdkInit && isNewSession) {
             renewSession(nanoTime)
+            // fake user interaction to avoid re-creating session when next real event arrives
+            lastUserInteractionNs.set(nanoTime)
         } else if (isInteraction) {
             if (isNewSession || isExpired || isTimedOut) {
                 renewSession(nanoTime)

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -320,6 +320,52 @@ internal class RumSessionScopeTest {
     }
 
     @Test
+    fun `𝕄 not create new session 𝕎 handleEvent(SdkInit+AnyEvent)+getRumContext()`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(100f)
+
+        // When
+        val scopeA = testedScope.handleEvent(RumRawEvent.SdkInit(), mockWriter)
+        val contextA = testedScope.getRumContext()
+        val scopeB = testedScope.handleEvent(
+            forge.anyRumEvent(),
+            mockWriter
+        )
+        val contextB = testedScope.getRumContext()
+
+        // Then
+        assertThat(scopeA).isSameAs(testedScope)
+        assertThat(scopeB).isSameAs(scopeA)
+        assertThat(contextA.sessionId).isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(contextB.sessionId).isEqualTo(contextA.sessionId)
+    }
+
+    @Test
+    fun `𝕄 not create new session 𝕎 handleEvent(SdkInit+AnyEvent)+getRumContext() {+backgroundTracking}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(100f, backgroundTrackingEnabled = true)
+
+        // When
+        val scopeA = testedScope.handleEvent(RumRawEvent.SdkInit(), mockWriter)
+        val contextA = testedScope.getRumContext()
+        val scopeB = testedScope.handleEvent(
+            forge.anyRumEvent(),
+            mockWriter
+        )
+        val contextB = testedScope.getRumContext()
+
+        // Then
+        assertThat(scopeA).isSameAs(testedScope)
+        assertThat(scopeB).isSameAs(scopeA)
+        assertThat(contextA.sessionId).isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(contextB.sessionId).isEqualTo(contextA.sessionId)
+    }
+
+    @Test
     fun `𝕄 create new untracked context 𝕎 handleEvent(view)+getRumContext() {sampling = 0}`(
         forge: Forge
     ) {


### PR DESCRIPTION
### What does this PR do?

There is a flaw in the [following change](https://github.com/DataDog/dd-sdk-android/pull/1399/files#diff-aaf8a259788b94b68810c152e9da1ac6b04935be9ffdfb30edafb9f67ecb5edfR149-R151): since it doesn't update last interaction time, next real interaction event arriving (or valid background event) will see `isExpired = true` and create a new session again, making original session very short-living and doubling the number of sessions (if we think about `ApplicationLaunchView` which may be linked to the original session).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

