### PR TITLE
REPLAY-1722 Implement recorded data queue

### DIFF
--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayFeature.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayFeature.kt
@@ -52,7 +52,6 @@ class SessionReplayFeature internal constructor(
                 privacy = configuration.privacy,
                 recordWriter = recordWriter,
                 timeProvider = SessionReplayTimeProvider(sdkCore),
-                recordCallback = SessionReplayRecordCallback(sdkCore),
                 customMappers = configuration.customMappers(),
                 customOptionSelectorDetectors =
                 configuration.extensionSupport.getOptionSelectorDetectors()
@@ -185,7 +184,8 @@ class SessionReplayFeature internal constructor(
     }
 
     private fun createDataWriter(): RecordWriter {
-        return SessionReplayRecordWriter(sdkCore)
+        val recordCallback = SessionReplayRecordCallback(sdkCore)
+        return SessionReplayRecordWriter(sdkCore, recordCallback)
     }
 
     internal fun stopRecording() {

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorder.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorder.kt
@@ -13,10 +13,9 @@ import android.view.Window
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import com.datadog.android.sessionreplay.internal.LifecycleCallback
-import com.datadog.android.sessionreplay.internal.NoOpRecordCallback
-import com.datadog.android.sessionreplay.internal.RecordCallback
 import com.datadog.android.sessionreplay.internal.RecordWriter
 import com.datadog.android.sessionreplay.internal.SessionReplayLifecycleCallback
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.processor.RecordedDataProcessor
 import com.datadog.android.sessionreplay.internal.processor.RumContextDataHandler
 import com.datadog.android.sessionreplay.internal.recorder.ComposedOptionSelectorDetector
@@ -31,9 +30,6 @@ import com.datadog.android.sessionreplay.internal.recorder.callback.OnWindowRefr
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MapperTypeWrapper
 import com.datadog.android.sessionreplay.internal.utils.RumContextProvider
 import com.datadog.android.sessionreplay.internal.utils.TimeProvider
-import java.util.concurrent.LinkedBlockingDeque
-import java.util.concurrent.ThreadPoolExecutor
-import java.util.concurrent.TimeUnit
 
 internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
 
@@ -42,24 +38,15 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
     private val privacy: SessionReplayPrivacy
     private val recordWriter: RecordWriter
     private val timeProvider: TimeProvider
-    private val recordCallback: RecordCallback
     private val customMappers: List<MapperTypeWrapper>
     private val customOptionSelectorDetectors: List<OptionSelectorDetector>
     private val windowInspector: WindowInspector
     private val windowCallbackInterceptor: WindowCallbackInterceptor
     private val sessionReplayLifecycleCallback: LifecycleCallback
-    private val processor: RecordedDataProcessor
+    private val recordedDataQueueHandler: RecordedDataQueueHandler
     private val viewOnDrawInterceptor: ViewOnDrawInterceptor
     private val uiHandler: Handler
 
-    @Suppress("UnsafeThirdPartyFunctionCall") // workQueue can't be null
-    private val processorExecutorService = ThreadPoolExecutor(
-        CORE_DEFAULT_POOL_SIZE,
-        CORE_DEFAULT_POOL_SIZE,
-        THREAD_POOL_MAX_KEEP_ALIVE_MS,
-        TimeUnit.MILLISECONDS,
-        LinkedBlockingDeque()
-    )
     private var shouldRecord = false
 
     constructor(
@@ -68,7 +55,6 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         privacy: SessionReplayPrivacy,
         recordWriter: RecordWriter,
         timeProvider: TimeProvider,
-        recordCallback: RecordCallback = NoOpRecordCallback(),
         customMappers: List<MapperTypeWrapper> = emptyList(),
         customOptionSelectorDetectors: List<OptionSelectorDetector> = emptyList(),
         windowInspector: WindowInspector = WindowInspector
@@ -78,23 +64,25 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
             timeProvider
         )
 
+        val processor = RecordedDataProcessor(
+            recordWriter
+        )
+
         this.appContext = appContext
         this.rumContextProvider = rumContextProvider
         this.privacy = privacy
         this.recordWriter = recordWriter
         this.timeProvider = timeProvider
-        this.recordCallback = recordCallback
         this.customMappers = customMappers
         this.customOptionSelectorDetectors = customOptionSelectorDetectors
         this.windowInspector = windowInspector
-        this.processor = RecordedDataProcessor(
-            rumContextDataHandler,
-            processorExecutorService,
-            recordWriter,
-            recordCallback
+        this.recordedDataQueueHandler = RecordedDataQueueHandler(
+            processor = processor,
+            rumContextDataHandler = rumContextDataHandler,
+            timeProvider = timeProvider
         )
         this.viewOnDrawInterceptor = ViewOnDrawInterceptor(
-            processor,
+            recordedDataQueueHandler = recordedDataQueueHandler,
             SnapshotProducer(
                 TreeViewTraversal(customMappers + privacy.mappers()),
                 ComposedOptionSelectorDetector(
@@ -102,7 +90,11 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
                 )
             )
         )
-        this.windowCallbackInterceptor = WindowCallbackInterceptor(processor, viewOnDrawInterceptor, timeProvider)
+        this.windowCallbackInterceptor = WindowCallbackInterceptor(
+            recordedDataQueueHandler,
+            viewOnDrawInterceptor,
+            timeProvider
+        )
         this.sessionReplayLifecycleCallback = SessionReplayLifecycleCallback(this)
         this.uiHandler = Handler(Looper.getMainLooper())
     }
@@ -114,14 +106,13 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         privacy: SessionReplayPrivacy,
         recordWriter: RecordWriter,
         timeProvider: TimeProvider,
-        recordCallback: RecordCallback = NoOpRecordCallback(),
         customMappers: List<MapperTypeWrapper> = emptyList(),
         customOptionSelectorDetectors: List<OptionSelectorDetector>,
         windowInspector: WindowInspector = WindowInspector,
         windowCallbackInterceptor: WindowCallbackInterceptor,
         sessionReplayLifecycleCallback: LifecycleCallback,
         viewOnDrawInterceptor: ViewOnDrawInterceptor,
-        processor: RecordedDataProcessor,
+        recordedDataQueueHandler: RecordedDataQueueHandler,
         uiHandler: Handler
     ) {
         this.appContext = appContext
@@ -129,11 +120,10 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         this.privacy = privacy
         this.recordWriter = recordWriter
         this.timeProvider = timeProvider
-        this.recordCallback = recordCallback
         this.customMappers = customMappers
         this.customOptionSelectorDetectors = customOptionSelectorDetectors
         this.windowInspector = windowInspector
-        this.processor = processor
+        this.recordedDataQueueHandler = recordedDataQueueHandler
         this.viewOnDrawInterceptor = viewOnDrawInterceptor
         this.windowCallbackInterceptor = windowCallbackInterceptor
         this.sessionReplayLifecycleCallback = sessionReplayLifecycleCallback
@@ -186,10 +176,5 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
             windowCallbackInterceptor.stopIntercepting(windows)
             viewOnDrawInterceptor.intercept(decorViews, appContext)
         }
-    }
-
-    companion object {
-        private val THREAD_POOL_MAX_KEEP_ALIVE_MS = TimeUnit.SECONDS.toMillis(5)
-        private const val CORE_DEFAULT_POOL_SIZE = 1 // Only one thread will be kept alive
     }
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
@@ -1,0 +1,209 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.async
+
+import androidx.annotation.MainThread
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.WorkerThread
+import com.datadog.android.sessionreplay.internal.processor.RecordedDataProcessor
+import com.datadog.android.sessionreplay.internal.processor.RumContextDataHandler
+import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
+import com.datadog.android.sessionreplay.internal.utils.TimeProvider
+import com.datadog.android.sessionreplay.model.MobileSegment
+import java.lang.ClassCastException
+import java.lang.NullPointerException
+import java.util.concurrent.ConcurrentLinkedQueue
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.RejectedExecutionException
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+/**
+ * Responsible for storing the Snapshot and Interaction events in a queue.
+ * Allows for asynchronous enrichment, which still preserving the event order.
+ * The items are added to the queue from the main thread and processed on a background thread.
+ */
+internal class RecordedDataQueueHandler {
+
+    private var executorService: ExecutorService
+    private var processor: RecordedDataProcessor
+    private var rumContextDataHandler: RumContextDataHandler
+    private var timeProvider: TimeProvider
+
+    internal constructor(
+        processor: RecordedDataProcessor,
+        rumContextDataHandler: RumContextDataHandler,
+        timeProvider: TimeProvider
+    ) : this(
+        processor = processor,
+        rumContextDataHandler = rumContextDataHandler,
+        timeProvider = timeProvider,
+
+        /**
+         * TODO: RUMM-0000 consider change to LoggingThreadPoolExecutor once V2 is merged.
+         * if we ever decide to make the poolsize greater than 1, we need to ensure
+         * synchronization works correctly in the triggerProcessingLoop method below
+         */
+        executorService = ThreadPoolExecutor(
+            CORE_DEFAULT_POOL_SIZE,
+            CORE_DEFAULT_POOL_SIZE,
+            THREAD_POOL_MAX_KEEP_ALIVE_MS,
+            TimeUnit.MILLISECONDS,
+            LinkedBlockingDeque()
+        )
+    )
+
+    @VisibleForTesting
+    internal constructor(
+        processor: RecordedDataProcessor,
+        rumContextDataHandler: RumContextDataHandler,
+        timeProvider: TimeProvider,
+        executorService: ExecutorService
+    ) {
+        this.processor = processor
+        this.rumContextDataHandler = rumContextDataHandler
+        this.executorService = executorService
+        this.timeProvider = timeProvider
+    }
+
+    // region internal
+    internal val recordedDataQueue = ConcurrentLinkedQueue<RecordedDataQueueItem>()
+
+    @MainThread
+    internal fun addTouchEventItem(
+        pointerInteractions: List<MobileSegment.MobileRecord>
+    ): TouchEventRecordedDataQueueItem? {
+        val rumContextData = rumContextDataHandler.createRumContextData()
+            ?: return null
+
+        val item = TouchEventRecordedDataQueueItem(
+            rumContextData = rumContextData,
+            touchData = pointerInteractions
+        )
+
+        insertIntoRecordedDataQueue(item)
+
+        return item
+    }
+
+    @MainThread
+    internal fun addSnapshotItem(
+        systemInformation: SystemInformation
+    ): SnapshotRecordedDataQueueItem? {
+        val rumContextData = rumContextDataHandler.createRumContextData()
+            ?: return null
+
+        val item = SnapshotRecordedDataQueueItem(
+            rumContextData = rumContextData,
+            systemInformation = systemInformation
+        )
+
+        insertIntoRecordedDataQueue(item)
+
+        return item
+    }
+
+    /**
+     * Goes through the queue one item at a time for as long as there are items in the queue.
+     * If an item is ready to be consumed, it is processed.
+     * If an invalid item is encountered, it is removed (invalid items are possible
+     * for example if a snapshot failed to traverse the tree).
+     * If neither of the previous conditions occurs, the loop breaks.
+     */
+    @MainThread
+    internal fun tryToConsumeItems() {
+        // no need to create a thread if the queue is empty
+        if (recordedDataQueue.isEmpty()) {
+            return
+        }
+
+        // currentTime needs to be obtained on the uithread
+        val currentTime = timeProvider.getDeviceTimestamp()
+
+        @Suppress("SwallowedException", "TooGenericExceptionCaught")
+        try {
+            executorService.execute {
+                triggerProcessingLoop(currentTime)
+            }
+        } catch (e: RejectedExecutionException) {
+            // TODO: REPLAY-1364 Add logs here once the sdkLogger is added
+        } catch (e: NullPointerException) {
+            // in theory will never happen but we'll log it
+            // TODO: REPLAY-1364 Add logs here once the sdkLogger is added
+        }
+    }
+
+    /**
+     * The threadpool that triggers this method has a size/maxsize of 1.
+     * This makes it implicitly synchronised so we should never have any multithreading issues
+     * where one thread peeks while another removes the element.
+     */
+    @WorkerThread
+    @Synchronized
+    private fun triggerProcessingLoop(currentTime: Long) {
+        while (recordedDataQueue.isNotEmpty()) {
+            val nextItem = recordedDataQueue.peek()
+
+            if (nextItem != null) {
+                if (shouldRemoveItem(nextItem, currentTime)) {
+                    recordedDataQueue.poll()
+                } else if (nextItem.isReady()) {
+                    processItem(recordedDataQueue.poll())
+                } else {
+                    break
+                }
+            }
+        }
+    }
+
+    private fun processItem(nextItem: RecordedDataQueueItem?) {
+        when (nextItem) {
+            is SnapshotRecordedDataQueueItem ->
+                processSnapshotEvent(nextItem)
+            is TouchEventRecordedDataQueueItem ->
+                processTouchEvent(nextItem)
+        }
+    }
+
+    private fun processSnapshotEvent(item: SnapshotRecordedDataQueueItem) {
+        processor.processScreenSnapshots(item)
+    }
+
+    private fun processTouchEvent(item: TouchEventRecordedDataQueueItem) {
+        processor.processTouchEventsRecords(item)
+    }
+
+    private fun shouldRemoveItem(recordedDataQueueItem: RecordedDataQueueItem, currentTime: Long) =
+        !recordedDataQueueItem.isValid() || isTooOld(currentTime, recordedDataQueueItem)
+
+    private fun isTooOld(currentTime: Long, recordedDataQueueItem: RecordedDataQueueItem): Boolean =
+        (currentTime - recordedDataQueueItem.rumContextData.timestamp) > MAX_DELAY_MS
+
+    private fun insertIntoRecordedDataQueue(recordedDataQueueItem: RecordedDataQueueItem) {
+        @Suppress("SwallowedException", "TooGenericExceptionCaught")
+        try {
+            recordedDataQueue.offer(recordedDataQueueItem)
+        } catch (e: IllegalArgumentException) {
+            // TODO: REPLAY-1364 Add logs here once the sdkLogger is added
+        } catch (e: ClassCastException) {
+            // in theory will never happen but we'll log it
+            // TODO: REPLAY-1364 Add logs here once the sdkLogger is added
+        } catch (e: NullPointerException) {
+            // in theory will never happen but we'll log it
+            // TODO: REPLAY-1364 Add logs here once the sdkLogger is added
+        }
+    }
+
+    // end region
+
+    internal companion object {
+        internal const val MAX_DELAY_MS = 200L
+        private val THREAD_POOL_MAX_KEEP_ALIVE_MS = TimeUnit.SECONDS.toMillis(5)
+        private const val CORE_DEFAULT_POOL_SIZE = 1 // Only one thread will be kept alive
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueItem.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueItem.kt
@@ -1,0 +1,16 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.async
+
+import com.datadog.android.sessionreplay.internal.processor.RumContextData
+
+internal abstract class RecordedDataQueueItem(
+    internal val rumContextData: RumContextData
+) {
+    internal abstract fun isValid(): Boolean
+    internal abstract fun isReady(): Boolean
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/SnapshotRecordedDataQueueItem.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/SnapshotRecordedDataQueueItem.kt
@@ -1,0 +1,31 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.async
+
+import com.datadog.android.sessionreplay.internal.processor.RumContextData
+import com.datadog.android.sessionreplay.internal.recorder.Node
+import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class SnapshotRecordedDataQueueItem(
+    rumContextData: RumContextData,
+    internal val systemInformation: SystemInformation
+) : RecordedDataQueueItem(rumContextData) {
+    internal var nodes = emptyList<Node>()
+    internal var pendingImages = AtomicInteger(0)
+
+    override fun isValid(): Boolean {
+        return nodes.isNotEmpty()
+    }
+
+    override fun isReady(): Boolean {
+        return pendingImages.get() == 0
+    }
+
+    internal fun incrementPendingImages() = pendingImages.incrementAndGet()
+    internal fun decrementPendingImages() = pendingImages.decrementAndGet()
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/TouchEventRecordedDataQueueItem.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/TouchEventRecordedDataQueueItem.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.async
+
+import com.datadog.android.sessionreplay.internal.processor.RumContextData
+import com.datadog.android.sessionreplay.model.MobileSegment
+
+internal class TouchEventRecordedDataQueueItem(
+    rumContextData: RumContextData,
+    internal val touchData: List<MobileSegment.MobileRecord> = emptyList()
+) : RecordedDataQueueItem(rumContextData) {
+
+    override fun isValid(): Boolean {
+        return touchData.isNotEmpty()
+    }
+
+    override fun isReady(): Boolean {
+        return true
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/Processor.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/Processor.kt
@@ -6,13 +6,12 @@
 
 package com.datadog.android.sessionreplay.internal.processor
 
-import com.datadog.android.sessionreplay.internal.recorder.Node
-import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
-import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.internal.async.SnapshotRecordedDataQueueItem
+import com.datadog.android.sessionreplay.internal.async.TouchEventRecordedDataQueueItem
 
 internal interface Processor {
 
-    fun processScreenSnapshots(nodes: List<Node>, systemInformation: SystemInformation)
+    fun processScreenSnapshots(item: SnapshotRecordedDataQueueItem)
 
-    fun processTouchEventsRecords(touchEventsRecords: List<MobileSegment.MobileRecord>)
+    fun processTouchEventsRecords(item: TouchEventRecordedDataQueueItem)
 }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessor.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedDataProcessor.kt
@@ -7,26 +7,20 @@
 package com.datadog.android.sessionreplay.internal.processor
 
 import android.content.res.Configuration
-import androidx.annotation.MainThread
 import androidx.annotation.WorkerThread
-import com.datadog.android.sessionreplay.internal.RecordCallback
 import com.datadog.android.sessionreplay.internal.RecordWriter
+import com.datadog.android.sessionreplay.internal.async.SnapshotRecordedDataQueueItem
+import com.datadog.android.sessionreplay.internal.async.TouchEventRecordedDataQueueItem
 import com.datadog.android.sessionreplay.internal.recorder.Node
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.internal.utils.SessionReplayRumContext
 import com.datadog.android.sessionreplay.model.MobileSegment
-import java.lang.NullPointerException
 import java.util.LinkedList
-import java.util.concurrent.ExecutorService
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.TimeUnit
 
 @Suppress("TooManyFunctions")
 internal class RecordedDataProcessor(
-    private val rumContextDataHandler: RumContextDataHandler,
-    private val executorService: ExecutorService,
     private val writer: RecordWriter,
-    private val recordCallback: RecordCallback,
     private val mutationResolver: MutationResolver = MutationResolver(),
     private val nodeFlattener: NodeFlattener = NodeFlattener()
 ) : Processor {
@@ -35,33 +29,25 @@ internal class RecordedDataProcessor(
     private var lastSnapshotTimestamp = 0L
     private var previousOrientation = Configuration.ORIENTATION_UNDEFINED
 
-    @MainThread
+    @WorkerThread
     override fun processScreenSnapshots(
-        nodes: List<Node>,
-        systemInformation: SystemInformation
+        item: SnapshotRecordedDataQueueItem
     ) {
-        buildRunnable { timestamp, newContext, currentContext ->
-            Runnable {
-                @Suppress("ThreadSafety") // this runs inside an executor
-                handleSnapshots(
-                    newContext,
-                    currentContext,
-                    timestamp,
-                    nodes,
-                    systemInformation
-                )
-            }
-        }?.let { executeRunnable(it) }
+        handleSnapshots(
+            newRumContext = item.rumContextData.newRumContext,
+            prevRumContext = item.rumContextData.prevRumContext,
+            timestamp = item.rumContextData.timestamp,
+            snapshots = item.nodes,
+            systemInformation = item.systemInformation
+        )
     }
 
-    @MainThread
-    override fun processTouchEventsRecords(touchEventsRecords: List<MobileSegment.MobileRecord>) {
-        buildRunnable { _, newContext, _ ->
-            Runnable {
-                @Suppress("ThreadSafety") // this runs inside an executor
-                handleTouchRecords(newContext, touchEventsRecords)
-            }
-        }?.let { executeRunnable(it) }
+    @WorkerThread
+    override fun processTouchEventsRecords(item: TouchEventRecordedDataQueueItem) {
+        handleTouchRecords(
+            rumContext = item.rumContextData.newRumContext,
+            touchData = item.touchData
+        )
     }
 
     // region Internal
@@ -163,47 +149,6 @@ internal class RecordedDataProcessor(
             val viewEndRecord = MobileSegment.MobileRecord.ViewEndRecord(timestamp)
             writer.write(bundleRecordInEnrichedRecord(prevRumContext, listOf(viewEndRecord)))
         }
-    }
-
-    private fun executeRunnable(runnable: Runnable) {
-        @Suppress("SwallowedException", "TooGenericExceptionCaught")
-        try {
-            executorService.submit(runnable)
-        } catch (e: RejectedExecutionException) {
-            // TODO: RUMM-2397 Add the proper logs here once the sdkLogger will be added
-        } catch (e: NullPointerException) {
-            // TODO: RUMM-2397 Add the proper logs here once the sdkLogger will be added
-            // the task will never be null so normally this exception should not be triggered.
-            // In any case we will add a log here later.
-        }
-    }
-
-    private fun buildRunnable(
-        runnableFactory: (
-            timestamp: Long,
-            newContext: SessionReplayRumContext,
-            prevRumContext: SessionReplayRumContext
-        ) -> Runnable
-    ): Runnable? {
-        val rumContextData = rumContextDataHandler.createRumContextData() ?: return null
-
-        // Because the runnable will be executed in another thread it can happen in case there is
-        // an exception in the chain that the record cannot be sent. In this case we will have
-        // a RUM view with `has_replay:true` but with no actual records. This is a corner case
-        // that we discussed with the RUM team and unfortunately and was accepted as there is
-        // another safety net logic in the player that handles this situation. Unfortunately this
-        // is a constraint that we must accept as this whole `has_replay` logic was thought for
-        // the browser SR sdk and not for mobile which handles features inter - communication
-        // completely differently. In any case have in mind that after a discussion with the
-        // browser team it appears that this situation may arrive also on their end and was
-        // accepted.
-        recordCallback.onRecordForViewSent(rumContextData.newRumContext.viewId)
-
-        return runnableFactory(
-            rumContextData.timestamp,
-            rumContextData.newRumContext,
-            rumContextData.prevRumContext
-        )
     }
 
     private fun bundleRecordInEnrichedRecord(

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptor.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptor.kt
@@ -9,19 +9,19 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.content.Context
 import android.view.View
 import android.view.ViewTreeObserver.OnDrawListener
-import com.datadog.android.sessionreplay.internal.processor.Processor
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener
 import java.util.WeakHashMap
 
 internal class ViewOnDrawInterceptor(
-    private val processor: Processor,
+    private val recordedDataQueueHandler: RecordedDataQueueHandler,
     private val snapshotProducer: SnapshotProducer,
     private val onDrawListenerProducer: (Context, List<View>) -> OnDrawListener =
         { activity, decorViews ->
             WindowsOnDrawListener(
                 activity,
                 decorViews,
-                processor,
+                recordedDataQueueHandler,
                 snapshotProducer
             )
         }

--- a/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptor.kt
+++ b/library/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptor.kt
@@ -8,14 +8,14 @@ package com.datadog.android.sessionreplay.internal.recorder
 
 import android.content.Context
 import android.view.Window
-import com.datadog.android.sessionreplay.internal.processor.Processor
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.callback.NoOpWindowCallback
 import com.datadog.android.sessionreplay.internal.recorder.callback.RecorderWindowCallback
 import com.datadog.android.sessionreplay.internal.utils.TimeProvider
 import java.util.WeakHashMap
 
 internal class WindowCallbackInterceptor(
-    private val processor: Processor,
+    private val recordedDataQueueHandler: RecordedDataQueueHandler,
     private val viewOnDrawInterceptor: ViewOnDrawInterceptor,
     private val timeProvider: TimeProvider
 ) {
@@ -46,7 +46,7 @@ internal class WindowCallbackInterceptor(
         val toWrap = window.callback ?: NoOpWindowCallback()
         window.callback = RecorderWindowCallback(
             appContext,
-            processor,
+            recordedDataQueueHandler,
             toWrap,
             timeProvider,
             viewOnDrawInterceptor

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
@@ -11,7 +11,6 @@ import android.os.Handler
 import android.view.View
 import android.view.Window
 import com.datadog.android.sessionreplay.internal.LifecycleCallback
-import com.datadog.android.sessionreplay.internal.RecordCallback
 import com.datadog.android.sessionreplay.internal.RecordWriter
 import com.datadog.android.sessionreplay.internal.recorder.ViewOnDrawInterceptor
 import com.datadog.android.sessionreplay.internal.recorder.WindowCallbackInterceptor
@@ -60,9 +59,6 @@ internal class SessionReplayRecorderTest {
     private lateinit var fakePrivacy: SessionReplayPrivacy
 
     @Mock
-    private lateinit var mockRecordCallback: RecordCallback
-
-    @Mock
     private lateinit var mockTimeProvider: TimeProvider
 
     @Mock
@@ -98,7 +94,6 @@ internal class SessionReplayRecorderTest {
             fakePrivacy,
             mockRecordWriter,
             mockTimeProvider,
-            mockRecordCallback,
             mock(),
             mock(),
             mockWindowInspector,

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ForgeConfigurator.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ForgeConfigurator.kt
@@ -51,6 +51,8 @@ internal class ForgeConfigurator : BaseConfigurator() {
         forge.addFactory(RumContextDataForgeryFactory())
         forge.addFactory(ImageWireframeForgeryFactory())
         forge.addFactory(PlaceholderWireframeForgeryFactory())
+        forge.addFactory(SnapshotRecordedDataQueueItemForgeryFactory())
+        forge.addFactory(TouchEventRecordedDataQueueItemForgeryFactory())
 
         forge.useJvmFactories()
     }

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SnapshotRecordedDataQueueItemForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SnapshotRecordedDataQueueItemForgeryFactory.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.forge
+
+import com.datadog.android.sessionreplay.internal.async.SnapshotRecordedDataQueueItem
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class SnapshotRecordedDataQueueItemForgeryFactory : ForgeryFactory<SnapshotRecordedDataQueueItem> {
+    override fun getForgery(forge: Forge): SnapshotRecordedDataQueueItem {
+        val item = SnapshotRecordedDataQueueItem(
+            rumContextData = forge.getForgery(),
+            systemInformation = forge.getForgery()
+        )
+
+        item.pendingImages = AtomicInteger(forge.anInt())
+        item.nodes = listOf(forge.getForgery())
+        return item
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/TouchEventRecordedDataQueueItemForgeryFactory.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/TouchEventRecordedDataQueueItemForgeryFactory.kt
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.forge
+
+import com.datadog.android.sessionreplay.internal.async.TouchEventRecordedDataQueueItem
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class TouchEventRecordedDataQueueItemForgeryFactory : ForgeryFactory<TouchEventRecordedDataQueueItem> {
+    override fun getForgery(forge: Forge): TouchEventRecordedDataQueueItem {
+        return TouchEventRecordedDataQueueItem(
+            rumContextData = forge.getForgery(),
+            touchData = listOf(forge.getForgery())
+        )
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
@@ -1,0 +1,462 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.async
+
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler.Companion.MAX_DELAY_MS
+import com.datadog.android.sessionreplay.internal.processor.RecordedDataProcessor
+import com.datadog.android.sessionreplay.internal.processor.RumContextData
+import com.datadog.android.sessionreplay.internal.processor.RumContextDataHandler
+import com.datadog.android.sessionreplay.internal.recorder.Node
+import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
+import com.datadog.android.sessionreplay.internal.time.SessionReplayTimeProvider
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.argumentCaptor
+import com.nhaarman.mockitokotlin2.doReturn
+import com.nhaarman.mockitokotlin2.inOrder
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.spy
+import com.nhaarman.mockitokotlin2.times
+import com.nhaarman.mockitokotlin2.verify
+import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
+import com.nhaarman.mockitokotlin2.whenever
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.api.fail
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.LinkedBlockingDeque
+import java.util.concurrent.ThreadPoolExecutor
+import java.util.concurrent.TimeUnit
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class RecordedDataQueueHandlerTest {
+    lateinit var testedHandler: RecordedDataQueueHandler
+
+    @Mock
+    lateinit var mockProcessor: RecordedDataProcessor
+
+    @Mock
+    lateinit var mockRumContextDataHandler: RumContextDataHandler
+
+    lateinit var mockExecutorService: ExecutorService
+
+    @Mock
+    lateinit var mockSystemInformation: SystemInformation
+
+    @Mock
+    lateinit var mockTimeProvider: SessionReplayTimeProvider
+
+    @Forgery
+    lateinit var fakeRumContextData: RumContextData
+
+    @Forgery
+    lateinit var fakeSnapshotQueueItem: SnapshotRecordedDataQueueItem
+
+    @Forgery
+    lateinit var fakeTouchEventItem: TouchEventRecordedDataQueueItem
+
+    private lateinit var fakeTouchData: List<MobileSegment.MobileRecord>
+
+    private lateinit var fakeNodeData: List<Node>
+
+    private val snapshotItemCaptor = argumentCaptor<SnapshotRecordedDataQueueItem>()
+    private val touchEventItemCaptor = argumentCaptor<TouchEventRecordedDataQueueItem>()
+
+    @BeforeEach
+    fun setup(forge: Forge) {
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(fakeRumContextData)
+
+        mockExecutorService = spy(
+            ThreadPoolExecutor(
+                1,
+                1,
+                100,
+                TimeUnit.MILLISECONDS,
+                LinkedBlockingDeque()
+            )
+        )
+
+        fakeTouchData = forge.aList { mock() }
+
+        fakeNodeData = forge.aList { mock() }
+
+        testedHandler = RecordedDataQueueHandler(
+            processor = mockProcessor,
+            rumContextDataHandler = mockRumContextDataHandler,
+            timeProvider = mockTimeProvider,
+            executorService = mockExecutorService
+        )
+    }
+
+    @Test
+    fun `M use executorService W tryToConsumeItems() { queue has snapshot items }`() {
+        // Given
+        val item = testedHandler.addSnapshotItem(mockSystemInformation)
+        testedHandler.recordedDataQueue.offer(item)
+
+        // When
+        testedHandler.tryToConsumeItems()
+        mockExecutorService.shutdown()
+        mockExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+
+        // Then
+        verify(mockExecutorService).execute(any())
+    }
+
+    @Test
+    fun `M use executorService W tryToConsumeItems() { queue has touch event items }`() {
+        // Given
+        val item = testedHandler.addTouchEventItem(fakeTouchData)
+        testedHandler.recordedDataQueue.offer(item)
+
+        // When
+        testedHandler.tryToConsumeItems()
+        mockExecutorService.shutdown()
+        mockExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+
+        // Then
+        verify(mockExecutorService).execute(any())
+    }
+
+    @Test
+    fun `M no threads spawned W tryToConsumeItems() { queue is empty }`() {
+        // When
+        testedHandler.tryToConsumeItems()
+
+        // Then
+        verifyNoMoreInteractions(mockExecutorService)
+    }
+
+    @Test
+    fun `M do not call processor W tryToConsumeItems() { empty queue }`() {
+        // When
+        testedHandler.tryToConsumeItems()
+
+        // Then
+        verifyNoMoreInteractions(mockProcessor)
+    }
+
+    @Test
+    fun `M do nothing W add() { snapshot with invalid RumContextData }`() {
+        // Given
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(null)
+
+        // When
+        val item = testedHandler.addSnapshotItem(mockSystemInformation)
+
+        // Then
+        assertThat(item).isNull()
+    }
+
+    @Test
+    fun `M do nothing W add() { touch event with invalid RumContextData }`() {
+        // Given
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(null)
+
+        // When
+        val item = testedHandler.addTouchEventItem(fakeTouchData)
+
+        // Then
+        assertThat(item).isNull()
+    }
+
+    @Test
+    fun `M snapshot item contains correct fields W add() { valid RumContextData }`() {
+        // Given
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(fakeRumContextData)
+        val currentRumContextData = mockRumContextDataHandler.createRumContextData()
+
+        // When
+        val item = testedHandler.addSnapshotItem(mockSystemInformation)
+
+        // Then
+        assertThat(item!!.rumContextData).isEqualTo(currentRumContextData)
+        assertThat(item.systemInformation).isEqualTo(mockSystemInformation)
+        assertThat(testedHandler.recordedDataQueue.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `M touch event item contains correct fields W add() { valid RumContextData }`
+    () {
+        // Given
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(fakeRumContextData)
+        val currentRumContextData = mockRumContextDataHandler.createRumContextData()
+
+        // When
+        val item =
+            testedHandler.addTouchEventItem(fakeTouchData)
+
+        // Then
+        assertThat(item!!.rumContextData).isEqualTo(currentRumContextData)
+        assertThat(item.touchData).isEqualTo(fakeTouchData)
+        assertThat(testedHandler.recordedDataQueue.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `M remove item from queue W tryToConsumeItems() { expired item }`() {
+        // Given
+        val item = testedHandler.addSnapshotItem(mockSystemInformation)
+            ?: fail("item is null")
+        item.nodes = fakeNodeData
+
+        whenever(mockTimeProvider.getDeviceTimestamp())
+            .thenReturn(item.rumContextData.timestamp + MAX_DELAY_MS + 1)
+
+        // When
+        testedHandler.tryToConsumeItems()
+        mockExecutorService.shutdown()
+        mockExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+
+        // Then
+        assertThat(testedHandler.recordedDataQueue.isEmpty()).isTrue()
+        verifyNoMoreInteractions(mockProcessor)
+    }
+
+    @Test
+    fun `M remove item from queue W tryToConsumeItems() { invalid snapshot item }`() {
+        // Given
+        val spy = spy(fakeSnapshotQueueItem)
+        spy.nodes = emptyList()
+        doReturn(false).whenever(spy).isValid()
+        testedHandler.recordedDataQueue.offer(spy)
+
+        val spyTimestamp = spy.rumContextData.timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp())
+            .thenReturn(spyTimestamp)
+
+        // When
+        testedHandler.tryToConsumeItems()
+        mockExecutorService.shutdown()
+        mockExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+
+        // Then
+        assertThat(testedHandler.recordedDataQueue.size).isEqualTo(0)
+        verifyNoMoreInteractions(mockProcessor)
+    }
+
+    @Test
+    fun `M remove item from queue W tryToConsumeItems() { invalid touch event item }`() {
+        // Given
+        val spy = spy(fakeTouchEventItem)
+
+        doReturn(false).whenever(spy).isValid()
+        testedHandler.recordedDataQueue.offer(spy)
+
+        val spyTimestamp = spy.rumContextData.timestamp
+        whenever(mockTimeProvider.getDeviceTimestamp())
+            .thenReturn(spyTimestamp)
+
+        // When
+        testedHandler.tryToConsumeItems()
+        mockExecutorService.shutdown()
+        mockExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+
+        // Then
+        assertThat(testedHandler.recordedDataQueue.size).isEqualTo(0)
+        verifyNoMoreInteractions(mockProcessor)
+    }
+
+    @Test
+    fun `M do nothing W tryToConsumeItems() { snapshot item not ready }`() {
+        // Given
+        val spy = spy(fakeSnapshotQueueItem)
+
+        doReturn(true).whenever(spy).isValid()
+        doReturn(false).whenever(spy).isReady()
+
+        testedHandler.recordedDataQueue.add(spy)
+
+        whenever(mockTimeProvider.getDeviceTimestamp())
+            .thenReturn(fakeRumContextData.timestamp)
+
+        // When
+        testedHandler.tryToConsumeItems()
+        mockExecutorService.shutdown()
+        mockExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+
+        // Then
+        verifyNoMoreInteractions(mockProcessor)
+    }
+
+    @Test
+    fun `M call processor W tryToConsumeItems() { valid snapshot item }`() {
+        // Given
+        val item = testedHandler.addSnapshotItem(mockSystemInformation) ?: fail("item is null")
+        item.nodes = fakeNodeData
+
+        whenever(mockTimeProvider.getDeviceTimestamp())
+            .thenReturn(item.rumContextData.timestamp)
+
+        // When
+        testedHandler.tryToConsumeItems()
+        mockExecutorService.shutdown()
+        mockExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+
+        // Then
+        verify(mockProcessor).processScreenSnapshots(snapshotItemCaptor.capture())
+
+        assertThat(snapshotItemCaptor.firstValue.nodes).isEqualTo(fakeNodeData)
+        assertThat(snapshotItemCaptor.firstValue.systemInformation).isEqualTo(mockSystemInformation)
+        assertThat(snapshotItemCaptor.firstValue.rumContextData).isEqualTo(item.rumContextData)
+    }
+
+    @Test
+    fun `M call processor W tryToConsumeItems() { valid Touch Event item }`() {
+        // Given
+        val item = testedHandler.addTouchEventItem(fakeTouchData) ?: fail("item is null")
+
+        whenever(mockTimeProvider.getDeviceTimestamp())
+            .thenReturn(item.rumContextData.timestamp)
+
+        // When
+        testedHandler.tryToConsumeItems()
+        mockExecutorService.shutdown()
+        mockExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+
+        // Then
+        verify(mockProcessor).processTouchEventsRecords(touchEventItemCaptor.capture())
+
+        assertThat(touchEventItemCaptor.firstValue.rumContextData).isEqualTo(item.rumContextData)
+        assertThat(touchEventItemCaptor.firstValue.touchData).isEqualTo(fakeTouchData)
+    }
+
+    @Test
+    fun `M consume items in the correct order W tryToConsumeItems() { spawn multiple threads }`() {
+        // Given
+        val item1 = createFakeSnapshotItemWithDelayMs(1)
+        val item2 = createFakeSnapshotItemWithDelayMs(2)
+        val item3 = createFakeSnapshotItemWithDelayMs(3)
+
+        assertThat(testedHandler.recordedDataQueue.size).isEqualTo(3)
+        val itemTimestamp = item1.rumContextData.timestamp
+
+        // When
+        repeat(50) {
+            whenever(mockTimeProvider.getDeviceTimestamp())
+                .thenReturn(itemTimestamp + it)
+
+            testedHandler.tryToConsumeItems()
+            mockExecutorService.shutdown()
+            mockExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+        }
+
+        // Then
+        inOrder(mockProcessor) {
+            verifySnapshotItemProcessed(item1)
+            verifySnapshotItemProcessed(item2)
+            verifySnapshotItemProcessed(item3)
+            verifyNoMoreInteractions(mockProcessor)
+        }
+    }
+
+    @Test
+    fun `M not consume items that are not ready W tryToConsumeItems() { some items not ready }`() {
+        // Given
+        // item1
+        val item1RumContextData = fakeRumContextData.copy(timestamp = 1)
+
+        val item1 = spy(
+            SnapshotRecordedDataQueueItem(
+                rumContextData = item1RumContextData,
+                systemInformation = mockSystemInformation
+            )
+        )
+
+        item1.nodes = fakeNodeData
+        doReturn(true).whenever(item1).isValid()
+        doReturn(true).whenever(item1).isReady()
+
+        // item2
+        val item2RumContextData = fakeRumContextData.copy(timestamp = 2)
+
+        val item2 = spy(
+            SnapshotRecordedDataQueueItem(
+                rumContextData = item2RumContextData,
+                systemInformation = mockSystemInformation
+            )
+        )
+
+        item2.nodes = emptyList()
+        doReturn(true).whenever(item2).isValid()
+        doReturn(false).whenever(item2).isReady()
+
+        // item3
+        val item3RumContextData = fakeRumContextData.copy(timestamp = 3)
+
+        val item3 = spy(
+            SnapshotRecordedDataQueueItem(
+                rumContextData = item3RumContextData,
+                systemInformation = mockSystemInformation
+            )
+        )
+
+        item3.nodes = fakeNodeData
+        doReturn(true).whenever(item3).isValid()
+        doReturn(true).whenever(item3).isReady()
+
+        testedHandler.recordedDataQueue.offer(item1)
+        testedHandler.recordedDataQueue.offer(item2)
+        testedHandler.recordedDataQueue.offer(item3)
+
+        assertThat(testedHandler.recordedDataQueue.size).isEqualTo(3)
+        val item1Time = item1.rumContextData.timestamp
+
+        whenever(mockTimeProvider.getDeviceTimestamp())
+            .thenReturn(item1Time + 1)
+
+        // When
+        repeat(3) {
+            testedHandler.tryToConsumeItems()
+        }
+
+        mockExecutorService.shutdown()
+        mockExecutorService.awaitTermination(1, TimeUnit.SECONDS)
+
+        assertThat(testedHandler.recordedDataQueue.size).isEqualTo(2)
+    }
+
+    private fun createFakeSnapshotItemWithDelayMs(delay: Int): SnapshotRecordedDataQueueItem {
+        val newRumContext = RumContextData(
+            timestamp = System.currentTimeMillis() + delay,
+            newRumContext = fakeRumContextData.newRumContext,
+            prevRumContext = fakeRumContextData.prevRumContext
+        )
+
+        whenever(mockRumContextDataHandler.createRumContextData())
+            .thenReturn(newRumContext)
+
+        val item = testedHandler.addSnapshotItem(mockSystemInformation)
+        item!!.nodes = fakeNodeData
+        return item
+    }
+
+    private fun verifySnapshotItemProcessed(item: SnapshotRecordedDataQueueItem) {
+        verify(mockProcessor, times(1)).processScreenSnapshots(item)
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/SnapshotRecordedDataQueueItemTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/SnapshotRecordedDataQueueItemTest.kt
@@ -1,0 +1,96 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.async
+
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class SnapshotRecordedDataQueueItemTest {
+
+    @Forgery
+    lateinit var fakeSnapshotRecordedDataQueueItem: SnapshotRecordedDataQueueItem
+
+    lateinit var testedItem: SnapshotRecordedDataQueueItem
+
+    @BeforeEach
+    fun `set up`() {
+        testedItem = fakeSnapshotRecordedDataQueueItem
+    }
+
+    @Test
+    fun `M return false W isValid() { Snapshot with empty nodes }`() {
+        // Given
+        testedItem.nodes = emptyList()
+
+        // Then
+        assertThat(testedItem.isValid()).isFalse()
+    }
+
+    @Test
+    fun `M return true W isValid() { Snapshot with nodes }`() {
+        // Then
+        assertThat(testedItem.isValid()).isTrue()
+    }
+
+    @Test
+    fun `M return true W isReady() { Snapshot with no pending images }`() {
+        // Given
+        testedItem.pendingImages.set(0)
+
+        // Then
+        assertThat(testedItem.isReady()).isTrue()
+    }
+
+    @Test
+    fun `M return false W isReady() { Snapshot with pending images greater than 0 }`() {
+        // Given
+        testedItem.incrementPendingImages()
+
+        // Then
+        assertThat(testedItem.isReady()).isFalse()
+    }
+
+    @Test
+    fun `M increment pending images W incrementPendingImages()`() {
+        // Given
+        val initial = testedItem.pendingImages.get()
+
+        // When
+        testedItem.incrementPendingImages()
+
+        // Then
+        assertThat(testedItem.pendingImages.get()).isEqualTo(initial + 1)
+    }
+
+    @Test
+    fun `M decrement pending images W decrementPendingImages()`() {
+        // Given
+        val initial = testedItem.pendingImages.get()
+
+        // When
+        testedItem.decrementPendingImages()
+
+        // Then
+        assertThat(testedItem.pendingImages.get()).isEqualTo(initial - 1)
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/TouchEventRecordedDataQueueItemTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/TouchEventRecordedDataQueueItemTest.kt
@@ -1,0 +1,63 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.async
+
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class TouchEventRecordedDataQueueItemTest {
+
+    @Forgery
+    lateinit var fakeTouchEventRecordedDataQueueItem: TouchEventRecordedDataQueueItem
+
+    lateinit var testedItem: TouchEventRecordedDataQueueItem
+
+    @BeforeEach
+    fun `set up`() {
+        testedItem = fakeTouchEventRecordedDataQueueItem
+    }
+
+    @Test
+    fun `M return false W isValid() { Touch Event with empty touchData }`() {
+        // Given
+        testedItem = TouchEventRecordedDataQueueItem(
+            rumContextData = fakeTouchEventRecordedDataQueueItem.rumContextData,
+            touchData = emptyList()
+        )
+
+        // Then
+        assertThat(testedItem.isValid()).isFalse()
+    }
+
+    @Test
+    fun `M return true W isValid() { Touch Event with interactions }`() {
+        // Then
+        assertThat(testedItem.isValid()).isTrue()
+    }
+
+    @Test
+    fun `M return true W isReady() { Touch Event }`() {
+        // Then
+        assertThat(testedItem.isReady()).isTrue()
+    }
+}

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptorTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptorTest.kt
@@ -12,7 +12,7 @@ import android.util.DisplayMetrics
 import android.view.View
 import android.view.ViewTreeObserver
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.internal.processor.Processor
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
@@ -44,7 +44,7 @@ internal class ViewOnDrawInterceptorTest {
     lateinit var testedInterceptor: ViewOnDrawInterceptor
 
     @Mock
-    lateinit var mockProcessor: Processor
+    lateinit var mockRecordedDataQueueHandler: RecordedDataQueueHandler
 
     @Mock
     lateinit var mockSnapshotProducer: SnapshotProducer
@@ -58,7 +58,7 @@ internal class ViewOnDrawInterceptorTest {
         mockActivity = forge.aMockedActivity()
         fakeDecorViews = forge.aMockedDecorViewsList()
         testedInterceptor = ViewOnDrawInterceptor(
-            mockProcessor,
+            mockRecordedDataQueueHandler,
             mockSnapshotProducer
         )
     }
@@ -81,7 +81,7 @@ internal class ViewOnDrawInterceptorTest {
         // Given
         val mockOnDrawListener = mock<ViewTreeObserver.OnDrawListener>()
         testedInterceptor = ViewOnDrawInterceptor(
-            mockProcessor,
+            mockRecordedDataQueueHandler,
             mockSnapshotProducer
         ) { _, _ -> mockOnDrawListener }
 

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptorTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptorTest.kt
@@ -12,7 +12,7 @@ import android.util.DisplayMetrics
 import android.view.View
 import android.view.Window
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.internal.processor.Processor
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.callback.NoOpWindowCallback
 import com.datadog.android.sessionreplay.internal.recorder.callback.RecorderWindowCallback
 import com.datadog.android.sessionreplay.internal.utils.TimeProvider
@@ -51,7 +51,7 @@ internal class WindowCallbackInterceptorTest {
     lateinit var mockViewOnDrawInterceptor: ViewOnDrawInterceptor
 
     @Mock
-    lateinit var mockProcessor: Processor
+    lateinit var mockRecordedDataQueueHandler: RecordedDataQueueHandler
 
     @Mock
     lateinit var mockTimeProvider: TimeProvider
@@ -65,7 +65,7 @@ internal class WindowCallbackInterceptorTest {
         mockActivity = forge.aMockedActivity()
         fakeWindowsList = forge.aMockedWindowsList()
         testedInterceptor = WindowCallbackInterceptor(
-            mockProcessor,
+            mockRecordedDataQueueHandler,
             mockViewOnDrawInterceptor,
             mockTimeProvider
         )

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallbackTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallbackTest.kt
@@ -13,7 +13,8 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.Window
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.internal.processor.Processor
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
+import com.datadog.android.sessionreplay.internal.async.TouchEventRecordedDataQueueItem
 import com.datadog.android.sessionreplay.internal.recorder.ViewOnDrawInterceptor
 import com.datadog.android.sessionreplay.internal.recorder.WindowInspector
 import com.datadog.android.sessionreplay.internal.utils.TimeProvider
@@ -21,6 +22,7 @@ import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.model.MobileSegment.MobileIncrementalData
 import com.datadog.android.sessionreplay.model.MobileSegment.MobileRecord
 import com.datadog.tools.unit.forge.aThrowable
+import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.argumentCaptor
 import com.nhaarman.mockitokotlin2.doThrow
 import com.nhaarman.mockitokotlin2.inOrder
@@ -30,6 +32,7 @@ import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -56,7 +59,7 @@ internal class RecorderWindowCallbackTest {
     lateinit var testedWindowCallback: RecorderWindowCallback
 
     @Mock
-    lateinit var mockProcessor: Processor
+    lateinit var mockRecordedDataQueueHandler: RecordedDataQueueHandler
 
     @Mock
     lateinit var mockWrappedCallback: Window.Callback
@@ -72,6 +75,9 @@ internal class RecorderWindowCallbackTest {
 
     @Mock
     lateinit var mockContext: Context
+
+    @Forgery
+    lateinit var fakeTouchEventRecordedDataQueueItem: TouchEventRecordedDataQueueItem
 
     @LongForgery(min = 0)
     var fakeTimestamp: Long = 0L
@@ -92,11 +98,13 @@ internal class RecorderWindowCallbackTest {
             val displayMetrics = DisplayMetrics().apply { density = fakeDensity.toFloat() }
             whenever(it.displayMetrics).thenReturn(displayMetrics)
         }
+        whenever(mockRecordedDataQueueHandler.addTouchEventItem(any<List<MobileRecord>>()))
+            .thenReturn(fakeTouchEventRecordedDataQueueItem)
         whenever(mockContext.resources).thenReturn(mockResources)
         whenever(mockTimeProvider.getDeviceTimestamp()).thenReturn(fakeTimestamp)
         testedWindowCallback = RecorderWindowCallback(
             mockContext,
-            mockProcessor,
+            mockRecordedDataQueueHandler,
             mockWrappedCallback,
             mockTimeProvider,
             mockViewOnDrawInterceptor,
@@ -191,7 +199,8 @@ internal class RecorderWindowCallbackTest {
 
         // Then
         assertThat(testedWindowCallback.pointerInteractions).isEmpty()
-        verify(mockProcessor).processTouchEventsRecords(fakeRecords)
+        verify(mockRecordedDataQueueHandler).addTouchEventItem(fakeRecords)
+        verify(mockRecordedDataQueueHandler).tryToConsumeItems()
     }
 
     @Test
@@ -223,7 +232,8 @@ internal class RecorderWindowCallbackTest {
         testedWindowCallback.dispatchTouchEvent(relatedMotionEvent5)
 
         // Then
-        verify(mockProcessor).processTouchEventsRecords(expectedRecords)
+        verify(mockRecordedDataQueueHandler).addTouchEventItem(expectedRecords)
+        verify(mockRecordedDataQueueHandler).tryToConsumeItems()
     }
 
     @Test
@@ -263,7 +273,8 @@ internal class RecorderWindowCallbackTest {
 
         // Then
         val argumentCaptor = argumentCaptor<List<MobileRecord>>()
-        verify(mockProcessor, times(2)).processTouchEventsRecords(argumentCaptor.capture())
+        verify(mockRecordedDataQueueHandler, times(2)).addTouchEventItem(argumentCaptor.capture())
+        verify(mockRecordedDataQueueHandler, times(2)).tryToConsumeItems()
         assertThat(argumentCaptor.firstValue).isEqualTo(expectedRecords1)
         assertThat(argumentCaptor.lastValue).isEqualTo(expectedRecords2)
     }
@@ -303,7 +314,8 @@ internal class RecorderWindowCallbackTest {
 
         // Then
         val argumentCaptor = argumentCaptor<List<MobileRecord>>()
-        verify(mockProcessor, times(2)).processTouchEventsRecords(argumentCaptor.capture())
+        verify(mockRecordedDataQueueHandler, times(2)).addTouchEventItem(argumentCaptor.capture())
+        verify(mockRecordedDataQueueHandler, times(2)).tryToConsumeItems()
         assertThat(argumentCaptor.firstValue).isEqualTo(expectedTouchRecords1)
         assertThat(argumentCaptor.lastValue).isEqualTo(expectedTouchRecords2)
     }
@@ -330,7 +342,8 @@ internal class RecorderWindowCallbackTest {
 
         // Then
         val argumentCaptor = argumentCaptor<List<MobileRecord>>()
-        verify(mockProcessor, times(2)).processTouchEventsRecords(argumentCaptor.capture())
+        verify(mockRecordedDataQueueHandler, times(2)).addTouchEventItem(argumentCaptor.capture())
+        verify(mockRecordedDataQueueHandler, times(2)).tryToConsumeItems()
         assertThat(argumentCaptor.firstValue).isEqualTo(expectedTouchRecords1)
         assertThat(argumentCaptor.lastValue).isEqualTo(fakeEvent2MoveRecords)
     }
@@ -352,7 +365,8 @@ internal class RecorderWindowCallbackTest {
 
         // Then
         val expectedRecords = fakeEvent1Records + fakeEvent2Records + fakeEvent3Records
-        verify(mockProcessor).processTouchEventsRecords(expectedRecords)
+        verify(mockRecordedDataQueueHandler).addTouchEventItem(expectedRecords)
+        verify(mockRecordedDataQueueHandler).tryToConsumeItems()
         assertThat(testedWindowCallback.pointerInteractions).isEmpty()
     }
 

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListenerTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListenerTest.kt
@@ -12,7 +12,8 @@ import android.content.res.Resources
 import android.content.res.Resources.Theme
 import android.view.View
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.internal.processor.Processor
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
+import com.datadog.android.sessionreplay.internal.async.SnapshotRecordedDataQueueItem
 import com.datadog.android.sessionreplay.internal.recorder.Debouncer
 import com.datadog.android.sessionreplay.internal.recorder.Node
 import com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer
@@ -20,6 +21,7 @@ import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.internal.utils.MiscUtils
 import com.nhaarman.mockitokotlin2.any
 import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.never
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
 import com.nhaarman.mockitokotlin2.whenever
@@ -28,6 +30,7 @@ import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -56,7 +59,7 @@ internal class WindowsOnDrawListenerTest {
     lateinit var mockSnapshotProducer: SnapshotProducer
 
     @Mock
-    lateinit var mockProcessor: Processor
+    lateinit var mockRecordedDataQueueHandler: RecordedDataQueueHandler
 
     @Mock
     lateinit var mockDebouncer: Debouncer
@@ -79,6 +82,9 @@ internal class WindowsOnDrawListenerTest {
 
     @Forgery
     lateinit var fakeSystemInformation: SystemInformation
+
+    @Forgery
+    lateinit var fakeSnapshotQueueItem: SnapshotRecordedDataQueueItem
 
     @Mock
     lateinit var mockContext: Context
@@ -110,7 +116,7 @@ internal class WindowsOnDrawListenerTest {
         testedListener = WindowsOnDrawListener(
             mockContext,
             fakeMockedDecorViews,
-            mockProcessor,
+            mockRecordedDataQueueHandler,
             mockSnapshotProducer,
             mockDebouncer,
             mockMiscUtils
@@ -118,18 +124,36 @@ internal class WindowsOnDrawListenerTest {
     }
 
     @Test
-    fun `M take and process snapshot W onDraw()`() {
+    fun `M take and add to queue W onDraw()`() {
         // Given
         stubDebouncer()
+
+        whenever(mockRecordedDataQueueHandler.addSnapshotItem(any<SystemInformation>()))
+            .thenReturn(fakeSnapshotQueueItem)
 
         // When
         testedListener.onDraw()
 
         // Then
-        verify(mockProcessor).processScreenSnapshots(
-            fakeWindowsSnapshots,
-            fakeSystemInformation
-        )
+        verify(mockRecordedDataQueueHandler).addSnapshotItem(fakeSystemInformation)
+    }
+
+    @Test
+    fun `M update queue with correct nodes W onDraw()`() {
+        // Given
+        stubDebouncer()
+
+        whenever(mockRecordedDataQueueHandler.addSnapshotItem(any<SystemInformation>()))
+            .thenReturn(fakeSnapshotQueueItem)
+
+        fakeSnapshotQueueItem.pendingImages.set(0)
+
+        // When
+        testedListener.onDraw()
+
+        // Then
+        assertThat(fakeSnapshotQueueItem.nodes).isEqualTo(fakeWindowsSnapshots)
+        verify(mockRecordedDataQueueHandler).tryToConsumeItems()
     }
 
     @Test
@@ -139,7 +163,7 @@ internal class WindowsOnDrawListenerTest {
         testedListener = WindowsOnDrawListener(
             mockContext,
             emptyList(),
-            mockProcessor,
+            mockRecordedDataQueueHandler,
             mockSnapshotProducer,
             mockDebouncer
         )
@@ -148,7 +172,7 @@ internal class WindowsOnDrawListenerTest {
         testedListener.onDraw()
 
         // Then
-        verifyZeroInteractions(mockProcessor)
+        verifyZeroInteractions(mockRecordedDataQueueHandler)
         verifyZeroInteractions(mockSnapshotProducer)
     }
 
@@ -162,8 +186,7 @@ internal class WindowsOnDrawListenerTest {
         testedListener.onDraw()
 
         // Then
-        verifyZeroInteractions(mockProcessor)
-        verifyZeroInteractions(mockSnapshotProducer)
+        verify(mockRecordedDataQueueHandler, never()).tryToConsumeItems()
     }
 
     // region Internal

--- a/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriterTest.kt
+++ b/library/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriterTest.kt
@@ -8,14 +8,17 @@ package com.datadog.android.sessionreplay.internal.storage
 
 import com.datadog.android.sessionreplay.SessionReplayFeature
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.RecordCallback
 import com.datadog.android.sessionreplay.internal.processor.EnrichedRecord
 import com.datadog.android.v2.api.EventBatchWriter
 import com.datadog.android.v2.api.FeatureScope
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.android.v2.api.context.DatadogContext
 import com.nhaarman.mockitokotlin2.any
+import com.nhaarman.mockitokotlin2.anyOrNull
 import com.nhaarman.mockitokotlin2.doAnswer
 import com.nhaarman.mockitokotlin2.eq
+import com.nhaarman.mockitokotlin2.times
 import com.nhaarman.mockitokotlin2.verify
 import com.nhaarman.mockitokotlin2.verifyNoMoreInteractions
 import com.nhaarman.mockitokotlin2.verifyZeroInteractions
@@ -47,6 +50,9 @@ internal class SessionReplayRecordWriterTest {
     lateinit var mockSdkCore: SdkCore
 
     @Mock
+    lateinit var mockRecordCallback: RecordCallback
+
+    @Mock
     lateinit var mockSessionReplayFeature: FeatureScope
 
     @Forgery
@@ -57,9 +63,13 @@ internal class SessionReplayRecordWriterTest {
 
     @BeforeEach
     fun `set up`() {
+        whenever(mockEventBatchWriter.write(anyOrNull(), anyOrNull()))
+            .thenReturn(true)
+
         whenever(mockSdkCore.getFeature(SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME))
             .thenReturn(mockSessionReplayFeature)
-        testedWriter = SessionReplayRecordWriter(mockSdkCore)
+
+        testedWriter = SessionReplayRecordWriter(mockSdkCore, mockRecordCallback)
     }
 
     @Test
@@ -77,6 +87,9 @@ internal class SessionReplayRecordWriterTest {
         // Then
         verify(mockEventBatchWriter).write(fakeRecord.toJson().toByteArray(), null)
         verifyNoMoreInteractions(mockEventBatchWriter)
+
+        verify(mockRecordCallback).onRecordForViewSent(fakeRecord.viewId)
+        verifyNoMoreInteractions(mockRecordCallback)
     }
 
     @Test
@@ -84,6 +97,7 @@ internal class SessionReplayRecordWriterTest {
         // Given
         val fakeRecord1 = forge.forgeEnrichedRecord()
         val fakeRecord2 = fakeRecord1.copy()
+
         testedWriter.write(fakeRecord1)
 
         // When
@@ -115,6 +129,10 @@ internal class SessionReplayRecordWriterTest {
         verify(mockEventBatchWriter).write(fakeRecord1.toJson().toByteArray(), null)
         verify(mockEventBatchWriter).write(fakeRecord2.toJson().toByteArray(), null)
         verifyNoMoreInteractions(mockEventBatchWriter)
+
+        verify(mockRecordCallback).onRecordForViewSent(fakeRecord1.viewId)
+        verify(mockRecordCallback).onRecordForViewSent(fakeRecord2.viewId)
+        verifyNoMoreInteractions(mockRecordCallback)
     }
 
     @Test
@@ -129,6 +147,29 @@ internal class SessionReplayRecordWriterTest {
 
         // Then
         verifyZeroInteractions(mockSessionReplayFeature)
+        verifyNoMoreInteractions(mockRecordCallback)
+    }
+
+    @Test
+    fun `M not call record callback W write { eventBatchWriter write failed }`(forge: Forge) {
+        // Given
+        whenever(mockEventBatchWriter.write(anyOrNull(), anyOrNull()))
+            .thenReturn(false)
+
+        val fakeRecord = forge.forgeEnrichedRecord()
+        whenever(mockSessionReplayFeature.withWriteContext(eq(true), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+        }
+
+        // When
+        testedWriter.write(fakeRecord)
+
+        // Then
+        verify(mockEventBatchWriter).write(fakeRecord.toJson().toByteArray(), null)
+        verifyNoMoreInteractions(mockEventBatchWriter)
+
+        verifyZeroInteractions(mockRecordCallback)
     }
 
     private fun Forge.forgeEnrichedRecord(): EnrichedRecord {


### PR DESCRIPTION
### What does this PR do?

The traversal of nodes and production of snapshots (and touch events) was, up until now, synchronous. The recorded data queue enables asynchronous tasks to be performed during the traversal and for snapshots and touch events to still be generated in order and sent. 

In general terms what happens is this (for a snapshot item):
1) An item is generated and inserted into the queue, however this item has no nodes yet and so cannot be processed. A reference to this item will be passed during the traversal through all the mappers.
2) The traversal of the node tree finishes. If we didn't find any images on the way and if we successfully got a list of nodes then we update the item and try to process the queue. In a future pr the logic will be: If we encounter an image in a mapper during the traversal we increment the pendingImages counter for the item that we inserted. If we finish processing an image in a mapper we decrement this counter asynchronously (and potentially trigger the queue processing if pendingImages has reached zero).
3) If a request to process the queue arrives, we start going through the queue from the head. If the next item is invalid (no nodes or has been in the queue too long) then we remove it. Since the traversals happen on the main thread, we shouldn't be able to have a situation where a later traversal interferes with a previous traversal and ejects it from the queue before it's finished. Even if the previous traversal has pendingImages, it will have it's nodes already populated before the later traversal can awaken the queue. Valid items without pending images are sent to the processor similar to the way it used to work.
4) We continue processing the queue until either it is empty or the next item is not ready for processing.

### Motivation

Base64 requires async work on drawables and bitmaps during the traversal


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

