### PR TITLE
REPLAY-1727: Base64 Caching Mechanism

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -577,6 +577,7 @@ datadog:
       - "java.lang.Object.constructor()"
       - "java.lang.Runtime.availableProcessors()"
       - "java.lang.Runtime.getRuntime()"
+      - "java.lang.Runtime.maxMemory()"
       - "java.lang.System.currentTimeMillis()"
       - "java.lang.System.getProperty(kotlin.String)"
       - "java.lang.System.identityHashCode(kotlin.Any)"

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -38,7 +38,7 @@ abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseWi
   protected fun android.graphics.drawable.Drawable.resolveShapeStyleAndBorder(Float): Pair<com.datadog.android.sessionreplay.model.MobileSegment.ShapeStyle?, com.datadog.android.sessionreplay.model.MobileSegment.ShapeBorder?>?
   protected fun resolveChildDrawableUniqueIdentifier(android.view.View): Long?
   protected fun getWebPMimeType(): String?
-  protected fun handleBitmap(android.util.DisplayMetrics, android.graphics.drawable.Drawable, com.datadog.android.sessionreplay.model.MobileSegment.Wireframe.ImageWireframe)
+  protected fun handleBitmap(android.content.Context, android.util.DisplayMetrics, android.graphics.drawable.Drawable, com.datadog.android.sessionreplay.model.MobileSegment.Wireframe.ImageWireframe)
   override fun startProcessingImage()
   override fun finishProcessingImage()
   companion object 

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -88,7 +88,7 @@ public final class com/datadog/android/sessionreplay/internal/recorder/SystemInf
 }
 
 public final class com/datadog/android/sessionreplay/internal/recorder/base64/Base64Serializer {
-	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;Lcom/datadog/android/sessionreplay/internal/utils/DrawableUtils;Lcom/datadog/android/sessionreplay/internal/utils/Base64Utils;Lcom/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;Lcom/datadog/android/sessionreplay/internal/utils/DrawableUtils;Lcom/datadog/android/sessionreplay/internal/utils/Base64Utils;Lcom/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression;Lcom/datadog/android/sessionreplay/internal/recorder/base64/Cache;Lcom/datadog/android/api/InternalLogger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract interface class com/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression {
@@ -113,7 +113,7 @@ public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper
 	protected final fun colorAndAlphaAsStringHexa (II)Ljava/lang/String;
 	public fun finishProcessingImage ()V
 	protected final fun getWebPMimeType ()Ljava/lang/String;
-	protected final fun handleBitmap (Landroid/util/DisplayMetrics;Landroid/graphics/drawable/Drawable;Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;)V
+	protected final fun handleBitmap (Landroid/content/Context;Landroid/util/DisplayMetrics;Landroid/graphics/drawable/Drawable;Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;)V
 	protected final fun resolveChildDrawableUniqueIdentifier (Landroid/view/View;)Ljava/lang/Long;
 	protected final fun resolveShapeStyleAndBorder (Landroid/graphics/drawable/Drawable;F)Lkotlin/Pair;
 	protected final fun resolveViewGlobalBounds (Landroid/view/View;F)Lcom/datadog/android/sessionreplay/internal/recorder/GlobalBounds;

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
@@ -12,6 +12,7 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.CheckedTextView
 import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.NumberPicker
 import android.widget.RadioButton
@@ -24,6 +25,7 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckedTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.EditTextViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ImageButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MapperTypeWrapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckedTextViewMapper
@@ -77,6 +79,7 @@ enum class SessionReplayPrivacy {
     internal fun mappers(): List<MapperTypeWrapper> {
         val viewWireframeMapper = ViewWireframeMapper()
         val unsupportedViewMapper = UnsupportedViewMapper()
+        val imageButtonMapper = ImageButtonMapper()
         val imageMapper: ViewScreenshotWireframeMapper
         val textMapper: TextViewMapper
         val buttonMapper: ButtonMapper
@@ -131,6 +134,7 @@ enum class SessionReplayPrivacy {
             MapperTypeWrapper(CheckBox::class.java, checkBoxMapper.toGenericMapper()),
             MapperTypeWrapper(CheckedTextView::class.java, checkedTextViewMapper.toGenericMapper()),
             MapperTypeWrapper(Button::class.java, buttonMapper.toGenericMapper()),
+            MapperTypeWrapper(ImageButton::class.java, imageButtonMapper.toGenericMapper()),
             MapperTypeWrapper(EditText::class.java, editTextViewMapper.toGenericMapper()),
             MapperTypeWrapper(TextView::class.java, textMapper.toGenericMapper()),
             MapperTypeWrapper(ImageView::class.java, imageMapper.toGenericMapper()),

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
@@ -6,12 +6,15 @@
 
 package com.datadog.android.sessionreplay.internal.async
 
+import android.graphics.drawable.Drawable
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import com.datadog.android.sessionreplay.internal.processor.RecordedDataProcessor
 import com.datadog.android.sessionreplay.internal.processor.RumContextDataHandler
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
+import com.datadog.android.sessionreplay.internal.recorder.base64.Base64LRUCache
+import com.datadog.android.sessionreplay.internal.recorder.base64.Cache
 import com.datadog.android.sessionreplay.internal.utils.TimeProvider
 import com.datadog.android.sessionreplay.model.MobileSegment
 import java.lang.ClassCastException
@@ -34,15 +37,18 @@ internal class RecordedDataQueueHandler {
     private var processor: RecordedDataProcessor
     private var rumContextDataHandler: RumContextDataHandler
     private var timeProvider: TimeProvider
+    private var cache: Cache<Drawable, String>
 
     internal constructor(
         processor: RecordedDataProcessor,
         rumContextDataHandler: RumContextDataHandler,
-        timeProvider: TimeProvider
+        timeProvider: TimeProvider,
+        cache: Cache<Drawable, String> = Base64LRUCache
     ) : this(
         processor = processor,
         rumContextDataHandler = rumContextDataHandler,
         timeProvider = timeProvider,
+        cache = cache,
 
         /**
          * TODO: RUMM-0000 consider change to LoggingThreadPoolExecutor once V2 is merged.
@@ -64,12 +70,14 @@ internal class RecordedDataQueueHandler {
         processor: RecordedDataProcessor,
         rumContextDataHandler: RumContextDataHandler,
         timeProvider: TimeProvider,
-        executorService: ExecutorService
+        executorService: ExecutorService,
+        cache: Cache<Drawable, String>
     ) {
         this.processor = processor
         this.rumContextDataHandler = rumContextDataHandler
         this.executorService = executorService
         this.timeProvider = timeProvider
+        this.cache = cache
     }
 
     // region internal
@@ -98,6 +106,11 @@ internal class RecordedDataQueueHandler {
     ): SnapshotRecordedDataQueueItem? {
         val rumContextData = rumContextDataHandler.createRumContextData()
             ?: return null
+
+        // if the view changed then clear the drawable cache
+        if (rumContextData.prevRumContext != rumContextData.newRumContext) {
+            cache.clear()
+        }
 
         val item = SnapshotRecordedDataQueueItem(
             rumContextData = rumContextData,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/Base64LRUCache.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/Base64LRUCache.kt
@@ -1,0 +1,134 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+import android.content.ComponentCallbacks2
+import android.content.res.Configuration
+import android.graphics.drawable.AnimationDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.DrawableContainer
+import android.graphics.drawable.LayerDrawable
+import android.util.LruCache
+import androidx.annotation.VisibleForTesting
+
+internal object Base64LRUCache : Cache<Drawable, String>, ComponentCallbacks2 {
+    @Suppress("MagicNumber")
+    val MAX_CACHE_MEMORY_SIZE_BYTES = 4 * 1024 * 1024 // 4MB
+    @Suppress("MagicNumber")
+    private val ON_LOW_MEMORY_SIZE_BYTES = MAX_CACHE_MEMORY_SIZE_BYTES / 2 // 50% size
+    @Suppress("MagicNumber")
+    private val ON_MODERATE_MEMORY_SIZE_BYTES = (MAX_CACHE_MEMORY_SIZE_BYTES / 4) * 3 // 75% size
+
+    private var cache: LruCache<String, ByteArray> = object :
+        LruCache<String, ByteArray>(MAX_CACHE_MEMORY_SIZE_BYTES) {
+        override fun sizeOf(key: String?, value: ByteArray): Int {
+            return value.size
+        }
+    }
+
+    override fun onTrimMemory(level: Int) {
+        when (level) {
+            ComponentCallbacks2.TRIM_MEMORY_BACKGROUND -> {
+                cache.evictAll()
+            }
+
+            ComponentCallbacks2.TRIM_MEMORY_COMPLETE -> {
+                cache.evictAll()
+            }
+
+            ComponentCallbacks2.TRIM_MEMORY_MODERATE -> {
+                cache.trimToSize(ON_MODERATE_MEMORY_SIZE_BYTES)
+            }
+
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL -> {
+                cache.evictAll()
+            }
+
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_LOW -> {
+                cache.trimToSize(ON_LOW_MEMORY_SIZE_BYTES)
+            }
+
+            ComponentCallbacks2.TRIM_MEMORY_RUNNING_MODERATE -> {
+                cache.trimToSize(ON_MODERATE_MEMORY_SIZE_BYTES)
+            }
+
+            ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN -> {
+                cache.evictAll()
+            }
+
+            else -> {
+                cache.evictAll()
+            }
+        }
+    }
+
+    override fun onConfigurationChanged(newConfig: Configuration) {}
+
+    override fun onLowMemory() {
+        cache.evictAll()
+    }
+
+    @VisibleForTesting
+    internal fun setBackingCache(cache: LruCache<String, ByteArray>) {
+        this.cache = cache
+    }
+
+    @Synchronized
+    override fun put(element: Drawable, value: String) {
+        val key = generateKey(element)
+        val byteArray = value.toByteArray(Charsets.UTF_8)
+        cache.put(key, byteArray)
+    }
+
+    @Synchronized
+    override fun get(element: Drawable): String? =
+        cache.get(generateKey(element))?.let {
+            String(it)
+        }
+
+    @Synchronized
+    override fun size(): Int = cache.size()
+
+    @Synchronized
+    override fun clear() {
+        cache.evictAll()
+    }
+
+    private fun generateKey(drawable: Drawable): String =
+        generatePrefix(drawable) + System.identityHashCode(drawable)
+
+    private fun generatePrefix(drawable: Drawable): String {
+        return when (drawable) {
+            is DrawableContainer -> getPrefixForDrawableContainer(drawable)
+            is LayerDrawable -> getPrefixForLayerDrawable(drawable)
+            else -> ""
+        }
+    }
+
+    private fun getPrefixForDrawableContainer(drawable: DrawableContainer): String {
+        if (drawable !is AnimationDrawable) {
+            return drawable.state.joinToString(separator = "", postfix = "-")
+        }
+
+        return ""
+    }
+
+    private fun getPrefixForLayerDrawable(drawable: LayerDrawable): String {
+        return if (drawable.numberOfLayers > 1) {
+            val sb = StringBuilder()
+            for (index in 0 until drawable.numberOfLayers) {
+                val layer = drawable.getDrawable(index)
+                val layerHash = System.identityHashCode(layer).toString()
+                sb.append(layerHash)
+                sb.append("-")
+            }
+            "$sb"
+        } else {
+            ""
+        }
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/Cache.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/Cache.kt
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+internal interface Cache<K : Any, V : Any> {
+    fun put(element: K, value: V)
+    fun get(element: K): V?
+    fun size(): Int
+    fun clear()
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
+import android.content.Context
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.InsetDrawable
@@ -103,10 +104,12 @@ abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wireframe>(
      */
     @MainThread
     protected fun handleBitmap(
+        applicationContext: Context,
         displayMetrics: DisplayMetrics,
         drawable: Drawable,
         imageWireframe: MobileSegment.Wireframe.ImageWireframe
     ) = base64Serializer.handleBitmap(
+        applicationContext,
         displayMetrics,
         drawable,
         imageWireframe

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapper.kt
@@ -27,7 +27,8 @@ internal class ImageButtonMapper(
         view: ImageButton,
         mappingContext: MappingContext
     ): List<MobileSegment.Wireframe.ImageWireframe> {
-        val drawable = view.drawable
+        val resources = view.resources
+        val drawable = view.drawable?.constantState?.newDrawable(resources)
         val id = resolveChildDrawableUniqueIdentifier(view)
 
         if (drawable == null || id == null) return emptyList()
@@ -40,6 +41,7 @@ internal class ImageButtonMapper(
 
         val mimeType = getWebPMimeType()
         val displayMetrics = view.resources.displayMetrics
+        val applicationContext = view.context.applicationContext
 
         val imageWireframe = MobileSegment.Wireframe.ImageWireframe(
             id = id,
@@ -56,6 +58,7 @@ internal class ImageButtonMapper(
 
         @Suppress("ThreadSafety") // TODO REPLAY-1861 caller thread of .map is unknown?
         handleBitmap(
+            applicationContext = applicationContext,
             displayMetrics = displayMetrics,
             drawable = drawable,
             imageWireframe = imageWireframe

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
@@ -12,6 +12,7 @@ import android.widget.Button
 import android.widget.CheckBox
 import android.widget.CheckedTextView
 import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.NumberPicker
 import android.widget.RadioButton
@@ -23,6 +24,7 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckedTextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.EditTextViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ImageButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MapperTypeWrapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckedTextViewMapper
@@ -111,11 +113,13 @@ internal class SessionReplayPrivacyTest {
         private val mockEditTextViewMapper: EditTextViewMapper = mock()
         private val mockImageMapper: ViewScreenshotWireframeMapper = mock()
         private val mockUnsupportedViewMapper: UnsupportedViewMapper = mock()
+        private val mockImageButtonViewMapper: ImageButtonMapper = mock()
 
         private val baseMappers = listOf(
             MapperTypeWrapper(Button::class.java, mockButtonMapper.toGenericMapper()),
             MapperTypeWrapper(EditText::class.java, mockEditTextViewMapper.toGenericMapper()),
             MapperTypeWrapper(ImageView::class.java, mockImageMapper.toGenericMapper()),
+            MapperTypeWrapper(ImageButton::class.java, mockImageButtonViewMapper.toGenericMapper()),
             MapperTypeWrapper(AppCompatToolbar::class.java, mockUnsupportedViewMapper.toGenericMapper())
         )
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/Base64LRUCacheTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/Base64LRUCacheTest.kt
@@ -1,0 +1,190 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+import android.graphics.drawable.AnimationDrawable
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.RippleDrawable
+import android.graphics.drawable.StateListDrawable
+import android.util.LruCache
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.Mockito.mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class Base64LRUCacheTest {
+    private val testedCache = Base64LRUCache
+
+    @Mock
+    lateinit var mockLruCache: LruCache<String, ByteArray>
+
+    @Mock
+    lateinit var mockDrawable: Drawable
+
+    @StringForgery
+    lateinit var fakeBase64: String
+
+    val argumentCaptor = argumentCaptor<String>()
+
+    @BeforeEach
+    fun setup() {
+        testedCache.setBackingCache(mockLruCache)
+    }
+
+    @Test
+    fun `M return null W get() { item not in cache }`() {
+        // When
+        val cacheItem = testedCache.get(mockDrawable)
+
+        // Then
+        assertThat(cacheItem).isNull()
+    }
+
+    @Test
+    fun `M return item W get() { item in cache }`(forge: Forge) {
+        // Given
+        val drawableID = System.identityHashCode(mockDrawable).toString()
+        val fakeBase64String = forge.aString()
+        val fakeValue = forge.anAsciiString().toByteArray()
+
+        whenever(mockLruCache.get(drawableID)).thenReturn(fakeValue)
+        testedCache.put(mockDrawable, fakeBase64String)
+
+        // When
+        val cacheItem = testedCache.get(mockDrawable)
+
+        // Then
+        verify(mockLruCache).get(drawableID)
+        assertThat(cacheItem).isEqualTo(String(fakeValue))
+    }
+
+    @Test
+    fun `M call LruCache put W put()`() {
+        // Given
+        val key = System.identityHashCode(mockDrawable).toString()
+
+        // When
+        testedCache.put(mockDrawable, fakeBase64)
+
+        // Then
+        verify(mockLruCache).put(key, fakeBase64.toByteArray())
+    }
+
+    @Test
+    fun `M return LruCache size W size()`() {
+        // Given
+        whenever(mockLruCache.size()).thenReturn(3)
+
+        // When
+        val size = testedCache.size()
+
+        // Then
+        verify(mockLruCache).size()
+        assertThat(size).isEqualTo(3)
+    }
+
+    @Test
+    fun `M clear LRUCache W clear()`() {
+        // When
+        testedCache.clear()
+
+        // Then
+        verify(mockLruCache).evictAll()
+    }
+
+    @Test
+    fun `M not generate prefix W put() { animationDrawable }`() {
+        // Given
+        val mockAnimationDrawable: AnimationDrawable = mock()
+
+        // When
+        testedCache.put(mockAnimationDrawable, fakeBase64)
+
+        // Then
+        verify(mockLruCache).put(argumentCaptor.capture(), any())
+        assertThat(argumentCaptor.firstValue).doesNotContain("-")
+    }
+
+    @Test
+    fun `M generate key prefix with state W put() { drawableContainer }`(forge: Forge) {
+        // Given
+        val mockStatelistDrawable: StateListDrawable = mock()
+        val fakeStateArray = intArrayOf(forge.aPositiveInt())
+        val expectedPrefix = fakeStateArray[0].toString() + "-"
+        whenever(mockStatelistDrawable.state).thenReturn(fakeStateArray)
+
+        // When
+        testedCache.put(mockStatelistDrawable, fakeBase64)
+
+        // Then
+        verify(mockLruCache).put(argumentCaptor.capture(), any())
+        assertThat(argumentCaptor.firstValue).startsWith(expectedPrefix)
+    }
+
+    @Test
+    fun `M generate key prefix with layer hash W put() { layerDrawable }`(forge: Forge) {
+        // Given
+        val mockRippleDrawable: RippleDrawable = mock()
+        val mockBgLayer: Drawable = mock()
+        val mockFgLayer: Drawable = mock()
+        whenever(mockRippleDrawable.numberOfLayers).thenReturn(2)
+        whenever(mockRippleDrawable.getDrawable(0)).thenReturn(mockBgLayer)
+        whenever(mockRippleDrawable.getDrawable(1)).thenReturn(mockFgLayer)
+
+        val fakeBase64 = forge.aString()
+        val captor = argumentCaptor<String>()
+
+        // When
+        testedCache.put(mockRippleDrawable, fakeBase64)
+
+        // Then
+        verify(mockLruCache).put(captor.capture(), any())
+        assertThat(captor.firstValue).contains(System.identityHashCode(mockBgLayer).toString())
+    }
+
+    @Test
+    fun `M not generate key prefix W put() { layerDrawable with only one layer }`(forge: Forge) {
+        // Given
+        val mockRippleDrawable: RippleDrawable = mock()
+        val mockBgLayer: Drawable = mock()
+        whenever(mockRippleDrawable.numberOfLayers).thenReturn(1)
+        whenever(mockRippleDrawable.getDrawable(0)).thenReturn(mockBgLayer)
+
+        val fakeBase64 = forge.aString()
+        val captor = argumentCaptor<String>()
+
+        // When
+        testedCache.put(mockRippleDrawable, fakeBase64)
+
+        // Then
+        verify(mockLruCache).put(captor.capture(), any())
+        assertThat(captor.firstValue).isEqualTo(System.identityHashCode(mockRippleDrawable).toString())
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapperTest.kt
@@ -6,8 +6,10 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
+import android.content.Context
 import android.content.res.Resources
 import android.graphics.drawable.Drawable
+import android.graphics.drawable.Drawable.ConstantState
 import android.util.DisplayMetrics
 import android.widget.ImageButton
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
@@ -80,6 +82,12 @@ internal class ImageButtonMapperTest {
     @Mock
     lateinit var mockBackground: Drawable
 
+    @Mock
+    lateinit var mockConstantState: ConstantState
+
+    @Mock
+    lateinit var mockContext: Context
+
     private val fakeId = Forge().aLong()
 
     private val fakeMimeType = Forge().aString()
@@ -89,6 +97,8 @@ internal class ImageButtonMapperTest {
         whenever(mockUniqueIdentifierGenerator.resolveChildUniqueIdentifier(any(), any()))
             .thenReturn(fakeId)
 
+        whenever(mockConstantState.newDrawable(any())).thenReturn(mockDrawable)
+        whenever(mockDrawable.constantState).thenReturn(mockConstantState)
         whenever(mockImageButton.drawable).thenReturn(mockDrawable)
 
         whenever(mockWebPImageCompression.getMimeType()).thenReturn(fakeMimeType)
@@ -100,6 +110,9 @@ internal class ImageButtonMapperTest {
         whenever(mockImageButton.resources).thenReturn(mockResources)
 
         whenever(mockImageButton.background).thenReturn(mockBackground)
+
+        whenever(mockContext.applicationContext).thenReturn(mockContext)
+        whenever(mockImageButton.context).thenReturn(mockContext)
 
         whenever(mockViewUtils.resolveViewGlobalBounds(any(), any())).thenReturn(mockGlobalBounds)
 


### PR DESCRIPTION
### What does this PR do?
Adds an LRUCache for base64 strings - cache base64 strings against drawable hashcodes. 
Evict all items in the LRUCache every time we change views. 

### Motivation
Without a caching mechanism we create and garbage collect an excessive number of bitmaps. 

### Additional Notes
This PR contains a revert commit of the revert of imagebuttonmapper (iow it adds base64 functionality back)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

