### PR TITLE
Use `implementation` dependency for features in integrations modules

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -142,6 +142,7 @@ tasks.register("unitTestDebug") {
 tasks.register("unitTestTools") {
     dependsOn(
         ":sample:kotlin:assembleUs1Release",
+        ":sample:wear:assembleUs1Release",
         ":tools:unit:testJvmReleaseUnitTest",
         ":tools:detekt:test",
         ":tools:lint:test",

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -15,6 +15,7 @@ object AndroidConfig {
 
     const val TARGET_SDK = 33
     const val MIN_SDK = 21
+    const val MIN_SDK_FOR_WEAR = 23
     const val BUILD_TOOLS_VERSION = "33.0.2"
 
     val VERSION = Version(2, 0, 0, Version.Type.Snapshot)

--- a/instrumented/integration/build.gradle.kts
+++ b/instrumented/integration/build.gradle.kts
@@ -92,12 +92,11 @@ repositories {
 }
 
 dependencies {
-    implementation(project(":dd-sdk-android-core"))
-    implementation(project(":integrations:dd-sdk-android-okhttp"))
     implementation(project(":features:dd-sdk-android-session-replay"))
     implementation(project(":features:dd-sdk-android-logs"))
     implementation(project(":features:dd-sdk-android-trace"))
     implementation(project(":features:dd-sdk-android-rum"))
+    implementation(project(":integrations:dd-sdk-android-okhttp"))
 
     implementation(libs.gson)
     implementation(libs.kotlin)

--- a/instrumented/nightly-tests/build.gradle.kts
+++ b/instrumented/nightly-tests/build.gradle.kts
@@ -102,13 +102,12 @@ repositories {
 }
 
 dependencies {
-    implementation(project(":dd-sdk-android-core"))
-    implementation(project(":integrations:dd-sdk-android-okhttp"))
     implementation(project(":features:dd-sdk-android-ndk"))
     implementation(project(":features:dd-sdk-android-logs"))
     implementation(project(":features:dd-sdk-android-trace"))
     implementation(project(":features:dd-sdk-android-webview"))
     implementation(project(":features:dd-sdk-android-rum"))
+    implementation(project(":integrations:dd-sdk-android-okhttp"))
 
     implementation(libs.bundles.androidXNavigation)
     implementation(libs.gson)

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -74,8 +74,7 @@ android {
 }
 
 dependencies {
-    api(project(":dd-sdk-android-core"))
-    api(project(":features:dd-sdk-android-rum"))
+    implementation(project(":features:dd-sdk-android-rum"))
     implementation(libs.kotlin)
     implementation(libs.okHttp)
     implementation(libs.coil)

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -83,8 +83,7 @@ android {
 }
 
 dependencies {
-    api(project(":dd-sdk-android-core"))
-    api(project(":features:dd-sdk-android-rum"))
+    implementation(project(":features:dd-sdk-android-rum"))
     implementation(libs.kotlin)
     implementation(libs.androidXComposeRuntime)
     implementation(libs.androidXComposeMaterial)

--- a/integrations/dd-sdk-android-fresco/build.gradle.kts
+++ b/integrations/dd-sdk-android-fresco/build.gradle.kts
@@ -74,8 +74,7 @@ android {
 }
 
 dependencies {
-    api(project(":dd-sdk-android-core"))
-    api(project(":features:dd-sdk-android-rum"))
+    implementation(project(":features:dd-sdk-android-rum"))
     implementation(libs.kotlin)
     implementation(libs.okHttp)
     implementation(libs.bundles.fresco)

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -75,8 +75,7 @@ android {
 }
 
 dependencies {
-    api(project(":dd-sdk-android-core"))
-    api(project(":features:dd-sdk-android-rum"))
+    implementation(project(":features:dd-sdk-android-rum"))
     implementation(project(":integrations:dd-sdk-android-okhttp"))
     implementation(libs.kotlin)
     implementation(libs.okHttp)

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -94,9 +94,8 @@ android {
 }
 
 dependencies {
-    api(project(":dd-sdk-android-core"))
-    api(project(":features:dd-sdk-android-trace"))
-    api(project(":features:dd-sdk-android-rum"))
+    implementation(project(":features:dd-sdk-android-trace"))
+    implementation(project(":features:dd-sdk-android-rum"))
     implementation(libs.kotlin)
     implementation(libs.okHttp)
     implementation(libs.androidXAnnotation)

--- a/integrations/dd-sdk-android-rx/build.gradle.kts
+++ b/integrations/dd-sdk-android-rx/build.gradle.kts
@@ -74,8 +74,7 @@ android {
 }
 
 dependencies {
-    api(project(":dd-sdk-android-core"))
-    api(project(":features:dd-sdk-android-rum"))
+    implementation(project(":features:dd-sdk-android-rum"))
     implementation(libs.kotlin)
     implementation(libs.okHttp)
     implementation(libs.rxJava3)

--- a/integrations/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/integrations/dd-sdk-android-sqldelight/build.gradle.kts
@@ -74,9 +74,8 @@ android {
 }
 
 dependencies {
-    api(project(":dd-sdk-android-core"))
-    api(project(":features:dd-sdk-android-trace"))
-    api(project(":features:dd-sdk-android-rum"))
+    implementation(project(":features:dd-sdk-android-trace"))
+    implementation(project(":features:dd-sdk-android-rum"))
     implementation(libs.kotlin)
     implementation(libs.okHttp)
     implementation(libs.sqlDelight)

--- a/integrations/dd-sdk-android-timber/build.gradle.kts
+++ b/integrations/dd-sdk-android-timber/build.gradle.kts
@@ -75,8 +75,7 @@ android {
 }
 
 dependencies {
-    api(project(":dd-sdk-android-core"))
-    api(project(":features:dd-sdk-android-logs"))
+    implementation(project(":features:dd-sdk-android-logs"))
     implementation(libs.kotlin)
     implementation(libs.timber)
 

--- a/integrations/dd-sdk-android-tv/build.gradle.kts
+++ b/integrations/dd-sdk-android-tv/build.gradle.kts
@@ -74,8 +74,7 @@ android {
 }
 
 dependencies {
-    api(project(":dd-sdk-android-core"))
-    api(project(":features:dd-sdk-android-rum"))
+    implementation(project(":features:dd-sdk-android-rum"))
     implementation(libs.kotlin)
     implementation(libs.androidXLeanback)
 

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -114,8 +114,6 @@ android {
 }
 
 dependencies {
-
-    implementation(project(":dd-sdk-android-core"))
     implementation(project(":features:dd-sdk-android-logs"))
     implementation(project(":features:dd-sdk-android-rum"))
     implementation(project(":features:dd-sdk-android-trace"))

--- a/sample/wear/build.gradle.kts
+++ b/sample/wear/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         applicationId = "com.datadog.android.wear.sample"
-        minSdk = AndroidConfig.MIN_SDK
+        minSdk = AndroidConfig.MIN_SDK_FOR_WEAR
         targetSdk = AndroidConfig.TARGET_SDK
         versionCode = AndroidConfig.VERSION.code
         versionName = AndroidConfig.VERSION.name
@@ -63,8 +63,6 @@ android {
 }
 
 dependencies {
-
-    implementation(project(":dd-sdk-android-core"))
     implementation(project(":features:dd-sdk-android-ndk"))
     implementation(project(":features:dd-sdk-android-trace"))
     implementation(project(":features:dd-sdk-android-rum"))


### PR DESCRIPTION
### What does this PR do?

This change switches from `api` to `implementation` dependency type for features in integrations modules, in order to put more focus towards the individual feature setup.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

