### PR TITLE
RUMM-3318: Improve Java public API surface

### DIFF
--- a/dd-sdk-android/api/dd-sdk-android.api
+++ b/dd-sdk-android/api/dd-sdk-android.api
@@ -10,7 +10,7 @@ public final class com/datadog/android/BuildConfig {
 
 public final class com/datadog/android/Datadog {
 	public static final field INSTANCE Lcom/datadog/android/Datadog;
-	public final fun _internalProxy (Ljava/lang/String;)Lcom/datadog/android/_InternalProxy;
+	public final synthetic fun _internalProxy (Ljava/lang/String;)Lcom/datadog/android/_InternalProxy;
 	public static synthetic fun _internalProxy$default (Lcom/datadog/android/Datadog;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/_InternalProxy;
 	public static final fun getInstance ()Lcom/datadog/android/v2/api/SdkCore;
 	public static final fun getInstance (Ljava/lang/String;)Lcom/datadog/android/v2/api/SdkCore;
@@ -36,13 +36,13 @@ public final class com/datadog/android/DatadogSite : java/lang/Enum {
 	public static final field US3 Lcom/datadog/android/DatadogSite;
 	public static final field US5 Lcom/datadog/android/DatadogSite;
 	public final fun getIntakeEndpoint ()Ljava/lang/String;
-	public final fun getSiteName ()Ljava/lang/String;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/DatadogSite;
 	public static fun values ()[Lcom/datadog/android/DatadogSite;
 }
 
 public final class com/datadog/android/SdkReference {
 	public fun <init> ()V
+	public fun <init> (Ljava/lang/String;)V
 	public fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
 	public synthetic fun <init> (Ljava/lang/String;Lkotlin/jvm/functions/Function1;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun get ()Lcom/datadog/android/v2/api/SdkCore;
@@ -145,7 +145,6 @@ public final class com/datadog/android/core/constraints/DataConstraints$DefaultI
 
 public final class com/datadog/android/core/constraints/DatadogDataConstraints : com/datadog/android/core/constraints/DataConstraints {
 	public fun <init> (Lcom/datadog/android/v2/api/InternalLogger;)V
-	public final fun getInternalLogger ()Lcom/datadog/android/v2/api/InternalLogger;
 	public fun validateAttributes (Ljava/util/Map;Ljava/lang/String;Ljava/lang/String;Ljava/util/Set;)Ljava/util/Map;
 	public fun validateTags (Ljava/util/List;)Ljava/util/List;
 	public fun validateTimings (Ljava/util/Map;)Ljava/util/Map;

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -242,6 +242,7 @@ object Datadog {
      * @see _InternalProxy
      */
     @Suppress("FunctionNaming", "FunctionName")
+    @JvmSynthetic
     fun _internalProxy(instanceName: String? = null): _InternalProxy {
         return _InternalProxy(getInstance(instanceName))
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogSite.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/DatadogSite.kt
@@ -13,7 +13,7 @@ package com.datadog.android
  * instance ID (because this value is used there) in case if enum values are renamed.
  * @property intakeHostName the host name for the given site.
  */
-enum class DatadogSite(val siteName: String, private val intakeHostName: String) {
+enum class DatadogSite(internal val siteName: String, private val intakeHostName: String) {
 
     /**
      *  The US1 site: [app.datadoghq.com](https://app.datadoghq.com).

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/SdkReference.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/SdkReference.kt
@@ -23,7 +23,7 @@ import java.util.concurrent.atomic.AtomicReference
  * SDK instance will be checked.
  * @param onSdkInstanceCaptured Callback which will be fired once SDK instance is acquired.
  */
-class SdkReference(
+class SdkReference @JvmOverloads constructor(
     private val sdkInstanceName: String? = null,
     private val onSdkInstanceCaptured: (SdkCore) -> Unit = {}
 ) {

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/constraints/DatadogDataConstraints.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/constraints/DatadogDataConstraints.kt
@@ -17,7 +17,7 @@ internal typealias StringTransform = (String) -> String?
  *
  * @param internalLogger Internal logger.
  */
-class DatadogDataConstraints(val internalLogger: InternalLogger) : DataConstraints {
+class DatadogDataConstraints(private val internalLogger: InternalLogger) : DataConstraints {
 
     // region DataConstraints
 

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -115,7 +115,7 @@ public final class com/datadog/android/rum/RumFeature$Builder {
 }
 
 public abstract interface class com/datadog/android/rum/RumMonitor {
-	public abstract fun _getInternal ()Lcom/datadog/android/rum/_RumInternalProxy;
+	public abstract synthetic fun _getInternal ()Lcom/datadog/android/rum/_RumInternalProxy;
 	public abstract fun addAttribute (Ljava/lang/String;Ljava/lang/Object;)V
 	public abstract fun addError (Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public abstract fun addErrorWithStacktrace (Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/util/Map;)V

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -290,6 +290,7 @@ interface RumMonitor {
      * @see _RumInternalProxy
      */
     @Suppress("FunctionName")
+    @JvmSynthetic
     fun _getInternal(): _RumInternalProxy?
 
     // region Builder

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -33,7 +33,6 @@ abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseWi
   protected fun colorAndAlphaAsStringHexa(Int, Int): String
   protected fun resolveViewGlobalBounds(android.view.View, Float): com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
   protected fun android.graphics.drawable.Drawable.resolveShapeStyleAndBorder(Float): Pair<com.datadog.android.sessionreplay.model.MobileSegment.ShapeStyle?, com.datadog.android.sessionreplay.model.MobileSegment.ShapeBorder?>?
-  companion object 
 class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllTextViewMapper : TextViewMapper
   constructor()
 class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskInputTextViewMapper : TextViewMapper
@@ -41,7 +40,6 @@ class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskInputTextVi
 open class com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper : BaseWireframeMapper<android.widget.TextView, com.datadog.android.sessionreplay.model.MobileSegment.Wireframe.TextWireframe>
   constructor()
   override fun map(android.widget.TextView, com.datadog.android.sessionreplay.internal.recorder.MappingContext): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe.TextWireframe>
-  companion object 
 interface com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper<T: android.view.View, S: com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
   fun map(T, com.datadog.android.sessionreplay.internal.recorder.MappingContext): List<S>
 object com.datadog.android.sessionreplay.utils.StringUtils

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -88,7 +88,6 @@ public final class com/datadog/android/sessionreplay/internal/recorder/SystemInf
 }
 
 public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper {
-	public static final field Companion Lcom/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper$Companion;
 	public fun <init> ()V
 	public fun <init> (Lcom/datadog/android/sessionreplay/utils/StringUtils;Lcom/datadog/android/sessionreplay/utils/ViewUtils;)V
 	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/utils/StringUtils;Lcom/datadog/android/sessionreplay/utils/ViewUtils;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
@@ -96,9 +95,6 @@ public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper
 	protected final fun resolveShapeStyleAndBorder (Landroid/graphics/drawable/Drawable;F)Lkotlin/Pair;
 	protected final fun resolveViewGlobalBounds (Landroid/view/View;F)Lcom/datadog/android/sessionreplay/internal/recorder/GlobalBounds;
 	protected final fun resolveViewId (Landroid/view/View;)J
-}
-
-public final class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper$Companion {
 }
 
 public final class com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllTextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper {
@@ -110,13 +106,9 @@ public final class com/datadog/android/sessionreplay/internal/recorder/mapper/Ma
 }
 
 public class com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper {
-	public static final field Companion Lcom/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper$Companion;
 	public fun <init> ()V
 	public synthetic fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;)Ljava/util/List;
 	public fun map (Landroid/widget/TextView;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;)Ljava/util/List;
-}
-
-public final class com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper$Companion {
 }
 
 public abstract interface class com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
@@ -78,7 +78,7 @@ abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wireframe>(
         }
     }
 
-    companion object {
+    internal companion object {
         internal const val OPAQUE_ALPHA_VALUE: Int = 255
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper.kt
@@ -163,7 +163,7 @@ open class TextViewMapper :
 
     // endregion
 
-    companion object {
+    internal companion object {
         internal const val STATIC_MASK = "***"
         internal const val SANS_SERIF_FAMILY_NAME = "roboto, sans-serif"
         internal const val SERIF_FAMILY_NAME = "serif"

--- a/integrations/dd-sdk-android-coil/api/apiSurface
+++ b/integrations/dd-sdk-android-coil/api/apiSurface
@@ -1,4 +1,3 @@
 class com.datadog.android.coil.DatadogCoilRequestListener : coil.request.ImageRequest.Listener
   constructor(com.datadog.android.v2.api.SdkCore)
   override fun onError(coil.request.ImageRequest, Throwable)
-  companion object 

--- a/integrations/dd-sdk-android-coil/api/dd-sdk-android-coil.api
+++ b/integrations/dd-sdk-android-coil/api/dd-sdk-android-coil.api
@@ -1,12 +1,8 @@
 public final class com/datadog/android/coil/DatadogCoilRequestListener : coil/request/ImageRequest$Listener {
-	public static final field Companion Lcom/datadog/android/coil/DatadogCoilRequestListener$Companion;
 	public fun <init> (Lcom/datadog/android/v2/api/SdkCore;)V
 	public fun onCancel (Lcoil/request/ImageRequest;)V
 	public fun onError (Lcoil/request/ImageRequest;Ljava/lang/Throwable;)V
 	public fun onStart (Lcoil/request/ImageRequest;)V
 	public fun onSuccess (Lcoil/request/ImageRequest;Lcoil/request/ImageResult$Metadata;)V
-}
-
-public final class com/datadog/android/coil/DatadogCoilRequestListener$Companion {
 }
 

--- a/integrations/dd-sdk-android-coil/src/main/kotlin/com/datadog/android/coil/DatadogCoilRequestListener.kt
+++ b/integrations/dd-sdk-android-coil/src/main/kotlin/com/datadog/android/coil/DatadogCoilRequestListener.kt
@@ -71,7 +71,7 @@ class DatadogCoilRequestListener(
 
     // endregion
 
-    companion object {
+    internal companion object {
         internal const val REQUEST_ERROR_MESSAGE = "Coil request error"
         internal const val REQUEST_PATH_TAG = "request_path"
     }

--- a/integrations/dd-sdk-android-fresco/api/apiSurface
+++ b/integrations/dd-sdk-android-fresco/api/apiSurface
@@ -8,4 +8,3 @@ class com.datadog.android.fresco.DatadogFrescoCacheListener : com.facebook.cache
   override fun onWriteAttempt(com.facebook.cache.common.CacheEvent)
   override fun onWriteSuccess(com.facebook.cache.common.CacheEvent)
   override fun onWriteException(com.facebook.cache.common.CacheEvent)
-  companion object 

--- a/integrations/dd-sdk-android-fresco/api/dd-sdk-android-fresco.api
+++ b/integrations/dd-sdk-android-fresco/api/dd-sdk-android-fresco.api
@@ -1,5 +1,4 @@
 public final class com/datadog/android/fresco/DatadogFrescoCacheListener : com/facebook/cache/common/CacheEventListener {
-	public static final field Companion Lcom/datadog/android/fresco/DatadogFrescoCacheListener$Companion;
 	public fun <init> (Lcom/datadog/android/v2/api/SdkCore;)V
 	public fun onCleared ()V
 	public fun onEviction (Lcom/facebook/cache/common/CacheEvent;)V
@@ -9,8 +8,5 @@ public final class com/datadog/android/fresco/DatadogFrescoCacheListener : com/f
 	public fun onWriteAttempt (Lcom/facebook/cache/common/CacheEvent;)V
 	public fun onWriteException (Lcom/facebook/cache/common/CacheEvent;)V
 	public fun onWriteSuccess (Lcom/facebook/cache/common/CacheEvent;)V
-}
-
-public final class com/datadog/android/fresco/DatadogFrescoCacheListener$Companion {
 }
 

--- a/integrations/dd-sdk-android-fresco/src/main/kotlin/com/datadog/android/fresco/DatadogFrescoCacheListener.kt
+++ b/integrations/dd-sdk-android-fresco/src/main/kotlin/com/datadog/android/fresco/DatadogFrescoCacheListener.kt
@@ -93,7 +93,7 @@ class DatadogFrescoCacheListener(
 
     // endregion
 
-    companion object {
+    internal companion object {
         internal const val CACHE_ENTRY_URI_TAG: String = "cache_entry_uri"
         internal const val CACHE_ERROR_READ_MESSAGE = "Fresco Disk Cache Read error"
         internal const val CACHE_ERROR_WRITE_MESSAGE = "Fresco Disk Cache Write error"

--- a/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
+++ b/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
@@ -6,8 +6,6 @@ public final class com/datadog/android/okhttp/DatadogEventListener : okhttp3/Eve
 	public fun connectStart (Lokhttp3/Call;Ljava/net/InetSocketAddress;Ljava/net/Proxy;)V
 	public fun dnsEnd (Lokhttp3/Call;Ljava/lang/String;Ljava/util/List;)V
 	public fun dnsStart (Lokhttp3/Call;Ljava/lang/String;)V
-	public final fun getKey ()Ljava/lang/String;
-	public final fun getSdkCore ()Lcom/datadog/android/v2/api/SdkCore;
 	public fun responseBodyEnd (Lokhttp3/Call;J)V
 	public fun responseBodyStart (Lokhttp3/Call;)V
 	public fun responseHeadersEnd (Lokhttp3/Call;Lokhttp3/Response;)V

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
@@ -46,8 +46,8 @@ import java.net.Proxy
  */
 class DatadogEventListener
 internal constructor(
-    val sdkCore: SdkCore,
-    val key: String
+    internal val sdkCore: SdkCore,
+    internal val key: String
 ) : EventListener() {
 
     private var callStart = 0L

--- a/integrations/dd-sdk-android-rx/api/apiSurface
+++ b/integrations/dd-sdk-android-rx/api/apiSurface
@@ -1,7 +1,6 @@
 class com.datadog.android.rx.DatadogRumErrorConsumer : io.reactivex.rxjava3.functions.Consumer<Throwable>
   constructor(com.datadog.android.v2.api.SdkCore)
   override fun accept(Throwable)
-  companion object 
 fun <T: Any> io.reactivex.rxjava3.core.Observable<T>.sendErrorToDatadog(com.datadog.android.v2.api.SdkCore): io.reactivex.rxjava3.core.Observable<T>
 fun <T: Any> io.reactivex.rxjava3.core.Single<T>.sendErrorToDatadog(com.datadog.android.v2.api.SdkCore): io.reactivex.rxjava3.core.Single<T>
 fun <T: Any> io.reactivex.rxjava3.core.Flowable<T>.sendErrorToDatadog(com.datadog.android.v2.api.SdkCore): io.reactivex.rxjava3.core.Flowable<T>

--- a/integrations/dd-sdk-android-rx/api/dd-sdk-android-rx.api
+++ b/integrations/dd-sdk-android-rx/api/dd-sdk-android-rx.api
@@ -1,11 +1,7 @@
 public final class com/datadog/android/rx/DatadogRumErrorConsumer : io/reactivex/rxjava3/functions/Consumer {
-	public static final field Companion Lcom/datadog/android/rx/DatadogRumErrorConsumer$Companion;
 	public fun <init> (Lcom/datadog/android/v2/api/SdkCore;)V
 	public synthetic fun accept (Ljava/lang/Object;)V
 	public fun accept (Ljava/lang/Throwable;)V
-}
-
-public final class com/datadog/android/rx/DatadogRumErrorConsumer$Companion {
 }
 
 public final class com/datadog/android/rx/DatadogRxExtKt {

--- a/integrations/dd-sdk-android-rx/src/main/kotlin/com/datadog/android/rx/DatadogRumErrorConsumer.kt
+++ b/integrations/dd-sdk-android-rx/src/main/kotlin/com/datadog/android/rx/DatadogRumErrorConsumer.kt
@@ -28,7 +28,7 @@ class DatadogRumErrorConsumer(
         GlobalRum.get(sdkCore).addError(REQUEST_ERROR_MESSAGE, RumErrorSource.SOURCE, error, emptyMap())
     }
 
-    companion object {
+    internal companion object {
         internal const val REQUEST_ERROR_MESSAGE = "RxJava stream error"
     }
 }

--- a/integrations/dd-sdk-android-sqldelight/api/apiSurface
+++ b/integrations/dd-sdk-android-sqldelight/api/apiSurface
@@ -1,7 +1,6 @@
 class com.datadog.android.sqldelight.DatadogSqliteCallback : com.squareup.sqldelight.android.AndroidSqliteDriver.Callback
   constructor(com.squareup.sqldelight.db.SqlDriver.Schema, com.datadog.android.v2.api.SdkCore)
   override fun onCorruption(androidx.sqlite.db.SupportSQLiteDatabase)
-  companion object 
 fun <T: com.squareup.sqldelight.Transacter> T.transactionTraced(String, Boolean = false, TransactionWithSpanAndWithoutReturn.() -> Unit)
 fun <T: com.squareup.sqldelight.Transacter, R> T.transactionTracedWithResult(String, Boolean = false, TransactionWithSpanAndWithReturn<R>.() -> R): R
 interface com.datadog.android.sqldelight.TransactionWithSpanAndWithReturn<R> : com.squareup.sqldelight.TransactionWithReturn<R>, io.opentracing.Span

--- a/integrations/dd-sdk-android-sqldelight/api/dd-sdk-android-sqldelight.api
+++ b/integrations/dd-sdk-android-sqldelight/api/dd-sdk-android-sqldelight.api
@@ -1,10 +1,6 @@
 public final class com/datadog/android/sqldelight/DatadogSqliteCallback : com/squareup/sqldelight/android/AndroidSqliteDriver$Callback {
-	public static final field Companion Lcom/datadog/android/sqldelight/DatadogSqliteCallback$Companion;
 	public fun <init> (Lcom/squareup/sqldelight/db/SqlDriver$Schema;Lcom/datadog/android/v2/api/SdkCore;)V
 	public fun onCorruption (Landroidx/sqlite/db/SupportSQLiteDatabase;)V
-}
-
-public final class com/datadog/android/sqldelight/DatadogSqliteCallback$Companion {
 }
 
 public final class com/datadog/android/sqldelight/SqlDelightExtKt {

--- a/integrations/dd-sdk-android-sqldelight/src/main/kotlin/com/datadog/android/sqldelight/DatadogSqliteCallback.kt
+++ b/integrations/dd-sdk-android-sqldelight/src/main/kotlin/com/datadog/android/sqldelight/DatadogSqliteCallback.kt
@@ -47,7 +47,7 @@ class DatadogSqliteCallback(
             )
     }
 
-    companion object {
+    internal companion object {
         internal const val DATABASE_CORRUPTION_ERROR_MESSAGE =
             "Corruption reported by sqlite database: %s"
     }


### PR DESCRIPTION
### What does this PR do?

This PR does the minor changes to the codebase to improve the public API surface from the Java side:

* All internal proxy methods are made synthetic - they are supposed to be called only by us and only from Kotlin, no need to have them in Java.
* No changes are done to the classes in the `internal` packages, they are used only by us.
* Prevent empty `Companion` objects from being visible.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

