### PR TITLE
RUMM-3021 internal logger only once

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -242,8 +242,8 @@ interface com.datadog.android.v2.api.InternalLogger
     - USER
     - MAINTAINER
     - TELEMETRY
-  fun log(Level, Target, String, Throwable? = null)
-  fun log(Level, List<Target>, String, Throwable? = null)
+  fun log(Level, Target, String, Throwable? = null, Boolean = false)
+  fun log(Level, List<Target>, String, Throwable? = null, Boolean = false)
   companion object 
     val UNBOUND: InternalLogger
 data class com.datadog.android.v2.api.Request

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -441,8 +441,8 @@ public final class com/datadog/android/v2/api/FeatureUploadConfiguration {
 
 public abstract interface class com/datadog/android/v2/api/InternalLogger {
 	public static final field Companion Lcom/datadog/android/v2/api/InternalLogger$Companion;
-	public abstract fun log (Lcom/datadog/android/v2/api/InternalLogger$Level;Lcom/datadog/android/v2/api/InternalLogger$Target;Ljava/lang/String;Ljava/lang/Throwable;)V
-	public abstract fun log (Lcom/datadog/android/v2/api/InternalLogger$Level;Ljava/util/List;Ljava/lang/String;Ljava/lang/Throwable;)V
+	public abstract fun log (Lcom/datadog/android/v2/api/InternalLogger$Level;Lcom/datadog/android/v2/api/InternalLogger$Target;Ljava/lang/String;Ljava/lang/Throwable;Z)V
+	public abstract fun log (Lcom/datadog/android/v2/api/InternalLogger$Level;Ljava/util/List;Ljava/lang/String;Ljava/lang/Throwable;Z)V
 }
 
 public final class com/datadog/android/v2/api/InternalLogger$Companion {
@@ -450,8 +450,8 @@ public final class com/datadog/android/v2/api/InternalLogger$Companion {
 }
 
 public final class com/datadog/android/v2/api/InternalLogger$DefaultImpls {
-	public static synthetic fun log$default (Lcom/datadog/android/v2/api/InternalLogger;Lcom/datadog/android/v2/api/InternalLogger$Level;Lcom/datadog/android/v2/api/InternalLogger$Target;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
-	public static synthetic fun log$default (Lcom/datadog/android/v2/api/InternalLogger;Lcom/datadog/android/v2/api/InternalLogger$Level;Ljava/util/List;Ljava/lang/String;Ljava/lang/Throwable;ILjava/lang/Object;)V
+	public static synthetic fun log$default (Lcom/datadog/android/v2/api/InternalLogger;Lcom/datadog/android/v2/api/InternalLogger$Level;Lcom/datadog/android/v2/api/InternalLogger$Target;Ljava/lang/String;Ljava/lang/Throwable;ZILjava/lang/Object;)V
+	public static synthetic fun log$default (Lcom/datadog/android/v2/api/InternalLogger;Lcom/datadog/android/v2/api/InternalLogger$Level;Ljava/util/List;Ljava/lang/String;Ljava/lang/Throwable;ZILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/v2/api/InternalLogger$Level : java/lang/Enum {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/v2/api/InternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/v2/api/InternalLogger.kt
@@ -82,7 +82,7 @@ interface InternalLogger {
      * @param message the log message
      * @param throwable an optional throwable error
      * @param onlyOnce whether only one instance of the message should be sent per lifetime of the
-     * logger (default is `false`)
+     * logger (default is `false`, onlyOnce applies to each target independently)
      */
     fun log(
         level: Level,
@@ -96,7 +96,7 @@ interface InternalLogger {
 
         /**
          * Logger for the cases when SDK instance is not yet available. Try to use the logger
-         * provided by [SdkCore._internalLogger] instead if possible.
+         * provided by [FeatureSdkCore.internalLogger] instead if possible.
          */
         val UNBOUND: InternalLogger = SdkInternalLogger(null)
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/v2/api/InternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/v2/api/InternalLogger.kt
@@ -64,12 +64,15 @@ interface InternalLogger {
      * @param target the target handler for the log
      * @param message the log message
      * @param throwable an optional throwable error
+     * @param onlyOnce whether only one instance of the message should be sent per lifetime of the
+     * logger (default is `false`)
      */
     fun log(
         level: Level,
         target: Target,
         message: String,
-        throwable: Throwable? = null
+        throwable: Throwable? = null,
+        onlyOnce: Boolean = false
     )
 
     /**
@@ -78,12 +81,15 @@ interface InternalLogger {
      * @param targets list of the target handlers for the log
      * @param message the log message
      * @param throwable an optional throwable error
+     * @param onlyOnce whether only one instance of the message should be sent per lifetime of the
+     * logger (default is `false`)
      */
     fun log(
         level: Level,
         targets: List<Target>,
         message: String,
-        throwable: Throwable? = null
+        throwable: Throwable? = null,
+        onlyOnce: Boolean = false
     )
 
     companion object {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/v2/core/SdkInternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/v2/core/SdkInternalLogger.kt
@@ -42,9 +42,9 @@ internal class SdkInternalLogger(
      */
     internal val maintainerLogger = maintainerLogHandlerFactory.invoke()
 
-    private val onlyOnceUserMessages = mutableListOf<String>()
-    private val onlyOnceMaintainerMessages = mutableListOf<String>()
-    private val onlyOnceTelemetryMessages = mutableListOf<String>()
+    private val onlyOnceUserMessages = mutableSetOf<String>()
+    private val onlyOnceMaintainerMessages = mutableSetOf<String>()
+    private val onlyOnceTelemetryMessages = mutableSetOf<String>()
 
     // region InternalLogger
 
@@ -118,7 +118,7 @@ internal class SdkInternalLogger(
         message: String,
         error: Throwable?,
         onlyOnce: Boolean,
-        knownSingleMessages: MutableList<String>
+        knownSingleMessages: MutableSet<String>
     ) {
         if (onlyOnce) {
             if (knownSingleMessages.contains(message)) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/v2/core/SdkInternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/v2/core/SdkInternalLogger.kt
@@ -15,12 +15,12 @@ import com.datadog.android.v2.api.InternalLogger
 
 internal class SdkInternalLogger(
     private val sdkCore: FeatureSdkCore?,
-    devLogHandlerFactory: () -> LogcatLogHandler = {
+    userLogHandlerFactory: () -> LogcatLogHandler = {
         LogcatLogHandler(DEV_LOG_TAG) { level ->
             level >= Datadog.getVerbosity()
         }
     },
-    sdkLogHandlerFactory: () -> LogcatLogHandler? = {
+    maintainerLogHandlerFactory: () -> LogcatLogHandler? = {
         if (BuildConfig.LOGCAT_ENABLED) {
             LogcatLogHandler(SDK_LOG_TAG)
         } else {
@@ -30,17 +30,21 @@ internal class SdkInternalLogger(
 ) : InternalLogger {
 
     /**
-     * Global Dev Logger. This logger is meant for user's debugging purposes.
+     * This logger is meant for user's debugging purposes.
      * Logcat logs are conditioned by the [Datadog.libraryVerbosity].
      * No Datadog logs should be sent.
      */
-    internal val devLogger = devLogHandlerFactory.invoke()
+    internal val userLogger = userLogHandlerFactory.invoke()
 
     /**
-     * Global SDK Logger. This logger is meant for internal debugging purposes.
+     * This logger is meant for internal debugging purposes.
      * Logcat logs are conditioned by a BuildConfig flag (set to false for releases).
      */
-    internal val sdkLogger = sdkLogHandlerFactory.invoke()
+    internal val maintainerLogger = maintainerLogHandlerFactory.invoke()
+
+    private val onlyOnceUserMessages = mutableListOf<String>()
+    private val onlyOnceMaintainerMessages = mutableListOf<String>()
+    private val onlyOnceTelemetryMessages = mutableListOf<String>()
 
     // region InternalLogger
 
@@ -48,12 +52,13 @@ internal class SdkInternalLogger(
         level: InternalLogger.Level,
         target: InternalLogger.Target,
         message: String,
-        throwable: Throwable?
+        throwable: Throwable?,
+        onlyOnce: Boolean
     ) {
         when (target) {
-            InternalLogger.Target.USER -> logToUser(level, message, throwable)
-            InternalLogger.Target.MAINTAINER -> logToMaintainer(level, message, throwable)
-            InternalLogger.Target.TELEMETRY -> logToTelemetry(level, message, throwable)
+            InternalLogger.Target.USER -> logToUser(level, message, throwable, onlyOnce)
+            InternalLogger.Target.MAINTAINER -> logToMaintainer(level, message, throwable, onlyOnce)
+            InternalLogger.Target.TELEMETRY -> logToTelemetry(level, message, throwable, onlyOnce)
         }
     }
 
@@ -61,7 +66,8 @@ internal class SdkInternalLogger(
         level: InternalLogger.Level,
         targets: List<InternalLogger.Target>,
         message: String,
-        throwable: Throwable?
+        throwable: Throwable?,
+        onlyOnce: Boolean
     ) {
         targets.forEach {
             log(level, it, message, throwable)
@@ -75,33 +81,71 @@ internal class SdkInternalLogger(
     private fun logToUser(
         level: InternalLogger.Level,
         message: String,
-        error: Throwable?
+        error: Throwable?,
+        onlyOnce: Boolean
     ) {
-        devLogger.log(
-            level.toLogLevel(),
-            message.withSdkName(),
-            error
+        sendToLogHandler(
+            userLogger,
+            level,
+            message,
+            error,
+            onlyOnce,
+            onlyOnceUserMessages
         )
     }
 
     private fun logToMaintainer(
         level: InternalLogger.Level,
         message: String,
-        error: Throwable?
+        error: Throwable?,
+        onlyOnce: Boolean
     ) {
-        sdkLogger?.log(
-            level.toLogLevel(),
-            message.withSdkName(),
-            error
-        )
+        maintainerLogger?.let {
+            sendToLogHandler(
+                it,
+                level,
+                message,
+                error,
+                onlyOnce,
+                onlyOnceMaintainerMessages
+            )
+        }
+    }
+
+    private fun sendToLogHandler(
+        handler: LogcatLogHandler,
+        level: InternalLogger.Level,
+        message: String,
+        error: Throwable?,
+        onlyOnce: Boolean,
+        knownSingleMessages: MutableList<String>
+    ) {
+        if (onlyOnce) {
+            if (knownSingleMessages.contains(message)) {
+                // drop the message… wait should we log that we dropped it?
+                return
+            } else {
+                knownSingleMessages.add(message)
+            }
+        }
+        handler.log(level.toLogLevel(), message.withSdkName(), error)
     }
 
     private fun logToTelemetry(
         level: InternalLogger.Level,
         message: String,
-        error: Throwable?
+        error: Throwable?,
+        onlyOnce: Boolean
     ) {
         val rumFeature = sdkCore?.getFeature(Feature.RUM_FEATURE_NAME) ?: return
+        if (onlyOnce) {
+            if (onlyOnceTelemetryMessages.contains(message)) {
+                // drop the message… wait should we log that we dropped it?
+                return
+            } else {
+                onlyOnceTelemetryMessages.add(message)
+            }
+        }
         val telemetryEvent = if (
             level == InternalLogger.Level.ERROR ||
             level == InternalLogger.Level.WARN ||

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/HostsSanitizerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/HostsSanitizerTest.kt
@@ -263,7 +263,8 @@ internal class HostsSanitizerTest {
                         fakeFeature
                     )
                 ),
-                any<MalformedURLException>()
+                any<MalformedURLException>(),
+                eq(false)
             )
         }
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/constraints/DatadogDataConstraintsTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/constraints/DatadogDataConstraintsTest.kt
@@ -367,7 +367,8 @@ internal class DatadogDataConstraintsTest {
             eq(InternalLogger.Level.WARN),
             eq(InternalLogger.Target.USER),
             logArgumentCaptor.capture(),
-            isNull()
+            isNull(),
+            eq(false)
         )
 
         assertThat(logArgumentCaptor.allValues).containsExactlyInAnyOrderElementsOf(

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/PlainFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/PlainFileReaderWriterTest.kt
@@ -25,7 +25,6 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.eq
-import org.mockito.kotlin.isNull
 import org.mockito.kotlin.verify
 import org.mockito.quality.Strictness
 import java.io.File
@@ -181,9 +180,10 @@ internal class PlainFileReaderWriterTest {
         assertThat(file).doesNotExist()
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.ERROR),
-            targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
+            eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
             eq(PlainFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path)),
-            any()
+            any(),
+            eq(false)
         )
     }
 
@@ -208,9 +208,10 @@ internal class PlainFileReaderWriterTest {
         assertThat(result).isFalse()
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.ERROR),
-            targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
+            eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
             eq(PlainFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path)),
-            any()
+            any(),
+            eq(false)
         )
     }
 
@@ -233,10 +234,10 @@ internal class PlainFileReaderWriterTest {
         assertThat(result).isEmpty()
         assertThat(file).doesNotExist()
         verify(mockInternalLogger).log(
-            eq(InternalLogger.Level.ERROR),
-            targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
-            eq(PlainFileReaderWriter.ERROR_READ.format(Locale.US, file.path)),
-            isNull()
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            PlainFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
+            null
         )
     }
 
@@ -254,10 +255,10 @@ internal class PlainFileReaderWriterTest {
         // Then
         assertThat(result).isEmpty()
         verify(mockInternalLogger).log(
-            eq(InternalLogger.Level.ERROR),
-            targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
-            eq(PlainFileReaderWriter.ERROR_READ.format(Locale.US, file.path)),
-            isNull()
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            PlainFileReaderWriter.ERROR_READ.format(Locale.US, file.path),
+            null
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestratorTest.kt
@@ -31,9 +31,7 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.atLeast
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.reset
-import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -816,10 +814,10 @@ internal class ConsentAwareFileOrchestratorTest {
 
         // Then
         verify(mockInternalLogger).log(
-            eq(InternalLogger.Level.ERROR),
-            eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
-            eq("Unable to schedule Data migration task on the executor"),
-            same(exception)
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
+            "Unable to schedule Data migration task on the executor",
+            exception
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ScheduledWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ScheduledWriterTest.kt
@@ -97,8 +97,9 @@ internal class ScheduledWriterTest {
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.ERROR),
             eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
-            any(),
-            same(exception)
+            any<String>(),
+            same(exception),
+            eq(false)
         )
     }
 
@@ -139,8 +140,9 @@ internal class ScheduledWriterTest {
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.ERROR),
             eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
-            any(),
-            same(exception)
+            any<String>(),
+            same(exception),
+            eq(false)
         )
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
@@ -184,9 +184,10 @@ internal class PlainBatchFileReaderWriterTest {
         assertThat(file).doesNotExist()
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.ERROR),
-            targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
+            eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
             eq(PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path)),
-            any()
+            any(),
+            eq(false)
         )
     }
 
@@ -211,9 +212,10 @@ internal class PlainBatchFileReaderWriterTest {
         assertThat(result).isFalse()
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.ERROR),
-            targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
+            eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
             eq(PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path)),
-            any()
+            any(),
+            eq(false)
         )
     }
 
@@ -237,9 +239,10 @@ internal class PlainBatchFileReaderWriterTest {
         assertThat(file).doesNotExist()
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.ERROR),
-            targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
+            eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
             eq(PlainBatchFileReaderWriter.ERROR_READ.format(Locale.US, file.path)),
-            any()
+            any(),
+            eq(false)
         )
     }
 
@@ -258,9 +261,10 @@ internal class PlainBatchFileReaderWriterTest {
         assertThat(result).isEmpty()
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.ERROR),
-            targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
+            eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
             eq(PlainBatchFileReaderWriter.ERROR_READ.format(Locale.US, file.path)),
-            any()
+            any(),
+            eq(false)
         )
     }
 
@@ -280,7 +284,7 @@ internal class PlainBatchFileReaderWriterTest {
         assertThat(result).isEmpty()
         verify(mockInternalLogger).log(
             InternalLogger.Level.ERROR,
-            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
             PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path)
         )
     }
@@ -361,7 +365,8 @@ internal class PlainBatchFileReaderWriterTest {
             eq(InternalLogger.Level.ERROR),
             eq(InternalLogger.Target.MAINTAINER),
             eq(PlainBatchFileReaderWriter.ERROR_FAILED_META_PARSE),
-            isA<JsonParseException>()
+            isA<JsonParseException>(),
+            eq(false)
         )
     }
 
@@ -416,7 +421,7 @@ internal class PlainBatchFileReaderWriterTest {
 
         verify(mockInternalLogger).log(
             InternalLogger.Level.ERROR,
-            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
             PlainBatchFileReaderWriter.WARNING_NOT_ALL_DATA_READ.format(Locale.US, file.path)
         )
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/AbstractLoggingExecutorServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/AbstractLoggingExecutorServiceTest.kt
@@ -175,9 +175,10 @@ internal abstract class AbstractLoggingExecutorServiceTest<T : ExecutorService> 
         verify(mockInternalLogger)
             .log(
                 eq(InternalLogger.Level.ERROR),
-                targets = eq(listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY)),
+                eq(listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY)),
                 eq(ERROR_UNCAUGHT_EXECUTION_EXCEPTION),
-                isA<CancellationException>()
+                isA<CancellationException>(),
+                eq(false)
             )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/LoggingScheduledThreadPoolExecutorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/LoggingScheduledThreadPoolExecutorTest.kt
@@ -73,7 +73,7 @@ internal class LoggingScheduledThreadPoolExecutorTest :
         verify(mockInternalLogger)
             .log(
                 InternalLogger.Level.ERROR,
-                targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+                listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
                 ERROR_UNCAUGHT_EXECUTION_EXCEPTION,
                 throwable
             )
@@ -94,9 +94,10 @@ internal class LoggingScheduledThreadPoolExecutorTest :
         verify(mockInternalLogger)
             .log(
                 eq(InternalLogger.Level.ERROR),
-                targets = eq(listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY)),
+                eq(listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY)),
                 eq(ERROR_UNCAUGHT_EXECUTION_EXCEPTION),
-                isA<CancellationException>()
+                isA<CancellationException>(),
+                eq(false)
             )
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/ndk/DatadogNdkCrashHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/ndk/DatadogNdkCrashHandlerTest.kt
@@ -171,7 +171,9 @@ internal class DatadogNdkCrashHandlerTest {
     ) {
         // Given
         fakeNdkCacheDir.mkdirs()
-        File(fakeNdkCacheDir, DatadogNdkCrashHandler.RUM_VIEW_EVENT_FILE_NAME).writeText(viewEventStr)
+        File(fakeNdkCacheDir, DatadogNdkCrashHandler.RUM_VIEW_EVENT_FILE_NAME).writeText(
+            viewEventStr
+        )
         val fakeViewEvent = forge.aFakeViewEvent()
         whenever(mockRumEventDeserializer.deserialize(viewEventStr)) doReturn fakeViewEvent.toJson()
 
@@ -405,9 +407,11 @@ internal class DatadogNdkCrashHandlerTest {
                 corruptedProperty,
                 forge.anElementFrom(JsonPrimitive(forge.anAlphabeticalString()), JsonArray())
             )
+
             "missing_id_property" -> fakeViewJson.get(corruptedProperty)
                 .asJsonObject
                 .remove("id")
+
             "wrong_id_type" -> fakeViewJson.get(corruptedProperty)
                 .asJsonObject.add(
                     "id",
@@ -430,7 +434,8 @@ internal class DatadogNdkCrashHandlerTest {
                 eq(InternalLogger.Level.WARN),
                 eq(InternalLogger.Target.MAINTAINER),
                 eq(DatadogNdkCrashHandler.WARN_CANNOT_READ_VIEW_INFO_DATA),
-                throwable = any()
+                any(),
+                eq(false)
             )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/v2/core/SdkInternalLoggerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/v2/core/SdkInternalLoggerTest.kt
@@ -78,13 +78,6 @@ internal class SdkInternalLoggerTest {
         }
     }
 
-//    Simple string
-//       withLambda:     3517458
-//    withoutLambda:     1570417
-//    String template
-//       withLambda:     4300250
-//    withoutLambda:    11746375
-
     // region Target.USER
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploaderTest.kt
@@ -42,7 +42,6 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.same
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -533,13 +532,11 @@ internal class DataOkHttpUploaderTest {
 
         // Then
         verify(mockLogger).log(
-            eq(InternalLogger.Level.ERROR),
-            eq(listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY)),
-            eq(
-                "Unable to create the request, probably due to bad data format. " +
-                    "The batch will be dropped."
-            ),
-            same(fakeException)
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            "Unable to create the request, probably due to bad data format. " +
+                "The batch will be dropped.",
+            fakeException
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/v2/core/internal/storage/ConsentAwareStorageTest.kt
@@ -274,8 +274,9 @@ internal class ConsentAwareStorageTest {
         verify(mockInternalLogger).log(
             eq(InternalLogger.Level.ERROR),
             eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
-            any(),
-            isA<RejectedExecutionException>()
+            any<String>(),
+            isA<RejectedExecutionException>(),
+            eq(false)
         )
     }
 

--- a/dd-sdk-android-core/src/testDebug/kotlin/com/datadog/android/core/internal/utils/InternalLoggerDebugTest.kt
+++ b/dd-sdk-android-core/src/testDebug/kotlin/com/datadog/android/core/internal/utils/InternalLoggerDebugTest.kt
@@ -35,7 +35,7 @@ internal class InternalLoggerDebugTest {
         val logger = SdkInternalLogger(forge.aNullable { mock() })
 
         // Then
-        val handler: LogcatLogHandler? = logger.sdkLogger
+        val handler: LogcatLogHandler? = logger.maintainerLogger
         assertThat(handler).isNotNull
         assertThat(handler?.tag).isEqualTo(SdkInternalLogger.SDK_LOG_TAG)
     }

--- a/dd-sdk-android-core/src/testRelease/kotlin/com/datadog/android/core/internal/utils/InternalLoggerReleaseTest.kt
+++ b/dd-sdk-android-core/src/testRelease/kotlin/com/datadog/android/core/internal/utils/InternalLoggerReleaseTest.kt
@@ -24,7 +24,7 @@ internal class InternalLoggerReleaseTest {
         )
 
         // Then
-        assertThat(logger.sdkLogger).isNull()
+        assertThat(logger.maintainerLogger).isNull()
     }
 
     // endregion

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -302,6 +302,7 @@ datadog:
       - "android.util.Log.i(kotlin.String?, kotlin.String)"
       - "android.util.Log.e(kotlin.String?, kotlin.String)"
       - "android.util.Log.e(kotlin.String?, kotlin.String?, kotlin.Throwable?)"
+      - "android.util.Log.w(kotlin.String?, kotlin.String)"
       - "android.util.Log.getStackTraceString(kotlin.Throwable?)"
       - "android.util.TypedValue.constructor()"
       - "android.view.Choreographer.postFrameCallback(android.view.Choreographer.FrameCallback)"
@@ -386,6 +387,7 @@ datadog:
       - "androidx.work.OneTimeWorkRequest.Builder.setInitialDelay(kotlin.Long, java.util.concurrent.TimeUnit)"
       - "androidx.work.WorkManager.cancelAllWorkByTag(kotlin.String)"
       - "androidx.work.WorkManager.getInstance(android.content.Context)"
+      - "androidx.work.WorkManager.isInitialized()"
       # endregion
       # region Glide
       - "com.bumptech.glide.GlideBuilder.setDiskCacheExecutor(com.bumptech.glide.load.engine.executor.GlideExecutor?)"
@@ -722,6 +724,7 @@ datadog:
       - "kotlin.collections.MutableSet.addAll(kotlin.collections.Collection)"
       - "kotlin.collections.MutableSet.clear()"
       - "kotlin.collections.MutableSet.contains(com.datadog.android.telemetry.internal.TelemetryEventId)"
+      - "kotlin.collections.MutableSet.contains(kotlin.String)"
       - "kotlin.collections.MutableSet.filter(kotlin.Function1)"
       - "kotlin.collections.MutableSet.firstOrNull(kotlin.Function1)"
       - "kotlin.collections.MutableSet.forEach(kotlin.Function1)"

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/storage/LogsDataWriterTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/storage/LogsDataWriterTest.kt
@@ -144,7 +144,8 @@ internal class LogsDataWriterTest {
                     )
                 ),
                 any(),
-                eq(fakeThrowable)
+                eq(fakeThrowable),
+                eq(false)
             )
 
         verifyNoInteractions(mockEventBatchWriter)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventSourceExtTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventSourceExtTest.kt
@@ -86,7 +86,8 @@ internal class RumEventSourceExtTest {
                 UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT
                     .format(Locale.US, fakeInvalidSource)
             ),
-            argThat { this is NoSuchElementException }
+            argThat { this is NoSuchElementException },
+            eq(false)
         )
     }
 
@@ -122,7 +123,8 @@ internal class RumEventSourceExtTest {
                 UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT
                     .format(Locale.US, fakeInvalidSource)
             ),
-            argThat { this is NoSuchElementException }
+            argThat { this is NoSuchElementException },
+            eq(false)
         )
     }
 
