### PR TITLE
RUMM-3346: Remove `SdkCore` parameter from `Feature#onInitialize`

### DIFF
--- a/dd-sdk-android/api/apiSurface
+++ b/dd-sdk-android/api/apiSurface
@@ -201,7 +201,7 @@ interface com.datadog.android.v2.api.EventBatchWriter
   fun write(ByteArray, ByteArray?): Boolean
 interface com.datadog.android.v2.api.Feature
   val name: String
-  fun onInitialize(FeatureSdkCore, android.content.Context)
+  fun onInitialize(android.content.Context)
   fun onStop()
   companion object 
     const val LOGS_FEATURE_NAME: String

--- a/dd-sdk-android/api/dd-sdk-android.api
+++ b/dd-sdk-android/api/dd-sdk-android.api
@@ -366,7 +366,7 @@ public abstract interface class com/datadog/android/v2/api/Feature {
 	public static final field SESSION_REPLAY_FEATURE_NAME Ljava/lang/String;
 	public static final field TRACING_FEATURE_NAME Ljava/lang/String;
 	public abstract fun getName ()Ljava/lang/String;
-	public abstract fun onInitialize (Lcom/datadog/android/v2/api/FeatureSdkCore;Landroid/content/Context;)V
+	public abstract fun onInitialize (Landroid/content/Context;)V
 	public abstract fun onStop ()V
 }
 

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -20,7 +20,6 @@ import com.datadog.android.v2.api.EventBatchWriter
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureEventReceiver
 import com.datadog.android.v2.api.FeatureScope
-import com.datadog.android.v2.api.FeatureSdkCore
 import com.datadog.android.v2.api.FeatureStorageConfiguration
 import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.api.RequestFactory
