### PR TITLE
Fix flaky test related to the Session Replay context update

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -858,6 +858,7 @@ internal class RumSessionScopeTest {
         forge: Forge
     ) {
         // Given
+        initializeTestedScope(backgroundTrackingEnabled = false)
         val fakeNonInteractionEvent1 = forge.anyRumEvent(
             excluding = listOf(
                 RumRawEvent.StartView::class.java,


### PR DESCRIPTION
### What does this PR do?

The issue is that in the test mentioned sometimes background tracking can be enabled, leading to the `keepSession = true`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