@@ -160,7 +162,8 @@ internal class RumEventSourceExtTest {
                 UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT
                     .format(Locale.US, fakeInvalidSource)
             ),
-            argThat { this is NoSuchElementException }
+            argThat { this is NoSuchElementException },
+            eq(false)
         )
     }
 
@@ -198,7 +201,8 @@ internal class RumEventSourceExtTest {
                 UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT
                     .format(Locale.US, fakeInvalidSource)
             ),
-            argThat { this is NoSuchElementException }
+            argThat { this is NoSuchElementException },
+            eq(false)
         )
     }
 
@@ -235,7 +239,8 @@ internal class RumEventSourceExtTest {
                 UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT
                     .format(Locale.US, fakeInvalidSource)
             ),
-            argThat { this is NoSuchElementException }
+            argThat { this is NoSuchElementException },
+            eq(false)
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventExtTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventExtTest.kt
@@ -79,7 +79,8 @@ internal class TelemetryEventExtTest {
                 UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT
                     .format(Locale.US, fakeInvalidSource)
             ),
-            argThat { this is NoSuchElementException }
+            argThat { this is NoSuchElementException },
+            eq(false)
         )
     }
 
@@ -115,7 +116,8 @@ internal class TelemetryEventExtTest {
                 UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT
                     .format(Locale.US, fakeInvalidSource)
             ),