@@ -56,7 +55,7 @@ internal class SdkFeature(
 
     // region SDK Feature
 
-    fun initialize(sdkCore: FeatureSdkCore, context: Context) {
+    fun initialize(context: Context) {
         if (initialized.get()) {
             return
         }
@@ -65,7 +64,7 @@ internal class SdkFeature(
             storage = createStorage(wrappedFeature.name, wrappedFeature.storageConfiguration)
         }
 
-        wrappedFeature.onInitialize(sdkCore, context)
+        wrappedFeature.onInitialize(context)
 
         if (wrappedFeature is StorageBackedFeature) {
             setupUploader(wrappedFeature.requestFactory)

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/error/internal/CrashReportsFeature.kt
@@ -11,22 +11,16 @@ import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureSdkCore
 import java.util.concurrent.atomic.AtomicBoolean
 
-internal class CrashReportsFeature : Feature {
+internal class CrashReportsFeature(private val sdkCore: FeatureSdkCore) : Feature {
 
     internal val initialized = AtomicBoolean(false)
     internal var originalUncaughtExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
-    private lateinit var sdkCore: FeatureSdkCore
 
     // region Feature
 
     override val name: String = CRASH_FEATURE_NAME
 
-    override fun onInitialize(
-        sdkCore: FeatureSdkCore,
-        appContext: Context
-    ) {
-        this.sdkCore = sdkCore
-
+    override fun onInitialize(appContext: Context) {
         setupExceptionHandler(appContext)
         initialized.set(true)
     }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/Feature.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/api/Feature.kt
@@ -21,13 +21,9 @@ interface Feature {
     /**
      * This method is called during feature initialization. At this stage feature should setup itself.
      *
-     * @param sdkCore Instance of [SdkCore] this feature is registering with.
      * @param appContext Application context.
      */
-    fun onInitialize(
-        sdkCore: FeatureSdkCore,
-        appContext: Context
-    )
+    fun onInitialize(appContext: Context)
 
     /**
      * This method is called during feature de-initialization. At this stage feature should stop

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/v2/core/DatadogCore.kt
@@ -135,10 +135,7 @@ internal class DatadogCore(
             internalLogger
         )
         features[feature.name] = sdkFeature
-        sdkFeature.initialize(
-            this,
-            context
-        )
+        sdkFeature.initialize(context)
 
         when (feature.name) {
             Feature.LOGS_FEATURE_NAME -> {
@@ -304,7 +301,7 @@ internal class DatadogCore(
 
     private fun initializeCrashReportFeature(configuration: Configuration.Feature.CrashReport?) {
         if (configuration != null) {
-            val crashReportsFeature = CrashReportsFeature()
+            val crashReportsFeature = CrashReportsFeature(this)
             registerFeature(crashReportsFeature)
         }
     }

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -19,7 +19,6 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.v2.api.EventBatchWriter
 import com.datadog.android.v2.api.Feature
 import com.datadog.android.v2.api.FeatureEventReceiver
-import com.datadog.android.v2.api.FeatureSdkCore
 import com.datadog.android.v2.api.FeatureStorageConfiguration
 import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.api.StorageBackedFeature
@@ -78,9 +77,6 @@ internal class SdkFeatureTest {
     lateinit var mockWrappedFeature: StorageBackedFeature
 
     @Mock
-    lateinit var mockSdkCore: FeatureSdkCore
-
-    @Mock
     lateinit var mockInternalLogger: InternalLogger
 
     @Forgery
@@ -109,7 +105,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 mark itself as initialized 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.isInitialized()).isTrue()
@@ -118,7 +114,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 initialize uploader 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.uploadScheduler)
@@ -145,7 +141,7 @@ internal class SdkFeatureTest {
         )
 
         // When
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
 
         // Then
         verify(coreFeature.mockInstance.trackingConsentProvider)
@@ -165,7 +161,7 @@ internal class SdkFeatureTest {
         )
 
         // When
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.isInitialized()).isTrue
@@ -183,7 +179,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 stop scheduler 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
         val mockUploadScheduler: UploadScheduler = mock()
         testedFeature.uploadScheduler = mockUploadScheduler
 
@@ -197,7 +193,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 cleanup data 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
 
         // When
         testedFeature.stop()
@@ -216,7 +212,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 mark itself as not initialized 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
 
         // When
         testedFeature.stop()
@@ -228,7 +224,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 call wrapped feature onStop 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
 
         // When
         testedFeature.stop()
@@ -248,7 +244,7 @@ internal class SdkFeatureTest {
             wrappedFeature = mockFeature,
             internalLogger = mockInternalLogger
         )
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
 
         // When
         testedFeature.stop()
@@ -260,14 +256,14 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 initialize only once 𝕎 initialize() twice`() {
         // Given
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
         val uploadScheduler = testedFeature.uploadScheduler
         val uploader = testedFeature.uploader
         val storage = testedFeature.storage
         val fileOrchestrator = testedFeature.fileOrchestrator
 
         // When
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.uploadScheduler).isSameAs(uploadScheduler)
@@ -282,7 +278,7 @@ internal class SdkFeatureTest {
         whenever(testedFeature.coreFeature.isMainProcess) doReturn false
 
         // When
-        testedFeature.initialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.uploadScheduler).isInstanceOf(NoOpUploadScheduler::class.java)
@@ -430,10 +426,7 @@ internal class SdkFeatureTest {
 
     class FakeFeature(override val name: String) : Feature {
 
-        override fun onInitialize(
-            sdkCore: FeatureSdkCore,
-            appContext: Context
-        ) {
+        override fun onInitialize(appContext: Context) {
             // no-op
         }
 
@@ -444,10 +437,7 @@ internal class SdkFeatureTest {
 
     class AnotherFakeFeature(override val name: String) : Feature {
 
-        override fun onInitialize(
-            sdkCore: FeatureSdkCore,
-            appContext: Context
-        ) {
+        override fun onInitialize(appContext: Context) {
             // no-op
         }
 
@@ -460,10 +450,7 @@ internal class SdkFeatureTest {
         Feature,
         TrackingConsentProviderCallback {
 
-        override fun onInitialize(
-            sdkCore: FeatureSdkCore,
-            appContext: Context
-        ) {
+        override fun onInitialize(appContext: Context) {
             // no-op
         }
 

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/error/internal/CrashReportsFeatureTest.kt
@@ -45,7 +45,7 @@ internal class CrashReportsFeatureTest {
 
     @BeforeEach
     fun `set up crash reports`() {
-        testedFeature = CrashReportsFeature()
+        testedFeature = CrashReportsFeature(mockSdkCore)
         jvmExceptionHandler = Thread.getDefaultUncaughtExceptionHandler()
     }
 
@@ -58,7 +58,7 @@ internal class CrashReportsFeatureTest {
     @Test
     fun `𝕄 register crash handler 𝕎 initialize`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         val handler = Thread.getDefaultUncaughtExceptionHandler()
@@ -73,7 +73,7 @@ internal class CrashReportsFeatureTest {
         Thread.setDefaultUncaughtExceptionHandler(mockOriginalHandler)
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         testedFeature.onStop()
 
         // Then

--- a/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
+++ b/dd-sdk-android/src/test/kotlin/com/datadog/android/v2/core/DatadogCoreTest.kt
@@ -142,7 +142,7 @@ internal class DatadogCoreTest {
 
         // Then
         assertThat(testedCore.features).containsKey(fakeFeatureName)
-        verify(mockFeature).onInitialize(testedCore, appContext.mockInstance)
+        verify(mockFeature).onInitialize(appContext.mockInstance)
     }
 
     @Test

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/Logs.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/Logs.kt
@@ -27,10 +27,11 @@ object Logs {
     @JvmStatic
     fun enable(logsConfiguration: LogsConfiguration, sdkCore: SdkCore = Datadog.getInstance()) {
         val logsFeature = LogsFeature(
+            sdkCore = sdkCore as FeatureSdkCore,
             customEndpointUrl = logsConfiguration.customEndpointUrl,
             eventMapper = logsConfiguration.eventMapper
         )
 
-        (sdkCore as FeatureSdkCore).registerFeature(logsFeature)
+        sdkCore.registerFeature(logsFeature)
     }
 }

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -37,12 +37,12 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Logs feature class, which needs to be registered with Datadog SDK instance.
  */
 internal class LogsFeature constructor(
+    private val sdkCore: FeatureSdkCore,
     customEndpointUrl: String?,
     internal val eventMapper: EventMapper<LogEvent>
 ) : StorageBackedFeature, FeatureEventReceiver {
 
     internal var dataWriter: DataWriter<LogEvent> = NoOpDataWriter()
-    internal lateinit var sdkCore: FeatureSdkCore
     internal val initialized = AtomicBoolean(false)
     internal var packageName = ""
     private val logGenerator = DatadogLogGenerator()
@@ -51,11 +51,7 @@ internal class LogsFeature constructor(
 
     override val name: String = Feature.LOGS_FEATURE_NAME
 
-    override fun onInitialize(
-        sdkCore: FeatureSdkCore,
-        appContext: Context
-    ) {
-        this.sdkCore = sdkCore
+    override fun onInitialize(appContext: Context) {
         sdkCore.setEventReceiver(name, this)
 
         packageName = appContext.packageName

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsTest.kt
@@ -58,7 +58,6 @@ internal class LogsTest {
             verify(mockSdkCore).registerFeature(capture())
 
             lastValue.onInitialize(
-                mockSdkCore,
                 appContext = mock { whenever(it.packageName) doReturn fakePackageName }
             )
             assertThat(lastValue.eventMapper).isEqualTo(fakeLogsConfiguration.eventMapper)

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -168,15 +168,13 @@ internal class LogsFeatureTest {
             }
         )
 
-        testedFeature = LogsFeature(fakeEndpointUrl, mockEventMapper).apply {
-            sdkCore = mockSdkCore
-        }
+        testedFeature = LogsFeature(mockSdkCore, fakeEndpointUrl, mockEventMapper)
     }
 
     @Test
     fun `𝕄 initialize data writer 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, mockApplicationContext)
+        testedFeature.onInitialize(mockApplicationContext)
 
         // Then
         assertThat(testedFeature.dataWriter)
@@ -186,7 +184,7 @@ internal class LogsFeatureTest {
     @Test
     fun `𝕄 use the eventMapper 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, mockApplicationContext)
+        testedFeature.onInitialize(mockApplicationContext)
 
         // Then
         val dataWriter = testedFeature.dataWriter as? LogsDataWriter
@@ -200,7 +198,7 @@ internal class LogsFeatureTest {
     @Test
     fun `𝕄 initialize packageName 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, mockApplicationContext)
+        testedFeature.onInitialize(mockApplicationContext)
 
         // Then
         assertThat(testedFeature.packageName).isEqualTo(fakePackageName)
@@ -338,7 +336,6 @@ internal class LogsFeatureTest {
     ) {
         // Given
         testedFeature.dataWriter = mockDataWriter
-        testedFeature.sdkCore = mockSdkCore
         val fakeThrowable = forge.aThrowable()
         val event = mapOf(
             "type" to "jvm_crash",
@@ -411,7 +408,6 @@ internal class LogsFeatureTest {
             }
         }
         testedFeature.dataWriter = mockDataWriter
-        testedFeature.sdkCore = mockSdkCore
         val fakeThrowable = forge.aThrowable()
         val event = mapOf(
             "type" to "jvm_crash",
@@ -477,7 +473,6 @@ internal class LogsFeatureTest {
             }
         }
         testedFeature.dataWriter = mockDataWriter
-        testedFeature.sdkCore = mockSdkCore
         val fakeThrowable = forge.aThrowable()
         val event = mapOf(
             "type" to "jvm_crash",
@@ -556,7 +551,6 @@ internal class LogsFeatureTest {
     ) {
         // Given
         testedFeature.dataWriter = mockDataWriter
-        testedFeature.sdkCore = mockSdkCore
         val fakeAttributes = forge.exhaustiveAttributes()
         val event = mutableMapOf<String, Any?>(
             "type" to "ndk_crash",
@@ -605,7 +599,6 @@ internal class LogsFeatureTest {
     ) {
         // Given
         testedFeature.dataWriter = mockDataWriter
-        testedFeature.sdkCore = mockSdkCore
         val fakeAttributes = forge.exhaustiveAttributes()
         val event = mutableMapOf<String, Any?>(
             "type" to "ndk_crash",
@@ -655,7 +648,6 @@ internal class LogsFeatureTest {
     ) {
         // Given
         testedFeature.dataWriter = mockDataWriter
-        testedFeature.sdkCore = mockSdkCore
         val fakeAttributes = forge.exhaustiveAttributes()
         val event = mutableMapOf<String, Any?>(
             "type" to "ndk_crash",
@@ -755,7 +747,6 @@ internal class LogsFeatureTest {
     ) {
         // Given
         testedFeature.dataWriter = mockDataWriter
-        testedFeature.sdkCore = mockSdkCore
         val fakeAttributes = forge.exhaustiveAttributes()
         val event = mutableMapOf<String, Any?>(
             "type" to "span_log",

--- a/features/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/NdkCrashReports.kt
+++ b/features/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/NdkCrashReports.kt
@@ -25,8 +25,8 @@ object NdkCrashReports {
     @JvmOverloads
     @JvmStatic
     fun enable(sdkCore: SdkCore = Datadog.getInstance()) {
-        val ndkCrashReportsFeature = NdkCrashReportsFeature()
+        val ndkCrashReportsFeature = NdkCrashReportsFeature(sdkCore as FeatureSdkCore)
 
-        (sdkCore as FeatureSdkCore).registerFeature(ndkCrashReportsFeature)
+        sdkCore.registerFeature(ndkCrashReportsFeature)
     }
 }

--- a/features/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/internal/NdkCrashReportsFeature.kt
+++ b/features/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/internal/NdkCrashReportsFeature.kt
@@ -20,16 +20,15 @@ import java.lang.NullPointerException
  * An implementation of the [Feature] which will allow to intercept and report the
  * NDK crashes to our logs dashboard.
  */
-internal class NdkCrashReportsFeature : Feature, TrackingConsentProviderCallback {
+internal class NdkCrashReportsFeature(private val sdkCore: FeatureSdkCore) :
+    Feature,
+    TrackingConsentProviderCallback {
     private var nativeLibraryLoaded = false
 
     override val name: String = "ndk-crash-reporting"
 
     // region Feature
-    override fun onInitialize(
-        sdkCore: FeatureSdkCore,
-        appContext: Context
-    ) {
+    override fun onInitialize(appContext: Context) {
         loadNativeLibrary(sdkCore.internalLogger)
         if (!nativeLibraryLoaded) {
             return

--- a/features/dd-sdk-android-ndk/src/test/kotlin/com/datadog/android/ndk/internal/NdkCrashReportsFeatureTest.kt
+++ b/features/dd-sdk-android-ndk/src/test/kotlin/com/datadog/android/ndk/internal/NdkCrashReportsFeatureTest.kt
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.api.io.TempDir
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.EnumSource
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.doReturn
@@ -36,12 +37,15 @@ class NdkCrashReportsFeatureTest {
 
     private lateinit var testedFeature: NdkCrashReportsFeature
 
+    @Mock
+    lateinit var mockSdkCore: InternalSdkCore
+
     @TempDir
     lateinit var tempDir: File
 
     @BeforeEach
     fun `set up`() {
-        testedFeature = NdkCrashReportsFeature()
+        testedFeature = NdkCrashReportsFeature(mockSdkCore)
     }
 
     @Test
@@ -71,7 +75,6 @@ class NdkCrashReportsFeatureTest {
         trackingConsent: TrackingConsent
     ) {
         // GIVEN
-        val mockSdkCore = mock<InternalSdkCore>()
         val mockContext: Context = mock()
         whenever(mockSdkCore.rootStorageDir) doReturn tempDir
         whenever(mockSdkCore.trackingConsent) doReturn trackingConsent
@@ -80,7 +83,7 @@ class NdkCrashReportsFeatureTest {
 
         // WHEN
         try {
-            testedFeature.onInitialize(mockSdkCore, mockContext)
+            testedFeature.onInitialize(mockContext)
         } catch (e: UnsatisfiedLinkError) {
             // Do nothing. Just to avoid the NDK linkage error.
         }
@@ -96,7 +99,6 @@ class NdkCrashReportsFeatureTest {
         trackingConsent: TrackingConsent
     ) {
         // GIVEN
-        val mockSdkCore = mock<InternalSdkCore>()
         val mockContext: Context = mock()
         whenever(mockSdkCore.rootStorageDir) doReturn tempDir
         whenever(mockSdkCore.trackingConsent) doReturn trackingConsent
@@ -104,7 +106,7 @@ class NdkCrashReportsFeatureTest {
 
         // WHEN
         try {
-            testedFeature.onInitialize(mockSdkCore, mockContext)
+            testedFeature.onInitialize(mockContext)
         } catch (e: UnsatisfiedLinkError) {
             // Do nothing. Just to avoid the NDK linkage error.
         }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -29,11 +29,12 @@ object Rum {
     @JvmStatic
     fun enable(rumConfiguration: RumConfiguration, sdkCore: SdkCore = Datadog.getInstance()) {
         val rumFeature = RumFeature(
+            sdkCore = sdkCore as FeatureSdkCore,
             applicationId = rumConfiguration.applicationId,
             configuration = rumConfiguration.featureConfiguration
         )
 
-        (sdkCore as FeatureSdkCore).registerFeature(rumFeature)
+        sdkCore.registerFeature(rumFeature)
     }
 
     /**

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -86,6 +86,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  */
 @Suppress("TooManyFunctions")
 internal class RumFeature constructor(
+    private val sdkCore: FeatureSdkCore,
     internal val applicationId: String,
     internal val configuration: Configuration,
     private val ndkCrashEventHandlerFactory: (InternalLogger) -> NdkCrashEventHandler = {
@@ -119,7 +120,6 @@ internal class RumFeature constructor(
     internal lateinit var anrDetectorRunnable: ANRDetectorRunnable
     internal lateinit var anrDetectorHandler: Handler
     internal lateinit var appContext: Context
-    internal lateinit var sdkCore: FeatureSdkCore
     internal lateinit var telemetry: Telemetry
 
     private val ndkCrashEventHandler by lazy { ndkCrashEventHandlerFactory(sdkCore.internalLogger) }
@@ -128,11 +128,7 @@ internal class RumFeature constructor(
 
     override val name: String = Feature.RUM_FEATURE_NAME
 
-    override fun onInitialize(
-        sdkCore: FeatureSdkCore,
-        appContext: Context
-    ) {
-        this.sdkCore = sdkCore
+    override fun onInitialize(appContext: Context) {
         this.appContext = appContext
         this.telemetry = Telemetry(sdkCore)
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -62,7 +62,6 @@ internal class RumTest {
             verify(mockSdkCore).registerFeature(capture())
 
             lastValue.onInitialize(
-                mockSdkCore,
                 appContext = mock { whenever(it.packageName) doReturn fakePackageName }
             )
             assertThat(lastValue.sampleRate)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -111,6 +111,7 @@ internal class RumFeatureTest {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
 
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
@@ -126,7 +127,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 initialize persistence strategy 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.dataWriter)
@@ -136,7 +137,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 store sample rate 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.sampleRate).isEqualTo(fakeConfiguration.sampleRate)
@@ -148,7 +149,7 @@ internal class RumFeatureTest {
         whenever(mockSdkCore.isDeveloperModeEnabled) doReturn true
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.sampleRate).isEqualTo(RumFeature.ALL_IN_SAMPLE_RATE)
@@ -163,7 +164,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 store telemetry sample rate 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.telemetrySampleRate)
@@ -173,7 +174,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 store background tracking 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.backgroundEventTracking)
@@ -189,13 +190,14 @@ internal class RumFeatureTest {
         fakeConfiguration =
             fakeConfiguration.copy(viewTrackingStrategy = mockViewTrackingStrategy)
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.viewTrackingStrategy).isEqualTo(mockViewTrackingStrategy)
@@ -208,13 +210,14 @@ internal class RumFeatureTest {
         fakeConfiguration =
             fakeConfiguration.copy(userActionTracking = false)
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         RumFeatureAssert.assertThat(testedFeature)
@@ -234,13 +237,14 @@ internal class RumFeatureTest {
             touchTargetExtraAttributesProviders = mockProviders.toList()
         )
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         RumFeatureAssert.assertThat(testedFeature)
@@ -255,13 +259,14 @@ internal class RumFeatureTest {
             userActionTracking = true
         )
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         RumFeatureAssert.assertThat(testedFeature)
@@ -278,13 +283,14 @@ internal class RumFeatureTest {
             interactionPredicate = mockInteractionPredicate
         )
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         RumFeatureAssert.assertThat(testedFeature)
@@ -300,13 +306,14 @@ internal class RumFeatureTest {
             interactionPredicate = NoOpInteractionPredicate()
         )
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         RumFeatureAssert.assertThat(testedFeature)
@@ -328,13 +335,14 @@ internal class RumFeatureTest {
             touchTargetExtraAttributesProviders = mockProviders.toList()
         )
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         RumFeatureAssert.assertThat(testedFeature)
@@ -345,7 +353,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 store longTaskTrackingStrategy 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.longTaskTrackingStrategy)
@@ -358,13 +366,14 @@ internal class RumFeatureTest {
     fun `𝕄 use noop viewTrackingStrategy 𝕎 initialize()`() {
         // Given
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration.copy(viewTrackingStrategy = null),
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.viewTrackingStrategy)
@@ -376,13 +385,14 @@ internal class RumFeatureTest {
         // Given
         fakeConfiguration = fakeConfiguration.copy(userActionTracking = false)
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.actionTrackingStrategy)
@@ -394,13 +404,14 @@ internal class RumFeatureTest {
         // Given
         fakeConfiguration = fakeConfiguration.copy(longTaskTrackingStrategy = null)
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.longTaskTrackingStrategy)
@@ -411,13 +422,14 @@ internal class RumFeatureTest {
     fun `𝕄 store eventMapper 𝕎 initialize()`() {
         // Given
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.dataWriter).isInstanceOf(RumDataWriter::class.java)
@@ -449,13 +461,14 @@ internal class RumFeatureTest {
         // Given
         fakeConfiguration = fakeConfiguration.copy(vitalsMonitorUpdateFrequency = fakeFrequency)
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.cpuVitalMonitor)
@@ -478,13 +491,14 @@ internal class RumFeatureTest {
             vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.NEVER
         )
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.cpuVitalMonitor)
@@ -502,7 +516,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 use noop viewTrackingStrategy 𝕎 onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         testedFeature.onStop()
@@ -515,7 +529,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 use noop userActionTrackingStrategy 𝕎 onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         testedFeature.onStop()
@@ -528,7 +542,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 unregister strategies 𝕎 onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val mockActionTrackingStrategy: UserActionTrackingStrategy = mock()
         val mockViewTrackingStrategy: ViewTrackingStrategy = mock()
         val mockLongTaskTrackingStrategy: TrackingStrategy = mock()
@@ -548,7 +562,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 reset data writer 𝕎 onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         testedFeature.onStop()
@@ -567,13 +581,14 @@ internal class RumFeatureTest {
             vitalsMonitorUpdateFrequency = fakeFrequency
         )
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         val scheduledRunnables = testedFeature.vitalExecutorService.shutdownNow()
@@ -587,13 +602,14 @@ internal class RumFeatureTest {
             vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.NEVER
         )
         testedFeature = RumFeature(
+            mockSdkCore,
             fakeApplicationId.toString(),
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.vitalExecutorService)
@@ -603,7 +619,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 shut down vital executor 𝕎 onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val mockVitalExecutorService: ScheduledThreadPoolExecutor = mock()
         testedFeature.vitalExecutorService = mockVitalExecutorService
 
@@ -617,7 +633,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 reset vital executor 𝕎 onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         testedFeature.onStop()
@@ -630,7 +646,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 reset vital monitors 𝕎 onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         testedFeature.onStop()
@@ -644,7 +660,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 enable RUM debugging 𝕎 enableDebugging()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         testedFeature.enableDebugging()
@@ -667,7 +683,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 disable RUM debugging 𝕎 disableDebugging()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         testedFeature.enableDebugging()
         val listener = testedFeature.debugActivityLifecycleListener
 
@@ -684,9 +700,6 @@ internal class RumFeatureTest {
 
     @Test
     fun `𝕄 log dev warning and do nothing else 𝕎 onReceive() { unknown type }`() {
-        // Given
-        testedFeature.sdkCore = mockSdkCore
-
         // When
         testedFeature.onReceive(Any())
 
@@ -712,7 +725,6 @@ internal class RumFeatureTest {
         val event = mapOf(
             "type" to forge.anAlphabeticalString()
         )
-        testedFeature.sdkCore = mockSdkCore
 
         // When
         testedFeature.onReceive(event)
@@ -748,7 +760,6 @@ internal class RumFeatureTest {
         event.remove(
             forge.anElementFrom(event.keys.filterNot { it == "type" })
         )
-        testedFeature.sdkCore = mockSdkCore
 
         // When
         testedFeature.onReceive(event)
@@ -769,7 +780,7 @@ internal class RumFeatureTest {
         forge: Forge
     ) {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val fakeThrowable = forge.aThrowable()
         val fakeMessage = forge.anAlphabeticalString()
         val event = mutableMapOf(
@@ -801,7 +812,7 @@ internal class RumFeatureTest {
         @Forgery fakeViewEventJson: JsonObject
     ) {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val event = mutableMapOf(
             "type" to "ndk_crash",
             "timestamp" to fakeTimestamp,
@@ -835,7 +846,7 @@ internal class RumFeatureTest {
         forge: Forge
     ) {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val fakeThrowable = forge.aNullable { forge.aThrowable() }
         val fakeMessage = forge.anAlphabeticalString()
         val fakeAttributes = forge.aNullable { forge.exhaustiveAttributes() }
@@ -872,7 +883,6 @@ internal class RumFeatureTest {
             "throwable" to fakeThrowable,
             "attributes" to fakeAttributes
         )
-        testedFeature.sdkCore = mockSdkCore
 
         // When
         testedFeature.onReceive(event)
@@ -893,7 +903,7 @@ internal class RumFeatureTest {
         forge: Forge
     ) {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val fakeStacktrace = forge.aNullable { forge.anAlphabeticalString() }
         val fakeMessage = forge.anAlphabeticalString()
         val fakeAttributes = forge.aNullable { forge.exhaustiveAttributes() }
@@ -931,7 +941,6 @@ internal class RumFeatureTest {
             "throwable" to fakeThrowable,
             "attributes" to fakeAttributes
         )
-        testedFeature.sdkCore = mockSdkCore
 
         // When
         testedFeature.onReceive(event)
@@ -952,7 +961,7 @@ internal class RumFeatureTest {
     @Test
     fun `𝕄 notify webview event received 𝕎 onReceive() {webview event received}`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val event = mapOf(
             "type" to "web_view_ingested_notification"
         )
@@ -972,7 +981,7 @@ internal class RumFeatureTest {
         @StringForgery fakeMessage: String
     ) {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val event = mapOf(
             "type" to "telemetry_debug",
             "message" to fakeMessage
@@ -993,7 +1002,6 @@ internal class RumFeatureTest {
         val event = mapOf(
             "type" to "telemetry_debug"
         )
-        testedFeature.sdkCore = mockSdkCore
 
         // When
         testedFeature.onReceive(event)
@@ -1015,7 +1023,7 @@ internal class RumFeatureTest {
         forge: Forge
     ) {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val fakeThrowable = forge.aThrowable()
         val event = mapOf(
             "type" to "telemetry_error",
@@ -1039,7 +1047,7 @@ internal class RumFeatureTest {
         forge: Forge
     ) {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val fakeStack = forge.aNullable { aString() }
         val fakeKind = forge.aNullable { aString() }
         val event = mapOf(
@@ -1067,7 +1075,6 @@ internal class RumFeatureTest {
         val event = mapOf(
             "type" to "telemetry_error"
         )
-        testedFeature.sdkCore = mockSdkCore
 
         // When
         testedFeature.onReceive(event)
@@ -1092,7 +1099,7 @@ internal class RumFeatureTest {
         @LongForgery(min = 0L) batchUploadFrequency: Long
     ) {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val event = mapOf(
             "type" to "telemetry_configuration",
             "track_errors" to trackErrors,
@@ -1101,7 +1108,6 @@ internal class RumFeatureTest {
             "use_proxy" to useProxy,
             "use_local_encryption" to useLocalEncryption
         )
-        testedFeature.sdkCore = mockSdkCore
 
         // When
         testedFeature.onReceive(event)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -30,12 +30,13 @@ object SessionReplay {
         sdkCore: SdkCore = Datadog.getInstance()
     ) {
         val sessionReplayFeature = SessionReplayFeature(
+            sdkCore = sdkCore as FeatureSdkCore,
             customEndpointUrl = sessionReplayConfiguration.customEndpointUrl,
             privacy = sessionReplayConfiguration.privacy,
             customMappers = sessionReplayConfiguration.customMappers,
             customOptionSelectorDetectors = sessionReplayConfiguration.customOptionSelectorDetectors
         )
 
-        (sdkCore as FeatureSdkCore).registerFeature(sessionReplayFeature)
+        sdkCore.registerFeature(sessionReplayFeature)
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
@@ -58,7 +58,6 @@ internal class SessionReplayTest {
             verify(mockSdkCore).registerFeature(capture())
 
             lastValue.onInitialize(
-                mockSdkCore,
                 appContext = mock { whenever(it.packageName) doReturn fakePackageName }
             )
             assertThat(lastValue.privacy).isEqualTo(fakeSessionReplayConfiguration.privacy)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -25,7 +25,6 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
@@ -75,15 +74,16 @@ internal class SessionReplayFeatureTest {
     fun `set up`(forge: Forge) {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         testedFeature = SessionReplayFeature(
+            sdkCore = mockSdkCore,
             customEndpointUrl = forge.aNullable { sessionReplayEndpointUrl },
             privacy = fakePrivacy
-        ) { _, _ -> mockSessionReplayLifecycleCallback }
+        ) { mockSessionReplayLifecycleCallback }
     }
 
     @Test
     fun `𝕄 initialize writer 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.dataWriter)
@@ -96,6 +96,7 @@ internal class SessionReplayFeatureTest {
     ) {
         // Given
         testedFeature = SessionReplayFeature(
+            sdkCore = mockSdkCore,
             customEndpointUrl = forge.aNullable { sessionReplayEndpointUrl },
             privacy = fakePrivacy,
             customMappers = emptyList(),
@@ -103,7 +104,7 @@ internal class SessionReplayFeatureTest {
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         assertThat(testedFeature.sessionReplayCallback)
@@ -116,6 +117,7 @@ internal class SessionReplayFeatureTest {
     ) {
         // Given
         testedFeature = SessionReplayFeature(
+            sdkCore = mockSdkCore,
             customEndpointUrl = forge.aNullable { sessionReplayEndpointUrl },
             privacy = fakePrivacy,
             customMappers = emptyList(),
@@ -123,7 +125,7 @@ internal class SessionReplayFeatureTest {
         )
 
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         verify(mockSdkCore).setEventReceiver(
@@ -135,7 +137,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M register the Session Replay lifecycle callback W initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // Then
         verify(mockSessionReplayLifecycleCallback)
@@ -145,7 +147,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M unregister the Session Replay lifecycle callback W onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         testedFeature.onStop()
@@ -158,7 +160,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M reset the Session Replay lifecycle callback W onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         testedFeature.onStop()
@@ -171,7 +173,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M unregister the SessionReplayCallback W stopRecording() { was recording }`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         testedFeature.stopRecording()
@@ -185,7 +187,7 @@ internal class SessionReplayFeatureTest {
     fun `M unregister only once the SessionReplayCallback W stopRecording() { multi threads }`() {
         // Given
         val countDownLatch = CountDownLatch(3)
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         repeat(3) {
@@ -207,7 +209,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M do nothing W stopRecording() { was already stopped }`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         testedFeature.stopRecording()
 
         // When
@@ -224,7 +226,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M do nothing W stopRecording() { initialize without Application context }`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, mock())
+        testedFeature.onInitialize(mock())
 
         // When
         testedFeature.stopRecording()
@@ -236,7 +238,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M register the SessionReplayCallback W startRecording() { was stopped before }`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         testedFeature.stopRecording()
 
         // When
@@ -251,7 +253,7 @@ internal class SessionReplayFeatureTest {
     fun `M register only once the SessionReplayCallback W startRecording() { multi threads }`() {
         // Given
         val countDownLatch = CountDownLatch(3)
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         repeat(3) {
@@ -270,7 +272,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M do nothing W startRecording() { was already started before }`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
 
         // When
         testedFeature.startRecording()
@@ -283,7 +285,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M do nothing W startRecording() { initialize without Application context }`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, mock())
+        testedFeature.onInitialize(mock())
 
         // When
         testedFeature.startRecording()
@@ -292,8 +294,6 @@ internal class SessionReplayFeatureTest {
         verifyNoInteractions(mockSessionReplayLifecycleCallback)
     }
 
-    // TODO RUMM-0000 Mock InternalLogger.UNBOUND
-    @Disabled("Needs mock of InternalLogger.UNBOUND")
     @Test
     fun `M log warning and do nothing W startRecording() { feature is not initialized }`() {
         // When
@@ -312,7 +312,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M stopRecording W rum session updated { session not tracked }`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         val rumSessionUpdateBusMessage = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
                 SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
@@ -335,7 +335,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M startRecording W rum session updated { session tracked }`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, appContext.mockInstance)
+        testedFeature.onInitialize(appContext.mockInstance)
         testedFeature.stopRecording()
         val rumSessionUpdateBusMessage = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
@@ -359,9 +359,6 @@ internal class SessionReplayFeatureTest {
 
     @Test
     fun `𝕄 log warning and do nothing 𝕎 onReceive() { unknown event type }`() {
-        // Given
-        testedFeature.sdkCore = mockSdkCore
-
         // When
         testedFeature.onReceive(Any())
 
@@ -388,7 +385,6 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
                 forge.anAlphabeticalString()
         )
-        testedFeature.sdkCore = mockSdkCore
 
         // When
         testedFeature.onReceive(event)
@@ -413,7 +409,6 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
                 SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE
         )
-        testedFeature.sdkCore = mockSdkCore
 
         // When
         testedFeature.onReceive(event)
@@ -440,7 +435,6 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to
                 forge.anAlphabeticalString()
         )
-        testedFeature.sdkCore = mockSdkCore
 
         // When
         testedFeature.onReceive(event)

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Traces.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Traces.kt
@@ -27,10 +27,11 @@ object Traces {
     @JvmStatic
     fun enable(tracesConfiguration: TracesConfiguration, sdkCore: SdkCore = Datadog.getInstance()) {
         val tracingFeature = TracingFeature(
+            sdkCore = sdkCore as FeatureSdkCore,
             customEndpointUrl = tracesConfiguration.customEndpointUrl,
             spanEventMapper = tracesConfiguration.eventMapper
         )
 
-        (sdkCore as FeatureSdkCore).registerFeature(tracingFeature)
+        sdkCore.registerFeature(tracingFeature)
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/TracingFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/TracingFeature.kt
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicBoolean
  * Tracing feature class, which needs to be registered with Datadog SDK instance.
  */
 internal class TracingFeature constructor(
+    private val sdkCore: FeatureSdkCore,
     customEndpointUrl: String?,
     internal val spanEventMapper: SpanEventMapper
 ) : StorageBackedFeature {
@@ -37,13 +38,7 @@ internal class TracingFeature constructor(
 
     override val name: String = Feature.TRACING_FEATURE_NAME
 
-    private lateinit var sdkCore: FeatureSdkCore
-
-    override fun onInitialize(
-        sdkCore: FeatureSdkCore,
-        appContext: Context
-    ) {
-        this.sdkCore = sdkCore
+    override fun onInitialize(appContext: Context) {
         dataWriter = createDataWriter(sdkCore)
         initialized.set(true)
     }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TracesTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TracesTest.kt
@@ -58,7 +58,6 @@ internal class TracesTest {
             verify(mockSdkCore).registerFeature(capture())
 
             lastValue.onInitialize(
-                mockSdkCore,
                 appContext = mock { whenever(it.packageName) doReturn fakePackageName }
             )
             assertThat(lastValue.spanEventMapper).isEqualTo(fakeTracesConfiguration.eventMapper)

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TracingFeatureTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TracingFeatureTest.kt
@@ -57,13 +57,13 @@ internal class TracingFeatureTest {
     fun `set up`() {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
 
-        testedFeature = TracingFeature(fakeEndpointUrl, mockSpanEventMapper)
+        testedFeature = TracingFeature(mockSdkCore, fakeEndpointUrl, mockSpanEventMapper)
     }
 
     @Test
     fun `𝕄 initialize writer 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, mock())
+        testedFeature.onInitialize(mock())
 
         // Then
         assertThat(testedFeature.dataWriter)
@@ -73,7 +73,7 @@ internal class TracingFeatureTest {
     @Test
     fun `𝕄 use the eventMapper 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, mock())
+        testedFeature.onInitialize(mock())
 
         // Then
         val dataWriter = testedFeature.dataWriter as? TraceWriter
@@ -92,7 +92,7 @@ internal class TracingFeatureTest {
     @Test
     fun `𝕄 provide tracing request factory 𝕎 requestFactory()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, mock())
+        testedFeature.onInitialize(mock())
 
         // When+Then
         assertThat(testedFeature.requestFactory)

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/DatadogEventBridge.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/DatadogEventBridge.kt
@@ -158,7 +158,7 @@ internal constructor(
                 ?.unwrap<StorageBackedFeature>()
 
             val webViewRumFeature = if (rumFeature != null) {
-                WebViewRumFeature(rumFeature.requestFactory)
+                WebViewRumFeature(sdkCore, rumFeature.requestFactory)
                     .apply { sdkCore.registerFeature(this) }
             } else {
                 sdkCore.internalLogger.log(
@@ -170,7 +170,7 @@ internal constructor(
             }
 
             val webViewLogsFeature = if (logsFeature != null) {
-                WebViewLogsFeature(logsFeature.requestFactory)
+                WebViewLogsFeature(sdkCore, logsFeature.requestFactory)
                     .apply { sdkCore.registerFeature(this) }
             } else {
                 sdkCore.internalLogger.log(

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeature.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeature.kt
@@ -20,6 +20,7 @@ import com.google.gson.JsonObject
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class WebViewLogsFeature(
+    private val sdkCore: FeatureSdkCore,
     override val requestFactory: RequestFactory
 ) : StorageBackedFeature {
 
@@ -29,10 +30,7 @@ internal class WebViewLogsFeature(
     // region Feature
 
     override val name: String = WEB_LOGS_FEATURE_NAME
-    override fun onInitialize(
-        sdkCore: FeatureSdkCore,
-        appContext: Context
-    ) {
+    override fun onInitialize(appContext: Context) {
         dataWriter = createDataWriter(sdkCore.internalLogger)
         initialized.set(true)
     }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeature.kt
@@ -20,6 +20,7 @@ import com.google.gson.JsonObject
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class WebViewRumFeature(
+    private val sdkCore: FeatureSdkCore,
     override val requestFactory: RequestFactory
 ) : StorageBackedFeature {
 
@@ -30,10 +31,7 @@ internal class WebViewRumFeature(
 
     override val name: String = WEB_RUM_FEATURE_NAME
 
-    override fun onInitialize(
-        sdkCore: FeatureSdkCore,
-        appContext: Context
-    ) {
+    override fun onInitialize(appContext: Context) {
         dataWriter = createDataWriter(sdkCore.internalLogger)
         initialized.set(true)
     }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/DatadogEventBridgeTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/DatadogEventBridgeTest.kt
@@ -122,7 +122,7 @@ internal class DatadogEventBridgeTest {
         val fakeHosts = fakeUrls.map { it.host }
         whenever(mockCore.registerFeature(any())) doAnswer {
             val feature = it.getArgument<Feature>(0)
-            feature.onInitialize(mockCore, mock())
+            feature.onInitialize(mock())
         }
 
         // When
@@ -159,7 +159,7 @@ internal class DatadogEventBridgeTest {
         whenever(mockCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn null
         whenever(mockCore.registerFeature(any())) doAnswer {
             val feature = it.getArgument<Feature>(0)
-            feature.onInitialize(mockCore, mock())
+            feature.onInitialize(mock())
         }
 
         // When
@@ -204,7 +204,7 @@ internal class DatadogEventBridgeTest {
         whenever(mockCore.getFeature(Feature.LOGS_FEATURE_NAME)) doReturn null
         whenever(mockCore.registerFeature(any())) doAnswer {
             val feature = it.getArgument<Feature>(0)
-            feature.onInitialize(mockCore, mock())
+            feature.onInitialize(mock())
         }
 
         // When
@@ -372,7 +372,7 @@ internal class DatadogEventBridgeTest {
 
         whenever(mockCore.registerFeature(any())) doAnswer {
             val feature = it.getArgument<Feature>(0)
-            feature.onInitialize(mockCore, mock())
+            feature.onInitialize(mock())
         }
 
         val mockDatadogContext = mock<DatadogContext>()

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeatureTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogsFeatureTest.kt
@@ -47,14 +47,14 @@ internal class WebViewLogsFeatureTest {
 
     @BeforeEach
     fun `set up`() {
-        testedFeature = WebViewLogsFeature(mockRequestFactory)
+        testedFeature = WebViewLogsFeature(mockSdkCore, mockRequestFactory)
         whenever(mockSdkCore.internalLogger) doReturn mock()
     }
 
     @Test
     fun `𝕄 initialize data writer 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, mock())
+        testedFeature.onInitialize(mock())
 
         // Then
         assertThat(testedFeature.dataWriter)
@@ -64,7 +64,7 @@ internal class WebViewLogsFeatureTest {
     @Test
     fun `𝕄 reset data writer 𝕎 onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, mock())
+        testedFeature.onInitialize(mock())
 
         // When
         testedFeature.onStop()

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumFeatureTest.kt
@@ -47,14 +47,14 @@ internal class WebViewRumFeatureTest {
 
     @BeforeEach
     fun `set up`() {
-        testedFeature = WebViewRumFeature(mockRequestFactory)
+        testedFeature = WebViewRumFeature(mockSdkCore, mockRequestFactory)
         whenever(mockSdkCore.internalLogger) doReturn mock()
     }
 
     @Test
     fun `𝕄 initialize data writer 𝕎 initialize()`() {
         // When
-        testedFeature.onInitialize(mockSdkCore, mock())
+        testedFeature.onInitialize(mock())
 
         // Then
         assertThat(testedFeature.dataWriter)
@@ -85,7 +85,7 @@ internal class WebViewRumFeatureTest {
     @Test
     fun `𝕄 reset data writer 𝕎 onStop()`() {
         // Given
-        testedFeature.onInitialize(mockSdkCore, mock())
+        testedFeature.onInitialize(mock())
 
         // When
         testedFeature.onStop()


### PR DESCRIPTION
### What does this PR do?

This change removes `sdkCore` parameter from `Feature#onInitialize`, because features can now capture SDK instance at the creation time.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

