### PR TITLE
RUMM-3338: Introduce known file cache and cleanup throttling in `BatchFileOrchestrator` in order to reduce the number of syscalls

### DIFF
--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FilePersistenceConfig.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FilePersistenceConfig.kt
@@ -15,7 +15,8 @@ internal data class FilePersistenceConfig(
     val maxItemSize: Long = MAX_ITEM_SIZE,
     val maxItemsPerBatch: Int = MAX_ITEMS_PER_BATCH,
     val oldFileThreshold: Long = OLD_FILE_THRESHOLD,
-    val maxDiskSpace: Long = MAX_DISK_SPACE
+    val maxDiskSpace: Long = MAX_DISK_SPACE,
+    val cleanupFrequencyThreshold: Long = CLEANUP_FREQUENCY_THRESHOLD_MS
 ) {
     companion object {
         internal const val MAX_BATCH_SIZE: Long = 4L * 1024 * 1024 // 4 MB
@@ -24,5 +25,6 @@ internal data class FilePersistenceConfig(
         internal const val OLD_FILE_THRESHOLD: Long = 18L * 60L * 60L * 1000L // 18 hours
         internal const val MAX_DISK_SPACE: Long = 128 * MAX_BATCH_SIZE // 512 MB
         internal const val MAX_DELAY_BETWEEN_MESSAGES_MS = 5000L
+        internal const val CLEANUP_FREQUENCY_THRESHOLD_MS = 1000L // 1s
     }
 }

--- a/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
+++ b/dd-sdk-android/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal.persistence.file.batch
 
 import androidx.annotation.WorkerThread
+import androidx.collection.LruCache
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.canWriteSafe
@@ -22,6 +23,8 @@ import java.io.FileFilter
 import java.util.Locale
 import kotlin.math.roundToLong
 
+// TODO RUMM-3373 Improve this class: need to make it thread-safe and optimize work with file
+//  system in order to reduce the number of syscalls (which are expensive) for files already seen
 internal class BatchFileOrchestrator(
     private val rootDir: File,
     private val config: FilePersistenceConfig,
@@ -42,6 +45,10 @@ internal class BatchFileOrchestrator(
     private var previousFile: File? = null
     private var previousFileItemCount: Int = 0
 
+    @Suppress("UnsafeThirdPartyFunctionCall") // argument is not negative
+    private val knownBatchFiles = LruCache<File, Unit>(KNOWN_FILES_MAX_CACHE_SIZE)
+    private var lastCleanupTimestamp: Long = 0L
+
     // region FileOrchestrator
 
     @WorkerThread
@@ -50,8 +57,11 @@ internal class BatchFileOrchestrator(
             return null
         }
 
-        deleteObsoleteFiles()
-        freeSpaceIfNeeded()
+        if (canDoCleanup()) {
+            deleteObsoleteFiles()
+            freeSpaceIfNeeded()
+            lastCleanupTimestamp = System.currentTimeMillis()
+        }
 
         return if (!forceNewFile) {
             getReusableWritableFile() ?: createNewFile()
@@ -67,6 +77,7 @@ internal class BatchFileOrchestrator(
         }
 
         deleteObsoleteFiles()
+        lastCleanupTimestamp = System.currentTimeMillis()
 
         val files = listSortedBatchFiles()
 
@@ -186,6 +197,8 @@ internal class BatchFileOrchestrator(
         val newFile = File(rootDir, newFileName)
         previousFile = newFile
         previousFileItemCount = 1
+        @Suppress("UnsafeThirdPartyFunctionCall") // value is not null
+        knownBatchFiles.put(newFile, Unit)
         return newFile
     }
 
@@ -231,6 +244,8 @@ internal class BatchFileOrchestrator(
             .filter { (it.name.toLongOrNull() ?: 0) < threshold }
             .forEach {
                 it.deleteSafe()
+                @Suppress("UnsafeThirdPartyFunctionCall") // value is not null
+                knownBatchFiles.remove(it)
                 if (it.metadata.existsSafe()) {
                     it.metadata.deleteSafe()
                 }
@@ -264,6 +279,8 @@ internal class BatchFileOrchestrator(
         if (!file.existsSafe()) return 0
 
         val size = file.lengthSafe()
+        @Suppress("UnsafeThirdPartyFunctionCall") // value is not null
+        knownBatchFiles.remove(file)
         return if (file.deleteSafe()) {
             size
         } else {
@@ -278,15 +295,33 @@ internal class BatchFileOrchestrator(
     private val File.metadata: File
         get() = File("${this.path}_metadata")
 
+    private fun canDoCleanup(): Boolean {
+        return System.currentTimeMillis() - lastCleanupTimestamp > config.cleanupFrequencyThreshold
+    }
+
     // endregion
 
     // region FileFilter
 
-    internal class BatchFileFilter : FileFilter {
+    internal inner class BatchFileFilter : FileFilter {
+        @Suppress("ReturnCount")
         override fun accept(file: File?): Boolean {
-            return file != null &&
-                file.isFileSafe() &&
+            if (file == null) return false
+
+            @Suppress("UnsafeThirdPartyFunctionCall") // value is not null
+            if (knownBatchFiles.get(file) != null) {
+                return true
+            }
+
+            return if (file.isFileSafe() &&
                 file.name.matches(batchFileNameRegex)
+            ) {
+                @Suppress("UnsafeThirdPartyFunctionCall") // both values are not null
+                knownBatchFiles.put(file, Unit)
+                true
+            } else {
+                false
+            }
         }
     }
 
@@ -296,6 +331,10 @@ internal class BatchFileOrchestrator(
 
         const val DECREASE_PERCENT = 0.95
         const val INCREASE_PERCENT = 1.05
+
+        // File class contains only few simple fields, so retained size usually is way below even 1Kb.
+        // Holding 400 items at max will be below 400 Kb of retained size.
+        private const val KNOWN_FILES_MAX_CACHE_SIZE = 400
 
         private val batchFileNameRegex = Regex("\\d+")
         internal const val ERROR_ROOT_NOT_WRITABLE = "The provided root dir is not writable: %s"

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -104,6 +104,10 @@ datadog:
       - "androidx.work.WorkManager.enqueueUniqueWork(kotlin.String, androidx.work.ExistingWorkPolicy, androidx.work.OneTimeWorkRequest):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
       - "android.content.res.Resources.getResourceName(kotlin.Int):android.content.res.Resources.NotFoundException"
       - "android.content.res.Resources.openRawResource(kotlin.Int):android.content.res.Resources.NotFoundException"
+      - "androidx.collection.LruCache.constructor(kotlin.Int):java.lang.IllegalArgumentException"
+      - "androidx.collection.LruCache.get(java.io.File):java.lang.NullPointerException"
+      - "androidx.collection.LruCache.put(java.io.File, kotlin.Unit):java.lang.NullPointerException"
+      - "androidx.collection.LruCache.remove(java.io.File):java.lang.NullPointerException"
       - "androidx.metrics.performance.JankStats.createAndTrack(android.view.Window, androidx.metrics.performance.JankStats.OnFrameListener):java.lang.IllegalStateException"
       # endregion
       # region Java File


### PR DESCRIPTION
### What does this PR do?

The goal of this PR is to reduce CPU consumption during the scenarios like described in https://github.com/DataDog/dd-sdk-android/issues/1469.

The issue comes from the fact that when we have many batch files on the disk calling `listSortedBatchFiles` as-is (which is called several times during `getWritableFile`, for example) becomes quite expensive because:

* syscalls (like `isFile`) are expensive
* pattern matching becomes expensive as well.

In order to optimize that, the following is done:

* Introduced the cache for the files already known to be batch files, so that we don't need to call `isFile` and use regex.
* Introduce throttling for the cleanup (only for the `getWritableFile` path, because a) it can be called much more often than `getReadableFile`, for every event; b) cleanup actions are a bit different between `getReadableFile` and `getWritableFile`, so having the same timestamp is not quite correct).

Test scenario: 300 batch files on the disk, disabled network, writing 1 log entry every 100 ms.

CPU usage after the change (same scenario and duration is used):

![image](https://github.com/DataDog/dd-sdk-android/assets/4046447/eb69d6ce-bc76-4624-8eff-9785194e1b56)

It gives a very good bump if the total number files on the disk is below the cache max size. If cache is not enough, the problem comes back (but maybe in a bit better state, because we have cleanup throttling)

CPU usage before the change:

![image](https://github.com/DataDog/dd-sdk-android/assets/4046447/bb1ff91b-512c-4846-9a85-2dd73afb983f)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

