### PR TITLE
REPLAY-1943: Refactor caches from singletons to class instances

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -339,6 +339,8 @@ datadog:
       - "android.view.Window.Callback.onMenuItemSelected(kotlin.Int, android.view.MenuItem)"
       - "android.view.View.getChildAt(kotlin.Int)"
       - "android.view.View.hashCode()"
+      - "androidx.collection.LruCache.size()"
+      - "androidx.collection.LruCache.maxSize()"
       # endregion
       # region Android Webview APIs
       - "android.webkit.ConsoleMessage.MessageLevel.toLogLevel()"

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -31,7 +31,7 @@ class com.datadog.android.sessionreplay.internal.recorder.base64.WebPImageCompre
   override fun compressBitmap(android.graphics.Bitmap): ByteArray
   companion object 
 abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseWireframeMapper<T: android.view.View, S: com.datadog.android.sessionreplay.model.MobileSegment.Wireframe> : WireframeMapper<T, S>, com.datadog.android.sessionreplay.internal.AsyncImageProcessingCallback
-  constructor(com.datadog.android.sessionreplay.utils.StringUtils = StringUtils, com.datadog.android.sessionreplay.utils.ViewUtils = ViewUtils, com.datadog.android.sessionreplay.internal.recorder.base64.ImageCompression = WebPImageCompression(), com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator = UniqueIdentifierGenerator, com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer = Base64Serializer.Builder().build())
+  constructor(com.datadog.android.sessionreplay.utils.StringUtils = StringUtils, com.datadog.android.sessionreplay.utils.ViewUtils = ViewUtils)
   protected fun resolveViewId(android.view.View): Long
   protected fun colorAndAlphaAsStringHexa(Int, Int): String
   protected fun resolveViewGlobalBounds(android.view.View, Float): com.datadog.android.sessionreplay.internal.recorder.GlobalBounds

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -88,7 +88,7 @@ public final class com/datadog/android/sessionreplay/internal/recorder/SystemInf
 }
 
 public final class com/datadog/android/sessionreplay/internal/recorder/base64/Base64Serializer {
-	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;Lcom/datadog/android/sessionreplay/internal/utils/DrawableUtils;Lcom/datadog/android/sessionreplay/internal/utils/Base64Utils;Lcom/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression;Lcom/datadog/android/sessionreplay/internal/recorder/base64/Cache;Lcom/datadog/android/sessionreplay/internal/recorder/base64/Cache;Lcom/datadog/android/api/InternalLogger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;Lcom/datadog/android/sessionreplay/internal/utils/DrawableUtils;Lcom/datadog/android/sessionreplay/internal/utils/Base64Utils;Lcom/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression;Lcom/datadog/android/sessionreplay/internal/recorder/base64/Cache;Lcom/datadog/android/sessionreplay/internal/recorder/base64/BitmapPool;Lcom/datadog/android/api/InternalLogger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
 }
 
 public abstract interface class com/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression {
@@ -108,12 +108,12 @@ public final class com/datadog/android/sessionreplay/internal/recorder/base64/We
 public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper : com/datadog/android/sessionreplay/internal/AsyncImageProcessingCallback, com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper$Companion;
 	public fun <init> ()V
-	public fun <init> (Lcom/datadog/android/sessionreplay/utils/StringUtils;Lcom/datadog/android/sessionreplay/utils/ViewUtils;Lcom/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression;Lcom/datadog/android/sessionreplay/utils/UniqueIdentifierGenerator;Lcom/datadog/android/sessionreplay/internal/recorder/base64/Base64Serializer;)V
-	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/utils/StringUtils;Lcom/datadog/android/sessionreplay/utils/ViewUtils;Lcom/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression;Lcom/datadog/android/sessionreplay/utils/UniqueIdentifierGenerator;Lcom/datadog/android/sessionreplay/internal/recorder/base64/Base64Serializer;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/sessionreplay/utils/StringUtils;Lcom/datadog/android/sessionreplay/utils/ViewUtils;)V
+	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/utils/StringUtils;Lcom/datadog/android/sessionreplay/utils/ViewUtils;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected final fun colorAndAlphaAsStringHexa (II)Ljava/lang/String;
 	public fun finishProcessingImage ()V
 	protected final fun getWebPMimeType ()Ljava/lang/String;