-            argThat { this is NoSuchElementException }
+            argThat { this is NoSuchElementException },
+            eq(false)
         )
     }
 
@@ -153,7 +155,8 @@ internal class TelemetryEventExtTest {
                 UNKNOWN_SOURCE_WARNING_MESSAGE_FORMAT
                     .format(Locale.US, fakeInvalidSource)
             ),
-            argThat { this is NoSuchElementException }
+            argThat { this is NoSuchElementException },
+            eq(false)
         )
     }
 

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/MixedWebViewEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/MixedWebViewEventConsumerTest.kt
@@ -254,7 +254,8 @@ internal class MixedWebViewEventConsumerTest {
                     fakeBadJsonFormatEvent
                 )
             ),
-            argThat { this is JsonParseException }
+            argThat { this is JsonParseException },
+            eq(false)
         )
     }
 

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
@@ -246,7 +246,8 @@ internal class WebViewLogEventConsumerTest {
             eq(WebViewLogEventConsumer.JSON_PARSING_ERROR_MESSAGE),
             argThat {
                 expectedThrowable.isAssignableFrom(this::class.java)
-            }
+            },
+            eq(false)
         )
     }
 

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
@@ -631,7 +631,8 @@ internal class WebViewRumEventConsumerTest {
             eq(InternalLogger.Level.ERROR),
             targets = eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
             eq(WebViewRumEventConsumer.JSON_PARSING_ERROR_MESSAGE),
-            any()
+            any(),
+            eq(false)
         )
     }
 

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/storage/WebViewDataWriterTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/storage/WebViewDataWriterTest.kt
@@ -144,7 +144,8 @@ internal class WebViewDataWriterTest {
                     )
                 ),
                 any(),
