### PR TITLE
REPLAY-1862 Increate batchSizeLimit to 10MB for SR feature

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -100,7 +100,7 @@ internal class SessionReplayFeature constructor(
         SessionReplayRequestFactory(customEndpointUrl)
 
     override val storageConfiguration: FeatureStorageConfiguration =
-        FeatureStorageConfiguration.DEFAULT
+        STORAGE_CONFIGURATION
 
     override fun onStop() {
         stopRecording()
@@ -211,6 +211,20 @@ internal class SessionReplayFeature constructor(
     // endregion
 
     internal companion object {
+
+        /**
+         * Session Replay storage configuration with the following parameters:
+         * max item size = 10 MB,
+         * max items per batch = 500,
+         * max batch size = 10 MB, SR intake batch limit is 10MB
+         * old batch threshold = 18 hours.
+         */
+        internal val STORAGE_CONFIGURATION: FeatureStorageConfiguration =
+            FeatureStorageConfiguration.DEFAULT.copy(
+                maxItemSize = 10 * 1024 * 1024,
+                maxBatchSize = 10 * 1024 * 1024
+            )
+
         internal const val REQUIRES_APPLICATION_CONTEXT_WARN_MESSAGE = "Session Replay could not " +
             "be initialized without the Application context."
         internal const val SESSION_SAMPLED_OUT_MESSAGE = "This session was sampled out from" +

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.sessionreplay.internal
 import android.app.Application
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.sessionreplay.NoOpRecorder
 import com.datadog.android.sessionreplay.Recorder
@@ -584,10 +583,10 @@ internal class SessionReplayFeatureTest {
     }
 
     @Test
-    fun `𝕄 provide default storage configuration 𝕎 storageConfiguration()`() {
+    fun `𝕄 provide custom storage configuration 𝕎 storageConfiguration()`() {
         // When+Then
         assertThat(testedFeature.storageConfiguration)
-            .isEqualTo(FeatureStorageConfiguration.DEFAULT)
+            .isEqualTo(SessionReplayFeature.STORAGE_CONFIGURATION)
     }
 
     companion object {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ComposedOptionSelectorDetectorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ComposedOptionSelectorDetectorTest.kt
@@ -44,7 +44,7 @@ internal class ComposedOptionSelectorDetectorTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        mockBundledDetectors = forge.aList {
+        mockBundledDetectors = forge.aList(size = forge.anInt(min = 1, max = 10)) {
             mock {
                 whenever(it.isOptionSelector(mockViewGroup))
                     .thenReturn(fakeBundledDetectorValue)
@@ -65,11 +65,24 @@ internal class ComposedOptionSelectorDetectorTest {
         mockBundledDetectors.forEach {
             whenever(it.isOptionSelector(mockViewGroup)).thenReturn(false)
         }
-        val fakeRandomIndex = forge.anInt(min = 0, max = mockBundledDetectors.size - 1)
+        val fakeRandomIndex = if (mockBundledDetectors.size > 1) {
+            forge.anInt(min = 0, max = mockBundledDetectors.size - 1)
+        } else {
+            0
+        }
         whenever(mockBundledDetectors[fakeRandomIndex].isOptionSelector(mockViewGroup))
             .thenReturn(true)
 
         // Then
         assertThat(testedComposedOptionSelectorDetector.isOptionSelector(mockViewGroup)).isTrue
+    }
+
+    @Test
+    fun `M return false W isOptionSelector { bundled detectors are empty }`() {
+        // Given
+        testedComposedOptionSelectorDetector = ComposedOptionSelectorDetector(emptyList())
+
+        // Then
+        assertThat(testedComposedOptionSelectorDetector.isOptionSelector(mockViewGroup)).isFalse
     }
 }


### PR DESCRIPTION
### What does this PR do?

In this PR we are increasing the SR batch size limit to 10MB into the core to support large payloads containing embedded base64 images. This follows the same approach as in iOS introduced with the Image recording feature added lately. 

Please note that the SR intake unlike RUM accepts payloads up to 10MB size.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

