### PR TITLE
RUMM-3368: Align pubilc API of Traces with iOS SDK

### DIFF
--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -13,13 +13,13 @@ class com.datadog.android.trace.AndroidTracer : com.datadog.opentracing.DDTracer
   companion object 
     fun logThrowable(io.opentracing.Span, Throwable)
     fun logErrorMessage(io.opentracing.Span, String)
-object com.datadog.android.trace.Traces
-  fun enable(TracesConfiguration, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
-data class com.datadog.android.trace.TracesConfiguration
+object com.datadog.android.trace.Trace
+  fun enable(TraceConfiguration, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
+data class com.datadog.android.trace.TraceConfiguration
   class Builder
     fun useCustomEndpoint(String): Builder
-    fun setSpanEventMapper(com.datadog.android.trace.event.SpanEventMapper): Builder
-    fun build(): TracesConfiguration
+    fun setEventMapper(com.datadog.android.trace.event.SpanEventMapper): Builder
+    fun build(): TraceConfiguration
 interface com.datadog.android.trace.event.SpanEventMapper : com.datadog.android.event.EventMapper<com.datadog.android.trace.model.SpanEvent>
   override fun map(com.datadog.android.trace.model.SpanEvent): com.datadog.android.trace.model.SpanEvent
 data class com.datadog.android.trace.model.SpanEvent

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -25,26 +25,26 @@ public final class com/datadog/android/trace/AndroidTracer$Companion {
 	public final fun logThrowable (Lio/opentracing/Span;Ljava/lang/Throwable;)V
 }
 
-public final class com/datadog/android/trace/Traces {
-	public static final field INSTANCE Lcom/datadog/android/trace/Traces;
-	public static final fun enable (Lcom/datadog/android/trace/TracesConfiguration;)V
-	public static final fun enable (Lcom/datadog/android/trace/TracesConfiguration;Lcom/datadog/android/v2/api/SdkCore;)V
-	public static synthetic fun enable$default (Lcom/datadog/android/trace/TracesConfiguration;Lcom/datadog/android/v2/api/SdkCore;ILjava/lang/Object;)V
+public final class com/datadog/android/trace/Trace {
+	public static final field INSTANCE Lcom/datadog/android/trace/Trace;
+	public static final fun enable (Lcom/datadog/android/trace/TraceConfiguration;)V
+	public static final fun enable (Lcom/datadog/android/trace/TraceConfiguration;Lcom/datadog/android/v2/api/SdkCore;)V
+	public static synthetic fun enable$default (Lcom/datadog/android/trace/TraceConfiguration;Lcom/datadog/android/v2/api/SdkCore;ILjava/lang/Object;)V
 }
 
-public final class com/datadog/android/trace/TracesConfiguration {
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;)Lcom/datadog/android/trace/TracesConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/trace/TracesConfiguration;Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ILjava/lang/Object;)Lcom/datadog/android/trace/TracesConfiguration;
+public final class com/datadog/android/trace/TraceConfiguration {
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;)Lcom/datadog/android/trace/TraceConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/trace/TraceConfiguration;Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ILjava/lang/Object;)Lcom/datadog/android/trace/TraceConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/trace/TracesConfiguration$Builder {
+public final class com/datadog/android/trace/TraceConfiguration$Builder {
 	public fun <init> ()V
-	public final fun build ()Lcom/datadog/android/trace/TracesConfiguration;
-	public final fun setSpanEventMapper (Lcom/datadog/android/trace/event/SpanEventMapper;)Lcom/datadog/android/trace/TracesConfiguration$Builder;
-	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/trace/TracesConfiguration$Builder;
+	public final fun build ()Lcom/datadog/android/trace/TraceConfiguration;
+	public final fun setEventMapper (Lcom/datadog/android/trace/event/SpanEventMapper;)Lcom/datadog/android/trace/TraceConfiguration$Builder;
+	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/trace/TraceConfiguration$Builder;
 }
 
 public abstract interface class com/datadog/android/trace/event/SpanEventMapper : com/datadog/android/event/EventMapper {

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/AndroidTracer.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/AndroidTracer.kt
@@ -30,7 +30,7 @@ import java.util.Random
 /**
  *  A class enabling Datadog tracing features.
  *
- * It allows you to create [ DDSpan ] and send them to Datadog servers.
+ * It allows you to create [DDSpan] and send them to Datadog servers.
  *
  * You can have multiple tracers configured in your application, each with their own settings.
  *

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Trace.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Trace.kt
@@ -14,22 +14,22 @@ import com.datadog.android.v2.api.SdkCore
 /**
  * An entry point to Datadog Traces feature.
  */
-object Traces {
+object Trace {
 
     /**
      * Enables a Traces feature based on the configuration provided.
      *
-     * @param tracesConfiguration Configuration to use for the feature.
+     * @param traceConfiguration Configuration to use for the feature.
      * @param sdkCore SDK instance to register feature in. If not provided, default SDK instance
      * will be used.
      */
     @JvmOverloads
     @JvmStatic
-    fun enable(tracesConfiguration: TracesConfiguration, sdkCore: SdkCore = Datadog.getInstance()) {
+    fun enable(traceConfiguration: TraceConfiguration, sdkCore: SdkCore = Datadog.getInstance()) {
         val tracingFeature = TracingFeature(
             sdkCore = sdkCore as FeatureSdkCore,
-            customEndpointUrl = tracesConfiguration.customEndpointUrl,
-            spanEventMapper = tracesConfiguration.eventMapper
+            customEndpointUrl = traceConfiguration.customEndpointUrl,
+            spanEventMapper = traceConfiguration.eventMapper
         )
 
         sdkCore.registerFeature(tracingFeature)

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
@@ -12,13 +12,13 @@ import com.datadog.android.trace.event.SpanEventMapper
 /**
  * Describes configuration to be used for the Traces feature.
  */
-data class TracesConfiguration internal constructor(
+data class TraceConfiguration internal constructor(
     internal val customEndpointUrl: String?,
     internal val eventMapper: SpanEventMapper
 ) {
 
     /**
-     * A Builder class for a [TracesConfiguration].
+     * A Builder class for a [TraceConfiguration].
      */
     class Builder {
         private var customEndpointUrl: String? = null
@@ -39,16 +39,16 @@ data class TracesConfiguration internal constructor(
          *
          * @param eventMapper the [SpanEventMapper] implementation.
          */
-        fun setSpanEventMapper(eventMapper: SpanEventMapper): Builder {
+        fun setEventMapper(eventMapper: SpanEventMapper): Builder {
             spanEventMapper = eventMapper
             return this
         }
 
         /**
-         * Builds a [TracesConfiguration] based on the current state of this Builder.
+         * Builds a [TraceConfiguration] based on the current state of this Builder.
          */
-        fun build(): TracesConfiguration {
-            return TracesConfiguration(
+        fun build(): TraceConfiguration {
+            return TraceConfiguration(
                 customEndpointUrl = customEndpointUrl,
                 eventMapper = spanEventMapper
             )

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceConfigurationBuilderTest.kt
@@ -33,9 +33,9 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class TracesConfigurationBuilderTest {
+internal class TraceConfigurationBuilderTest {
 
-    private val testedBuilder: TracesConfiguration.Builder = TracesConfiguration.Builder()
+    private val testedBuilder: TraceConfiguration.Builder = TraceConfiguration.Builder()
 
     @Mock
     lateinit var mockSdkCore: FeatureSdkCore
@@ -51,11 +51,11 @@ internal class TracesConfigurationBuilderTest {
     @Test
     fun `𝕄 use sensible defaults 𝕎 build()`() {
         // When
-        val tracesConfiguration = testedBuilder.build()
+        val traceConfiguration = testedBuilder.build()
 
         // Then
-        assertThat(tracesConfiguration.customEndpointUrl).isNull()
-        assertThat(tracesConfiguration.eventMapper)
+        assertThat(traceConfiguration.customEndpointUrl).isNull()
+        assertThat(traceConfiguration.eventMapper)
             .isInstanceOf(NoOpSpanEventMapper::class.java)
     }
 
@@ -64,26 +64,26 @@ internal class TracesConfigurationBuilderTest {
         @StringForgery(regex = "https://[a-z]+\\.com") tracesEndpointUrl: String
     ) {
         // When
-        val tracesConfiguration = testedBuilder.useCustomEndpoint(tracesEndpointUrl).build()
+        val traceConfiguration = testedBuilder.useCustomEndpoint(tracesEndpointUrl).build()
 
         // Then
-        assertThat(tracesConfiguration.customEndpointUrl).isEqualTo(tracesEndpointUrl)
-        assertThat(tracesConfiguration.eventMapper)
+        assertThat(traceConfiguration.customEndpointUrl).isEqualTo(tracesEndpointUrl)
+        assertThat(traceConfiguration.eventMapper)
             .isInstanceOf(NoOpSpanEventMapper::class.java)
     }
 
     @Test
-    fun `𝕄 build configuration with Span eventMapper 𝕎 setSpanEventMapper() and build()`() {
+    fun `𝕄 build configuration with Span eventMapper 𝕎 setEventMapper() and build()`() {
         // Given
         val mockEventMapper = mock<SpanEventMapper>()
 
         // When
-        val tracesConfiguration = testedBuilder
-            .setSpanEventMapper(mockEventMapper)
+        val traceConfiguration = testedBuilder
+            .setEventMapper(mockEventMapper)
             .build()
 
         // Then
-        assertThat(tracesConfiguration.customEndpointUrl).isNull()
-        assertThat(tracesConfiguration.eventMapper).isEqualTo(mockEventMapper)
+        assertThat(traceConfiguration.customEndpointUrl).isNull()
+        assertThat(traceConfiguration.eventMapper).isEqualTo(mockEventMapper)
     }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/TraceTest.kt
@@ -35,7 +35,7 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-internal class TracesTest {
+internal class TraceTest {
 
     @Mock
     lateinit var mockSdkCore: FeatureSdkCore
@@ -48,10 +48,10 @@ internal class TracesTest {
     @Test
     fun `𝕄 register traces feature 𝕎 enable()`(
         @StringForgery fakePackageName: String,
-        @Forgery fakeTracesConfiguration: TracesConfiguration
+        @Forgery fakeTraceConfiguration: TraceConfiguration
     ) {
         // When
-        Traces.enable(fakeTracesConfiguration, mockSdkCore)
+        Trace.enable(fakeTraceConfiguration, mockSdkCore)
 
         // Then
         argumentCaptor<TracingFeature> {
@@ -60,9 +60,9 @@ internal class TracesTest {
             lastValue.onInitialize(
                 appContext = mock { whenever(it.packageName) doReturn fakePackageName }
             )
-            assertThat(lastValue.spanEventMapper).isEqualTo(fakeTracesConfiguration.eventMapper)
+            assertThat(lastValue.spanEventMapper).isEqualTo(fakeTraceConfiguration.eventMapper)
             assertThat((lastValue.requestFactory as TracesRequestFactory).customEndpointUrl)
-                .isEqualTo(fakeTracesConfiguration.customEndpointUrl)
+                .isEqualTo(fakeTraceConfiguration.customEndpointUrl)
         }
     }
 }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -22,7 +22,7 @@ internal class Configurator : BaseConfigurator() {
         // APM
         forge.addFactory(SpanForgeryFactory())
         forge.addFactory(SpanEventForgeryFactory())
-        forge.addFactory(TracesConfigurationForgeryFactory())
+        forge.addFactory(TraceConfigurationForgeryFactory())
 
         // MISC
         forge.addFactory(BigIntegerFactory())

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/TraceConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/TraceConfigurationForgeryFactory.kt
@@ -6,14 +6,14 @@
 
 package com.datadog.android.utils.forge
 
-import com.datadog.android.trace.TracesConfiguration
+import com.datadog.android.trace.TraceConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 import org.mockito.kotlin.mock
 
-class TracesConfigurationForgeryFactory : ForgeryFactory<TracesConfiguration> {
-    override fun getForgery(forge: Forge): TracesConfiguration {
-        return TracesConfiguration(
+class TraceConfigurationForgeryFactory : ForgeryFactory<TraceConfiguration> {
+    override fun getForgery(forge: Forge): TraceConfiguration {
+        return TraceConfiguration(
             customEndpointUrl = forge.aNullable { aStringMatching("https://[a-z]+\\.com") },
             eventMapper = mock()
         )

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -26,8 +26,8 @@ import com.datadog.android.security.Encryption
 import com.datadog.android.sessionreplay.SessionReplay
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.trace.AndroidTracer
-import com.datadog.android.trace.Traces
-import com.datadog.android.trace.TracesConfiguration
+import com.datadog.android.trace.Trace
+import com.datadog.android.trace.TraceConfiguration
 import com.datadog.tools.unit.setStaticValue
 import fr.xgouchet.elmyr.junit4.ForgeRule
 import io.opentracing.Tracer
@@ -71,7 +71,7 @@ internal class EncryptionTest {
                 Rum.enable(rumConfig, sdkCore)
             },
             { Logs.enable(LogsConfiguration.Builder().build(), sdkCore) },
-            { Traces.enable(TracesConfiguration.Builder().build(), sdkCore) },
+            { Trace.enable(TraceConfiguration.Builder().build(), sdkCore) },
             { SessionReplay.enable(SessionReplayConfiguration.Builder().build(), sdkCore) }
         )
         featureActivations.shuffled(Random(forge.seed)).forEach { it() }

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
@@ -16,7 +16,7 @@ import com.datadog.android.log.LogsConfiguration
 import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.trace.AndroidTracer
-import com.datadog.android.trace.TracesConfiguration
+import com.datadog.android.trace.TraceConfiguration
 import com.datadog.android.v2.api.SdkCore
 import java.util.UUID
 
@@ -91,8 +91,8 @@ internal object RuntimeConfig {
             .useCustomEndpoint(logsEndpointUrl)
     }
 
-    fun tracesConfigBuilder(): TracesConfiguration.Builder {
-        return TracesConfiguration.Builder()
+    fun tracesConfigBuilder(): TraceConfiguration.Builder {
+        return TraceConfiguration.Builder()
             .useCustomEndpoint(tracesEndpointUrl)
     }
 

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/log/ActivityLifecycleLogs.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/log/ActivityLifecycleLogs.kt
@@ -16,7 +16,7 @@ import com.datadog.android.sdk.integration.R
 import com.datadog.android.sdk.integration.RuntimeConfig
 import com.datadog.android.sdk.utils.getForgeSeed
 import com.datadog.android.sdk.utils.getTrackingConsent
-import com.datadog.android.trace.Traces
+import com.datadog.android.trace.Trace
 import fr.xgouchet.elmyr.Forge
 import java.util.Random
 
@@ -44,7 +44,7 @@ internal class ActivityLifecycleLogs : AppCompatActivity() {
         checkNotNull(sdkCore)
         val featureActivations = mutableListOf(
             { Logs.enable(RuntimeConfig.logsConfigBuilder().build(), sdkCore) },
-            { Traces.enable(RuntimeConfig.tracesConfigBuilder().build(), sdkCore) }
+            { Trace.enable(RuntimeConfig.tracesConfigBuilder().build(), sdkCore) }
         )
         featureActivations.shuffled(Random(intent.getForgeSeed())).forEach { it() }
 

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/KioskSplashPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/KioskSplashPlaygroundActivity.kt
@@ -20,7 +20,7 @@ import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.sdk.integration.R
 import com.datadog.android.sdk.integration.RuntimeConfig
 import com.datadog.android.sdk.utils.getForgeSeed
-import com.datadog.android.trace.Traces
+import com.datadog.android.trace.Trace
 import java.util.Random
 
 internal class KioskSplashPlaygroundActivity : AppCompatActivity() {
@@ -49,7 +49,7 @@ internal class KioskSplashPlaygroundActivity : AppCompatActivity() {
                 Rum.enable(rumConfig, sdkCore)
             },
             { Logs.enable(RuntimeConfig.logsConfigBuilder().build(), sdkCore) },
-            { Traces.enable(RuntimeConfig.tracesConfigBuilder().build(), sdkCore) }
+            { Trace.enable(RuntimeConfig.tracesConfigBuilder().build(), sdkCore) }
         )
         featureActivations.shuffled(Random(intent.getForgeSeed())).forEach { it() }
 

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/trace/ActivityLifecycleTrace.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/trace/ActivityLifecycleTrace.kt
@@ -16,7 +16,7 @@ import com.datadog.android.sdk.integration.RuntimeConfig
 import com.datadog.android.sdk.utils.getForgeSeed
 import com.datadog.android.sdk.utils.getTrackingConsent
 import com.datadog.android.trace.AndroidTracer
-import com.datadog.android.trace.Traces
+import com.datadog.android.trace.Trace
 import com.datadog.opentracing.DDSpan
 import fr.xgouchet.elmyr.Forge
 import io.opentracing.Scope
@@ -48,7 +48,7 @@ internal class ActivityLifecycleTrace : AppCompatActivity() {
         checkNotNull(sdkCore)
         mutableListOf(
             { Logs.enable(RuntimeConfig.logsConfigBuilder().build(), sdkCore) },
-            { Traces.enable(RuntimeConfig.tracesConfigBuilder().build(), sdkCore) }
+            { Trace.enable(RuntimeConfig.tracesConfigBuilder().build(), sdkCore) }
         )
             .shuffled(Random(intent.getForgeSeed()))
             .forEach { it() }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -43,8 +43,8 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.rum.RumConfiguration$Builder#fun setAdditionalConfiguration(Map<String, Any>): Builder
  * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#fun startTracking()
  * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#fun stopTracking()
- * apiMethodSignature: com.datadog.android.trace.Traces#fun enable(TracesConfiguration, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
- * apiMethodSignature: com.datadog.android.trace.TracesConfiguration$Builder#fun useCustomEndpoint(String): Builder
+ * apiMethodSignature: com.datadog.android.trace.Trace#fun enable(TraceConfiguration, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
+ * apiMethodSignature: com.datadog.android.trace.TraceConfiguration$Builder#fun useCustomEndpoint(String): Builder
  * apiMethodSignature: com.datadog.android.SdkReference#constructor(String? = null, (com.datadog.android.v2.api.SdkCore) -> Unit = {})
  * apiMethodSignature: com.datadog.android.SdkReference#fun get(): com.datadog.android.v2.api.SdkCore?
  * apiMethodSignature: com.datadog.android.sessionreplay.SessionReplay#fun enable(SessionReplayConfiguration, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanBuilderE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanBuilderE2ETests.kt
@@ -34,7 +34,7 @@ class SpanBuilderE2ETests {
      * apiMethodSignature: com.datadog.android.Datadog#fun initialize(android.content.Context, com.datadog.android.core.configuration.Credentials, com.datadog.android.core.configuration.Configuration, com.datadog.android.privacy.TrackingConsent): com.datadog.android.v2.api.SdkCore?
      * apiMethodSignature: com.datadog.android.Datadog#fun initialize(String?, android.content.Context, com.datadog.android.core.configuration.Credentials, com.datadog.android.core.configuration.Configuration, com.datadog.android.privacy.TrackingConsent): com.datadog.android.v2.api.SdkCore?
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun build(): Configuration
-     * apiMethodSignature: com.datadog.android.trace.TracesConfiguration$Builder#fun build(): TracesConfiguration
+     * apiMethodSignature: com.datadog.android.trace.TraceConfiguration$Builder#fun build(): TraceConfiguration
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#constructor(Boolean)
      * apiMethodSignature: com.datadog.android.trace.AndroidTracer$Builder#fun build(): AndroidTracer
      */

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
@@ -23,7 +23,7 @@ import com.datadog.android.nightly.utils.sendRandomActionOutcomeEvent
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.trace.AndroidTracer
-import com.datadog.android.trace.TracesConfiguration
+import com.datadog.android.trace.TraceConfiguration
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.trace.event.SpanEventMapper
 import com.datadog.android.trace.model.SpanEvent
@@ -104,7 +104,7 @@ class SpanConfigE2ETests {
 
     /**
      * apiMethodSignature: com.datadog.android.trace.AndroidTracer$Builder#constructor(com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
-     * apiMethodSignature: com.datadog.android.trace.TracesConfiguration$Builder#fun setSpanEventMapper(com.datadog.android.trace.event.SpanEventMapper): Builder
+     * apiMethodSignature: com.datadog.android.trace.TraceConfiguration$Builder#fun setEventMapper(com.datadog.android.trace.event.SpanEventMapper): Builder
      */
     @Test
     fun trace_config_set_span_event_mapper() {
@@ -118,7 +118,7 @@ class SpanConfigE2ETests {
                     crashReportsEnabled = true
                 ).build(),
                 tracesConfigProvider = {
-                    TracesConfiguration.Builder().setSpanEventMapper(object : SpanEventMapper {
+                    TraceConfiguration.Builder().setEventMapper(object : SpanEventMapper {
                         override fun map(event: SpanEvent): SpanEvent {
                             if (event.resource == fakeResourceName) {
                                 event.name = testMethodName

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanE2ETests.kt
@@ -40,7 +40,7 @@ class SpanE2ETests {
      * apiMethodSignature: com.datadog.android.Datadog#fun initialize(android.content.Context, com.datadog.android.core.configuration.Credentials, com.datadog.android.core.configuration.Configuration, com.datadog.android.privacy.TrackingConsent): com.datadog.android.v2.api.SdkCore?
      * apiMethodSignature: com.datadog.android.Datadog#fun initialize(String?, android.content.Context, com.datadog.android.core.configuration.Credentials, com.datadog.android.core.configuration.Configuration, com.datadog.android.privacy.TrackingConsent): com.datadog.android.v2.api.SdkCore?
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun build(): Configuration
-     * apiMethodSignature: com.datadog.android.trace.TracesConfiguration$Builder#fun build(): TracesConfiguration
+     * apiMethodSignature: com.datadog.android.trace.TraceConfiguration$Builder#fun build(): TraceConfiguration
      * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#constructor(Boolean)
      */
     @Before

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -25,8 +25,8 @@ import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.trace.AndroidTracer
-import com.datadog.android.trace.Traces
-import com.datadog.android.trace.TracesConfiguration
+import com.datadog.android.trace.Trace
+import com.datadog.android.trace.TraceConfiguration
 import com.datadog.android.v2.api.SdkCore
 import com.datadog.tools.unit.forge.aThrowable
 import com.datadog.tools.unit.getStaticValue
@@ -98,7 +98,7 @@ fun initializeSdk(
     consent: TrackingConsent = TrackingConsent.GRANTED,
     config: Configuration = createDatadogDefaultConfiguration(),
     logsConfigProvider: () -> LogsConfiguration? = { LogsConfiguration.Builder().build() },
-    tracesConfigProvider: () -> TracesConfiguration? = { TracesConfiguration.Builder().build() },
+    tracesConfigProvider: () -> TraceConfiguration? = { TraceConfiguration.Builder().build() },
     rumConfigProvider: (RumConfiguration.Builder) -> RumConfiguration? = {
         it.build()
     },
@@ -127,7 +127,7 @@ fun initializeSdk(
             when (it) {
                 is RumConfiguration -> Rum.enable(it, sdkCore)
                 is LogsConfiguration -> Logs.enable(it, sdkCore)
-                is TracesConfiguration -> Traces.enable(it, sdkCore)
+                is TraceConfiguration -> Trace.enable(it, sdkCore)
                 else -> throw IllegalArgumentException(
                     "Unknown configuration of type ${it::class.qualifiedName}"
                 )

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/JvmCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/JvmCrashService.kt
@@ -22,8 +22,8 @@ import com.datadog.android.nightly.exceptions.RumEnabledException
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
-import com.datadog.android.trace.Traces
-import com.datadog.android.trace.TracesConfiguration
+import com.datadog.android.trace.Trace
+import com.datadog.android.trace.TraceConfiguration
 import com.datadog.android.v2.api.SdkCore
 
 internal open class JvmCrashService : CrashService() {
@@ -87,7 +87,7 @@ internal open class JvmCrashService : CrashService() {
             Rum.enable(rumConfig, sdkCore)
         }
         Logs.enable(LogsConfiguration.Builder().build(), sdkCore)
-        Traces.enable(TracesConfiguration.Builder().build(), sdkCore)
+        Trace.enable(TraceConfiguration.Builder().build(), sdkCore)
         return sdkCore
     }
 

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/NdkCrashService.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/services/NdkCrashService.kt
@@ -22,8 +22,8 @@ import com.datadog.android.nightly.utils.NeverUseThatEncryption
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
-import com.datadog.android.trace.Traces
-import com.datadog.android.trace.TracesConfiguration
+import com.datadog.android.trace.Trace
+import com.datadog.android.trace.TraceConfiguration
 import com.datadog.android.v2.api.SdkCore
 
 internal open class NdkCrashService : CrashService() {
@@ -96,7 +96,7 @@ internal open class NdkCrashService : CrashService() {
             Rum.enable(rumConfig, sdkCore)
         }
         Logs.enable(LogsConfiguration.Builder().build(), sdkCore)
-        Traces.enable(TracesConfiguration.Builder().build(), sdkCore)
+        Trace.enable(TraceConfiguration.Builder().build(), sdkCore)
         if (ndkCrashReportsEnabled) {
             NdkCrashReports.enable(sdkCore)
         }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -45,8 +45,8 @@ import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.sessionreplay.material.MaterialExtensionSupport
 import com.datadog.android.timber.DatadogTree
 import com.datadog.android.trace.AndroidTracer
-import com.datadog.android.trace.Traces
-import com.datadog.android.trace.TracesConfiguration
+import com.datadog.android.trace.Trace
+import com.datadog.android.trace.TraceConfiguration
 import com.datadog.android.v2.api.context.UserInfo
 import com.facebook.stetho.Stetho
 import com.google.gson.GsonBuilder
@@ -134,12 +134,12 @@ class SampleApplication : Application() {
         }.build()
         Logs.enable(logsConfig)
 
-        val tracesConfig = TracesConfiguration.Builder().apply {
+        val tracesConfig = TraceConfiguration.Builder().apply {
             if (BuildConfig.DD_OVERRIDE_TRACES_URL.isNotBlank()) {
                 useCustomEndpoint(BuildConfig.DD_OVERRIDE_TRACES_URL)
             }
         }.build()
-        Traces.enable(tracesConfig)
+        Trace.enable(tracesConfig)
 
         NdkCrashReports.enable()
 

--- a/sample/wear/src/main/java/com/datadog/android/wear/sample/WearApplication.kt
+++ b/sample/wear/src/main/java/com/datadog/android/wear/sample/WearApplication.kt
@@ -21,8 +21,8 @@ import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.rum.RumMonitor
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.trace.AndroidTracer
-import com.datadog.android.trace.Traces
-import com.datadog.android.trace.TracesConfiguration
+import com.datadog.android.trace.Trace
+import com.datadog.android.trace.TraceConfiguration
 import com.datadog.android.v2.api.context.UserInfo
 import io.opentracing.util.GlobalTracer
 import timber.log.Timber
@@ -69,14 +69,14 @@ class WearApplication : Application() {
             .build()
         Logs.enable(logsConfig)
 
-        val tracesConfig = TracesConfiguration.Builder()
+        val tracesConfig = TraceConfiguration.Builder()
             .apply {
                 if (BuildConfig.DD_OVERRIDE_TRACES_URL.isNotBlank()) {
                     useCustomEndpoint(BuildConfig.DD_OVERRIDE_TRACES_URL)
                 }
             }
             .build()
-        Traces.enable(tracesConfig)
+        Trace.enable(tracesConfig)
 
         Datadog.getInstance().setUserInfo(
             UserInfo(


### PR DESCRIPTION
### What does this PR do?

Some minor changes in the wording in order to align with iOS SDK.

**NOTE**: `Tracer` object is created outside of `Trace.enable` call, because we have to use anyway `GlobalTracer` from `io.opentracing` (meaning we cannot remove the method responsible to `Tracer` object registration in `GlobalTracer` like in https://github.com/DataDog/dd-sdk-android/pull/1502).


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

