### PR TITLE
Update JNI bindings in NDK module

### DIFF
--- a/features/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.cpp
+++ b/features/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.cpp
@@ -99,7 +99,7 @@ void update_tracking_consent(jint consent) {
 
 /// Jni bindings
 extern "C" JNIEXPORT void JNICALL
-Java_com_datadog_android_ndk_NdkCrashReportsFeature_registerSignalHandler(
+Java_com_datadog_android_ndk_internal_NdkCrashReportsFeature_registerSignalHandler(
         JNIEnv *env,
         jobject /* this */,
         jstring storage_path,
@@ -112,14 +112,14 @@ Java_com_datadog_android_ndk_NdkCrashReportsFeature_registerSignalHandler(
 
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_datadog_android_ndk_NdkCrashReportsFeature_unregisterSignalHandler(
+Java_com_datadog_android_ndk_internal_NdkCrashReportsFeature_unregisterSignalHandler(
         JNIEnv *env,
         jobject /* this */) {
     stop_monitoring();
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_datadog_android_ndk_NdkCrashReportsFeature_updateTrackingConsent(
+Java_com_datadog_android_ndk_internal_NdkCrashReportsFeature_updateTrackingConsent(
         JNIEnv *env,
         jobject /* this */,
         jint consent) {


### PR DESCRIPTION
### What does this PR do?

Reference to the `NdkCrashReportsFeature` was broken in the JNI bindings after changes done in https://github.com/DataDog/dd-sdk-android/pull/1474.

Fixing it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

