### PR TITLE
RUMM-3359: Move position of `sdkCore` argument in case of being default one to the tail

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -8,7 +8,7 @@ class com.datadog.android.rum.DdRumContentProvider : android.content.ContentProv
 typealias GlobalRum = GlobalRumMonitor
 object com.datadog.android.rum.GlobalRumMonitor
   fun isRegistered(com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): Boolean
-  fun registerIfAbsent(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), RumMonitor): Boolean
+  fun registerIfAbsent(RumMonitor, com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): Boolean
   fun registerIfAbsent(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), java.util.concurrent.Callable<RumMonitor>): Boolean
   fun get(com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): RumMonitor
 object com.datadog.android.rum.Rum

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -17,10 +17,10 @@ public final class com/datadog/android/rum/GlobalRumMonitor {
 	public static final fun isRegistered (Lcom/datadog/android/v2/api/SdkCore;)Z
 	public static synthetic fun isRegistered$default (Lcom/datadog/android/v2/api/SdkCore;ILjava/lang/Object;)Z
 	public static final fun registerIfAbsent (Lcom/datadog/android/rum/RumMonitor;)Z
-	public static final fun registerIfAbsent (Lcom/datadog/android/v2/api/SdkCore;Lcom/datadog/android/rum/RumMonitor;)Z
+	public static final fun registerIfAbsent (Lcom/datadog/android/rum/RumMonitor;Lcom/datadog/android/v2/api/SdkCore;)Z
 	public static final fun registerIfAbsent (Lcom/datadog/android/v2/api/SdkCore;Ljava/util/concurrent/Callable;)Z
 	public static final fun registerIfAbsent (Ljava/util/concurrent/Callable;)Z
-	public static synthetic fun registerIfAbsent$default (Lcom/datadog/android/v2/api/SdkCore;Lcom/datadog/android/rum/RumMonitor;ILjava/lang/Object;)Z
+	public static synthetic fun registerIfAbsent$default (Lcom/datadog/android/rum/RumMonitor;Lcom/datadog/android/v2/api/SdkCore;ILjava/lang/Object;)Z
 	public static synthetic fun registerIfAbsent$default (Lcom/datadog/android/v2/api/SdkCore;Ljava/util/concurrent/Callable;ILjava/lang/Object;)Z
 }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/GlobalRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/GlobalRumMonitor.kt
