### PR TITLE
RUMM-3367: Align APIs of Logs feature and Logger configuration with iOS SDK

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
@@ -156,7 +156,7 @@ object LogAttributes {
     /**
      * The name of the logger. (String)
      * This value is filled automatically by the [Logger].
-     * @see [Logger.Builder.setLoggerName]
+     * @see [Logger.Builder.setName]
      */
     const val LOGGER_NAME: String = "logger.name"
 

--- a/features/dd-sdk-android-logs/api/apiSurface
+++ b/features/dd-sdk-android-logs/api/apiSurface
@@ -11,14 +11,13 @@ class com.datadog.android.log.Logger
     constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
     fun build(): Logger
     fun setService(String): Builder
-    fun setDatadogLogsEnabled(Boolean): Builder
-    fun setDatadogLogsMinPriority(Int): Builder
+    fun setRemoteLogThreshold(Int): Builder
     fun setLogcatLogsEnabled(Boolean): Builder
     fun setNetworkInfoEnabled(Boolean): Builder
-    fun setLoggerName(String): Builder
+    fun setName(String): Builder
     fun setBundleWithTraceEnabled(Boolean): Builder
     fun setBundleWithRumEnabled(Boolean): Builder
-    fun setSampleRate(Float): Builder
+    fun setRemoteSampleRate(Float): Builder
   fun addAttribute(String, Any?)
   fun removeAttribute(String)
   fun addTag(String, String)
@@ -30,7 +29,7 @@ object com.datadog.android.log.Logs
 data class com.datadog.android.log.LogsConfiguration
   class Builder
     fun useCustomEndpoint(String): Builder
-    fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
+    fun setEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
     fun build(): LogsConfiguration
 data class com.datadog.android.log.model.LogEvent
   constructor(Status, kotlin.String, kotlin.String, kotlin.String, Logger, Dd, Usr? = null, Network? = null, Error? = null, kotlin.String, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())

--- a/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
+++ b/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
@@ -45,12 +45,11 @@ public final class com/datadog/android/log/Logger$Builder {
 	public final fun build ()Lcom/datadog/android/log/Logger;
 	public final fun setBundleWithRumEnabled (Z)Lcom/datadog/android/log/Logger$Builder;
 	public final fun setBundleWithTraceEnabled (Z)Lcom/datadog/android/log/Logger$Builder;
-	public final fun setDatadogLogsEnabled (Z)Lcom/datadog/android/log/Logger$Builder;
-	public final fun setDatadogLogsMinPriority (I)Lcom/datadog/android/log/Logger$Builder;
 	public final fun setLogcatLogsEnabled (Z)Lcom/datadog/android/log/Logger$Builder;
-	public final fun setLoggerName (Ljava/lang/String;)Lcom/datadog/android/log/Logger$Builder;
+	public final fun setName (Ljava/lang/String;)Lcom/datadog/android/log/Logger$Builder;
 	public final fun setNetworkInfoEnabled (Z)Lcom/datadog/android/log/Logger$Builder;
-	public final fun setSampleRate (F)Lcom/datadog/android/log/Logger$Builder;
+	public final fun setRemoteLogThreshold (I)Lcom/datadog/android/log/Logger$Builder;
+	public final fun setRemoteSampleRate (F)Lcom/datadog/android/log/Logger$Builder;
 	public final fun setService (Ljava/lang/String;)Lcom/datadog/android/log/Logger$Builder;
 }
 
@@ -72,7 +71,7 @@ public final class com/datadog/android/log/LogsConfiguration {
 public final class com/datadog/android/log/LogsConfiguration$Builder {
 	public fun <init> ()V
 	public final fun build ()Lcom/datadog/android/log/LogsConfiguration;
-	public final fun setLogEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/log/LogsConfiguration$Builder;
+	public final fun setEventMapper (Lcom/datadog/android/event/EventMapper;)Lcom/datadog/android/log/LogsConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/log/LogsConfiguration$Builder;
 }
 

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/Logger.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/Logger.kt
@@ -206,7 +206,6 @@ internal constructor(internal var handler: LogHandler) {
 
         private var serviceName: String? = null
         private var loggerName: String? = null
-        private var datadogLogsEnabled: Boolean = true
         private var logcatLogsEnabled: Boolean = false
         private var networkInfoEnabled: Boolean = false
         private var bundleWithTraceEnabled: Boolean = true
@@ -221,6 +220,7 @@ internal constructor(internal var handler: LogHandler) {
             val logsFeature = sdkCore
                 .getFeature(Feature.LOGS_FEATURE_NAME)
                 ?.unwrap<LogsFeature>()
+            val datadogLogsEnabled = sampleRate > 0
             val handler = when {
                 datadogLogsEnabled && logcatLogsEnabled -> {
                     CombinedLogHandler(
@@ -246,23 +246,12 @@ internal constructor(internal var handler: LogHandler) {
         }
 
         /**
-         * Enables your logs to be sent to the Datadog servers.
-         * You can use this feature to disable Datadog logs based on a configuration or an
-         * application flavor.
-         * @param enabled true by default
-         */
-        fun setDatadogLogsEnabled(enabled: Boolean): Builder {
-            datadogLogsEnabled = enabled
-            return this
-        }
-
-        /**
-         * Sets a minimum priority for the log to be sent to the Datadog servers. If log priority
+         * Sets a minimum threshold (priority) for the log to be sent to the Datadog servers. If log priority
          * is below this one, then it won't be sent. Default value is -1 (allow all).
-         * @param minLogPriority Minimum log priority to be sent to the Datadog servers.
+         * @param minLogThreshold Minimum log threshold to be sent to the Datadog servers.
          */
-        fun setDatadogLogsMinPriority(minLogPriority: Int): Builder {
-            minDatadogLogsPriority = minLogPriority
+        fun setRemoteLogThreshold(minLogThreshold: Int): Builder {
+            minDatadogLogsPriority = minLogThreshold
             return this
         }
 
@@ -288,7 +277,7 @@ internal constructor(internal var handler: LogHandler) {
          * Sets the logger name that will appear in your logs when a throwable is attached.
          * @param name the logger custom name (default = application package name)
          */
-        fun setLoggerName(name: String): Builder {
+        fun setName(name: String): Builder {
             loggerName = name
             return this
         }
@@ -318,10 +307,11 @@ internal constructor(internal var handler: LogHandler) {
         /**
          * Sets the sample rate for this Logger.
          * @param sampleRate the sample rate, in percent.
-         * A value of `30` means we'll send 30% of the logs.
+         * A value of `30` means we'll send 30% of the logs. If value is `0`, no logs will be sent
+         * to Datadog.
          * Default is 100.0 (ie: all logs are sent).
          */
-        fun setSampleRate(@FloatRange(from = 0.0, to = 100.0) sampleRate: Float): Builder {
+        fun setRemoteSampleRate(@FloatRange(from = 0.0, to = 100.0) sampleRate: Float): Builder {
             this.sampleRate = sampleRate
             return this
         }

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/LogsConfiguration.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/LogsConfiguration.kt
@@ -40,7 +40,7 @@ data class LogsConfiguration internal constructor(
          *
          * @param eventMapper the [EventMapper] implementation.
          */
-        fun setLogEventMapper(eventMapper: EventMapper<LogEvent>): Builder {
+        fun setEventMapper(eventMapper: EventMapper<LogEvent>): Builder {
             logsEventMapper = eventMapper
             return this
         }

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -125,7 +125,7 @@ internal class LoggerBuilderTest {
     }
 
     @Test
-    fun `builder can set a ServiceName`(@Forgery forge: Forge) {
+    fun `builder can set a service name`(@Forgery forge: Forge) {
         val serviceName = forge.anAlphabeticalString()
 
         val logger = Logger.Builder(mockSdkCore)
@@ -139,10 +139,8 @@ internal class LoggerBuilderTest {
 
     @Test
     fun `builder can disable datadog logs`() {
-        val datadogLogsEnabled = false
-
         val logger: Logger = Logger.Builder(mockSdkCore)
-            .setDatadogLogsEnabled(datadogLogsEnabled)
+            .setRemoteSampleRate(0f)
             .build()
 
         val handler: LogHandler = logger.handler
@@ -151,14 +149,14 @@ internal class LoggerBuilderTest {
 
     @Test
     fun `builder can set min datadog logs priority`(
-        @IntForgery minLogPriority: Int
+        @IntForgery minLogThreshold: Int
     ) {
         val logger: Logger = Logger.Builder(mockSdkCore)
-            .setDatadogLogsMinPriority(minLogPriority)
+            .setRemoteLogThreshold(minLogThreshold)
             .build()
 
         val handler: DatadogLogHandler = logger.handler as DatadogLogHandler
-        assertThat(handler.minLogPriority).isEqualTo(minLogPriority)
+        assertThat(handler.minLogPriority).isEqualTo(minLogThreshold)
     }
 
     @Test
@@ -185,7 +183,7 @@ internal class LoggerBuilderTest {
         val fakeServiceName = forge.anAlphaNumericalString()
 
         val logger = Logger.Builder(mockSdkCore)
-            .setDatadogLogsEnabled(false)
+            .setRemoteSampleRate(0f)
             .setLogcatLogsEnabled(logcatLogsEnabled)
             .setService(fakeServiceName)
             .build()
@@ -216,7 +214,7 @@ internal class LoggerBuilderTest {
         val loggerName = forge.anAlphabeticalString()
 
         val logger = Logger.Builder(mockSdkCore)
-            .setLoggerName(loggerName)
+            .setName(loggerName)
             .build()
 
         val handler: DatadogLogHandler = logger.handler as DatadogLogHandler
@@ -237,7 +235,7 @@ internal class LoggerBuilderTest {
     fun `builder can set a sample rate`(@Forgery forge: Forge) {
         val expectedSampleRate = forge.aFloat(min = 0.0f, max = 100.0f)
 
-        val logger = Logger.Builder(mockSdkCore).setSampleRate(expectedSampleRate).build()
+        val logger = Logger.Builder(mockSdkCore).setRemoteSampleRate(expectedSampleRate).build()
 
         val handler: DatadogLogHandler = logger.handler as DatadogLogHandler
         val sampler = handler.sampler

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsConfigurationBuilderTest.kt
@@ -55,13 +55,13 @@ internal class LogsConfigurationBuilderTest {
     }
 
     @Test
-    fun `𝕄 build configuration with Log eventMapper 𝕎 setLogEventMapper() and build()`() {
+    fun `𝕄 build configuration with Log eventMapper 𝕎 setEventMapper() and build()`() {
         // Given
         val mockEventMapper: EventMapper<LogEvent> = mock()
 
         // When
         val logsConfiguration = testedBuilder
-            .setLogEventMapper(mockEventMapper)
+            .setEventMapper(mockEventMapper)
             .build()
 
         // Then

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerBuilderE2ETests.kt
@@ -48,7 +48,7 @@ class LoggerBuilderE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setSampleRate(Float): Builder
+     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setRemoteSampleRate(Float): Builder
      * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun build(): Logger
      * apiMethodSignature: com.datadog.android.log.Logger$Builder#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.Datadog#fun getInstance(String? = null): com.datadog.android.v2.api.SdkCore?
@@ -57,13 +57,13 @@ class LoggerBuilderE2ETests {
     fun logs_logger_builder_sample_all_in() {
         val testMethodName = "logs_logger_builder_sample_all_in"
         measureLoggerInitialize {
-            logger = Logger.Builder(sdkCore).setSampleRate(100f).build()
+            logger = Logger.Builder(sdkCore).setRemoteSampleRate(100f).build()
         }
         logger.sendRandomLog(testMethodName, forge)
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setSampleRate(Float): Builder
+     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setRemoteSampleRate(Float): Builder
      * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun build(): Logger
      * apiMethodSignature: com.datadog.android.log.Logger$Builder#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.Datadog#fun getInstance(String? = null): com.datadog.android.v2.api.SdkCore?
@@ -72,13 +72,13 @@ class LoggerBuilderE2ETests {
     fun logs_logger_builder_sample_all_out() {
         val testMethodName = "logs_logger_builder_sample_all_out"
         measureLoggerInitialize {
-            logger = Logger.Builder(sdkCore).setSampleRate(0f).build()
+            logger = Logger.Builder(sdkCore).setRemoteSampleRate(0f).build()
         }
         logger.sendRandomLog(testMethodName, forge)
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setSampleRate(Float): Builder
+     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setRemoteSampleRate(Float): Builder
      * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun build(): Logger
      * apiMethodSignature: com.datadog.android.log.Logger$Builder#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.Datadog#fun getInstance(String? = null): com.datadog.android.v2.api.SdkCore?
@@ -88,7 +88,7 @@ class LoggerBuilderE2ETests {
         val testMethodName = "logs_logger_builder_sample_in_75_percent"
         val logsNumber = 10
         measureLoggerInitialize {
-            logger = Logger.Builder(sdkCore).setSampleRate(75f).build()
+            logger = Logger.Builder(sdkCore).setRemoteSampleRate(75f).build()
         }
         repeat(logsNumber) {
             logger.sendRandomLog(testMethodName, forge)
@@ -96,37 +96,7 @@ class LoggerBuilderE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setDatadogLogsEnabled(Boolean): Builder
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun build(): Logger
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
-     * apiMethodSignature: com.datadog.android.Datadog#fun getInstance(String? = null): com.datadog.android.v2.api.SdkCore?
-     */
-    @Test
-    fun logs_logger_builder_datadog_logs_enabled() {
-        val testMethodName = "logs_logger_builder_datadog_logs_enabled"
-        measureLoggerInitialize {
-            logger = Logger.Builder(sdkCore).setDatadogLogsEnabled(true).build()
-        }
-        logger.sendRandomLog(testMethodName, forge)
-    }
-
-    /**
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setDatadogLogsEnabled(Boolean): Builder
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun build(): Logger
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
-     * apiMethodSignature: com.datadog.android.Datadog#fun getInstance(String? = null): com.datadog.android.v2.api.SdkCore?
-     */
-    @Test
-    fun logs_logger_builder_datadog_logs_disabled() {
-        val testMethodName = "logs_logger_builder_datadog_logs_disabled"
-        measureLoggerInitialize {
-            logger = Logger.Builder(sdkCore).setDatadogLogsEnabled(false).build()
-        }
-        logger.sendRandomLog(testMethodName, forge)
-    }
-
-    /**
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setDatadogLogsMinPriority(Int): Builder
+     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setRemoteLogThreshold(Int): Builder
      * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun build(): Logger
      * apiMethodSignature: com.datadog.android.log.Logger$Builder#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.Datadog#fun getInstance(String? = null): com.datadog.android.v2.api.SdkCore?
@@ -144,8 +114,7 @@ class LoggerBuilderE2ETests {
 
         measureLoggerInitialize {
             logger = Logger.Builder(sdkCore)
-                .setDatadogLogsEnabled(true)
-                .setDatadogLogsMinPriority(minLogLevel)
+                .setRemoteLogThreshold(minLogLevel)
                 .build()
         }
         logger.sendRandomLog(
@@ -202,7 +171,7 @@ class LoggerBuilderE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setLoggerName(String): Builder
+     * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setName(String): Builder
      * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun build(): Logger
      * apiMethodSignature: com.datadog.android.log.Logger$Builder#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
      * apiMethodSignature: com.datadog.android.Datadog#fun getInstance(String? = null): com.datadog.android.v2.api.SdkCore?
@@ -211,7 +180,7 @@ class LoggerBuilderE2ETests {
     fun logs_logger_builder_set_logger_name() {
         val testMethodName = "logs_logger_builder_set_logger_name"
         measureLoggerInitialize {
-            logger = Logger.Builder(sdkCore).setLoggerName(CUSTOM_LOGGER_NAME).build()
+            logger = Logger.Builder(sdkCore).setName(CUSTOM_LOGGER_NAME).build()
         }
         logger.sendRandomLog(testMethodName, forge)
     }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LoggerE2ETests.kt
@@ -70,7 +70,7 @@ class LoggerE2ETests {
             forgeSeed = forge.seed
         )
         logger = Logger.Builder(sdkCore)
-            .setLoggerName(LOGGER_NAME)
+            .setName(LOGGER_NAME)
             .build()
     }
 

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsConfigE2ETests.kt
@@ -108,7 +108,7 @@ class LogsConfigE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.log.LogsConfiguration$Builder#fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
+     * apiMethodSignature: com.datadog.android.log.LogsConfiguration$Builder#fun setEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
      */
     @Test
     fun logs_config_set_event_mapper() {
@@ -123,7 +123,7 @@ class LogsConfigE2ETests {
                 ).build(),
                 logsConfigProvider = {
                     LogsConfiguration.Builder()
-                        .setLogEventMapper(
+                        .setEventMapper(
                             object : EventMapper<LogEvent> {
                                 override fun map(event: LogEvent): LogEvent {
                                     event.status = LogEvent.Status.ERROR
@@ -144,7 +144,7 @@ class LogsConfigE2ETests {
     }
 
     /**
-     * apiMethodSignature: com.datadog.android.log.LogsConfiguration$Builder#fun setLogEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
+     * apiMethodSignature: com.datadog.android.log.LogsConfiguration$Builder#fun setEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
      */
     @Test
     fun logs_config_set_event_mapper_with_drop_event() {
@@ -159,7 +159,7 @@ class LogsConfigE2ETests {
                 ).build(),
                 logsConfigProvider = {
                     LogsConfiguration.Builder()
-                        .setLogEventMapper(
+                        .setEventMapper(
                             object : EventMapper<LogEvent> {
                                 override fun map(event: LogEvent): LogEvent? {
                                     return null

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/logs/LogsUtils.kt
@@ -14,7 +14,7 @@ import com.datadog.tools.unit.forge.aThrowable
 import fr.xgouchet.elmyr.Forge
 
 fun initializeLogger(sdkCore: SdkCore) = Logger.Builder(sdkCore)
-    .setLoggerName(LOGGER_NAME)
+    .setName(LOGGER_NAME)
     .build()
 
 fun Logger.sendRandomLog(

--- a/integrations/dd-sdk-android-timber/src/main/kotlin/com/datadog/android/timber/DatadogTree.kt
+++ b/integrations/dd-sdk-android-timber/src/main/kotlin/com/datadog/android/timber/DatadogTree.kt
@@ -24,9 +24,9 @@ class DatadogTree(
      * Creates a [Timber.Tree] with a default [Logger] having a minimum log priority
      * for Datadog logs set to specified value.
      *
-     * See [Logger.Builder.setDatadogLogsMinPriority] for details.
+     * See [Logger.Builder.setRemoteLogThreshold] for details.
      *
-     * @param minLogPriority Minimum log priority to be sent to the Datadog servers.
+     * @param minLogPriority Minimum log threshold (priority) to be sent to the Datadog servers.
      * @param sdkCore SDK instance to bind to. If not provided, default instance will be used.
      */
     @Suppress("unused")
@@ -34,7 +34,7 @@ class DatadogTree(
     constructor(minLogPriority: Int, sdkCore: SdkCore = Datadog.getInstance()) :
         this(
             Logger.Builder(sdkCore)
-                .setDatadogLogsMinPriority(minLogPriority)
+                .setRemoteLogThreshold(minLogPriority)
                 .build()
         )
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -244,7 +244,7 @@ class SampleApplication : Application() {
     @Suppress("TooGenericExceptionCaught", "CheckInternal")
     private fun initializeTimber() {
         val logger = Logger.Builder()
-            .setLoggerName("timber")
+            .setName("timber")
             .setNetworkInfoEnabled(true)
             .build()
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/logs/LogsFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/logs/LogsFragment.kt
@@ -26,7 +26,7 @@ internal class LogsFragment :
     @Suppress("CheckInternal")
     private val logger: Logger by lazy {
         Logger.Builder()
-            .setLoggerName("logs_fragment")
+            .setName("logs_fragment")
             .setLogcatLogsEnabled(true)
             .build()
             .apply {

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesViewModel.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesViewModel.kt
@@ -268,7 +268,7 @@ internal class TracesViewModel(private val okHttpClient: OkHttpClient) : ViewMod
         @Suppress("CheckInternal")
         private val logger: Logger by lazy {
             Logger.Builder()
-                .setLoggerName("async_task")
+                .setName("async_task")
                 .setLogcatLogsEnabled(true)
                 .build()
                 .apply {


### PR DESCRIPTION
### What does this PR do?

This change aligns APIs used to configure Logs feature and `Logger` with wording used in iOS SDK.

Changes:

For `Logger`:

* `setLoggerName` -> `setName`
*  `setSampleRate` -> `setRemoteSampleRate`
* `setDatadogLogsMinPriority` -> `setRemoteLogThreshold` 

`setDatadogLogsEnabled` method is removed, because it duplicates functionality which can be achieved by the `setRemoteSampleRate` method.

`setLogcatLogsEnabled`, `setNetworkInfoEnabled`, `setBundleWithTraceEnabled` and `setBundleWithRumEnabled` are not changed, because this naming works better with `Builder` pattern and anyway wording stay the same in general (iOS SDK is using `bundleWithRUM`, `bundleWithTrace`, `consoleLogFormat`, `sendNetworkInfo` properties).

`LogsConfiguration` got `setLogEventMapper` renamed to `setEventMapper`, because we are anyway already in the Logs context.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

