### PR TITLE
Remove dependency on Navigation Kotlin extensions

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/debug/UiRumDebugListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/debug/UiRumDebugListener.kt
@@ -20,10 +20,6 @@ import android.widget.TextView
 import androidx.annotation.AnyThread
 import androidx.annotation.MainThread
 import androidx.annotation.UiThread
-import androidx.core.graphics.blue
-import androidx.core.graphics.green
-import androidx.core.graphics.red
-import androidx.core.view.setPadding
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
@@ -165,13 +161,14 @@ internal class UiRumDebugListener(
             setBackgroundColor(
                 Color.argb(
                     alpha,
-                    ACTIVE_COLOR.red,
-                    ACTIVE_COLOR.green,
-                    ACTIVE_COLOR.blue
+                    Color.red(ACTIVE_COLOR),
+                    Color.green(ACTIVE_COLOR),
+                    Color.blue(ACTIVE_COLOR)
                 )
             )
             setTextColor(Color.WHITE)
-            setPadding(dpToPx(2f, context))
+            val paddingPx = dpToPx(2f, context)
+            setPadding(paddingPx, paddingPx, paddingPx, paddingPx)
             text = viewName
         }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
@@ -14,7 +14,7 @@ import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
-import androidx.navigation.findNavController
+import androidx.navigation.Navigation
 import androidx.navigation.fragment.NavHostFragment
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.rum.GlobalRumMonitor
@@ -180,7 +180,7 @@ class NavigationViewTrackingStrategy(
     @Suppress("SwallowedException")
     private fun Activity.findNavControllerOrNull(@IdRes viewId: Int): NavController? {
         return try {
-            findNavController(viewId)
+            Navigation.findNavController(this, viewId)
         } catch (e: IllegalArgumentException) {
             null
         } catch (e: IllegalStateException) {

--- a/features/dd-sdk-android-rum/transitiveDependencies
+++ b/features/dd-sdk-android-rum/transitiveDependencies
@@ -1,30 +1,24 @@
 Dependencies List
 
-androidx.activity:activity-ktx:1.1.0                            :    7 Kb
 androidx.activity:activity:1.1.0                                :   13 Kb
 androidx.annotation:annotation-experimental:1.1.0               :   16 Kb
 androidx.annotation:annotation:1.3.0                            :   30 Kb
 androidx.arch.core:core-common:2.1.0                            :   10 Kb
 androidx.arch.core:core-runtime:2.1.0                           :    5 Kb
 androidx.collection:collection:1.1.0                            :   41 Kb
-androidx.core:core-ktx:1.1.0                                    :  152 Kb
 androidx.core:core:1.6.0                                        :  905 Kb
 androidx.customview:customview:1.0.0                            :   32 Kb
 androidx.fragment:fragment:1.2.4                                :  221 Kb
 androidx.lifecycle:lifecycle-common:2.2.0                       :   21 Kb
 androidx.lifecycle:lifecycle-livedata-core:2.2.0                :    8 Kb
 androidx.lifecycle:lifecycle-livedata:2.1.0                     :   10 Kb
-androidx.lifecycle:lifecycle-runtime-ktx:2.2.0                  :   40 Kb
 androidx.lifecycle:lifecycle-runtime:2.2.0                      :   10 Kb
-androidx.lifecycle:lifecycle-viewmodel-ktx:2.2.0                :    5 Kb
 androidx.lifecycle:lifecycle-viewmodel-savedstate:2.2.0         :   13 Kb
 androidx.lifecycle:lifecycle-viewmodel:2.2.0                    :    9 Kb
 androidx.loader:loader:1.0.0                                    :   32 Kb
 androidx.metrics:metrics-performance:1.0.0-alpha04              :   47 Kb
-androidx.navigation:navigation-common-ktx:2.3.0                 :   25 Kb
 androidx.navigation:navigation-common:2.3.0                     :   54 Kb
 androidx.navigation:navigation-fragment:2.3.0                   :   18 Kb
-androidx.navigation:navigation-runtime-ktx:2.3.0                :   12 Kb
 androidx.navigation:navigation-runtime:2.3.0                    :   46 Kb
 androidx.recyclerview:recyclerview:1.1.0                        :  349 Kb
 androidx.savedstate:savedstate:1.0.0                            :    9 Kb
@@ -37,9 +31,7 @@ org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10                :  212 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10                  :  963 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10                  :  969 b 
 org.jetbrains.kotlin:kotlin-stdlib:1.8.10                       : 1598 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.0          :   20 Kb
-org.jetbrains.kotlinx:kotlinx-coroutines-core:1.3.0             : 1487 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :    6 Mb
+Total transitive dependencies size                              :    5 Mb
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -117,7 +117,7 @@ androidXAnnotation = { module = "androidx.annotation:annotation", version.ref = 
 androidXAppCompat = { module = "androidx.appcompat:appcompat", version.ref = "androidXAppCompat" }
 androidXCore = { module = "androidx.core:core", version.ref = "androidXCore" }
 androidXNavigationFragment = { module = "androidx.navigation:navigation-fragment", version.ref = "androidXNavigation" }
-androidXNavigationRuntimeKtx = { module = "androidx.navigation:navigation-runtime-ktx", version.ref = "androidXNavigation" }
+androidXNavigationRuntime = { module = "androidx.navigation:navigation-runtime", version.ref = "androidXNavigation" }
 androidXRecyclerView = { module = "androidx.recyclerview:recyclerview", version.ref = "androidXRecyclerView" }
 androidXWorkManager = { module = "androidx.work:work-runtime", version.ref = "androidXWorkManager" }
 androidXConstraintLayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidXConstraintLayout" }
@@ -238,7 +238,7 @@ testTools = [
 
 androidXNavigation = [
     "androidXNavigationFragment",
-    "androidXNavigationRuntimeKtx"
+    "androidXNavigationRuntime"
 ]
 
 androidXSupportBase = [

--- a/instrumented/integration/test-proguard-rules.pro
+++ b/instrumented/integration/test-proguard-rules.pro
@@ -41,3 +41,5 @@
 -dontwarn java.lang.StackWalker
 -dontwarn org.apiguardian.api.API$Status
 -dontwarn org.apiguardian.api.API
+-dontwarn kotlinx.coroutines.BuildersKt
+-dontwarn kotlinx.coroutines.CoroutineScope


### PR DESCRIPTION
### What does this PR do?

`androidx.navigation:navigation-runtime-ktx` was used just for a single method, but it was bringing quite a lot of dependencies, and also Kotlin Coroutines, which attributed quite a lot to the transitive dependencies size.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

