### PR TITLE
RUMM-3508 Add the additionalProperties capability to telemetry debug log event

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -42,8 +42,8 @@ interface com.datadog.android.api.InternalLogger
     - USER
     - MAINTAINER
     - TELEMETRY
-  fun log(Level, Target, () -> String, Throwable? = null, Boolean = false)
-  fun log(Level, List<Target>, () -> String, Throwable? = null, Boolean = false)
+  fun log(Level, Target, () -> String, Throwable? = null, Boolean = false, Map<String, Any?>? = null)
+  fun log(Level, List<Target>, () -> String, Throwable? = null, Boolean = false, Map<String, Any?>? = null)
   companion object 
     val UNBOUND: InternalLogger
 interface com.datadog.android.api.SdkCore

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -75,8 +75,8 @@ public final class com/datadog/android/_InternalProxy$_TelemetryProxy {
 
 public abstract interface class com/datadog/android/api/InternalLogger {
 	public static final field Companion Lcom/datadog/android/api/InternalLogger$Companion;
-	public abstract fun log (Lcom/datadog/android/api/InternalLogger$Level;Lcom/datadog/android/api/InternalLogger$Target;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;Z)V
-	public abstract fun log (Lcom/datadog/android/api/InternalLogger$Level;Ljava/util/List;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;Z)V
+	public abstract fun log (Lcom/datadog/android/api/InternalLogger$Level;Lcom/datadog/android/api/InternalLogger$Target;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ZLjava/util/Map;)V
+	public abstract fun log (Lcom/datadog/android/api/InternalLogger$Level;Ljava/util/List;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ZLjava/util/Map;)V
 }
 
 public final class com/datadog/android/api/InternalLogger$Companion {
@@ -84,8 +84,8 @@ public final class com/datadog/android/api/InternalLogger$Companion {
 }
 
 public final class com/datadog/android/api/InternalLogger$DefaultImpls {
-	public static synthetic fun log$default (Lcom/datadog/android/api/InternalLogger;Lcom/datadog/android/api/InternalLogger$Level;Lcom/datadog/android/api/InternalLogger$Target;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ZILjava/lang/Object;)V
-	public static synthetic fun log$default (Lcom/datadog/android/api/InternalLogger;Lcom/datadog/android/api/InternalLogger$Level;Ljava/util/List;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ZILjava/lang/Object;)V
+	public static synthetic fun log$default (Lcom/datadog/android/api/InternalLogger;Lcom/datadog/android/api/InternalLogger$Level;Lcom/datadog/android/api/InternalLogger$Target;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ZLjava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun log$default (Lcom/datadog/android/api/InternalLogger;Lcom/datadog/android/api/InternalLogger$Level;Ljava/util/List;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ZLjava/util/Map;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/api/InternalLogger$Level : java/lang/Enum {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/InternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/InternalLogger.kt
@@ -66,13 +66,15 @@ interface InternalLogger {
      * @param throwable an optional throwable error
      * @param onlyOnce whether only one instance of the message should be sent per lifetime of the
      * logger (default is `false`)
+     * @param additionalProperties additional properties to add to the log
      */
     fun log(
         level: Level,
         target: Target,
         messageBuilder: () -> String,
         throwable: Throwable? = null,
-        onlyOnce: Boolean = false
+        onlyOnce: Boolean = false,
+        additionalProperties: Map<String, Any?>? = null
     )
 
     /**
@@ -83,13 +85,15 @@ interface InternalLogger {
      * @param throwable an optional throwable error
      * @param onlyOnce whether only one instance of the message should be sent per lifetime of the
      * logger (default is `false`, onlyOnce applies to each target independently)
+     * @param additionalProperties additional properties to add to the log
      */
     fun log(
         level: Level,
         targets: List<Target>,
         messageBuilder: () -> String,
         throwable: Throwable? = null,
-        onlyOnce: Boolean = false
+        onlyOnce: Boolean = false,
+        additionalProperties: Map<String, Any?>? = null
     )
 
     companion object {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -409,7 +409,8 @@ internal class DatadogTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             val actualMessage = firstValue()
             val filteredActualMessage = actualMessage

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/SdkInternalLoggerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/SdkInternalLoggerTest.kt
@@ -283,6 +283,72 @@ internal class SdkInternalLoggerTest {
     }
 
     @Test
+    fun `𝕄 send telemetry log 𝕎 log { TELEMETRY target, additional properties + info or debug }`(
+        @StringForgery fakeMessage: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeAdditionalProperties = forge.aMap {
+            forge.anAlphabeticalString() to forge.aNullable { anAlphabeticalString() }
+        }
+        val mockLambda: () -> String = mock()
+        whenever(mockLambda.invoke()) doReturn fakeMessage
+        val fakeLevel = forge.anElementFrom(InternalLogger.Level.INFO, InternalLogger.Level.DEBUG)
+        val mockRumFeatureScope = mock<FeatureScope>()
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+
+        // When
+        testedInternalLogger.log(
+            fakeLevel,
+            InternalLogger.Target.TELEMETRY,
+            mockLambda,
+            null,
+            additionalProperties = fakeAdditionalProperties
+        )
+
+        // Then
+        verify(mockRumFeatureScope)
+            .sendEvent(
+                mapOf(
+                    "type" to "telemetry_debug",
+                    "message" to fakeMessage,
+                    "additionalProperties" to fakeAdditionalProperties
+                )
+            )
+    }
+
+    @Test
+    fun `𝕄 send telemetry log 𝕎 log { TELEMETRY target, additional prop empty + info or debug }`(
+        @StringForgery fakeMessage: String,
+        forge: Forge
+    ) {
+        // Given
+        val mockLambda: () -> String = mock()
+        whenever(mockLambda.invoke()) doReturn fakeMessage
+        val fakeLevel = forge.anElementFrom(InternalLogger.Level.INFO, InternalLogger.Level.DEBUG)
+        val mockRumFeatureScope = mock<FeatureScope>()
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+
+        // When
+        testedInternalLogger.log(
+            fakeLevel,
+            InternalLogger.Target.TELEMETRY,
+            mockLambda,
+            null,
+            additionalProperties = emptyMap()
+        )
+
+        // Then
+        verify(mockRumFeatureScope)
+            .sendEvent(
+                mapOf(
+                    "type" to "telemetry_debug",
+                    "message" to fakeMessage
+                )
+            )
+    }
+
+    @Test
     fun `𝕄 send telemetry log 𝕎 log { TELEMETRY target, no throwable + warn or error }`(
         @StringForgery fakeMessage: String,
         forge: Forge

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/HostsSanitizerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/HostsSanitizerTest.kt
@@ -136,7 +136,8 @@ internal class HostsSanitizerTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(allValues.map { it() })
                 .containsExactlyInAnyOrderElementsOf(expectedMessages)
@@ -171,7 +172,8 @@ internal class HostsSanitizerTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(allValues.map { it() })
                 .containsExactlyInAnyOrderElementsOf(expectedMessages)
@@ -256,7 +258,8 @@ internal class HostsSanitizerTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(allValues.map { it() })
                 .containsExactlyInAnyOrderElementsOf(expectedMessages)
@@ -289,7 +292,8 @@ internal class HostsSanitizerTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 any<MalformedURLException>(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(allValues.map { it() })
                 .containsExactlyInAnyOrderElementsOf(expectedMessages)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/constraints/DatadogDataConstraintsTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/constraints/DatadogDataConstraintsTest.kt
@@ -373,7 +373,8 @@ internal class DatadogDataConstraintsTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
 
             assertThat(allValues.map { it() })

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
@@ -280,7 +280,8 @@ internal class ConsentAwareStorageTest {
             eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
             any(),
             isA<RejectedExecutionException>(),
-            eq(false)
+            eq(false),
+            eq(null)
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/PlainBatchFileReaderWriterTest.kt
@@ -189,7 +189,8 @@ internal class PlainBatchFileReaderWriterTest {
                 eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
                 capture(),
                 any(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue())
                 .isEqualTo(PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path))
@@ -221,7 +222,8 @@ internal class PlainBatchFileReaderWriterTest {
                 eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
                 capture(),
                 any(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue())
                 .isEqualTo(PlainBatchFileReaderWriter.ERROR_WRITE.format(Locale.US, file.path))
@@ -253,7 +255,8 @@ internal class PlainBatchFileReaderWriterTest {
                 eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
                 capture(),
                 any(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue())
                 .isEqualTo(PlainBatchFileReaderWriter.ERROR_READ.format(Locale.US, file.path))
@@ -279,7 +282,8 @@ internal class PlainBatchFileReaderWriterTest {
                 eq(listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY)),
                 capture(),
                 any(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue())
                 .isEqualTo(PlainBatchFileReaderWriter.ERROR_READ.format(Locale.US, file.path))
@@ -384,7 +388,8 @@ internal class PlainBatchFileReaderWriterTest {
                 eq(InternalLogger.Target.MAINTAINER),
                 capture(),
                 any(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue())
                 .isEqualTo(PlainBatchFileReaderWriter.ERROR_FAILED_META_PARSE)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/InternalLoggerUtils.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/InternalLoggerUtils.kt
@@ -22,7 +22,8 @@ fun InternalLogger.verifyLog(
     message: String,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -30,7 +31,8 @@ fun InternalLogger.verifyLog(
             eq(target),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -44,7 +46,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -52,7 +55,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(target),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -66,7 +70,8 @@ fun InternalLogger.verifyLog(
     message: String?,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -74,7 +79,8 @@ fun InternalLogger.verifyLog(
             eq(targets),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }
@@ -86,7 +92,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String?,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -94,7 +101,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(targets),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -710,6 +710,7 @@ datadog:
       - "kotlin.collections.Map.get(kotlin.String)"
       - "kotlin.collections.Map.isEmpty()"
       - "kotlin.collections.Map.isNotEmpty()"
+      - "kotlin.collections.Map.isNullOrEmpty()"
       - "kotlin.collections.Map.map(kotlin.Function1)"
       - "kotlin.collections.Map.mapKeys(kotlin.Function1)"
       - "kotlin.collections.Map.mapNotNull(kotlin.Function1)"

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LoggerBuilderTest.kt
@@ -100,7 +100,8 @@ internal class LoggerBuilderTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue()).isEqualTo(Logger.SDK_NOT_INITIALIZED_WARNING_MESSAGE)
         }

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -243,7 +243,8 @@ internal class LogsFeatureTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue()).isEqualTo(
                 LogsFeature.UNSUPPORTED_EVENT_TYPE.format(
@@ -276,7 +277,8 @@ internal class LogsFeatureTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue()).isEqualTo(
                 LogsFeature.UNKNOWN_EVENT_TYPE_PROPERTY_VALUE.format(Locale.US, event["type"])
@@ -336,7 +338,8 @@ internal class LogsFeatureTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue()).isEqualTo(
                 LogsFeature.JVM_CRASH_EVENT_MISSING_MANDATORY_FIELDS_WARNING
@@ -559,7 +562,8 @@ internal class LogsFeatureTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue()).isEqualTo(
                 LogsFeature.NDK_CRASH_EVENT_MISSING_MANDATORY_FIELDS_WARNING
@@ -763,7 +767,8 @@ internal class LogsFeatureTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue()).isEqualTo(
                 LogsFeature.SPAN_LOG_EVENT_MISSING_MANDATORY_FIELDS_WARNING

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventMapperWrapperTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/domain/event/LogEventMapperWrapperTest.kt
@@ -97,7 +97,8 @@ internal class LogEventMapperWrapperTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue()).isEqualTo(
                 LogEventMapperWrapper.NOT_SAME_EVENT_INSTANCE_WARNING_MESSAGE.format(
@@ -136,7 +137,8 @@ internal class LogEventMapperWrapperTest {
                 eq(InternalLogger.Target.USER),
                 capture(),
                 isNull(),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue()).isEqualTo(
                 LogEventMapperWrapper.EVENT_NULL_WARNING_MESSAGE.format(

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/storage/LogsDataWriterTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/storage/LogsDataWriterTest.kt
@@ -139,7 +139,8 @@ internal class LogsDataWriterTest {
                 eq(listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY)),
                 capture(),
                 eq(fakeThrowable),
-                eq(false)
+                eq(false),
+                eq(null)
             )
             assertThat(firstValue()).isEqualTo("Error serializing LogEvent model")
         }

--- a/features/dd-sdk-android-ndk/src/test/kotlin/com/datadog/android/ndk/internal/NdkCrashReportsFeatureTest.kt
+++ b/features/dd-sdk-android-ndk/src/test/kotlin/com/datadog/android/ndk/internal/NdkCrashReportsFeatureTest.kt
@@ -151,7 +151,8 @@ class NdkCrashReportsFeatureTest {
                     eq(InternalLogger.Target.USER),
                     capture(),
                     isNull(),
-                    eq(false)
+                    eq(false),
+                    eq(null)
                 )
             assertThat(lastValue()).isEqualTo(NdkCrashReportsFeature.NO_SDK_ROOT_DIR_MESSAGE)
         }

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -1531,7 +1531,7 @@ data class com.datadog.android.telemetry.model.TelemetryConfigurationEvent
       fun fromJson(kotlin.String): Telemetry
       fun fromJsonObject(com.google.gson.JsonObject): Telemetry
   data class Configuration
-    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<SelectedTracingPropagator>? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.Boolean? = null, ViewTrackingStrategy? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<SelectedTracingPropagator>? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.Boolean? = null, ViewTrackingStrategy? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration
@@ -1599,7 +1599,7 @@ data class com.datadog.android.telemetry.model.TelemetryDebugEvent
       fun fromJson(kotlin.String): Action
       fun fromJsonObject(com.google.gson.JsonObject): Action
   data class Telemetry
-    constructor(kotlin.String)
+    constructor(kotlin.String, kotlin.collections.MutableMap<kotlin.String, kotlin.Any?> = mutableMapOf())
     val type: kotlin.String
     val status: kotlin.String
     fun toJson(): com.google.gson.JsonElement

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -4642,8 +4642,8 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 public final class com/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Long;
 	public final fun component10 ()Ljava/lang/Boolean;
 	public final fun component11 ()Ljava/lang/Boolean;
@@ -4652,52 +4652,57 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public final fun component14 ()Ljava/lang/Boolean;
 	public final fun component15 ()Ljava/lang/Boolean;
 	public final fun component16 ()Ljava/lang/Boolean;
-	public final fun component17 ()Ljava/lang/String;
+	public final fun component17 ()Ljava/lang/Boolean;
 	public final fun component18 ()Ljava/lang/Boolean;
-	public final fun component19 ()Ljava/lang/Boolean;
+	public final fun component19 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/Long;
-	public final fun component20 ()Ljava/util/List;
-	public final fun component21 ()Ljava/lang/String;
-	public final fun component22 ()Ljava/lang/Boolean;
-	public final fun component23 ()Ljava/lang/Boolean;
+	public final fun component20 ()Ljava/lang/Boolean;
+	public final fun component21 ()Ljava/lang/Boolean;
+	public final fun component22 ()Ljava/util/List;
+	public final fun component23 ()Ljava/lang/String;
 	public final fun component24 ()Ljava/lang/Boolean;
 	public final fun component25 ()Ljava/lang/Boolean;
 	public final fun component26 ()Ljava/lang/Boolean;
 	public final fun component27 ()Ljava/lang/Boolean;
-	public final fun component28 ()Ljava/util/List;
-	public final fun component29 ()Ljava/util/List;
+	public final fun component28 ()Ljava/lang/Boolean;
+	public final fun component29 ()Ljava/lang/Boolean;
 	public final fun component3 ()Ljava/lang/Long;
 	public final fun component30 ()Ljava/lang/Boolean;
-	public final fun component31 ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;
-	public final fun component32 ()Ljava/lang/Boolean;
-	public final fun component33 ()Ljava/lang/Long;
-	public final fun component34 ()Ljava/lang/Boolean;
+	public final fun component31 ()Ljava/util/List;
+	public final fun component32 ()Ljava/util/List;
+	public final fun component33 ()Ljava/lang/Boolean;
+	public final fun component34 ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;
 	public final fun component35 ()Ljava/lang/Boolean;
-	public final fun component36 ()Ljava/lang/Boolean;
+	public final fun component36 ()Ljava/lang/Long;
 	public final fun component37 ()Ljava/lang/Boolean;
 	public final fun component38 ()Ljava/lang/Boolean;
 	public final fun component39 ()Ljava/lang/Boolean;
 	public final fun component4 ()Ljava/lang/Long;
 	public final fun component40 ()Ljava/lang/Boolean;
 	public final fun component41 ()Ljava/lang/Boolean;
-	public final fun component42 ()Ljava/lang/String;
+	public final fun component42 ()Ljava/lang/Boolean;
 	public final fun component43 ()Ljava/lang/Boolean;
-	public final fun component44 ()Ljava/lang/Long;
-	public final fun component45 ()Ljava/lang/Long;
-	public final fun component46 ()Ljava/lang/String;
-	public final fun component47 ()Ljava/lang/String;
-	public final fun component48 ()Ljava/lang/String;
+	public final fun component44 ()Ljava/lang/Boolean;
+	public final fun component45 ()Ljava/lang/String;
+	public final fun component46 ()Ljava/lang/Boolean;
+	public final fun component47 ()Ljava/lang/Long;
+	public final fun component48 ()Ljava/lang/Long;
+	public final fun component49 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/Long;
+	public final fun component50 ()Ljava/lang/String;
+	public final fun component51 ()Ljava/lang/String;
 	public final fun component6 ()Ljava/lang/Long;
 	public final fun component7 ()Ljava/lang/Long;
 	public final fun component8 ()Ljava/lang/Boolean;
 	public final fun component9 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
+	public final fun copy (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
 	public final fun getActionNameAttribute ()Ljava/lang/String;
+	public final fun getAllowFallbackToLocalStorage ()Ljava/lang/Boolean;
+	public final fun getAllowUntrustedEvents ()Ljava/lang/Boolean;
 	public final fun getBatchSize ()Ljava/lang/Long;
 	public final fun getBatchUploadFrequency ()Ljava/lang/Long;
 	public final fun getDartVersion ()Ljava/lang/String;
@@ -4744,6 +4749,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public final fun getUseProxy ()Ljava/lang/Boolean;
 	public final fun getUseSecureSessionCookie ()Ljava/lang/Boolean;
 	public final fun getUseTracing ()Ljava/lang/Boolean;
+	public final fun getUseWorkerUrl ()Ljava/lang/Boolean;
 	public final fun getViewTrackingStrategy ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;
 	public fun hashCode ()I
 	public final fun setDartVersion (Ljava/lang/String;)V
@@ -5022,13 +5028,16 @@ public final class com/datadog/android/telemetry/model/TelemetryDebugEvent$Sourc
 
 public final class com/datadog/android/telemetry/model/TelemetryDebugEvent$Telemetry {
 	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Telemetry$Companion;
-	public fun <init> (Ljava/lang/String;)V
+	public fun <init> (Ljava/lang/String;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun copy (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Telemetry;
-	public static synthetic fun copy$default (Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Telemetry;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Telemetry;
+	public final fun component2 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Ljava/util/Map;)Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Telemetry;
+	public static synthetic fun copy$default (Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Telemetry;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Telemetry;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Telemetry;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryDebugEvent$Telemetry;
+	public final fun getAdditionalProperties ()Ljava/util/Map;
 	public final fun getMessage ()Ljava/lang/String;
 	public final fun getStatus ()Ljava/lang/String;
 	public final fun getType ()Ljava/lang/String;

--- a/features/dd-sdk-android-rum/src/main/json/telemetry/configuration-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/telemetry/configuration-schema.json
@@ -63,7 +63,7 @@
                 },
                 "session_replay_sample_rate": {
                   "type": "integer",
-                  "description": "The percentage of sessions with Browser RUM & Session Replay pricing tracked",
+                  "description": "The percentage of sessions with RUM & Session Replay pricing tracked",
                   "minimum": 0,
                   "maximum": 100,
                   "readOnly": false
@@ -75,7 +75,7 @@
                 },
                 "use_proxy": {
                   "type": "boolean",
-                  "description": "Whether a proxy configured is used",
+                  "description": "Whether a proxy is used",
                   "readOnly": false
                 },
                 "use_before_send": {
@@ -108,6 +108,14 @@
                   "type": "boolean",
                   "description": "Whether a secure session cookie is used"
                 },
+                "allow_fallback_to_local_storage": {
+                  "type": "boolean",
+                  "description": "Whether it is allowed to use LocalStorage when cookies are not available"
+                },
+                "allow_untrusted_events": {
+                  "type": "boolean",
+                  "description": "Whether untrusted events are allowed"
+                },
                 "action_name_attribute": {
                   "type": "string",
                   "description": "Attribute to be used to name actions"
@@ -136,6 +144,10 @@
                 "use_excluded_activity_urls": {
                   "type": "boolean",
                   "description": "Whether the request origins list to ignore when computing the page activity is used"
+                },
+                "use_worker_url": {
+                  "type": "boolean",
+                  "description": "Whether the Worker is loaded from an external URL"
                 },
                 "track_frustrations": {
                   "type": "boolean",

--- a/features/dd-sdk-android-rum/src/main/json/telemetry/debug-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/telemetry/debug-schema.json
@@ -13,6 +13,7 @@
       "properties": {
         "telemetry": {
           "type": "object",
+          "additionalProperties": true,
           "description": "The telemetry log information",
           "required": ["status", "message"],
           "properties": {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -470,7 +470,6 @@ internal class RumFeature constructor(
         val throwable = telemetryEvent[EVENT_THROWABLE_PROPERTY] as? Throwable
         val stack = telemetryEvent[EVENT_STACKTRACE_PROPERTY] as? String
         val kind = telemetryEvent["kind"] as? String
-
         if (throwable != null) {
             telemetry.error(message, throwable)
         } else {
@@ -480,6 +479,9 @@ internal class RumFeature constructor(
 
     private fun logTelemetryDebug(telemetryEvent: Map<*, *>) {
         val message = telemetryEvent[EVENT_MESSAGE_PROPERTY] as? String
+
+        @Suppress("UNCHECKED_CAST")
+        val additionalProperties = telemetryEvent[EVENT_ADDITIONAL_PROPERTIES] as? Map<String, Any?>
         if (message == null) {
             sdkCore.internalLogger.log(
                 InternalLogger.Level.WARN,
@@ -488,7 +490,7 @@ internal class RumFeature constructor(
             )
             return
         }
-        telemetry.debug(message)
+        telemetry.debug(message, additionalProperties)
     }
 
     private fun logTelemetryConfiguration(event: Map<*, *>) {
@@ -561,6 +563,7 @@ internal class RumFeature constructor(
         internal val startupTimeNs: Long = System.nanoTime()
 
         internal const val EVENT_MESSAGE_PROPERTY = "message"
+        internal const val EVENT_ADDITIONAL_PROPERTIES = "additionalProperties"
         internal const val EVENT_THROWABLE_PROPERTY = "throwable"
         internal const val EVENT_ATTRIBUTES_PROPERTY = "attributes"
         internal const val EVENT_STACKTRACE_PROPERTY = "stacktrace"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -204,6 +204,7 @@ internal sealed class RumRawEvent {
         val stack: String?,
         val kind: String?,
         val coreConfiguration: TelemetryCoreConfiguration?,
+        val additionalProperties: Map<String, Any?>?,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -38,11 +38,21 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
 
     fun setDebugListener(listener: RumDebugListener?)
 
-    fun sendDebugTelemetryEvent(message: String)
+    fun sendDebugTelemetryEvent(
+        message: String,
+        additionalProperties: Map<String, Any?>?
+    )
 
-    fun sendErrorTelemetryEvent(message: String, throwable: Throwable?)
+    fun sendErrorTelemetryEvent(
+        message: String,
+        throwable: Throwable?
+    )
 
-    fun sendErrorTelemetryEvent(message: String, stack: String?, kind: String?)
+    fun sendErrorTelemetryEvent(
+        message: String,
+        stack: String?,
+        kind: String?
+    )
 
     @Suppress("FunctionMaxLength")
     fun sendConfigurationTelemetryEvent(coreConfiguration: TelemetryCoreConfiguration)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -393,36 +393,81 @@ internal class DatadogRumMonitor(
         debugListener = listener
     }
 
-    override fun sendDebugTelemetryEvent(message: String) {
-        handleEvent(RumRawEvent.SendTelemetry(TelemetryType.DEBUG, message, null, null, null))
+    override fun sendDebugTelemetryEvent(
+        message: String,
+        additionalProperties: Map<String, Any?>?
+    ) {
+        handleEvent(
+            RumRawEvent.SendTelemetry(
+                type = TelemetryType.DEBUG,
+                message = message,
+                stack = null,
+                kind = null,
+                coreConfiguration = null,
+                additionalProperties = additionalProperties
+            )
+        )
     }
 
-    override fun sendErrorTelemetryEvent(message: String, throwable: Throwable?) {
+    override fun sendErrorTelemetryEvent(
+        message: String,
+        throwable: Throwable?
+    ) {
         val stack: String? = throwable?.loggableStackTrace()
         val kind: String? = throwable?.javaClass?.canonicalName ?: throwable?.javaClass?.simpleName
-        handleEvent(RumRawEvent.SendTelemetry(TelemetryType.ERROR, message, stack, kind, null))
+        handleEvent(
+            RumRawEvent.SendTelemetry(
+                type = TelemetryType.ERROR,
+                message = message,
+                stack = stack,
+                kind = kind,
+                coreConfiguration = null,
+                additionalProperties = null
+            )
+        )
     }
 
-    override fun sendErrorTelemetryEvent(message: String, stack: String?, kind: String?) {
-        handleEvent(RumRawEvent.SendTelemetry(TelemetryType.ERROR, message, stack, kind, null))
+    override fun sendErrorTelemetryEvent(
+        message: String,
+        stack: String?,
+        kind: String?
+    ) {
+        handleEvent(
+            RumRawEvent.SendTelemetry(
+                type = TelemetryType.ERROR,
+                message = message,
+                stack = stack,
+                kind = kind,
+                coreConfiguration = null,
+                additionalProperties = null
+            )
+        )
     }
 
     @Suppress("FunctionMaxLength")
     override fun sendConfigurationTelemetryEvent(coreConfiguration: TelemetryCoreConfiguration) {
         handleEvent(
             RumRawEvent.SendTelemetry(
-                TelemetryType.CONFIGURATION,
-                "",
-                null,
-                null,
-                coreConfiguration
+                type = TelemetryType.CONFIGURATION,
+                message = "",
+                stack = null,
+                kind = null,
+                coreConfiguration = coreConfiguration,
+                additionalProperties = null
             )
         )
     }
 
     override fun notifyInterceptorInstantiated() {
         handleEvent(
-            RumRawEvent.SendTelemetry(TelemetryType.INTERCEPTOR_SETUP, "", null, null, null)
+            RumRawEvent.SendTelemetry(
+                TelemetryType.INTERCEPTOR_SETUP,
+                message = "",
+                stack = null,
+                kind = null,
+                coreConfiguration = null,
+                additionalProperties = null
+            )
         )
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/Telemetry.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/Telemetry.kt
@@ -18,18 +18,25 @@ internal class Telemetry(
         get() {
             return GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor ?: NoOpAdvancedRumMonitor()
         }
-    fun error(message: String, throwable: Throwable? = null) {
+    fun error(
+        message: String,
+        throwable: Throwable? = null
+    ) {
         (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor)
             ?.sendErrorTelemetryEvent(message, throwable)
     }
 
-    fun error(message: String, stack: String?, kind: String?) {
+    fun error(
+        message: String,
+        stack: String? = null,
+        kind: String? = null
+    ) {
         (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor)
             ?.sendErrorTelemetryEvent(message, stack, kind)
     }
 
-    fun debug(message: String) {
+    fun debug(message: String, additionalProperties: Map<String, Any?>? = null) {
         (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor)
-            ?.sendDebugTelemetryEvent(message)
+            ?.sendDebugTelemetryEvent(message, additionalProperties)
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -51,7 +51,12 @@ internal class TelemetryEventHandler(
                 val timestamp = event.eventTime.timestamp + datadogContext.time.serverTimeOffsetMs
                 val telemetryEvent: Any? = when (event.type) {
                     TelemetryType.DEBUG -> {
-                        createDebugEvent(datadogContext, timestamp, event.message)
+                        createDebugEvent(
+                            datadogContext,
+                            timestamp,
+                            event.message,
+                            event.additionalProperties
+                        )
                     }
                     TelemetryType.ERROR -> {
                         createErrorEvent(
@@ -132,10 +137,11 @@ internal class TelemetryEventHandler(
     private fun createDebugEvent(
         datadogContext: DatadogContext,
         timestamp: Long,
-        message: String
+        message: String,
+        additionalProperties: Map<String, Any?>?
     ): TelemetryDebugEvent {
         val rumContext = datadogContext.rumContext()
-
+        val resolvedAdditionalProperties = additionalProperties?.toMutableMap() ?: mutableMapOf()
         return TelemetryDebugEvent(
             dd = TelemetryDebugEvent.Dd(),
             date = timestamp,
@@ -150,7 +156,8 @@ internal class TelemetryEventHandler(
             view = rumContext.viewId?.let { TelemetryDebugEvent.View(it) },
             action = rumContext.actionId?.let { TelemetryDebugEvent.Action(it) },
             telemetry = TelemetryDebugEvent.Telemetry(
-                message = message
+                message = message,
+                additionalProperties = resolvedAdditionalProperties
             )
         )
     }
@@ -164,7 +171,6 @@ internal class TelemetryEventHandler(
         kind: String?
     ): TelemetryErrorEvent {
         val rumContext = datadogContext.rumContext()
-
         return TelemetryErrorEvent(
             dd = TelemetryErrorEvent.Dd(),
             date = timestamp,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -988,7 +988,7 @@ internal class RumFeatureTest {
     // region FeatureEventReceiver#onReceive + telemetry event
 
     @Test
-    fun `𝕄 handle telemetry debug event 𝕎 onReceive()`(
+    fun `𝕄 handle telemetry debug event 𝕎 onReceive(){no additionalProperties}`(
         @StringForgery fakeMessage: String
     ) {
         // Given
@@ -1002,7 +1002,52 @@ internal class RumFeatureTest {
         testedFeature.onReceive(event)
 
         // Then
-        verify(mockRumMonitor).sendDebugTelemetryEvent(fakeMessage)
+        verify(mockRumMonitor).sendDebugTelemetryEvent(fakeMessage, null)
+        verifyNoMoreInteractions(mockRumMonitor)
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `𝕄 handle telemetry debug event 𝕎 onReceive() {additionalProperties}`(
+        @StringForgery fakeMessage: String,
+        forge: Forge
+    ) {
+        // Given
+        val fakeAdditionalProperties = forge.exhaustiveAttributes()
+        testedFeature.onInitialize(appContext.mockInstance)
+        val event = mapOf(
+            "type" to "telemetry_debug",
+            "message" to fakeMessage,
+            "additionalProperties" to fakeAdditionalProperties
+        )
+
+        // When
+        testedFeature.onReceive(event)
+
+        // Then
+        verify(mockRumMonitor).sendDebugTelemetryEvent(fakeMessage, fakeAdditionalProperties)
+        verifyNoMoreInteractions(mockRumMonitor)
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `𝕄 handle telemetry debug event 𝕎 onReceive {additionalProperties is null}`(
+        @StringForgery fakeMessage: String
+    ) {
+        // Given
+        val fakeAdditionalProperties = null
+        testedFeature.onInitialize(appContext.mockInstance)
+        val event = mapOf(
+            "type" to "telemetry_debug",
+            "message" to fakeMessage,
+            "additionalProperties" to fakeAdditionalProperties
+        )
+
+        // When
+        testedFeature.onReceive(event)
+
+        // Then
+        verify(mockRumMonitor).sendDebugTelemetryEvent(fakeMessage, fakeAdditionalProperties)
         verifyNoMoreInteractions(mockRumMonitor)
         verifyNoInteractions(mockInternalLogger)
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1379,10 +1379,14 @@ internal class DatadogRumMonitorTest {
 
     @Test
     fun `M handle debug telemetry event W sendDebugTelemetryEvent()`(
-        @StringForgery message: String
+        @StringForgery message: String,
+        forge: Forge
     ) {
+        // Given
+        val fakeAdditionalProperties = forge.aNullable { exhaustiveAttributes() }
+
         // When
-        testedMonitor.sendDebugTelemetryEvent(message)
+        testedMonitor.sendDebugTelemetryEvent(message, fakeAdditionalProperties)
 
         // Then
         argumentCaptor<RumRawEvent.SendTelemetry> {
@@ -1395,6 +1399,7 @@ internal class DatadogRumMonitorTest {
             assertThat(lastValue.stack).isNull()
             assertThat(lastValue.kind).isNull()
             assertThat(lastValue.coreConfiguration).isNull()
+            assertThat(lastValue.additionalProperties).isEqualTo(fakeAdditionalProperties)
         }
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/InternalLoggerUtils.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/InternalLoggerUtils.kt
@@ -22,7 +22,8 @@ fun InternalLogger.verifyLog(
     message: String,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -30,7 +31,8 @@ fun InternalLogger.verifyLog(
             eq(target),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -44,7 +46,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -52,7 +55,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(target),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -66,7 +70,8 @@ fun InternalLogger.verifyLog(
     message: String?,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -74,7 +79,8 @@ fun InternalLogger.verifyLog(
             eq(targets),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }
@@ -86,7 +92,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String?,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -94,7 +101,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(targets),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryDebugEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryDebugEventAssert.kt
@@ -99,6 +99,16 @@ internal class TelemetryDebugEventAssert(actual: TelemetryDebugEvent) :
         return this
     }
 
+    fun hasAdditionalProperties(additionalProperties: Map<String, Any?>): TelemetryDebugEventAssert {
+        assertThat(actual.telemetry.additionalProperties)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.additionalProperties $additionalProperties" +
+                    " but was ${actual.telemetry.additionalProperties}"
+            )
+            .isEqualTo(additionalProperties)
+        return this
+    }
+
     companion object {
         fun assertThat(actual: TelemetryDebugEvent) = TelemetryDebugEventAssert(actual)
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -31,6 +31,7 @@ import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 import com.datadog.android.telemetry.model.TelemetryDebugEvent
 import com.datadog.android.telemetry.model.TelemetryErrorEvent
 import com.datadog.tools.unit.forge.aThrowable
+import com.datadog.tools.unit.forge.exhaustiveAttributes
 import com.datadog.tools.unit.setStaticValue
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
@@ -390,7 +391,14 @@ internal class TelemetryEventHandlerTest {
         // When
         if (trackNetworkRequests) {
             testedTelemetryHandler.handleEvent(
-                RumRawEvent.SendTelemetry(TelemetryType.INTERCEPTOR_SETUP, "", null, null, null),
+                RumRawEvent.SendTelemetry(
+                    TelemetryType.INTERCEPTOR_SETUP,
+                    "",
+                    null,
+                    null,
+                    coreConfiguration = null,
+                    additionalProperties = null
+                ),
                 mockWriter
             )
         }
@@ -700,6 +708,7 @@ internal class TelemetryEventHandlerTest {
             .hasSessionId(rumContext.sessionId)
             .hasViewId(rumContext.viewId)
             .hasActionId(rumContext.actionId)
+            .hasAdditionalProperties(rawEvent.additionalProperties ?: emptyMap())
     }
 
     private fun assertErrorEventMatchesRawEvent(
@@ -755,7 +764,8 @@ internal class TelemetryEventHandlerTest {
             aString(),
             null,
             null,
-            null
+            coreConfiguration = null,
+            additionalProperties = aNullable { exhaustiveAttributes() }
         )
     }
 
@@ -766,7 +776,8 @@ internal class TelemetryEventHandlerTest {
             aString(),
             throwable?.loggableStackTrace(),
             throwable?.javaClass?.canonicalName,
-            null
+            coreConfiguration = null,
+            additionalProperties = null
         )
     }
 
@@ -778,7 +789,8 @@ internal class TelemetryEventHandlerTest {
             "",
             null,
             null,
-            configuration ?: getForgery()
+            coreConfiguration = (configuration ?: getForgery()),
+            additionalProperties = null
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryTest.kt
@@ -13,6 +13,7 @@ import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.forge.aThrowable
+import com.datadog.tools.unit.forge.exhaustiveAttributes
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -60,14 +61,17 @@ internal class TelemetryTest {
 
     @Test
     fun `𝕄 report debug event 𝕎 debug()`(
-        @StringForgery message: String
+        @StringForgery message: String,
+        forge: Forge
     ) {
+        // Given
+        val fakeAdditionalProperties = forge.aNullable { exhaustiveAttributes() }
         // When
-        testedTelemetry.debug(message)
+        testedTelemetry.debug(message, fakeAdditionalProperties)
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)
-            .sendDebugTelemetryEvent(message)
+            .sendDebugTelemetryEvent(message, fakeAdditionalProperties)
     }
 
     companion object {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/InternalLoggerUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/InternalLoggerUtils.kt
@@ -22,7 +22,8 @@ fun InternalLogger.verifyLog(
     message: String,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -30,7 +31,8 @@ fun InternalLogger.verifyLog(
             eq(target),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -44,7 +46,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -52,7 +55,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(target),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -66,7 +70,8 @@ fun InternalLogger.verifyLog(
     message: String?,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -74,7 +79,8 @@ fun InternalLogger.verifyLog(
             eq(targets),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }
@@ -86,7 +92,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String?,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -94,7 +101,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(targets),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/utils/InternalLoggerUtils.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/utils/InternalLoggerUtils.kt
@@ -22,7 +22,8 @@ fun InternalLogger.verifyLog(
     message: String,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -30,7 +31,8 @@ fun InternalLogger.verifyLog(
             eq(target),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -44,7 +46,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -52,7 +55,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(target),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -66,7 +70,8 @@ fun InternalLogger.verifyLog(
     message: String?,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -74,7 +79,8 @@ fun InternalLogger.verifyLog(
             eq(targets),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }
@@ -86,7 +92,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String?,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -94,7 +101,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(targets),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/InternalLoggerUtils.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/InternalLoggerUtils.kt
@@ -22,7 +22,8 @@ fun InternalLogger.verifyLog(
     message: String,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -30,7 +31,8 @@ fun InternalLogger.verifyLog(
             eq(target),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -44,7 +46,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -52,7 +55,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(target),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -66,7 +70,8 @@ fun InternalLogger.verifyLog(
     message: String?,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -74,7 +79,8 @@ fun InternalLogger.verifyLog(
             eq(targets),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }
@@ -86,7 +92,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String?,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -94,7 +101,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(targets),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/InternalLoggerUtils.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/InternalLoggerUtils.kt
@@ -22,7 +22,8 @@ fun InternalLogger.verifyLog(
     message: String,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -30,7 +31,8 @@ fun InternalLogger.verifyLog(
             eq(target),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -44,7 +46,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -52,7 +55,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(target),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         allValues.forEach {
             assertThat(it()).isEqualTo(message)
@@ -66,7 +70,8 @@ fun InternalLogger.verifyLog(
     message: String?,
     throwable: Throwable? = null,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -74,7 +79,8 @@ fun InternalLogger.verifyLog(
             eq(targets),
             capture(),
             same(throwable),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }
@@ -86,7 +92,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
     message: String?,
     throwableClass: Class<T>,
     onlyOnce: Boolean = false,
-    mode: VerificationMode = times(1)
+    mode: VerificationMode = times(1),
+    additionalProperties: Map<String, Any?>? = null
 ) {
     argumentCaptor<() -> String> {
         verify(this@verifyLog, mode).log(
@@ -94,7 +101,8 @@ fun <T : Throwable> InternalLogger.verifyLog(
             eq(targets),
             capture(),
             isA(throwableClass),
-            eq(onlyOnce)
+            eq(onlyOnce),
+            eq(additionalProperties)
         )
         assertThat(firstValue()).isEqualTo(message)
     }


### PR DESCRIPTION
### What does this PR do?

Following up on the the latest [changes](https://github.com/DataDog/rum-events-format/pull/154) on the telemetry events schema we are adding the capability to add additional properties as a `Map<String,Any?>` to our Telemetry debug log events.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

