### PR TITLE
Temporarily remove imagebutton mapper

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
@@ -12,7 +12,6 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.CheckedTextView
 import android.widget.EditText
-import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.NumberPicker
 import android.widget.RadioButton
@@ -25,7 +24,6 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckedTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.EditTextViewMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.ImageButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MapperTypeWrapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckedTextViewMapper
@@ -79,7 +77,6 @@ enum class SessionReplayPrivacy {
     internal fun mappers(): List<MapperTypeWrapper> {
         val viewWireframeMapper = ViewWireframeMapper()
         val unsupportedViewMapper = UnsupportedViewMapper()
-        val imageButtonMapper = ImageButtonMapper()
         val imageMapper: ViewScreenshotWireframeMapper
         val textMapper: TextViewMapper
         val buttonMapper: ButtonMapper
@@ -134,7 +131,6 @@ enum class SessionReplayPrivacy {
             MapperTypeWrapper(CheckBox::class.java, checkBoxMapper.toGenericMapper()),
             MapperTypeWrapper(CheckedTextView::class.java, checkedTextViewMapper.toGenericMapper()),
             MapperTypeWrapper(Button::class.java, buttonMapper.toGenericMapper()),
-            MapperTypeWrapper(ImageButton::class.java, imageButtonMapper.toGenericMapper()),
             MapperTypeWrapper(EditText::class.java, editTextViewMapper.toGenericMapper()),
             MapperTypeWrapper(TextView::class.java, textMapper.toGenericMapper()),
             MapperTypeWrapper(ImageView::class.java, imageMapper.toGenericMapper()),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
@@ -12,7 +12,6 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.CheckedTextView
 import android.widget.EditText
-import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.NumberPicker
 import android.widget.RadioButton
@@ -24,7 +23,6 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckedTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.EditTextViewMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.ImageButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MapperTypeWrapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckedTextViewMapper
@@ -113,13 +111,11 @@ internal class SessionReplayPrivacyTest {
         private val mockEditTextViewMapper: EditTextViewMapper = mock()
         private val mockImageMapper: ViewScreenshotWireframeMapper = mock()
         private val mockUnsupportedViewMapper: UnsupportedViewMapper = mock()
-        private val mockImageButtonViewMapper: ImageButtonMapper = mock()
 
         private val baseMappers = listOf(
             MapperTypeWrapper(Button::class.java, mockButtonMapper.toGenericMapper()),
             MapperTypeWrapper(EditText::class.java, mockEditTextViewMapper.toGenericMapper()),
             MapperTypeWrapper(ImageView::class.java, mockImageMapper.toGenericMapper()),
-            MapperTypeWrapper(ImageButton::class.java, mockImageButtonViewMapper.toGenericMapper()),
             MapperTypeWrapper(AppCompatToolbar::class.java, mockUnsupportedViewMapper.toGenericMapper())
         )
 


### PR DESCRIPTION
### What does this PR do?
We have an issue at the moment with base64 where too many bitmaps are being created and recycled, resulting in excessive garbage collection. We need to turn off the feature until it can be fixed. In this PR I'm temporarily removing `ImageButtonMapper` from the list of mappers used in the traversal, as this is the only place where we enter the base64 logic. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