@@ -56,14 +56,14 @@ object GlobalRumMonitor {
      * Every application intending to use the global monitor is responsible for registering it once
      * during its initialization.
      *
+     * @param monitor the monitor to use as global monitor.
      * @param sdkCore the instance to register the given monitor with. If not provided, default
      * instance will be used.
-     * @param monitor the monitor to use as global monitor.
      * @return `true` if the provided monitor was registered as a result of this call, `false` otherwise.
      */
     @JvmOverloads
     @JvmStatic
-    fun registerIfAbsent(sdkCore: SdkCore = Datadog.getInstance(), monitor: RumMonitor): Boolean {
+    fun registerIfAbsent(monitor: RumMonitor, sdkCore: SdkCore = Datadog.getInstance()): Boolean {
         return registerIfAbsent(sdkCore) { monitor }
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/GlobalRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/GlobalRumMonitorTest.kt
@@ -55,7 +55,7 @@ internal class GlobalRumMonitorTest {
     @Test
     fun `M return true W registerIfAbsent(monitor)`() {
         // When
-        val result = GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        val result = GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
 
         // Then
         assertThat(result).isTrue()
@@ -64,8 +64,8 @@ internal class GlobalRumMonitorTest {
     @Test
     fun `M return false W registerIfAbsent(monitor) twice {same sdkCore}`() {
         // When
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
-        val result = GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
+        val result = GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
 
         // Then
         assertThat(result).isFalse()
@@ -78,8 +78,8 @@ internal class GlobalRumMonitorTest {
         val mockMonitor2 = mock<RumMonitor>()
 
         // When
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
-        val result = GlobalRumMonitor.registerIfAbsent(mockSdkCore2, mockMonitor2)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
+        val result = GlobalRumMonitor.registerIfAbsent(mockMonitor2, mockSdkCore2)
 
         // Then
         assertThat(result).isTrue()
@@ -97,7 +97,7 @@ internal class GlobalRumMonitorTest {
     @Test
     fun `M return false W registerIfAbsent(provider) twice {same sdkCore}`() {
         // When
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
         val result = GlobalRumMonitor.registerIfAbsent(mockSdkCore, fakeRumMonitorProvider)
 
         // Then
@@ -122,7 +122,7 @@ internal class GlobalRumMonitorTest {
     @Test
     fun `M return true W registerIfAbsent(monitor) + isRegistered() {same sdkCore}`() {
         // When
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
         val result = GlobalRumMonitor.isRegistered(mockSdkCore)
 
         // Then
@@ -135,7 +135,7 @@ internal class GlobalRumMonitorTest {
         val mockSdkCore2 = mock<SdkCore>()
 
         // When
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
         val result = GlobalRumMonitor.isRegistered(mockSdkCore2)
 
         // Then
@@ -168,7 +168,7 @@ internal class GlobalRumMonitorTest {
     @Test
     fun `M return monitor W registerIfAbsent(monitor) + get() {same sdkCore}`() {
         // When
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
         val result = GlobalRumMonitor.get(mockSdkCore)
 
         // Then
@@ -181,7 +181,7 @@ internal class GlobalRumMonitorTest {
         val mockSdkCore2 = mock<SdkCore>()
 
         // When
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
         val result = GlobalRumMonitor.get(mockSdkCore2)
 
         // Then

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -117,7 +117,7 @@ internal class RumFeatureTest {
             fakeConfiguration,
             ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
         )
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
     }
 
     @AfterEach

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/config/GlobalRumMonitorTestConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/config/GlobalRumMonitorTestConfiguration.kt
@@ -22,7 +22,7 @@ internal class GlobalRumMonitorTestConfiguration :
     override fun setUp(forge: Forge) {
         super.setUp(forge)
         mockSdkCore = mock()
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockInstance)
+        GlobalRumMonitor.registerIfAbsent(mockInstance, mockSdkCore)
     }
 
     override fun tearDown(forge: Forge) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/sqlite/DatadogDatabaseErrorHandlerTest.kt
@@ -70,7 +70,7 @@ internal class DatadogDatabaseErrorHandlerTest {
         testedHandler = DatadogDatabaseErrorHandler(defaultErrorHandler = mockDefaultHandler)
         whenever(mockSqliteDatabase.path).thenReturn(fakeDbPath)
         whenever(mockSqliteDatabase.version).thenReturn(fakeDbVersion)
-        GlobalRumMonitor.registerIfAbsent(datadog.mockInstance, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, datadog.mockInstance)
     }
 
     @AfterEach

--- a/features/dd-sdk-android-webview/api/apiSurface
+++ b/features/dd-sdk-android-webview/api/apiSurface
@@ -1,9 +1,9 @@
 class com.datadog.android.webview.DatadogEventBridge
-  constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), List<String>)
+  constructor(List<String>, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
   fun send(String)
   fun getAllowedWebViewHosts(): String
   class _InternalWebViewProxy
     constructor(com.datadog.android.v2.api.SdkCore)
     fun consumeWebviewEvent(String)
   companion object 
-    fun setup(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), android.webkit.WebView, List<String>)
+    fun setup(android.webkit.WebView, List<String>, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())

--- a/features/dd-sdk-android-webview/api/dd-sdk-android-webview.api
+++ b/features/dd-sdk-android-webview/api/dd-sdk-android-webview.api
@@ -1,18 +1,18 @@
 public final class com/datadog/android/webview/DatadogEventBridge {
 	public static final field Companion Lcom/datadog/android/webview/DatadogEventBridge$Companion;
-	public fun <init> (Lcom/datadog/android/v2/api/SdkCore;Ljava/util/List;)V
-	public synthetic fun <init> (Lcom/datadog/android/v2/api/SdkCore;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Ljava/util/List;)V
+	public fun <init> (Ljava/util/List;Lcom/datadog/android/v2/api/SdkCore;)V
+	public synthetic fun <init> (Ljava/util/List;Lcom/datadog/android/v2/api/SdkCore;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun getAllowedWebViewHosts ()Ljava/lang/String;
 	public final fun send (Ljava/lang/String;)V
 	public static final fun setup (Landroid/webkit/WebView;Ljava/util/List;)V
-	public static final fun setup (Lcom/datadog/android/v2/api/SdkCore;Landroid/webkit/WebView;Ljava/util/List;)V
+	public static final fun setup (Landroid/webkit/WebView;Ljava/util/List;Lcom/datadog/android/v2/api/SdkCore;)V
 }
 
 public final class com/datadog/android/webview/DatadogEventBridge$Companion {
 	public final fun setup (Landroid/webkit/WebView;Ljava/util/List;)V
-	public final fun setup (Lcom/datadog/android/v2/api/SdkCore;Landroid/webkit/WebView;Ljava/util/List;)V
-	public static synthetic fun setup$default (Lcom/datadog/android/webview/DatadogEventBridge$Companion;Lcom/datadog/android/v2/api/SdkCore;Landroid/webkit/WebView;Ljava/util/List;ILjava/lang/Object;)V
+	public final fun setup (Landroid/webkit/WebView;Ljava/util/List;Lcom/datadog/android/v2/api/SdkCore;)V
+	public static synthetic fun setup$default (Lcom/datadog/android/webview/DatadogEventBridge$Companion;Landroid/webkit/WebView;Ljava/util/List;Lcom/datadog/android/v2/api/SdkCore;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/webview/DatadogEventBridge$_InternalWebViewProxy {

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/DatadogEventBridge.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/DatadogEventBridge.kt
@@ -48,13 +48,13 @@ internal constructor(
      * Please note that the WebView events will not be tracked unless the web page's URL Host is part of
      * the list defined in this constructor.
      *
-     * @param sdkCore SDK instance on which to attach the bridge. If not provided, default
-     * instance will be used.
      * @param allowedHosts a list of all the hosts that you want to track when loaded in the
      * WebView (e.g.: `listOf("example.com", "example.net")`).
+     * @param sdkCore SDK instance on which to attach the bridge. If not provided, default
+     * instance will be used.
      */
     @JvmOverloads
-    constructor(sdkCore: SdkCore = Datadog.getInstance(), allowedHosts: List<String>) : this(
+    constructor(allowedHosts: List<String>, sdkCore: SdkCore = Datadog.getInstance()) : this(
         buildWebViewEventConsumer(sdkCore as FeatureSdkCore),
         allowedHosts
     )
@@ -131,19 +131,19 @@ internal constructor(
          * ```
          * webView.webViewClient = WebViewClient()
          * ```
-         * @param sdkCore SDK instance on which to attach the bridge.
          * @param webView the webView on which to attach the bridge.
          * @param allowedHosts a list of all the hosts that you want to track when loaded in the
          * WebView (e.g.: `listOf("example.com", "example.net")`).
+         * @param sdkCore SDK instance on which to attach the bridge.
          * [More here](https://developer.android.com/guide/webapps/webview#HandlingNavigation).
          */
         @MainThread
         @JvmOverloads
         @JvmStatic
         fun setup(
-            sdkCore: SdkCore = Datadog.getInstance(),
             webView: WebView,
-            allowedHosts: List<String>
+            allowedHosts: List<String>,
+            sdkCore: SdkCore = Datadog.getInstance()
         ) {
             if (!webView.settings.javaScriptEnabled) {
                 (sdkCore as FeatureSdkCore).internalLogger.log(
@@ -153,7 +153,7 @@ internal constructor(
                 )
             }
             webView.addJavascriptInterface(
-                DatadogEventBridge(sdkCore, allowedHosts),
+                DatadogEventBridge(allowedHosts, sdkCore),
                 DATADOG_EVENT_BRIDGE_NAME
             )
         }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/DatadogEventBridgeTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/DatadogEventBridgeTest.kt
@@ -126,7 +126,7 @@ internal class DatadogEventBridgeTest {
         }
 
         // When
-        val bridge = DatadogEventBridge(mockCore, fakeHosts)
+        val bridge = DatadogEventBridge(fakeHosts, mockCore)
 
         // Then
         val consumer = bridge.webViewEventConsumer
@@ -163,7 +163,7 @@ internal class DatadogEventBridgeTest {
         }
 
         // When
-        val bridge = DatadogEventBridge(mockCore, fakeHosts)
+        val bridge = DatadogEventBridge(fakeHosts, mockCore)
 
         // Then
         val consumer = bridge.webViewEventConsumer
@@ -208,7 +208,7 @@ internal class DatadogEventBridgeTest {
         }
 
         // When
-        val bridge = DatadogEventBridge(mockCore, fakeHosts)
+        val bridge = DatadogEventBridge(fakeHosts, mockCore)
 
         // Then
         val consumer = bridge.webViewEventConsumer
@@ -258,7 +258,7 @@ internal class DatadogEventBridgeTest {
     ) {
         // Given
         val expectedHosts = hosts.joinToString(",", prefix = "[", postfix = "]") { "\"$it\"" }
-        testedDatadogEventBridge = DatadogEventBridge(mockCore, hosts)
+        testedDatadogEventBridge = DatadogEventBridge(hosts, mockCore)
 
         // When
         val allowedWebViewHosts = testedDatadogEventBridge.getAllowedWebViewHosts()
@@ -276,7 +276,7 @@ internal class DatadogEventBridgeTest {
     ) {
         // Given
         val expectedHosts = hosts.joinToString(",", prefix = "[", postfix = "]") { "\"$it\"" }
-        testedDatadogEventBridge = DatadogEventBridge(mockCore, hosts)
+        testedDatadogEventBridge = DatadogEventBridge(hosts, mockCore)
 
         // When
         val allowedWebViewHosts = testedDatadogEventBridge.getAllowedWebViewHosts()
@@ -294,7 +294,7 @@ internal class DatadogEventBridgeTest {
         // Given
         val expectedHosts = hosts.map { URL(it).host }
             .joinToString(",", prefix = "[", postfix = "]") { "\"$it\"" }
-        testedDatadogEventBridge = DatadogEventBridge(mockCore, hosts)
+        testedDatadogEventBridge = DatadogEventBridge(hosts, mockCore)
 
         // When
         val allowedWebViewHosts = testedDatadogEventBridge.getAllowedWebViewHosts()
@@ -315,7 +315,7 @@ internal class DatadogEventBridgeTest {
         }
 
         // When
-        DatadogEventBridge.setup(mockCore, mockWebView, fakeHosts)
+        DatadogEventBridge.setup(mockWebView, fakeHosts, mockCore)
 
         // Then
         verify(mockWebView).addJavascriptInterface(
@@ -338,7 +338,7 @@ internal class DatadogEventBridgeTest {
         }
 
         // When
-        DatadogEventBridge.setup(mockCore, mockWebView, fakeHosts)
+        DatadogEventBridge.setup(mockWebView, fakeHosts, mockCore)
 
         // Then
         verify(mockWebView).addJavascriptInterface(

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -76,7 +76,7 @@ internal class EncryptionTest {
         )
         featureActivations.shuffled(Random(forge.seed)).forEach { it() }
         val rumMonitor = RumMonitor.Builder(sdkCore).build()
-        GlobalRumMonitor.registerIfAbsent(sdkCore, rumMonitor)
+        GlobalRumMonitor.registerIfAbsent(rumMonitor, sdkCore)
 
         val tracer = AndroidTracer.Builder(sdkCore).setBundleWithRumEnabled(true).build()
         GlobalTracer.registerIfAbsent(tracer)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/GesturesTrackingActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/GesturesTrackingActivityTestRule.kt
@@ -50,6 +50,6 @@ internal class GesturesTrackingActivityTestRule<T : Activity>(
             isAccessible = true
             invoke(null, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
         }
-        GlobalRumMonitor.registerIfAbsent(sdkCore, RumMonitor.Builder(sdkCore).build())
+        GlobalRumMonitor.registerIfAbsent(RumMonitor.Builder(sdkCore).build(), sdkCore)
     }
 }

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingPlaygroundActivity.kt
@@ -49,7 +49,7 @@ internal class ActivityTrackingPlaygroundActivity : AppCompatActivity() {
             isAccessible = true
             invoke(null, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
         }
-        GlobalRumMonitor.registerIfAbsent(sdkCore, RumMonitor.Builder(sdkCore).build())
+        GlobalRumMonitor.registerIfAbsent(RumMonitor.Builder(sdkCore).build(), sdkCore)
         setContentView(R.layout.fragment_tracking_layout)
     }
 }

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingPlaygroundActivity.kt
@@ -45,7 +45,7 @@ internal class FragmentTrackingPlaygroundActivity : AppCompatActivity() {
             .useViewTrackingStrategy(FragmentViewTrackingStrategy(true))
             .build()
         Rum.enable(rumConfig, sdkCore)
-        GlobalRumMonitor.registerIfAbsent(sdkCore, RumMonitor.Builder(sdkCore).build())
+        GlobalRumMonitor.registerIfAbsent(RumMonitor.Builder(sdkCore).build(), sdkCore)
 
         setContentView(R.layout.fragment_tracking_layout)
         viewPager = findViewById(R.id.pager)

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/KioskSplashPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/KioskSplashPlaygroundActivity.kt
@@ -53,7 +53,7 @@ internal class KioskSplashPlaygroundActivity : AppCompatActivity() {
         )
         featureActivations.shuffled(Random(intent.getForgeSeed())).forEach { it() }
 
-        GlobalRumMonitor.registerIfAbsent(sdkCore, RumMonitor.Builder(sdkCore).build())
+        GlobalRumMonitor.registerIfAbsent(RumMonitor.Builder(sdkCore).build(), sdkCore)
 
         setContentView(R.layout.kiosk_splash_layout)
 

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplayPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplayPlaygroundActivity.kt
@@ -62,7 +62,7 @@ internal open class SessionReplayPlaygroundActivity : AppCompatActivity() {
         )
         featureActivations.shuffled(Random(intent.getForgeSeed()))
             .forEach { it() }
-        GlobalRumMonitor.registerIfAbsent(sdkCore, RumMonitor.Builder(sdkCore).build())
+        GlobalRumMonitor.registerIfAbsent(RumMonitor.Builder(sdkCore).build(), sdkCore)
         setContentView(R.layout.session_replay_layout)
         titleTextView = findViewById(R.id.title)
         clickMeButton = findViewById(R.id.button)

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/telemetry/TelemetryPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/telemetry/TelemetryPlaygroundActivity.kt
@@ -58,7 +58,7 @@ internal class TelemetryPlaygroundActivity : AppCompatActivity(R.layout.main_act
             .build()
         Rum.enable(rumConfig, sdkCore)
 
-        GlobalRumMonitor.registerIfAbsent(sdkCore, RumMonitor.Builder(sdkCore).build())
+        GlobalRumMonitor.registerIfAbsent(RumMonitor.Builder(sdkCore).build(), sdkCore)
     }
 
     override fun onPostResume() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -36,7 +36,6 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun registerIfAbsent(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), java.util.concurrent.Callable<RumMonitor>): Boolean
  * apiMethodSignature: com.datadog.android.rum.resource.RumResourceInputStream#constructor(java.io.InputStream, String, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
  * apiMethodSignature: com.datadog.android.rum.Rum#fun enable(RumConfiguration, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
- * apiMethodSignature: com.datadog.android.rum.Rum#fun enableDebugging(Boolean, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
  * apiMethodSignature: com.datadog.android.rum.RumConfiguration$Builder#fun disableUserInteractionTracking(): Builder
  * apiMethodSignature: com.datadog.android.rum.RumMonitor$Builder#fun setSessionListener(RumSessionListener): Builder
  * apiMethodSignature: com.datadog.android.rum.RumConfiguration$Builder#fun setTelemetrySampleRate(Float): Builder

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/GlobalRumMonitorE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/GlobalRumMonitorE2ETests.kt
@@ -52,7 +52,7 @@ class GlobalRumMonitorE2ETests {
      * apiMethodSignature: com.datadog.android.rum.RumConfiguration$Builder#fun build(): RumConfiguration
      * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun get(com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): RumMonitor
      * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun isRegistered(com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): Boolean
-     * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun registerIfAbsent(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), RumMonitor): Boolean
+     * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun registerIfAbsent(RumMonitor, com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): Boolean
      */
     @Before
     fun setUp() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBackgroundE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBackgroundE2ETests.kt
@@ -55,7 +55,7 @@ class RumMonitorBackgroundE2ETests {
      * apiMethodSignature: com.datadog.android.rum.RumConfiguration$Builder#fun trackFrustrations(Boolean): Builder
      * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun get(com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): RumMonitor
      * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun isRegistered(com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): Boolean
-     * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun registerIfAbsent(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), RumMonitor): Boolean
+     * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun registerIfAbsent(RumMonitor, com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): Boolean
      */
     @Before
     fun setUp() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorBuilderE2ETests.kt
@@ -33,7 +33,7 @@ class RumMonitorBuilderE2ETests {
      * apiMethodSignature: com.datadog.android.rum.RumMonitor$Builder#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.rum.RumMonitor$Builder#fun setSessionSampleRate(Float): Builder
      * apiMethodSignature: com.datadog.android.rum.RumMonitor$Builder#fun build(): RumMonitor
-     * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun registerIfAbsent(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), RumMonitor): Boolean
+     * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun registerIfAbsent(RumMonitor, com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): Boolean
      */
     @Test
     fun rum_rummonitor_builder_sample_all_in() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumMonitorE2ETests.kt
@@ -57,7 +57,7 @@ class RumMonitorE2ETests {
      * apiMethodSignature: com.datadog.android.rum.RumConfiguration$Builder#fun build(): RumConfiguration
      * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun get(com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): RumMonitor
      * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun isRegistered(com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): Boolean
-     * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun registerIfAbsent(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), RumMonitor): Boolean
+     * apiMethodSignature: com.datadog.android.rum.GlobalRumMonitor#fun registerIfAbsent(RumMonitor, com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): Boolean
      */
     @Before
     fun setUp() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -134,7 +134,7 @@ fun initializeSdk(
             }
         }
     GlobalTracer.registerIfAbsent(tracerProvider.invoke(sdkCore))
-    GlobalRumMonitor.registerIfAbsent(sdkCore, rumMonitorProvider.invoke(sdkCore))
+    GlobalRumMonitor.registerIfAbsent(rumMonitorProvider.invoke(sdkCore), sdkCore)
     return sdkCore
 }
 

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
@@ -45,7 +45,7 @@ internal class WebViewTrackingE2ETests {
     // region Tests
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), List<String>)
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(List<String>, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge$_InternalWebViewProxy#constructor(com.datadog.android.v2.api.SdkCore)
@@ -64,7 +64,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), List<String>)
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(List<String>, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge$_InternalWebViewProxy#constructor(com.datadog.android.v2.api.SdkCore)
@@ -83,7 +83,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), List<String>)
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(List<String>, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge$_InternalWebViewProxy#constructor(com.datadog.android.v2.api.SdkCore)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge$_InternalWebViewProxy#fun consumeWebviewEvent(String)
@@ -102,7 +102,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), List<String>)
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(List<String>, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge$_InternalWebViewProxy#constructor(com.datadog.android.v2.api.SdkCore)
@@ -117,7 +117,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), List<String>)
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(List<String>, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge$_InternalWebViewProxy#constructor(com.datadog.android.v2.api.SdkCore)
@@ -133,7 +133,7 @@ internal class WebViewTrackingE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), List<String>)
+     * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#constructor(List<String>, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun getAllowedWebViewHosts(): String
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge#fun send(String)
      * apiMethodSignature: com.datadog.android.webview.DatadogEventBridge$_InternalWebViewProxy#constructor(com.datadog.android.v2.api.SdkCore)

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/CrashService.kt
@@ -18,7 +18,7 @@ internal abstract class CrashService : Service() {
 
     protected fun initRum(sdkCore: SdkCore, extras: Bundle?) {
         val rumMonitor = RumMonitor.Builder(sdkCore).build()
-        GlobalRumMonitor.registerIfAbsent(sdkCore, rumMonitor)
+        GlobalRumMonitor.registerIfAbsent(rumMonitor, sdkCore)
         extras?.let { bundle ->
             bundle.keySet().forEach {
                 // TODO RUMM-2717 Bundle#get is deprecated, but there is no replacement for it.

--- a/integrations/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/DatadogCoilRequestListenerTest.kt
+++ b/integrations/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/DatadogCoilRequestListenerTest.kt
@@ -62,7 +62,7 @@ internal class DatadogCoilRequestListenerTest {
 
     @BeforeEach
     fun `set up`() {
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
         underTest = DatadogCoilRequestListener(mockSdkCore)
     }
 

--- a/integrations/dd-sdk-android-compose/api/apiSurface
+++ b/integrations/dd-sdk-android-compose/api/apiSurface
@@ -1,9 +1,9 @@
 annotation com.datadog.android.compose.ExperimentalTrackingApi
-fun trackClick(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), String, Map<String, Any?> = remember { emptyMap() }, () -> Unit): () -> Unit
-fun TrackInteractionEffect(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), String, androidx.compose.foundation.interaction.InteractionSource, InteractionType, Map<String, Any?> = emptyMap())
+fun trackClick(String, Map<String, Any?> = remember { emptyMap() }, com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), () -> Unit): () -> Unit
+fun TrackInteractionEffect(String, androidx.compose.foundation.interaction.InteractionSource, InteractionType, Map<String, Any?> = emptyMap(), com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
 sealed class com.datadog.android.compose.InteractionType
   class Swipe<T: Any> : InteractionType
     constructor(androidx.compose.material.SwipeableState<T>, androidx.compose.foundation.gestures.Orientation, Boolean = false)
   class Scroll : InteractionType
     constructor(androidx.compose.foundation.gestures.ScrollableState, androidx.compose.foundation.gestures.Orientation, Boolean = false)
-fun NavigationViewTrackingEffect(androidx.navigation.NavController, com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), Boolean = true, com.datadog.android.rum.tracking.ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())
+fun NavigationViewTrackingEffect(androidx.navigation.NavController, Boolean = true, com.datadog.android.rum.tracking.ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations(), com.datadog.android.v2.api.SdkCore = Datadog.getInstance())

--- a/integrations/dd-sdk-android-compose/api/dd-sdk-android-compose.api
+++ b/integrations/dd-sdk-android-compose/api/dd-sdk-android-compose.api
@@ -2,8 +2,8 @@ public abstract interface annotation class com/datadog/android/compose/Experimen
 }
 
 public final class com/datadog/android/compose/InteractionTrackingKt {
-	public static final fun TrackInteractionEffect (Lcom/datadog/android/v2/api/SdkCore;Ljava/lang/String;Landroidx/compose/foundation/interaction/InteractionSource;Lcom/datadog/android/compose/InteractionType;Ljava/util/Map;Landroidx/compose/runtime/Composer;II)V
-	public static final fun trackClick (Lcom/datadog/android/v2/api/SdkCore;Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lkotlin/jvm/functions/Function0;
+	public static final fun TrackInteractionEffect (Ljava/lang/String;Landroidx/compose/foundation/interaction/InteractionSource;Lcom/datadog/android/compose/InteractionType;Ljava/util/Map;Lcom/datadog/android/v2/api/SdkCore;Landroidx/compose/runtime/Composer;II)V
+	public static final fun trackClick (Ljava/lang/String;Ljava/util/Map;Lcom/datadog/android/v2/api/SdkCore;Lkotlin/jvm/functions/Function0;Landroidx/compose/runtime/Composer;II)Lkotlin/jvm/functions/Function0;
 }
 
 public abstract class com/datadog/android/compose/InteractionType {
@@ -23,6 +23,6 @@ public final class com/datadog/android/compose/InteractionType$Swipe : com/datad
 }
 
 public final class com/datadog/android/compose/NavigationKt {
-	public static final fun NavigationViewTrackingEffect (Landroidx/navigation/NavController;Lcom/datadog/android/v2/api/SdkCore;ZLcom/datadog/android/rum/tracking/ComponentPredicate;Landroidx/compose/runtime/Composer;II)V
+	public static final fun NavigationViewTrackingEffect (Landroidx/navigation/NavController;ZLcom/datadog/android/rum/tracking/ComponentPredicate;Lcom/datadog/android/v2/api/SdkCore;Landroidx/compose/runtime/Composer;II)V
 }
 

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/InteractionTracking.kt
@@ -37,18 +37,18 @@ import kotlin.math.roundToInt
 /**
  * Creates a proxy around click listener, which will report clicks to Datadog.
  *
- * @param sdkCore the SDK instance to use. If not provided, default instance will be used.
  * @param targetName Name of the click target.
  * @param attributes Additional custom attributes to attach to the action. Attributes can be
  * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
+ * @param sdkCore the SDK instance to use. If not provided, default instance will be used.
  * @param onClick Click listener.
  */
 @ExperimentalTrackingApi
 @Composable
 fun trackClick(
-    sdkCore: SdkCore = Datadog.getInstance(),
     targetName: String,
     attributes: Map<String, Any?> = remember { emptyMap() },
+    sdkCore: SdkCore = Datadog.getInstance(),
     onClick: () -> Unit
 ): () -> Unit {
     val onTapState = rememberUpdatedState(newValue = onClick)
@@ -64,22 +64,22 @@ fun trackClick(
  *
  * For tracking clicks check [trackClick].
  *
- * @param sdkCore the SDK instance to use. If not provided, default instance will be used.
  * @param targetName Name of the tracking target.
  * @param interactionSource [InteractionSource] which hosts the flow of interactions happening.
  * @param interactionType Type of the interaction, either [InteractionType.Scroll]
  * or [InteractionType.Swipe]
  * @param attributes Additional custom attributes to attach to the action. Attributes can be
  * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
+ * @param sdkCore the SDK instance to use. If not provided, default instance will be used.
  */
 @ExperimentalTrackingApi
 @Composable
 fun TrackInteractionEffect(
-    sdkCore: SdkCore = Datadog.getInstance(),
     targetName: String,
     interactionSource: InteractionSource,
     interactionType: InteractionType,
-    attributes: Map<String, Any?> = emptyMap()
+    attributes: Map<String, Any?> = emptyMap(),
+    sdkCore: SdkCore = Datadog.getInstance()
 ) {
     val isRtl = LocalLayoutDirection.current == LayoutDirection.Rtl
 

--- a/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation.kt
+++ b/integrations/dd-sdk-android-compose/src/main/kotlin/com/datadog/android/compose/Navigation.kt
@@ -107,19 +107,19 @@ internal class ComposeNavigationObserver(
  * for Compose setup.
  *
  * @param navController [NavController] to watch
- * @param sdkCore the SDK instance to use. If not provided, default instance will be used.
  * @param trackArguments whether to track navigation arguments
  * @param destinationPredicate to accept the [NavDestination] that will be taken into account as
  * valid RUM View events.
+ * @param sdkCore the SDK instance to use. If not provided, default instance will be used.
  */
 @ExperimentalTrackingApi
 @Composable
 @NonRestartableComposable
 fun NavigationViewTrackingEffect(
     navController: NavController,
-    sdkCore: SdkCore = Datadog.getInstance(),
     trackArguments: Boolean = true,
-    destinationPredicate: ComponentPredicate<NavDestination> = AcceptAllNavDestinations()
+    destinationPredicate: ComponentPredicate<NavDestination> = AcceptAllNavDestinations(),
+    sdkCore: SdkCore = Datadog.getInstance()
 ) {
     val currentTrackArguments by rememberUpdatedState(newValue = trackArguments)
     val currentDestinationPredicate by rememberUpdatedState(newValue = destinationPredicate)

--- a/integrations/dd-sdk-android-fresco/src/test/kotlin/com/datadog/android/fresco/DatadogFrescoCacheListenerTest.kt
+++ b/integrations/dd-sdk-android-fresco/src/test/kotlin/com/datadog/android/fresco/DatadogFrescoCacheListenerTest.kt
@@ -66,7 +66,7 @@ internal class DatadogFrescoCacheListenerTest {
 
     @BeforeEach
     fun `set up`() {
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
         fakeEventKey =
             BitmapMemoryCacheKey(
                 fakeCacheEventUri,

--- a/integrations/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/DatadogRUMUncaughtThrowableStrategyTest.kt
+++ b/integrations/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/DatadogRUMUncaughtThrowableStrategyTest.kt
@@ -48,7 +48,7 @@ internal class DatadogRUMUncaughtThrowableStrategyTest {
 
     @BeforeEach
     fun `set up`() {
-        GlobalRumMonitor.registerIfAbsent(datadog.mockInstance, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, datadog.mockInstance)
 
         testedStrategy = DatadogRUMUncaughtThrowableStrategy(fakeName)
     }

--- a/integrations/dd-sdk-android-ktx/api/apiSurface
+++ b/integrations/dd-sdk-android-ktx/api/apiSurface
@@ -6,7 +6,7 @@ fun <T: Any?> withContextTraced(String, kotlin.coroutines.CoroutineContext, Coro
 interface com.datadog.android.ktx.coroutine.CoroutineScopeSpan : kotlinx.coroutines.CoroutineScope, io.opentracing.Span
 fun <T> kotlinx.coroutines.flow.Flow<T>.sendErrorToDatadog(com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): kotlinx.coroutines.flow.Flow<T>
 fun <T: java.io.Closeable, R> T.useMonitored(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), (T) -> R): R
-fun android.content.Context.getAssetAsRumResource(String, com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), Int = AssetManager.ACCESS_STREAMING): java.io.InputStream
+fun android.content.Context.getAssetAsRumResource(String, Int = AssetManager.ACCESS_STREAMING, com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun android.content.Context.getRawResAsRumResource(Int, com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun java.io.InputStream.asRumResource(String, com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun <T> android.database.sqlite.SQLiteDatabase.transactionTraced(String, Boolean = true, io.opentracing.Span.(android.database.sqlite.SQLiteDatabase) -> T): T

--- a/integrations/dd-sdk-android-ktx/api/dd-sdk-android-ktx.api
+++ b/integrations/dd-sdk-android-ktx/api/dd-sdk-android-ktx.api
@@ -23,8 +23,8 @@ public final class com/datadog/android/ktx/rum/CloseableExtKt {
 }
 
 public final class com/datadog/android/ktx/rum/ContextExtKt {
-	public static final fun getAssetAsRumResource (Landroid/content/Context;Ljava/lang/String;Lcom/datadog/android/v2/api/SdkCore;I)Ljava/io/InputStream;
-	public static synthetic fun getAssetAsRumResource$default (Landroid/content/Context;Ljava/lang/String;Lcom/datadog/android/v2/api/SdkCore;IILjava/lang/Object;)Ljava/io/InputStream;
+	public static final fun getAssetAsRumResource (Landroid/content/Context;Ljava/lang/String;ILcom/datadog/android/v2/api/SdkCore;)Ljava/io/InputStream;
+	public static synthetic fun getAssetAsRumResource$default (Landroid/content/Context;Ljava/lang/String;ILcom/datadog/android/v2/api/SdkCore;ILjava/lang/Object;)Ljava/io/InputStream;
 	public static final fun getRawResAsRumResource (Landroid/content/Context;ILcom/datadog/android/v2/api/SdkCore;)Ljava/io/InputStream;
 	public static synthetic fun getRawResAsRumResource$default (Landroid/content/Context;ILcom/datadog/android/v2/api/SdkCore;ILjava/lang/Object;)Ljava/io/InputStream;
 }

--- a/integrations/dd-sdk-android-ktx/src/main/kotlin/com/datadog/android/ktx/rum/ContextExt.kt
+++ b/integrations/dd-sdk-android-ktx/src/main/kotlin/com/datadog/android/ktx/rum/ContextExt.kt
@@ -24,8 +24,8 @@ internal const val HEX_RADIX = 16
  * files placed into the "assets" directory.
  *
  * @param fileName The name of the asset to open.  This name can be hierarchical.
- * @param sdkCore the SDK instance to use. If not provided, default instance will be used.
  * @param accessMode Desired access mode for retrieving the data.
+ * @param sdkCore the SDK instance to use. If not provided, default instance will be used.
  *
  * @return [InputStream] access to the asset data
  *
@@ -36,8 +36,8 @@ internal const val HEX_RADIX = 16
  */
 fun Context.getAssetAsRumResource(
     fileName: String,
-    sdkCore: SdkCore = Datadog.getInstance(),
-    accessMode: Int = AssetManager.ACCESS_STREAMING
+    accessMode: Int = AssetManager.ACCESS_STREAMING,
+    sdkCore: SdkCore = Datadog.getInstance()
 ): InputStream {
     return RumResourceInputStream(
         assets.open(fileName, accessMode),

--- a/integrations/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/coroutine/FlowExtTest.kt
+++ b/integrations/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/coroutine/FlowExtTest.kt
@@ -46,7 +46,7 @@ class FlowExtTest {
 
     @BeforeEach
     fun `set up`() {
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
     }
 
     @AfterEach

--- a/integrations/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/rum/CloseableExtTest.kt
+++ b/integrations/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/rum/CloseableExtTest.kt
@@ -58,7 +58,7 @@ class CloseableExtTest {
 
     @BeforeEach
     fun `set up`() {
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
     }
 
     @AfterEach

--- a/integrations/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/rum/ContextExtTest.kt
+++ b/integrations/dd-sdk-android-ktx/src/test/kotlin/com/datadog/android/ktx/rum/ContextExtTest.kt
@@ -69,7 +69,7 @@ class ContextExtTest {
         whenever(mockAssetManager.open(fileName, accessMode)) doReturn mockIS
 
         // When
-        val result = mockContext.getAssetAsRumResource(fileName, mockSdkCore, accessMode)
+        val result = mockContext.getAssetAsRumResource(fileName, accessMode, mockSdkCore)
 
         // Then
         assertThat(result).isInstanceOf(RumResourceInputStream::class.java)
@@ -88,7 +88,7 @@ class ContextExtTest {
         whenever(mockAssetManager.open(fileName, AssetManager.ACCESS_STREAMING)) doReturn mockIS
 
         // When
-        val result = mockContext.getAssetAsRumResource(fileName, mockSdkCore)
+        val result = mockContext.getAssetAsRumResource(fileName, sdkCore = mockSdkCore)
 
         // Then
         assertThat(result).isInstanceOf(RumResourceInputStream::class.java)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/config/GlobalRumMonitorTestConfiguration.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/config/GlobalRumMonitorTestConfiguration.kt
@@ -24,7 +24,7 @@ internal class GlobalRumMonitorTestConfiguration(
     override fun setUp(forge: Forge) {
         super.setUp(forge)
         mockSdkCore = datadogSingletonTestConfiguration?.mockInstance ?: mock()
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockInstance)
+        GlobalRumMonitor.registerIfAbsent(mockInstance, mockSdkCore)
     }
 
     override fun tearDown(forge: Forge) {

--- a/integrations/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRumErrorConsumerTest.kt
+++ b/integrations/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRumErrorConsumerTest.kt
@@ -48,7 +48,7 @@ class DatadogRumErrorConsumerTest {
 
     @BeforeEach
     fun `set up`() {
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
         testedConsumer = DatadogRumErrorConsumer(mockSdkCore)
     }
 

--- a/integrations/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRxExtTest.kt
+++ b/integrations/dd-sdk-android-rx/src/test/kotlin/com/datadog/android/rx/DatadogRxExtTest.kt
@@ -54,7 +54,7 @@ class DatadogRxExtTest {
 
     @BeforeEach
     fun `set up`() {
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
     }
 
     @AfterEach

--- a/integrations/dd-sdk-android-sqldelight/src/test/kotlin/com/datadog/android/sqldelight/DatadogSqliteCallbackTest.kt
+++ b/integrations/dd-sdk-android-sqldelight/src/test/kotlin/com/datadog/android/sqldelight/DatadogSqliteCallbackTest.kt
@@ -61,7 +61,7 @@ class DatadogSqliteCallbackTest {
 
     @BeforeEach
     fun `set up`() {
-        GlobalRumMonitor.registerIfAbsent(mockSdkCore, mockRumMonitor)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
         testedSqliteCallback = DatadogSqliteCallback(mock(), mockSdkCore)
         whenever(mockSqliteDatabase.path).thenReturn(fakeDbPath)
         whenever(mockSqliteDatabase.version).thenReturn(fakeDbVersion)

--- a/integrations/dd-sdk-android-timber/api/apiSurface
+++ b/integrations/dd-sdk-android-timber/api/apiSurface
@@ -1,4 +1,4 @@
 class com.datadog.android.timber.DatadogTree : timber.log.Timber.Tree
   constructor(com.datadog.android.log.Logger)
-  constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), Int)
+  constructor(Int, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
   override fun log(Int, String?, String, Throwable?)

--- a/integrations/dd-sdk-android-timber/api/dd-sdk-android-timber.api
+++ b/integrations/dd-sdk-android-timber/api/dd-sdk-android-timber.api
@@ -1,7 +1,7 @@
 public final class com/datadog/android/timber/DatadogTree : timber/log/Timber$Tree {
 	public fun <init> (I)V
+	public fun <init> (ILcom/datadog/android/v2/api/SdkCore;)V
+	public synthetic fun <init> (ILcom/datadog/android/v2/api/SdkCore;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun <init> (Lcom/datadog/android/log/Logger;)V
-	public fun <init> (Lcom/datadog/android/v2/api/SdkCore;I)V
-	public synthetic fun <init> (Lcom/datadog/android/v2/api/SdkCore;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 

--- a/integrations/dd-sdk-android-timber/src/main/kotlin/com/datadog/android/timber/DatadogTree.kt
+++ b/integrations/dd-sdk-android-timber/src/main/kotlin/com/datadog/android/timber/DatadogTree.kt
@@ -18,8 +18,7 @@ import timber.log.Timber
  */
 class DatadogTree(
     private val logger: Logger
-) :
-    Timber.Tree() {
+) : Timber.Tree() {
 
     /**
      * Creates a [Timber.Tree] with a default [Logger] having a minimum log priority
@@ -27,12 +26,12 @@ class DatadogTree(
      *
      * See [Logger.Builder.setDatadogLogsMinPriority] for details.
      *
-     * @param sdkCore SDK instance to bind to. If not provided, default instance will be used.
      * @param minLogPriority Minimum log priority to be sent to the Datadog servers.
+     * @param sdkCore SDK instance to bind to. If not provided, default instance will be used.
      */
     @Suppress("unused")
     @JvmOverloads
-    constructor(sdkCore: SdkCore = Datadog.getInstance(), minLogPriority: Int) :
+    constructor(minLogPriority: Int, sdkCore: SdkCore = Datadog.getInstance()) :
         this(
             Logger.Builder(sdkCore)
                 .setDatadogLogsMinPriority(minLogPriority)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/WebFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/WebFragment.kt
@@ -14,7 +14,6 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
-import com.datadog.android.Datadog
 import com.datadog.android.sample.R
 import com.datadog.android.webview.DatadogEventBridge
 
@@ -39,7 +38,7 @@ internal class WebFragment : Fragment() {
         webView = rootView.findViewById(R.id.webview)
         webView.webViewClient = WebViewClient()
         webView.settings.javaScriptEnabled = true
-        DatadogEventBridge.setup(Datadog.getInstance(), webView, webViewTrackingHosts)
+        DatadogEventBridge.setup(webView, webViewTrackingHosts)
         return rootView
     }
 


### PR DESCRIPTION
### What does this PR do?

This change moves `sdkCore` argument to the end of method/constructor arguments in case if it is default one, because it will simplify the migration: in case if value is default, there won't be need to update old method/constructor signature on the client side.

The only exception to this rule is made when the last argument is lambda, in this case `sdkCore` comes right before the lambda. It creates some discrepancy in case of `registerIfAbsent` method:

* `fun registerIfAbsent(RumMonitor, com.datadog.android.v2.api.SdkCore = Datadog.getInstance()): Boolean`
* `fun registerIfAbsent(com.datadog.android.v2.api.SdkCore = Datadog.getInstance(), java.util.concurrent.Callable<RumMonitor>): Boolean`

But in the latter case we cannot move `Callable` to the first position, because something with named argument like `registerIfAbsent(sdkCore) { ... }` to make lambda last in the call won't compile.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