-                eq(fakeThrowable)
+                eq(fakeThrowable),
+                eq(false)
             )
 
         verifyNoInteractions(mockEventBatchWriter)

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -222,10 +222,9 @@ internal constructor(
                 "SDK instance with name=$sdkInstanceName"
             }
             (sdkCore?.internalLogger ?: InternalLogger.UNBOUND).log(
-                InternalLogger.Level.WARN,
+                InternalLogger.Level.INFO,
                 InternalLogger.Target.USER,
-                WARN_RUM_DISABLED.format(Locale.US, prefix),
-                onlyOnce = true
+                WARN_RUM_DISABLED.format(Locale.US, prefix)
             )
         }
         return super.intercept(chain)

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -224,7 +224,8 @@ internal constructor(
             (sdkCore?.internalLogger ?: InternalLogger.UNBOUND).log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                WARN_RUM_DISABLED.format(Locale.US, prefix)
+                WARN_RUM_DISABLED.format(Locale.US, prefix),
+                onlyOnce = true
             )
         }
         return super.intercept(chain)

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -258,7 +258,8 @@ internal constructor(
             (sdkCore as FeatureSdkCore).internalLogger.log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                WARNING_TRACING_NO_HOSTS
+                WARNING_TRACING_NO_HOSTS,
+                onlyOnce = true
             )
         }
     }
