### PR TITLE
REPLAY-1887 Provide the uploadFrequency per feature

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -131,7 +131,7 @@ interface com.datadog.android.api.storage.EventBatchWriter
   fun currentMetadata(): ByteArray?
   fun write(ByteArray, ByteArray?): Boolean
 data class com.datadog.android.api.storage.FeatureStorageConfiguration
-  constructor(Long, Int, Long, Long)
+  constructor(Long, Int, Long, Long, com.datadog.android.core.configuration.UploadFrequency?, com.datadog.android.core.configuration.BatchSize?)
   companion object 
     val DEFAULT: FeatureStorageConfiguration
 interface com.datadog.android.core.InternalSdkCore : com.datadog.android.api.feature.FeatureSdkCore

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -394,18 +394,22 @@ public abstract interface class com/datadog/android/api/storage/EventBatchWriter
 
 public final class com/datadog/android/api/storage/FeatureStorageConfiguration {
 	public static final field Companion Lcom/datadog/android/api/storage/FeatureStorageConfiguration$Companion;
-	public fun <init> (JIJJ)V
+	public fun <init> (JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;)V
 	public final fun component1 ()J
 	public final fun component2 ()I
 	public final fun component3 ()J
 	public final fun component4 ()J
-	public final fun copy (JIJJ)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/api/storage/FeatureStorageConfiguration;JIJJILjava/lang/Object;)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
+	public final fun component5 ()Lcom/datadog/android/core/configuration/UploadFrequency;
+	public final fun component6 ()Lcom/datadog/android/core/configuration/BatchSize;
+	public final fun copy (JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/api/storage/FeatureStorageConfiguration;JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;ILjava/lang/Object;)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBatchSize ()Lcom/datadog/android/core/configuration/BatchSize;
 	public final fun getMaxBatchSize ()J
 	public final fun getMaxItemSize ()J
 	public final fun getMaxItemsPerBatch ()I
 	public final fun getOldBatchThreshold ()J
+	public final fun getUploadFrequency ()Lcom/datadog/android/core/configuration/UploadFrequency;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/FeatureStorageConfiguration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/FeatureStorageConfiguration.kt
@@ -6,6 +6,9 @@
 
 package com.datadog.android.api.storage
 
+import com.datadog.android.core.configuration.BatchSize
+import com.datadog.android.core.configuration.UploadFrequency
+
 /**
  * Contains the storage configuration for an [FeatureScope] instance.
  * @property maxItemSize the maximum size (in bytes) for a single item in a batch
@@ -13,12 +16,18 @@ package com.datadog.android.api.storage
  * @property maxBatchSize the maximum size (in bytes) of a complete batch
  * @property oldBatchThreshold the duration (in milliseconds) after which a batch is considered too
  * old to be uploaded (usually because it'll be discarded at ingestion by the backend)
+ * @property uploadFrequency the desired upload frequency policy. If not explicitly provided this
+ * value will be taken from core configuration.
+ * @property batchSize the desired batch size policy.If not explicitly provided this
+ * value will be taken from core configuration.
  */
 data class FeatureStorageConfiguration(
     val maxItemSize: Long,
     val maxItemsPerBatch: Int,
     val maxBatchSize: Long,
-    val oldBatchThreshold: Long
+    val oldBatchThreshold: Long,
+    val uploadFrequency: UploadFrequency?,
+    val batchSize: BatchSize?
 ) {
     companion object {
 
@@ -36,7 +45,9 @@ data class FeatureStorageConfiguration(
             // 4 MB
             maxBatchSize = 4L * 1024 * 1024,
             // 18 hours
-            oldBatchThreshold = 18L * 60L * 60L * 1000L
+            oldBatchThreshold = 18L * 60L * 60L * 1000L,
+            uploadFrequency = null,
+            batchSize = null
         )
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnable.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnable.kt
@@ -33,7 +33,7 @@ internal class DataUploadRunnable(
     private val contextProvider: ContextProvider,
     private val networkInfoProvider: NetworkInfoProvider,
     private val systemInfoProvider: SystemInfoProvider,
-    uploadFrequency: UploadFrequency,
+    internal val uploadFrequency: UploadFrequency,
     private val batchUploadWaitTimeoutMs: Long = CoreFeature.NETWORK_TIMEOUT_MS,
     private val internalLogger: InternalLogger
 ) : UploadRunnable {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadScheduler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadScheduler.kt
@@ -28,7 +28,7 @@ internal class DataUploadScheduler(
     private val internalLogger: InternalLogger
 ) : UploadScheduler {
 
-    private val runnable = DataUploadRunnable(
+    internal val runnable = DataUploadRunnable(
         scheduledThreadPoolExecutor,
         storage,
         dataUploader,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
@@ -30,7 +30,7 @@ internal class ConsentAwareStorage(
     private val batchMetadataReaderWriter: FileReaderWriter,
     private val fileMover: FileMover,
     private val internalLogger: InternalLogger,
-    private val filePersistenceConfig: FilePersistenceConfig
+    internal val filePersistenceConfig: FilePersistenceConfig
 ) : Storage {
 
     /**

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/FeatureStorageConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/FeatureStorageConfigurationForgeryFactory.kt
@@ -7,6 +7,8 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.core.configuration.BatchSize
+import com.datadog.android.core.configuration.UploadFrequency
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
@@ -17,7 +19,9 @@ internal class FeatureStorageConfigurationForgeryFactory :
             maxBatchSize = forge.aPositiveLong(),
             maxItemsPerBatch = forge.aBigInt(),
             maxItemSize = forge.aPositiveLong(),
-            oldBatchThreshold = forge.aPositiveLong()
+            oldBatchThreshold = forge.aPositiveLong(),
+            uploadFrequency = forge.aNullable { forge.aValueFrom(UploadFrequency::class.java) },
+            batchSize = forge.aNullable { forge.aValueFrom(BatchSize::class.java) }
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -15,6 +15,8 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.core.configuration.BatchSize
+import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.sessionreplay.NoOpRecorder
@@ -222,7 +224,9 @@ internal class SessionReplayFeature constructor(
         internal val STORAGE_CONFIGURATION: FeatureStorageConfiguration =
             FeatureStorageConfiguration.DEFAULT.copy(
                 maxItemSize = 10 * 1024 * 1024,
-                maxBatchSize = 10 * 1024 * 1024
+                maxBatchSize = 10 * 1024 * 1024,
+                uploadFrequency = UploadFrequency.FREQUENT,
+                batchSize = BatchSize.SMALL
             )
 
         internal const val REQUIRES_APPLICATION_CONTEXT_WARN_MESSAGE = "Session Replay could not " +


### PR DESCRIPTION
### What does this PR do?

This PR is follow - up on the [ios PR](https://github.com/DataDog/dd-sdk-ios/pull/1363) where we are providing a custom (batchSize, uploadFrequency) configuration for Session Replay feature to decrease the number of sessions with corrupted/not-enough records.
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

