### PR TITLE
RUMM-3314: Keep old viewIds for view scope

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -31,7 +31,7 @@ internal class RumSessionScope(
     internal val samplingRate: Float,
     internal val backgroundTrackingEnabled: Boolean,
     internal val trackFrustrations: Boolean,
-    internal val viewChangedListener: RumViewChangedListener?,
+    viewChangedListener: RumViewChangedListener?,
     internal val firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
     cpuVitalMonitor: VitalMonitor,
     memoryVitalMonitor: VitalMonitor,
@@ -148,6 +148,8 @@ internal class RumSessionScope(
 
         if (event is RumRawEvent.SdkInit && isNewSession) {
             renewSession(nanoTime)
+            // fake user interaction to avoid re-creating session when next real event arrives
+            lastUserInteractionNs.set(nanoTime)
         } else if (isInteraction) {
             if (isNewSession || isExpired || isTimedOut) {
                 renewSession(nanoTime)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -70,7 +70,11 @@ internal open class RumViewScope(
 
     private var sessionId: String = parentScope.getRumContext().sessionId
     internal var viewId: String = UUID.randomUUID().toString()
-        private set
+        set(value) {
+            oldViewIds += field
+            field = value
+        }
+    private val oldViewIds = mutableSetOf<String>()
     private val startedNanos: Long = eventTime.nanoTime
 
     internal val serverTimeOffsetInMs = sdkCore.time.serverTimeOffsetMs
@@ -575,7 +579,7 @@ internal open class RumViewScope(
         event: RumRawEvent.ResourceSent,
         writer: DataWriter<Any>
     ) {
-        if (event.viewId == viewId) {
+        if (event.viewId == viewId || event.viewId in oldViewIds) {
             pendingResourceCount--
             resourceCount++
             sendViewUpdate(event, writer)
@@ -587,7 +591,7 @@ internal open class RumViewScope(
         event: RumRawEvent.ActionSent,
         writer: DataWriter<Any>
     ) {
-        if (event.viewId == viewId) {
+        if (event.viewId == viewId || event.viewId in oldViewIds) {
             pendingActionCount--
             actionCount++
             frustrationCount += event.frustrationCount
@@ -600,7 +604,7 @@ internal open class RumViewScope(
         event: RumRawEvent.LongTaskSent,
         writer: DataWriter<Any>
     ) {
-        if (event.viewId == viewId) {
+        if (event.viewId == viewId || event.viewId in oldViewIds) {
             pendingLongTaskCount--
             longTaskCount++
             if (event.isFrozenFrame) {
@@ -616,7 +620,7 @@ internal open class RumViewScope(
         event: RumRawEvent.ErrorSent,
         writer: DataWriter<Any>
     ) {
-        if (event.viewId == viewId) {
+        if (event.viewId == viewId || event.viewId in oldViewIds) {
             pendingErrorCount--
             errorCount++
             sendViewUpdate(event, writer)
@@ -624,25 +628,25 @@ internal open class RumViewScope(
     }
 
     private fun onResourceDropped(event: RumRawEvent.ResourceDropped) {
-        if (event.viewId == viewId) {
+        if (event.viewId == viewId || event.viewId in oldViewIds) {
             pendingResourceCount--
         }
     }
 
     private fun onActionDropped(event: RumRawEvent.ActionDropped) {
-        if (event.viewId == viewId) {
+        if (event.viewId == viewId || event.viewId in oldViewIds) {
             pendingActionCount--
         }
     }
 
     private fun onErrorDropped(event: RumRawEvent.ErrorDropped) {
-        if (event.viewId == viewId) {
+        if (event.viewId == viewId || event.viewId in oldViewIds) {
             pendingErrorCount--
         }
     }
 
     private fun onLongTaskDropped(event: RumRawEvent.LongTaskDropped) {
-        if (event.viewId == viewId) {
+        if (event.viewId == viewId || event.viewId in oldViewIds) {
             pendingLongTaskCount--
             if (event.isFrozenFrame) {
                 pendingFrozenFrameCount--

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -320,6 +320,52 @@ internal class RumSessionScopeTest {
     }
 
     @Test
+    fun `𝕄 not create new session 𝕎 handleEvent(SdkInit+AnyEvent)+getRumContext()`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(100f)
+
+        // When
+        val scopeA = testedScope.handleEvent(RumRawEvent.SdkInit(), mockWriter)
+        val contextA = testedScope.getRumContext()
+        val scopeB = testedScope.handleEvent(
+            forge.anyRumEvent(),
+            mockWriter
+        )
+        val contextB = testedScope.getRumContext()
+
+        // Then
+        assertThat(scopeA).isSameAs(testedScope)
+        assertThat(scopeB).isSameAs(scopeA)
+        assertThat(contextA.sessionId).isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(contextB.sessionId).isEqualTo(contextA.sessionId)
+    }
+
+    @Test
+    fun `𝕄 not create new session 𝕎 handleEvent(SdkInit+AnyEvent)+getRumContext() {+backgroundTracking}`(
+        forge: Forge
+    ) {
+        // Given
+        initializeTestedScope(100f, backgroundTrackingEnabled = true)
+
+        // When
+        val scopeA = testedScope.handleEvent(RumRawEvent.SdkInit(), mockWriter)
+        val contextA = testedScope.getRumContext()
+        val scopeB = testedScope.handleEvent(
+            forge.anyRumEvent(),
+            mockWriter
+        )
+        val contextB = testedScope.getRumContext()
+
+        // Then
+        assertThat(scopeA).isSameAs(testedScope)
+        assertThat(scopeB).isSameAs(scopeA)
+        assertThat(contextA.sessionId).isNotEqualTo(RumContext.NULL_UUID)
+        assertThat(contextB.sessionId).isEqualTo(contextA.sessionId)
+    }
+
+    @Test
     fun `𝕄 create new untracked context 𝕎 handleEvent(view)+getRumContext() {sampling = 0}`(
         forge: Forge
     ) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -1935,6 +1935,73 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `𝕄 send event 𝕎 handleEvent(ErrorSent) on active view {viewId changed}`(
+        @LongForgery(1) pending: Long,
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        fakeEvent = RumRawEvent.ErrorSent(testedScope.viewId)
+        testedScope.pendingErrorCount = pending
+        testedScope.viewId = fakeNewViewId.toString()
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            assertThat(lastValue)
+                .apply {
+                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
+                    hasName(fakeName)
+                    hasUrl(fakeUrl)
+                    hasDurationGreaterThan(1)
+                    hasVersion(2)
+                    hasErrorCount(1)
+                    hasCrashCount(0)
+                    hasResourceCount(0)
+                    hasActionCount(0)
+                    hasFrustrationCount(0)
+                    hasLongTaskCount(0)
+                    hasFrozenFrameCount(0)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(null, null)
+                    isActive(true)
+                    isSlowRendered(false)
+                    hasNoCustomTimings()
+                    hasUserInfo(fakeDatadogContext.userInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasLiteSessionPlan()
+                    hasReplay(fakeHasReplay)
+                    containsExactlyContextAttributes(fakeAttributes)
+                    hasSource(fakeSourceViewEvent)
+                    hasDeviceInfo(
+                        fakeDatadogContext.deviceInfo.deviceName,
+                        fakeDatadogContext.deviceInfo.deviceModel,
+                        fakeDatadogContext.deviceInfo.deviceBrand,
+                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
+                        fakeDatadogContext.deviceInfo.architecture
+                    )
+                    hasOsInfo(
+                        fakeDatadogContext.deviceInfo.osName,
+                        fakeDatadogContext.deviceInfo.osVersion,
+                        fakeDatadogContext.deviceInfo.osMajorVersion
+                    )
+                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasServiceName(fakeDatadogContext.service)
+                    hasVersion(fakeDatadogContext.version)
+                    hasSessionActive(fakeParentContext.isSessionActive)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+        assertThat(testedScope.pendingErrorCount).isEqualTo(pending - 1)
+    }
+
+    @Test
     fun `𝕄 do nothing 𝕎 handleEvent(ErrorSent) on active view {unknown viewId}`(
         @Forgery viewUuid: UUID,
         @LongForgery(1) pending: Long
@@ -1961,6 +2028,73 @@ internal class RumViewScopeTest {
         // Given
         testedScope.pendingResourceCount = pending
         fakeEvent = RumRawEvent.ResourceSent(testedScope.viewId)
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            assertThat(lastValue)
+                .apply {
+                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
+                    hasName(fakeName)
+                    hasUrl(fakeUrl)
+                    hasDurationGreaterThan(1)
+                    hasVersion(2)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasResourceCount(1)
+                    hasActionCount(0)
+                    hasFrustrationCount(0)
+                    hasLongTaskCount(0)
+                    hasFrozenFrameCount(0)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(null, null)
+                    isActive(true)
+                    isSlowRendered(false)
+                    hasNoCustomTimings()
+                    hasUserInfo(fakeDatadogContext.userInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasLiteSessionPlan()
+                    hasReplay(fakeHasReplay)
+                    containsExactlyContextAttributes(fakeAttributes)
+                    hasSource(fakeSourceViewEvent)
+                    hasDeviceInfo(
+                        fakeDatadogContext.deviceInfo.deviceName,
+                        fakeDatadogContext.deviceInfo.deviceModel,
+                        fakeDatadogContext.deviceInfo.deviceBrand,
+                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
+                        fakeDatadogContext.deviceInfo.architecture
+                    )
+                    hasOsInfo(
+                        fakeDatadogContext.deviceInfo.osName,
+                        fakeDatadogContext.deviceInfo.osVersion,
+                        fakeDatadogContext.deviceInfo.osMajorVersion
+                    )
+                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasServiceName(fakeDatadogContext.service)
+                    hasVersion(fakeDatadogContext.version)
+                    hasSessionActive(fakeParentContext.isSessionActive)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+        assertThat(testedScope.pendingResourceCount).isEqualTo(pending - 1)
+    }
+
+    @Test
+    fun `𝕄 send event 𝕎 handleEvent(ResourceSent) on active view {viewId changed}`(
+        @LongForgery(1) pending: Long,
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingResourceCount = pending
+        fakeEvent = RumRawEvent.ResourceSent(testedScope.viewId)
+        testedScope.viewId = fakeNewViewId.toString()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
@@ -2047,6 +2181,74 @@ internal class RumViewScopeTest {
         // Given
         fakeEvent = RumRawEvent.ActionSent(testedScope.viewId, frustrationCount)
         testedScope.pendingActionCount = pending
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            assertThat(lastValue)
+                .apply {
+                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
+                    hasName(fakeName)
+                    hasUrl(fakeUrl)
+                    hasDurationGreaterThan(1)
+                    hasVersion(2)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasResourceCount(0)
+                    hasActionCount(1)
+                    hasFrustrationCount(frustrationCount.toLong())
+                    hasLongTaskCount(0)
+                    hasFrozenFrameCount(0)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(null, null)
+                    isActive(true)
+                    isSlowRendered(false)
+                    hasNoCustomTimings()
+                    hasUserInfo(fakeDatadogContext.userInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasLiteSessionPlan()
+                    hasReplay(fakeHasReplay)
+                    containsExactlyContextAttributes(fakeAttributes)
+                    hasSource(fakeSourceViewEvent)
+                    hasDeviceInfo(
+                        fakeDatadogContext.deviceInfo.deviceName,
+                        fakeDatadogContext.deviceInfo.deviceModel,
+                        fakeDatadogContext.deviceInfo.deviceBrand,
+                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
+                        fakeDatadogContext.deviceInfo.architecture
+                    )
+                    hasOsInfo(
+                        fakeDatadogContext.deviceInfo.osName,
+                        fakeDatadogContext.deviceInfo.osVersion,
+                        fakeDatadogContext.deviceInfo.osMajorVersion
+                    )
+                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasServiceName(fakeDatadogContext.service)
+                    hasVersion(fakeDatadogContext.version)
+                    hasSessionActive(fakeParentContext.isSessionActive)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+        assertThat(testedScope.pendingActionCount).isEqualTo(pending - 1)
+    }
+
+    @Test
+    fun `𝕄 send event 𝕎 handleEvent(ActionSent) on active view {viewId changed}`(
+        @LongForgery(1) pending: Long,
+        @IntForgery(0) frustrationCount: Int,
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        fakeEvent = RumRawEvent.ActionSent(testedScope.viewId, frustrationCount)
+        testedScope.pendingActionCount = pending
+        testedScope.viewId = fakeNewViewId.toString()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
@@ -2195,6 +2397,76 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `𝕄 send event 𝕎 handleEvent(LongTaskSent) on active view {not frozen, viewId changed}`(
+        @LongForgery(1) pendingLongTask: Long,
+        @LongForgery(1) pendingFrozenFrame: Long,
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId)
+        testedScope.pendingLongTaskCount = pendingLongTask
+        testedScope.pendingFrozenFrameCount = pendingFrozenFrame
+        testedScope.viewId = fakeNewViewId.toString()
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            assertThat(lastValue)
+                .apply {
+                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
+                    hasName(fakeName)
+                    hasUrl(fakeUrl)
+                    hasDurationGreaterThan(1)
+                    hasVersion(2)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasResourceCount(0)
+                    hasActionCount(0)
+                    hasFrustrationCount(0)
+                    hasLongTaskCount(1)
+                    hasFrozenFrameCount(0)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(null, null)
+                    isActive(true)
+                    isSlowRendered(false)
+                    hasNoCustomTimings()
+                    hasUserInfo(fakeDatadogContext.userInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasLiteSessionPlan()
+                    hasReplay(fakeHasReplay)
+                    containsExactlyContextAttributes(fakeAttributes)
+                    hasSource(fakeSourceViewEvent)
+                    hasDeviceInfo(
+                        fakeDatadogContext.deviceInfo.deviceName,
+                        fakeDatadogContext.deviceInfo.deviceModel,
+                        fakeDatadogContext.deviceInfo.deviceBrand,
+                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
+                        fakeDatadogContext.deviceInfo.architecture
+                    )
+                    hasOsInfo(
+                        fakeDatadogContext.deviceInfo.osName,
+                        fakeDatadogContext.deviceInfo.osVersion,
+                        fakeDatadogContext.deviceInfo.osMajorVersion
+                    )
+                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasServiceName(fakeDatadogContext.service)
+                    hasVersion(fakeDatadogContext.version)
+                    hasSessionActive(fakeParentContext.isSessionActive)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+        assertThat(testedScope.pendingLongTaskCount).isEqualTo(pendingLongTask - 1)
+        assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(pendingFrozenFrame)
+    }
+
+    @Test
     fun `𝕄 send event 𝕎 handleEvent(LongTaskSent) on active view {frozen}`(
         @LongForgery(1) pendingLongTask: Long,
         @LongForgery(1) pendingFrozenFrame: Long
@@ -2203,6 +2475,76 @@ internal class RumViewScopeTest {
         fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId, true)
         testedScope.pendingLongTaskCount = pendingLongTask
         testedScope.pendingFrozenFrameCount = pendingFrozenFrame
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            assertThat(lastValue)
+                .apply {
+                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
+                    hasName(fakeName)
+                    hasUrl(fakeUrl)
+                    hasDurationGreaterThan(1)
+                    hasVersion(2)
+                    hasErrorCount(0)
+                    hasCrashCount(0)
+                    hasResourceCount(0)
+                    hasActionCount(0)
+                    hasFrustrationCount(0)
+                    hasLongTaskCount(1)
+                    hasFrozenFrameCount(1)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(null, null)
+                    isActive(true)
+                    isSlowRendered(false)
+                    hasNoCustomTimings()
+                    hasUserInfo(fakeDatadogContext.userInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasLiteSessionPlan()
+                    hasReplay(fakeHasReplay)
+                    containsExactlyContextAttributes(fakeAttributes)
+                    hasSource(fakeSourceViewEvent)
+                    hasDeviceInfo(
+                        fakeDatadogContext.deviceInfo.deviceName,
+                        fakeDatadogContext.deviceInfo.deviceModel,
+                        fakeDatadogContext.deviceInfo.deviceBrand,
+                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
+                        fakeDatadogContext.deviceInfo.architecture
+                    )
+                    hasOsInfo(
+                        fakeDatadogContext.deviceInfo.osName,
+                        fakeDatadogContext.deviceInfo.osVersion,
+                        fakeDatadogContext.deviceInfo.osMajorVersion
+                    )
+                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasServiceName(fakeDatadogContext.service)
+                    hasVersion(fakeDatadogContext.version)
+                    hasSessionActive(fakeParentContext.isSessionActive)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+        assertThat(testedScope.pendingLongTaskCount).isEqualTo(pendingLongTask - 1)
+        assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(pendingFrozenFrame - 1)
+    }
+
+    @Test
+    fun `𝕄 send event 𝕎 handleEvent(LongTaskSent) on active view {frozen, viewId changed}`(
+        @LongForgery(1) pendingLongTask: Long,
+        @LongForgery(1) pendingFrozenFrame: Long,
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        fakeEvent = RumRawEvent.LongTaskSent(testedScope.viewId, true)
+        testedScope.pendingLongTaskCount = pendingLongTask
+        testedScope.pendingFrozenFrameCount = pendingFrozenFrame
+        testedScope.viewId = fakeNewViewId.toString()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
@@ -3285,11 +3627,43 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `𝕄 decrease pending Action 𝕎 handleEvent(ActionDropped) on active view {viewId changed}`(
+        @LongForgery(1) pending: Long,
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingActionCount = pending
+        fakeEvent = RumRawEvent.ActionDropped(testedScope.viewId)
+        testedScope.viewId = fakeNewViewId.toString()
+
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        assertThat(testedScope.pendingActionCount).isEqualTo(pending - 1)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
     fun `𝕄 decrease pending Action 𝕎 handleEvent(ActionDropped) on stopped view`() {
         // Given
         testedScope.pendingActionCount = 1
         fakeEvent = RumRawEvent.ActionDropped(testedScope.viewId)
         testedScope.stopped = true
+
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        assertThat(testedScope.pendingActionCount).isEqualTo(0)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `𝕄 decrease pending Action 𝕎 handleEvent(ActionDropped) on stopped view {viewId changed}`(
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingActionCount = 1
+        fakeEvent = RumRawEvent.ActionDropped(testedScope.viewId)
+        testedScope.stopped = true
+        testedScope.viewId = fakeNewViewId.toString()
 
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
@@ -3488,11 +3862,43 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `𝕄 decrease pending Resource 𝕎 handleEvent(ResourceDropped) on active view {viewId changed}`(
+        @LongForgery(1) pending: Long,
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingResourceCount = pending
+        fakeEvent = RumRawEvent.ResourceDropped(testedScope.viewId)
+        testedScope.viewId = fakeNewViewId.toString()
+
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        assertThat(testedScope.pendingResourceCount).isEqualTo(pending - 1)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
     fun `𝕄 decrease pending Resource 𝕎 handleEvent(ResourceDropped) on stopped view`() {
         // Given
         testedScope.pendingResourceCount = 1
         fakeEvent = RumRawEvent.ResourceDropped(testedScope.viewId)
         testedScope.stopped = true
+
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        assertThat(testedScope.pendingResourceCount).isEqualTo(0)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `𝕄 decrease pending Resource 𝕎 handleEvent(ResourceDropped) on stopped view {viewId changed}`(
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingResourceCount = 1
+        fakeEvent = RumRawEvent.ResourceDropped(testedScope.viewId)
+        testedScope.stopped = true
+        testedScope.viewId = fakeNewViewId.toString()
 
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
@@ -4759,11 +5165,43 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `𝕄 decrease pending Error 𝕎 handleEvent(ErrorDropped) on active view {viewId changed}`(
+        @LongForgery(1) pending: Long,
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingErrorCount = pending
+        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId)
+        testedScope.viewId = fakeNewViewId.toString()
+
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        assertThat(testedScope.pendingErrorCount).isEqualTo(pending - 1)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
     fun `𝕄 decrease pending Error 𝕎 handleEvent(ErrorDropped) on stopped view`() {
         // Given
         testedScope.pendingErrorCount = 1
         fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId)
         testedScope.stopped = true
+
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        assertThat(testedScope.pendingErrorCount).isEqualTo(0)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `𝕄 decrease pending Error 𝕎 handleEvent(ErrorDropped) on stopped view {viewId changed}`(
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingErrorCount = 1
+        fakeEvent = RumRawEvent.ErrorDropped(testedScope.viewId)
+        testedScope.stopped = true
+        testedScope.viewId = fakeNewViewId.toString()
 
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
@@ -5107,6 +5545,27 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `𝕄 decrease pending Long Task 𝕎 handleEvent(LongTaskDropped) on active view {not frozen, viewId changed}`(
+        @LongForgery(1) pendingLongTask: Long,
+        @LongForgery(1) pendingFrozenFrame: Long,
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingLongTaskCount = pendingLongTask
+        testedScope.pendingFrozenFrameCount = pendingFrozenFrame
+        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, false)
+        testedScope.viewId = fakeNewViewId.toString()
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.pendingLongTaskCount).isEqualTo(pendingLongTask - 1)
+        assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(pendingFrozenFrame)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
     fun `𝕄 decrease pending LT and FF 𝕎 handleEvent(LongTaskDropped) on active view {frozen}`(
         @LongForgery(1) pendingLongTask: Long,
         @LongForgery(1) pendingFrozenFrame: Long
@@ -5115,6 +5574,27 @@ internal class RumViewScopeTest {
         testedScope.pendingLongTaskCount = pendingLongTask
         testedScope.pendingFrozenFrameCount = pendingFrozenFrame
         fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, true)
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.pendingLongTaskCount).isEqualTo(pendingLongTask - 1)
+        assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(pendingFrozenFrame - 1)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
+    fun `𝕄 decrease pending LT and FF 𝕎 handleEvent(LongTaskDropped) on active view {frozen, viewId changed}`(
+        @LongForgery(1) pendingLongTask: Long,
+        @LongForgery(1) pendingFrozenFrame: Long,
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingLongTaskCount = pendingLongTask
+        testedScope.pendingFrozenFrameCount = pendingFrozenFrame
+        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, true)
+        testedScope.viewId = fakeNewViewId.toString()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
@@ -5143,12 +5623,52 @@ internal class RumViewScopeTest {
     }
 
     @Test
+    fun `𝕄 decrease pending LT 𝕎 handleEvent(LongTaskDropped) on stopped view {not frozen, viewId changed}`(
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingLongTaskCount = 1
+        testedScope.pendingFrozenFrameCount = 0
+        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, false)
+        testedScope.stopped = true
+        testedScope.viewId = fakeNewViewId.toString()
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.pendingLongTaskCount).isEqualTo(0)
+        assertThat(testedScope.pendingFrozenFrameCount).isEqualTo(0)
+        assertThat(result).isNull()
+    }
+
+    @Test
     fun `𝕄 decrease pending LT and FF 𝕎 handleEvent(LongTaskDropped) on stopped view {frozen}`() {
         // Given
         testedScope.pendingLongTaskCount = 1
         testedScope.pendingFrozenFrameCount = 1
         fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, true)
         testedScope.stopped = true
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.pendingLongTaskCount).isEqualTo(0)
+        assertThat(testedScope.pendingLongTaskCount).isEqualTo(0)
+        assertThat(result).isNull()
+    }
+
+    @Test
+    fun `𝕄 decrease pending LT and FF 𝕎 handleEvent(LongTaskDropped) on stopped view {frozen, viewId changed}`(
+        @Forgery fakeNewViewId: UUID
+    ) {
+        // Given
+        testedScope.pendingLongTaskCount = 1
+        testedScope.pendingFrozenFrameCount = 1
+        fakeEvent = RumRawEvent.LongTaskDropped(testedScope.viewId, true)
+        testedScope.stopped = true
+        testedScope.viewId = fakeNewViewId.toString()
 
         // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)


### PR DESCRIPTION
### What does this PR do?

We need to keep old RUM view scope IDs, because `viewId` can be changed on the [session renewal](https://github.com/DataDog/dd-sdk-android/blob/c9ab67cf0a1565f94a0ed3002eb5a6a78ad0cde0/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt#L199), meaning that events like `ActionSent`, etc. which do the match by `viewId` won't match, because they will carry old `viewId`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

