### PR TITLE
REPLAY- 1893: Implement bitmap downscaling

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -727,6 +727,7 @@ datadog:
       - "kotlin.collections.MutableList.add(com.datadog.android.plugin.DatadogPlugin)"
       - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.internal.processor.MutationResolver.Entry)"
       - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.model.MobileSegment.Add)"
+      - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.model.MobileSegment.Wireframe)"
       - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.model.MobileSegment.WireframeUpdateMutation)"
       - "kotlin.collections.MutableList.add(com.datadog.android.rum.internal.domain.scope.RumScope)"
       - "kotlin.collections.MutableList.add(com.datadog.android.rum.model.ActionEvent.Type)"
@@ -838,6 +839,7 @@ datadog:
       - "kotlin.Float.toFloat()"
       - "kotlin.Int.inv()"
       - "kotlin.Int.toChar()"
+      - "kotlin.Int.toDouble()"
       - "kotlin.Int.toFloat()"
       - "kotlin.Int.toLong()"
       - "kotlin.Int.and(kotlin.Int)"
@@ -857,6 +859,7 @@ datadog:
       - "kotlin.Pair.constructor(com.datadog.android.sessionreplay.internal.utils.SessionReplayRumContext, com.google.gson.JsonArray)"
       - "kotlin.Pair.constructor(com.datadog.android.sessionreplay.model.MobileSegment, com.google.gson.JsonObject)"
       - "kotlin.Pair.constructor(com.google.gson.JsonObject, kotlin.Long)"