@@ -324,7 +325,8 @@ internal constructor(
             sdkCore.internalLogger.log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                WARNING_TRACING_DISABLED
+                WARNING_TRACING_DISABLED,
+                onlyOnce = true
             )
             null
         } else if (GlobalTracer.isRegistered()) {

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutRumTest.kt
@@ -77,7 +77,7 @@ internal class DatadogInterceptorWithoutRumTest : TracingInterceptorTest() {
 
         // Then
         verify(mockInternalLogger).log(
-            InternalLogger.Level.WARN,
+            InternalLogger.Level.INFO,
             InternalLogger.Target.USER,
             DatadogInterceptor.WARN_RUM_DISABLED.format(Locale.US, "Default SDK instance")
         )

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -952,7 +952,9 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             .log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                TracingInterceptor.WARNING_TRACING_DISABLED
+                TracingInterceptor.WARNING_TRACING_DISABLED,
+                null,
+                true
             )
     }
 
@@ -1180,7 +1182,9 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             .log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                TracingInterceptor.WARNING_TRACING_NO_HOSTS
+                TracingInterceptor.WARNING_TRACING_NO_HOSTS,
+                null,
+                true
             )
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -1074,7 +1074,9 @@ internal open class TracingInterceptorNonDdTracerTest {
             .log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                TracingInterceptor.WARNING_TRACING_DISABLED
+                TracingInterceptor.WARNING_TRACING_DISABLED,
+                null,
+                true
             )
     }
 
