### PR TITLE
Revert SdkInit command changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 1.19.2 / 2023-06-05
+
+* [REVERT] RUM: Force new session at SDK initialization. See [#1399](https://github.com/DataDog/dd-sdk-android/pull/1399)
+
 # 1.19.1 / 2023-05-30
 
 * [IMPROVEMENT] RUM: Force new session at SDK initialization. See [#1399](https://github.com/DataDog/dd-sdk-android/pull/1399)

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -19,7 +19,7 @@ object AndroidConfig {
     const val MIN_SDK_FOR_WEAR = 23
     const val BUILD_TOOLS_VERSION = "33.0.0"
 
-    val VERSION = Version(1, 19, 1, Version.Type.Release)
+    val VERSION = Version(1, 19, 2, Version.Type.Release)
 }
 
 @Suppress("UnstableApiUsage")

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -204,10 +204,6 @@ internal sealed class RumRawEvent {
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
-    internal data class SdkInit(
-        override val eventTime: Time = Time()
-    ) : RumRawEvent()
-
     internal data class WebViewEvent(override val eventTime: Time = Time()) : RumRawEvent()
 
     internal data class SendTelemetry(

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -146,9 +146,7 @@ internal class RumSessionScope(
         val isInteraction = (event is RumRawEvent.StartView) || (event is RumRawEvent.StartAction)
         val isBackgroundEvent = (event.javaClass in RumViewManagerScope.validBackgroundEventTypes)
 
-        if (event is RumRawEvent.SdkInit && isNewSession) {
-            renewSession(nanoTime)
-        } else if (isInteraction) {
+        if (isInteraction) {
             if (isNewSession || isExpired || isTimedOut) {
                 renewSession(nanoTime)
             }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -64,8 +64,7 @@ internal class DatadogRumMonitor(
     frameRateVitalMonitor: VitalMonitor,
     sessionListener: RumSessionListener?,
     contextProvider: ContextProvider,
-    private val executorService: ExecutorService = Executors.newSingleThreadExecutor(),
-    sendSdkInit: Boolean = true
+    private val executorService: ExecutorService = Executors.newSingleThreadExecutor()
 ) : RumMonitor, AdvancedRumMonitor {
 
     internal var rootScope: RumScope = RumApplicationScope(
@@ -96,9 +95,6 @@ internal class DatadogRumMonitor(
 
     init {
         handler.postDelayed(keepAliveRunnable, KEEP_ALIVE_MS)
-        if (sendSdkInit) {
-            sendSdkInitEvent()
-        }
     }
 
     // region RumMonitor
@@ -509,12 +505,6 @@ internal class DatadogRumMonitor(
             "flutter" -> RumErrorSourceType.FLUTTER
             else -> RumErrorSourceType.ANDROID
         }
-    }
-
-    private fun sendSdkInitEvent() {
-        handleEvent(
-            RumRawEvent.SdkInit()
-        )
     }
 
     // endregion

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -284,23 +284,6 @@ internal class RumSessionScopeTest {
     }
 
     @Test
-    fun `𝕄 create new session context 𝕎 handleEvent(sdkInit)+getRumContext() {sampling = 100}`() {
-        // Given
-        initializeTestedScope(100f)
-
-        // When
-        val result = testedScope.handleEvent(RumRawEvent.SdkInit(), mockWriter)
-        val context = testedScope.getRumContext()
-
-        // Then
-        assertThat(result).isSameAs(testedScope)
-        assertThat(context.sessionId).isNotEqualTo(RumContext.NULL_UUID)
-        assertThat(context.sessionState).isEqualTo(RumSessionScope.State.TRACKED)
-        assertThat(context.applicationId).isEqualTo(fakeParentContext.applicationId)
-        assertThat(context.viewId).isEqualTo(fakeParentContext.viewId)
-    }
-
-    @Test
     fun `𝕄 create new session context 𝕎 handleEvent(view)+getRumContext() {sampling = 100}`(
         forge: Forge
     ) {

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -159,8 +159,7 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
-            mockContextProvider,
-            sendSdkInit = false
+            mockContextProvider
         )
         testedMonitor.rootScope = mockScope
     }
@@ -1132,39 +1131,6 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
-    fun `M delegate SdkInit event to rootScope W init()`() {
-        // When
-        testedMonitor = DatadogRumMonitor(
-            fakeApplicationId,
-            mockSdkCore,
-            fakeSamplingRate,
-            fakeBackgroundTrackingEnabled,
-            fakeTrackFrustrations,
-            mockWriter,
-            mockHandler,
-            mockTelemetryEventHandler,
-            mockResolver,
-            mockCpuVitalMonitor,
-            mockMemoryVitalMonitor,
-            mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockContextProvider,
-            sendSdkInit = true
-        )
-        testedMonitor.rootScope = mockScope
-
-        Thread.sleep(PROCESSING_DELAY)
-
-        // Then
-        verify(mockScope).handleEvent(
-            argThat { this is RumRawEvent.SdkInit },
-            same(mockWriter)
-        )
-
-        verifyNoMoreInteractions(mockScope, mockWriter)
-    }
-
-    @Test
     fun `delays keep alive runnable on other event`() {
         val mockEvent: RumRawEvent = mock()
         val runnable = testedMonitor.keepAliveRunnable
@@ -1292,8 +1258,7 @@ internal class DatadogRumMonitorTest {
             mockFrameRateVitalMonitor,
             mockSessionListener,
             mockContextProvider,
-            mockExecutorService,
-            false
+            mockExecutorService
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)
 
@@ -1605,8 +1570,7 @@ internal class DatadogRumMonitorTest {
             mockFrameRateVitalMonitor,
             mockSessionListener,
             mockContextProvider,
-            executorService = mockExecutorService,
-            false
+            executorService = mockExecutorService
         )
 
         var isMethodOccupied = false


### PR DESCRIPTION
### What does this PR do?

This PR reverts changes related to the `SdkInit` command (because it may introduce unwanted sessions) and prepares 1.19.2 release.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

