### PR TITLE
Restore Datadog.setUserInfo method signature from v1

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -7,7 +7,7 @@ object com.datadog.android.Datadog
   fun setVerbosity(Int)
   fun getVerbosity(): Int
   fun setTrackingConsent(com.datadog.android.privacy.TrackingConsent, com.datadog.android.api.SdkCore = getInstance())
-  fun setUserInfo(com.datadog.android.api.context.UserInfo, com.datadog.android.api.SdkCore = getInstance())
+  fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap(), com.datadog.android.api.SdkCore = getInstance())
   fun addUserProperties(Map<String, Any?>, com.datadog.android.api.SdkCore = getInstance())
   fun clearAllData(com.datadog.android.api.SdkCore = getInstance())
   fun _internalProxy(String? = null): _InternalProxy
@@ -51,7 +51,7 @@ interface com.datadog.android.api.SdkCore
   val time: com.datadog.android.api.context.TimeInfo
   val service: String
   fun setTrackingConsent(com.datadog.android.privacy.TrackingConsent)
-  fun setUserInfo(com.datadog.android.api.context.UserInfo)
+  fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap())
   fun addUserProperties(Map<String, Any?>)
   fun clearAllData()
 data class com.datadog.android.api.context.DatadogContext

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -30,9 +30,13 @@ public final class com/datadog/android/Datadog {
 	public static final fun setTrackingConsent (Lcom/datadog/android/privacy/TrackingConsent;)V
 	public static final fun setTrackingConsent (Lcom/datadog/android/privacy/TrackingConsent;Lcom/datadog/android/api/SdkCore;)V
 	public static synthetic fun setTrackingConsent$default (Lcom/datadog/android/privacy/TrackingConsent;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
-	public static final fun setUserInfo (Lcom/datadog/android/api/context/UserInfo;)V
-	public static final fun setUserInfo (Lcom/datadog/android/api/context/UserInfo;Lcom/datadog/android/api/SdkCore;)V
-	public static synthetic fun setUserInfo$default (Lcom/datadog/android/api/context/UserInfo;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
+	public static final fun setUserInfo ()V
+	public static final fun setUserInfo (Ljava/lang/String;)V
+	public static final fun setUserInfo (Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun setUserInfo (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public static final fun setUserInfo (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public static final fun setUserInfo (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/datadog/android/api/SdkCore;)V
+	public static synthetic fun setUserInfo$default (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
 	public static final fun setVerbosity (I)V
 	public static final fun stopInstance ()V
 	public static final fun stopInstance (Ljava/lang/String;)V
@@ -109,7 +113,11 @@ public abstract interface class com/datadog/android/api/SdkCore {
 	public abstract fun getService ()Ljava/lang/String;
 	public abstract fun getTime ()Lcom/datadog/android/api/context/TimeInfo;
 	public abstract fun setTrackingConsent (Lcom/datadog/android/privacy/TrackingConsent;)V
-	public abstract fun setUserInfo (Lcom/datadog/android/api/context/UserInfo;)V
+	public abstract fun setUserInfo (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+}
+
+public final class com/datadog/android/api/SdkCore$DefaultImpls {
+	public static synthetic fun setUserInfo$default (Lcom/datadog/android/api/SdkCore;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/api/context/DatadogContext {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -224,14 +224,24 @@ object Datadog {
     /**
      * Sets the user information.
      *
-     * @param userInfo the new user info to set, or null
+     * @param id (nullable) a unique user identifier (relevant to your business domain)
+     * @param name (nullable) the user name or alias
+     * @param email (nullable) the user email
+     * @param extraInfo additional information. An extra information can be
+     * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
      * @param sdkCore SDK instance to set user info in. If not provided, default SDK instance
      * will be used.
      */
     @JvmStatic
     @JvmOverloads
-    fun setUserInfo(userInfo: UserInfo, sdkCore: SdkCore = getInstance()) {
-        sdkCore.setUserInfo(userInfo)
+    fun setUserInfo(
+        id: String? = null,
+        name: String? = null,
+        email: String? = null,
+        extraInfo: Map<String, Any?> = emptyMap(),
+        sdkCore: SdkCore = getInstance()
+    ) {
+        sdkCore.setUserInfo(id, name, email, extraInfo)
     }
 
     /**

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/SdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/SdkCore.kt
@@ -42,9 +42,18 @@ interface SdkCore {
     /**
      * Sets the user information.
      *
-     * @param userInfo the new user info to set, or null
+     * @param id (nullable) a unique user identifier (relevant to your business domain)
+     * @param name (nullable) the user name or alias
+     * @param email (nullable) the user email
+     * @param extraInfo additional information. An extra information can be
+     * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
      */
-    fun setUserInfo(userInfo: UserInfo)
+    fun setUserInfo(
+        id: String? = null,
+        name: String? = null,
+        email: String? = null,
+        extraInfo: Map<String, Any?> = emptyMap()
+    )
 
     /**
      * Sets additional information on the [UserInfo] object

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
@@ -154,8 +154,20 @@ internal class DatadogCore(
     }
 
     /** @inheritDoc */
-    override fun setUserInfo(userInfo: UserInfo) {
-        coreFeature.userInfoProvider.setUserInfo(userInfo)
+    override fun setUserInfo(
+        id: String?,
+        name: String?,
+        email: String?,
+        extraInfo: Map<String, Any?>
+    ) {
+        coreFeature.userInfoProvider.setUserInfo(
+            UserInfo(
+                id = id,
+                name = name,
+                email = email,
+                additionalProperties = extraInfo
+            )
+        )
     }
 
     /** @inheritDoc */

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/NoOpInternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/NoOpInternalSdkCore.kt
@@ -11,7 +11,6 @@ import com.datadog.android.api.SdkCore
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.context.TimeInfo
-import com.datadog.android.api.context.UserInfo
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureEventReceiver
 import com.datadog.android.api.feature.FeatureScope
@@ -65,7 +64,12 @@ internal class NoOpInternalSdkCore : InternalSdkCore {
 
     override fun setTrackingConsent(consent: TrackingConsent) = Unit
 
-    override fun setUserInfo(userInfo: UserInfo) = Unit
+    override fun setUserInfo(
+        id: String?,
+        name: String?,
+        email: String?,
+        extraInfo: Map<String, Any?>
+    ) = Unit
 
     override fun addUserProperties(extraInfo: Map<String, Any?>) = Unit
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -11,7 +11,6 @@ import android.content.Context
 import android.net.ConnectivityManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
-import com.datadog.android.api.context.UserInfo
 import com.datadog.android.core.DatadogCore
 import com.datadog.android.core.NoOpInternalSdkCore
 import com.datadog.android.core.configuration.Configuration
@@ -478,15 +477,23 @@ internal class DatadogTest {
     }
 
     @Test
-    fun `𝕄 set user info 𝕎 setUserInfo()`(@Forgery fakeUserInfo: UserInfo) {
+    fun `𝕄 set user info 𝕎 setUserInfo()`(
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String,
+        @StringForgery(regex = "\\w+@\\w+") email: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)])
+        ) fakeUserProperties: Map<String, String>
+    ) {
         // Given
         val mockSdkCore = mock<SdkCore>()
 
         // When
-        Datadog.setUserInfo(fakeUserInfo, mockSdkCore)
+        Datadog.setUserInfo(id, name, email, fakeUserProperties, mockSdkCore)
 
         // Then
-        verify(mockSdkCore).setUserInfo(fakeUserInfo)
+        verify(mockSdkCore).setUserInfo(id, name, email, fakeUserProperties)
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -192,17 +192,30 @@ internal class DatadogCoreTest {
 
     @Test
     fun `𝕄 update userInfoProvider 𝕎 setUserInfo()`(
-        @Forgery userInfo: UserInfo
+        @StringForgery(type = StringForgeryType.HEXADECIMAL) id: String,
+        @StringForgery name: String,
+        @StringForgery(regex = "\\w+@\\w+") email: String,
+        @MapForgery(
+            key = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)]),
+            value = AdvancedForgery(string = [StringForgery(StringForgeryType.ALPHA_NUMERICAL)])
+        ) fakeUserProperties: Map<String, String>
     ) {
         // Given
         val mockUserInfoProvider = mock<MutableUserInfoProvider>()
         testedCore.coreFeature.userInfoProvider = mockUserInfoProvider
 
         // When
-        testedCore.setUserInfo(userInfo)
+        testedCore.setUserInfo(id, name, email, fakeUserProperties)
 
         // Then
-        verify(mockUserInfoProvider).setUserInfo(userInfo)
+        verify(mockUserInfoProvider).setUserInfo(
+            UserInfo(
+                id = id,
+                name = name,
+                email = email,
+                additionalProperties = fakeUserProperties
+            )
+        )
     }
 
     @Test
@@ -218,7 +231,7 @@ internal class DatadogCoreTest {
         whenever(testedCore.coreFeature.userInfoProvider) doReturn mockUserInfoProvider
 
         // When
-        testedCore.setUserInfo(UserInfo(id, name, email))
+        testedCore.setUserInfo(id, name, email)
         testedCore.addUserProperties(
             mapOf(
                 "key1" to 1,

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/trace/SpanConfigE2ETests.kt
@@ -10,7 +10,6 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
 import androidx.test.platform.app.InstrumentationRegistry
 import com.datadog.android.Datadog
-import com.datadog.android.api.context.UserInfo
 import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.nightly.SPECIAL_STRING_TAG_NAME
@@ -320,7 +319,7 @@ class SpanConfigE2ETests {
 
     /**
      * apiMethodSignature: com.datadog.android.trace.AndroidTracer$Builder#constructor(com.datadog.android.api.SdkCore = Datadog.getInstance())
-     * apiMethodSignature: com.datadog.android.Datadog#fun setUserInfo(com.datadog.android.api.context.UserInfo, com.datadog.android.api.SdkCore = getInstance())
+     * apiMethodSignature: com.datadog.android.Datadog#fun setUserInfo(String? = null, String? = null, String? = null, Map<String, Any?> = emptyMap(), com.datadog.android.api.SdkCore = getInstance())
      * apiMethodSignature: com.datadog.android.Datadog#fun getInstance(String? = null): com.datadog.android.api.SdkCore
      */
     @Test
@@ -343,12 +342,10 @@ class SpanConfigE2ETests {
 
         measure(testMethodName) {
             Datadog.setUserInfo(
-                UserInfo(
-                    userId,
-                    userName,
-                    userEmail,
-                    userExtraInfo
-                )
+                userId,
+                userName,
+                userEmail,
+                userExtraInfo
             )
         }
         GlobalTracer.get().buildSpan(testMethodName).start().finish()

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -12,7 +12,6 @@ import android.util.Log
 import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
-import com.datadog.android.api.context.UserInfo
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.event.EventMapper
@@ -140,14 +139,12 @@ class SampleApplication : Application() {
         NdkCrashReports.enable()
 
         Datadog.setUserInfo(
-            UserInfo(
-                preferences.getUserId(),
-                preferences.getUserName(),
-                preferences.getUserEmail(),
-                mapOf(
-                    UserFragment.GENDER_KEY to preferences.getUserGender(),
-                    UserFragment.AGE_KEY to preferences.getUserAge()
-                )
+            id = preferences.getUserId(),
+            name = preferences.getUserName(),
+            email = preferences.getUserEmail(),
+            extraInfo = mapOf(
+                UserFragment.GENDER_KEY to preferences.getUserGender(),
+                UserFragment.AGE_KEY to preferences.getUserAge()
             )
         )
 

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/user/UserFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/user/UserFragment.kt
@@ -13,7 +13,6 @@ import android.view.ViewGroup
 import android.widget.EditText
 import androidx.fragment.app.Fragment
 import com.datadog.android.Datadog
-import com.datadog.android.api.context.UserInfo
 import com.datadog.android.ktx.tracing.withinSpan
 import com.datadog.android.sample.Preferences
 import com.datadog.android.sample.R
@@ -67,7 +66,7 @@ internal class UserFragment : Fragment(), View.OnClickListener {
             val age: Int = Integer.valueOf(userAgeField.text.toString())
             Preferences.defaultPreferences(requireContext())
                 .setUserCredentials(id, name, email, gender, age)
-            Datadog.setUserInfo(UserInfo(id, name, email, emptyMap()))
+            Datadog.setUserInfo(id, name, email, emptyMap())
             Datadog.addUserProperties(
                 mapOf<String, Any>(
                     GENDER_KEY to gender,

--- a/sample/wear/src/main/java/com/datadog/android/wear/sample/WearApplication.kt
+++ b/sample/wear/src/main/java/com/datadog/android/wear/sample/WearApplication.kt
@@ -10,7 +10,6 @@ import android.app.Application
 import android.util.Log
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
-import com.datadog.android.api.context.UserInfo
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.log.Logs
 import com.datadog.android.log.LogsConfiguration
@@ -75,11 +74,9 @@ class WearApplication : Application() {
         Trace.enable(tracesConfig)
 
         Datadog.setUserInfo(
-            UserInfo(
-                id = "wear 42",
-                name = null,
-                email = null
-            )
+            id = "wear 42",
+            name = null,
+            email = null
         )
 
         GlobalTracer.registerIfAbsent(


### PR DESCRIPTION
### What does this PR do?

Changing `Datadog.setUserInfo` arguments was not necessary for v2, restoring v1 version (same as in iOS SDK).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

