### PR TITLE
REPLAY-1905 Do not resolve WindowManager from Application context

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorder.kt
@@ -147,7 +147,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
             val windows = sessionReplayLifecycleCallback.getCurrentWindows()
             val decorViews = windowInspector.getGlobalWindowViews()
             windowCallbackInterceptor.intercept(windows, appContext)
-            viewOnDrawInterceptor.intercept(decorViews, appContext)
+            viewOnDrawInterceptor.intercept(decorViews)
         }
     }
 
@@ -165,7 +165,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         if (shouldRecord) {
             val decorViews = windowInspector.getGlobalWindowViews()
             windowCallbackInterceptor.intercept(windows, appContext)
-            viewOnDrawInterceptor.intercept(decorViews, appContext)
+            viewOnDrawInterceptor.intercept(decorViews)
         }
     }
 
@@ -174,7 +174,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         if (shouldRecord) {
             val decorViews = windowInspector.getGlobalWindowViews()
             windowCallbackInterceptor.stopIntercepting(windows)
-            viewOnDrawInterceptor.intercept(decorViews, appContext)
+            viewOnDrawInterceptor.intercept(decorViews)
         }
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptor.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.sessionreplay.internal.recorder
 
-import android.content.Context
 import android.view.View
 import android.view.ViewTreeObserver.OnDrawListener
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
@@ -16,10 +15,9 @@ import java.util.WeakHashMap
 internal class ViewOnDrawInterceptor(
     private val recordedDataQueueHandler: RecordedDataQueueHandler,
     private val snapshotProducer: SnapshotProducer,
-    private val onDrawListenerProducer: (Context, List<View>) -> OnDrawListener =
-        { activity, decorViews ->
+    private val onDrawListenerProducer: (List<View>) -> OnDrawListener =
+        { decorViews ->
             WindowsOnDrawListener(
-                activity,
                 decorViews,
                 recordedDataQueueHandler,
                 snapshotProducer
@@ -29,9 +27,9 @@ internal class ViewOnDrawInterceptor(
     internal val decorOnDrawListeners: WeakHashMap<View, OnDrawListener> =
         WeakHashMap()
 
-    fun intercept(decorViews: List<View>, appContext: Context) {
+    fun intercept(decorViews: List<View>) {
         stopInterceptingAndRemove(decorViews)
-        val onDrawListener = onDrawListenerProducer(appContext, decorViews)
+        val onDrawListener = onDrawListenerProducer(decorViews)
         decorViews.forEach { decorView ->
             decorOnDrawListeners[decorView] = onDrawListener
             decorView.viewTreeObserver?.addOnDrawListener(onDrawListener)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallback.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallback.kt
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 
 @Suppress("TooGenericExceptionCaught")
 internal class RecorderWindowCallback(
-    private val appContext: Context,
+    appContext: Context,
     private val recordedDataQueueHandler: RecordedDataQueueHandler,
     internal val wrappedCallback: Window.Callback,
     private val timeProvider: TimeProvider,
@@ -146,7 +146,7 @@ internal class RecorderWindowCallback(
             // a new window was added or removed so we stop recording the previous root views
             // and we start recording the new ones.
             viewOnDrawInterceptor.stopIntercepting()
-            viewOnDrawInterceptor.intercept(rootViews, appContext)
+            viewOnDrawInterceptor.intercept(rootViews)
         }
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
@@ -131,8 +131,7 @@ internal class SessionReplayRecorderTest {
         // Then
         verify(mockWindowCallbackInterceptor).intercept(fakeActiveWindows, appContext.mockInstance)
         verify(mockViewOnDrawInterceptor).intercept(
-            fakeActiveWindowsDecorViews,
-            appContext.mockInstance
+            fakeActiveWindowsDecorViews
         )
     }
 
@@ -161,7 +160,7 @@ internal class SessionReplayRecorderTest {
 
         // Then
         verify(mockWindowCallbackInterceptor).intercept(fakeAddedWindows, appContext.mockInstance)
-        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews, appContext.mockInstance)
+        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews)
     }
 
     @Test
@@ -182,7 +181,7 @@ internal class SessionReplayRecorderTest {
         verify(mockWindowCallbackInterceptor, never())
             .intercept(fakeAddedWindows, appContext.mockInstance)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, appContext.mockInstance)
+            .intercept(fakeNewDecorViews)
     }
 
     @Test
@@ -203,7 +202,7 @@ internal class SessionReplayRecorderTest {
         verify(mockWindowCallbackInterceptor, never())
             .intercept(fakeAddedWindows, appContext.mockInstance)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, appContext.mockInstance)
+            .intercept(fakeNewDecorViews)
     }
 
     @Test
@@ -221,7 +220,7 @@ internal class SessionReplayRecorderTest {
 
         // Then
         verify(mockWindowCallbackInterceptor).stopIntercepting(fakeAddedWindows)
-        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews, appContext.mockInstance)
+        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews)
     }
 
     @Test
@@ -241,7 +240,7 @@ internal class SessionReplayRecorderTest {
         // Then
         verify(mockWindowCallbackInterceptor, never()).stopIntercepting(fakeAddedWindows)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, appContext.mockInstance)
+            .intercept(fakeNewDecorViews)
     }
 
     @Test
@@ -259,7 +258,7 @@ internal class SessionReplayRecorderTest {
         // Then
         verify(mockWindowCallbackInterceptor, never()).stopIntercepting(fakeAddedWindows)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, appContext.mockInstance)
+            .intercept(fakeNewDecorViews)
     }
 
     companion object {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptorTest.kt
@@ -6,9 +6,6 @@
 
 package com.datadog.android.sessionreplay.internal.recorder
 
-import android.app.Activity
-import android.content.res.Resources
-import android.util.DisplayMetrics
 import android.view.View
 import android.view.ViewTreeObserver
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
@@ -25,7 +22,6 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
@@ -51,11 +47,8 @@ internal class ViewOnDrawInterceptorTest {
 
     lateinit var fakeDecorViews: List<View>
 
-    lateinit var mockActivity: Activity
-
     @BeforeEach
     fun `set up`(forge: Forge) {
-        mockActivity = forge.aMockedActivity()
         fakeDecorViews = forge.aMockedDecorViewsList()
         testedInterceptor = ViewOnDrawInterceptor(
             mockRecordedDataQueueHandler,
@@ -66,7 +59,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M register the OnDrawListener W intercept()`() {
         // When
-        testedInterceptor.intercept(fakeDecorViews, mockActivity)
+        testedInterceptor.intercept(fakeDecorViews)
 
         // Then
         val captor = argumentCaptor<ViewTreeObserver.OnDrawListener>()
@@ -83,10 +76,10 @@ internal class ViewOnDrawInterceptorTest {
         testedInterceptor = ViewOnDrawInterceptor(
             mockRecordedDataQueueHandler,
             mockSnapshotProducer
-        ) { _, _ -> mockOnDrawListener }
+        ) { _ -> mockOnDrawListener }
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, mockActivity)
+        testedInterceptor.intercept(fakeDecorViews)
 
         // Then
         fakeDecorViews.forEach {
@@ -98,7 +91,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M register one single listener instance W intercept()`() {
         // When
-        testedInterceptor.intercept(fakeDecorViews, mockActivity)
+        testedInterceptor.intercept(fakeDecorViews)
 
         // Then
         val captor = argumentCaptor<ViewTreeObserver.OnDrawListener>()
@@ -115,7 +108,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister and clean the listeners W stopIntercepting(decorViews)`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, mockActivity)
+        testedInterceptor.intercept(fakeDecorViews)
 
         // When
         testedInterceptor.stopIntercepting(fakeDecorViews)
@@ -132,7 +125,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister and clean the listeners W stopIntercepting()`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, mockActivity)
+        testedInterceptor.intercept(fakeDecorViews)
 
         // When
         testedInterceptor.stopIntercepting()
@@ -149,10 +142,10 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister first and clean the listeners W intercepting()`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, mockActivity)
+        testedInterceptor.intercept(fakeDecorViews)
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, mockActivity)
+        testedInterceptor.intercept(fakeDecorViews)
 
         // Then
         fakeDecorViews.forEach {
@@ -165,38 +158,7 @@ internal class ViewOnDrawInterceptorTest {
         }
     }
 
-    @Test
-    fun `M register listener startRecording() { more activities }`(forge: Forge) {
-        // Given
-        val fakeDecorsActivitiesPairs = forge.aList {
-            aMockedDecorViewsList() to aMockedActivity()
-        }
-
-        // When
-        fakeDecorsActivitiesPairs.forEach {
-            testedInterceptor.intercept(it.first, it.second)
-        }
-
-        // Then
-        fakeDecorsActivitiesPairs.map { it.first }.flatten().forEach {
-            it.viewTreeObserver.inOrder {
-                verify().addOnDrawListener(any())
-            }
-        }
-    }
-
     // region Internal
-
-    private fun Forge.aMockedActivity(): Activity {
-        val mockActivity: Activity = mock()
-        val fakeDensity = aPositiveFloat()
-        val displayMetrics = DisplayMetrics().apply { density = fakeDensity }
-        val mockResources: Resources = mock {
-            whenever(it.displayMetrics).thenReturn(displayMetrics)
-        }
-        whenever(mockActivity.resources).thenReturn(mockResources)
-        return mockActivity
-    }
 
     private fun Forge.aMockedDecorViewsList(): List<View> {
         return aList {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallbackTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallbackTest.kt
@@ -386,7 +386,7 @@ internal class RecorderWindowCallbackTest {
         // Then
         inOrder(mockViewOnDrawInterceptor) {
             verify(mockViewOnDrawInterceptor).stopIntercepting()
-            verify(mockViewOnDrawInterceptor).intercept(fakeDecorViews, mockContext)
+            verify(mockViewOnDrawInterceptor).intercept(fakeDecorViews)
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

In this PR we are fixing the `StrictMode` `IllegalAccesException` when trying to get the `WindowManager` from the `Application` instead of getting it from a visual `Context` as recommended. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

