### PR TITLE
REPLAY-1891: Optimize bitmap processing

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -359,6 +359,7 @@ datadog:
       - "android.webkit.WebViewClient.onReceivedSslError(android.webkit.WebView, android.webkit.SslErrorHandler, android.net.http.SslError)"
       # endregion
       # region Android View APIs
+      - "android.widget.ImageView.getScaleType()"
       - "android.widget.FrameLayout.LayoutParams.constructor(kotlin.Int, kotlin.Int)"
       - "android.widget.FrameLayout.removeView(android.view.View)"
       - "android.widget.LinearLayout.constructor(android.content.Context)"
@@ -862,6 +863,7 @@ datadog:
       - "kotlin.Pair.constructor(com.datadog.android.sessionreplay.model.MobileSegment, com.google.gson.JsonObject)"
       - "kotlin.Pair.constructor(com.google.gson.JsonObject, kotlin.Long)"
       - "kotlin.Pair.constructor(kotlin.Int, kotlin.Int)"
+      - "kotlin.Pair.constructor(kotlin.Long, kotlin.Long)"
       - "kotlin.Triple.constructor(kotlin.String, kotlin.String, kotlin.String)"
       - "kotlin.Triple.constructor(kotlin.Nothing?, kotlin.Nothing?, kotlin.Nothing?)"
       # endregion

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaskInputTabWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaskInputTabWireframeMapper.kt
@@ -16,6 +16,6 @@ import com.datadog.android.sessionreplay.utils.ViewUtils
 internal class MaskInputTabWireframeMapper(
     viewUtils: ViewUtils = ViewUtils,
     uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator,
-    textViewMapper: WireframeMapper<TextView, MobileSegment.Wireframe.TextWireframe> =
+    textViewMapper: WireframeMapper<TextView, MobileSegment.Wireframe> =
         MaskInputTextViewMapper()
 ) : TabWireframeMapper(viewUtils, uniqueIdentifierGenerator, textViewMapper)

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaskTabWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaskTabWireframeMapper.kt
@@ -16,6 +16,6 @@ import com.datadog.android.sessionreplay.utils.ViewUtils
 internal class MaskTabWireframeMapper(
     viewUtils: ViewUtils = ViewUtils,
     uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator,
-    textViewMapper: WireframeMapper<TextView, MobileSegment.Wireframe.TextWireframe> =
+    textViewMapper: WireframeMapper<TextView, MobileSegment.Wireframe> =
         MaskTextViewMapper()
 ) : TabWireframeMapper(viewUtils, uniqueIdentifierGenerator, textViewMapper)

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/TabWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/TabWireframeMapper.kt
@@ -13,7 +13,6 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
 import com.datadog.android.sessionreplay.material.internal.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
-import com.datadog.android.sessionreplay.model.MobileSegment.Wireframe.TextWireframe
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
 import com.google.android.material.tabs.TabLayout
