### PR TITLE
REPLAY-1768 Extract RumContext logic from Processor

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorder.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorder.kt
@@ -18,6 +18,7 @@ import com.datadog.android.sessionreplay.internal.RecordCallback
 import com.datadog.android.sessionreplay.internal.RecordWriter
 import com.datadog.android.sessionreplay.internal.SessionReplayLifecycleCallback
 import com.datadog.android.sessionreplay.internal.processor.RecordedDataProcessor
+import com.datadog.android.sessionreplay.internal.processor.RumContextDataHandler
 import com.datadog.android.sessionreplay.internal.recorder.ComposedOptionSelectorDetector
 import com.datadog.android.sessionreplay.internal.recorder.DefaultOptionSelectorDetector
 import com.datadog.android.sessionreplay.internal.recorder.OptionSelectorDetector
@@ -72,6 +73,11 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         customOptionSelectorDetectors: List<OptionSelectorDetector> = emptyList(),
         windowInspector: WindowInspector = WindowInspector
     ) {
+        val rumContextDataHandler = RumContextDataHandler(
+            rumContextProvider,
+            timeProvider
+        )
+
         this.appContext = appContext
         this.rumContextProvider = rumContextProvider
         this.privacy = privacy
@@ -82,8 +88,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         this.customOptionSelectorDetectors = customOptionSelectorDetectors
         this.windowInspector = windowInspector
         this.processor = RecordedDataProcessor(
-            rumContextProvider,
-            timeProvider,
+            rumContextDataHandler,
             processorExecutorService,
             recordWriter,
             recordCallback

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RumContextData.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RumContextData.kt
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.processor
+
+import com.datadog.android.sessionreplay.internal.utils.SessionReplayRumContext
+
+internal data class RumContextData(
+    internal val timestamp: Long,
+    internal val newRumContext: SessionReplayRumContext,
+    internal val prevRumContext: SessionReplayRumContext
+)

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RumContextDataHandler.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RumContextDataHandler.kt
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.processor
+
+import androidx.annotation.MainThread
+import com.datadog.android.sessionreplay.internal.utils.RumContextProvider
+import com.datadog.android.sessionreplay.internal.utils.SessionReplayRumContext
+import com.datadog.android.sessionreplay.internal.utils.TimeProvider
+
+internal class RumContextDataHandler(
+    private val rumContextProvider: RumContextProvider,
+    private val timeProvider: TimeProvider
+) {
+    private var prevRumContext = SessionReplayRumContext()
+
+    @MainThread
+    internal fun createRumContextData(): RumContextData? {
+        // we will make sure we get the timestamp on the UI thread to avoid time skewing
+        val timestamp = timeProvider.getDeviceTimestamp()
+
+        // TODO: RUMM-2426 Fetch the RumContext from the core SDKContext when available
+        val newRumContext = rumContextProvider.getRumContext()
+
+        if (newRumContext.isNotValid()) {
+            // TODO: RUMM-2397 Add the proper logs here once the sdkLogger will be added
+            return null
+        }
+
+        val rumContextData = RumContextData(timestamp, newRumContext.copy(), prevRumContext.copy())
+
+        prevRumContext = newRumContext
+
+        return rumContextData
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ForgeConfigurator.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ForgeConfigurator.kt
@@ -48,6 +48,7 @@ internal class ForgeConfigurator : BaseConfigurator() {
         forge.addFactory(GlobalBoundsForgeryFactory())
         forge.addFactory(SystemInformationForgeryFactory())
         forge.addFactory(MappingContextForgeryFactory())
+        forge.addFactory(RumContextDataForgeryFactory())
 
         forge.useJvmFactories()
     }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/RumContextDataForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/RumContextDataForgeryFactory.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.forge
+
+import com.datadog.android.sessionreplay.internal.processor.RumContextData
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class RumContextDataForgeryFactory : ForgeryFactory<RumContextData> {
+    override fun getForgery(forge: Forge): RumContextData {
+        return RumContextData(
+            forge.aLong(),
+            forge.getForgery(),
+            forge.getForgery()
+        )
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessorTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessorTest.kt
@@ -12,7 +12,6 @@ import com.datadog.android.sessionreplay.internal.RecordCallback
 import com.datadog.android.sessionreplay.internal.RecordWriter
 import com.datadog.android.sessionreplay.internal.recorder.Node
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
-import com.datadog.android.sessionreplay.internal.utils.RumContextProvider
 import com.datadog.android.sessionreplay.internal.utils.SessionReplayRumContext
 import com.datadog.android.sessionreplay.internal.utils.TimeProvider
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -63,9 +62,6 @@ internal class RecordedDataProcessorTest {
     lateinit var mockTimeProvider: TimeProvider
 
     @Mock
-    lateinit var mockRumContextProvider: RumContextProvider
-
-    @Mock
     lateinit var mockExecutorService: ExecutorService
 
     @Mock
@@ -85,11 +81,42 @@ internal class RecordedDataProcessorTest {
     @Mock
     lateinit var mockRecordCallback: RecordCallback
 
+    @Mock
+    lateinit var mockRumContextDataHandler: RumContextDataHandler
+
     @Forgery
     lateinit var fakeSystemInformation: SystemInformation
 
+    private val invalidRumContext = SessionReplayRumContext()
+
+    private lateinit var sameViewRumContextData: RumContextData
+    private lateinit var invalidRumContextData: RumContextData
+    private lateinit var initialRumContextData: RumContextData
+
     @BeforeEach
     fun `set up`(forge: Forge) {
+        initialRumContextData = RumContextData(
+            fakeTimestamp,
+            fakeRumContext,
+            invalidRumContext
+        )
+
+        invalidRumContextData = RumContextData(
+            fakeTimestamp,
+            invalidRumContext,
+            invalidRumContext
+        )
+
+        sameViewRumContextData = RumContextData(
+            fakeTimestamp,
+            fakeRumContext,
+            fakeRumContext
+        )
+
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(initialRumContextData)
+            .thenReturn(sameViewRumContextData)
+
         // we make sure the fullsnapshot was not triggered by a screen orientation change
         fakeSystemInformation = fakeSystemInformation
             .copy(screenOrientation = Configuration.ORIENTATION_UNDEFINED)
@@ -102,10 +129,8 @@ internal class RecordedDataProcessorTest {
             mock<Future<Boolean>>()
         }
         whenever(mockTimeProvider.getDeviceTimestamp()).thenReturn(fakeTimestamp)
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(fakeRumContext)
         testedProcessor = RecordedDataProcessor(
-            mockRumContextProvider,
-            mockTimeProvider,
+            mockRumContextDataHandler,
             mockExecutorService,
             mockWriter,
             mockRecordCallback,
@@ -164,9 +189,17 @@ internal class RecordedDataProcessorTest {
     fun `M send FullSnapshot W process { new view }`(forge: Forge) {
         // Given
         val fakeRumContext2 = forge.getForgery<SessionReplayRumContext>()
-        whenever(mockRumContextProvider.getRumContext())
-            .thenReturn(fakeRumContext)
-            .thenReturn(fakeRumContext2)
+
+        val newerRumContextData = RumContextData(
+            fakeTimestamp,
+            fakeRumContext2,
+            initialRumContextData.newRumContext
+        )
+
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(initialRumContextData)
+            .thenReturn(newerRumContextData)
+
         val fakeSnapshotView1 = forge.aList { aSingleLevelSnapshot() }
         val fakeSnapshotView2 = forge.aList { aSingleLevelSnapshot() }
         fakeSnapshotView1.forEach {
@@ -395,6 +428,19 @@ internal class RecordedDataProcessorTest {
     @Test
     fun `M send MetaRecord W process { snapshot 3 on new view }`(forge: Forge) {
         // Given
+        val fakeRumContext2: SessionReplayRumContext = forge.getForgery()
+
+        val newerRumContextData = RumContextData(
+            fakeTimestamp,
+            fakeRumContext2,
+            initialRumContextData.newRumContext
+        )
+
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(initialRumContextData)
+            .thenReturn(sameViewRumContextData)
+            .thenReturn(newerRumContextData)
+
         val fakeSystemInformation2 = forge.getForgery<SystemInformation>().copy(
             screenOrientation = fakeSystemInformation.screenOrientation
         )
@@ -404,9 +450,6 @@ internal class RecordedDataProcessorTest {
 
         testedProcessor.processScreenSnapshots(fakeSnapshot1, fakeSystemInformation)
         testedProcessor.processScreenSnapshots(fakeSnapshot2, fakeSystemInformation)
-        val fakeRumContext2: SessionReplayRumContext = forge.getForgery()
-        whenever(mockRumContextProvider.getRumContext())
-            .thenReturn(fakeRumContext2)
 
         // When
         testedProcessor.processScreenSnapshots(fakeSnapshot3, fakeSystemInformation2)
@@ -430,13 +473,24 @@ internal class RecordedDataProcessorTest {
     @Test
     fun `M send FocusRecord W process { snapshot 3 on new view }`(forge: Forge) {
         // Given
+        val fakeRumContext2: SessionReplayRumContext = forge.getForgery()
+
+        val newerRumContextData = RumContextData(
+            fakeTimestamp,
+            fakeRumContext2,
+            initialRumContextData.newRumContext
+        )
+
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(initialRumContextData)
+            .thenReturn(sameViewRumContextData)
+            .thenReturn(newerRumContextData)
+
         val fakeSnapshot1 = listOf(forge.aSingleLevelSnapshot())
         val fakeSnapshot2 = listOf(forge.aSingleLevelSnapshot())
         val fakeSnapshot3 = listOf(forge.aSingleLevelSnapshot())
         testedProcessor.processScreenSnapshots(fakeSnapshot1, fakeSystemInformation)
         testedProcessor.processScreenSnapshots(fakeSnapshot2, fakeSystemInformation)
-        val fakeRumContext2: SessionReplayRumContext = forge.getForgery()
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(fakeRumContext2)
 
         // When
         testedProcessor.processScreenSnapshots(fakeSnapshot3, fakeSystemInformation)
@@ -459,13 +513,24 @@ internal class RecordedDataProcessorTest {
     @Test
     fun `M send ViewEndRecord on prev view W process { snapshot 3 on new view }`(forge: Forge) {
         // Given
+        val fakeRumContext2: SessionReplayRumContext = forge.getForgery()
+
+        val newRumContextData = RumContextData(
+            fakeTimestamp,
+            fakeRumContext2,
+            sameViewRumContextData.newRumContext
+        )
+
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(initialRumContextData)
+            .thenReturn(sameViewRumContextData)
+            .thenReturn(newRumContextData)
+
         val fakeSnapshot1 = listOf(forge.aSingleLevelSnapshot())
         val fakeSnapshot2 = listOf(forge.aSingleLevelSnapshot())
         val fakeSnapshot3 = listOf(forge.aSingleLevelSnapshot())
         testedProcessor.processScreenSnapshots(fakeSnapshot1, fakeSystemInformation)
         testedProcessor.processScreenSnapshots(fakeSnapshot2, fakeSystemInformation)
-        val fakeRumContext2: SessionReplayRumContext = forge.getForgery()
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(fakeRumContext2)
 
         // When
         testedProcessor.processScreenSnapshots(fakeSnapshot3, fakeSystemInformation)
@@ -721,6 +786,7 @@ internal class RecordedDataProcessorTest {
         )
         val fakeSnapshot1 = forge.aList { aSingleLevelSnapshot() }
         val fakeSnapshot2 = forge.aList { aSingleLevelSnapshot() }
+
         // When
         testedProcessor.processScreenSnapshots(fakeSnapshot1, fakeSystemInformation)
         testedProcessor.processScreenSnapshots(fakeSnapshot2, fakeSystemInformation2)
@@ -760,9 +826,17 @@ internal class RecordedDataProcessorTest {
         )
 
         val fakeRumContext2 = forge.getForgery<SessionReplayRumContext>()
-        whenever(mockRumContextProvider.getRumContext())
-            .thenReturn(fakeRumContext)
-            .thenReturn(fakeRumContext2)
+
+        val newerRumContextData = RumContextData(
+            fakeTimestamp,
+            fakeRumContext2,
+            fakeRumContext
+        )
+
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(initialRumContextData)
+            .thenReturn(newerRumContextData)
+
         val fakeSnapshot1 = forge.aList { aSingleLevelSnapshot() }
         val fakeSnapshot2 = forge.aList { aSingleLevelSnapshot() }
 
@@ -800,26 +874,12 @@ internal class RecordedDataProcessorTest {
 
     // region Misc
 
-    @ParameterizedTest
-    @MethodSource("processorArguments")
-    fun `M do nothing W process { context is not invalid }`(argument: Any) {
-        // Given
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(SessionReplayRumContext())
-
-        // When
-        processArgument(argument)
-
-        // Then
-        verifyZeroInteractions(mockWriter)
-    }
-
     // TODO: RUMM-2397 When proper logs are added modify this test accordingly
     @ParameterizedTest
     @MethodSource("processorArguments")
     fun `M do nothing W process { executor was shutdown }`(argument: Any) {
         // Given
         whenever(mockExecutorService.submit(any())).thenThrow(RejectedExecutionException())
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(SessionReplayRumContext())
 
         // When
         processArgument(argument)
@@ -834,32 +894,12 @@ internal class RecordedDataProcessorTest {
     fun `M do nothing W process { executor throws NPE }`(argument: Any) {
         // Given
         whenever(mockExecutorService.submit(any())).thenThrow(NullPointerException())
-        whenever(mockRumContextProvider.getRumContext()).thenReturn(SessionReplayRumContext())
 
         // When
         processArgument(argument)
 
         // Then
         verifyZeroInteractions(mockWriter)
-    }
-
-    @ParameterizedTest
-    @MethodSource("processorArguments")
-    fun `M update current RUM context W process`(
-        argument: Any,
-        @Forgery
-        fakeRumContext2: SessionReplayRumContext
-    ) {
-        // Given
-        whenever(mockRumContextProvider.getRumContext())
-            .thenReturn(fakeRumContext)
-            .thenReturn(fakeRumContext2)
-
-        // When
-        processArgument(argument)
-        assertThat(testedProcessor.prevRumContext).isEqualTo(fakeRumContext)
-        processArgument(argument)
-        assertThat(testedProcessor.prevRumContext).isEqualTo(fakeRumContext2)
     }
 
     // endregion

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/RumContextDataHandlerTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/RumContextDataHandlerTest.kt
@@ -1,0 +1,114 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.processor
+
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.utils.RumContextProvider
+import com.datadog.android.sessionreplay.internal.utils.SessionReplayRumContext
+import com.datadog.android.sessionreplay.internal.utils.TimeProvider
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class RumContextDataHandlerTest {
+    @Mock
+    lateinit var mockRumContextProvider: RumContextProvider
+
+    @Mock
+    lateinit var mockTimeProvider: TimeProvider
+
+    @Forgery
+    lateinit var fakeRumContext: SessionReplayRumContext
+
+    private lateinit var testedHandler: RumContextDataHandler
+    private val invalidRumContext = SessionReplayRumContext()
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockRumContextProvider.getRumContext()).thenReturn(fakeRumContext)
+
+        testedHandler = RumContextDataHandler(
+            mockRumContextProvider,
+            mockTimeProvider
+        )
+    }
+
+    @Test
+    fun `M return RumContextData W createRumContextData { valid rum context }`(forge: Forge) {
+        // Given
+        val fakeTime = forge.aLong()
+
+        whenever(mockTimeProvider.getDeviceTimestamp()).thenReturn(fakeTime)
+
+        // When
+        val rumContextData = testedHandler.createRumContextData()
+
+        // Then
+        assertThat(rumContextData?.timestamp).isEqualTo(fakeTime)
+        assertThat(rumContextData?.newRumContext).isEqualTo(fakeRumContext)
+    }
+
+    @Test
+    fun `M update prevRumContext W createRumContextData { valid context }`() {
+        // When
+        testedHandler.createRumContextData()
+        val rumContextData = testedHandler.createRumContextData()
+
+        // Then
+        assertThat(rumContextData?.prevRumContext).isEqualTo(fakeRumContext)
+    }
+
+    @Test
+    fun `M return null W createRumContextData { invalid context }`() {
+        // Given
+        whenever(mockRumContextProvider.getRumContext()).thenReturn(invalidRumContext)
+
+        // When
+        val rumContextData = testedHandler.createRumContextData()
+
+        // Then
+        assertThat(rumContextData).isNull()
+    }
+
+    @Test
+    fun `M not update prevRumContext W createRumContextData { invalid context }`() {
+        // Given
+
+        // overwrite prevRumContext with a valid context
+        testedHandler.createRumContextData()
+
+        whenever(mockRumContextProvider.getRumContext()).thenReturn(invalidRumContext)
+
+        // pass an invalid context - prevRumContext should not be overwritten
+        testedHandler.createRumContextData()
+
+        whenever(mockRumContextProvider.getRumContext()).thenReturn(fakeRumContext)
+
+        // When
+        val rumContextData = testedHandler.createRumContextData()
+
+        // Then
+        assertThat(rumContextData?.prevRumContext).isEqualTo(fakeRumContext)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Extracts the RumContext logic from the Processor as preparation for the blockingQueue implementation

### Motivation

BlockingQueueHandler is also going to need to perform the RumContext logic, since it will enrich the BlockingQueueItems at the time they are inserted into the queue

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

