### PR TITLE
RUMM-3475: Fix memory leak in `JankStats` usage

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -750,6 +750,7 @@ datadog:
       - "kotlin.collections.MutableList.forEachIndexed(kotlin.Function2)"
       - "kotlin.collections.MutableList.isEmpty()"
       - "kotlin.collections.MutableList.isNotEmpty()"
+      - "kotlin.collections.MutableList.isNullOrEmpty()"
       - "kotlin.collections.MutableList.iterator()"
       - "kotlin.collections.MutableList.joinToString(kotlin.CharSequence, kotlin.CharSequence, kotlin.CharSequence, kotlin.Int, kotlin.CharSequence, kotlin.Function1?)"
       - "kotlin.collections.MutableList.remove(java.io.File)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListener.kt
@@ -27,8 +27,8 @@ internal class JankStatsActivityLifecycleListener(
     private val jankStatsProvider: JankStatsProvider = JankStatsProvider.DEFAULT
 ) : ActivityLifecycleCallbacks, JankStats.OnFrameListener {
 
-    private val activeWindowsListener = WeakHashMap<Window, JankStats>()
-    private val activeActivities = WeakHashMap<Window, MutableList<WeakReference<Activity>>>()
+    internal val activeWindowsListener = WeakHashMap<Window, JankStats>()
+    internal val activeActivities = WeakHashMap<Window, MutableList<WeakReference<Activity>>>()
 
     // region ActivityLifecycleCallbacks
     @MainThread
@@ -106,6 +106,10 @@ internal class JankStatsActivityLifecycleListener(
 
     @MainThread
     override fun onActivityDestroyed(activity: Activity) {
+        if (activeActivities[activity.window].isNullOrEmpty()) {
+            activeWindowsListener.remove(activity.window)
+            activeActivities.remove(activity.window)
+        }
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListenerTest.kt
@@ -18,6 +18,7 @@ import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
@@ -142,7 +143,40 @@ internal class JankStatsActivityLifecycleListenerTest {
     }
 
     @Test
-    fun `𝕄 foNothing 𝕎 onActivityStopped() {}`() {
+    fun `𝕄 remove window 𝕎 onActivityDestroyed() { no more activities for window }`() {
+        // Given
+
+        // When
+        testedJankListener.onActivityStarted(mockActivity)
+        testedJankListener.onActivityStopped(mockActivity)
+        testedJankListener.onActivityDestroyed(mockActivity)
+
+        // Then
+        assertThat(testedJankListener.activeActivities).isEmpty()
+        assertThat(testedJankListener.activeWindowsListener).isEmpty()
+    }
+
+    @Test
+    fun `𝕄 not remove window 𝕎 onActivityDestroyed() { there are activities for window }`() {
+        // Given
+        val anotherActivity = mock<Activity>().apply {
+            whenever(window) doReturn mockWindow
+            whenever(display) doReturn mockDisplay
+        }
+
+        // When
+        testedJankListener.onActivityStarted(mockActivity)
+        testedJankListener.onActivityStopped(mockActivity)
+        testedJankListener.onActivityStarted(anotherActivity)
+        testedJankListener.onActivityDestroyed(mockActivity)
+
+        // Then
+        assertThat(testedJankListener.activeActivities).isNotEmpty
+        assertThat(testedJankListener.activeWindowsListener).isNotEmpty
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 onActivityStopped() {}`() {
         // Given
 
         // When


### PR DESCRIPTION
### What does this PR do?

There is a memory leak in the structure like `WeakHashMap<Window, JankStats>`, because `WeakHashMap` has strongly-referenced values, so it means if `JankStats` holds internally `Window` instance, it won't be GC-ed, even if it is a key of `WeakHashMap`.

In this PR we are removing the keys explicitly if activity is destroyed and there are no more activities left. This may increase the number of times we create `JankStats` instance, but it is not a big deal compared to the memory leak mitigation.

Even if there is a configuration change and activity will be re-created, it may be backed by new/another window anyway.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