@@ -1299,7 +1301,9 @@ internal open class TracingInterceptorNonDdTracerTest {
             .log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                TracingInterceptor.WARNING_TRACING_NO_HOSTS
+                TracingInterceptor.WARNING_TRACING_NO_HOSTS,
+                null,
+                true
             )
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -1009,7 +1009,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
             .log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                TracingInterceptor.WARNING_TRACING_DISABLED
+                TracingInterceptor.WARNING_TRACING_DISABLED,
+                null,
+                true
             )
     }
 
@@ -1249,7 +1251,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
             .log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                TracingInterceptor.WARNING_TRACING_NO_HOSTS
+                TracingInterceptor.WARNING_TRACING_NO_HOSTS,
+                null,
+                true
             )
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -1178,7 +1178,9 @@ internal open class TracingInterceptorTest {
             .log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                TracingInterceptor.WARNING_TRACING_DISABLED
+                TracingInterceptor.WARNING_TRACING_DISABLED,
+                null,
+                true
             )
     }
 
@@ -1415,7 +1417,9 @@ internal open class TracingInterceptorTest {
             .log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
-                TracingInterceptor.WARNING_TRACING_NO_HOSTS
+                TracingInterceptor.WARNING_TRACING_NO_HOSTS,
+                null,
+                true
             )
     }
 

