### PR TITLE
Update GSON library to version 2.10.1

### DIFF
--- a/buildSrc/src/test/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
@@ -54,7 +54,7 @@ internal fun Any?.fromJsonElement(): Any? {
                 this
             }
         }
-        is JsonObject -> this.asMap()
+        is JsonObject -> this.asDeepMap()
         else -> this
     }
 }
@@ -67,7 +67,7 @@ internal fun Iterable<*>.toJsonArray(): JsonElement {
     return array
 }
 
-internal fun JsonObject.asMap(): Map<String, Any?> {
+internal fun JsonObject.asDeepMap(): Map<String, Any?> {
     val map = mutableMapOf<String, Any?>()
     entrySet().forEach {
         map[it.key] = it.value.fromJsonElement()
@@ -75,9 +75,9 @@ internal fun JsonObject.asMap(): Map<String, Any?> {
     return map
 }
 
-internal fun JsonElement?.asMap(): Map<String, Any?> {
+internal fun JsonElement?.asDeepMap(): Map<String, Any?> {
     return if (this is JsonObject) {
-        this.asMap()
+        this.asDeepMap()
     } else {
         emptyMap()
     }

--- a/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelValidationTest.kt
+++ b/buildSrc/src/test/kotlin/com/datadog/gradle/plugin/jsonschema/ModelValidationTest.kt
@@ -155,7 +155,7 @@ class ModelValidationTest(
             is JsonObject -> v1.asJsonObject.toString() != v2.toString()
             is JsonArray -> v1.asJsonArray != v2
             is Iterable<*> -> v1.asJsonArray.toList() != v2
-            is Map<*, *> -> mapTypeComparator.compare(v1.asJsonObject.asMap(), v2) == 0
+            is Map<*, *> -> mapTypeComparator.compare(v1.asJsonObject.asDeepMap(), v2) == 0
             else -> v1.asString != v2.toString()
         }
     }
@@ -166,7 +166,7 @@ class ModelValidationTest(
         }
     }
 
-    internal fun JsonObject.asMap(): Map<String, Any?> {
+    internal fun JsonObject.asDeepMap(): Map<String, Any?> {
         val map = mutableMapOf<String, Any?>()
         entrySet().forEach {
             map[it.key] = it.value.fromJsonElement()

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/utils/MiscUtils.kt
@@ -94,7 +94,7 @@ internal fun Any?.fromJsonElement(): Any? {
                 this
             }
         }
-        is JsonObject -> this.asMap()
+        is JsonObject -> this.asDeepMap()
         else -> this
     }
 }
@@ -133,7 +133,7 @@ internal fun JSONArray.toJsonArray(): JsonElement {
     return obj
 }
 
-internal fun JsonObject.asMap(): Map<String, Any?> {
+internal fun JsonObject.asDeepMap(): Map<String, Any?> {
     val map = mutableMapOf<String, Any?>()
     entrySet().forEach {
         map[it.key] = it.value.fromJsonElement()
@@ -141,9 +141,9 @@ internal fun JsonObject.asMap(): Map<String, Any?> {
     return map
 }
 
-internal fun JsonElement?.asMap(): Map<String, Any?> {
+internal fun JsonElement?.asDeepMap(): Map<String, Any?> {
     return if (this is JsonObject) {
-        this.asMap()
+        this.asDeepMap()
     } else {
         emptyMap()
     }

--- a/dd-sdk-android/transitiveDependencies
+++ b/dd-sdk-android/transitiveDependencies
@@ -32,7 +32,7 @@ androidx.startup:startup-runtime:1.0.0                          :   18 Kb
 androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
 androidx.viewpager:viewpager:1.0.0                              :   52 Kb
 androidx.work:work-runtime:2.7.0                                : 1493 Kb
-com.google.code.gson:gson:2.8.8                                 :  236 Kb
+com.google.code.gson:gson:2.10.1                                :  276 Kb
 com.google.guava:listenablefuture:1.0                           :    3 Kb
 com.lyft.kronos:kronos-android:0.0.1-alpha11                    :    5 Kb
 com.lyft.kronos:kronos-java:0.0.1-alpha11                       :   29 Kb

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 # Commons
 kotlin = "1.8.10"
 kotlinSP = "1.8.10-1.0.9"
-gson = "2.8.8"
+gson = "2.10.1"
 okHttp = "3.12.13"
 kronosNTP = "0.0.1-alpha11"
 

--- a/library/dd-sdk-android-session-replay/transitiveDependencies
+++ b/library/dd-sdk-android-session-replay/transitiveDependencies
@@ -26,7 +26,7 @@ androidx.vectordrawable:vectordrawable-animated:1.1.0           :   33 Kb
 androidx.vectordrawable:vectordrawable:1.1.0                    :   32 Kb
 androidx.versionedparcelable:versionedparcelable:1.1.1          :   30 Kb
 androidx.viewpager:viewpager:1.0.0                              :   52 Kb
-com.google.code.gson:gson:2.8.8                                 :  236 Kb
+com.google.code.gson:gson:2.10.1                                :  276 Kb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10                :  212 Kb
 org.jetbrains.kotlin:kotlin-stdlib:1.8.10                       : 1598 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb


### PR DESCRIPTION
### What does this PR do?

This PR updates GSON to the version `2.10.1`, changelog can be found [here](https://github.com/google/gson/releases). It is needed, because otherwise [mvrepository site reports vulnerability](https://mvnrepository.com/artifact/com.datadoghq/dd-sdk-android/1.19.0) from Gson lib (which doesn't affect us, but still better to get rid of it).

Gson added `JsonObject.asMap` method in version `2.10.0` which clashes obviously with the extension method we had in our codebase, so I had to rename out method to `asDeepMap`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