+      - "kotlin.Pair.constructor(kotlin.Int, kotlin.Int)"
       - "kotlin.Triple.constructor(kotlin.String, kotlin.String, kotlin.String)"
       - "kotlin.Triple.constructor(kotlin.Nothing?, kotlin.Nothing?, kotlin.Nothing?)"
       # endregion

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/wrappers/BitmapWrapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/wrappers/BitmapWrapper.kt
@@ -17,7 +17,7 @@ internal class BitmapWrapper {
         bitmapHeight: Int,
         config: Config
     ): Bitmap? {
-        @Suppress("SwallowedException", "TooGenericExceptionCaught")
+        @Suppress("SwallowedException")
         return try {
             Bitmap.createBitmap(displayMetrics, bitmapWidth, bitmapHeight, config)
         } catch (e: IllegalArgumentException) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
@@ -13,22 +13,67 @@ import android.util.DisplayMetrics
 import androidx.annotation.MainThread
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.BitmapWrapper
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.CanvasWrapper
+import kotlin.math.sqrt
 
 internal class DrawableUtils(
     private val bitmapWrapper: BitmapWrapper = BitmapWrapper(),
     private val canvasWrapper: CanvasWrapper = CanvasWrapper()
 ) {
+    /**
+     * This method attempts to create a bitmap from a drawable, such that the bitmap file size will
+     * be equal or less than a given size. It does so by modifying the dimensions of the
+     * bitmap, since the file size of a bitmap can be known by the formula width*height*color depth
+     */
     @MainThread
     @Suppress("ReturnCount")
-    internal fun createBitmapFromDrawable(drawable: Drawable, displayMetrics: DisplayMetrics): Bitmap? {
-        val bitmapWidth = if (drawable.intrinsicWidth <= 0) 1 else drawable.intrinsicWidth
-        val bitmapHeight = if (drawable.intrinsicHeight <= 0) 1 else drawable.intrinsicHeight
-        val bitmap = bitmapWrapper.createBitmap(displayMetrics, bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888)
+    internal fun createBitmapOfApproxSizeFromDrawable(
+        drawable: Drawable,
+        displayMetrics: DisplayMetrics,
+        requestedSizeInBytes: Int = MAX_BITMAP_SIZE_IN_BYTES
+    ): Bitmap? {
+        val (width, height) = getScaledWidthAndHeight(drawable, requestedSizeInBytes)
+
+        val bitmap = bitmapWrapper.createBitmap(
+            displayMetrics,
+            width,
+            height,
+            Bitmap.Config.ARGB_8888
+        )
             ?: return null
 
         val canvas = canvasWrapper.createCanvas(bitmap) ?: return null
         drawable.setBounds(0, 0, canvas.width, canvas.height)
         drawable.draw(canvas)
         return bitmap
+    }
+
+    private fun getScaledWidthAndHeight(
+        drawable: Drawable,
+        requestedSizeInBytes: Int
+    ): Pair<Int, Int> {
+        var width = drawable.intrinsicWidth
+        var height = drawable.intrinsicHeight
+        val sizeAfterCreation = width * height * ARGB_8888_PIXEL_SIZE_BYTES
+
+        if (sizeAfterCreation > requestedSizeInBytes) {
+            val bitmapRatio = width.toDouble() / height.toDouble()
+            val totalMaxPixels = (requestedSizeInBytes / ARGB_8888_PIXEL_SIZE_BYTES).toDouble()
+            val maxSize = sqrt(totalMaxPixels).toInt()
+            width = maxSize
+            height = maxSize
+
+            if (bitmapRatio > 1) { // width gt height
+                height = (maxSize / bitmapRatio).toInt()
+            } else {
+                width = (maxSize * bitmapRatio).toInt()
+            }
+        }
+
+        return Pair(width, height)
+    }
+
+    internal companion object {
+        internal const val MAX_BITMAP_SIZE_IN_BYTES = 10240 // 10kb
+        private const val ARGB_8888_PIXEL_SIZE_BYTES = 4
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtilsTest.kt
@@ -7,10 +7,13 @@
 package com.datadog.android.sessionreplay.internal.utils
 
 import android.graphics.Bitmap
+import android.graphics.Canvas
 import android.graphics.drawable.Drawable
 import android.util.DisplayMetrics
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.BitmapWrapper
+import com.datadog.android.sessionreplay.internal.recorder.wrappers.CanvasWrapper
+import com.datadog.android.sessionreplay.internal.utils.DrawableUtils.Companion.MAX_BITMAP_SIZE_IN_BYTES
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -46,85 +49,147 @@ internal class DrawableUtilsTest {
     private lateinit var mockBitmapWrapper: BitmapWrapper
 
     @Mock
-    private lateinit var fakeBitmap: Bitmap
+    private lateinit var mockCanvasWrapper: CanvasWrapper
+
+    @Mock
+    private lateinit var mockBitmap: Bitmap
+
+    @Mock
+    private lateinit var mockCanvas: Canvas
 
     @BeforeEach
     fun setup() {
         whenever(mockBitmapWrapper.createBitmap(any(), any(), any(), any()))
-            .thenReturn(fakeBitmap)
-        testedDrawableUtils = DrawableUtils(mockBitmapWrapper)
+            .thenReturn(mockBitmap)
+        whenever(mockBitmap.byteCount).thenReturn(MAX_BITMAP_SIZE_IN_BYTES + 1)
+        whenever(mockCanvasWrapper.createCanvas(mockBitmap))
+            .thenReturn(mockCanvas)
+        testedDrawableUtils = DrawableUtils(
+            bitmapWrapper = mockBitmapWrapper,
+            canvasWrapper = mockCanvasWrapper
+        )
     }
 
-    @Test
-    fun `M set width to 1 W createBitmapFromDrawable() { with width 0 }`() {
-        // Given
-        whenever(mockDrawable.intrinsicWidth).thenReturn(0)
-        whenever(mockDrawable.intrinsicHeight).thenReturn(0)
+    // region createBitmap
 
-        val boundsCaptor = argumentCaptor<Int>()
+    @Test
+    fun `M set width to drawable intrinsic W createBitmapFromDrawableOfApproxSize() { no resizing }`() {
+        // Given
+        val requestedSize = 1000
+        val edge = 10
+        whenever(mockDrawable.intrinsicWidth).thenReturn(edge)
+        whenever(mockDrawable.intrinsicHeight).thenReturn(edge)
+
+        val argumentCaptor = argumentCaptor<Int>()
         val displayMetricsCaptor = argumentCaptor<DisplayMetrics>()
 
         // When
-        val result = testedDrawableUtils.createBitmapFromDrawable(mockDrawable, mockDisplayMetrics)
+        testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
+            mockDrawable,
+            mockDisplayMetrics,
+            requestedSize
+        )
 
         // Then
         verify(mockBitmapWrapper).createBitmap(
             displayMetrics = displayMetricsCaptor.capture(),
-            bitmapWidth = boundsCaptor.capture(),
-            bitmapHeight = boundsCaptor.capture(),
+            bitmapWidth = argumentCaptor.capture(),
+            bitmapHeight = argumentCaptor.capture(),
             config = any()
         )
 
-        boundsCaptor.allValues.forEach {
-            assertThat(it).isEqualTo(1)
-        }
-
-        assertThat(displayMetricsCaptor.firstValue).isEqualTo(mockDisplayMetrics)
-
-        assertThat(result).isEqualTo(fakeBitmap)
+        val width = argumentCaptor.firstValue
+        val height = argumentCaptor.secondValue
+        assertThat(width).isEqualTo(edge)
+        assertThat(height).isEqualTo(edge)
     }
 
     @Test
-    fun `M set width to drawable intrinsic W createBitmapFromDrawable()`() {
+    fun `M set height higher W createBitmapFromDrawableOfApproxSize() { when resizing }`() {
         // Given
-        whenever(mockDrawable.intrinsicWidth).thenReturn(200)
-        whenever(mockDrawable.intrinsicHeight).thenReturn(200)
+        whenever(mockDrawable.intrinsicWidth).thenReturn(900)
+        whenever(mockDrawable.intrinsicHeight).thenReturn(1000)
 
-        val boundsCaptor = argumentCaptor<Int>()
+        val argumentCaptor = argumentCaptor<Int>()
         val displayMetricsCaptor = argumentCaptor<DisplayMetrics>()
 
         // When
-        val result = testedDrawableUtils.createBitmapFromDrawable(mockDrawable, mockDisplayMetrics)
+        testedDrawableUtils
+            .createBitmapOfApproxSizeFromDrawable(mockDrawable, mockDisplayMetrics)
 
         // Then
         verify(mockBitmapWrapper).createBitmap(
             displayMetrics = displayMetricsCaptor.capture(),
-            bitmapWidth = boundsCaptor.capture(),
-            bitmapHeight = boundsCaptor.capture(),
+            bitmapWidth = argumentCaptor.capture(),
+            bitmapHeight = argumentCaptor.capture(),
             config = any()
         )
 
-        boundsCaptor.allValues.forEach {
-            assertThat(it).isEqualTo(200)
-        }
-
-        assertThat(displayMetricsCaptor.firstValue).isEqualTo(mockDisplayMetrics)
-
-        assertThat(result).isEqualTo(fakeBitmap)
+        val width = argumentCaptor.firstValue
+        val height = argumentCaptor.secondValue
+        assertThat(height).isGreaterThanOrEqualTo(width)
     }
 
     @Test
-    fun `M return null W createBitmapFromDrawable() { failed to create bmp }`() {
+    fun `M set width higher W createBitmapFromDrawableOfApproxSize() { when resizing }`() {
         // Given
-        whenever(mockDrawable.intrinsicWidth).thenReturn(200)
-        whenever(mockDrawable.intrinsicHeight).thenReturn(200)
+        whenever(mockDrawable.intrinsicWidth).thenReturn(1000)
+        whenever(mockDrawable.intrinsicHeight).thenReturn(900)
+
+        val argumentCaptor = argumentCaptor<Int>()
+        val displayMetricsCaptor = argumentCaptor<DisplayMetrics>()
+
+        // When
+        val result = testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(mockDrawable, mockDisplayMetrics)
+
+        // Then
+        verify(mockBitmapWrapper).createBitmap(
+            displayMetrics = displayMetricsCaptor.capture(),
+            bitmapWidth = argumentCaptor.capture(),
+            bitmapHeight = argumentCaptor.capture(),
+            config = any()
+        )
+
+        val width = argumentCaptor.firstValue
+        val height = argumentCaptor.secondValue
+        assertThat(width).isGreaterThanOrEqualTo(height)
+
+        assertThat(displayMetricsCaptor.firstValue).isEqualTo(mockDisplayMetrics)
+
+        assertThat(result).isEqualTo(mockBitmap)
+    }
+
+    @Test
+    fun `M return null W createBitmapFromDrawableOfApproxSize() { failed to create bmp }`() {
+        // Given
+        val edge = 200
+        whenever(mockDrawable.intrinsicWidth).thenReturn(edge)
+        whenever(mockDrawable.intrinsicHeight).thenReturn(edge)
         whenever(mockBitmapWrapper.createBitmap(any(), any(), any(), any()))
             .thenReturn(null)
 
         // When
-        val result = testedDrawableUtils.createBitmapFromDrawable(mockDrawable, mockDisplayMetrics)
+        val result = testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(mockDrawable, mockDisplayMetrics)
 
         // Then
         assertThat(result).isNull()
     }
+
+    @Test
+    fun `M return null W createBitmapFromDrawableOfApproxSize() { failed to create canvas }`() {
+        // Given
+        val edge = 200
+        whenever(mockDrawable.intrinsicWidth).thenReturn(edge)
+        whenever(mockDrawable.intrinsicHeight).thenReturn(edge)
+        whenever(mockCanvasWrapper.createCanvas(any()))
+            .thenReturn(null)
+
+        // When
+        val result = testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(mockDrawable, mockDisplayMetrics)
+
+        // Then
+        assertThat(result).isNull()
+    }
+
+    // endregion
 }

--- a/sample/kotlin/src/main/res/drawable/ic_dd_shape_oval.xml
+++ b/sample/kotlin/src/main/res/drawable/ic_dd_shape_oval.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#800080" />
+    <size android:width="100dp"
+        android:height="100dp" />
+</shape>

--- a/sample/kotlin/src/main/res/drawable/ic_dd_shape_rect.xml
+++ b/sample/kotlin/src/main/res/drawable/ic_dd_shape_rect.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#800080" />
+    <size android:width="100dp"
+        android:height="100dp" />
+</shape>

--- a/sample/kotlin/src/main/res/layout/fragment_image_components.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_image_components.xml
@@ -210,6 +210,29 @@
 
             </LinearLayout>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:gravity="center"
+                >
+
+                <ImageButton
+                    android:id="@+id/imageButtonWithShapeOval"
+                    android:layout_width="160dp"
+                    android:layout_height="160dp"
+                    android:src="@drawable/ic_dd_shape_oval"
+                    />
+
+                <ImageButton
+                    android:id="@+id/imageButtonWithShapeRect"
+                    android:layout_width="160dp"
+                    android:layout_height="160dp"
+                    android:src="@drawable/ic_dd_shape_rect"
+                    />
+
+            </LinearLayout>
+
             <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"


### PR DESCRIPTION
### What does this PR do?
Implement bitmap downscaling similar to what was done on iOS, aiming to end up with a bitmap of 10kb or less. We calculate the expected dimensions sizes for a perfect square with the required filesize, and then work out the dimensions of the resized bitmap from that.

Things to consider: 

- We are later compressing the bitmaps to webp and this gives additional savings in file size, but it's difficult to predict in advance how much the savings will be. Should we be taking this into account in the scaling of the raw bitmap?

Some numbers from testing:
Initial bitmap size: 26544 
Size of bitmap after downscaling: 9400
After webp compression: 3136

### Motivation
This pr will allow us to more accurately size the lrucache

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

