### PR TITLE
REPLAY-1817 Require sampleRate when building the SR configuration

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -5,10 +5,10 @@ object com.datadog.android.sessionreplay.SessionReplay
   fun enable(SessionReplayConfiguration, com.datadog.android.v2.api.SdkCore = Datadog.getInstance())
 data class com.datadog.android.sessionreplay.SessionReplayConfiguration
   class Builder
+    constructor(Float)
     fun addExtensionSupport(ExtensionSupport): Builder
     fun useCustomEndpoint(String): Builder
     fun setPrivacy(SessionReplayPrivacy): Builder
-    fun setSessionReplaySampleRate(Float): Builder
     fun build(): SessionReplayConfiguration
 enum com.datadog.android.sessionreplay.SessionReplayPrivacy
   - ALLOW_ALL

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -19,11 +19,10 @@ public final class com/datadog/android/sessionreplay/SessionReplayConfiguration 
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayConfiguration$Builder {
-	public fun <init> ()V
+	public fun <init> (F)V
 	public final fun addExtensionSupport (Lcom/datadog/android/sessionreplay/ExtensionSupport;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun build ()Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public final fun setPrivacy (Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
-	public final fun setSessionReplaySampleRate (F)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -24,12 +24,13 @@ data class SessionReplayConfiguration internal constructor(
 
     /**
      * A Builder class for a [SessionReplayConfiguration].
+     * @param sampleRate must be a value between 0 and 100. A value of 0
+     * means no session will be recorded, 100 means all sessions will be recorded.
      */
-    class Builder {
+    class Builder(@FloatRange(from = 0.0, to = 100.0)private val sampleRate: Float) {
         private var customEndpointUrl: String? = null
         private var privacy = SessionReplayPrivacy.MASK_ALL
         private var extensionSupport: ExtensionSupport = NoOpExtensionSupport()
-        private var sampleRate: Float = DEFAULT_SAMPLE_RATE
 
         /**
          * Adds an extension support implementation. This is mostly used when you want to provide
@@ -62,22 +63,7 @@ data class SessionReplayConfiguration internal constructor(
         }
 
         /**
-         * Sets the sample rate for Session Replay recorded Sessions. Please note that this
-         * sample rate will be applied on top of the already sampled in RUM session.
-         *
-         * @param sampleRate must be a value between 0 and 100. A value of 0
-         * means no session will be recorded, 100 means all sessions will be recorded.
-         * The default value for the sample rate will be 0 meaning that no session replay will be
-         * recorded if the sample rate will not be explicitly set.
-         */
-        fun setSessionReplaySampleRate(@FloatRange(from = 0.0, to = 100.0) sampleRate: Float):
-            Builder {
-            this.sampleRate = sampleRate
-            return this
-        }
-
-        /**
-         * * Builds a [SessionReplayConfiguration] based on the current state of this Builder.
+         * Builds a [SessionReplayConfiguration] based on the current state of this Builder.
          */
         fun build(): SessionReplayConfiguration {
             return SessionReplayConfiguration(
@@ -100,9 +86,5 @@ data class SessionReplayConfiguration internal constructor(
             }
             return emptyList()
         }
-    }
-
-    internal companion object {
-        internal const val DEFAULT_SAMPLE_RATE = 0f
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -36,8 +36,7 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(value = ForgeConfigurator::class)
 internal class SessionReplayConfigurationBuilderTest {
 
-    private var testedBuilder: SessionReplayConfiguration.Builder =
-        SessionReplayConfiguration.Builder()
+    lateinit var testedBuilder: SessionReplayConfiguration.Builder
 
     @Mock
     lateinit var mockExtensionSupport: ExtensionSupport
@@ -46,6 +45,9 @@ internal class SessionReplayConfigurationBuilderTest {
     lateinit var fakeExpectedMaskAllCustomMappers: List<MapperTypeWrapper>
     lateinit var fakeAllowAllCustomMappers: Map<Class<*>, WireframeMapper<View, *>>
     lateinit var fakeMaskAllCustomMappers: Map<Class<*>, WireframeMapper<View, *>>
+
+    @FloatForgery
+    var fakeSampleRate: Float = 0f
 
     @BeforeEach
     fun `set up`() {
@@ -61,6 +63,7 @@ internal class SessionReplayConfigurationBuilderTest {
             SessionReplayPrivacy.MASK_ALL to fakeMaskAllCustomMappers
         )
         whenever(mockExtensionSupport.getCustomViewMappers()).thenReturn(fakeCustomMappers)
+        testedBuilder = SessionReplayConfiguration.Builder(fakeSampleRate)
     }
 
     @Test
@@ -73,8 +76,7 @@ internal class SessionReplayConfigurationBuilderTest {
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK_ALL)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
-        assertThat(sessionReplayConfiguration.sampleRate)
-            .isEqualTo(SessionReplayConfiguration.DEFAULT_SAMPLE_RATE)
+        assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
     }
 
     @Test
@@ -82,7 +84,9 @@ internal class SessionReplayConfigurationBuilderTest {
         @StringForgery(regex = "https://[a-z]+\\.com") sessionReplayUrl: String
     ) {
         // When
-        val sessionReplayConfiguration = testedBuilder.useCustomEndpoint(sessionReplayUrl).build()
+        val sessionReplayConfiguration = testedBuilder
+            .useCustomEndpoint(sessionReplayUrl)
+            .build()
 
         // Then
         assertThat(sessionReplayConfiguration.customEndpointUrl)
@@ -90,8 +94,7 @@ internal class SessionReplayConfigurationBuilderTest {
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK_ALL)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
-        assertThat(sessionReplayConfiguration.sampleRate)
-            .isEqualTo(SessionReplayConfiguration.DEFAULT_SAMPLE_RATE)
+        assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
     }
 
     @Test
@@ -99,28 +102,13 @@ internal class SessionReplayConfigurationBuilderTest {
         @Forgery fakePrivacy: SessionReplayPrivacy
     ) {
         // When
-        val sessionReplayConfiguration = testedBuilder.setPrivacy(fakePrivacy).build()
+        val sessionReplayConfiguration = testedBuilder
+            .setPrivacy(fakePrivacy)
+            .build()
 
         // Then
         assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(fakePrivacy)
-        assertThat(sessionReplayConfiguration.customMappers).isEmpty()
-        assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
-        assertThat(sessionReplayConfiguration.sampleRate)
-            .isEqualTo(SessionReplayConfiguration.DEFAULT_SAMPLE_RATE)
-    }
-
-    @Test
-    fun `M use the given sample rate W setSessionReplaySampleRate`(
-        @FloatForgery fakeSampleRate: Float
-    ) {
-        // When
-        val sessionReplayConfiguration =
-            testedBuilder.setSessionReplaySampleRate(fakeSampleRate).build()
-
-        // Then
-        assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
-        assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK_ALL)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -72,7 +72,12 @@ internal class EncryptionTest {
             },
             { Logs.enable(LogsConfiguration.Builder().build(), sdkCore) },
             { Trace.enable(TraceConfiguration.Builder().build(), sdkCore) },
-            { SessionReplay.enable(SessionReplayConfiguration.Builder().build(), sdkCore) }
+            {
+                val sessionReplayConfiguration = SessionReplayConfiguration
+                    .Builder(100f)
+                    .build()
+                SessionReplay.enable(sessionReplayConfiguration, sdkCore)
+            }
         )
         featureActivations.shuffled(Random(forge.seed)).forEach { it() }
 

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/RuntimeConfig.kt
@@ -81,8 +81,8 @@ internal object RuntimeConfig {
             .useCustomEndpoint(rumEndpointUrl)
     }
 
-    fun sessionReplayConfigBuilder(): SessionReplayConfiguration.Builder {
-        return SessionReplayConfiguration.Builder()
+    fun sessionReplayConfigBuilder(sampleRate: Float): SessionReplayConfiguration.Builder {
+        return SessionReplayConfiguration.Builder(sampleRate)
             .useCustomEndpoint(sessionReplayEndpointUrl)
     }
 

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplayPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplayPlaygroundActivity.kt
@@ -66,9 +66,8 @@ internal open class SessionReplayPlaygroundActivity : AppCompatActivity() {
     }
 
     open fun sessionReplayConfiguration(): SessionReplayConfiguration =
-        RuntimeConfig.sessionReplayConfigBuilder()
+        RuntimeConfig.sessionReplayConfigBuilder(SAMPLE_IN_ALL_SESSIONS)
             .setPrivacy(SessionReplayPrivacy.ALLOW_ALL)
-            .setSessionReplaySampleRate(SAMPLE_IN_ALL_SESSIONS)
             .build()
 
     @Suppress("LongMethod")

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplaySampledOutPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplaySampledOutPlaygroundActivity.kt
@@ -13,9 +13,8 @@ import com.datadog.android.sessionreplay.SessionReplayPrivacy
 internal class SessionReplaySampledOutPlaygroundActivity : SessionReplayPlaygroundActivity() {
 
     override fun sessionReplayConfiguration(): SessionReplayConfiguration =
-        RuntimeConfig.sessionReplayConfigBuilder()
+        RuntimeConfig.sessionReplayConfigBuilder(0f)
             .setPrivacy(SessionReplayPrivacy.ALLOW_ALL)
-            .setSessionReplaySampleRate(0f)
             .build()
 
     @Suppress("LongMethod")

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -115,13 +115,12 @@ class SampleApplication : Application() {
         val rumConfig = createRumConfiguration()
         Rum.enable(rumConfig)
 
-        val sessionReplayConfig = SessionReplayConfiguration.Builder()
+        val sessionReplayConfig = SessionReplayConfiguration.Builder(SAMPLE_IN_ALL_SESSIONS)
             .apply {
                 if (BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL.isNotBlank()) {
                     useCustomEndpoint(BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL)
                 }
             }
-            .setSessionReplaySampleRate(SAMPLE_IN_ALL_SESSIONS)
             .addExtensionSupport(MaterialExtensionSupport())
             .build()
         SessionReplay.enable(sessionReplayConfig)


### PR DESCRIPTION
### What does this PR do?

In the iOS sdk we are currently explicitly require the `sampleRate` value when enabling the Session Replay feature. We need to align on the Android side also and require this when building the SR configuration object.

Please also note that given this change the `setSessionReplayRate` method doesn't make sense anymore and was removed.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

