### PR TITLE
REPLAY-1894: Remove explicit dependency on RUM module from Session Replay

### DIFF
--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -88,7 +88,6 @@ android {
 
 dependencies {
     api(project(":dd-sdk-android-core"))
-    api(project(":features:dd-sdk-android-rum"))
     implementation(libs.okHttp)
     implementation(libs.kotlin)
     implementation(libs.gson)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactory.kt
@@ -9,7 +9,6 @@ package com.datadog.android.sessionreplay.internal.domain
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.net.Request
 import com.datadog.android.api.net.RequestFactory
-import com.datadog.android.rum.RumAttributes
 import com.datadog.android.sessionreplay.internal.exception.InvalidPayloadFormatException
 import com.datadog.android.sessionreplay.internal.net.BatchesToSegmentsMapper
 import okhttp3.RequestBody
@@ -45,14 +44,13 @@ internal class SessionReplayRequestFactory(
 
     private fun tags(datadogContext: DatadogContext): String {
         val elements = mutableListOf(
-            "${RumAttributes.SERVICE_NAME}:${datadogContext.service}",
-            "${RumAttributes.APPLICATION_VERSION}:" +
-                datadogContext.version,
-            "${RumAttributes.SDK_VERSION}:${datadogContext.sdkVersion}",
-            "${RumAttributes.ENV}:${datadogContext.env}"
+            "$SERVICE_NAME:${datadogContext.service}",
+            "$APPLICATION_VERSION:${datadogContext.version}",
+            "$SDK_VERSION:${datadogContext.sdkVersion}",
+            "$ENV:${datadogContext.env}"
         )
         if (datadogContext.variant.isNotEmpty()) {
-            elements.add("${RumAttributes.VARIANT}:${datadogContext.variant}")
+            elements.add("$VARIANT:${datadogContext.variant}")
         }
         return elements.joinToString(",")
     }
@@ -115,5 +113,10 @@ internal class SessionReplayRequestFactory(
 
     companion object {
         private const val UPLOAD_URL = "%s/api/v2/%s"
+        internal const val APPLICATION_VERSION = "version"
+        internal const val ENV = "env"
+        internal const val SERVICE_NAME = "service"
+        internal const val VARIANT = "variant"
+        internal const val SDK_VERSION = "sdk_version"
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactoryTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactoryTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.sessionreplay.internal.domain
 
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.net.RequestFactory
-import com.datadog.android.rum.RumAttributes
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.exception.InvalidPayloadFormatException
 import com.datadog.android.sessionreplay.internal.net.BatchesToSegmentsMapper
@@ -178,14 +177,14 @@ internal class SessionReplayRequestFactoryTest {
 
     private fun expectedUrl(endpointUrl: String): String {
         val queryTags = mutableListOf(
-            "${RumAttributes.SERVICE_NAME}:${fakeDatadogContext.service}",
-            "${RumAttributes.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-            "${RumAttributes.SDK_VERSION}:${fakeDatadogContext.sdkVersion}",
-            "${RumAttributes.ENV}:${fakeDatadogContext.env}"
+            "${SessionReplayRequestFactory.SERVICE_NAME}:${fakeDatadogContext.service}",
+            "${SessionReplayRequestFactory.APPLICATION_VERSION}:${fakeDatadogContext.version}",
+            "${SessionReplayRequestFactory.SDK_VERSION}:${fakeDatadogContext.sdkVersion}",
+            "${SessionReplayRequestFactory.ENV}:${fakeDatadogContext.env}"
         )
 
         if (fakeDatadogContext.variant.isNotEmpty()) {
-            queryTags.add("${RumAttributes.VARIANT}:${fakeDatadogContext.variant}")
+            queryTags.add("${SessionReplayRequestFactory.VARIANT}:${fakeDatadogContext.variant}")
         }
 
         return "$endpointUrl/api/v2/replay?${RequestFactory.QUERY_PARAM_SOURCE}=" +

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -116,8 +116,10 @@ android {
 dependencies {
 
     implementation(project(":dd-sdk-android-core"))
-    implementation(project(":features:dd-sdk-android-ndk"))
+    implementation(project(":features:dd-sdk-android-logs"))
+    implementation(project(":features:dd-sdk-android-rum"))
     implementation(project(":features:dd-sdk-android-trace"))
+    implementation(project(":features:dd-sdk-android-ndk"))
     implementation(project(":features:dd-sdk-android-webview"))
     implementation(project(":features:dd-sdk-android-session-replay"))
     implementation(project(":features:dd-sdk-android-session-replay-material"))


### PR DESCRIPTION
### What does this PR do?

We were using just few symbols from RUM module, and they probably even are not needed.

This change is to have the consistency in the setup with iOS SDK, where `DatadogRUM` should be added alongside with Session Replay module.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

