### PR TITLE
Fixes for nightly E2E tests

### DIFF
--- a/instrumented/integration/proguard-rules.pro
+++ b/instrumented/integration/proguard-rules.pro
@@ -16,6 +16,11 @@
     private boolean isRegistered;
 }
 
+# Required because we need access to GlobalRumMonitor reset method to reset it through reflection
+-keepnames class com.datadog.android.rum.GlobalRumMonitor {
+    private void reset();
+}
+
 # Required because we need access to RumContext fields by reflection
 -keepnames class com.datadog.android.rum.internal.domain.RumContext {
     *;

--- a/instrumented/nightly-tests/proguard-rules.pro
+++ b/instrumented/nightly-tests/proguard-rules.pro
@@ -20,6 +20,11 @@
     private boolean isRegistered;
 }
 
+# Required because we need access to GlobalRumMonitor reset method to reset it through reflection
+-keepnames class com.datadog.android.rum.GlobalRumMonitor {
+    private void reset();
+}
+
 # Required because we need access to RumContext fields by reflection
 -keepnames class com.datadog.android.rum.internal.domain.RumContext {
     *;

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -27,13 +27,11 @@ import com.datadog.android.trace.AndroidTracer
 import com.datadog.android.trace.Trace
 import com.datadog.android.trace.TraceConfiguration
 import com.datadog.tools.unit.forge.aThrowable
-import com.datadog.tools.unit.getStaticValue
 import com.datadog.tools.unit.setStaticValue
 import fr.xgouchet.elmyr.Forge
 import io.opentracing.Tracer
 import io.opentracing.util.GlobalTracer
 import java.util.Random
-import java.util.concurrent.atomic.AtomicBoolean
 
 fun defaultTestAttributes(testMethodName: String) = mapOf(
     TEST_METHOD_NAME_KEY to testMethodName
@@ -82,8 +80,10 @@ fun stopSdk() {
 
     // Reset Global states
     GlobalTracer::class.java.setStaticValue("isRegistered", false)
-    val isRumRegistered: AtomicBoolean = GlobalRumMonitor::class.java.getStaticValue("isRegistered")
-    isRumRegistered.set(false)
+    GlobalRumMonitor::class.java.getDeclaredMethod("reset").apply {
+        isAccessible = true
+        invoke(null)
+    }
 }
 
 fun flushAndShutdownExecutors() {

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/webview/WebViewTrackingE2ETests.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.nightly.webview
 
+import android.content.Intent
 import androidx.test.core.app.ActivityScenario.launch
 import androidx.test.espresso.web.model.Atoms.script
 import androidx.test.espresso.web.sugar.Web.onWebView
@@ -72,7 +73,12 @@ internal class WebViewTrackingE2ETests {
             crashReportsEnabled = true
         ).build()
         initSdk(config)
-        launch(WebViewTrackingActivity::class.java)
+        val intent = Intent(
+            InstrumentationRegistry.getInstrumentation().targetContext,
+            WebViewTrackingActivity::class.java
+        )
+        intent.putExtra(WebViewTrackingActivity.NO_ALLOWED_HOSTS_KEY, true)
+        launch<WebViewTrackingActivity>(intent)
 
         onWebView().withElement(findElement(Locator.ID, "make-fetch-request"))
             .perform(webClick())

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/WebViewTrackingActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/WebViewTrackingActivity.kt
@@ -37,12 +37,20 @@ internal class WebViewTrackingActivity : AppCompatActivity() {
     @Suppress("CheckInternal")
     private fun setupWebView(webView: WebView) {
         measure(TEST_METHOD_NAME) {
-            WebViewTracking.enable(webView, allowedHosts = listOf("datadoghq.dev"))
+            val isNoAllowedHosts = intent.extras
+                ?.getBoolean(NO_ALLOWED_HOSTS_KEY, false) ?: false
+            val allowedHosts = if (isNoAllowedHosts) {
+                emptyList()
+            } else {
+                listOf("datadoghq.dev")
+            }
+            WebViewTracking.enable(webView, allowedHosts)
         }
     }
 
     companion object {
         const val HEX_RADIX = 16
+        const val NO_ALLOWED_HOSTS_KEY = "no_allowed_hosts"
         internal const val TEST_METHOD_NAME = "web_view_tracking"
     }
 }


### PR DESCRIPTION
### What does this PR do?

This PR does 2 small fixes:

* Fixes a reflection call to clean up `GlobalRumMonitor`.
* Fixes `WebViewTracking` test when there is no allowed hosts defined.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