--- a/tools/noopfactory/src/main/kotlin/com/datadog/tools/noopfactory/NoOpFactorySymbolProcessor.kt
+++ b/tools/noopfactory/src/main/kotlin/com/datadog/tools/noopfactory/NoOpFactorySymbolProcessor.kt
@@ -339,6 +339,7 @@ class NoOpFactorySymbolProcessor(
                     "emptyList"
                 )
             )
+
             rawTypeName == MAP -> funSpecBuilder.addStatement(
                 returnNewInstance,
                 MemberName(
@@ -346,6 +347,7 @@ class NoOpFactorySymbolProcessor(
                     "emptyMap"
                 )
             )
+
             rawTypeName == SET -> funSpecBuilder.addStatement(
                 returnNewInstance,
                 MemberName(
@@ -353,9 +355,11 @@ class NoOpFactorySymbolProcessor(
                     "emptySet"
                 )
             )
+
             matchingParamName != null && !returnTypeName.isNullable -> {
                 funSpecBuilder.addStatement("return %L", matchingParamName)
             }
+
             returnClassKind == ClassKind.ENUM_CLASS -> {
                 val firstValue = returnClassDeclaration.declarations.firstOrNull {
                     (it as? KSClassDeclaration)?.classKind == ClassKind.ENUM_ENTRY
@@ -372,6 +376,7 @@ class NoOpFactorySymbolProcessor(
                     )
                 }
             }
+
             returnClassKind == ClassKind.INTERFACE -> {
                 val packageName = returnClassDeclaration.qualifiedName
                     ?.asString()
@@ -382,6 +387,7 @@ class NoOpFactorySymbolProcessor(
                 )
                 funSpecBuilder.addStatement("return %T()", noOpReturnType)
             }
+
             else -> {
                 funSpecBuilder.addStatement("return %T()", returnTypeName)
             }


### PR DESCRIPTION
### What does this PR do?

Add an optional setting to send an internal log only once. This can be used to limit the spam in the Logcat/Telemetry.

