### PR TITLE
RUMM-3445: Support `navHost` hosted by `FragmentContainerView` for `NavigationViewTrackingStrategy`

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -85,7 +85,6 @@ datadog:
     treatUnknownConstructorAsThrowing: true
     knownThrowingCalls:
       # region Android
-      - "android.app.Activity.findNavController(kotlin.Int):java.lang.IllegalStateException"
       - "android.content.pm.PackageManager.getPackageInfo(kotlin.String, android.content.pm.PackageManager.PackageInfoFlags):android.content.pm.PackageManager.NameNotFoundException"
       - "android.content.pm.PackageManager.getPackageInfo(kotlin.String, kotlin.Int):android.content.pm.PackageManager.NameNotFoundException"
       - "android.content.res.Resources.getResourceEntryName(kotlin.Int):android.content.res.Resources.NotFoundException"
@@ -105,7 +104,6 @@ datadog:
       - "android.view.View.getLocationInWindow(kotlin.IntArray):java.lang.IllegalArgumentException"
       - "android.widget.FrameLayout.addView(android.view.View, android.view.ViewGroup.LayoutParams):java.lang.IllegalArgumentException"
       - "android.widget.LinearLayout.addView(android.view.View):java.lang.IllegalArgumentException"
-      - "androidx.work.WorkManager.enqueueUniqueWork(kotlin.String, androidx.work.ExistingWorkPolicy, androidx.work.OneTimeWorkRequest):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
       - "android.content.res.Resources.getResourceName(kotlin.Int):android.content.res.Resources.NotFoundException"
       - "android.content.res.Resources.openRawResource(kotlin.Int):android.content.res.Resources.NotFoundException"
       - "androidx.collection.LruCache.constructor(kotlin.Int):java.lang.IllegalArgumentException"
@@ -113,6 +111,8 @@ datadog:
       - "androidx.collection.LruCache.put(java.io.File, kotlin.Unit):java.lang.NullPointerException"
       - "androidx.collection.LruCache.remove(java.io.File):java.lang.NullPointerException"
       - "androidx.metrics.performance.JankStats.createAndTrack(android.view.Window, androidx.metrics.performance.JankStats.OnFrameListener):java.lang.IllegalStateException"
+      - "androidx.navigation.Navigation.findNavController(android.app.Activity, kotlin.Int):java.lang.IllegalStateException"
+      - "androidx.work.WorkManager.enqueueUniqueWork(kotlin.String, androidx.work.ExistingWorkPolicy, androidx.work.OneTimeWorkRequest):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
       # endregion
       # region Java File
       - "java.io.ByteArrayOutputStream.write(kotlin.ByteArray, kotlin.Int, kotlin.Int):java.lang.IndexOutOfBoundsException"
@@ -365,11 +365,15 @@ datadog:
       - "android.widget.TextView.constructor(android.content.Context)"
       - "android.widget.TextView.setBackgroundColor(kotlin.Int)"
       - "android.widget.TextView.setPadding(kotlin.Int)"
+      - "android.widget.TextView.setPadding(kotlin.Int, kotlin.Int, kotlin.Int, kotlin.Int)"
       - "android.widget.TextView.setTextColor(kotlin.Int)"
       # endregion
       # region Android Graphics
       - "android.graphics.Bitmap.recycle()"
       - "android.graphics.Color.argb(kotlin.Int, kotlin.Int, kotlin.Int, kotlin.Int)"
+      - "android.graphics.Color.blue(kotlin.Int)"
+      - "android.graphics.Color.green(kotlin.Int)"
+      - "android.graphics.Color.red(kotlin.Int)"
       - "android.graphics.Color.rgb(kotlin.Int, kotlin.Int, kotlin.Int)"
       - "android.graphics.drawable.Drawable.draw(android.graphics.Canvas)"
       - "android.graphics.drawable.Drawable.getDrawable(kotlin.Int)"
