### PR TITLE
REPLAY-1895 Remove the query parameters from SR requests

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactory.kt
@@ -42,29 +42,13 @@ internal class SessionReplayRequestFactory(
         return resolveRequest(context, body)
     }
 
-    private fun tags(datadogContext: DatadogContext): String {
-        val elements = mutableListOf(
-            "$SERVICE_NAME:${datadogContext.service}",
-            "$APPLICATION_VERSION:${datadogContext.version}",
-            "$SDK_VERSION:${datadogContext.sdkVersion}",
-            "$ENV:${datadogContext.env}"
-        )
-        if (datadogContext.variant.isNotEmpty()) {
-            elements.add("$VARIANT:${datadogContext.variant}")
-        }
-        return elements.joinToString(",")
-    }
-
     private fun buildUrl(datadogContext: DatadogContext): String {
-        val queryParams = buildQueryParameters(datadogContext)
-        val intakeUrl = String.format(
+        return String.format(
             Locale.US,
             UPLOAD_URL,
             customEndpointUrl ?: datadogContext.site.intakeEndpoint,
             "replay"
         )
-        return intakeUrl + queryParams.map { "${it.key}=${it.value}" }
-            .joinToString("&", prefix = "?")
     }
 
     private fun resolveHeaders(datadogContext: DatadogContext, requestId: String):
@@ -74,13 +58,6 @@ internal class SessionReplayRequestFactory(
             RequestFactory.HEADER_EVP_ORIGIN to datadogContext.source,
             RequestFactory.HEADER_EVP_ORIGIN_VERSION to datadogContext.sdkVersion,
             RequestFactory.HEADER_REQUEST_ID to requestId
-        )
-    }
-
-    private fun buildQueryParameters(datadogContext: DatadogContext): Map<String, Any> {
-        return mapOf(
-            RequestFactory.QUERY_PARAM_SOURCE to datadogContext.source,
-            RequestFactory.QUERY_PARAM_TAGS to tags(datadogContext)
         )
     }
 
@@ -113,10 +90,5 @@ internal class SessionReplayRequestFactory(
 
     companion object {
         private const val UPLOAD_URL = "%s/api/v2/%s"
-        internal const val APPLICATION_VERSION = "version"
-        internal const val ENV = "env"
-        internal const val SERVICE_NAME = "service"
-        internal const val VARIANT = "variant"
-        internal const val SDK_VERSION = "sdk_version"
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactoryTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/domain/SessionReplayRequestFactoryTest.kt
@@ -176,20 +176,7 @@ internal class SessionReplayRequestFactoryTest {
     // region Internal
 
     private fun expectedUrl(endpointUrl: String): String {
-        val queryTags = mutableListOf(
-            "${SessionReplayRequestFactory.SERVICE_NAME}:${fakeDatadogContext.service}",
-            "${SessionReplayRequestFactory.APPLICATION_VERSION}:${fakeDatadogContext.version}",
-            "${SessionReplayRequestFactory.SDK_VERSION}:${fakeDatadogContext.sdkVersion}",
-            "${SessionReplayRequestFactory.ENV}:${fakeDatadogContext.env}"
-        )
-
-        if (fakeDatadogContext.variant.isNotEmpty()) {
-            queryTags.add("${SessionReplayRequestFactory.VARIANT}:${fakeDatadogContext.variant}")
-        }
-
-        return "$endpointUrl/api/v2/replay?${RequestFactory.QUERY_PARAM_SOURCE}=" +
-            "${fakeDatadogContext.source}&${RequestFactory.QUERY_PARAM_TAGS}=" +
-            queryTags.joinToString(",")
+        return "$endpointUrl/api/v2/replay"
     }
 
     private fun RequestBody.toByteArray(): ByteArray {


### PR DESCRIPTION
### What does this PR do?

In this PR we align with the Session Replay payload upload request format in [iOS](https://github.com/DataDog/dd-sdk-ios/blob/670006d6c3f41ad2652c6f154fd4fda7d04a04a8/DatadogSessionReplay/Sources/Feature/RequestBuilder/RequestBuilder.swift) by dropping the query parameters.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

