### PR TITLE
Fix flaky test after 1.19.2 release merge

### DIFF
--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -6679,6 +6679,12 @@ internal class RumViewScopeTest {
             viewUpdatePredicate = mockViewUpdatePredicate,
             trackFrustrations = fakeTrackFrustrations
         )
+        whenever(
+            mockFeaturesContextResolver.resolveHasReplay(
+                fakeDatadogContext,
+                testedScope.viewId
+            )
+        ) doReturn fakeHasReplay
         val listenerCaptor = argumentCaptor<VitalListener> {
             verify(mockFrameRateVitalMonitor).register(capture())
         }


### PR DESCRIPTION
### What does this PR do?

There is a flaky test after https://github.com/DataDog/dd-sdk-android/pull/1461 merge, which wasn't updated there. Fixing it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

