### PR TITLE
RUMM-1594: Drop KitKat support

### DIFF
--- a/ZEN.md
+++ b/ZEN.md
@@ -32,7 +32,7 @@ This SDK lives in our customer’s applications, and is run on end users devices
 ## Compatibility
 
 - Support old versions of the OS’s
-    - Android: KitKat (5 years old)
+    - Android: Lollipop (released in 2014)
 - Support all main languages; especially the behavior should be the same for any language, but can be enhanced for modern languages.
     - Android: Java/Kotlin
 - Support vanilla flavors of the OS first, and add possible extensions for derived flavors of the OSs (Watch, TV, …)

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -14,11 +14,7 @@ import org.gradle.api.JavaVersion
 object AndroidConfig {
 
     const val TARGET_SDK = 33
-    const val MIN_SDK = 19
-
-    // this is temporary, until we bump min sdk. Compose requires min sdk 21.
-    const val MIN_SDK_FOR_COMPOSE = 21
-    const val MIN_SDK_FOR_WEAR = 23
+    const val MIN_SDK = 21
     const val BUILD_TOOLS_VERSION = "33.0.2"
 
     val VERSION = Version(2, 0, 0, Version.Type.Snapshot)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -422,7 +422,6 @@ internal class CoreFeature(
             configuration.needsClearTextHttp -> ConnectionSpec.CLEARTEXT
             else -> ConnectionSpec.Builder(ConnectionSpec.RESTRICTED_TLS)
                 .tlsVersions(TlsVersion.TLS_1_2, TlsVersion.TLS_1_3)
-                .supportsTlsExtensions(true)
                 .cipherSuites(*RESTRICTED_CIPHER_SUITES)
                 .build()
         }
@@ -554,15 +553,7 @@ internal class CoreFeature(
             CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
 
             CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-
-            // these 4 are not listed in OpenSSL (because of CBC), but
-            // claimed to be FIPS 140-2 compliant in other sources. Keep them for now, can be safely
-            // dropped once min API is 21 (TODO RUMM-1594).
-            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
-            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
-            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
         )
 
         const val DRAIN_WAIT_SECONDS = 10L

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/CurlInterceptor.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/CurlInterceptor.kt
@@ -59,11 +59,11 @@ internal class CurlInterceptor(
 
         constructor(request: Request, printBody: Boolean) :
             this(
-                url = request.url().toString(),
-                method = request.method(),
-                contentType = request.body()?.contentType()?.toString(),
-                requestBody = request.body(),
-                headers = request.headers().toMultimap(),
+                url = request.url.toString(),
+                method = request.method,
+                contentType = request.body?.contentType()?.toString(),
+                requestBody = request.body,
+                headers = request.headers.toMultimap(),
                 printBody = printBody
             )
 
@@ -91,12 +91,12 @@ internal class CurlInterceptor(
         private fun RequestBody.toParts(): List<String> {
             return if (this is MultipartBody) {
                 val requestCurlPart = mutableListOf<String>()
-                this.parts().forEach {
-                    it.headers()?.toMultimap()?.forEach { (key, value) ->
+                this.parts.forEach {
+                    it.headers?.toMultimap()?.forEach { (key, value) ->
                         requestCurlPart.add(FORMAT_HEADER.format(Locale.US, key, value))
                     }
                     if (printBody) {
-                        requestCurlPart.add(FORMAT_BODY.format(Locale.US, peekBody(it.body())))
+                        requestCurlPart.add(FORMAT_BODY.format(Locale.US, peekBody(it.body)))
                     }
                 }
                 requestCurlPart

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolver.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolver.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal.net
 
 import com.datadog.android.trace.TracingHeaderType
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
 import java.util.Locale
 
 /**
@@ -24,7 +25,7 @@ class DefaultFirstPartyHostHeaderTypeResolver(
 
     /** @inheritdoc */
     override fun isFirstPartyUrl(url: HttpUrl): Boolean {
-        val host = url.host()
+        val host = url.host
         return knownHosts.keys.any {
             it == "*" || host == it || host.endsWith(".$it")
         }
@@ -32,19 +33,19 @@ class DefaultFirstPartyHostHeaderTypeResolver(
 
     /** @inheritdoc */
     override fun isFirstPartyUrl(url: String): Boolean {
-        val httpUrl = HttpUrl.parse(url) ?: return false
+        val httpUrl = url.toHttpUrlOrNull() ?: return false
         return isFirstPartyUrl(httpUrl)
     }
 
     /** @inheritdoc */
     override fun headerTypesForUrl(url: String): Set<TracingHeaderType> {
-        val httpUrl = HttpUrl.parse(url) ?: return emptySet()
+        val httpUrl = url.toHttpUrlOrNull() ?: return emptySet()
         return headerTypesForUrl(httpUrl)
     }
 
     /** @inheritdoc */
     override fun headerTypesForUrl(url: HttpUrl): Set<TracingHeaderType> {
-        val host = url.host()
+        val host = url.host
         val filteredHosts = knownHosts.filter {
             it.key == "*" || it.key == host || host.endsWith(".${it.key}")
         }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/RotatingDnsResolver.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/RotatingDnsResolver.kt
@@ -39,12 +39,12 @@ internal class RotatingDnsResolver(
 
     // region Dns
 
-    override fun lookup(hostname: String): MutableList<InetAddress> {
+    override fun lookup(hostname: String): List<InetAddress> {
         val knownHost = knownHosts[hostname]
 
         return if (knownHost != null && isValid(knownHost)) {
             knownHost.rotate()
-            knownHost.addresses.toMutableList()
+            knownHost.addresses
         } else {
             @Suppress("UnsafeThirdPartyFunctionCall") // handled by caller
             val result = delegate.lookup(hostname)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/system/BroadcastReceiverSystemInfoProvider.kt
@@ -11,14 +11,12 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.os.BatteryManager
-import android.os.Build
 import android.os.PowerManager
 import com.datadog.android.core.internal.receiver.ThreadSafeReceiver
 import com.datadog.android.v2.api.InternalLogger
 import kotlin.math.roundToInt
 
 internal class BroadcastReceiverSystemInfoProvider(
-    private val buildSdkVersionProvider: BuildSdkVersionProvider = DefaultBuildSdkVersionProvider(),
     private val internalLogger: InternalLogger
 ) :
     ThreadSafeReceiver(), SystemInfoProvider {
@@ -55,9 +53,7 @@ internal class BroadcastReceiverSystemInfoProvider(
     @SuppressLint("InlinedApi")
     override fun register(context: Context) {
         registerIntentFilter(context, Intent.ACTION_BATTERY_CHANGED)
-        if (buildSdkVersionProvider.version() >= Build.VERSION_CODES.LOLLIPOP) {
-            registerIntentFilter(context, PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
-        }
+        registerIntentFilter(context, PowerManager.ACTION_POWER_SAVE_MODE_CHANGED)
     }
 
     override fun unregister(context: Context) {
@@ -100,15 +96,12 @@ internal class BroadcastReceiverSystemInfoProvider(
         )
     }
 
-    @SuppressLint("NewApi")
     private fun handlePowerSaveIntent(context: Context) {
-        if (buildSdkVersionProvider.version() >= Build.VERSION_CODES.LOLLIPOP) {
-            val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
-            val powerSaveMode = powerManager?.isPowerSaveMode ?: false
-            systemInfo = systemInfo.copy(
-                powerSaveMode = powerSaveMode
-            )
-        }
+        val powerManager = context.getSystemService(Context.POWER_SERVICE) as? PowerManager
+        val powerSaveMode = powerManager?.isPowerSaveMode ?: false
+        systemInfo = systemInfo.copy(
+            powerSaveMode = powerSaveMode
+        )
     }
 
     // endregion

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploader.kt
@@ -13,9 +13,9 @@ import com.datadog.android.v2.api.InternalLogger
 import com.datadog.android.v2.api.RequestFactory
 import com.datadog.android.v2.api.context.DatadogContext
 import okhttp3.Call
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import java.util.Locale
 import com.datadog.android.v2.api.Request as DatadogRequest
 
@@ -104,7 +104,7 @@ internal class DataOkHttpUploader(
         val call = callFactory.newCall(okHttpRequest)
         val response = call.execute()
         response.close()
-        return responseCodeToUploadStatus(response.code(), request)
+        return responseCodeToUploadStatus(response.code, request)
     }
 
     @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
@@ -112,11 +112,11 @@ internal class DataOkHttpUploader(
         val mediaType = if (request.contentType == null) {
             null
         } else {
-            MediaType.parse(request.contentType)
+            request.contentType.toMediaTypeOrNull()
         }
         val builder = Request.Builder()
             .url(request.url)
-            .post(RequestBody.create(mediaType, request.body))
+            .post(request.body.toRequestBody(mediaType))
 
         for ((header, value) in request.headers) {
             if (header.lowercase(Locale.US) == "user-agent") {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -193,8 +193,7 @@ internal class CoreFeatureTest {
     }
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
-    fun `𝕄 initialize network info provider 𝕎 initialize {LOLLIPOP}`() {
+    fun `𝕄 initialize network info provider 𝕎 initialize`() {
         // When
         testedFeature.initialize(
             appContext.mockInstance,
@@ -308,8 +307,7 @@ internal class CoreFeatureTest {
     }
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
-    fun `𝕄 initializes app info 𝕎 initialize() { LOLLIPOP }`() {
+    fun `𝕄 initializes app info 𝕎 initialize()`() {
         // When
         testedFeature.initialize(
             appContext.mockInstance,
@@ -410,8 +408,7 @@ internal class CoreFeatureTest {
     }
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
-    fun `𝕄 initializes app info 𝕎 initialize() {unknown package name, LOLLIPOP}`() {
+    fun `𝕄 initializes app info 𝕎 initialize() {unknown package name}`() {
         // Given
         @Suppress("DEPRECATION")
         whenever(appContext.mockPackageManager.getPackageInfo(appContext.fakePackageName, 0))
@@ -491,31 +488,26 @@ internal class CoreFeatureTest {
 
         // Then
         val okHttpClient = testedFeature.okHttpClient
-        assertThat(okHttpClient.protocols())
+        assertThat(okHttpClient.protocols)
             .containsExactly(Protocol.HTTP_2, Protocol.HTTP_1_1)
-        assertThat(okHttpClient.callTimeoutMillis())
+        assertThat(okHttpClient.callTimeoutMillis)
             .isEqualTo(CoreFeature.NETWORK_TIMEOUT_MS.toInt())
-        assertThat(okHttpClient.connectionSpecs())
+        assertThat(okHttpClient.connectionSpecs)
             .hasSize(1)
 
-        val connectionSpec = okHttpClient.connectionSpecs().first()
+        val connectionSpec = okHttpClient.connectionSpecs.first()
 
         assertThat(connectionSpec.isTls).isTrue()
-        assertThat(connectionSpec.tlsVersions())
+        assertThat(connectionSpec.tlsVersions)
             .containsExactly(TlsVersion.TLS_1_2, TlsVersion.TLS_1_3)
-        assertThat(connectionSpec.supportsTlsExtensions()).isTrue()
-        assertThat(connectionSpec.cipherSuites()).containsExactly(
+        assertThat(connectionSpec.cipherSuites).containsExactly(
             CipherSuite.TLS_AES_128_GCM_SHA256,
             CipherSuite.TLS_AES_256_GCM_SHA384,
             CipherSuite.TLS_CHACHA20_POLY1305_SHA256,
             CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
             CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
             CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-            CipherSuite.TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA256,
-            CipherSuite.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA384,
-            CipherSuite.TLS_RSA_WITH_AES_128_CBC_SHA256,
-            CipherSuite.TLS_RSA_WITH_AES_256_CBC_SHA256
+            CipherSuite.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
         )
     }
 
@@ -532,11 +524,11 @@ internal class CoreFeatureTest {
 
         // Then
         val okHttpClient = testedFeature.okHttpClient
-        assertThat(okHttpClient.protocols())
+        assertThat(okHttpClient.protocols)
             .containsExactly(Protocol.HTTP_2, Protocol.HTTP_1_1)
-        assertThat(okHttpClient.callTimeoutMillis())
+        assertThat(okHttpClient.callTimeoutMillis)
             .isEqualTo(CoreFeature.NETWORK_TIMEOUT_MS.toInt())
-        assertThat(okHttpClient.connectionSpecs())
+        assertThat(okHttpClient.connectionSpecs)
             .containsExactly(ConnectionSpec.CLEARTEXT)
     }
 
@@ -555,8 +547,8 @@ internal class CoreFeatureTest {
 
         // Then
         val okHttpClient = testedFeature.okHttpClient
-        assertThat(okHttpClient.proxy()).isSameAs(proxy)
-        assertThat(okHttpClient.proxyAuthenticator()).isSameAs(proxyAuth)
+        assertThat(okHttpClient.proxy).isSameAs(proxy)
+        assertThat(okHttpClient.proxyAuthenticator).isSameAs(proxyAuth)
     }
 
     @Test
@@ -572,8 +564,8 @@ internal class CoreFeatureTest {
 
         // Then
         val okHttpClient = testedFeature.okHttpClient
-        assertThat(okHttpClient.proxy()).isNull()
-        assertThat(okHttpClient.proxyAuthenticator()).isEqualTo(Authenticator.NONE)
+        assertThat(okHttpClient.proxy).isNull()
+        assertThat(okHttpClient.proxyAuthenticator).isEqualTo(Authenticator.NONE)
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/CurlInterceptorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/CurlInterceptorTest.kt
@@ -16,11 +16,11 @@ import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import okhttp3.Interceptor
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.Protocol
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -118,7 +118,7 @@ internal class CurlInterceptorTest {
         testedInterceptor = CurlInterceptor(false, mockOutput)
         fakeRequest = Request.Builder()
             .url(fakeUrl)
-            .post(RequestBody.create(null, fakeBody.toByteArray()))
+            .post(fakeBody.toByteArray().toRequestBody(null))
             .build()
         fakeResponse = forgeResponse(statusCode)
         stubChain()
@@ -140,7 +140,7 @@ internal class CurlInterceptorTest {
         testedInterceptor = CurlInterceptor(true, mockOutput)
         fakeRequest = Request.Builder()
             .url(fakeUrl)
-            .post(RequestBody.create(null, fakeBody.toByteArray()))
+            .post(fakeBody.toByteArray().toRequestBody(null))
             .build()
         fakeResponse = forgeResponse(statusCode)
         stubChain()
@@ -192,7 +192,7 @@ internal class CurlInterceptorTest {
         testedInterceptor = CurlInterceptor(true, mockOutput)
         fakeRequest = Request.Builder()
             .url(fakeUrl)
-            .post(RequestBody.create(MediaType.parse("$type/$subtype"), fakeBody.toByteArray()))
+            .post(fakeBody.toByteArray().toRequestBody("$type/$subtype".toMediaTypeOrNull()))
             .build()
         fakeResponse = forgeResponse(statusCode)
         stubChain()
@@ -224,10 +224,8 @@ internal class CurlInterceptorTest {
                     .setType(MultipartBody.FORM)
                     .addFormDataPart(fakeFormKey, fakeFormKeyValue)
                     .addPart(
-                        RequestBody.create(
-                            MediaType.parse("$type/$subtype"),
-                            fakeBody.toByteArray()
-                        )
+                        fakeBody.toByteArray()
+                            .toRequestBody("$type/$subtype".toMediaTypeOrNull())
                     )
                     .build()
             )

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolverTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/DefaultFirstPartyHostHeaderTypeResolverTest.kt
@@ -12,7 +12,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -54,7 +54,7 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
         while (host in fakeHosts) {
             host = forge.aStringMatching(HOST_REGEX)
         }
-        val url = HttpUrl.get("$scheme://$host$path")
+        val url = "$scheme://$host$path".toHttpUrl()
 
         // When
         val result = testedDetector.isFirstPartyUrl(url)
@@ -71,7 +71,7 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
     ) {
         // Given
         val host = forge.anElementFrom(fakeHosts.keys)
-        val url = HttpUrl.get("$scheme://$host$path")
+        val url = "$scheme://$host$path".toHttpUrl()
 
         // When
         val result = testedDetector.isFirstPartyUrl(url)
@@ -90,7 +90,7 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
         val fakeNewAllowedHosts = forge.aList { forge.aStringMatching(HOST_REGEX) }
         testedDetector.addKnownHosts(fakeNewAllowedHosts)
         val host = forge.anElementFrom(fakeNewAllowedHosts)
-        val url = HttpUrl.get("$scheme://$host$path")
+        val url = "$scheme://$host$path".toHttpUrl()
 
         // When
         val result = testedDetector.isFirstPartyUrl(url)
@@ -108,7 +108,7 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
     ) {
         // Given
         val host = forge.anElementFrom(fakeHosts.keys)
-        val url = HttpUrl.get("$scheme://$subdomain.$host$path")
+        val url = "$scheme://$subdomain.$host$path".toHttpUrl()
 
         // When
         val result = testedDetector.isFirstPartyUrl(url)
@@ -126,7 +126,7 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
     ) {
         // Given
         val host = forge.anElementFrom(fakeHosts.keys)
-        val url = HttpUrl.get("$scheme://$prefix$host$path")
+        val url = "$scheme://$prefix$host$path".toHttpUrl()
 
         // When
         val result = testedDetector.isFirstPartyUrl(url)
@@ -237,7 +237,7 @@ internal class DefaultFirstPartyHostHeaderTypeResolverTest {
         // GIVEN
         val fakeNewAllowedHosts = forge.aList { forge.aStringMatching(HOST_REGEX) }
         val host = forge.anElementFrom(fakeNewAllowedHosts)
-        val url = HttpUrl.get("$scheme://$host$path")
+        val url = "$scheme://$host$path".toHttpUrl()
         testedDetector = DefaultFirstPartyHostHeaderTypeResolver(mapOf("*" to emptySet()))
 
         // WHEN

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/GzipRequestInterceptorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/GzipRequestInterceptorTest.kt
@@ -15,7 +15,7 @@ import okhttp3.Interceptor
 import okhttp3.MultipartBody
 import okhttp3.Protocol
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
@@ -59,7 +59,7 @@ internal class GzipRequestInterceptorTest {
         fakeBody = forge.anAlphabeticalString()
         fakeRequest = Request.Builder()
             .url(fakeUrl)
-            .post(RequestBody.create(null, fakeBody.toByteArray()))
+            .post(fakeBody.toByteArray().toRequestBody(null))
             .build()
         testedInterceptor = GzipRequestInterceptor(mockInternalLogger)
     }
@@ -75,7 +75,7 @@ internal class GzipRequestInterceptorTest {
             verify(mockChain).proceed(capture())
             val buffer = Buffer()
             val stream = ByteArrayOutputStream()
-            lastValue.body()!!.writeTo(buffer)
+            lastValue.body!!.writeTo(buffer)
             buffer.copyTo(stream)
 
             assertThat(stream.toString())
@@ -102,7 +102,7 @@ internal class GzipRequestInterceptorTest {
             verify(mockChain).proceed(capture())
             val buffer = Buffer()
             val stream = ByteArrayOutputStream()
-            lastValue.body()!!.writeTo(buffer)
+            lastValue.body!!.writeTo(buffer)
             buffer.copyTo(stream)
 
             assertThat(stream.toString())
@@ -122,7 +122,7 @@ internal class GzipRequestInterceptorTest {
             .addFormDataPart(
                 forge.aString(),
                 forge.aString(),
-                RequestBody.create(null, fakeBody.toByteArray())
+                fakeBody.toByteArray().toRequestBody(null)
             )
             .build()
 
@@ -140,8 +140,8 @@ internal class GzipRequestInterceptorTest {
             verify(mockChain).proceed(capture())
             val buffer = Buffer()
             val stream = ByteArrayOutputStream()
-            val part = (lastValue.body() as MultipartBody).part(0)
-            part.body().writeTo(buffer)
+            val part = (lastValue.body as MultipartBody).part(0)
+            part.body.writeTo(buffer)
             buffer.copyTo(stream)
 
             assertThat(stream.toString())
@@ -163,7 +163,7 @@ internal class GzipRequestInterceptorTest {
 
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.body())
+            assertThat(lastValue.body)
                 .isNull()
             assertThat(lastValue.header("Content-Encoding"))
                 .isNull()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/net/info/CallbackNetworkInfoProviderTest.kt
@@ -125,7 +125,6 @@ internal class CallbackNetworkInfoProviderTest {
         whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) doReturn true
         whenever(mockCapabilities.linkUpstreamBandwidthKbps) doReturn upSpeed
         whenever(mockCapabilities.linkDownstreamBandwidthKbps) doReturn downSpeed
-        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.LOLLIPOP
 
         // WHEN
         testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
@@ -145,7 +144,6 @@ internal class CallbackNetworkInfoProviderTest {
     fun `connected to wifi (no up or down bandwidth, no strength)`() {
         // GIVEN
         whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) doReturn true
-        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.LOLLIPOP
 
         // WHEN
         testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
@@ -199,7 +197,6 @@ internal class CallbackNetworkInfoProviderTest {
             .doReturn(true)
         whenever(mockCapabilities.linkUpstreamBandwidthKbps) doReturn upSpeed
         whenever(mockCapabilities.linkDownstreamBandwidthKbps) doReturn downSpeed
-        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.LOLLIPOP
 
         // WHEN
         testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)
@@ -220,7 +217,6 @@ internal class CallbackNetworkInfoProviderTest {
         // GIVEN
         whenever(mockCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI_AWARE))
             .doReturn(true)
-        whenever(mockBuildSdkVersionProvider.version()) doReturn Build.VERSION_CODES.LOLLIPOP
 
         // WHEN
         testedProvider.onCapabilitiesChanged(mockNetwork, mockCapabilities)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/system/DefaultAndroidInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/system/DefaultAndroidInfoProviderTest.kt
@@ -104,37 +104,10 @@ internal class DefaultAndroidInfoProviderTest {
     }
 
     @Test
-    fun `𝕄 return TV type 𝕎 deviceType { Lollipop & FEATURE_LEANBACK }`(
-        @IntForgery(
-            min = Build.VERSION_CODES.LOLLIPOP
-        ) fakeSdkVersion: Int
-    ) {
+    fun `𝕄 return TV type 𝕎 deviceType { FEATURE_LEANBACK }`() {
         // Given
-        whenever(mockSdkVersionProvider.version()) doReturn fakeSdkVersion
         whenever(
             mockPackageManager.hasSystemFeature(PackageManager.FEATURE_LEANBACK)
-        ) doReturn true
-        testedProvider = createProvider()
-
-        // When
-        val type = testedProvider.deviceType
-
-        // Then
-        assertThat(type).isEqualTo(DeviceType.TV)
-    }
-
-    @Test
-    fun `𝕄 return TV type 𝕎 deviceType { pre-Lollipop & FEATURE_TELEVISION }`(
-        @IntForgery(
-            min = Build.VERSION_CODES.BASE,
-            max = Build.VERSION_CODES.LOLLIPOP
-        ) fakeSdkVersion: Int
-    ) {
-        // Given
-        whenever(mockSdkVersionProvider.version()) doReturn fakeSdkVersion
-        @Suppress("DEPRECATION")
-        whenever(
-            mockPackageManager.hasSystemFeature(PackageManager.FEATURE_TELEVISION)
         ) doReturn true
         testedProvider = createProvider()
 
@@ -407,8 +380,7 @@ internal class DefaultAndroidInfoProviderTest {
 
     // region private
 
-    private fun createProvider(): AndroidInfoProvider =
-        DefaultAndroidInfoProvider(mockContext, mockSdkVersionProvider)
+    private fun createProvider(): AndroidInfoProvider = DefaultAndroidInfoProvider(mockContext)
 
     private fun String.capitalize() =
         replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString() }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/v2/core/internal/net/DataOkHttpUploaderTest.kt
@@ -24,6 +24,7 @@ import fr.xgouchet.elmyr.junit5.ForgeExtension
 import okhttp3.Call
 import okhttp3.Headers
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Protocol
 import okhttp3.Request
 import okhttp3.RequestBody
@@ -596,27 +597,27 @@ internal class DataOkHttpUploaderTest {
         argumentCaptor<Request> {
             verify(mockCallFactory).newCall(capture())
 
-            verifyRequestUrl(firstValue.url(), HttpUrl.get(expectedRequest.url))
+            verifyRequestUrl(firstValue.url, expectedRequest.url.toHttpUrl())
             verifyRequestHeaders(
-                firstValue.headers(),
+                firstValue.headers,
                 expectedRequest.headers,
                 expectedUserAgentHeader
             )
-            verifyRequestBody(firstValue.body(), expectedRequest.body, expectedRequest.contentType)
+            verifyRequestBody(firstValue.body, expectedRequest.body, expectedRequest.contentType)
         }
     }
 
     private fun verifyRequestUrl(url: HttpUrl, expectedUrl: HttpUrl) {
-        assertThat(url.scheme()).isEqualTo(expectedUrl.scheme())
-        assertThat(url.host()).isEqualTo(expectedUrl.host())
-        assertThat(url.encodedPath()).isEqualTo(expectedUrl.encodedPath())
+        assertThat(url.scheme).isEqualTo(expectedUrl.scheme)
+        assertThat(url.host).isEqualTo(expectedUrl.host)
+        assertThat(url.encodedPath).isEqualTo(expectedUrl.encodedPath)
 
-        val expectedQueryParams = expectedUrl.queryParameterNames()
+        val expectedQueryParams = expectedUrl.queryParameterNames
 
-        assertThat(url.queryParameterNames().size).isEqualTo(expectedQueryParams.size)
+        assertThat(url.queryParameterNames.size).isEqualTo(expectedQueryParams.size)
 
         if (expectedQueryParams.isEmpty()) {
-            assertThat(url.query()).isNullOrEmpty()
+            assertThat(url.query).isNullOrEmpty()
         } else {
             expectedQueryParams.forEach {
                 val actualValue = url.queryParameter(it)
@@ -665,7 +666,7 @@ internal class DataOkHttpUploaderTest {
     }
 
     private fun verifyResponseIsClosed() {
-        verify(fakeResponse.body())!!.close()
+        verify(fakeResponse.body)!!.close()
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DefaultAppStartTimeProviderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DefaultAppStartTimeProviderTest.kt
@@ -47,7 +47,7 @@ class DefaultAppStartTimeProviderTest {
 
     @Test
     fun `M return rum load time W appStartTime { Legacy }`(
-        @IntForgery(min = Build.VERSION_CODES.KITKAT, max = Build.VERSION_CODES.N) apiVersion: Int
+        @IntForgery(min = Build.VERSION_CODES.LOLLIPOP, max = Build.VERSION_CODES.N) apiVersion: Int
     ) {
         // GIVEN
         val mockBuildSdkVersionProvider: BuildSdkVersionProvider = mock()

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
@@ -137,9 +137,10 @@ enum class SessionReplayPrivacy {
             MapperTypeWrapper(AppCompatToolbar::class.java, unsupportedViewMapper.toGenericMapper())
         )
 
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            mappersList.add(0, MapperTypeWrapper(Toolbar::class.java, unsupportedViewMapper.toGenericMapper()))
-        }
+        mappersList.add(
+            0,
+            MapperTypeWrapper(Toolbar::class.java, unsupportedViewMapper.toGenericMapper())
+        )
 
         seekBarMapper?.let {
             mappersList.add(0, MapperTypeWrapper(SeekBar::class.java, it.toGenericMapper()))

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/domain/RequestBodyFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/domain/RequestBodyFactory.kt
@@ -9,9 +9,10 @@ package com.datadog.android.sessionreplay.internal.domain
 import com.datadog.android.sessionreplay.internal.net.BytesCompressor
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.google.gson.JsonObject
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 
 internal class RequestBodyFactory(
     private val compressor: BytesCompressor = BytesCompressor()
@@ -35,10 +36,8 @@ internal class RequestBodyFactory(
             .addFormDataPart(
                 SEGMENT_FORM_KEY,
                 segment.session.id,
-                RequestBody.create(
-                    MediaType.parse(CONTENT_TYPE_BINARY),
-                    compressedData
-                )
+                compressedData
+                    .toRequestBody(CONTENT_TYPE_BINARY.toMediaTypeOrNull())
             )
             .addFormDataPart(
                 APPLICATION_ID_FORM_KEY,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewUtilsInternal.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewUtilsInternal.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.sessionreplay.internal.recorder
 
-import android.os.Build
 import android.view.View
 import android.view.ViewStub
 import androidx.appcompat.widget.ActionBarContextView
@@ -15,11 +14,7 @@ import androidx.appcompat.widget.Toolbar
 internal class ViewUtilsInternal {
 
     private val systemViewIds by lazy {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            setOf(android.R.id.navigationBarBackground, android.R.id.statusBarBackground)
-        } else {
-            emptySet()
-        }
+        setOf(android.R.id.navigationBarBackground, android.R.id.statusBarBackground)
     }
 
     internal fun isNotVisible(view: View): Boolean {
@@ -33,13 +28,7 @@ internal class ViewUtilsInternal {
     }
 
     internal fun isToolbar(view: View): Boolean {
-        return (
-            Toolbar::class.java.isAssignableFrom(view::class.java)
-            ) ||
-            (
-                Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
-                    android.widget.Toolbar::class.java
-                        .isAssignableFrom(view::class.java)
-                )
+        return Toolbar::class.java.isAssignableFrom(view::class.java) ||
+            android.widget.Toolbar::class.java.isAssignableFrom(view::class.java)
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
@@ -62,10 +62,7 @@ abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wireframe>(
         return if (this is ColorDrawable) {
             val color = colorAndAlphaAsStringHexa(color, alpha)
             MobileSegment.ShapeStyle(color, viewAlpha) to null
-        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP &&
-            this is RippleDrawable &&
-            numberOfLayers >= 1
-        ) {
+        } else if (this is RippleDrawable && numberOfLayers >= 1) {
             getDrawable(0).resolveShapeStyleAndBorder(viewAlpha)
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && this is InsetDrawable) {
             drawable?.resolveShapeStyleAndBorder(viewAlpha)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckedTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckedTextViewMapper.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
-import android.os.Build
 import android.widget.CheckedTextView
 import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
@@ -29,13 +28,11 @@ internal open class CheckedTextViewMapper(
     // region CheckableTextViewMapper
 
     override fun resolveCheckableColor(view: CheckedTextView): String {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            view.checkMarkTintList?.let {
-                return stringUtils.formatColorAndAlphaAsHexa(
-                    it.defaultColor,
-                    OPAQUE_ALPHA_VALUE
-                )
-            }
+        view.checkMarkTintList?.let {
+            return stringUtils.formatColorAndAlphaAsHexa(
+                it.defaultColor,
+                OPAQUE_ALPHA_VALUE
+            )
         }
         return stringUtils.formatColorAndAlphaAsHexa(view.currentTextColor, OPAQUE_ALPHA_VALUE)
     }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/EditTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/EditTextViewMapper.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
-import android.os.Build
 import android.widget.EditText
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
@@ -66,13 +65,11 @@ internal open class EditTextViewMapper(
     }
 
     private fun resolveUnderlineColor(view: EditText): String {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            view.backgroundTintList?.let {
-                return colorAndAlphaAsStringHexa(
-                    it.defaultColor,
-                    OPAQUE_ALPHA_VALUE
-                )
-            }
+        view.backgroundTintList?.let {
+            return colorAndAlphaAsStringHexa(
+                it.defaultColor,
+                OPAQUE_ALPHA_VALUE
+            )
         }
         return colorAndAlphaAsStringHexa(view.currentTextColor, OPAQUE_ALPHA_VALUE)
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
@@ -209,15 +209,12 @@ internal class SessionReplayPrivacyTest {
             val maskUserInputLevel = SessionReplayPrivacy.MASK_USER_INPUT.toString()
 
             return Stream.of(
-                Arguments.of(Build.VERSION_CODES.KITKAT, allowAllLevel, allowAll),
                 Arguments.of(Build.VERSION_CODES.LOLLIPOP, allowAllLevel, allowAllFromApi21),
                 Arguments.of(Build.VERSION_CODES.O, allowAllLevel, allowAllFromApi26),
                 Arguments.of(Build.VERSION_CODES.Q, allowAllLevel, allowAllFromApi29),
-                Arguments.of(Build.VERSION_CODES.KITKAT, maskAllLevel, maskAll),
                 Arguments.of(Build.VERSION_CODES.LOLLIPOP, maskAllLevel, maskAllFromApi21),
                 Arguments.of(Build.VERSION_CODES.O, maskAllLevel, maskAllFromApi26),
                 Arguments.of(Build.VERSION_CODES.Q, maskAllLevel, maskAllFromApi29),
-                Arguments.of(Build.VERSION_CODES.KITKAT, maskUserInputLevel, maskUserInput),
                 Arguments.of(Build.VERSION_CODES.LOLLIPOP, maskUserInputLevel, maskUserInputFromApi21),
                 Arguments.of(Build.VERSION_CODES.O, maskUserInputLevel, maskUserInputFromApi26),
                 Arguments.of(Build.VERSION_CODES.Q, maskUserInputLevel, maskUserInputFromApi29)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/domain/RequestBodyFactoryTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/domain/RequestBodyFactoryTest.kt
@@ -14,10 +14,11 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.MultipartBody
 import okhttp3.MultipartBody.Part
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okio.Buffer
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
@@ -72,15 +73,13 @@ internal class RequestBodyFactoryTest {
         // Then
         assertThat(body).isInstanceOf(MultipartBody::class.java)
         val multipartBody = body as MultipartBody
-        assertThat(multipartBody.type()).isEqualTo(MultipartBody.FORM)
-        val parts = multipartBody.parts()
+        assertThat(multipartBody.type).isEqualTo(MultipartBody.FORM)
+        val parts = multipartBody.parts
         val compressedSegmentPart = Part.createFormData(
             RequestBodyFactory.SEGMENT_FORM_KEY,
             fakeSegment.session.id,
-            RequestBody.create(
-                MediaType.parse(RequestBodyFactory.CONTENT_TYPE_BINARY),
-                fakeCompressedData
-            )
+            fakeCompressedData
+                .toRequestBody(RequestBodyFactory.CONTENT_TYPE_BINARY.toMediaTypeOrNull())
         )
         val applicationIdPart = Part.createFormData(
             RequestBodyFactory.APPLICATION_ID_FORM_KEY,
@@ -121,8 +120,8 @@ internal class RequestBodyFactoryTest {
 
         assertThat(parts)
             .usingElementComparator { first, second ->
-                val headersEval = first.headers() == second.headers()
-                val bodyEval = first.body().toByteArray().contentEquals(second.body().toByteArray())
+                val headersEval = first.headers == second.headers
+                val bodyEval = first.body.toByteArray().contentEquals(second.body.toByteArray())
                 if (headersEval && bodyEval) {
                     0
                 } else {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewUtilsInternalTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewUtilsInternalTest.kt
@@ -6,14 +6,11 @@
 
 package com.datadog.android.sessionreplay.internal.recorder
 
-import android.os.Build
 import android.view.View
 import android.view.ViewStub
-import androidx.annotation.RequiresApi
 import androidx.appcompat.widget.ActionBarContextView
 import androidx.appcompat.widget.Toolbar
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.tools.unit.annotations.TestTargetApi
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -96,9 +93,7 @@ internal class ViewUtilsInternalTest {
     // region System Noise
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    fun `M return true W checkIfSystemNoise(){view the navigationBarBackground }`(forge: Forge) {
+    fun `M return true W checkIfSystemNoise(){ view the navigationBarBackground }`(forge: Forge) {
         // Given
         val mockView = forge
             .aMockView<View>()
@@ -111,9 +106,7 @@ internal class ViewUtilsInternalTest {
     }
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    fun `M return true W checkIfSystemNoise(){view is statusBarBackground }`(forge: Forge) {
+    fun `M return true W checkIfSystemNoise(){ view is statusBarBackground }`(forge: Forge) {
         // Given
         val mockView = forge
             .aMockView<View>()
@@ -126,7 +119,7 @@ internal class ViewUtilsInternalTest {
     }
 
     @Test
-    fun `M return true W checkIfSystemNoise(){view is ViewStub }`() {
+    fun `M return true W checkIfSystemNoise(){ view is ViewStub }`() {
         // Given
         val mockView: ViewStub = mock()
 
@@ -135,7 +128,7 @@ internal class ViewUtilsInternalTest {
     }
 
     @Test
-    fun `M return true W checkIfSystemNoise(){view is ActionBarContextView }`() {
+    fun `M return true W checkIfSystemNoise(){ view is ActionBarContextView }`() {
         // Given
         val mockView: ActionBarContextView = mock()
 
@@ -144,7 +137,7 @@ internal class ViewUtilsInternalTest {
     }
 
     @Test
-    fun `M return false W checkIfSystemNoise(){view is not system noise }`(forge: Forge) {
+    fun `M return false W checkIfSystemNoise(){ view is not system noise }`(forge: Forge) {
         // Given
         val mockView = forge.aMockView<View>()
 
@@ -157,7 +150,7 @@ internal class ViewUtilsInternalTest {
     // region Toolbar
 
     @Test
-    fun `M return true W checkIsToolbar(){view androidx Toolbar }`(
+    fun `M return true W checkIsToolbar(){ view androidx Toolbar }`(
         forge: Forge
     ) {
         // Given
@@ -169,10 +162,8 @@ internal class ViewUtilsInternalTest {
         assertThat(testViewUtilsInternal.isToolbar(mockToolBar)).isTrue
     }
 
-    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
     @Test
-    fun `M return true W checkIsToolbar(){view android Toolbar }`(
+    fun `M return true W checkIsToolbar(){ view android Toolbar }`(
         forge: Forge
     ) {
         // Given
@@ -183,7 +174,7 @@ internal class ViewUtilsInternalTest {
     }
 
     @Test
-    fun `M return false W checkIsToolbar(){view is not toolbar }`(forge: Forge) {
+    fun `M return false W checkIsToolbar(){ view is not toolbar }`(forge: Forge) {
         // Given
         val mockView = forge.aMockView<View>()
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckedTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckedTextViewMapperTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
-import android.os.Build
 import android.widget.CheckedTextView
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
@@ -17,7 +16,6 @@ import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.StringUtils
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
-import com.datadog.tools.unit.annotations.TestTargetApi
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -235,7 +233,6 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         assertThat(resolvedWireframes).isEqualTo(fakeTextWireframes + expectedCheckBoxWireframe)
     }
 
-    @TestTargetApi(value = Build.VERSION_CODES.LOLLIPOP)
     @Test
     fun `M resolve the checkbox as ShapeWireframe W map() { checkMarkTintList available }`() {
         // Given
@@ -268,7 +265,6 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         assertThat(resolvedWireframes).isEqualTo(fakeTextWireframes + expectedCheckBoxWireframe)
     }
 
-    @TestTargetApi(value = Build.VERSION_CODES.LOLLIPOP)
     @Test
     fun `M resolve the checkbox as ShapeWireframe W map() { checkMarkTintList is null }`() {
         // Given

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseEditTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseEditTextViewMapperTest.kt
@@ -7,14 +7,12 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.content.res.ColorStateList
-import android.os.Build
 import android.widget.EditText
 import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.StringUtils
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
-import com.datadog.tools.unit.annotations.TestTargetApi
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -87,7 +85,6 @@ internal abstract class BaseEditTextViewMapperTest : BaseWireframeMapperTest() {
 
     abstract fun initTestInstance(): EditTextViewMapper
 
-    @TestTargetApi(value = Build.VERSION_CODES.LOLLIPOP)
     @Test
     fun `M resolve the underline as ShapeWireframe W map()`(forge: Forge) {
         // Given
@@ -118,43 +115,12 @@ internal abstract class BaseEditTextViewMapperTest : BaseWireframeMapperTest() {
             .isEqualTo(fakeTextWireframes + expectedUnderlineShapeWireframe)
     }
 
-    @TestTargetApi(value = Build.VERSION_CODES.LOLLIPOP)
     @Test
-    fun `M resolve the underline color from textColor W map{Lollipop, backgroundTint is null}`(
+    fun `M resolve the underline color from textColor W map{backgroundTint is null}`(
         forge: Forge
     ) {
         // Given
         whenever(mockEditText.backgroundTintList).thenReturn(null)
-        val fakeExpectedUnderlineColor = forge.aStringMatching("#[0-9A-Fa-f]{8}")
-        whenever(
-            mockStringUtils.formatColorAndAlphaAsHexa(
-                fakeTextColor,
-                OPAQUE_ALPHA_VALUE
-            )
-        )
-            .thenReturn(fakeExpectedUnderlineColor)
-        val expectedUnderlineShapeWireframe = MobileSegment.Wireframe.ShapeWireframe(
-            id = fakeGeneratedIdentifier,
-            x = fakeViewGlobalBounds.x,
-            y = fakeViewGlobalBounds.y +
-                fakeViewGlobalBounds.height -
-                EditTextViewMapper.UNDERLINE_HEIGHT_IN_PIXELS,
-            width = fakeViewGlobalBounds.width,
-            height = EditTextViewMapper.UNDERLINE_HEIGHT_IN_PIXELS,
-            shapeStyle = MobileSegment.ShapeStyle(
-                backgroundColor = fakeExpectedUnderlineColor,
-                opacity = mockEditText.alpha
-            )
-        )
-
-        // When
-        assertThat(testedEditTextViewMapper.map(mockEditText, fakeMappingContext))
-            .isEqualTo(fakeTextWireframes + expectedUnderlineShapeWireframe)
-    }
-
-    @Test
-    fun `M resolve the underline color from textColor W map{ bellow Lollipop }`(forge: Forge) {
-        // Given
         val fakeExpectedUnderlineColor = forge.aStringMatching("#[0-9A-Fa-f]{8}")
         whenever(
             mockStringUtils.formatColorAndAlphaAsHexa(

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/UnsupportedViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/UnsupportedViewMapperTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
-import android.os.Build
 import android.view.View
 import android.widget.Toolbar
 import androidx.appcompat.widget.ActionBarContainer
@@ -16,7 +15,6 @@ import com.datadog.android.sessionreplay.internal.recorder.optionselectormocks.A
 import com.datadog.android.sessionreplay.internal.recorder.optionselectormocks.ToolbarCustomSubclass
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.ViewUtils
-import com.datadog.tools.unit.annotations.TestTargetApi
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -99,7 +97,6 @@ internal class UnsupportedViewMapperTest : BaseTextViewWireframeMapperTest() {
     }
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
     fun `M resolve with the toolbar label as text W map { Subclass of Toolbar }`() {
         // Given
         actualWireframe = getWireframe(mockToolbarSubclass)
@@ -110,7 +107,6 @@ internal class UnsupportedViewMapperTest : BaseTextViewWireframeMapperTest() {
     }
 
     @Test
-    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
     fun `M resolve with the toolbar label as text W map { Toolbar }`() {
         // Given
         actualWireframe = getWireframe(mockToolbar)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapperTest.kt
@@ -208,10 +208,8 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         assertThat(shapeWireframes).isEqualTo(expectedWireframes)
     }
 
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
     @Test
-    fun `M resolve a ShapeWireframe with shapeStyle W map {RippleDrawable, ColorDrawable, L}`(
+    fun `M resolve a ShapeWireframe with shapeStyle W map {RippleDrawable, ColorDrawable}`(
         forge: Forge
     ) {
         // Given
@@ -257,45 +255,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
     }
 
     @Test
-    fun `M resolve a ShapeWireframe no shapeStyle W map {RippleDrawable, ColorDrawable, lowL}`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeStyleColor = forge.aStringMatching("#[0-9a-f]{8}")
-        val fakeDrawableColor = fakeStyleColor
-            .substring(1)
-            .toLong(16)
-            .shr(8)
-            .toInt()
-        val fakeDrawableAlpha = fakeStyleColor
-            .substring(1)
-            .toLong(16)
-            .and(ALPHA_MASK)
-            .toInt()
-        val mockDrawable = mock<ColorDrawable> {
-            whenever(it.color).thenReturn(fakeDrawableColor)
-            whenever(it.alpha).thenReturn(fakeDrawableAlpha)
-        }
-        val mockRipple = mock<RippleDrawable> {
-            whenever(it.numberOfLayers).thenReturn(forge.anInt(min = 1))
-            whenever(it.getDrawable(0)).thenReturn(mockDrawable)
-        }
-        val mockView = forge.aMockView<View>().apply {
-            whenever(this.background).thenReturn(mockRipple)
-        }
-
-        // When
-        val shapeWireframes = testedWireframeMapper.map(mockView, fakeMappingContext)
-
-        // Then
-        val expectedWireframes = mockView.toShapeWireframes()
-        assertThat(shapeWireframes).isEqualTo(expectedWireframes)
-    }
-
-    @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
-    @TestTargetApi(Build.VERSION_CODES.LOLLIPOP)
-    @Test
-    fun `M resolve a ShapeWireframe no shapeStyle W produce {RippleDrawable, NonColorDrawable, L}`(
+    fun `M resolve a ShapeWireframe no shapeStyle W produce {RippleDrawable, NonColorDrawable}`(
         forge: Forge
     ) {
         // Given

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@
 kotlin = "1.8.10"
 kotlinSP = "1.8.10-1.0.9"
 gson = "2.10.1"
-okHttp = "3.12.13"
+okHttp = "4.11.0"
 kronosNTP = "0.0.1-alpha11"
 
 # Android

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
@@ -67,7 +67,7 @@ internal open class MockServerActivityTestRule<T : Activity>(
             }
         requests.clear()
         mockWebServer.start()
-        mockWebServer.setDispatcher(
+        mockWebServer.dispatcher =
             object : Dispatcher() {
                 override fun dispatch(request: RecordedRequest): MockResponse {
                     if (keepRequests) {
@@ -80,14 +80,13 @@ internal open class MockServerActivityTestRule<T : Activity>(
 
                     return if (request.path == CONNECTION_ISSUE_PATH) {
                         MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE)
-                    } else if (request.path.endsWith("nyan-cat.gif")) {
+                    } else if (request.path?.endsWith("nyan-cat.gif") == true) {
                         mockResponse(200)
                     } else {
                         mockResponse(HttpURLConnection.HTTP_ACCEPTED)
                     }
                 }
             }
-        )
 
         getConnectionUrl().let {
             RuntimeConfig.logsEndpointUrl = "$it/$LOGS_URL_SUFFIX"
@@ -192,7 +191,7 @@ internal open class MockServerActivityTestRule<T : Activity>(
     }
 
     private fun RecordedRequest.unzip(): String {
-        if (body.size() <= 0) {
+        if (body.size <= 0) {
             return ""
         }
         val gzipInputStream =

--- a/integrations/dd-sdk-android-coil/src/main/kotlin/com/datadog/android/coil/DatadogCoilRequestListener.kt
+++ b/integrations/dd-sdk-android-coil/src/main/kotlin/com/datadog/android/coil/DatadogCoilRequestListener.kt
@@ -59,7 +59,7 @@ class DatadogCoilRequestListener @JvmOverloads constructor(
             }
             is HttpUrl -> {
                 mapOf(
-                    REQUEST_PATH_TAG to (request.data as HttpUrl).url().toString()
+                    REQUEST_PATH_TAG to (request.data as HttpUrl).toUrl().toString()
                 )
             }
             is File -> {

--- a/integrations/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/DatadogCoilRequestListenerTest.kt
+++ b/integrations/dd-sdk-android-coil/src/test/kotlin/com/datadog/android/coil/DatadogCoilRequestListenerTest.kt
@@ -19,7 +19,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -128,7 +128,7 @@ internal class DatadogCoilRequestListenerTest {
     @Test
     fun `M send RUM error event W HttpUrl Request fails`(forge: Forge) {
         // GIVEN
-        val fakeHttpUrl = HttpUrl.get(forgeImagePath(forge))
+        val fakeHttpUrl = forgeImagePath(forge).toHttpUrl()
         mockRequest = mockImageRequest(fakeHttpUrl)
 
         // WHEN
@@ -144,7 +144,7 @@ internal class DatadogCoilRequestListenerTest {
         )
         Assertions.assertThat(argumentCaptor.firstValue).containsEntry(
             DatadogCoilRequestListener.REQUEST_PATH_TAG,
-            fakeHttpUrl.url().toString()
+            fakeHttpUrl.toUrl().toString()
         )
     }
 

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -43,7 +43,7 @@ android {
     buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK_FOR_COMPOSE
+        minSdk = AndroidConfig.MIN_SDK
         targetSdk = AndroidConfig.TARGET_SDK
     }
 

--- a/integrations/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/DatadogGlideModuleTest.kt
+++ b/integrations/dd-sdk-android-glide/src/test/kotlin/com/datadog/android/glide/DatadogGlideModuleTest.kt
@@ -88,7 +88,7 @@ internal class DatadogGlideModuleTest {
 
             assertThat(firstValue).isInstanceOf(OkHttpUrlLoader.Factory::class.java)
             val client: OkHttpClient = firstValue.getFieldValue("client")
-            assertThat(client.interceptors()).containsInstanceOf(DatadogInterceptor::class.java)
+            assertThat(client.interceptors).containsInstanceOf(DatadogInterceptor::class.java)
         }
     }
 

--- a/integrations/dd-sdk-android-okhttp/api/apiSurface
+++ b/integrations/dd-sdk-android-okhttp/api/apiSurface
@@ -1,7 +1,7 @@
 class com.datadog.android.okhttp.DatadogEventListener : okhttp3.EventListener
   override fun callStart(okhttp3.Call)
   override fun dnsStart(okhttp3.Call, String)
-  override fun dnsEnd(okhttp3.Call, String, MutableList<java.net.InetAddress>)
+  override fun dnsEnd(okhttp3.Call, String, List<java.net.InetAddress>)
   override fun connectStart(okhttp3.Call, java.net.InetSocketAddress, java.net.Proxy)
   override fun connectEnd(okhttp3.Call, java.net.InetSocketAddress, java.net.Proxy, okhttp3.Protocol?)
   override fun secureConnectStart(okhttp3.Call)

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
@@ -84,7 +84,7 @@ internal constructor(
     }
 
     /** @inheritdoc */
-    override fun dnsEnd(call: Call, domainName: String, inetAddressList: MutableList<InetAddress>) {
+    override fun dnsEnd(call: Call, domainName: String, inetAddressList: List<InetAddress>) {
         super.dnsEnd(call, domainName, inetAddressList)
         dnsEnd = System.nanoTime()
     }
@@ -131,7 +131,7 @@ internal constructor(
     override fun responseHeadersEnd(call: Call, response: Response) {
         super.responseHeadersEnd(call, response)
         headersEnd = System.nanoTime()
-        if (response.code() >= HttpURLConnection.HTTP_BAD_REQUEST) {
+        if (response.code >= HttpURLConnection.HTTP_BAD_REQUEST) {
             sendTiming()
         }
     }
@@ -253,7 +253,7 @@ internal constructor(
                     InternalLogger.Target.USER,
                     {
                         "No SDK instance is available, skipping tracking" +
-                            " timing information of request with url ${call.request().url()}."
+                            " timing information of request with url ${call.request().url}."
                     }
                 )
                 NO_OP_EVENT_LISTENER

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -15,7 +15,6 @@ import com.datadog.android.okhttp.trace.TracedRequestListener
 import com.datadog.android.okhttp.trace.TracingInterceptor
 import com.datadog.android.okhttp.utils.identifyRequest
 import com.datadog.android.rum.GlobalRumMonitor
-import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
@@ -45,7 +44,7 @@ import java.util.Locale
  * For RUM integration: this interceptor will log the request as a RUM Resource, and fill the
  * request information (url, method, status code, optional error). Note that RUM Resources are only
  * tracked when a view is active. You can use one of the existing [ViewTrackingStrategy] when
- * configuring the SDK (see [Rum.Builder.useViewTrackingStrategy]) or start a view
+ * configuring the SDK (see [RumConfiguration.Builder.useViewTrackingStrategy]) or start a view
  * manually (see [RumMonitor.startView]).
  *
  * For APM integration: This interceptor will create a [Span] around the request and fill the
@@ -211,8 +210,8 @@ internal constructor(
         val rumFeature = sdkCore?.getFeature(Feature.RUM_FEATURE_NAME)
         if (rumFeature != null) {
             val request = chain.request()
-            val url = request.url().toString()
-            val method = request.method()
+            val url = request.url.toString()
+            val method = request.method
             val requestId = identifyRequest(request)
 
             GlobalRumMonitor.get(sdkCore).startResource(requestId, method, url)
@@ -282,7 +281,7 @@ internal constructor(
         isSampled: Boolean
     ) {
         val requestId = identifyRequest(request)
-        val statusCode = response.code()
+        val statusCode = response.code
         val kind = when (val mimeType = response.header(HEADER_CT)) {
             null -> RumResourceKind.NATIVE
             else -> RumResourceKind.fromMimeType(mimeType)
@@ -311,8 +310,8 @@ internal constructor(
         throwable: Throwable
     ) {
         val requestId = identifyRequest(request)
-        val method = request.method()
-        val url = request.url().toString()
+        val method = request.method
+        val url = request.url.toString()
         GlobalRumMonitor.get(sdkCore).stopResourceWithError(
             requestId,
             null,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -200,7 +200,7 @@ internal constructor(
                 InternalLogger.Target.USER,
                 {
                     "$prefix for OkHttp instrumentation is not found, skipping" +
-                        " tracking of request with url=${chain.request().url()}"
+                        " tracking of request with url=${chain.request().url}"
                 }
             )
             @Suppress("UnsafeThirdPartyFunctionCall") // we are in method which allows throwing IOException
@@ -269,7 +269,7 @@ internal constructor(
     }
 
     private fun isRequestTraceable(sdkCore: InternalSdkCore, request: Request): Boolean {
-        val url = request.url()
+        val url = request.url
         return sdkCore.firstPartyHostResolver.isFirstPartyUrl(url) ||
             localFirstPartyHostHeaderTypeResolver.isFirstPartyUrl(url)
     }
@@ -362,7 +362,7 @@ internal constructor(
 
     private fun buildSpan(tracer: Tracer, request: Request): Span {
         val parentContext = extractParentContext(tracer, request)
-        val url = request.url().toString()
+        val url = request.url.toString()
 
         val spanBuilder = tracer.buildSpan(SPAN_NAME)
         (spanBuilder as? DDTracer.DDSpanBuilder)?.withOrigin(traceOrigin)
@@ -372,7 +372,7 @@ internal constructor(
 
         (span as? MutableSpan)?.resourceName = url.substringBefore(URL_QUERY_PARAMS_BLOCK_SEPARATOR)
         span.setTag(Tags.HTTP_URL.key, url)
-        span.setTag(Tags.HTTP_METHOD.key, request.method())
+        span.setTag(Tags.HTTP_METHOD.key, request.method)
 
         return span
     }
@@ -431,7 +431,7 @@ internal constructor(
         val headerContext = tracer.extract(
             Format.Builtin.TEXT_MAP_EXTRACT,
             TextMapExtractAdapter(
-                request.headers().toMultimap()
+                request.headers.toMultimap()
                     .map { it.key to it.value.joinToString(";") }
                     .toMap()
             )
@@ -502,9 +502,9 @@ internal constructor(
     ): Request.Builder {
         val tracedRequestBuilder = request.newBuilder()
         val tracingHeaderTypes =
-            localFirstPartyHostHeaderTypeResolver.headerTypesForUrl(request.url())
+            localFirstPartyHostHeaderTypeResolver.headerTypesForUrl(request.url)
                 .ifEmpty {
-                    sdkCore.firstPartyHostResolver.headerTypesForUrl(request.url())
+                    sdkCore.firstPartyHostResolver.headerTypesForUrl(request.url)
                 }
 
         if (!isSampled) {
@@ -561,7 +561,7 @@ internal constructor(
         if (!isSampled || span == null) {
             onRequestIntercepted(sdkCore, request, null, response, null)
         } else {
-            val statusCode = response.code()
+            val statusCode = response.code
             span.setTag(Tags.HTTP_STATUS.key, statusCode)
             if (statusCode in HttpURLConnection.HTTP_BAD_REQUEST until HttpURLConnection.HTTP_INTERNAL_ERROR) {
                 (span as? MutableSpan)?.isError = true

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/utils/RequestUniqueIdentifier.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/utils/RequestUniqueIdentifier.kt
@@ -13,9 +13,9 @@ import java.io.IOException
  * Generates an identifier to uniquely track requests.
  */
 internal fun identifyRequest(request: Request): String {
-    val method = request.method()
-    val url = request.url()
-    val body = request.body()
+    val method = request.method
+    val url = request.url
+    val body = request.body
     return if (body == null) {
         "$method•$url"
     } else {

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -34,6 +34,8 @@ import okhttp3.MediaType
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
+import okio.Buffer
 import okio.BufferedSource
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
@@ -50,6 +52,7 @@ import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.spy
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -174,7 +177,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.RULE_PSR to fakeTracingSampleRate
         ) + fakeAttributes
         val requestId = identifyRequest(fakeRequest)
-        val mimeType = fakeMediaType?.type()
+        val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
             else -> RumResourceKind.NATIVE
@@ -212,7 +215,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
         val requestId = identifyRequest(fakeRequest)
-        val mimeType = fakeMediaType?.type()
+        val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
             else -> RumResourceKind.NATIVE
@@ -250,8 +253,8 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                 .protocol(Protocol.HTTP_2)
                 .code(statusCode)
                 .message("HTTP $statusCode")
-                .body(ResponseBody.create(fakeMediaType, ""))
-                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
+                .body("".toResponseBody(fakeMediaType))
+                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
                 .build()
         }
         val expectedStopAttrs = mapOf(
@@ -260,7 +263,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.RULE_PSR to fakeTracingSampleRate
         ) + fakeAttributes
         val requestId = identifyRequest(fakeRequest)
-        val mimeType = fakeMediaType?.type()
+        val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
             else -> RumResourceKind.NATIVE
@@ -299,14 +302,14 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                 .protocol(Protocol.HTTP_2)
                 .code(statusCode)
                 .message("HTTP $statusCode")
-                .body(ResponseBody.create(fakeMediaType, ""))
-                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
+                .body("".toResponseBody(fakeMediaType))
+                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
                 .build()
         }
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
         val requestId = identifyRequest(fakeRequest)
-        val mimeType = fakeMediaType?.type()
+        val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
             else -> RumResourceKind.NATIVE
@@ -344,15 +347,16 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                 .protocol(Protocol.HTTP_2)
                 .code(statusCode)
                 .message("HTTP $statusCode")
-                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
+                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
                 .body(object : ResponseBody() {
                     override fun contentType(): MediaType? = fakeMediaType
 
                     override fun contentLength(): Long = fakeResponseBody.length.toLong()
 
                     override fun source(): BufferedSource {
-                        return mock<BufferedSource>().apply {
-                            whenever(this.request(any())) doThrow IOException()
+                        val buffer = Buffer()
+                        return spy(buffer).apply {
+                            whenever(request(any())) doThrow IOException()
                         }
                     }
                 })
@@ -365,7 +369,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.RULE_PSR to fakeTracingSampleRate
         ) + fakeAttributes
         val requestId = identifyRequest(fakeRequest)
-        val mimeType = fakeMediaType?.type()
+        val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
             else -> RumResourceKind.NATIVE
@@ -404,15 +408,16 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                 .protocol(Protocol.HTTP_2)
                 .code(statusCode)
                 .message("HTTP $statusCode")
-                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
+                .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
                 .body(object : ResponseBody() {
                     override fun contentType(): MediaType? = fakeMediaType
 
                     override fun contentLength(): Long = fakeResponseBody.length.toLong()
 
                     override fun source(): BufferedSource {
-                        return mock<BufferedSource>().apply {
-                            whenever(this.request(any())) doThrow IOException()
+                        val buffer = Buffer()
+                        return spy(buffer).apply {
+                            whenever(request(any())) doThrow IOException()
                         }
                     }
                 })
@@ -422,7 +427,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
         val requestId = identifyRequest(fakeRequest)
-        val mimeType = fakeMediaType?.type()
+        val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
             else -> RumResourceKind.NATIVE
@@ -462,7 +467,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.RULE_PSR to fakeTracingSampleRate
         ) + fakeAttributes
         val requestId = identifyRequest(fakeRequest)
-        val mimeType = fakeMediaType?.type()
+        val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
             else -> RumResourceKind.NATIVE
@@ -500,7 +505,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
         val requestId = identifyRequest(fakeRequest)
-        val mimeType = fakeMediaType?.type()
+        val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
             else -> RumResourceKind.NATIVE

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -37,14 +37,15 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import io.opentracing.SpanContext
 import io.opentracing.Tracer
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Protocol
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -147,7 +148,7 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         val mediaType = forge.anElementFrom("application", "image", "text", "model") +
             "/" + forge.anAlphabeticalString()
-        fakeMediaType = MediaType.parse(mediaType)
+        fakeMediaType = mediaType.toMediaTypeOrNull()
         fakeRequest = forgeRequest(forge)
         testedInterceptor = DatadogInterceptor(
             sdkInstanceName = null,
@@ -181,7 +182,7 @@ internal class DatadogInterceptorWithoutTracesTest {
         val expectedStartAttrs = emptyMap<String, Any?>()
         val expectedStopAttrs = fakeResourceAttributes
         val requestId = identifyRequest(fakeRequest)
-        val mimeType = fakeMediaType?.type()
+        val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
             else -> RumResourceKind.NATIVE
@@ -217,7 +218,7 @@ internal class DatadogInterceptorWithoutTracesTest {
         val expectedStartAttrs = emptyMap<String, Any?>()
         val expectedStopAttrs = fakeResourceAttributes
         val requestId = identifyRequest(fakeRequest)
-        val mimeType = fakeMediaType?.type()
+        val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
             else -> RumResourceKind.NATIVE
@@ -283,7 +284,7 @@ internal class DatadogInterceptorWithoutTracesTest {
     fun `𝕄 create and drop a Span with info 𝕎 intercept() for successful request`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -297,7 +298,7 @@ internal class DatadogInterceptorWithoutTracesTest {
     fun `𝕄 create and drop a span with info 𝕎 intercept() for failing request {4xx}`(
         @IntForgery(min = 400, max = 500) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -330,7 +331,7 @@ internal class DatadogInterceptorWithoutTracesTest {
         if (forge.aBool()) {
             fakeMethod = "POST"
             fakeBody = forge.anAlphabeticalString()
-            builder.post(RequestBody.create(null, fakeBody!!.toByteArray()))
+            builder.post(fakeBody!!.toByteArray().toRequestBody(null))
         } else {
             fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE")
             fakeBody = null
@@ -348,8 +349,8 @@ internal class DatadogInterceptorWithoutTracesTest {
             .protocol(Protocol.HTTP_2)
             .code(statusCode)
             .message("HTTP $statusCode")
-            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
-            .body(ResponseBody.create(fakeMediaType, fakeResponseBody))
+            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            .body(fakeResponseBody.toResponseBody(fakeMediaType))
         return builder.build()
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -37,13 +37,15 @@ import io.opentracing.propagation.TextMapExtract
 import io.opentracing.propagation.TextMapInject
 import io.opentracing.util.GlobalTracer
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Protocol
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -166,7 +168,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         fakeMediaType = if (forge.aBool()) {
             val mediaType = forge.anElementFrom("application", "image", "text", "model") +
                 "/" + forge.anAlphabeticalString()
-            MediaType.parse(mediaType)
+            mediaType.toMediaTypeOrNull()
         } else {
             null
         }
@@ -181,7 +183,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         whenever(datadogCore.mockInstance.internalLogger) doReturn mockInternalLogger
         whenever(datadogCore.mockInstance.firstPartyHostResolver) doReturn mockResolver
         doAnswer { false }.whenever(mockResolver).isFirstPartyUrl(any<HttpUrl>())
-        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(HttpUrl.get(fakeUrl))
+        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
 
         GlobalTracer.registerIfAbsent(mockTracer)
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
@@ -217,7 +219,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) value: String,
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -239,8 +241,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG
             )
@@ -267,8 +269,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3MULTI
             )
@@ -295,8 +297,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3
             )
@@ -321,8 +323,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.TRACECONTEXT
             )
@@ -355,7 +357,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     ) {
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -380,7 +382,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         whenever(mockTraceSampler.sample()).thenReturn(false)
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -412,7 +414,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -444,7 +446,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -474,7 +476,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -506,8 +508,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         whenever(parentSpan.context()) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(parentSpanContext)) doReturn mockSpanBuilder
         fakeRequest = forgeRequest(forge) { it.tag(Span::class.java, parentSpan) }
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(HttpUrl.get(fakeUrl))
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -534,9 +536,9 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         val parentSpanContext: SpanContext = mock()
         whenever(mockTracer.extract<TextMapExtract>(any(), any())) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(any<SpanContext>())) doReturn mockSpanBuilder
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge)
-        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(HttpUrl.get(fakeUrl))
+        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -561,7 +563,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
@@ -597,7 +599,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
@@ -630,7 +632,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
@@ -663,7 +665,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
@@ -694,8 +696,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG
             )
@@ -733,8 +735,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3MULTI
             )
@@ -769,8 +771,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3
             )
@@ -806,8 +808,8 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.TRACECONTEXT
             )
@@ -845,7 +847,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         // When
@@ -859,7 +861,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     fun `𝕄 create a span with info 𝕎 intercept() for successful request`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -875,7 +877,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     fun `𝕄 create a span with info 𝕎 intercept() for failing request {4xx}`(
         @IntForgery(min = 400, max = 500) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -891,7 +893,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     fun `𝕄 create a span with info 𝕎 intercept() for failing request {5xx}`(
         @IntForgery(min = 500, max = 600) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -905,7 +907,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
 
     @Test
     fun `𝕄 create a span with info 𝕎 intercept() for 404 request`() {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, 404)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -921,7 +923,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     fun `𝕄 create a span with info 𝕎 intercept() for throwing request`(
         @Forgery throwable: Throwable
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable
 
@@ -965,7 +967,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         val localSpanBuilder: Tracer.SpanBuilder = mock()
         val localSpan: Span = mock()
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
@@ -995,7 +997,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         val localSpanBuilder: Tracer.SpanBuilder = mock()
         val localSpan: Span = mock()
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
@@ -1034,7 +1036,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
@@ -1060,7 +1062,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
@@ -1086,7 +1088,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         // When
@@ -1103,7 +1105,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
         ).doAnswer {
@@ -1133,7 +1135,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable
 
@@ -1150,7 +1152,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1193,7 +1195,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         var called = 0
         val tracedHosts =
             listOf(fakeHostIp, fakeHostName).associateWith { setOf(TracingHeaderType.DATADOG) }
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         testedInterceptor = instantiateTestedInterceptor(tracedHosts) { _, _ ->
             called++
             mockLocalTracer
@@ -1261,7 +1263,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         if (forge.aBool()) {
             fakeMethod = "POST"
             fakeBody = forge.anAlphabeticalString()
-            builder.post(RequestBody.create(null, fakeBody!!.toByteArray()))
+            builder.post(fakeBody!!.toByteArray().toRequestBody(null))
         } else {
             fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE")
             fakeBody = null
@@ -1279,9 +1281,9 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             .protocol(Protocol.HTTP_2)
             .code(statusCode)
             .message("HTTP $statusCode")
-            .body(ResponseBody.create(fakeMediaType, fakeResponseBody))
+            .body(fakeResponseBody.toResponseBody(fakeMediaType))
         if (fakeMediaType != null) {
-            builder.header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
+            builder.header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
         }
         return builder.build()
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -38,13 +38,15 @@ import io.opentracing.propagation.TextMapExtract
 import io.opentracing.propagation.TextMapInject
 import io.opentracing.util.GlobalTracer
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Protocol
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -166,7 +168,7 @@ internal open class TracingInterceptorNonDdTracerTest {
                 TracingHeaderType.DATADOG
             )
         }
-        fakeMediaType = MediaType.parse(mediaType)
+        fakeMediaType = mediaType.toMediaTypeOrNull()
         fakeUrl = forgeUrlWithQueryParams(forge)
         fakeRequest = forgeRequest(forge)
         whenever(datadogCore.mockInstance.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
@@ -247,7 +249,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         stubChain(mockChain, statusCode)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -268,8 +270,8 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG
             )
@@ -296,8 +298,8 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3MULTI
             )
@@ -324,8 +326,8 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3
             )
@@ -350,8 +352,8 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.TRACECONTEXT
             )
@@ -384,7 +386,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -409,7 +411,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         whenever(mockTraceSampler.sample()).thenReturn(false)
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -441,7 +443,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -473,7 +475,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -503,7 +505,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -535,7 +537,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         whenever(parentSpan.context()) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(parentSpanContext)) doReturn mockSpanBuilder
         fakeRequest = forgeRequest(forge) { it.tag(Span::class.java, parentSpan) }
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -561,7 +563,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         fakeRequest = fakeRequest.newBuilder().addHeader(key, previousValue).build()
         stubChain(mockChain, statusCode)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -586,7 +588,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge).newBuilder().addHeader(key, previousValue).build()
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -610,7 +612,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
         doThrow(IllegalStateException(message)).whenever(mockTracer)
             .inject<TextMapInject>(any(), any(), any())
@@ -620,7 +622,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(firstValue.headers().size()).isZero()
+            assertThat(firstValue.headers.size).isZero()
         }
     }
 
@@ -633,7 +635,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         val parentSpanContext: SpanContext = mock()
         whenever(mockTracer.extract<TextMapExtract>(any(), any())) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(any<SpanContext>())) doReturn mockSpanBuilder
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -658,8 +660,8 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG
             )
@@ -699,8 +701,8 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3MULTI
             )
@@ -737,8 +739,8 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3
             )
@@ -775,8 +777,8 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.TRACECONTEXT
             )
@@ -811,8 +813,8 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG
             )
@@ -850,8 +852,8 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3MULTI
             )
@@ -886,8 +888,8 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3
             )
@@ -923,8 +925,8 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.TRACECONTEXT
             )
@@ -960,7 +962,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     fun `𝕄 create a span with info 𝕎 intercept() for successful request`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -979,7 +981,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         val fakeUrlWithoutQueryParams = forgeUrlWithoutQueryParams(forge)
         fakeRequest = forgeRequest(forge, fakeUrlWithoutQueryParams)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrlWithoutQueryParams)))
+        whenever(mockResolver.isFirstPartyUrl(fakeUrlWithoutQueryParams.toHttpUrl()))
             .thenReturn(true)
         stubChain(mockChain, statusCode)
 
@@ -996,7 +998,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     fun `𝕄 create a span with info 𝕎 intercept() for failing request {4xx}`(
         @IntForgery(min = 400, max = 500) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1012,7 +1014,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     fun `𝕄 create a span with info 𝕎 intercept() for failing request {5xx}`(
         @IntForgery(min = 500, max = 600) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1026,7 +1028,7 @@ internal open class TracingInterceptorNonDdTracerTest {
 
     @Test
     fun `𝕄 create a span with info 𝕎 intercept() for 404 request`() {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, 404)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1042,7 +1044,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     fun `𝕄 create a span with info 𝕎 intercept() for throwing request`(
         @Forgery throwable: Throwable
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable
 
@@ -1064,7 +1066,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
         whenever(datadogCore.mockInstance.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn null
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         testedInterceptor.intercept(mockChain)
@@ -1087,7 +1089,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         val localSpanBuilder: Tracer.SpanBuilder = mock()
         val localSpan: Span = mock()
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
@@ -1117,7 +1119,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         val localSpanBuilder: Tracer.SpanBuilder = mock()
         val localSpan: Span = mock()
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
@@ -1156,7 +1158,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
@@ -1182,7 +1184,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
@@ -1208,7 +1210,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         // When
@@ -1225,7 +1227,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
         ).doAnswer {
@@ -1255,7 +1257,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable
 
@@ -1270,7 +1272,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     fun `𝕄 do nothing 𝕎 intercept() for request with unknown host`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1315,7 +1317,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             mockLocalTracer
         }
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         // need this setup, otherwise #intercept actually throws NPE, which pollutes the log
@@ -1378,7 +1380,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         if (forge.aBool()) {
             fakeMethod = "POST"
             fakeBody = forge.anAlphabeticalString()
-            builder.post(RequestBody.create(null, fakeBody!!.toByteArray()))
+            builder.post(fakeBody!!.toByteArray().toRequestBody(null))
         } else {
             fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE")
             fakeBody = null
@@ -1396,8 +1398,8 @@ internal open class TracingInterceptorNonDdTracerTest {
             .protocol(Protocol.HTTP_2)
             .code(statusCode)
             .message("HTTP $statusCode")
-            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
-            .body(ResponseBody.create(fakeMediaType, fakeResponseBody))
+            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            .body(fakeResponseBody.toResponseBody(fakeMediaType))
         return builder.build()
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -39,13 +39,15 @@ import io.opentracing.propagation.TextMapExtract
 import io.opentracing.propagation.TextMapInject
 import io.opentracing.util.GlobalTracer
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Protocol
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -164,7 +166,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         fakeMediaType = if (forge.aBool()) {
             val mediaType = forge.anElementFrom("application", "image", "text", "model") +
                 "/" + forge.anAlphabeticalString()
-            MediaType.parse(mediaType)
+            mediaType.toMediaTypeOrNull()
         } else {
             null
         }
@@ -179,7 +181,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(rumMonitor.mockSdkCore.firstPartyHostResolver) doReturn mockResolver
         doAnswer { false }.whenever(mockResolver).isFirstPartyUrl(any<HttpUrl>())
-        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(HttpUrl.get(fakeUrl))
+        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
 
         GlobalTracer.registerIfAbsent(mockTracer)
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
@@ -220,8 +222,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int,
         forge: Forge
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 forge.anElementFrom(
                     setOf(
@@ -254,8 +256,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG
             )
@@ -282,8 +284,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3MULTI
             )
@@ -310,8 +312,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3
             )
@@ -336,8 +338,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.TRACECONTEXT
             )
@@ -367,8 +369,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG,
                 TracingHeaderType.B3,
@@ -415,7 +417,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     ) {
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -440,7 +442,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         whenever(mockTraceSampler.sample()).thenReturn(false)
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -472,7 +474,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -504,7 +506,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -534,7 +536,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -566,8 +568,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
         whenever(parentSpan.context()) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(parentSpanContext)) doReturn mockSpanBuilder
         fakeRequest = forgeRequest(forge) { it.tag(Span::class.java, parentSpan) }
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(HttpUrl.get(fakeUrl))
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -595,9 +597,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val parentSpanContext: SpanContext = mock()
         whenever(mockTracer.extract<TextMapExtract>(any(), any())) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(any<SpanContext>())) doReturn mockSpanBuilder
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge)
-        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(HttpUrl.get(fakeUrl))
+        doAnswer { true }.whenever(mockResolver).isFirstPartyUrl(fakeUrl.toHttpUrl())
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -623,7 +625,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
@@ -659,7 +661,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
@@ -692,7 +694,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
                 TracingInterceptor.B3_HEADER_KEY,
@@ -725,7 +727,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
                 TracingInterceptor.W3C_TRACEPARENT_KEY,
@@ -756,8 +758,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG
             )
@@ -794,8 +796,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3MULTI
             )
@@ -829,8 +831,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3
             )
@@ -865,8 +867,8 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.TRACECONTEXT
             )
@@ -918,7 +920,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     fun `𝕄 create a span with info 𝕎 intercept() for failing request {4xx}`(
         @IntForgery(min = 400, max = 500) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -938,7 +940,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     fun `𝕄 create a span with info 𝕎 intercept() for failing request {5xx}`(
         @IntForgery(min = 500, max = 600) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -956,7 +958,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     @Test
     fun `𝕄 create a span with info 𝕎 intercept() for 404 request`() {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, 404)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -976,7 +978,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     fun `𝕄 create a span with info 𝕎 intercept() for throwing request`(
         @Forgery throwable: Throwable
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable
 
@@ -1022,7 +1024,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val localSpanBuilder: DDTracer.DDSpanBuilder = mock()
         val localSpan: Span = mock(extraInterfaces = arrayOf(MutableSpan::class))
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
@@ -1054,7 +1056,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         val localSpanBuilder: DDTracer.DDSpanBuilder = mock()
         val localSpan: Span = mock(extraInterfaces = arrayOf(MutableSpan::class))
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
@@ -1097,7 +1099,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
@@ -1125,7 +1127,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
@@ -1153,7 +1155,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         // When
@@ -1170,7 +1172,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
         ).doAnswer {
@@ -1202,7 +1204,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable
 
@@ -1219,7 +1221,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1262,7 +1264,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         var called = 0
         val tracedHosts =
             listOf(fakeHostIp, fakeHostName).associateWith { setOf(TracingHeaderType.DATADOG) }
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         testedInterceptor = instantiateTestedInterceptor(tracedHosts) { _, _ ->
             called++
             mockLocalTracer
@@ -1330,7 +1332,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         if (forge.aBool()) {
             fakeMethod = "POST"
             fakeBody = forge.anAlphabeticalString()
-            builder.post(RequestBody.create(null, fakeBody!!.toByteArray()))
+            builder.post(fakeBody!!.toByteArray().toRequestBody(null))
         } else {
             fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE")
             fakeBody = null
@@ -1348,9 +1350,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
             .protocol(Protocol.HTTP_2)
             .code(statusCode)
             .message("HTTP $statusCode")
-            .body(ResponseBody.create(fakeMediaType, fakeResponseBody))
+            .body(fakeResponseBody.toResponseBody(fakeMediaType))
         if (fakeMediaType != null) {
-            builder.header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
+            builder.header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
         }
         return builder.build()
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -40,13 +40,15 @@ import io.opentracing.propagation.TextMapExtract
 import io.opentracing.propagation.TextMapInject
 import io.opentracing.util.GlobalTracer
 import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import okhttp3.Interceptor
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Protocol
 import okhttp3.Request
-import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
-import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
@@ -164,7 +166,7 @@ internal open class TracingInterceptorTest {
             "/" + forge.anAlphabeticalString()
         fakeLocalHosts =
             forge.aMap { forge.aStringMatching(HOSTNAME_PATTERN) to setOf(TracingHeaderType.DATADOG) }
-        fakeMediaType = MediaType.parse(mediaType)
+        fakeMediaType = mediaType.toMediaTypeOrNull()
         fakeUrl = forgeUrlWithQueryParams(forge)
         fakeRequest = forgeRequest(forge)
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn mock()
@@ -250,8 +252,8 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         stubChain(mockChain, statusCode)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 forge.anElementFrom(
                     setOf(
@@ -284,8 +286,8 @@ internal open class TracingInterceptorTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG
             )
@@ -313,8 +315,8 @@ internal open class TracingInterceptorTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3MULTI
             )
@@ -341,8 +343,8 @@ internal open class TracingInterceptorTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3
             )
@@ -367,8 +369,8 @@ internal open class TracingInterceptorTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.TRACECONTEXT
             )
@@ -398,8 +400,8 @@ internal open class TracingInterceptorTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG,
                 TracingHeaderType.B3,
@@ -446,7 +448,7 @@ internal open class TracingInterceptorTest {
     ) {
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -471,7 +473,7 @@ internal open class TracingInterceptorTest {
         whenever(mockTraceSampler.sample()).thenReturn(false)
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -501,7 +503,7 @@ internal open class TracingInterceptorTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         // When
@@ -530,7 +532,7 @@ internal open class TracingInterceptorTest {
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
 
         stubChain(mockChain, statusCode)
 
@@ -559,7 +561,7 @@ internal open class TracingInterceptorTest {
 
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
 
         stubChain(mockChain, statusCode)
 
@@ -599,7 +601,7 @@ internal open class TracingInterceptorTest {
 
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
 
         stubChain(mockChain, statusCode)
 
@@ -643,7 +645,7 @@ internal open class TracingInterceptorTest {
         whenever(parentSpan.context()) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(parentSpanContext)) doReturn mockSpanBuilder
         fakeRequest = forgeRequest(forge) { it.tag(Span::class.java, parentSpan) }
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -670,7 +672,7 @@ internal open class TracingInterceptorTest {
     ) {
         fakeRequest = fakeRequest.newBuilder().addHeader(key, previousValue).build()
         stubChain(mockChain, statusCode)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -695,7 +697,7 @@ internal open class TracingInterceptorTest {
     ) {
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge).newBuilder().addHeader(key, previousValue).build()
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -719,7 +721,7 @@ internal open class TracingInterceptorTest {
     ) {
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
         doThrow(IllegalStateException(message)).whenever(mockTracer)
             .inject<TextMapInject>(any(), any(), any())
@@ -729,7 +731,7 @@ internal open class TracingInterceptorTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(firstValue.headers().size()).isZero()
+            assertThat(firstValue.headers.size).isZero()
         }
     }
 
@@ -742,7 +744,7 @@ internal open class TracingInterceptorTest {
         val parentSpanContext: SpanContext = mock()
         whenever(mockTracer.extract<TextMapExtract>(any(), any())) doReturn parentSpanContext
         whenever(mockSpanBuilder.asChildOf(any<SpanContext>())) doReturn mockSpanBuilder
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
@@ -768,7 +770,7 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
                 TracingInterceptor.DATADOG_SAMPLING_PRIORITY_HEADER,
@@ -804,7 +806,7 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
                 TracingInterceptor.B3M_SAMPLING_PRIORITY_KEY,
@@ -837,7 +839,7 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
 
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
@@ -871,7 +873,7 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
 
         fakeRequest = forgeRequest(forge) {
             it.addHeader(
@@ -903,8 +905,8 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.DATADOG
             )
@@ -941,8 +943,8 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3MULTI
             )
@@ -976,8 +978,8 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.B3
             )
@@ -1012,8 +1014,8 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
-        whenever(mockResolver.headerTypesForUrl(HttpUrl.get(fakeUrl))).thenReturn(
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
+        whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
                 TracingHeaderType.TRACECONTEXT
             )
@@ -1048,7 +1050,7 @@ internal open class TracingInterceptorTest {
     fun `𝕄 create a span with info 𝕎 intercept() for successful request`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1069,7 +1071,7 @@ internal open class TracingInterceptorTest {
     ) {
         val fakeUrlWithoutQueryParams = forgeUrlWithoutQueryParams(forge)
         fakeRequest = forgeRequest(forge, fakeUrlWithoutQueryParams)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrlWithoutQueryParams)))
+        whenever(mockResolver.isFirstPartyUrl(fakeUrlWithoutQueryParams.toHttpUrl()))
             .thenReturn(true)
         stubChain(mockChain, statusCode)
 
@@ -1089,7 +1091,7 @@ internal open class TracingInterceptorTest {
     fun `𝕄 create a span with info 𝕎 intercept() for failing request {4xx}`(
         @IntForgery(min = 400, max = 500) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1108,7 +1110,7 @@ internal open class TracingInterceptorTest {
     fun `𝕄 create a span with info 𝕎 intercept() for failing request {5xx}`(
         @IntForgery(min = 500, max = 600) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1125,7 +1127,7 @@ internal open class TracingInterceptorTest {
 
     @Test
     fun `𝕄 create a span with info 𝕎 intercept() for 404 request`() {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, 404)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1144,7 +1146,7 @@ internal open class TracingInterceptorTest {
     fun `𝕄 create a span with info 𝕎 intercept() for throwing request`(
         @Forgery throwable: Throwable
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable
 
@@ -1168,7 +1170,7 @@ internal open class TracingInterceptorTest {
     ) {
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
         whenever(rumMonitor.mockSdkCore.getFeature(Feature.TRACING_FEATURE_NAME)) doReturn null
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         testedInterceptor.intercept(mockChain)
@@ -1191,7 +1193,7 @@ internal open class TracingInterceptorTest {
         val localSpanBuilder: DDTracer.DDSpanBuilder = mock()
         val localSpan: Span = mock(extraInterfaces = arrayOf(MutableSpan::class))
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.withOrigin(getExpectedOrigin())) doReturn localSpanBuilder
@@ -1224,7 +1226,7 @@ internal open class TracingInterceptorTest {
         val localSpanBuilder: DDTracer.DDSpanBuilder = mock()
         val localSpan: Span = mock(extraInterfaces = arrayOf(MutableSpan::class))
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.withOrigin(getExpectedOrigin())) doReturn localSpanBuilder
@@ -1268,7 +1270,7 @@ internal open class TracingInterceptorTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
@@ -1296,7 +1298,7 @@ internal open class TracingInterceptorTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
@@ -1323,7 +1325,7 @@ internal open class TracingInterceptorTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         // When
@@ -1340,7 +1342,7 @@ internal open class TracingInterceptorTest {
         @StringForgery tagKey: String,
         @StringForgery(type = StringForgeryType.ALPHA_NUMERICAL) tagValue: String
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(
             mockRequestListener.onRequestIntercepted(any(), any(), anyOrNull(), anyOrNull())
         ).doAnswer {
@@ -1371,7 +1373,7 @@ internal open class TracingInterceptorTest {
     ) {
         // Given
         whenever(mockTraceSampler.sample()).thenReturn(false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable
 
@@ -1386,7 +1388,7 @@ internal open class TracingInterceptorTest {
     fun `𝕄 do nothing 𝕎 intercept() for request with unknown host`(
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(false)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
         stubChain(mockChain, statusCode)
 
         val response = testedInterceptor.intercept(mockChain)
@@ -1431,7 +1433,7 @@ internal open class TracingInterceptorTest {
             mockLocalTracer
         }
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        whenever(mockResolver.isFirstPartyUrl(HttpUrl.get(fakeUrl))).thenReturn(true)
+        whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
         // need this setup, otherwise #intercept actually throws NPE, which pollutes the log
@@ -1494,7 +1496,7 @@ internal open class TracingInterceptorTest {
         if (forge.aBool()) {
             fakeMethod = "POST"
             fakeBody = forge.anAlphabeticalString()
-            builder.post(RequestBody.create(null, fakeBody!!.toByteArray()))
+            builder.post(fakeBody!!.toByteArray().toRequestBody(null))
         } else {
             fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE")
             fakeBody = null
@@ -1512,8 +1514,8 @@ internal open class TracingInterceptorTest {
             .protocol(Protocol.HTTP_2)
             .code(statusCode)
             .message("HTTP $statusCode")
-            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type().orEmpty())
-            .body(ResponseBody.create(fakeMediaType, fakeResponseBody))
+            .header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
+            .body(fakeResponseBody.toResponseBody(fakeMediaType))
         return builder.build()
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/RequestUniqueIdentifierTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/RequestUniqueIdentifierTest.kt
@@ -11,8 +11,10 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.RequestBody
+import okhttp3.RequestBody.Companion.toRequestBody
 import okio.BufferedSink
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
@@ -55,7 +57,7 @@ internal class RequestUniqueIdentifierTest {
 
     @Test
     fun `identify POST request`() {
-        val body = RequestBody.create(null, fakeBody)
+        val body = fakeBody.toRequestBody(null)
         val request = Request.Builder()
             .post(body).url(fakeUrl)
             .build()
@@ -69,7 +71,7 @@ internal class RequestUniqueIdentifierTest {
 
     @Test
     fun `identify POST request with content type`() {
-        val body = RequestBody.create(MediaType.parse(fakeContentType), fakeBody)
+        val body = fakeBody.toRequestBody(fakeContentType.toMediaTypeOrNull())
         val request = Request.Builder()
             .post(body).url(fakeUrl)
             .build()
@@ -83,7 +85,7 @@ internal class RequestUniqueIdentifierTest {
 
     @Test
     fun `identify PUT request`() {
-        val body = RequestBody.create(null, fakeBody)
+        val body = fakeBody.toRequestBody(null)
         val request = Request.Builder()
             .put(body).url(fakeUrl)
             .build()
@@ -97,7 +99,7 @@ internal class RequestUniqueIdentifierTest {
 
     @Test
     fun `identify PUT request with content type`() {
-        val body = RequestBody.create(MediaType.parse(fakeContentType), fakeBody)
+        val body = fakeBody.toRequestBody(fakeContentType.toMediaTypeOrNull())
         val request = Request.Builder()
             .put(body).url(fakeUrl)
             .build()
@@ -111,7 +113,7 @@ internal class RequestUniqueIdentifierTest {
 
     @Test
     fun `identify PATCH request`() {
-        val body = RequestBody.create(null, fakeBody)
+        val body = fakeBody.toRequestBody(null)
         val request = Request.Builder()
             .patch(body).url(fakeUrl)
             .build()
@@ -125,7 +127,7 @@ internal class RequestUniqueIdentifierTest {
 
     @Test
     fun `identify PATCH request with content type`() {
-        val body = RequestBody.create(MediaType.parse(fakeContentType), fakeBody)
+        val body = fakeBody.toRequestBody(fakeContentType.toMediaTypeOrNull())
         val request = Request.Builder()
             .patch(body).url(fakeUrl)
             .build()
@@ -151,7 +153,7 @@ internal class RequestUniqueIdentifierTest {
 
     @Test
     fun `identify DELETE request with body`() {
-        val body = RequestBody.create(null, fakeBody)
+        val body = fakeBody.toRequestBody(null)
         val request = Request.Builder()
             .delete(body).url(fakeUrl)
             .build()
@@ -165,7 +167,7 @@ internal class RequestUniqueIdentifierTest {
 
     @Test
     fun `identify DELETE request with content type`() {
-        val body = RequestBody.create(MediaType.parse(fakeContentType), fakeBody)
+        val body = fakeBody.toRequestBody(fakeContentType.toMediaTypeOrNull())
         val request = Request.Builder()
             .delete(body).url(fakeUrl)
             .build()
@@ -188,7 +190,7 @@ internal class RequestUniqueIdentifierTest {
             }
 
             override fun contentType(): MediaType? {
-                return MediaType.parse(fakeContentType)
+                return fakeContentType.toMediaTypeOrNull()
             }
 
             override fun writeTo(sink: BufferedSink) {

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -39,7 +39,7 @@ android {
     buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK_FOR_COMPOSE
+        minSdk = AndroidConfig.MIN_SDK
         targetSdk = AndroidConfig.TARGET_SDK
         versionCode = AndroidConfig.VERSION.code
         versionName = AndroidConfig.VERSION.name

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -255,10 +255,8 @@ class SampleApplication : Application() {
             device.addProperty("brand", Build.BRAND)
             device.addProperty("manufacturer", Build.MANUFACTURER)
             device.addProperty("model", Build.MODEL)
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-                for (abi in Build.SUPPORTED_ABIS) {
-                    abis.add(abi)
-                }
+            for (abi in Build.SUPPORTED_ABIS) {
+                abis.add(abi)
             }
         } catch (t: Throwable) {
             Timber.e(t, "Error setting device and abi properties")

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesViewModel.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesViewModel.kt
@@ -215,7 +215,7 @@ internal class TracesViewModel(private val okHttpClient: OkHttpClient) : ViewMod
             val request = builder.build()
             return try {
                 val response = okHttpClient.newCall(request).execute()
-                val body = response.body()
+                val body = response.body
                 if (body != null) {
                     val content: String = body.string()
                     // Necessary to consume the response

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/widget/WidgetIntentService.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/widget/WidgetIntentService.kt
@@ -65,7 +65,7 @@ class WidgetIntentService : IntentService("WidgetIntentService") {
         val request = builder.build()
         try {
             val response = okHttpClient.newCall(request).execute()
-            val body = response.body()
+            val body = response.body
             if (body != null) {
                 val content: String = body.string()
                 // Necessary to consume the response

--- a/sample/wear/build.gradle.kts
+++ b/sample/wear/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         applicationId = "com.datadog.android.wear.sample"
-        minSdk = AndroidConfig.MIN_SDK_FOR_WEAR
+        minSdk = AndroidConfig.MIN_SDK
         targetSdk = AndroidConfig.TARGET_SDK
         versionCode = AndroidConfig.VERSION.code
         versionName = AndroidConfig.VERSION.name


### PR DESCRIPTION
### What does this PR do?

This PR drops support of API 19 (KitKat) by bumping min SDK to 21, removing non-relevant code and also bumping OkHttp version to 4.x (because 4.x cannot be used with min SDK = 19).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