-	protected final fun handleBitmap (Landroid/content/Context;Landroid/util/DisplayMetrics;Landroid/graphics/drawable/Drawable;Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;)V
+	protected final fun handleBitmap (Landroid/content/Context;Landroid/util/DisplayMetrics;Landroid/graphics/drawable/Drawable;Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;)Lkotlin/Unit;
 	protected final fun resolveChildDrawableUniqueIdentifier (Landroid/view/View;)Ljava/lang/Long;
 	protected final fun resolveShapeStyleAndBorder (Landroid/graphics/drawable/Drawable;F)Lkotlin/Pair;
 	protected final fun resolveViewGlobalBounds (Landroid/view/View;F)Lcom/datadog/android/sessionreplay/internal/recorder/GlobalBounds;

--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -27,7 +27,6 @@ plugins {
     id("com.github.ben-manes.versions")
 
     // Tests
-    id("de.mobilej.unmock")
     id("org.jetbrains.kotlinx.kover")
 
     // Internal Generation
@@ -111,10 +110,6 @@ dependencies {
 
 apply(from = "clone_session_replay_schema.gradle.kts")
 apply(from = "generate_session_replay_models.gradle.kts")
-
-unMock {
-    keep("android.util.LruCache")
-}
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
 junitConfig()

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
@@ -20,6 +20,9 @@ import android.widget.SeekBar
 import android.widget.TextView
 import android.widget.Toolbar
 import androidx.appcompat.widget.SwitchCompat
+import com.datadog.android.sessionreplay.internal.recorder.base64.Base64LRUCache
+import com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer
+import com.datadog.android.sessionreplay.internal.recorder.base64.BitmapPool
 import com.datadog.android.sessionreplay.internal.recorder.mapper.BasePickerMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
@@ -77,9 +80,11 @@ enum class SessionReplayPrivacy {
 
     @Suppress("LongMethod")
     internal fun mappers(): List<MapperTypeWrapper> {
+        val base64Serializer = buildBase64Serializer()
+
         val viewWireframeMapper = ViewWireframeMapper()
         val unsupportedViewMapper = UnsupportedViewMapper()
-        val imageButtonMapper = ImageButtonMapper()
+        val imageButtonMapper = ImageButtonMapper(base64Serializer = base64Serializer)
         val imageMapper: ViewScreenshotWireframeMapper
         val textMapper: TextViewMapper
         val buttonMapper: ButtonMapper
@@ -159,6 +164,17 @@ enum class SessionReplayPrivacy {
             )
         }
         return mappersList
+    }
+
+    private fun buildBase64Serializer(): Base64Serializer {
+        val bitmapPool = BitmapPool()
+        val base64LRUCache = Base64LRUCache()
+
+        val builder = Base64Serializer.Builder(
+            bitmapPool = bitmapPool,
+            base64LRUCache = base64LRUCache
+        )
+        return builder.build()
     }
 
     private fun getMaskSeekBarMapper(): MaskSeekBarWireframeMapper? {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/BitmapPoolHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/BitmapPoolHelper.kt
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+import android.graphics.Bitmap
+import com.datadog.android.sessionreplay.internal.utils.InvocationUtils
+
+internal class BitmapPoolHelper(
+    private val invocationUtils: InvocationUtils = InvocationUtils()
+) {
+    internal fun generateKey(bitmap: Bitmap) =
+        generateKey(bitmap.width, bitmap.height, bitmap.config)
+
+    internal fun generateKey(width: Int, height: Int, config: Bitmap.Config) =
+        "$width-$height-$config"
+
+    internal fun<R> safeCall(call: () -> R): R? =
+        invocationUtils.safeCallWithErrorLogging(
+            call = { call() },
+            failureMessage = BITMAP_OPERATION_FAILED
+        )
+
+    private companion object {
+        private const val BITMAP_OPERATION_FAILED = "operation failed for bitmap pool"
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
@@ -28,12 +28,29 @@ import com.datadog.android.sessionreplay.utils.ViewUtils
 @Suppress("UndocumentedPublicClass")
 abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wireframe>(
     private val stringUtils: StringUtils = StringUtils,
-    private val viewUtils: ViewUtils = ViewUtils,
-    private val webPImageCompression: ImageCompression = WebPImageCompression(),
-    private val uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator,
-    // TODO: REPLAY-1856 find a way to remove base64 dependency from the constructor
-    private val base64Serializer: Base64Serializer = Base64Serializer.Builder().build()
+    private val viewUtils: ViewUtils = ViewUtils
 ) : WireframeMapper<T, S>, AsyncImageProcessingCallback {
+    private var base64Serializer: Base64Serializer? = null
+    private var webPImageCompression: ImageCompression = WebPImageCompression()
+    private var uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator
+
+    internal constructor(
+        base64Serializer: Base64Serializer? = null,
+        webPImageCompression: ImageCompression? = null,
+        uniqueIdentifierGenerator: UniqueIdentifierGenerator? = null
+    ) : this() {
+        base64Serializer?.let {
+            this.base64Serializer = it
+        }
+
+        webPImageCompression?.let {
+            this.webPImageCompression = it
+        }
+
+        uniqueIdentifierGenerator?.let {
+            this.uniqueIdentifierGenerator = it
+        }
+    }
 
     /**
      * Resolves the [View] unique id to be used in the mapped [MobileSegment.Wireframe].
@@ -108,7 +125,7 @@ abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wireframe>(
         displayMetrics: DisplayMetrics,
         drawable: Drawable,
         imageWireframe: MobileSegment.Wireframe.ImageWireframe
-    ) = base64Serializer.handleBitmap(
+    ) = base64Serializer?.handleBitmap(
         applicationContext,
         displayMetrics,
         drawable,
@@ -118,7 +135,7 @@ abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wireframe>(
     internal fun registerAsyncImageProcessingCallback(
         asyncImageProcessingCallback: AsyncImageProcessingCallback
     ) {
-        base64Serializer.registerAsyncLoadingCallback(asyncImageProcessingCallback)
+        base64Serializer?.registerAsyncLoadingCallback(asyncImageProcessingCallback)
     }
 
     override fun startProcessingImage() {}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
@@ -24,7 +24,7 @@ import kotlin.math.sqrt
 internal class DrawableUtils(
     private val bitmapWrapper: BitmapWrapper = BitmapWrapper(),
     private val canvasWrapper: CanvasWrapper = CanvasWrapper(),
-    private val bitmapPool: BitmapPool = BitmapPool
+    private val bitmapPool: BitmapPool? = null
 ) {
     /**
      * This method attempts to create a bitmap from a drawable, such that the bitmap file size will
@@ -88,7 +88,7 @@ internal class DrawableUtils(
         height: Int,
         config: Config
     ): Bitmap? =
-        bitmapPool.getBitmapByProperties(width, height, config)
+        bitmapPool?.getBitmapByProperties(width, height, config)
             ?: bitmapWrapper.createBitmap(displayMetrics, width, height, config)
 
     @MainThread

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/InvocationUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/InvocationUtils.kt
@@ -11,7 +11,8 @@ import com.datadog.android.api.InternalLogger
 internal class InvocationUtils {
     @Suppress("SwallowedException", "TooGenericExceptionCaught")
     inline fun<R> safeCallWithErrorLogging(
-        logger: InternalLogger,
+        // Temporarily use UNBOUND until we handle the loggers
+        logger: InternalLogger = InternalLogger.UNBOUND,
         call: () -> R,
         failureMessage: String,
         level: InternalLogger.Level = InternalLogger.Level.WARN,
@@ -24,7 +25,8 @@ internal class InvocationUtils {
             logger.log(
                 level,
                 target,
-                { failureMessage }
+                { failureMessage },
+                e
             )
         }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapperTest.kt
@@ -46,7 +46,7 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(ForgeConfigurator::class)
 internal class ImageButtonMapperTest {
 
-    lateinit var testedMapper: ImageButtonMapper
+    private lateinit var testedMapper: ImageButtonMapper
 
     @Mock
     lateinit var mockImageButton: ImageButton


### PR DESCRIPTION
### What does this PR do?
Refactor the base64 drawable cache and the bitmap pool to be class instances instead of singletons.

### Motivation
Make things more straightforward to test and remove mutable variables

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

