### PR TITLE
REPLAY-1841 Align the SessionReplayPrivacy API with the last RFC

### DIFF
--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaskSliderWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaskSliderWireframeMapper.kt
@@ -4,22 +4,19 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.sessionreplay.internal.recorder.mapper
+package com.datadog.android.sessionreplay.material
 
-import android.os.Build
-import androidx.annotation.RequiresApi
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.StringUtils
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
 
-@RequiresApi(Build.VERSION_CODES.O)
-internal class MaskAllSeekBarWireframeMapper(
+internal open class MaskSliderWireframeMapper(
     viewUtils: ViewUtils = ViewUtils,
     stringUtils: StringUtils = StringUtils,
     uniqueIdentifierGenerator: UniqueIdentifierGenerator =
         UniqueIdentifierGenerator
-) : SeekBarWireframeMapper(viewUtils, stringUtils, uniqueIdentifierGenerator) {
+) : SliderWireframeMapper(viewUtils, stringUtils, uniqueIdentifierGenerator) {
 
     override fun resolveViewAsWireframesList(
         nonActiveTrackWireframe: MobileSegment.Wireframe.ShapeWireframe,

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaskTabWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaskTabWireframeMapper.kt
@@ -7,15 +7,15 @@
 package com.datadog.android.sessionreplay.material
 
 import android.widget.TextView
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllTextViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
 
-internal class MaskAllTabWireframeMapper(
+internal class MaskTabWireframeMapper(
     viewUtils: ViewUtils = ViewUtils,
     uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator,
     textViewMapper: WireframeMapper<TextView, MobileSegment.Wireframe.TextWireframe> =
-        MaskAllTextViewMapper()
+        MaskTextViewMapper()
 ) : TabWireframeMapper(viewUtils, uniqueIdentifierGenerator, textViewMapper)

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupport.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupport.kt
@@ -22,23 +22,23 @@ class MaterialExtensionSupport : ExtensionSupport {
     @Suppress("UNCHECKED_CAST")
     override fun getCustomViewMappers():
         Map<SessionReplayPrivacy, Map<Class<*>, WireframeMapper<View, *>>> {
-        val maskUserInputSliderMapper = MaskAllSliderWireframeMapper() as WireframeMapper<View, *>
-        val maskAllSliderMapper = MaskAllSliderWireframeMapper() as WireframeMapper<View, *>
-        val allowAllSliderMapper = SliderWireframeMapper() as WireframeMapper<View, *>
-        val maskAllTabWireframeMapper = MaskAllTabWireframeMapper() as WireframeMapper<View, *>
-        val allowAllTabWireframeMapper = TabWireframeMapper() as WireframeMapper<View, *>
+        val maskUserInputSliderMapper = MaskSliderWireframeMapper() as WireframeMapper<View, *>
+        val maskSliderMapper = MaskSliderWireframeMapper() as WireframeMapper<View, *>
+        val allowSliderMapper = SliderWireframeMapper() as WireframeMapper<View, *>
+        val maskTabWireframeMapper = MaskTabWireframeMapper() as WireframeMapper<View, *>
+        val allowTabWireframeMapper = TabWireframeMapper() as WireframeMapper<View, *>
         return mapOf(
-            SessionReplayPrivacy.ALLOW_ALL to mapOf(
-                Slider::class.java to allowAllSliderMapper,
-                TabLayout.TabView::class.java to allowAllTabWireframeMapper
+            SessionReplayPrivacy.ALLOW to mapOf(
+                Slider::class.java to allowSliderMapper,
+                TabLayout.TabView::class.java to allowTabWireframeMapper
             ),
-            SessionReplayPrivacy.MASK_ALL to mapOf(
-                Slider::class.java to maskAllSliderMapper,
-                TabLayout.TabView::class.java to maskAllTabWireframeMapper
+            SessionReplayPrivacy.MASK to mapOf(
+                Slider::class.java to maskSliderMapper,
+                TabLayout.TabView::class.java to maskTabWireframeMapper
             ),
             SessionReplayPrivacy.MASK_USER_INPUT to mapOf(
                 Slider::class.java to maskUserInputSliderMapper,
-                TabLayout.TabView::class.java to allowAllTabWireframeMapper
+                TabLayout.TabView::class.java to allowTabWireframeMapper
             )
         )
     }

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/MaskSliderWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/MaskSliderWireframeMapperTest.kt
@@ -24,10 +24,10 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllSliderWireframeMapperTest : BaseSliderWireframeMapperTest() {
+internal class MaskSliderWireframeMapperTest : BaseSliderWireframeMapperTest() {
 
     override fun provideTestInstance(): SliderWireframeMapper {
-        return MaskAllSliderWireframeMapper(
+        return MaskSliderWireframeMapper(
             viewUtils = mockViewUtils,
             stringUtils = mockStringUtils,
             uniqueIdentifierGenerator = mockUniqueIdentifierGenerator

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/MaskTabWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/MaskTabWireframeMapperTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.material
 
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllTextViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskTextViewMapper
 import com.datadog.android.sessionreplay.material.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -24,10 +24,10 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllTabWireframeMapperTest : BaseTabWireframeMapperTest() {
+internal class MaskTabWireframeMapperTest : BaseTabWireframeMapperTest() {
 
     override fun provideTestInstance(): TabWireframeMapper {
-        return MaskAllTabWireframeMapper(
+        return MaskTabWireframeMapper(
             viewUtils = mockViewUtils,
             uniqueIdentifierGenerator = mockUniqueIdentifierGenerator,
             textViewMapper = mockTextWireframeMapper
@@ -35,12 +35,12 @@ internal class MaskAllTabWireframeMapperTest : BaseTabWireframeMapperTest() {
     }
 
     @Test
-    fun `M use a MaskAllTextViewMapper when initialized`() {
+    fun `M use a MaskTextViewMapper when initialized`() {
         // Given
-        val maskAllTabWireframeMapper = MaskAllTabWireframeMapper()
+        val maskTabWireframeMapper = MaskTabWireframeMapper()
 
         // Then
-        assertThat(maskAllTabWireframeMapper.textViewMapper)
-            .isInstanceOf(MaskAllTextViewMapper::class.java)
+        assertThat(maskTabWireframeMapper.textViewMapper)
+            .isInstanceOf(MaskTextViewMapper::class.java)
     }
 }

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupportTest.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupportTest.kt
@@ -30,58 +30,58 @@ class MaterialExtensionSupportTest {
     }
 
     @Test
-    fun `M return a SliderMapper W getCustomViewMappers() { ALLOW_ALL }`() {
+    fun `M return a SliderMapper W getCustomViewMappers() { ALLOW }`() {
         // When
         val customMappers = testedMaterialExtensionSupport.getCustomViewMappers()
 
         // Then
         assertThat(customMappers.entries.size).isEqualTo(3)
-        assertThat(customMappers[SessionReplayPrivacy.ALLOW_ALL]?.get(Slider::class.java))
+        assertThat(customMappers[SessionReplayPrivacy.ALLOW]?.get(Slider::class.java))
             .isInstanceOf(SliderWireframeMapper::class.java)
     }
 
     @Test
-    fun `M return a MaskAllSliderMapper W getCustomViewMappers() { MASK_ALL }`() {
+    fun `M return a MaskSliderMapper W getCustomViewMappers() { MASK }`() {
         // When
         val customMappers = testedMaterialExtensionSupport.getCustomViewMappers()
 
         // Then
         assertThat(customMappers.entries.size).isEqualTo(3)
-        assertThat(customMappers[SessionReplayPrivacy.MASK_ALL]?.get(Slider::class.java))
-            .isInstanceOf(MaskAllSliderWireframeMapper::class.java)
+        assertThat(customMappers[SessionReplayPrivacy.MASK]?.get(Slider::class.java))
+            .isInstanceOf(MaskSliderWireframeMapper::class.java)
     }
 
     @Test
-    fun `M return a MaskAllSliderMapper W getCustomViewMappers() { MASK_USER_INPUT }`() {
+    fun `M return a MaskSliderMapper W getCustomViewMappers() { MASK_USER_INPUT }`() {
         // When
         val customMappers = testedMaterialExtensionSupport.getCustomViewMappers()
 
         // Then
         assertThat(customMappers.entries.size).isEqualTo(3)
-        assertThat(customMappers[SessionReplayPrivacy.MASK_ALL]?.get(Slider::class.java))
-            .isInstanceOf(MaskAllSliderWireframeMapper::class.java)
+        assertThat(customMappers[SessionReplayPrivacy.MASK_USER_INPUT]?.get(Slider::class.java))
+            .isInstanceOf(MaskSliderWireframeMapper::class.java)
     }
 
     @Test
-    fun `M return a TabMapper W getCustomViewMappers() { ALLOW_ALL }`() {
+    fun `M return a TabMapper W getCustomViewMappers() { ALLOW }`() {
         // When
         val customMappers = testedMaterialExtensionSupport.getCustomViewMappers()
 
         // Then
         assertThat(customMappers.entries.size).isEqualTo(3)
-        assertThat(customMappers[SessionReplayPrivacy.ALLOW_ALL]?.get(TabView::class.java))
+        assertThat(customMappers[SessionReplayPrivacy.ALLOW]?.get(TabView::class.java))
             .isInstanceOf(TabWireframeMapper::class.java)
     }
 
     @Test
-    fun `M return a MaskAllTabMapper W getCustomViewMappers() { MASK_ALL  }`() {
+    fun `M return a MaskTabMapper W getCustomViewMappers() { MASK  }`() {
         // When
         val customMappers = testedMaterialExtensionSupport.getCustomViewMappers()
 
         // Then
         assertThat(customMappers.entries.size).isEqualTo(3)
-        assertThat(customMappers[SessionReplayPrivacy.MASK_ALL]?.get(TabView::class.java))
-            .isInstanceOf(MaskAllTabWireframeMapper::class.java)
+        assertThat(customMappers[SessionReplayPrivacy.MASK]?.get(TabView::class.java))
+            .isInstanceOf(MaskTabWireframeMapper::class.java)
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -11,8 +11,8 @@ data class com.datadog.android.sessionreplay.SessionReplayConfiguration
     fun setPrivacy(SessionReplayPrivacy): Builder
     fun build(): SessionReplayConfiguration
 enum com.datadog.android.sessionreplay.SessionReplayPrivacy
-  - ALLOW_ALL
-  - MASK_ALL
+  - ALLOW
+  - MASK
   - MASK_USER_INPUT
 data class com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
   constructor(Long, Long, Long, Long)
@@ -28,9 +28,9 @@ abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseWi
   protected fun colorAndAlphaAsStringHexa(Int, Int): String
   protected fun resolveViewGlobalBounds(android.view.View, Float): com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
   protected fun android.graphics.drawable.Drawable.resolveShapeStyleAndBorder(Float): Pair<com.datadog.android.sessionreplay.model.MobileSegment.ShapeStyle?, com.datadog.android.sessionreplay.model.MobileSegment.ShapeBorder?>?
-class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllTextViewMapper : TextViewMapper
-  constructor()
 class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskInputTextViewMapper : TextViewMapper
+  constructor()
+class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskTextViewMapper : TextViewMapper
   constructor()
 open class com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper : BaseWireframeMapper<android.widget.TextView, com.datadog.android.sessionreplay.model.MobileSegment.Wireframe.TextWireframe>
   constructor()

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -27,8 +27,8 @@ public final class com/datadog/android/sessionreplay/SessionReplayConfiguration$
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayPrivacy : java/lang/Enum {
-	public static final field ALLOW_ALL Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
-	public static final field MASK_ALL Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
+	public static final field ALLOW Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
+	public static final field MASK Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public static final field MASK_USER_INPUT Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
@@ -97,11 +97,11 @@ public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper
 	protected final fun resolveViewId (Landroid/view/View;)J
 }
 
-public final class com/datadog/android/sessionreplay/internal/recorder/mapper/MaskAllTextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper {
+public final class com/datadog/android/sessionreplay/internal/recorder/mapper/MaskInputTextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper {
 	public fun <init> ()V
 }
 
-public final class com/datadog/android/sessionreplay/internal/recorder/mapper/MaskInputTextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper {
+public final class com/datadog/android/sessionreplay/internal/recorder/mapper/MaskTextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper {
 	public fun <init> ()V
 }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -29,7 +29,7 @@ data class SessionReplayConfiguration internal constructor(
      */
     class Builder(@FloatRange(from = 0.0, to = 100.0)private val sampleRate: Float) {
         private var customEndpointUrl: String? = null
-        private var privacy = SessionReplayPrivacy.MASK_ALL
+        private var privacy = SessionReplayPrivacy.MASK
         private var extensionSupport: ExtensionSupport = NoOpExtensionSupport()
 
         /**
@@ -53,9 +53,9 @@ data class SessionReplayConfiguration internal constructor(
 
         /**
          * Sets the privacy rule for the Session Replay feature.
-         * If not specified all the elements will be masked by default (MASK_ALL).
-         * @see SessionReplayPrivacy.ALLOW_ALL
-         * @see SessionReplayPrivacy.MASK_ALL
+         * If not specified all the elements will be masked by default (MASK).
+         * @see SessionReplayPrivacy.ALLOW
+         * @see SessionReplayPrivacy.MASK
          */
         fun setPrivacy(privacy: SessionReplayPrivacy): Builder {
             this.privacy = privacy

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
@@ -25,14 +25,14 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckedTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.EditTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MapperTypeWrapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllCheckBoxMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllCheckedTextViewMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllNumberPickerMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllRadioButtonMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllSeekBarWireframeMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllSwitchCompatMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllTextViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckBoxMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckedTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskInputTextViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskNumberPickerMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskRadioButtonMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskSeekBarWireframeMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskSwitchCompatMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.NumberPickerMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.RadioButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.SeekBarWireframeMapper
@@ -46,8 +46,8 @@ import androidx.appcompat.widget.Toolbar as AppCompatToolbar
 
 /**
  * Defines the Session Replay privacy policy when recording the sessions.
- * @see SessionReplayPrivacy.ALLOW_ALL
- * @see SessionReplayPrivacy.MASK_ALL
+ * @see SessionReplayPrivacy.ALLOW
+ * @see SessionReplayPrivacy.MASK
  * @see SessionReplayPrivacy.MASK_USER_INPUT
  *
  */
@@ -58,14 +58,14 @@ enum class SessionReplayPrivacy {
      * inputType will be masked no matter what the privacy option with space-preserving "x" mask
      * (each char individually)
      **/
-    ALLOW_ALL,
+    ALLOW,
 
     /**
      *  Masks all the elements. All the characters in texts will be replaced by X, images will be
      *  replaced with just a placeholder and switch buttons, check boxes and radio buttons will also
      *  be masked. This is the default privacy rule.
      **/
-    MASK_ALL,
+    MASK,
 
     /**
      * Masks most form fields such as inputs, checkboxes, radio buttons, switchers, sliders, etc.
@@ -88,7 +88,7 @@ enum class SessionReplayPrivacy {
         val seekBarMapper: SeekBarWireframeMapper?
         val numberPickerMapper: BasePickerMapper?
         when (this) {
-            ALLOW_ALL -> {
+            ALLOW -> {
                 imageMapper = ViewScreenshotWireframeMapper(viewWireframeMapper)
                 textMapper = TextViewMapper()
                 buttonMapper = ButtonMapper(textMapper)
@@ -100,29 +100,29 @@ enum class SessionReplayPrivacy {
                 seekBarMapper = getSeekBarMapper()
                 numberPickerMapper = getNumberPickerMapper()
             }
-            MASK_ALL -> {
+            MASK -> {
                 imageMapper = ViewScreenshotWireframeMapper(viewWireframeMapper)
-                textMapper = MaskAllTextViewMapper()
+                textMapper = MaskTextViewMapper()
                 buttonMapper = ButtonMapper(textMapper)
                 editTextViewMapper = EditTextViewMapper(textMapper)
-                checkedTextViewMapper = MaskAllCheckedTextViewMapper(textMapper)
-                checkBoxMapper = MaskAllCheckBoxMapper(textMapper)
-                radioButtonMapper = MaskAllRadioButtonMapper(textMapper)
-                switchCompatMapper = MaskAllSwitchCompatMapper(textMapper)
-                seekBarMapper = getMaskAllSeekBarMapper()
-                numberPickerMapper = getMaskAllNumberPickerMapper()
+                checkedTextViewMapper = MaskCheckedTextViewMapper(textMapper)
+                checkBoxMapper = MaskCheckBoxMapper(textMapper)
+                radioButtonMapper = MaskRadioButtonMapper(textMapper)
+                switchCompatMapper = MaskSwitchCompatMapper(textMapper)
+                seekBarMapper = getMaskSeekBarMapper()
+                numberPickerMapper = getMaskNumberPickerMapper()
             }
             MASK_USER_INPUT -> {
                 imageMapper = ViewScreenshotWireframeMapper(viewWireframeMapper)
                 textMapper = MaskInputTextViewMapper()
                 buttonMapper = ButtonMapper(textMapper)
                 editTextViewMapper = EditTextViewMapper(textMapper)
-                checkedTextViewMapper = MaskAllCheckedTextViewMapper(textMapper)
-                checkBoxMapper = MaskAllCheckBoxMapper(textMapper)
-                radioButtonMapper = MaskAllRadioButtonMapper(textMapper)
-                switchCompatMapper = MaskAllSwitchCompatMapper(textMapper)
-                seekBarMapper = getMaskAllSeekBarMapper()
-                numberPickerMapper = getMaskAllNumberPickerMapper()
+                checkedTextViewMapper = MaskCheckedTextViewMapper(textMapper)
+                checkBoxMapper = MaskCheckBoxMapper(textMapper)
+                radioButtonMapper = MaskRadioButtonMapper(textMapper)
+                switchCompatMapper = MaskSwitchCompatMapper(textMapper)
+                seekBarMapper = getMaskSeekBarMapper()
+                numberPickerMapper = getMaskNumberPickerMapper()
             }
         }
         val mappersList = mutableListOf(
@@ -157,9 +157,9 @@ enum class SessionReplayPrivacy {
         return mappersList
     }
 
-    private fun getMaskAllSeekBarMapper(): MaskAllSeekBarWireframeMapper? {
+    private fun getMaskSeekBarMapper(): MaskSeekBarWireframeMapper? {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-            MaskAllSeekBarWireframeMapper()
+            MaskSeekBarWireframeMapper()
         } else {
             null
         }
@@ -181,9 +181,9 @@ enum class SessionReplayPrivacy {
         }
     }
 
-    private fun getMaskAllNumberPickerMapper(): BasePickerMapper? {
+    private fun getMaskNumberPickerMapper(): BasePickerMapper? {
         return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-            MaskAllNumberPickerMapper()
+            MaskNumberPickerMapper()
         } else {
             null
         }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/EditTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/EditTextViewMapper.kt
@@ -16,7 +16,7 @@ import com.datadog.android.sessionreplay.utils.ViewUtils
 
 /**
  * A [WireframeMapper] implementation to map a [EditText] component in case the
- * [SessionReplayPrivacy.ALLOW_ALL] rule was used in the configuration.
+ * [SessionReplayPrivacy.ALLOW] rule was used in the configuration.
  * In this case the mapper will use the provided [textViewMapper] used for the current privacy
  * level and will only mask the [EditText] for which the input type is considered sensible
  * (password, email, address, postal address, numeric password) with the static mask: [***].

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskCheckBoxMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskCheckBoxMapper.kt
@@ -6,28 +6,22 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
-import android.widget.CheckedTextView
+import android.widget.CheckBox
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.StringUtils
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
 
-internal class MaskAllCheckedTextViewMapper(
+internal class MaskCheckBoxMapper(
     textWireframeMapper: TextViewMapper,
     stringUtils: StringUtils = StringUtils,
-    uniqueIdentifierGenerator: UniqueIdentifierGenerator =
-        UniqueIdentifierGenerator,
+    uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator,
     viewUtils: ViewUtils = ViewUtils
-) : CheckedTextViewMapper(
-    textWireframeMapper,
-    stringUtils,
-    uniqueIdentifierGenerator,
-    viewUtils
-) {
+) : CheckBoxMapper(textWireframeMapper, stringUtils, uniqueIdentifierGenerator, viewUtils) {
 
-    override fun resolveCheckedShapeStyle(view: CheckedTextView, checkBoxColor: String):
+    override fun resolveCheckedShapeStyle(view: CheckBox, checkBoxColor: String):
         MobileSegment.ShapeStyle? {
-        // in case the MASK_ALL rule is applied we do not want to show the selection in the
+        // in case the MASK rule is applied we do not want to show the selection in the
         // checkbox related wireframe and in order to achieve that we need to provide
         // a null value for the `ShapeStyle` and only keep the `ShapeBorder`.
         return null

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskCheckedTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskCheckedTextViewMapper.kt
@@ -6,30 +6,30 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
-import android.widget.RadioButton
+import android.widget.CheckedTextView
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.StringUtils
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
 
-internal class MaskAllRadioButtonMapper(
+internal class MaskCheckedTextViewMapper(
     textWireframeMapper: TextViewMapper,
     stringUtils: StringUtils = StringUtils,
-    uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator,
+    uniqueIdentifierGenerator: UniqueIdentifierGenerator =
+        UniqueIdentifierGenerator,
     viewUtils: ViewUtils = ViewUtils
-) : RadioButtonMapper(
+) : CheckedTextViewMapper(
     textWireframeMapper,
     stringUtils,
     uniqueIdentifierGenerator,
     viewUtils
 ) {
 
-    override fun resolveCheckedShapeStyle(view: RadioButton, checkBoxColor: String):
-        MobileSegment.ShapeStyle {
-        return MobileSegment.ShapeStyle(
-            backgroundColor = null,
-            view.alpha,
-            cornerRadius = CORNER_RADIUS
-        )
+    override fun resolveCheckedShapeStyle(view: CheckedTextView, checkBoxColor: String):
+        MobileSegment.ShapeStyle? {
+        // in case the MASK rule is applied we do not want to show the selection in the
+        // checkbox related wireframe and in order to achieve that we need to provide
+        // a null value for the `ShapeStyle` and only keep the `ShapeBorder`.
+        return null
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskNumberPickerMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskNumberPickerMapper.kt
@@ -17,7 +17,7 @@ import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
 
 @RequiresApi(Build.VERSION_CODES.Q)
-internal open class MaskAllNumberPickerMapper(
+internal open class MaskNumberPickerMapper(
     stringUtils: StringUtils = StringUtils,
     private val viewUtils: ViewUtils = ViewUtils,
     private val uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskRadioButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskRadioButtonMapper.kt
@@ -6,24 +6,30 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
-import android.widget.CheckBox
+import android.widget.RadioButton
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.StringUtils
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
 
-internal class MaskAllCheckBoxMapper(
+internal class MaskRadioButtonMapper(
     textWireframeMapper: TextViewMapper,
     stringUtils: StringUtils = StringUtils,
     uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator,
     viewUtils: ViewUtils = ViewUtils
-) : CheckBoxMapper(textWireframeMapper, stringUtils, uniqueIdentifierGenerator, viewUtils) {
+) : RadioButtonMapper(
+    textWireframeMapper,
+    stringUtils,
+    uniqueIdentifierGenerator,
+    viewUtils
+) {
 
-    override fun resolveCheckedShapeStyle(view: CheckBox, checkBoxColor: String):
-        MobileSegment.ShapeStyle? {
-        // in case the MASK_ALL rule is applied we do not want to show the selection in the
-        // checkbox related wireframe and in order to achieve that we need to provide
-        // a null value for the `ShapeStyle` and only keep the `ShapeBorder`.
-        return null
+    override fun resolveCheckedShapeStyle(view: RadioButton, checkBoxColor: String):
+        MobileSegment.ShapeStyle {
+        return MobileSegment.ShapeStyle(
+            backgroundColor = null,
+            view.alpha,
+            cornerRadius = CORNER_RADIUS
+        )
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskSeekBarWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskSeekBarWireframeMapper.kt
@@ -4,19 +4,22 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.sessionreplay.material
+package com.datadog.android.sessionreplay.internal.recorder.mapper
 
+import android.os.Build
+import androidx.annotation.RequiresApi
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.StringUtils
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
 
-internal open class MaskAllSliderWireframeMapper(
+@RequiresApi(Build.VERSION_CODES.O)
+internal class MaskSeekBarWireframeMapper(
     viewUtils: ViewUtils = ViewUtils,
     stringUtils: StringUtils = StringUtils,
     uniqueIdentifierGenerator: UniqueIdentifierGenerator =
         UniqueIdentifierGenerator
-) : SliderWireframeMapper(viewUtils, stringUtils, uniqueIdentifierGenerator) {
+) : SeekBarWireframeMapper(viewUtils, stringUtils, uniqueIdentifierGenerator) {
 
     override fun resolveViewAsWireframesList(
         nonActiveTrackWireframe: MobileSegment.Wireframe.ShapeWireframe,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskSwitchCompatMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskSwitchCompatMapper.kt
@@ -13,7 +13,7 @@ import com.datadog.android.sessionreplay.utils.StringUtils
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
 
-internal class MaskAllSwitchCompatMapper(
+internal class MaskSwitchCompatMapper(
     textWireframeMapper: TextViewMapper,
     stringUtils: StringUtils = StringUtils,
     private val uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskTextViewMapper.kt
@@ -9,15 +9,15 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 import android.widget.TextView
 import androidx.annotation.VisibleForTesting
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import com.datadog.android.sessionreplay.internal.recorder.obfuscator.rules.MaskAllObfuscationRule
+import com.datadog.android.sessionreplay.internal.recorder.obfuscator.rules.MaskObfuscationRule
 import com.datadog.android.sessionreplay.internal.recorder.obfuscator.rules.TextValueObfuscationRule
 
 /**
  * A [WireframeMapper] implementation to map a [TextView] component and apply the
- * [SessionReplayPrivacy.MASK_ALL] masking rule.
+ * [SessionReplayPrivacy.MASK] masking rule.
  */
-class MaskAllTextViewMapper : TextViewMapper {
-    constructor() : super(textValueObfuscationRule = MaskAllObfuscationRule())
+class MaskTextViewMapper : TextViewMapper {
+    constructor() : super(textValueObfuscationRule = MaskObfuscationRule())
 
     @VisibleForTesting
     internal constructor(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper.kt
@@ -11,7 +11,7 @@ import android.view.Gravity
 import android.widget.TextView
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
-import com.datadog.android.sessionreplay.internal.recorder.obfuscator.rules.AllowAllObfuscationRule
+import com.datadog.android.sessionreplay.internal.recorder.obfuscator.rules.AllowObfuscationRule
 import com.datadog.android.sessionreplay.internal.recorder.obfuscator.rules.TextValueObfuscationRule
 import com.datadog.android.sessionreplay.model.MobileSegment
 
@@ -28,7 +28,7 @@ open class TextViewMapper :
     internal val textValueObfuscationRule: TextValueObfuscationRule
 
     constructor() {
-        textValueObfuscationRule = AllowAllObfuscationRule()
+        textValueObfuscationRule = AllowObfuscationRule()
     }
 
     internal constructor(textValueObfuscationRule: TextValueObfuscationRule) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/obfuscator/rules/AllowObfuscationRule.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/obfuscator/rules/AllowObfuscationRule.kt
@@ -10,7 +10,7 @@ import android.widget.TextView
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.obfuscator.FixedLengthStringObfuscator
 
-internal class AllowAllObfuscationRule(
+internal class AllowObfuscationRule(
     private val fixedLengthStringObfuscator: FixedLengthStringObfuscator =
         FixedLengthStringObfuscator(),
     private val textTypeResolver: TextTypeResolver = TextTypeResolver(),

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/obfuscator/rules/MaskObfuscationRule.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/obfuscator/rules/MaskObfuscationRule.kt
@@ -11,7 +11,7 @@ import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.obfuscator.DefaultStringObfuscator
 import com.datadog.android.sessionreplay.internal.recorder.obfuscator.FixedLengthStringObfuscator
 
-internal class MaskAllObfuscationRule(
+internal class MaskObfuscationRule(
     private val defaultStringObfuscator: DefaultStringObfuscator =
         DefaultStringObfuscator(),
     private val fixedLengthStringObfuscator: FixedLengthStringObfuscator =

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -41,26 +41,26 @@ internal class SessionReplayConfigurationBuilderTest {
     @Mock
     lateinit var mockExtensionSupport: ExtensionSupport
     lateinit var fakeCustomMappers: Map<SessionReplayPrivacy, Map<Class<*>, WireframeMapper<View, *>>>
-    lateinit var fakeExpectedAllowAllCustomMappers: List<MapperTypeWrapper>
-    lateinit var fakeExpectedMaskAllCustomMappers: List<MapperTypeWrapper>
-    lateinit var fakeAllowAllCustomMappers: Map<Class<*>, WireframeMapper<View, *>>
-    lateinit var fakeMaskAllCustomMappers: Map<Class<*>, WireframeMapper<View, *>>
+    lateinit var fakeExpectedAllowCustomMappers: List<MapperTypeWrapper>
+    lateinit var fakeExpectedMaskCustomMappers: List<MapperTypeWrapper>
+    lateinit var fakeAllowCustomMappers: Map<Class<*>, WireframeMapper<View, *>>
+    lateinit var fakeMaskCustomMappers: Map<Class<*>, WireframeMapper<View, *>>
 
     @FloatForgery
     var fakeSampleRate: Float = 0f
 
     @BeforeEach
     fun `set up`() {
-        fakeExpectedAllowAllCustomMappers = listOf(MapperTypeWrapper(Any::class.java, mock()))
-        fakeExpectedMaskAllCustomMappers = listOf(MapperTypeWrapper(Any::class.java, mock()))
-        fakeAllowAllCustomMappers = fakeExpectedAllowAllCustomMappers.associate {
+        fakeExpectedAllowCustomMappers = listOf(MapperTypeWrapper(Any::class.java, mock()))
+        fakeExpectedMaskCustomMappers = listOf(MapperTypeWrapper(Any::class.java, mock()))
+        fakeAllowCustomMappers = fakeExpectedAllowCustomMappers.associate {
             it.type to it.mapper
         }
-        fakeMaskAllCustomMappers =
-            fakeExpectedMaskAllCustomMappers.associate { it.type to it.mapper }
+        fakeMaskCustomMappers =
+            fakeExpectedMaskCustomMappers.associate { it.type to it.mapper }
         fakeCustomMappers = mapOf(
-            SessionReplayPrivacy.ALLOW_ALL to fakeAllowAllCustomMappers,
-            SessionReplayPrivacy.MASK_ALL to fakeMaskAllCustomMappers
+            SessionReplayPrivacy.ALLOW to fakeAllowCustomMappers,
+            SessionReplayPrivacy.MASK to fakeMaskCustomMappers
         )
         whenever(mockExtensionSupport.getCustomViewMappers()).thenReturn(fakeCustomMappers)
         testedBuilder = SessionReplayConfiguration.Builder(fakeSampleRate)
@@ -73,7 +73,7 @@ internal class SessionReplayConfigurationBuilderTest {
 
         // Then
         assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
-        assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK_ALL)
+        assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -91,7 +91,7 @@ internal class SessionReplayConfigurationBuilderTest {
         // Then
         assertThat(sessionReplayConfiguration.customEndpointUrl)
             .isEqualTo(sessionReplayUrl)
-        assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK_ALL)
+        assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -115,29 +115,29 @@ internal class SessionReplayConfigurationBuilderTest {
     }
 
     @Test
-    fun `M resolve the correct custom Mappers W addExtensionSupport { ALLOW_ALL }`() {
+    fun `M resolve the correct custom Mappers W addExtensionSupport { ALLOW }`() {
         // Given
         val sessionReplayConfiguration = testedBuilder
-            .setPrivacy(SessionReplayPrivacy.ALLOW_ALL)
+            .setPrivacy(SessionReplayPrivacy.ALLOW)
             .addExtensionSupport(mockExtensionSupport)
             .build()
 
         // Then
         assertThat(sessionReplayConfiguration.customMappers)
-            .isEqualTo(fakeExpectedAllowAllCustomMappers)
+            .isEqualTo(fakeExpectedAllowCustomMappers)
     }
 
     @Test
-    fun `M resolve the correct custom Mappers W addExtensionSupport { MASK_ALL }`() {
+    fun `M resolve the correct custom Mappers W addExtensionSupport { MASK }`() {
         // Given
         val sessionReplayConfiguration = testedBuilder
-            .setPrivacy(SessionReplayPrivacy.MASK_ALL)
+            .setPrivacy(SessionReplayPrivacy.MASK)
             .addExtensionSupport(mockExtensionSupport)
             .build()
 
         // Then
         assertThat(sessionReplayConfiguration.customMappers)
-            .isEqualTo(fakeExpectedMaskAllCustomMappers)
+            .isEqualTo(fakeExpectedMaskCustomMappers)
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
@@ -24,14 +24,14 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckedTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.EditTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MapperTypeWrapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllCheckBoxMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllCheckedTextViewMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllNumberPickerMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllRadioButtonMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllSeekBarWireframeMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllSwitchCompatMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskAllTextViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckBoxMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckedTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskInputTextViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskNumberPickerMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskRadioButtonMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskSeekBarWireframeMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskSwitchCompatMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.NumberPickerMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.RadioButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.SeekBarWireframeMapper
@@ -77,8 +77,8 @@ internal class SessionReplayPrivacyTest {
 
         // When
         val actualMappers = when (maskLevel) {
-            SessionReplayPrivacy.ALLOW_ALL.toString() -> SessionReplayPrivacy.ALLOW_ALL.mappers()
-            SessionReplayPrivacy.MASK_ALL.toString() -> SessionReplayPrivacy.MASK_ALL.mappers()
+            SessionReplayPrivacy.ALLOW.toString() -> SessionReplayPrivacy.ALLOW.mappers()
+            SessionReplayPrivacy.MASK.toString() -> SessionReplayPrivacy.MASK.mappers()
             SessionReplayPrivacy.MASK_USER_INPUT.toString() -> SessionReplayPrivacy.MASK_USER_INPUT.mappers()
             else -> throw IllegalArgumentException("Unknown masking level")
         }
@@ -120,7 +120,7 @@ internal class SessionReplayPrivacyTest {
             MapperTypeWrapper(AppCompatToolbar::class.java, mockUnsupportedViewMapper.toGenericMapper())
         )
 
-        // ALLOW_ALL
+        // ALLOW
         private val mockTextViewMapper: TextViewMapper = mock()
         private val mockSwitchCompatMapper: SwitchCompatMapper = mock()
         private val mockCheckedTextViewMapper: CheckedTextViewMapper = mock()
@@ -129,7 +129,7 @@ internal class SessionReplayPrivacyTest {
         private val mockSeekBarMapper: SeekBarWireframeMapper = mock()
         private val mockNumberPickerMapper: NumberPickerMapper = mock()
 
-        private val allowAll = baseMappers + listOf(
+        private val allow = baseMappers + listOf(
             MapperTypeWrapper(TextView::class.java, mockTextViewMapper.toGenericMapper()),
             MapperTypeWrapper(CheckedTextView::class.java, mockCheckedTextViewMapper.toGenericMapper()),
             MapperTypeWrapper(CheckBox::class.java, mockCheckBoxMapper.toGenericMapper()),
@@ -137,45 +137,45 @@ internal class SessionReplayPrivacyTest {
             MapperTypeWrapper(SwitchCompat::class.java, mockSwitchCompatMapper.toGenericMapper())
         )
 
-        private val allowAllFromApi21 = allowAll + listOf(
+        private val allowFromApi21 = allow + listOf(
             MapperTypeWrapper(Toolbar::class.java, mockUnsupportedViewMapper.toGenericMapper())
         )
 
-        private val allowAllFromApi26 = allowAllFromApi21 + listOf(
+        private val allowFromApi26 = allowFromApi21 + listOf(
             MapperTypeWrapper(SeekBar::class.java, mockSeekBarMapper.toGenericMapper())
         )
 
-        private val allowAllFromApi29 = allowAllFromApi26 + listOf(
+        private val allowFromApi29 = allowFromApi26 + listOf(
             MapperTypeWrapper(NumberPicker::class.java, mockNumberPickerMapper.toGenericMapper())
         )
 
-        // MASK_ALL
-        private val mockMaskAllTextViewMapper: MaskAllTextViewMapper = mock()
-        private val mockMaskAllCheckedTextViewMapper: MaskAllCheckedTextViewMapper = mock()
-        private val mockMaskAllCheckBoxMapper: MaskAllCheckBoxMapper = mock()
-        private val mockMaskAllRadioButtonMapper: MaskAllRadioButtonMapper = mock()
-        private val mockMaskAllSwitchCompatMapper: MaskAllSwitchCompatMapper = mock()
-        private val mockMaskAllSeekBarWireframeMapper: MaskAllSeekBarWireframeMapper = mock()
-        private val mockMaskAllNumberPickerMapper: MaskAllNumberPickerMapper = mock()
+        // MASK
+        private val mockMaskTextViewMapper: MaskTextViewMapper = mock()
+        private val mockMaskCheckedTextViewMapper: MaskCheckedTextViewMapper = mock()
+        private val mockMaskCheckBoxMapper: MaskCheckBoxMapper = mock()
+        private val mockMaskRadioButtonMapper: MaskRadioButtonMapper = mock()
+        private val mockMaskSwitchCompatMapper: MaskSwitchCompatMapper = mock()
+        private val mockMaskSeekBarWireframeMapper: MaskSeekBarWireframeMapper = mock()
+        private val mockMaskNumberPickerMapper: MaskNumberPickerMapper = mock()
 
-        private val maskAll = baseMappers + listOf(
-            MapperTypeWrapper(TextView::class.java, mockMaskAllTextViewMapper.toGenericMapper()),
-            MapperTypeWrapper(CheckedTextView::class.java, mockMaskAllCheckedTextViewMapper.toGenericMapper()),
-            MapperTypeWrapper(CheckBox::class.java, mockMaskAllCheckBoxMapper.toGenericMapper()),
-            MapperTypeWrapper(RadioButton::class.java, mockMaskAllRadioButtonMapper.toGenericMapper()),
-            MapperTypeWrapper(SwitchCompat::class.java, mockMaskAllSwitchCompatMapper.toGenericMapper())
+        private val mask = baseMappers + listOf(
+            MapperTypeWrapper(TextView::class.java, mockMaskTextViewMapper.toGenericMapper()),
+            MapperTypeWrapper(CheckedTextView::class.java, mockMaskCheckedTextViewMapper.toGenericMapper()),
+            MapperTypeWrapper(CheckBox::class.java, mockMaskCheckBoxMapper.toGenericMapper()),
+            MapperTypeWrapper(RadioButton::class.java, mockMaskRadioButtonMapper.toGenericMapper()),
+            MapperTypeWrapper(SwitchCompat::class.java, mockMaskSwitchCompatMapper.toGenericMapper())
         )
 
-        private val maskAllFromApi21 = maskAll + listOf(
+        private val maskFromApi21 = mask + listOf(
             MapperTypeWrapper(Toolbar::class.java, mockUnsupportedViewMapper.toGenericMapper())
         )
 
-        private val maskAllFromApi26 = maskAllFromApi21 + listOf(
-            MapperTypeWrapper(SeekBar::class.java, mockMaskAllSeekBarWireframeMapper.toGenericMapper())
+        private val maskFromApi26 = maskFromApi21 + listOf(
+            MapperTypeWrapper(SeekBar::class.java, mockMaskSeekBarWireframeMapper.toGenericMapper())
         )
 
-        private val maskAllFromApi29 = maskAllFromApi26 + listOf(
-            MapperTypeWrapper(NumberPicker::class.java, mockMaskAllNumberPickerMapper.toGenericMapper())
+        private val maskFromApi29 = maskFromApi26 + listOf(
+            MapperTypeWrapper(NumberPicker::class.java, mockMaskNumberPickerMapper.toGenericMapper())
         )
 
         // MASK_USER_INPUT
@@ -183,10 +183,10 @@ internal class SessionReplayPrivacyTest {
 
         private val maskUserInput = baseMappers + listOf(
             MapperTypeWrapper(TextView::class.java, mockMaskInputTextViewMapper.toGenericMapper()),
-            MapperTypeWrapper(CheckedTextView::class.java, mockMaskAllCheckedTextViewMapper.toGenericMapper()),
-            MapperTypeWrapper(CheckBox::class.java, mockMaskAllCheckBoxMapper.toGenericMapper()),
-            MapperTypeWrapper(RadioButton::class.java, mockMaskAllRadioButtonMapper.toGenericMapper()),
-            MapperTypeWrapper(SwitchCompat::class.java, mockMaskAllSwitchCompatMapper.toGenericMapper())
+            MapperTypeWrapper(CheckedTextView::class.java, mockMaskCheckedTextViewMapper.toGenericMapper()),
+            MapperTypeWrapper(CheckBox::class.java, mockMaskCheckBoxMapper.toGenericMapper()),
+            MapperTypeWrapper(RadioButton::class.java, mockMaskRadioButtonMapper.toGenericMapper()),
+            MapperTypeWrapper(SwitchCompat::class.java, mockMaskSwitchCompatMapper.toGenericMapper())
         )
 
         private val maskUserInputFromApi21 = maskUserInput + listOf(
@@ -194,27 +194,27 @@ internal class SessionReplayPrivacyTest {
         )
 
         private val maskUserInputFromApi26 = maskUserInputFromApi21 + listOf(
-            MapperTypeWrapper(SeekBar::class.java, mockMaskAllSeekBarWireframeMapper.toGenericMapper())
+            MapperTypeWrapper(SeekBar::class.java, mockMaskSeekBarWireframeMapper.toGenericMapper())
         )
 
         private val maskUserInputFromApi29 = maskUserInputFromApi26 + listOf(
-            MapperTypeWrapper(NumberPicker::class.java, mockMaskAllNumberPickerMapper.toGenericMapper())
+            MapperTypeWrapper(NumberPicker::class.java, mockMaskNumberPickerMapper.toGenericMapper())
         )
 
         @JvmStatic
         @Parameterized.Parameters
         fun provideTestArguments(): Stream<Arguments> {
-            val allowAllLevel = SessionReplayPrivacy.ALLOW_ALL.toString()
-            val maskAllLevel = SessionReplayPrivacy.MASK_ALL.toString()
+            val allowLevel = SessionReplayPrivacy.ALLOW.toString()
+            val maskLevel = SessionReplayPrivacy.MASK.toString()
             val maskUserInputLevel = SessionReplayPrivacy.MASK_USER_INPUT.toString()
 
             return Stream.of(
-                Arguments.of(Build.VERSION_CODES.LOLLIPOP, allowAllLevel, allowAllFromApi21),
-                Arguments.of(Build.VERSION_CODES.O, allowAllLevel, allowAllFromApi26),
-                Arguments.of(Build.VERSION_CODES.Q, allowAllLevel, allowAllFromApi29),
-                Arguments.of(Build.VERSION_CODES.LOLLIPOP, maskAllLevel, maskAllFromApi21),
-                Arguments.of(Build.VERSION_CODES.O, maskAllLevel, maskAllFromApi26),
-                Arguments.of(Build.VERSION_CODES.Q, maskAllLevel, maskAllFromApi29),
+                Arguments.of(Build.VERSION_CODES.LOLLIPOP, allowLevel, allowFromApi21),
+                Arguments.of(Build.VERSION_CODES.O, allowLevel, allowFromApi26),
+                Arguments.of(Build.VERSION_CODES.Q, allowLevel, allowFromApi29),
+                Arguments.of(Build.VERSION_CODES.LOLLIPOP, maskLevel, maskFromApi21),
+                Arguments.of(Build.VERSION_CODES.O, maskLevel, maskFromApi26),
+                Arguments.of(Build.VERSION_CODES.Q, maskLevel, maskFromApi29),
                 Arguments.of(Build.VERSION_CODES.LOLLIPOP, maskUserInputLevel, maskUserInputFromApi21),
                 Arguments.of(Build.VERSION_CODES.O, maskUserInputLevel, maskUserInputFromApi26),
                 Arguments.of(Build.VERSION_CODES.Q, maskUserInputLevel, maskUserInputFromApi29)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskCheckBoxMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskCheckBoxMapperTest.kt
@@ -7,12 +7,10 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.internal.recorder.obfuscator.rules.MaskAllObfuscationRule
+import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.junit.jupiter.MockitoExtension
@@ -26,19 +24,17 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllTextViewMapperTest : BaseTextViewWireframeMapperTest() {
+internal class MaskCheckBoxMapperTest : BaseCheckBoxMapperTest() {
 
-    override fun initTestedMapper(): TextViewMapper {
-        return MaskAllTextViewMapper(mockObfuscationRule)
+    override fun setupTestedMapper(): CheckBoxMapper {
+        return MaskCheckBoxMapper(
+            textWireframeMapper = mockTextWireframeMapper,
+            uniqueIdentifierGenerator = mockuniqueIdentifierGenerator,
+            viewUtils = mockViewUtils
+        )
     }
 
-    @Test
-    fun `M use the MaskAllObfuscationRule as defaultObfuscator when initialized`() {
-        // When
-        val textViewMapper = MaskAllTextViewMapper()
-
-        // Then
-        assertThat(textViewMapper.textValueObfuscationRule)
-            .isInstanceOf(MaskAllObfuscationRule::class.java)
+    override fun expectedCheckedShapeStyle(checkBoxColor: String): MobileSegment.ShapeStyle? {
+        return null
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskCheckedTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskCheckedTextViewMapperTest.kt
@@ -24,10 +24,10 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllCheckBoxMapperTest : BaseCheckBoxMapperTest() {
+internal class MaskCheckedTextViewMapperTest : BaseCheckedTextViewMapperTest() {
 
-    override fun setupTestedMapper(): CheckBoxMapper {
-        return MaskAllCheckBoxMapper(
+    override fun setupTestedMapper(): CheckedTextViewMapper {
+        return MaskCheckedTextViewMapper(
             textWireframeMapper = mockTextWireframeMapper,
             uniqueIdentifierGenerator = mockuniqueIdentifierGenerator,
             viewUtils = mockViewUtils

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskNumberPickerMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskNumberPickerMapperTest.kt
@@ -25,10 +25,10 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllNumberPickerMapperTest : BaseNumberPickerMapperTest() {
+internal class MaskNumberPickerMapperTest : BaseNumberPickerMapperTest() {
 
     override fun provideTestInstance(): BasePickerMapper {
-        return MaskAllNumberPickerMapper(
+        return MaskNumberPickerMapper(
             mockStringUtils,
             mockViewUtils,
             mockUniqueIdentifierGenerator

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskRadioButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskRadioButtonMapperTest.kt
@@ -24,10 +24,10 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllRadioButtonMapperTest : BaseRadioButtonMapperTest() {
+internal class MaskRadioButtonMapperTest : BaseRadioButtonMapperTest() {
 
     override fun setupTestedMapper(): RadioButtonMapper {
-        return MaskAllRadioButtonMapper(
+        return MaskRadioButtonMapper(
             textWireframeMapper = mockTextWireframeMapper,
             uniqueIdentifierGenerator = mockuniqueIdentifierGenerator,
             viewUtils = mockViewUtils

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskSeekBarWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskSeekBarWireframeMapperTest.kt
@@ -30,10 +30,10 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllSeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
+internal class MaskSeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
 
     override fun provideTestInstance(): SeekBarWireframeMapper {
-        return MaskAllSeekBarWireframeMapper(
+        return MaskSeekBarWireframeMapper(
             viewUtils = mockViewUtils,
             stringUtils = mockStringUtils,
             uniqueIdentifierGenerator = mockUniqueIdentifierGenerator

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskSwitchCompatMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskSwitchCompatMapperTest.kt
@@ -26,10 +26,10 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllSwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
+internal class MaskSwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
 
     override fun setupTestedMapper(): SwitchCompatMapper {
-        return MaskAllSwitchCompatMapper(
+        return MaskSwitchCompatMapper(
             mockTextWireframeMapper,
             uniqueIdentifierGenerator = mockuniqueIdentifierGenerator,
             viewUtils = mockViewUtils

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskTextViewMapperTest.kt
@@ -7,10 +7,12 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.internal.recorder.obfuscator.rules.MaskObfuscationRule
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.junit.jupiter.MockitoExtension
@@ -24,17 +26,19 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllCheckedTextViewMapperTest : BaseCheckedTextViewMapperTest() {
+internal class MaskTextViewMapperTest : BaseTextViewWireframeMapperTest() {
 
-    override fun setupTestedMapper(): CheckedTextViewMapper {
-        return MaskAllCheckedTextViewMapper(
-            textWireframeMapper = mockTextWireframeMapper,
-            uniqueIdentifierGenerator = mockuniqueIdentifierGenerator,
-            viewUtils = mockViewUtils
-        )
+    override fun initTestedMapper(): TextViewMapper {
+        return MaskTextViewMapper(mockObfuscationRule)
     }
 
-    override fun expectedCheckedShapeStyle(checkBoxColor: String): MobileSegment.ShapeStyle? {
-        return null
+    @Test
+    fun `M use the MaskObfuscationRule as defaultObfuscator when initialized`() {
+        // When
+        val textViewMapper = MaskTextViewMapper()
+
+        // Then
+        assertThat(textViewMapper.textValueObfuscationRule)
+            .isInstanceOf(MaskObfuscationRule::class.java)
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapperTest.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.internal.recorder.obfuscator.rules.AllowAllObfuscationRule
+import com.datadog.android.sessionreplay.internal.recorder.obfuscator.rules.AllowObfuscationRule
 import com.datadog.tools.unit.extensions.ApiLevelExtension
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -29,12 +29,12 @@ import org.mockito.quality.Strictness
 internal class TextViewMapperTest : BaseTextViewWireframeMapperTest() {
 
     @Test
-    fun `M use the AllowAllObfuscationRule when initialized`() {
+    fun `M use the AllowObfuscationRule when initialized`() {
         // When
         val textViewMapper = TextViewMapper()
 
         // Then
         assertThat(textViewMapper.textValueObfuscationRule)
-            .isInstanceOf(AllowAllObfuscationRule::class.java)
+            .isInstanceOf(AllowObfuscationRule::class.java)
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/obfuscator/rules/AllowObfuscationRuleTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/obfuscator/rules/AllowObfuscationRuleTest.kt
@@ -14,6 +14,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.whenever
@@ -25,15 +27,14 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class MaskAllObfuscationRuleTest : BaseObfuscationRuleTest() {
+internal class AllowObfuscationRuleTest : BaseObfuscationRuleTest() {
 
-    lateinit var testedRule: MaskAllObfuscationRule
+    lateinit var testedRule: AllowObfuscationRule
 
     @BeforeEach
     fun `set up`() {
         super.setUp()
-        testedRule = MaskAllObfuscationRule(
-            defaultStringObfuscator = mockDefaultStringObfuscator,
+        testedRule = AllowObfuscationRule(
             fixedLengthStringObfuscator = mockFixedLengthStringObfuscator,
             textTypeResolver = mockTextTypeResolver,
             textValueResolver = mockTextValueResolver
@@ -54,59 +55,24 @@ internal class MaskAllObfuscationRuleTest : BaseObfuscationRuleTest() {
         assertThat(obfuscatedTextValue).isEqualTo(fakeFixedLengthMask)
     }
 
-    @Test
-    fun `M resolve as fix length mask W resolveObfuscatedValue { INPUT_TEXT }`() {
+    @ParameterizedTest
+    @EnumSource(
+        TextType::class,
+        names = ["SENSITIVE_TEXT"],
+        mode = EnumSource.Mode.EXCLUDE
+    )
+    fun `M resolve non obfuscated text W resolveObfuscatedValue { non SENSITIVE_TEXT }`(
+        textType: TextType
+    ) {
         // Given
         whenever(mockTextTypeResolver.resolveTextType(mockTextView, fakeMappingContext))
-            .thenReturn(TextType.INPUT_TEXT)
+            .thenReturn(textType)
 
         // When
         val obfuscatedTextValue =
             testedRule.resolveObfuscatedValue(mockTextView, fakeMappingContext)
 
         // Then
-        assertThat(obfuscatedTextValue).isEqualTo(fakeFixedLengthMask)
-    }
-
-    @Test
-    fun `M resolve as fix length mask W resolveObfuscatedValue { OPTION_TEXT }`() {
-        // Given
-        whenever(mockTextTypeResolver.resolveTextType(mockTextView, fakeMappingContext))
-            .thenReturn(TextType.OPTION_TEXT)
-
-        // When
-        val obfuscatedTextValue =
-            testedRule.resolveObfuscatedValue(mockTextView, fakeMappingContext)
-
-        // Then
-        assertThat(obfuscatedTextValue).isEqualTo(fakeFixedLengthMask)
-    }
-
-    @Test
-    fun `M resolve as fix length mask W resolveObfuscatedValue { HINTS_TEXT }`() {
-        // Given
-        whenever(mockTextTypeResolver.resolveTextType(mockTextView, fakeMappingContext))
-            .thenReturn(TextType.HINTS_TEXT)
-
-        // When
-        val obfuscatedTextValue =
-            testedRule.resolveObfuscatedValue(mockTextView, fakeMappingContext)
-
-        // Then
-        assertThat(obfuscatedTextValue).isEqualTo(fakeFixedLengthMask)
-    }
-
-    @Test
-    fun `M resolve as preserved length text mask W resolveObfuscatedValue { STATIC_TEXT }`() {
-        // Given
-        whenever(mockTextTypeResolver.resolveTextType(mockTextView, fakeMappingContext))
-            .thenReturn(TextType.STATIC_TEXT)
-
-        // When
-        val obfuscatedTextValue =
-            testedRule.resolveObfuscatedValue(mockTextView, fakeMappingContext)
-
-        // Then
-        assertThat(obfuscatedTextValue).isEqualTo(fakeDefaultMask)
+        assertThat(obfuscatedTextValue).isEqualTo(fakeTextValue)
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/obfuscator/rules/MaskObfuscationRuleTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/obfuscator/rules/MaskObfuscationRuleTest.kt
@@ -14,8 +14,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.whenever
@@ -27,14 +25,15 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class AllowAllObfuscationRuleTest : BaseObfuscationRuleTest() {
+internal class MaskObfuscationRuleTest : BaseObfuscationRuleTest() {
 
-    lateinit var testedRule: AllowAllObfuscationRule
+    lateinit var testedRule: MaskObfuscationRule
 
     @BeforeEach
     fun `set up`() {
         super.setUp()
-        testedRule = AllowAllObfuscationRule(
+        testedRule = MaskObfuscationRule(
+            defaultStringObfuscator = mockDefaultStringObfuscator,
             fixedLengthStringObfuscator = mockFixedLengthStringObfuscator,
             textTypeResolver = mockTextTypeResolver,
             textValueResolver = mockTextValueResolver
@@ -55,24 +54,59 @@ internal class AllowAllObfuscationRuleTest : BaseObfuscationRuleTest() {
         assertThat(obfuscatedTextValue).isEqualTo(fakeFixedLengthMask)
     }
 
-    @ParameterizedTest
-    @EnumSource(
-        TextType::class,
-        names = ["SENSITIVE_TEXT"],
-        mode = EnumSource.Mode.EXCLUDE
-    )
-    fun `M resolve non obfuscated text W resolveObfuscatedValue { non SENSITIVE_TEXT }`(
-        textType: TextType
-    ) {
+    @Test
+    fun `M resolve as fix length mask W resolveObfuscatedValue { INPUT_TEXT }`() {
         // Given
         whenever(mockTextTypeResolver.resolveTextType(mockTextView, fakeMappingContext))
-            .thenReturn(textType)
+            .thenReturn(TextType.INPUT_TEXT)
 
         // When
         val obfuscatedTextValue =
             testedRule.resolveObfuscatedValue(mockTextView, fakeMappingContext)
 
         // Then
-        assertThat(obfuscatedTextValue).isEqualTo(fakeTextValue)
+        assertThat(obfuscatedTextValue).isEqualTo(fakeFixedLengthMask)
+    }
+
+    @Test
+    fun `M resolve as fix length mask W resolveObfuscatedValue { OPTION_TEXT }`() {
+        // Given
+        whenever(mockTextTypeResolver.resolveTextType(mockTextView, fakeMappingContext))
+            .thenReturn(TextType.OPTION_TEXT)
+
+        // When
+        val obfuscatedTextValue =
+            testedRule.resolveObfuscatedValue(mockTextView, fakeMappingContext)
+
+        // Then
+        assertThat(obfuscatedTextValue).isEqualTo(fakeFixedLengthMask)
+    }
+
+    @Test
+    fun `M resolve as fix length mask W resolveObfuscatedValue { HINTS_TEXT }`() {
+        // Given
+        whenever(mockTextTypeResolver.resolveTextType(mockTextView, fakeMappingContext))
+            .thenReturn(TextType.HINTS_TEXT)
+
+        // When
+        val obfuscatedTextValue =
+            testedRule.resolveObfuscatedValue(mockTextView, fakeMappingContext)
+
+        // Then
+        assertThat(obfuscatedTextValue).isEqualTo(fakeFixedLengthMask)
+    }
+
+    @Test
+    fun `M resolve as preserved length text mask W resolveObfuscatedValue { STATIC_TEXT }`() {
+        // Given
+        whenever(mockTextTypeResolver.resolveTextType(mockTextView, fakeMappingContext))
+            .thenReturn(TextType.STATIC_TEXT)
+
+        // When
+        val obfuscatedTextValue =
+            testedRule.resolveObfuscatedValue(mockTextView, fakeMappingContext)
+
+        // Then
+        assertThat(obfuscatedTextValue).isEqualTo(fakeDefaultMask)
     }
 }

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplayPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplayPlaygroundActivity.kt
@@ -66,7 +66,7 @@ internal open class SessionReplayPlaygroundActivity : AppCompatActivity() {
 
     open fun sessionReplayConfiguration(): SessionReplayConfiguration =
         RuntimeConfig.sessionReplayConfigBuilder(SAMPLE_IN_ALL_SESSIONS)
-            .setPrivacy(SessionReplayPrivacy.ALLOW_ALL)
+            .setPrivacy(SessionReplayPrivacy.ALLOW)
             .build()
 
     @Suppress("LongMethod")

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplaySampledOutPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/SessionReplaySampledOutPlaygroundActivity.kt
@@ -14,7 +14,7 @@ internal class SessionReplaySampledOutPlaygroundActivity : SessionReplayPlaygrou
 
     override fun sessionReplayConfiguration(): SessionReplayConfiguration =
         RuntimeConfig.sessionReplayConfigBuilder(0f)
-            .setPrivacy(SessionReplayPrivacy.ALLOW_ALL)
+            .setPrivacy(SessionReplayPrivacy.ALLOW)
             .build()
 
     @Suppress("LongMethod")


### PR DESCRIPTION
### What does this PR do?

In this PR we are updating the `SessionReplayPrivacy` enum names following the latest RFC and to align with the iOS sdk for public beta release.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