@@ -23,7 +22,7 @@ internal open class TabWireframeMapper(
     private val viewUtils: ViewUtils = ViewUtils,
     private val uniqueIdentifierGenerator: UniqueIdentifierGenerator =
         UniqueIdentifierGenerator,
-    internal val textViewMapper: WireframeMapper<TextView, TextWireframe> = TextViewMapper()
+    internal val textViewMapper: WireframeMapper<TextView, MobileSegment.Wireframe> = TextViewMapper()
 ) : WireframeMapper<TabLayout.TabView, MobileSegment.Wireframe> {
 
     override fun map(
@@ -47,7 +46,7 @@ internal open class TabWireframeMapper(
     protected open fun resolveTabIndicatorWireframe(
         view: TabView,
         systemInformation: SystemInformation,
-        textWireframe: TextWireframe?
+        wireframe: MobileSegment.Wireframe?
     ): MobileSegment.Wireframe? {
         val selectorId = uniqueIdentifierGenerator.resolveChildUniqueIdentifier(
             view,
@@ -62,8 +61,11 @@ internal open class TabWireframeMapper(
         val selectionIndicatorXPos = viewBounds.x + paddingStart
         val selectionIndicatorYPos = viewBounds.y + viewBounds.height - selectionIndicatorHeight
         val selectionIndicatorWidth = viewBounds.width - paddingStart - paddingEnd
-        val selectionIndicatorColor = textWireframe?.textStyle?.color
-            ?: SELECTED_TAB_INDICATOR_DEFAULT_COLOR
+        val selectionIndicatorColor = if (wireframe is MobileSegment.Wireframe.TextWireframe) {
+            wireframe.textStyle.color
+        } else {
+            SELECTED_TAB_INDICATOR_DEFAULT_COLOR
+        }
         val selectionIndicatorShapeStyle = MobileSegment.ShapeStyle(
             backgroundColor = selectionIndicatorColor,
             opacity = view.alpha
@@ -79,7 +81,7 @@ internal open class TabWireframeMapper(
     }
 
     private fun findAndResolveLabelWireframes(view: TabView, mappingContext: MappingContext):
-        List<TextWireframe> {
+        List<MobileSegment.Wireframe> {
         for (i in 0 until view.childCount) {
             val viewChild = view.getChildAt(i) ?: continue
             if (TextView::class.java.isAssignableFrom(viewChild::class.java)) {

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -22,23 +22,13 @@ interface com.datadog.android.sessionreplay.internal.recorder.OptionSelectorDete
   fun isOptionSelector(android.view.ViewGroup): Boolean
 data class com.datadog.android.sessionreplay.internal.recorder.SystemInformation
   constructor(GlobalBounds, Int = Configuration.ORIENTATION_UNDEFINED, Float, String? = null)
-class com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer
-interface com.datadog.android.sessionreplay.internal.recorder.base64.ImageCompression
-  fun getMimeType(): String?
-  fun compressBitmap(android.graphics.Bitmap): ByteArray
-class com.datadog.android.sessionreplay.internal.recorder.base64.WebPImageCompression : ImageCompression
-  override fun getMimeType(): String?
-  override fun compressBitmap(android.graphics.Bitmap): ByteArray
-  companion object 
-abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseWireframeMapper<T: android.view.View, S: com.datadog.android.sessionreplay.model.MobileSegment.Wireframe> : WireframeMapper<T, S>, com.datadog.android.sessionreplay.internal.AsyncImageProcessingCallback
+abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseWireframeMapper<T: android.view.View, S: com.datadog.android.sessionreplay.model.MobileSegment.Wireframe> : WireframeMapper<T, com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>, com.datadog.android.sessionreplay.internal.AsyncImageProcessingCallback
   constructor(com.datadog.android.sessionreplay.utils.StringUtils = StringUtils, com.datadog.android.sessionreplay.utils.ViewUtils = ViewUtils)
+  override fun map(T, com.datadog.android.sessionreplay.internal.recorder.MappingContext): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
   protected fun resolveViewId(android.view.View): Long
   protected fun colorAndAlphaAsStringHexa(Int, Int): String
   protected fun resolveViewGlobalBounds(android.view.View, Float): com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
   protected fun android.graphics.drawable.Drawable.resolveShapeStyleAndBorder(Float): Pair<com.datadog.android.sessionreplay.model.MobileSegment.ShapeStyle?, com.datadog.android.sessionreplay.model.MobileSegment.ShapeBorder?>?
-  protected fun resolveChildDrawableUniqueIdentifier(android.view.View): Long?
-  protected fun getWebPMimeType(): String?
-  protected fun handleBitmap(android.content.Context, android.util.DisplayMetrics, android.graphics.drawable.Drawable, com.datadog.android.sessionreplay.model.MobileSegment.Wireframe.ImageWireframe)
   override fun startProcessingImage()
   override fun finishProcessingImage()
   companion object 

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -87,24 +87,6 @@ public final class com/datadog/android/sessionreplay/internal/recorder/SystemInf
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/sessionreplay/internal/recorder/base64/Base64Serializer {
-	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;Lcom/datadog/android/sessionreplay/internal/utils/DrawableUtils;Lcom/datadog/android/sessionreplay/internal/utils/Base64Utils;Lcom/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression;Lcom/datadog/android/sessionreplay/internal/recorder/base64/Cache;Lcom/datadog/android/sessionreplay/internal/recorder/base64/BitmapPool;Lcom/datadog/android/api/InternalLogger;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
-}
-
-public abstract interface class com/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression {
-	public abstract fun compressBitmap (Landroid/graphics/Bitmap;)[B
-	public abstract fun getMimeType ()Ljava/lang/String;
-}
-
-public final class com/datadog/android/sessionreplay/internal/recorder/base64/WebPImageCompression : com/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression {
-	public static final field Companion Lcom/datadog/android/sessionreplay/internal/recorder/base64/WebPImageCompression$Companion;
-	public fun compressBitmap (Landroid/graphics/Bitmap;)[B
-	public fun getMimeType ()Ljava/lang/String;
-}
-
-public final class com/datadog/android/sessionreplay/internal/recorder/base64/WebPImageCompression$Companion {
-}
-
 public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper : com/datadog/android/sessionreplay/internal/AsyncImageProcessingCallback, com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper$Companion;
 	public fun <init> ()V
@@ -112,9 +94,7 @@ public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper
 	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/utils/StringUtils;Lcom/datadog/android/sessionreplay/utils/ViewUtils;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected final fun colorAndAlphaAsStringHexa (II)Ljava/lang/String;
 	public fun finishProcessingImage ()V
-	protected final fun getWebPMimeType ()Ljava/lang/String;
-	protected final fun handleBitmap (Landroid/content/Context;Landroid/util/DisplayMetrics;Landroid/graphics/drawable/Drawable;Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;)Lkotlin/Unit;
-	protected final fun resolveChildDrawableUniqueIdentifier (Landroid/view/View;)Ljava/lang/Long;
+	public fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;)Ljava/util/List;
 	protected final fun resolveShapeStyleAndBorder (Landroid/graphics/drawable/Drawable;F)Lkotlin/Pair;
 	protected final fun resolveViewGlobalBounds (Landroid/view/View;F)Lcom/datadog/android/sessionreplay/internal/recorder/GlobalBounds;
 	protected final fun resolveViewId (Landroid/view/View;)J

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
@@ -23,6 +23,7 @@ import androidx.appcompat.widget.SwitchCompat
 import com.datadog.android.sessionreplay.internal.recorder.base64.Base64LRUCache
 import com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer
 import com.datadog.android.sessionreplay.internal.recorder.base64.BitmapPool
+import com.datadog.android.sessionreplay.internal.recorder.base64.ImageWireframeHelper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.BasePickerMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
@@ -47,6 +48,7 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.UnsupportedVie
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ViewScreenshotWireframeMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ViewWireframeMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
+import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import androidx.appcompat.widget.Toolbar as AppCompatToolbar
 
 /**
@@ -81,10 +83,16 @@ enum class SessionReplayPrivacy {
     @Suppress("LongMethod")
     internal fun mappers(): List<MapperTypeWrapper> {
         val base64Serializer = buildBase64Serializer()
+        val imageWireframeHelper = ImageWireframeHelper(base64Serializer = base64Serializer)
+        val uniqueIdentifierGenerator = UniqueIdentifierGenerator
 
         val viewWireframeMapper = ViewWireframeMapper()
         val unsupportedViewMapper = UnsupportedViewMapper()
-        val imageButtonMapper = ImageButtonMapper(base64Serializer = base64Serializer)
+        val imageButtonMapper = ImageButtonMapper(
+            base64Serializer = base64Serializer,
+            imageWireframeHelper = imageWireframeHelper,
+            uniqueIdentifierGenerator = uniqueIdentifierGenerator
+        )
         val imageMapper: ViewScreenshotWireframeMapper
         val textMapper: TextViewMapper
         val buttonMapper: ButtonMapper

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression.kt
@@ -12,7 +12,7 @@ import java.io.ByteArrayOutputStream
 /**
  * Interface for handling image compression formats.
  */
-interface ImageCompression {
+internal interface ImageCompression {
 
     /**
      * Get the mimetype for the image format.

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelper.kt
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+import android.graphics.drawable.Drawable
+import android.view.View
+import androidx.annotation.MainThread
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
+
+internal class ImageWireframeHelper(
+    private val imageCompression: ImageCompression = WebPImageCompression(),
+    private val uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator,
+    private val base64Serializer: Base64Serializer
+) {
+    @MainThread
+    internal fun createImageWireframe(
+        view: View,
+        index: Int,
+        x: Long,
+        y: Long,
+        width: Long,
+        height: Long,
+        drawable: Drawable? = null,
+        shapeStyle: MobileSegment.ShapeStyle? = null,
+        border: MobileSegment.ShapeBorder? = null,
+        prefix: String = DRAWABLE_CHILD_NAME
+    ): MobileSegment.Wireframe.ImageWireframe? {
+        val id = uniqueIdentifierGenerator.resolveChildUniqueIdentifier(view, prefix + index)
+
+        @Suppress("ComplexCondition")
+        if (drawable == null || id == null || drawable.intrinsicWidth < 0 || drawable.intrinsicHeight < 0) {
+            return null
+        }
+
+        val displayMetrics = view.resources.displayMetrics
+        val applicationContext = view.context.applicationContext
+        val mimeType = imageCompression.getMimeType()
+
+        val imageWireframe =
+            MobileSegment.Wireframe.ImageWireframe(
+                id = id,
+                x = x,
+                y = y,
+                width = width,
+                height = height,
+                shapeStyle = shapeStyle,
+                border = border,
+                base64 = "",
+                mimeType = mimeType,
+                isEmpty = true
+            )
+
+        base64Serializer.handleBitmap(
+            applicationContext = applicationContext,
+            displayMetrics = displayMetrics,
+            drawable = drawable,
+            imageWireframe = imageWireframe
+        )
+
+        return imageWireframe
+    }
+
+    private companion object {
+        private const val DRAWABLE_CHILD_NAME = "drawable"
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/WebPImageCompression.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/WebPImageCompression.kt
@@ -15,7 +15,7 @@ import java.io.ByteArrayOutputStream
 /**
  * Handle webp image compression.
  */
-class WebPImageCompression internal constructor() : ImageCompression {
+internal class WebPImageCompression : ImageCompression {
 
     override fun getMimeType(): String? =
         MimeTypeMap.getSingleton().getMimeTypeFromExtension(WEBP_EXTENSION)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapper.kt
@@ -6,97 +6,59 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
-import android.graphics.drawable.Drawable
 import android.widget.ImageButton
-import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer
-import com.datadog.android.sessionreplay.internal.recorder.base64.ImageCompression
-import com.datadog.android.sessionreplay.internal.recorder.base64.WebPImageCompression
+import com.datadog.android.sessionreplay.internal.recorder.base64.ImageWireframeHelper
+import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 
 internal class ImageButtonMapper(
-    webPImageCompression: ImageCompression = WebPImageCompression(),
-    base64Serializer: Base64Serializer = Base64Serializer.Builder().build(),
-    uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator
+    private val base64Serializer: Base64Serializer,
+    private val imageWireframeHelper: ImageWireframeHelper,
+    private val uniqueIdentifierGenerator: UniqueIdentifierGenerator
 ) : BaseWireframeMapper<ImageButton, MobileSegment.Wireframe>(
-    webPImageCompression = webPImageCompression,
     base64Serializer = base64Serializer,
+    imageWireframeHelper = imageWireframeHelper,
     uniqueIdentifierGenerator = uniqueIdentifierGenerator
 ) {
     override fun map(
         view: ImageButton,
         mappingContext: MappingContext
     ): List<MobileSegment.Wireframe> {
-        val resources = view.resources
-        val drawable = view.drawable?.constantState?.newDrawable(resources)
-        val id = resolveChildDrawableUniqueIdentifier(view)
-
-        if (drawable == null || id == null) return emptyList()
-
-        val screenDensity = mappingContext.systemInformation.screenDensity
-        val bounds = resolveViewGlobalBounds(view, screenDensity)
-
-        val (shapeStyle, border) = view.background?.resolveShapeStyleAndBorder(view.alpha)
-            ?: (null to null)
-
         val wireframes = mutableListOf<MobileSegment.Wireframe>()
 
-        // if the drawable has no width/height then there's no point trying to get a bitmap
-        if (drawable.intrinsicWidth > 0 && drawable.intrinsicHeight > 0) {
-            val imageWireframe = resolveImageWireframe(
-                view,
-                id,
-                bounds,
-                shapeStyle,
-                border,
-                drawable
-            )
-            wireframes.add(imageWireframe)
+        // add background wireframes if any
+        wireframes.addAll(super.map(view, mappingContext))
+
+        val drawable = view.drawable?.current ?: return wireframes
+        val resources = view.resources
+        val density = resources.displayMetrics.density
+        val bounds = resolveViewGlobalBounds(view, density)
+
+        val (scaledDrawableWidth, scaledDrawableHeight) =
+            base64Serializer.getDrawableScaledDimensions(view, drawable, density)
+
+        val centerX = (bounds.x + view.width.densityNormalized(density) / 2) - (scaledDrawableWidth / 2)
+        val centerY = (bounds.y + view.height.densityNormalized(density) / 2) - (scaledDrawableHeight / 2)
+
+        // resolve foreground
+        @Suppress("ThreadSafety") // TODO REPLAY-1861 caller thread of .map is unknown?
+        imageWireframeHelper.createImageWireframe(
+            view = view,
+            index = wireframes.size,
+            x = centerX,
+            y = centerY,
+            width = scaledDrawableWidth,
+            height = scaledDrawableHeight,
+            drawable = drawable.constantState?.newDrawable(resources),
+            shapeStyle = null,
+            border = null
+        )?.let {
+            wireframes.add(it)
         }
 
         return wireframes
     }
-
-    // region internal
-
-    private fun resolveImageWireframe(
-        view: ImageButton,
-        id: Long,
-        bounds: GlobalBounds,
-        shapeStyle: MobileSegment.ShapeStyle?,
-        border: MobileSegment.ShapeBorder?,
-        drawable: Drawable
-    ): MobileSegment.Wireframe.ImageWireframe {
-        val mimeType = getWebPMimeType()
-        val displayMetrics = view.resources.displayMetrics
-        val applicationContext = view.context.applicationContext
-
-        val imageWireframe =
-            MobileSegment.Wireframe.ImageWireframe(
-                id = id,
-                x = bounds.x,
-                y = bounds.y,
-                width = bounds.width,
-                height = bounds.height,
-                shapeStyle = shapeStyle,
-                border = border,
-                base64 = "",
-                mimeType = mimeType,
-                isEmpty = true
-            )
-
-        @Suppress("ThreadSafety") // TODO REPLAY-1861 caller thread of .map is unknown?
-        handleBitmap(
-            applicationContext = applicationContext,
-            displayMetrics = displayMetrics,
-            drawable = drawable,
-            imageWireframe = imageWireframe
-        )
-
-        return imageWireframe
-    }
-
-    // endregion
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/QueueableViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/QueueableViewMapper.kt
@@ -18,7 +18,7 @@ internal class QueueableViewMapper(
 ) : BaseWireframeMapper<View, MobileSegment.Wireframe>(), AsyncImageProcessingCallback {
     override fun map(view: View, mappingContext: MappingContext):
         List<MobileSegment.Wireframe> {
-        (mapper as? BaseWireframeMapper)?.registerAsyncImageProcessingCallback(this)
+        (mapper as? BaseWireframeMapper<View, *>)?.registerAsyncImageProcessingCallback(this)
         return mapper.map(view, mappingContext)
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableDimensions.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableDimensions.kt
@@ -1,0 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.utils
+
+internal data class DrawableDimensions(
+    val width: Long,
+    val height: Long
+)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelperTest.kt
@@ -1,0 +1,246 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+import android.content.Context
+import android.content.res.Resources
+import android.graphics.drawable.Drawable
+import android.util.DisplayMetrics
+import android.view.View
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class ImageWireframeHelperTest {
+    private lateinit var testedHelper: ImageWireframeHelper
+
+    @Mock
+    lateinit var mockBase64Serializer: Base64Serializer
+
+    @Mock
+    lateinit var mockUniqueIdentifierGenerator: UniqueIdentifierGenerator
+
+    @Mock
+    lateinit var mockImageCompression: ImageCompression
+
+    @Mock
+    lateinit var mockView: View
+
+    @Mock
+    lateinit var mockDrawable: Drawable
+
+    @Mock
+    lateinit var mockBounds: GlobalBounds
+
+    @Mock
+    lateinit var mockResources: Resources
+
+    @Mock
+    lateinit var mockDisplayMetrics: DisplayMetrics
+
+    @Mock
+    lateinit var mockContext: Context
+
+    @LongForgery
+    var fakeGeneratedIdentifier: Long = 0L
+
+    @LongForgery(min = 1, max = 300)
+    var fakeDrawableWidth: Long = 0L
+
+    @LongForgery(min = 1, max = 300)
+    var fakeDrawableHeight: Long = 0L
+
+    private lateinit var fakeDrawableXY: Pair<Long, Long>
+
+    @StringForgery
+    var fakeMimeType: String = ""
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        val fakeScreenWidth = 1000
+        val fakeScreenHeight = 1000
+
+        val randomXLocation = forge.aLong(min = 0, max = fakeScreenWidth - fakeDrawableWidth)
+        val randomYLocation = forge.aLong(min = 0, max = fakeScreenHeight - fakeDrawableHeight)
+        fakeDrawableXY = Pair(randomXLocation, randomYLocation)
+
+        whenever(mockUniqueIdentifierGenerator.resolveChildUniqueIdentifier(mockView, "drawable"))
+            .thenReturn(fakeGeneratedIdentifier)
+
+        whenever(mockDrawable.intrinsicWidth).thenReturn(fakeDrawableWidth.toInt())
+        whenever(mockDrawable.intrinsicHeight).thenReturn(fakeDrawableHeight.toInt())
+
+        whenever(mockView.resources).thenReturn(mockResources)
+        whenever(mockResources.displayMetrics).thenReturn(mockDisplayMetrics)
+
+        whenever(mockView.context).thenReturn(mockContext)
+        whenever(mockContext.applicationContext).thenReturn(mockContext)
+
+        whenever(mockImageCompression.getMimeType()).thenReturn(fakeMimeType)
+
+        whenever(mockBounds.width).thenReturn(fakeDrawableWidth)
+        whenever(mockBounds.height).thenReturn(fakeDrawableHeight)
+        whenever(mockBounds.x).thenReturn(fakeDrawableXY.first)
+        whenever(mockBounds.y).thenReturn(fakeDrawableXY.second)
+
+        testedHelper = ImageWireframeHelper(
+            imageCompression = mockImageCompression,
+            uniqueIdentifierGenerator = mockUniqueIdentifierGenerator,
+            base64Serializer = mockBase64Serializer
+        )
+    }
+
+    @Test
+    fun `M return null W createImageWireframe() { drawable is null }`() {
+        // When
+        val wireframe = testedHelper.createImageWireframe(
+            view = mockView,
+            index = 0,
+            x = 0,
+            y = 0,
+            width = 0,
+            height = 0,
+            drawable = null,
+            shapeStyle = null,
+            border = null
+        )
+
+        // Then
+        assertThat(wireframe).isNull()
+    }
+
+    @Test
+    fun `M return null W createImageWireframe() { id is null }`() {
+        // Given
+        whenever(mockUniqueIdentifierGenerator.resolveChildUniqueIdentifier(any(), any()))
+            .thenReturn(null)
+
+        // When
+        val wireframe = testedHelper.createImageWireframe(
+            view = mockView,
+            index = 0,
+            x = 0,
+            y = 0,
+            width = 0,
+            height = 0,
+            drawable = mockDrawable,
+            shapeStyle = null,
+            border = null
+        )
+
+        // Then
+        assertThat(wireframe).isNull()
+    }
+
+    @Test
+    fun `M return null W createImageWireframe() { drawable has no intrinsic width }`() {
+        // Given
+        whenever(mockDrawable.intrinsicWidth).thenReturn(-1)
+
+        // When
+        val wireframe = testedHelper.createImageWireframe(
+            view = mockView,
+            index = 0,
+            x = 0,
+            y = 0,
+            width = 0,
+            height = 0,
+            drawable = mockDrawable,
+            shapeStyle = null,
+            border = null
+        )
+
+        // Then
+        assertThat(wireframe).isNull()
+    }
+
+    @Test
+    fun `M return null W createImageWireframe() { drawable has no intrinsic height }`() {
+        // Given
+        whenever(mockDrawable.intrinsicHeight).thenReturn(-1)
+
+        // When
+        val wireframe = testedHelper.createImageWireframe(
+            view = mockView,
+            index = 0,
+            x = 0,
+            y = 0,
+            width = 0,
+            height = 0,
+            drawable = mockDrawable,
+            shapeStyle = null,
+            border = null
+        )
+
+        // Then
+        assertThat(wireframe).isNull()
+    }
+
+    @Test
+    fun `M return wireframe W createImageWireframe()`(
+        @LongForgery id: Long
+    ) {
+        // Given
+        whenever(
+            mockUniqueIdentifierGenerator
+                .resolveChildUniqueIdentifier(any(), any())
+        )
+            .thenReturn(id)
+
+        val expectedWireframe = MobileSegment.Wireframe.ImageWireframe(
+            id = id,
+            x = fakeDrawableXY.first,
+            y = fakeDrawableXY.second,
+            width = fakeDrawableWidth,
+            height = fakeDrawableHeight,
+            shapeStyle = null,
+            border = null,
+            base64 = "",
+            mimeType = fakeMimeType,
+            isEmpty = true
+        )
+
+        // When
+        val wireframe = testedHelper.createImageWireframe(
+            view = mockView,
+            index = 0,
+            x = fakeDrawableXY.first,
+            y = fakeDrawableXY.second,
+            width = fakeDrawableWidth,
+            height = fakeDrawableHeight,
+            drawable = mockDrawable,
+            shapeStyle = null,
+            border = null
+        )
+
+        // Then
+        assertThat(wireframe).isEqualTo(expectedWireframe)
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapperTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.content.Context
 import android.content.res.Resources
+import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.Drawable.ConstantState
 import android.util.DisplayMetrics
@@ -18,10 +19,13 @@ import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer
 import com.datadog.android.sessionreplay.internal.recorder.base64.ImageCompression
+import com.datadog.android.sessionreplay.internal.recorder.base64.ImageWireframeHelper
+import com.datadog.android.sessionreplay.internal.utils.DrawableDimensions
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import com.datadog.android.sessionreplay.utils.ViewUtils
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
@@ -33,6 +37,8 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -50,6 +56,9 @@ internal class ImageButtonMapperTest {
 
     @Mock
     lateinit var mockImageButton: ImageButton
+
+    @Mock
+    lateinit var mockImageWireframeHelper: ImageWireframeHelper
 
     @Mock
     lateinit var mockMappingContext: MappingContext
@@ -94,14 +103,19 @@ internal class ImageButtonMapperTest {
 
     private val fakeMimeType = Forge().aString()
 
+    lateinit var expectedWireframe: MobileSegment.Wireframe.ImageWireframe
+
     @BeforeEach
     fun setup(forge: Forge) {
+        whenever(mockImageButton.background).thenReturn(null)
+
         whenever(mockUniqueIdentifierGenerator.resolveChildUniqueIdentifier(any(), any()))
             .thenReturn(fakeId)
 
         whenever(mockConstantState.newDrawable(any())).thenReturn(mockDrawable)
         whenever(mockDrawable.constantState).thenReturn(mockConstantState)
         whenever(mockImageButton.drawable).thenReturn(mockDrawable)
+        whenever(mockImageButton.drawable.current).thenReturn(mockDrawable)
 
         whenever(mockDrawable.intrinsicWidth).thenReturn(forge.aPositiveInt())
         whenever(mockDrawable.intrinsicHeight).thenReturn(forge.aPositiveInt())
@@ -114,92 +128,18 @@ internal class ImageButtonMapperTest {
         whenever(mockResources.displayMetrics).thenReturn(mockDisplayMetrics)
         whenever(mockImageButton.resources).thenReturn(mockResources)
 
-        whenever(mockImageButton.background).thenReturn(mockBackground)
-
         whenever(mockContext.applicationContext).thenReturn(mockContext)
         whenever(mockImageButton.context).thenReturn(mockContext)
+        whenever(mockBackground.current).thenReturn(mockBackground)
 
         whenever(mockViewUtils.resolveViewGlobalBounds(any(), any())).thenReturn(mockGlobalBounds)
 
-        testedMapper = ImageButtonMapper(
-            webPImageCompression = mockWebPImageCompression,
-            base64Serializer = mockBase64Serializer,
-            uniqueIdentifierGenerator = mockUniqueIdentifierGenerator
-        )
-    }
-
-    @Test
-    fun `M return emptylist W map() { and could not get view id }`() {
-        // Given
-        whenever(mockUniqueIdentifierGenerator.resolveChildUniqueIdentifier(any(), any()))
-            .thenReturn(null)
-
-        // When
-        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
-
-        // Then
-        assertThat(wireframes).isEmpty()
-    }
-
-    @Test
-    fun `M return emptylist W map() { and could not get drawable }`() {
-        // Given
-        whenever(mockImageButton.drawable).thenReturn(null)
-
-        // When
-        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
-
-        // Then
-        assertThat(wireframes).isEmpty()
-    }
-
-    @Test
-    fun `M return emptylist W map() { drawable has no intrinsicWidth }`() {
-        // Given
-        whenever(mockDrawable.intrinsicWidth).thenReturn(-1)
-
-        // When
-        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
-
-        // Then
-        assertThat(wireframes).isEmpty()
-    }
-
-    @Test
-    fun `M return emptylist W map() { drawable has no intrinsicHeight }`() {
-        // Given
-        whenever(mockDrawable.intrinsicHeight).thenReturn(-1)
-
-        // When
-        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
-
-        // Then
-        assertThat(wireframes).isEmpty()
-    }
-
-    @Test
-    fun `M set null shapestyle and border W map() { view without background }`() {
-        // Given
-        whenever(mockImageButton.background).thenReturn(null)
-
-        // When
-        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
-        val actualWireframe = wireframes[0] as? MobileSegment.Wireframe.ShapeWireframe
-
-        // Then
-        assertThat(actualWireframe?.shapeStyle).isNull()
-        assertThat(actualWireframe?.border).isNull()
-    }
-
-    @Test
-    fun `M return expected wireframe W map()`() {
-        // Given
-        val expectedWireframe = MobileSegment.Wireframe.ImageWireframe(
+        expectedWireframe = MobileSegment.Wireframe.ImageWireframe(
             id = fakeId,
-            width = mockGlobalBounds.width,
-            height = mockGlobalBounds.height,
             x = mockGlobalBounds.x,
             y = mockGlobalBounds.y,
+            width = mockImageButton.width.toLong(),
+            height = mockImageButton.height.toLong(),
             shapeStyle = null,
             border = null,
             base64 = "",
@@ -207,23 +147,241 @@ internal class ImageButtonMapperTest {
             isEmpty = true
         )
 
-        // When
-        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
-        val actualWireframe = wireframes[0]
+        whenever(mockBase64Serializer.getDrawableScaledDimensions(any(), any(), any()))
+            .thenReturn(DrawableDimensions(0, 0))
 
-        // Then
-        assertThat(actualWireframe).isEqualTo(expectedWireframe)
-        verify(mockBase64Serializer, times(1))
-            .handleBitmap(any(), any(), any(), any())
+        testedMapper = ImageButtonMapper(
+            base64Serializer = mockBase64Serializer,
+            imageWireframeHelper = mockImageWireframeHelper,
+            uniqueIdentifierGenerator = mockUniqueIdentifierGenerator
+        )
     }
 
     @Test
-    fun `M call handleBitmap W map()`() {
+    fun `M return foreground wireframe W map() { no background }`() {
+        // Given
+        whenever(mockImageButton.background).thenReturn(null)
+
+        whenever(
+            mockImageWireframeHelper.createImageWireframe(
+                mockImageButton,
+                0,
+                mockGlobalBounds.x,
+                mockGlobalBounds.y,
+                mockImageButton.width.toLong(),
+                mockImageButton.height.toLong(),
+                mockDrawable.constantState?.newDrawable(mockResources),
+                null,
+                null
+            )
+        ).thenReturn(expectedWireframe)
+
+        // When
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
+
+        // Then
+        assertThat(wireframes.size).isEqualTo(1)
+        assertThat(wireframes[0]).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M resolve background images W map() { with background }`(
+        @LongForgery id: Long
+    ) {
+        // Given
+        val expectedBackgroundWireframe = MobileSegment.Wireframe.ImageWireframe(
+            id = id,
+            x = mockGlobalBounds.x,
+            y = mockGlobalBounds.y,
+            width = mockImageButton.width.toLong(),
+            height = mockImageButton.height.toLong(),
+            shapeStyle = null,
+            border = null,
+            base64 = "",
+            mimeType = fakeMimeType,
+            isEmpty = true
+        )
+
+        whenever(mockImageButton.background).thenReturn(mockBackground)
+        mockCreateImageWireframe(
+            expectedBackgroundWireframe,
+            expectedWireframe
+        )
+
+        // When
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
+
+        // Then
+        assertThat(wireframes.size).isEqualTo(2)
+        assertThat(wireframes[0]).isEqualTo(expectedBackgroundWireframe)
+        assertThat(wireframes[1]).isEqualTo(expectedWireframe)
+    }
+
+    @Test
+    fun `M set index to 1 W map() { has background wireframe }`(
+        @LongForgery id: Long
+    ) {
+        // Given
+        val expectedBackgroundWireframe = MobileSegment.Wireframe.ImageWireframe(
+            id = id,
+            x = mockGlobalBounds.x,
+            y = mockGlobalBounds.y,
+            width = mockImageButton.width.toLong(),
+            height = mockImageButton.height.toLong(),
+            shapeStyle = null,
+            border = null,
+            base64 = "",
+            mimeType = fakeMimeType,
+            isEmpty = true
+        )
+        whenever(mockImageButton.background).thenReturn(mockBackground)
+
+        mockCreateImageWireframe(
+            expectedBackgroundWireframe,
+            expectedWireframe
+        )
+
         // When
         testedMapper.map(mockImageButton, mockMappingContext)
 
         // Then
-        verify(mockBase64Serializer, times(1))
-            .handleBitmap(any(), any(), any(), any())
+        val captor = argumentCaptor<Int>()
+        verify(mockImageWireframeHelper, times(2)).createImageWireframe(
+            any(),
+            captor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull()
+        )
+        val allValues = captor.allValues
+        assertThat(allValues[0]).isEqualTo(0)
+        assertThat(allValues[1]).isEqualTo(1)
+    }
+
+    @Test
+    fun `M set index to 0 W map() { no background wireframe }`() {
+        // Given
+        whenever(mockImageButton.background).thenReturn(mockBackground)
+
+        mockCreateImageWireframe(
+            null,
+            expectedWireframe
+        )
+
+        // When
+        testedMapper.map(mockImageButton, mockMappingContext)
+
+        // Then
+        val captor = argumentCaptor<Int>()
+        verify(mockImageWireframeHelper, times(2)).createImageWireframe(
+            any(),
+            captor.capture(),
+            any(),
+            any(),
+            any(),
+            any(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull(),
+            anyOrNull()
+        )
+        val allValues = captor.allValues
+        assertThat(allValues[0]).isEqualTo(0)
+        assertThat(allValues[1]).isEqualTo(0)
+    }
+
+    @Test
+    fun `M return background of type ImageWireframe W map() { no shapestyle or border }`(
+        @LongForgery id: Long
+    ) {
+        // Given
+        whenever(mockImageButton.background).thenReturn(mockBackground)
+
+        val expectedBackgroundWireframe = MobileSegment.Wireframe.ImageWireframe(
+            id = id,
+            x = mockGlobalBounds.x,
+            y = mockGlobalBounds.y,
+            width = mockImageButton.width.toLong(),
+            height = mockImageButton.height.toLong(),
+            shapeStyle = null,
+            border = null,
+            base64 = "",
+            mimeType = fakeMimeType,
+            isEmpty = true
+        )
+
+        mockCreateImageWireframe(
+            expectedBackgroundWireframe,
+            expectedWireframe
+        )
+
+        // When
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
+
+        // Then
+        assertThat(wireframes[0]::class.java).isEqualTo(MobileSegment.Wireframe.ImageWireframe::class.java)
+    }
+
+    @Test
+    fun `M return background of type ShapeWireframe W map() { has shapestyle or border }`(
+        @Mock mockColorDrawable: ColorDrawable
+    ) {
+        // Given
+        whenever(mockImageButton.background).thenReturn(mockColorDrawable)
+
+        // When
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
+
+        // Then
+        assertThat(wireframes[0]::class.java).isEqualTo(MobileSegment.Wireframe.ShapeWireframe::class.java)
+    }
+
+    @Test
+    fun `M return no background W map() { cant resolve id for shapeDrawable }`(
+        @Mock mockColorDrawable: ColorDrawable
+    ) {
+        // Given
+        whenever(mockImageButton.background).thenReturn(mockColorDrawable)
+
+        whenever(mockUniqueIdentifierGenerator.resolveChildUniqueIdentifier(any(), any()))
+            .thenReturn(null)
+
+        mockCreateImageWireframe(
+            expectedWireframe,
+            null
+        )
+
+        // When
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
+
+        // Then
+        assertThat(wireframes.size).isEqualTo(1)
+    }
+
+    private fun mockCreateImageWireframe(
+        expectedFirstWireframe: MobileSegment.Wireframe.ImageWireframe?,
+        expectedSecondWireframe: MobileSegment.Wireframe.ImageWireframe?
+    ) {
+        whenever(
+            mockImageWireframeHelper.createImageWireframe(
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                any(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull(),
+                anyOrNull()
+            )
+        )
+            .thenReturn(expectedFirstWireframe)
+            .thenReturn(expectedSecondWireframe)
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/ImageComponentsFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/ImageComponentsFragment.kt
@@ -12,8 +12,10 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import android.widget.Button
+import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.TextView
+import androidx.appcompat.widget.AppCompatImageButton
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.sample.R
@@ -28,6 +30,8 @@ internal class ImageComponentsFragment : Fragment() {
     private lateinit var buttonRemote: Button
     private lateinit var viewRemote: View
     private lateinit var imageViewRemote: ImageView
+    private lateinit var imageButtonRemote: ImageButton
+    private lateinit var appCompatButtonRemote: AppCompatImageButton
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -39,6 +43,8 @@ internal class ImageComponentsFragment : Fragment() {
         buttonRemote = rootView.findViewById(R.id.buttonRemote)
         viewRemote = rootView.findViewById(R.id.viewRemote)
         imageViewRemote = rootView.findViewById(R.id.imageView_remote)
+        imageButtonRemote = rootView.findViewById(R.id.imageButtonRemote)
+        appCompatButtonRemote = rootView.findViewById(R.id.appCompatImageButtonRemote)
         return rootView
     }
 
@@ -55,6 +61,7 @@ internal class ImageComponentsFragment : Fragment() {
         loadImageView()
         loadButton()
         loadTextView()
+        loadImageButtonBackground()
     }
 
     private fun loadView() {
@@ -100,6 +107,19 @@ internal class ImageComponentsFragment : Fragment() {
             object : ImageLoadedCallback {
                 override fun onImageLoaded(resource: Drawable) {
                     textViewRemote.setCompoundDrawablesWithIntrinsicBounds(resource, null, null, null)
+                }
+            }
+        )
+    }
+
+    private fun loadImageButtonBackground() {
+        viewModel.fetchRemoteImage(
+            LARGE_IMAGE_URL,
+            imageButtonRemote,
+            object : ImageLoadedCallback {
+                override fun onImageLoaded(resource: Drawable) {
+                    imageButtonRemote.background = resource
+                    appCompatButtonRemote.background = resource
                 }
             }
         )

--- a/sample/kotlin/src/main/res/layout/fragment_image_components.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_image_components.xml
@@ -185,14 +185,32 @@
 
             <LinearLayout
                 android:layout_width="match_parent"
-                android:layout_height="160dp"
+                android:layout_height="80dp"
                 android:orientation="horizontal"
                 android:gravity="center"
                 >
 
-                <androidx.appcompat.widget.AppCompatImageButton
+                <ImageButton
                     android:id="@+id/imageButtonBundled"
-                    android:layout_width="160dp"
+                    android:layout_width="80dp"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_dd_icon_rgb"
+                    android:contentDescription="@string/title_imagebuttons"
+                    />
+
+                <ImageButton
+                    android:id="@+id/imageButtonBundledStatelist"
+                    android:layout_width="80dp"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_dd_statelist"
+                    android:contentDescription="@string/title_imagebuttons"
+                    />
+
+                <androidx.appcompat.widget.AppCompatImageButton
+                    android:id="@+id/appCompatImageButtonBundled"
+                    android:layout_width="80dp"
                     android:layout_height="match_parent"
                     android:scaleType="centerCrop"
                     android:src="@drawable/ic_dd_icon_rgb"
@@ -200,11 +218,38 @@
                     />
 
                 <androidx.appcompat.widget.AppCompatImageButton
-                    android:id="@+id/imageButtonBundledStatelist"
-                    android:layout_width="160dp"
+                    android:id="@+id/appCompatImageButtonBundledStatelist"
+                    android:layout_width="80dp"
                     android:layout_height="match_parent"
                     android:scaleType="centerCrop"
                     android:src="@drawable/ic_dd_statelist"
+                    android:contentDescription="@string/title_imagebuttons"
+                    />
+
+            </LinearLayout>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="80dp"
+                android:orientation="horizontal"
+                android:gravity="center"
+                >
+
+                <ImageButton
+                    android:id="@+id/imageButtonRemote"
+                    android:layout_width="80dp"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_dd_icon_rgb"
+                    android:contentDescription="@string/title_imagebuttons"
+                    />
+
+                <androidx.appcompat.widget.AppCompatImageButton
+                    android:id="@+id/appCompatImageButtonRemote"
+                    android:layout_width="80dp"
+                    android:layout_height="match_parent"
+                    android:scaleType="centerCrop"
+                    android:src="@drawable/ic_dd_icon_rgb"
                     android:contentDescription="@string/title_imagebuttons"
                     />
 
@@ -219,16 +264,38 @@
 
                 <ImageButton
                     android:id="@+id/imageButtonWithShapeOval"
-                    android:layout_width="160dp"
-                    android:layout_height="160dp"
+                    android:layout_width="80dp"
+                    android:layout_height="80dp"
                     android:src="@drawable/ic_dd_shape_oval"
+                    android:scaleType="centerCrop"
+                    android:contentDescription="@string/title_imagebuttons"
                     />
 
                 <ImageButton
                     android:id="@+id/imageButtonWithShapeRect"
-                    android:layout_width="160dp"
-                    android:layout_height="160dp"
+                    android:layout_width="80dp"
+                    android:layout_height="80dp"
                     android:src="@drawable/ic_dd_shape_rect"
+                    android:scaleType="centerCrop"
+                    android:contentDescription="@string/title_imagebuttons"
+                    />
+
+                <androidx.appcompat.widget.AppCompatImageButton
+                    android:id="@+id/appCompatImageButtonWithShapeOval"
+                    android:layout_width="80dp"
+                    android:layout_height="80dp"
+                    android:src="@drawable/ic_dd_shape_oval"
+                    android:scaleType="centerCrop"
+                    android:contentDescription="@string/title_imagebuttons"
+                    />
+
+                <androidx.appcompat.widget.AppCompatImageButton
+                    android:id="@+id/appCompatImageButtonWithShapeRect"
+                    android:layout_width="80dp"
+                    android:layout_height="80dp"
+                    android:src="@drawable/ic_dd_shape_rect"
+                    android:scaleType="centerCrop"
+                    android:contentDescription="@string/title_imagebuttons"
                     />
 
             </LinearLayout>


### PR DESCRIPTION
### What does this PR do?
• Gets the bitmap from BitmapDrawable if available (use new EnrichedBitmap class to know if we should later cache it)
• Extraction of the base64 logic from the ImageButtonMapper to ImageWireframeHelper
• Gets background images if they exist (added an example to the sample app)
• Support scaletypes (atm only fitXY and center-crop)
• Move registration of bitmapPool for callbacks from DrawableUtils to Base64Serializer

### Motivation
Additional improvements necessary to rollout base64 imagebutton support

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