@@ -391,6 +395,7 @@ datadog:
       - "androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks.onFragmentPaused(androidx.fragment.app.FragmentManager, androidx.fragment.app.Fragment)"
       - "androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks.onFragmentResumed(androidx.fragment.app.FragmentManager, androidx.fragment.app.Fragment)"
       - "androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks.onFragmentStarted(androidx.fragment.app.FragmentManager, androidx.fragment.app.Fragment)"
+      - "androidx.fragment.app.FragmentManager.findFragmentById(kotlin.Int)"
       - "androidx.fragment.app.FragmentManager.registerFragmentLifecycleCallbacks(androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks, kotlin.Boolean)"
       - "androidx.fragment.app.FragmentManager.unregisterFragmentLifecycleCallbacks(androidx.fragment.app.FragmentManager.FragmentLifecycleCallbacks)"
       - "androidx.lifecycle.Lifecycle.addObserver(androidx.lifecycle.LifecycleObserver)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
@@ -180,12 +180,24 @@ class NavigationViewTrackingStrategy(
     @Suppress("SwallowedException")
     private fun Activity.findNavControllerOrNull(@IdRes viewId: Int): NavController? {
         return try {
-            Navigation.findNavController(this, viewId)
+            val navController = if (this is FragmentActivity) {
+                findNavControllerFromNavHostFragmentOrNull(viewId)
+            } else {
+                null
+            }
+            navController ?: Navigation.findNavController(this, viewId)
         } catch (e: IllegalArgumentException) {
             null
         } catch (e: IllegalStateException) {
             null
         }
+    }
+
+    private fun FragmentActivity.findNavControllerFromNavHostFragmentOrNull(
+        @IdRes viewId: Int
+    ): NavController? {
+        val navHostFragment = supportFragmentManager.findFragmentById(viewId) as? NavHostFragment
+        return navHostFragment?.navController
     }
 
     // endregion

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumViewTrackingE2ETests.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rum/RumViewTrackingE2ETests.kt
@@ -20,6 +20,7 @@ import com.datadog.android.nightly.activities.ViewTrackingFragmentActivity
 import com.datadog.android.nightly.activities.ViewTrackingMixedFragmentActivity
 import com.datadog.android.nightly.activities.ViewTrackingMixedNoFragmentActivity
 import com.datadog.android.nightly.activities.ViewTrackingNavigationActivity
+import com.datadog.android.nightly.activities.ViewTrackingNavigationFragmentContainerViewActivity
 import com.datadog.android.nightly.rules.NightlyTestRule
 import com.datadog.android.nightly.utils.defaultConfigurationBuilder
 import com.datadog.android.nightly.utils.initializeSdk
@@ -272,6 +273,35 @@ internal class RumViewTrackingE2ETests {
      * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#constructor(Int, Boolean, ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())
      */
     @Test
+    fun rum_navigation_view_tracking_strategy_fragment_container_view() {
+        measureSdkInitialize {
+            val config = defaultConfigurationBuilder(
+                crashReportsEnabled = true
+            ).build()
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
+                rumConfigProvider = {
+                    it.useViewTrackingStrategy(
+                        NavigationViewTrackingStrategy(
+                            R.id.nav_host_fragment,
+                            true
+                        )
+                    )
+                        .build()
+                },
+                config = config
+            )
+        }
+        launch(ViewTrackingNavigationFragmentContainerViewActivity::class.java)
+            .moveToState(Lifecycle.State.DESTROYED)
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.rum.RumConfiguration$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
+     * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#constructor(Int, Boolean, ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())
+     */
+    @Test
     fun rum_navigation_view_tracking_strategy_all_views_dropped() {
         measureSdkInitialize {
             val config = defaultConfigurationBuilder(
@@ -309,6 +339,43 @@ internal class RumViewTrackingE2ETests {
      * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#constructor(Int, Boolean, ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())
      */
     @Test
+    fun rum_navigation_view_tracking_strategy_fragment_container_view_all_views_dropped() {
+        measureSdkInitialize {
+            val config = defaultConfigurationBuilder(
+                crashReportsEnabled = true
+            ).build()
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
+                rumConfigProvider = {
+                    it.useViewTrackingStrategy(
+                        NavigationViewTrackingStrategy(
+                            R.id.nav_host_fragment,
+                            true,
+                            object : ComponentPredicate<NavDestination> {
+                                override fun accept(component: NavDestination): Boolean {
+                                    return false
+                                }
+
+                                override fun getViewName(component: NavDestination): String {
+                                    return "ViewTrackingNavigationFragmentContainerViewActivityAllViewsDropped"
+                                }
+                            }
+                        )
+                    ).build()
+                },
+                config = config
+            )
+        }
+        launch(ViewTrackingNavigationFragmentContainerViewActivity::class.java)
+            .moveToState(Lifecycle.State.DESTROYED)
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.rum.RumConfiguration$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
+     * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#constructor(Int, Boolean, ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())
+     */
+    @Test
     fun rum_navigation_view_tracking_strategy_custom_view_name() {
         measureSdkInitialize {
             val config = defaultConfigurationBuilder(
@@ -338,6 +405,43 @@ internal class RumViewTrackingE2ETests {
             )
         }
         launch(ViewTrackingNavigationActivity::class.java)
+            .moveToState(Lifecycle.State.DESTROYED)
+    }
+
+    /**
+     * apiMethodSignature: com.datadog.android.rum.RumConfiguration$Builder#fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
+     * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#constructor(Int, Boolean, ComponentPredicate<androidx.navigation.NavDestination> = AcceptAllNavDestinations())
+     */
+    @Test
+    fun rum_navigation_view_tracking_strategy_fragment_container_view_custom_view_name() {
+        measureSdkInitialize {
+            val config = defaultConfigurationBuilder(
+                crashReportsEnabled = true
+            ).build()
+            initializeSdk(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                forgeSeed = forge.seed,
+                rumConfigProvider = {
+                    it.useViewTrackingStrategy(
+                        NavigationViewTrackingStrategy(
+                            R.id.nav_host_fragment,
+                            true,
+                            object : ComponentPredicate<NavDestination> {
+                                override fun accept(component: NavDestination): Boolean {
+                                    return true
+                                }
+
+                                override fun getViewName(component: NavDestination): String {
+                                    return component.label.toString()
+                                }
+                            }
+                        )
+                    ).build()
+                },
+                config = config
+            )
+        }
+        launch(ViewTrackingNavigationFragmentContainerViewActivity::class.java)
             .moveToState(Lifecycle.State.DESTROYED)
     }
 

--- a/instrumented/nightly-tests/src/main/AndroidManifest.xml
+++ b/instrumented/nightly-tests/src/main/AndroidManifest.xml
@@ -20,6 +20,7 @@
         <activity android:name=".activities.ViewTrackingActivity"/>
         <activity android:name=".activities.ViewTrackingFragmentActivity"/>
         <activity android:name=".activities.ViewTrackingNavigationActivity"/>
+        <activity android:name=".activities.ViewTrackingNavigationFragmentContainerViewActivity"/>
         <activity android:name=".activities.UserInteractionTrackingActivity"/>
         <activity android:name=".activities.UserInteractionCustomTargetActivity"/>
         <activity android:name=".activities.ViewTrackingMixedFragmentActivity"/>

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ViewTrackingNavigationFragmentContainerViewActivity.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/activities/ViewTrackingNavigationFragmentContainerViewActivity.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.activities
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.datadog.android.nightly.R
+
+internal class ViewTrackingNavigationFragmentContainerViewActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.tracking_strategy_navigation_fragment_container_view)
+    }
+}

--- a/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/fragments/ViewTrackingNavigationFragmentContainerViewHomeFragment.kt
+++ b/instrumented/nightly-tests/src/main/kotlin/com/datadog/android/nightly/fragments/ViewTrackingNavigationFragmentContainerViewHomeFragment.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.nightly.fragments
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.datadog.android.nightly.R
+
+internal class ViewTrackingNavigationFragmentContainerViewHomeFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.tracking_strategy_fragment, container, false)
+    }
+}

--- a/instrumented/nightly-tests/src/main/res/layout/tracking_strategy_navigation_fragment_container_view.xml
+++ b/instrumented/nightly-tests/src/main/res/layout/tracking_strategy_navigation_fragment_container_view.xml
@@ -6,19 +6,17 @@
   -->
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
-             xmlns:app="http://schemas.android.com/apk/res-auto"
-             xmlns:tools="http://schemas.android.com/tools"
-             android:id="@+id/frame_container"
-             android:layout_width="match_parent"
-             android:layout_height="match_parent"
-             tools:context=".NavActivity">
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/frame_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".activities.ViewTrackingNavigationFragmentContainerViewActivity">
 
     <TextView
         android:id="@+id/app_info"
         android:layout_width="match_parent"
         android:layout_height="32dp"
-        android:background="@color/datadog_violet"
-        android:textColor="@color/white"
         android:singleLine="true"
         android:gravity="center"
         android:textSize="12sp"
@@ -32,6 +30,6 @@
         android:layout_height="match_parent"
         android:layout_marginTop="32dp"
         app:defaultNavHost="true"
-        app:navGraph="@navigation/nav_graph"/>
+        app:navGraph="@navigation/nav_graph_fragment_container_view"/>
 
 </FrameLayout>

--- a/instrumented/nightly-tests/src/main/res/navigation/nav_graph_fragment_container_view.xml
+++ b/instrumented/nightly-tests/src/main/res/navigation/nav_graph_fragment_container_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-Present Datadog, Inc.
+  -->
+
+<navigation xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:id="@+id/nav_graph"
+    app:startDestination="@id/fragment_home">
+
+    <fragment
+        android:id="@+id/fragment_home"
+        android:name="com.datadog.android.nightly.fragments.ViewTrackingNavigationFragmentContainerViewHomeFragment"
+        android:label="@string/navigation_home_fragment_container_view_label"/>
+
+
+</navigation>

--- a/instrumented/nightly-tests/src/main/res/values/strings.xml
+++ b/instrumented/nightly-tests/src/main/res/values/strings.xml
@@ -8,5 +8,6 @@
 <resources>
     <string name="app_name">Datadog Nightly Tests</string>
     <string name="navigation_home_fragment_label">ViewTrackingNavigationCustomView</string>
+    <string name="navigation_home_fragment_container_view_label">ViewTrackingNavigationCustomFragmentContainerView</string>
     <string name="user_interaction_strategy_button_label">UserInteractionTrackingButton</string>
 </resources>

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/NavActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/NavActivity.kt
@@ -41,8 +41,6 @@ class NavActivity : AppCompatActivity(), TrackingConsentChangeListener {
         setContentView(R.layout.activity_nav)
         rootView = findViewById(R.id.frame_container)
         appInfoView = findViewById(R.id.app_info)
-
-        navController = findNavController(R.id.nav_host_fragment)
     }
 
     override fun onStart() {
@@ -58,6 +56,8 @@ class NavActivity : AppCompatActivity(), TrackingConsentChangeListener {
     override fun onResume() {
         super.onResume()
         Timber.d("onResume")
+
+        navController = findNavController(R.id.nav_host_fragment)
 
         val tracking = Preferences.defaultPreferences(this).getTrackingConsent()
         updateTrackingConsentLabel(tracking)


### PR DESCRIPTION
### What does this PR do?

This PR addresses the issue described [here](https://github.com/DataDog/dd-sdk-android/issues/760#issuecomment-1511050310). Basically now the [recommendation](https://developer.android.com/guide/navigation/get-started#add-navhostfragment) is to use `FragmentContainerView` for hosting `NavHostFragment`, this now will be the priority for lookup, and if not found we fall back to the old strategy.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

