### PR TITLE
RUMM-3506 Collect the batch deleted telemetry

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/DataUploadConfiguration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/DataUploadConfiguration.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.configuration
+
+internal data class DataUploadConfiguration(internal val frequency: UploadFrequency) {
+    internal val minDelayMs = MIN_DELAY_FACTOR * frequency.baseStepMs
+    internal val maxDelayMs = MAX_DELAY_FACTOR * frequency.baseStepMs
+    internal val defaultDelayMs = DEFAULT_DELAY_FACTOR * frequency.baseStepMs
+    companion object {
+        internal const val MIN_DELAY_FACTOR = 1
+        internal const val MAX_DELAY_FACTOR = 10
+        internal const val DEFAULT_DELAY_FACTOR = 5
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -16,8 +16,8 @@ import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.FeatureStorageConfiguration
-import com.datadog.android.core.configuration.DataUploadConfiguration
 import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.internal.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.data.upload.DataOkHttpUploader
 import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
 import com.datadog.android.core.internal.data.upload.UploadScheduler
@@ -25,11 +25,15 @@ import com.datadog.android.core.internal.data.upload.v2.DataFlusher
 import com.datadog.android.core.internal.data.upload.v2.DataUploadScheduler
 import com.datadog.android.core.internal.data.upload.v2.DataUploader
 import com.datadog.android.core.internal.data.upload.v2.NoOpDataUploader
+import com.datadog.android.core.internal.metrics.BatchMetricsDispatcher
+import com.datadog.android.core.internal.metrics.MetricsDispatcher
+import com.datadog.android.core.internal.metrics.NoOpMetricsDispatcher
 import com.datadog.android.core.internal.persistence.ConsentAwareStorage
 import com.datadog.android.core.internal.persistence.NoOpStorage
 import com.datadog.android.core.internal.persistence.Storage
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
+import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.NoOpFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOrchestrator
@@ -52,25 +56,44 @@ internal class SdkFeature(
     internal var uploader: DataUploader = NoOpDataUploader()
     internal var uploadScheduler: UploadScheduler = NoOpUploadScheduler()
     internal var fileOrchestrator: FileOrchestrator = NoOpFileOrchestrator()
+    private var metricsDispatcher: MetricsDispatcher = NoOpMetricsDispatcher()
 
-    // region SDK Feature
+    // region SdkFeature
 
     fun initialize(context: Context) {
         if (initialized.get()) {
             return
         }
 
-        val uploadFrequency = resolveUploadFrequency()
-        val uploadConfiguration = DataUploadConfiguration(uploadFrequency)
-
+        var dataUploadConfiguration: DataUploadConfiguration? = null
         if (wrappedFeature is StorageBackedFeature) {
-            storage = createStorage(wrappedFeature.name, wrappedFeature.storageConfiguration)
+            val uploadFrequency = resolveUploadFrequency()
+            dataUploadConfiguration = DataUploadConfiguration(uploadFrequency)
+
+            val storageConfiguration = wrappedFeature.storageConfiguration
+            val recentDelayMs = resolveBatchingDelay(coreFeature, storageConfiguration)
+            val filePersistenceConfig = coreFeature.buildFilePersistenceConfig().copy(
+                maxBatchSize = storageConfiguration.maxBatchSize,
+                maxItemSize = storageConfiguration.maxItemSize,
+                maxItemsPerBatch = storageConfiguration.maxItemsPerBatch,
+                oldFileThreshold = storageConfiguration.oldBatchThreshold,
+                recentDelayMs = recentDelayMs
+            )
+            metricsDispatcher = BatchMetricsDispatcher(
+                wrappedFeature.name,
+                dataUploadConfiguration,
+                filePersistenceConfig,
+                internalLogger,
+                coreFeature.timeProvider
+            )
+
+            storage = createStorage(wrappedFeature.name, filePersistenceConfig)
         }
 
         wrappedFeature.onInitialize(context)
 
-        if (wrappedFeature is StorageBackedFeature) {
-            setupUploader(wrappedFeature.requestFactory, uploadConfiguration)
+        if (wrappedFeature is StorageBackedFeature && dataUploadConfiguration != null) {
+            setupUploader(wrappedFeature.requestFactory, dataUploadConfiguration)
         }
 
         if (wrappedFeature is TrackingConsentProviderCallback) {
@@ -188,14 +211,15 @@ internal class SdkFeature(
 
     private fun createStorage(
         featureName: String,
-        storageConfiguration: FeatureStorageConfiguration
+        filePersistenceConfig: FilePersistenceConfig
     ): Storage {
         val fileOrchestrator = FeatureFileOrchestrator(
             consentProvider = coreFeature.trackingConsentProvider,
             storageDir = coreFeature.storageDir,
             featureName = featureName,
             executorService = coreFeature.persistenceExecutorService,
-            internalLogger = internalLogger
+            internalLogger = internalLogger,
+            metricsDispatcher = metricsDispatcher
         )
         this.fileOrchestrator = fileOrchestrator
 
@@ -213,16 +237,8 @@ internal class SdkFeature(
             ),
             fileMover = FileMover(internalLogger),
             internalLogger = internalLogger,
-            filePersistenceConfig = coreFeature.buildFilePersistenceConfig().copy(
-                maxBatchSize = storageConfiguration.maxBatchSize,
-                maxItemSize = storageConfiguration.maxItemSize,
-                maxItemsPerBatch = storageConfiguration.maxItemsPerBatch,
-                oldFileThreshold = storageConfiguration.oldBatchThreshold,
-                recentDelayMs = resolveBatchingDelay(
-                    coreFeature,
-                    storageConfiguration
-                )
-            )
+            filePersistenceConfig = filePersistenceConfig,
+            metricsDispatcher = metricsDispatcher
         )
     }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/configuration/DataUploadConfiguration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/configuration/DataUploadConfiguration.kt
@@ -4,7 +4,9 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.core.configuration
+package com.datadog.android.core.internal.configuration
+
+import com.datadog.android.core.configuration.UploadFrequency
 
 internal data class DataUploadConfiguration(internal val frequency: UploadFrequency) {
     internal val minDelayMs = MIN_DELAY_FACTOR * frequency.baseStepMs

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploader.kt
@@ -47,7 +47,7 @@ internal class DataOkHttpUploader(
                 },
                 e
             )
-            return UploadStatus.REQUEST_CREATION_ERROR
+            return UploadStatus.RequestCreationError
         }
 
         val uploadStatus = try {
@@ -59,7 +59,7 @@ internal class DataOkHttpUploader(
                 { "Unable to execute the request; we will retry later." },
                 e
             )
-            UploadStatus.NETWORK_ERROR
+            UploadStatus.NetworkError
         }
 
         uploadStatus.logStatus(
@@ -96,7 +96,7 @@ internal class DataOkHttpUploader(
             }
             ?.value
         if (apiKey != null && (apiKey.isEmpty() || !isValidHeaderValue(apiKey))) {
-            return UploadStatus.INVALID_TOKEN_ERROR
+            return UploadStatus.InvalidTokenError(UploadStatus.UNKNOWN_RESPONSE_CODE)
         }
 
         val okHttpRequest = buildOkHttpRequest(request)
@@ -152,22 +152,22 @@ internal class DataOkHttpUploader(
         request: DatadogRequest
     ): UploadStatus {
         return when (code) {
-            HTTP_ACCEPTED -> UploadStatus.SUCCESS
-            HTTP_BAD_REQUEST -> UploadStatus.HTTP_CLIENT_ERROR
-            HTTP_UNAUTHORIZED -> UploadStatus.INVALID_TOKEN_ERROR
-            HTTP_FORBIDDEN -> UploadStatus.INVALID_TOKEN_ERROR
-            HTTP_CLIENT_TIMEOUT -> UploadStatus.HTTP_CLIENT_RATE_LIMITING
-            HTTP_ENTITY_TOO_LARGE -> UploadStatus.HTTP_CLIENT_ERROR
-            HTTP_TOO_MANY_REQUESTS -> UploadStatus.HTTP_CLIENT_RATE_LIMITING
-            HTTP_INTERNAL_ERROR -> UploadStatus.HTTP_SERVER_ERROR
-            HTTP_UNAVAILABLE -> UploadStatus.HTTP_SERVER_ERROR
+            HTTP_ACCEPTED -> UploadStatus.Success(code)
+            HTTP_BAD_REQUEST -> UploadStatus.HttpClientError(code)
+            HTTP_UNAUTHORIZED -> UploadStatus.InvalidTokenError(code)
+            HTTP_FORBIDDEN -> UploadStatus.InvalidTokenError(code)
+            HTTP_CLIENT_TIMEOUT -> UploadStatus.HttpClientRateLimiting(code)
+            HTTP_ENTITY_TOO_LARGE -> UploadStatus.HttpClientError(code)
+            HTTP_TOO_MANY_REQUESTS -> UploadStatus.HttpClientRateLimiting(code)
+            HTTP_INTERNAL_ERROR -> UploadStatus.HttpServerError(code)
+            HTTP_UNAVAILABLE -> UploadStatus.HttpServerError(code)
             else -> {
                 internalLogger.log(
                     InternalLogger.Level.WARN,
                     listOf(InternalLogger.Target.MAINTAINER, InternalLogger.Target.TELEMETRY),
                     { "Unexpected status code $code on upload request: ${request.description}" }
                 )
-                UploadStatus.UNKNOWN_ERROR
+                UploadStatus.UnknownError(code)
             }
         }
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/NoOpDataUploader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/NoOpDataUploader.kt
@@ -6,7 +6,8 @@
 
 package com.datadog.android.core.internal.data.upload
 
-internal interface DataUploader {
-
-    fun upload(data: ByteArray): UploadStatus
+internal interface NoOpDataUploader : DataUploader {
+    override fun upload(data: ByteArray): UploadStatus {
+        return UploadStatus.UnknownStatus
+    }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnable.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnable.kt
@@ -10,7 +10,7 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.NetworkInfo
-import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.ContextProvider
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.data.upload.UploadRunnable
@@ -33,14 +33,14 @@ internal class DataUploadRunnable(
     private val contextProvider: ContextProvider,
     private val networkInfoProvider: NetworkInfoProvider,
     private val systemInfoProvider: SystemInfoProvider,
-    internal val uploadFrequency: UploadFrequency,
+    uploadConfiguration: DataUploadConfiguration,
     private val batchUploadWaitTimeoutMs: Long = CoreFeature.NETWORK_TIMEOUT_MS,
     private val internalLogger: InternalLogger
 ) : UploadRunnable {
 
-    internal var currentDelayIntervalMs = DEFAULT_DELAY_FACTOR * uploadFrequency.baseStepMs
-    internal var minDelayMs = MIN_DELAY_FACTOR * uploadFrequency.baseStepMs
-    internal var maxDelayMs = MAX_DELAY_FACTOR * uploadFrequency.baseStepMs
+    internal var currentDelayIntervalMs = uploadConfiguration.defaultDelayMs
+    internal val minDelayMs = uploadConfiguration.minDelayMs
+    internal val maxDelayMs = uploadConfiguration.maxDelayMs
 
     //  region Runnable
 
@@ -148,11 +148,6 @@ internal class DataUploadRunnable(
 
     companion object {
         internal const val LOW_BATTERY_THRESHOLD = 10
-
-        internal const val MIN_DELAY_FACTOR = 1
-        internal const val DEFAULT_DELAY_FACTOR = 5
-        internal const val MAX_DELAY_FACTOR = 10
-
         const val DECREASE_PERCENT = 0.90
         const val INCREASE_PERCENT = 1.10
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadScheduler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadScheduler.kt
@@ -7,8 +7,8 @@
 package com.datadog.android.core.internal.data.upload.v2
 
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.core.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.ContextProvider
+import com.datadog.android.core.internal.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.data.upload.UploadScheduler
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.persistence.Storage

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadScheduler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadScheduler.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.core.internal.data.upload.v2
 
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.ContextProvider
 import com.datadog.android.core.internal.data.upload.UploadScheduler
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
@@ -23,7 +23,7 @@ internal class DataUploadScheduler(
     contextProvider: ContextProvider,
     networkInfoProvider: NetworkInfoProvider,
     systemInfoProvider: SystemInfoProvider,
-    uploadFrequency: UploadFrequency,
+    uploadConfiguration: DataUploadConfiguration,
     private val scheduledThreadPoolExecutor: ScheduledThreadPoolExecutor,
     private val internalLogger: InternalLogger
 ) : UploadScheduler {
@@ -35,7 +35,7 @@ internal class DataUploadScheduler(
         contextProvider,
         networkInfoProvider,
         systemInfoProvider,
-        uploadFrequency,
+        uploadConfiguration,
         internalLogger = internalLogger
     )
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/NoOpDataUploader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/NoOpDataUploader.kt
@@ -9,10 +9,8 @@ package com.datadog.android.core.internal.data.upload.v2
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.core.internal.data.upload.UploadStatus
 
-internal interface DataUploader {
-    fun upload(
-        context: DatadogContext,
-        batch: List<ByteArray>,
-        batchMeta: ByteArray?
-    ): UploadStatus
+internal class NoOpDataUploader : DataUploader {
+    override fun upload(context: DatadogContext, batch: List<ByteArray>, batchMeta: ByteArray?): UploadStatus {
+        return UploadStatus.UnknownStatus
+    }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
@@ -1,0 +1,136 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.metrics
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.internal.configuration.DataUploadConfiguration
+import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
+import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.core.sampling.RateBasedSampler
+import com.datadog.android.core.sampling.Sampler
+import java.io.File
+import java.util.Locale
+
+internal class BatchMetricsDispatcher(
+    featureName: String,
+    private val uploadConfiguration: DataUploadConfiguration,
+    private val filePersistenceConfig: FilePersistenceConfig,
+    private val internalLogger: InternalLogger,
+    private val dateTimeProvider: TimeProvider,
+    private val sampler: Sampler = RateBasedSampler(METRICS_DISPATCHER_DEFAULT_SAMPLING_RATE)
+) :
+    MetricsDispatcher {
+
+    private val trackName: String? = resolveTrackName(featureName)
+
+    override fun sendBatchDeletedMetric(batchFile: File, removalReason: RemovalReason) {
+        if (!removalReason.includeInMetrics() || trackName == null || !sampler.sample()) {
+            return
+        }
+        resolveBatchDeletedMetricAttributes(batchFile, removalReason)?.let {
+            internalLogger.logMetric(
+                messageBuilder = { BATCH_DELETED_MESSAGE },
+                additionalProperties = it
+            )
+        }
+    }
+
+    private fun resolveBatchDeletedMetricAttributes(
+        file: File,
+        deletionReason: RemovalReason
+    ): Map<String, Any?>? {
+        val fileAgeInMillis = resolveFileAge(file)
+        if (fileAgeInMillis < 0) {
+            return null
+        }
+        return mutableMapOf<String, Any?>(
+            TRACK_KEY to trackName,
+            TYPE_KEY to BATCH_DELETED_TYPE_VALUE,
+            BATCH_AGE_KEY to fileAgeInMillis,
+            UPLOADER_DELAY_KEY to mapOf(
+                UPLOADER_DELAY_MIN_KEY to uploadConfiguration.minDelayMs,
+                UPLOADER_DELAY_MAX_KEY to uploadConfiguration.maxDelayMs
+            ),
+            UPLOADER_WINDOW_KEY to filePersistenceConfig.recentDelayMs,
+
+            BATCH_REMOVAL_KEY to deletionReason.toString(),
+            // TODO: RUMM-952 add inBackground flag value
+            IN_BACKGROUND_KEY to false
+        )
+    }
+
+    private fun resolveFileAge(file: File): Long {
+        return try {
+            dateTimeProvider.getDeviceTimestamp() - file.name.toLong()
+        } catch (e: NumberFormatException) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.MAINTAINER,
+                { WRONG_FILE_NAME_MESSAGE_FORMAT.format(Locale.ENGLISH, file.name) },
+                e
+            )
+            -1L
+        }
+    }
+
+    private fun resolveTrackName(featureName: String): String? {
+        return when (featureName) {
+            Feature.RUM_FEATURE_NAME -> RUM_TRACK_NAME
+            Feature.LOGS_FEATURE_NAME -> LOGS_TRACK_NAME
+            Feature.TRACING_FEATURE_NAME -> TRACE_TRACK_NAME
+            Feature.SESSION_REPLAY_FEATURE_NAME -> SR_TRACK_NAME
+            else -> null
+        }
+    }
+
+    companion object {
+
+        internal const val RUM_TRACK_NAME = "rum"
+        internal const val LOGS_TRACK_NAME = "logs"
+        internal const val TRACE_TRACK_NAME = "trace"
+        internal const val SR_TRACK_NAME = "sr"
+
+        private const val METRICS_DISPATCHER_DEFAULT_SAMPLING_RATE = 15f
+
+        internal const val WRONG_FILE_NAME_MESSAGE_FORMAT =
+            "Unable to parse the file name as a timestamp: %s"
+
+        internal const val BATCH_DELETED_MESSAGE: String = "[Mobile Metric] Batch Deleted"
+
+        /* The key for the type of the metric.*/
+        internal const val TYPE_KEY = "metric_type"
+
+        /* The value for the type of the metric.*/
+        internal const val BATCH_DELETED_TYPE_VALUE = "batch deleted"
+
+        /* The key for the track name.*/
+        internal const val TRACK_KEY = "track"
+
+        /* The key for uploader's delay options.*/
+        internal const val UPLOADER_DELAY_KEY = "uploader_delay"
+
+        /* The min delay of uploads for this track (in ms).*/
+        internal const val UPLOADER_DELAY_MIN_KEY = "min"
+
+        /* The min delay of uploads for this track (in ms).*/
+        internal const val UPLOADER_DELAY_MAX_KEY = "max"
+
+        /* The default duration since last write (in ms) after which the uploader considers
+         the file to be "ready for upload".*/
+        internal const val UPLOADER_WINDOW_KEY = "uploader_window"
+
+        /* The duration from batch creation to batch deletion (in ms).*/
+        internal const val BATCH_AGE_KEY = "batch_age"
+
+        /* The reason of batch deletion. */
+        internal const val BATCH_REMOVAL_KEY = "batch_removal_reason"
+
+        /* If the batch was deleted in the background. */
+        internal const val IN_BACKGROUND_KEY = "in_background"
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/MetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/MetricsDispatcher.kt
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.metrics
+
+import com.datadog.tools.annotation.NoOpImplementation
+import java.io.File
+
+@NoOpImplementation
+internal interface MetricsDispatcher {
+    fun sendBatchDeletedMetric(batchFile: File, removalReason: RemovalReason)
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/RemovalReason.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/RemovalReason.kt
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.metrics
+
+internal sealed class RemovalReason {
+
+    internal fun includeInMetrics(): Boolean {
+        return this !is Flushed
+    }
+    internal class IntakeCode(private val responseCode: Int) : RemovalReason() {
+        override fun toString(): String {
+            return "intake-code-$responseCode"
+        }
+    }
+
+    internal object Invalid : RemovalReason() {
+        override fun toString(): String {
+            return "invalid"
+        }
+    }
+
+    internal object Purged : RemovalReason() {
+        override fun toString(): String {
+            return "purged"
+        }
+    }
+
+    internal object Obsolete : RemovalReason() {
+        override fun toString(): String {
+            return "obsolete"
+        }
+    }
+
+    internal object Flushed : RemovalReason() {
+        override fun toString(): String {
+            return "flushed"
+        }
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
@@ -10,6 +10,7 @@ import androidx.annotation.AnyThread
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.core.internal.metrics.RemovalReason
 import com.datadog.tools.annotation.NoOpImplementation
 
 /**
@@ -52,10 +53,15 @@ internal interface Storage {
     /**
      * Utility to update the state of a batch, asynchronously.
      * @param batchId the id of the Batch to confirm
+     * @param removalReason the reason why the batch is being removed
      * @param callback an operation to perform with a [BatchConfirmation]
      */
     @WorkerThread
-    fun confirmBatchRead(batchId: BatchId, callback: (BatchConfirmation) -> Unit)
+    fun confirmBatchRead(
+        batchId: BatchId,
+        removalReason: RemovalReason,
+        callback: (BatchConfirmation) -> Unit
+    )
 
     /**
      * Removes all the files backed by this storage, synchronously.

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestrator.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal.persistence.file.advanced
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.metrics.MetricsDispatcher
 import com.datadog.android.core.internal.persistence.file.FileMover
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
@@ -38,18 +39,21 @@ internal class FeatureFileOrchestrator(
         storageDir: File,
         featureName: String,
         executorService: ExecutorService,
-        internalLogger: InternalLogger
+        internalLogger: InternalLogger,
+        metricsDispatcher: MetricsDispatcher
     ) : this(
         consentProvider,
         BatchFileOrchestrator(
             File(storageDir, PENDING_DIR.format(Locale.US, featureName)),
             PERSISTENCE_CONFIG,
-            internalLogger
+            internalLogger,
+            metricsDispatcher
         ),
         BatchFileOrchestrator(
             File(storageDir, GRANTED_DIR.format(Locale.US, featureName)),
             PERSISTENCE_CONFIG,
-            internalLogger
+            internalLogger,
+            metricsDispatcher
         ),
         ConsentAwareFileMigrator(
             FileMover(internalLogger),

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/DataUploadConfigurationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/DataUploadConfigurationTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.configuration
+
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@Extensions(
+        ExtendWith(MockitoExtension::class),
+        ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class DataUploadConfigurationTest {
+
+    @Forgery
+    lateinit var fakeUploadFrequency: UploadFrequency
+
+    lateinit var testedConfiguration: DataUploadConfiguration
+    @BeforeEach
+    fun `set up`(){
+        testedConfiguration = DataUploadConfiguration(fakeUploadFrequency)
+    }
+
+    @Test
+    fun `M correctly compute the min delay`(){
+        assertThat(testedConfiguration.minDelayMs)
+            .isEqualTo(fakeUploadFrequency.baseStepMs * DataUploadConfiguration.MIN_DELAY_FACTOR)
+    }
+
+    @Test
+    fun `M correctly compute the max delay`(){
+        assertThat(testedConfiguration.maxDelayMs)
+            .isEqualTo(fakeUploadFrequency.baseStepMs * DataUploadConfiguration.MAX_DELAY_FACTOR)
+    }
+
+    @Test
+    fun `M correctly compute the default delay`(){
+        assertThat(testedConfiguration.defaultDelayMs)
+            .isEqualTo(fakeUploadFrequency.baseStepMs *
+                    DataUploadConfiguration.DEFAULT_DELAY_FACTOR)
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -16,8 +16,8 @@ import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.core.configuration.BatchSize
-import com.datadog.android.core.configuration.DataUploadConfiguration
 import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.internal.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.data.upload.DataOkHttpUploader
 import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
 import com.datadog.android.core.internal.data.upload.UploadScheduler

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -16,6 +16,7 @@ import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.core.configuration.BatchSize
+import com.datadog.android.core.configuration.DataUploadConfiguration
 import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.core.internal.data.upload.DataOkHttpUploader
 import com.datadog.android.core.internal.data.upload.NoOpUploadScheduler
@@ -130,6 +131,9 @@ internal class SdkFeatureTest {
 
     @Test
     fun `𝕄 initialize uploader 𝕎 initialize()`() {
+        // Given
+        val expectedUploadConfiguration = DataUploadConfiguration(fakeCoreUploadFrequency)
+
         // When
         testedFeature.initialize(appContext.mockInstance)
 
@@ -137,7 +141,10 @@ internal class SdkFeatureTest {
         assertThat(testedFeature.uploadScheduler)
             .isInstanceOf(DataUploadScheduler::class.java)
         val dataUploadRunnable = (testedFeature.uploadScheduler as DataUploadScheduler).runnable
-        assertThat(dataUploadRunnable.uploadFrequency).isEqualTo(fakeCoreUploadFrequency)
+        assertThat(dataUploadRunnable.minDelayMs).isEqualTo(expectedUploadConfiguration.minDelayMs)
+        assertThat(dataUploadRunnable.maxDelayMs).isEqualTo(expectedUploadConfiguration.maxDelayMs)
+        assertThat(dataUploadRunnable.currentDelayIntervalMs)
+            .isEqualTo(expectedUploadConfiguration.defaultDelayMs)
         argumentCaptor<Runnable> {
             verify(coreFeature.mockUploadExecutor).schedule(
                 any(),
@@ -145,7 +152,6 @@ internal class SdkFeatureTest {
                 eq(TimeUnit.MILLISECONDS)
             )
         }
-
         assertThat(testedFeature.uploader).isInstanceOf(DataOkHttpUploader::class.java)
     }
 
@@ -153,6 +159,7 @@ internal class SdkFeatureTest {
     fun `𝕄 use the storage frequency if set 𝕎 initialize()`(forge: Forge) {
         // Given
         val fakeUploadFrequency = forge.aValueFrom(UploadFrequency::class.java)
+        val expectedUploadConfiguration = DataUploadConfiguration(fakeUploadFrequency)
         val fakeStorageConfig = mockWrappedFeature.storageConfiguration
             .copy(uploadFrequency = fakeUploadFrequency)
         whenever(mockWrappedFeature.storageConfiguration)
@@ -165,7 +172,10 @@ internal class SdkFeatureTest {
         assertThat(testedFeature.uploadScheduler)
             .isInstanceOf(DataUploadScheduler::class.java)
         val dataUploadRunnable = (testedFeature.uploadScheduler as DataUploadScheduler).runnable
-        assertThat(dataUploadRunnable.uploadFrequency).isEqualTo(fakeUploadFrequency)
+        assertThat(dataUploadRunnable.minDelayMs).isEqualTo(expectedUploadConfiguration.minDelayMs)
+        assertThat(dataUploadRunnable.maxDelayMs).isEqualTo(expectedUploadConfiguration.maxDelayMs)
+        assertThat(dataUploadRunnable.currentDelayIntervalMs)
+            .isEqualTo(expectedUploadConfiguration.defaultDelayMs)
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/configuration/DataUploadConfigurationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/configuration/DataUploadConfigurationTest.kt
@@ -4,24 +4,25 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.core.configuration
+package com.datadog.android.core.internal.configuration
 
+import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
-import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Test
 
 @Extensions(
-        ExtendWith(MockitoExtension::class),
-        ExtendWith(ForgeExtension::class)
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
@@ -31,27 +32,30 @@ internal class DataUploadConfigurationTest {
     lateinit var fakeUploadFrequency: UploadFrequency
 
     lateinit var testedConfiguration: DataUploadConfiguration
+
     @BeforeEach
-    fun `set up`(){
+    fun `set up`() {
         testedConfiguration = DataUploadConfiguration(fakeUploadFrequency)
     }
 
     @Test
-    fun `M correctly compute the min delay`(){
+    fun `M correctly compute the min delay`() {
         assertThat(testedConfiguration.minDelayMs)
             .isEqualTo(fakeUploadFrequency.baseStepMs * DataUploadConfiguration.MIN_DELAY_FACTOR)
     }
 
     @Test
-    fun `M correctly compute the max delay`(){
+    fun `M correctly compute the max delay`() {
         assertThat(testedConfiguration.maxDelayMs)
             .isEqualTo(fakeUploadFrequency.baseStepMs * DataUploadConfiguration.MAX_DELAY_FACTOR)
     }
 
     @Test
-    fun `M correctly compute the default delay`(){
+    fun `M correctly compute the default delay`() {
         assertThat(testedConfiguration.defaultDelayMs)
-            .isEqualTo(fakeUploadFrequency.baseStepMs *
-                    DataUploadConfiguration.DEFAULT_DELAY_FACTOR)
+            .isEqualTo(
+                fakeUploadFrequency.baseStepMs *
+                    DataUploadConfiguration.DEFAULT_DELAY_FACTOR
+            )
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploaderTest.kt
@@ -192,7 +192,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.SUCCESS)
+        assertThat(result).isInstanceOf(UploadStatus.Success::class.java)
+        assertThat(result.code).isEqualTo(202)
         verifyRequest(fakeDatadogRequest, expectedUserAgentHeader = validValue)
         verifyResponseIsClosed()
     }
@@ -215,7 +216,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.SUCCESS)
+        assertThat(result).isInstanceOf(UploadStatus.Success::class.java)
+        assertThat(result.code).isEqualTo(202)
         verifyRequest(fakeDatadogRequest, expectedUserAgentHeader = fakeSdkUserAgent)
         verifyResponseIsClosed()
     }
@@ -242,7 +244,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.INVALID_TOKEN_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.InvalidTokenError::class.java)
+        assertThat(result.code).isEqualTo(UploadStatus.UNKNOWN_RESPONSE_CODE)
         verifyNoInteractions(mockCallFactory)
     }
 
@@ -263,7 +266,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.SUCCESS)
+        assertThat(result).isInstanceOf(UploadStatus.Success::class.java)
+        assertThat(result.code).isEqualTo(202)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -283,7 +287,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.HTTP_CLIENT_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.HttpClientError::class.java)
+        assertThat(result.code).isEqualTo(400)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -303,7 +308,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.INVALID_TOKEN_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.InvalidTokenError::class.java)
+        assertThat(result.code).isEqualTo(401)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -323,7 +329,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.INVALID_TOKEN_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.InvalidTokenError::class.java)
+        assertThat(result.code).isEqualTo(403)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -343,7 +350,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.HTTP_CLIENT_RATE_LIMITING)
+        assertThat(result).isInstanceOf(UploadStatus.HttpClientRateLimiting::class.java)
+        assertThat(result.code).isEqualTo(408)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -363,7 +371,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.HTTP_CLIENT_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.HttpClientError::class.java)
+        assertThat(result.code).isEqualTo(413)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -383,7 +392,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.HTTP_CLIENT_RATE_LIMITING)
+        assertThat(result).isInstanceOf(UploadStatus.HttpClientRateLimiting::class.java)
+        assertThat(result.code).isEqualTo(429)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -403,7 +413,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.HTTP_SERVER_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.HttpServerError::class.java)
+        assertThat(result.code).isEqualTo(500)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -423,7 +434,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.HTTP_SERVER_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.HttpServerError::class.java)
+        assertThat(result.code).isEqualTo(503)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -453,7 +465,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.UNKNOWN_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.UnknownError::class.java)
+        assertThat(result.code).isEqualTo(statusCode)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -473,7 +486,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.NETWORK_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.NetworkError::class.java)
+        assertThat(result.code).isEqualTo(UploadStatus.UNKNOWN_RESPONSE_CODE)
         verifyRequest(fakeDatadogRequest)
     }
 
@@ -492,7 +506,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.NETWORK_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.NetworkError::class.java)
+        assertThat(result.code).isEqualTo(UploadStatus.UNKNOWN_RESPONSE_CODE)
         verifyRequest(fakeDatadogRequest)
     }
 
@@ -512,7 +527,8 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batchData, batchMetadata)
 
         // Then
-        assertThat(result).isEqualTo(UploadStatus.REQUEST_CREATION_ERROR)
+        assertThat(result).isInstanceOf(UploadStatus.RequestCreationError::class.java)
+        assertThat(result.code).isEqualTo(UploadStatus.UNKNOWN_RESPONSE_CODE)
         verifyNoInteractions(mockCallFactory)
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -77,6 +77,9 @@ internal class DataUploadRunnableTest {
 
     lateinit var testedRunnable: DataUploadRunnable
 
+    @Forgery
+    lateinit var fakeUploadSuccess: UploadStatus.Success
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         val fakeNetworkInfo =
@@ -114,7 +117,7 @@ internal class DataUploadRunnableTest {
             )
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn networkInfo
         whenever(mockReader.lockAndReadNext()) doReturn batch
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn fakeUploadSuccess
 
         testedRunnable.run()
 
@@ -141,7 +144,7 @@ internal class DataUploadRunnableTest {
         )
         whenever(mockReader.lockAndReadNext()) doReturn batch
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn fakeUploadSuccess
 
         testedRunnable.run()
 
@@ -168,7 +171,7 @@ internal class DataUploadRunnableTest {
         )
         whenever(mockReader.lockAndReadNext()) doReturn batch
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn fakeUploadSuccess
 
         testedRunnable.run()
 
@@ -195,7 +198,7 @@ internal class DataUploadRunnableTest {
         )
         whenever(mockReader.lockAndReadNext()) doReturn batch
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn fakeUploadSuccess
 
         testedRunnable.run()
 
@@ -222,7 +225,7 @@ internal class DataUploadRunnableTest {
         )
         whenever(mockReader.lockAndReadNext()) doReturn batch
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn fakeUploadSuccess
 
         testedRunnable.run()
 
@@ -249,7 +252,7 @@ internal class DataUploadRunnableTest {
         )
         whenever(mockReader.lockAndReadNext()) doReturn batch
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn fakeUploadSuccess
 
         testedRunnable.run()
 
@@ -276,7 +279,7 @@ internal class DataUploadRunnableTest {
         )
         whenever(mockReader.lockAndReadNext()) doReturn batch
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn fakeUploadSuccess
 
         testedRunnable.run()
 
@@ -303,7 +306,7 @@ internal class DataUploadRunnableTest {
         )
         whenever(mockReader.lockAndReadNext()) doReturn batch
         whenever(mockSystemInfoProvider.getLatestSystemInfo()) doReturn fakeSystemInfo
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn fakeUploadSuccess
 
         testedRunnable.run()
 
@@ -336,7 +339,7 @@ internal class DataUploadRunnableTest {
     @Test
     fun `batch sent successfully`(@Forgery batch: Batch) {
         whenever(mockReader.lockAndReadNext()) doReturn batch
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(batch.data)) doReturn fakeUploadSuccess
 
         testedRunnable.run()
 
@@ -351,9 +354,12 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `batch kept on Network Error`(@Forgery batch: Batch) {
+    fun `batch kept on Network Error`(
+        @Forgery batch: Batch,
+        @Forgery status: UploadStatus.NetworkError
+    ) {
         whenever(mockReader.lockAndReadNext()) doReturn batch
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.NETWORK_ERROR
+        whenever(mockDataUploader.upload(batch.data)) doReturn status
 
         testedRunnable.run()
 
@@ -370,10 +376,11 @@ internal class DataUploadRunnableTest {
     @Test
     fun `batch kept after n Network Error`(
         @Forgery batch: Batch,
-        @IntForgery(min = 3, max = 42) runCount: Int
+        @IntForgery(min = 3, max = 42) runCount: Int,
+        @Forgery status: UploadStatus.NetworkError
     ) {
         whenever(mockReader.lockAndReadNext()) doReturn batch
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.NETWORK_ERROR
+        whenever(mockDataUploader.upload(batch.data)) doReturn status
 
         repeat(runCount) {
             testedRunnable.run()
@@ -389,9 +396,12 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `batch dropped on Redirection`(@Forgery batch: Batch) {
+    fun `batch dropped on Redirection`(
+        @Forgery batch: Batch,
+        @Forgery status: UploadStatus.HttpRedirection
+    ) {
         whenever(mockReader.lockAndReadNext()) doReturn batch
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.HTTP_REDIRECTION
+        whenever(mockDataUploader.upload(batch.data)) doReturn status
 
         testedRunnable.run()
 
@@ -406,10 +416,12 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `batch dropped on Client Error`(@Forgery batch: Batch) {
+    fun `batch dropped on Client Error`(
+        @Forgery batch: Batch,
+        @Forgery status: UploadStatus.HttpClientError
+    ) {
         whenever(mockReader.lockAndReadNext()) doReturn batch
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.HTTP_CLIENT_ERROR
-
+        whenever(mockDataUploader.upload(batch.data)) doReturn status
         testedRunnable.run()
 
         verify(mockReader).drop(batch)
@@ -423,10 +435,12 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `batch dropped on Invalid Token Error`(@Forgery batch: Batch) {
+    fun `batch dropped on Invalid Token Error`(
+        @Forgery batch: Batch,
+        @Forgery status: UploadStatus.InvalidTokenError
+    ) {
         whenever(mockReader.lockAndReadNext()) doReturn batch
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.INVALID_TOKEN_ERROR
-
+        whenever(mockDataUploader.upload(batch.data)) doReturn status
         testedRunnable.run()
 
         verify(mockReader).drop(batch)
@@ -440,10 +454,12 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `batch kept on Server Error`(@Forgery batch: Batch) {
+    fun `batch kept on Server Error`(
+        @Forgery batch: Batch,
+        @Forgery status: UploadStatus.HttpServerError
+    ) {
         whenever(mockReader.lockAndReadNext()) doReturn batch
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.HTTP_SERVER_ERROR
-
+        whenever(mockDataUploader.upload(batch.data)) doReturn status
         testedRunnable.run()
 
         verify(mockReader, never()).drop(batch)
@@ -459,10 +475,11 @@ internal class DataUploadRunnableTest {
     @Test
     fun `batch kept after n Server Error`(
         @Forgery batch: Batch,
-        @IntForgery(min = 3, max = 42) runCount: Int
+        @IntForgery(min = 3, max = 42) runCount: Int,
+        @Forgery status: UploadStatus.HttpServerError
     ) {
         whenever(mockReader.lockAndReadNext()) doReturn batch
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.HTTP_SERVER_ERROR
+        whenever(mockDataUploader.upload(batch.data)) doReturn status
 
         repeat(runCount) {
             testedRunnable.run()
@@ -479,9 +496,12 @@ internal class DataUploadRunnableTest {
     }
 
     @Test
-    fun `batch dropped on Unknown error`(@Forgery batch: Batch) {
+    fun `batch dropped on Unknown error`(
+        @Forgery batch: Batch,
+        @Forgery status: UploadStatus.UnknownError
+    ) {
         whenever(mockReader.lockAndReadNext()) doReturn batch
-        whenever(mockDataUploader.upload(batch.data)) doReturn UploadStatus.UNKNOWN_ERROR
+        whenever(mockDataUploader.upload(batch.data)) doReturn status
 
         testedRunnable.run()
 
@@ -499,7 +519,7 @@ internal class DataUploadRunnableTest {
     fun `when has batches the upload frequency will increase`(
         @Forgery batch: Batch
     ) {
-        whenever(mockDataUploader.upload(any())) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(any())) doReturn fakeUploadSuccess
         whenever(mockReader.lockAndReadNext()).doReturn(batch)
 
         repeat(5) {
@@ -521,7 +541,7 @@ internal class DataUploadRunnableTest {
         @IntForgery(16, 64) runCount: Int
     ) {
         // Given
-        whenever(mockDataUploader.upload(any())) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(any())) doReturn fakeUploadSuccess
         whenever(mockReader.lockAndReadNext()).doReturn(batch)
 
         // When
@@ -548,11 +568,7 @@ internal class DataUploadRunnableTest {
     }
 
     @ParameterizedTest
-    @EnumSource(
-        UploadStatus::class,
-        names = ["HTTP_REDIRECTION", "HTTP_CLIENT_ERROR", "UNKNOWN_ERROR"],
-        mode = EnumSource.Mode.INCLUDE
-    )
+    @MethodSource("dropBatchStatusValues")
     fun `𝕄 reduce delay between runs 𝕎 batch fails and should be dropped`(
         uploadStatus: UploadStatus,
         @Forgery batch: Batch,
@@ -592,7 +608,7 @@ internal class DataUploadRunnableTest {
         @IntForgery(16, 64) runCount: Int
     ) {
         // Given
-        whenever(mockDataUploader.upload(any())) doReturn UploadStatus.SUCCESS
+        whenever(mockDataUploader.upload(any())) doReturn fakeUploadSuccess
         whenever(mockReader.lockAndReadNext()) doReturn null
 
         // When
@@ -618,24 +634,14 @@ internal class DataUploadRunnableTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("retryBatchStatusValues")
     fun `𝕄 increase delay between runs 𝕎 batch fails and should be retried`(
-        @IntForgery(16, 64) runCount: Int,
-        forge: Forge
+        status: UploadStatus,
+        @IntForgery(16, 64) runCount: Int
     ) {
         // Given
-        whenever(mockDataUploader.upload(any())) doAnswer {
-            forge.aValueFrom(
-                UploadStatus::class.java,
-                exclude = listOf(
-                    UploadStatus.SUCCESS,
-                    UploadStatus.HTTP_REDIRECTION,
-                    UploadStatus.HTTP_CLIENT_ERROR,
-                    UploadStatus.UNKNOWN_ERROR,
-                    UploadStatus.REQUEST_CREATION_ERROR
-                )
-            )
-        }
+        whenever(mockDataUploader.upload(any())) doReturn status
         whenever(mockReader.lockAndReadNext()) doReturn null
 
         // When
@@ -658,6 +664,36 @@ internal class DataUploadRunnableTest {
                     .isBetween(testedRunnable.minDelayMs, testedRunnable.maxDelayMs)
                 next
             }
+        }
+    }
+
+    companion object {
+
+        @JvmStatic
+        fun dropBatchStatusValues(): List<UploadStatus> {
+            val forge = Forge().apply {
+                Configurator().configure(this)
+            }
+
+            return listOf(
+                forge.getForgery(UploadStatus.HttpClientError::class.java),
+                forge.getForgery(UploadStatus.HttpRedirection::class.java),
+                forge.getForgery(UploadStatus.UnknownError::class.java),
+                forge.getForgery(UploadStatus.UnknownStatus::class.java)
+            )
+        }
+
+        @JvmStatic
+        fun retryBatchStatusValues(): List<UploadStatus> {
+            val forge = Forge().apply {
+                Configurator().configure(this)
+            }
+
+            return listOf(
+                forge.getForgery(UploadStatus.HttpServerError::class.java),
+                forge.getForgery(UploadStatus.HttpClientRateLimiting::class.java),
+                forge.getForgery(UploadStatus.NetworkError::class.java)
+            )
         }
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadStatusTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadStatusTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -45,9 +46,11 @@ internal class UploadStatusTest {
     }
 
     @Test
-    fun `𝕄 log SUCCESS only to USER 𝕎 logStatus()`() {
+    fun `𝕄 log SUCCESS only to USER 𝕎 logStatus()`(
+        @Forgery status: UploadStatus.Success
+    ) {
         // When
-        UploadStatus.SUCCESS.logStatus(
+        status.logStatus(
             fakeContext,
             fakeByteSize,
             mockLogger
@@ -63,9 +66,11 @@ internal class UploadStatusTest {
     }
 
     @Test
-    fun `𝕄 log NETWORK_ERROR only to USER 𝕎 logStatus()`() {
+    fun `𝕄 log NETWORK_ERROR only to USER 𝕎 logStatus()`(
+        @Forgery status: UploadStatus.NetworkError
+    ) {
         // When
-        UploadStatus.NETWORK_ERROR.logStatus(
+        status.logStatus(
             fakeContext,
             fakeByteSize,
             mockLogger
@@ -82,9 +87,11 @@ internal class UploadStatusTest {
     }
 
     @Test
-    fun `𝕄 log INVALID_TOKEN_ERROR only to USER 𝕎 logStatus()`() {
+    fun `𝕄 log INVALID_TOKEN_ERROR only to USER 𝕎 logStatus()`(
+        @Forgery status: UploadStatus.InvalidTokenError
+    ) {
         // When
-        UploadStatus.INVALID_TOKEN_ERROR.logStatus(
+        status.logStatus(
             fakeContext,
             fakeByteSize,
             mockLogger
@@ -103,9 +110,11 @@ internal class UploadStatusTest {
     }
 
     @Test
-    fun `𝕄 log HTTP_REDIRECTION only to USER 𝕎 logStatus()`() {
+    fun `𝕄 log HTTP_REDIRECTION only to USER 𝕎 logStatus()`(
+        @Forgery status: UploadStatus.HttpRedirection
+    ) {
         // When
-        UploadStatus.HTTP_REDIRECTION.logStatus(
+        status.logStatus(
             fakeContext,
             fakeByteSize,
             mockLogger
@@ -122,9 +131,11 @@ internal class UploadStatusTest {
     }
 
     @Test
-    fun `𝕄 log HTTP_CLIENT_ERROR to USER and TELEMETRY 𝕎 logStatus()`() {
+    fun `𝕄 log HTTP_CLIENT_ERROR to USER and TELEMETRY 𝕎 logStatus()`(
+        @Forgery status: UploadStatus.HttpClientError
+    ) {
         // When
-        UploadStatus.HTTP_CLIENT_ERROR.logStatus(
+        status.logStatus(
             fakeContext,
             fakeByteSize,
             mockLogger
@@ -142,9 +153,11 @@ internal class UploadStatusTest {
     }
 
     @Test
-    fun `𝕄 log HTTP_CLIENT_ERROR_RATE_LIMITING to USER and TELEMETRY 𝕎 logStatus()`() {
+    fun `𝕄 log HTTP_CLIENT_ERROR_RATE_LIMITING to USER and TELEMETRY 𝕎 logStatus()`(
+        @Forgery status: UploadStatus.HttpClientRateLimiting
+    ) {
         // When
-        UploadStatus.HTTP_CLIENT_RATE_LIMITING.logStatus(
+        status.logStatus(
             fakeContext,
             fakeByteSize,
             mockLogger
@@ -160,9 +173,11 @@ internal class UploadStatusTest {
     }
 
     @Test
-    fun `𝕄 log HTTP_SERVER_ERROR only to USER 𝕎 logStatus()`() {
+    fun `𝕄 log HTTP_SERVER_ERROR only to USER 𝕎 logStatus()`(
+        @Forgery status: UploadStatus.HttpServerError
+    ) {
         // When
-        UploadStatus.HTTP_SERVER_ERROR.logStatus(
+        status.logStatus(
             fakeContext,
             fakeByteSize,
             mockLogger
@@ -179,9 +194,11 @@ internal class UploadStatusTest {
     }
 
     @Test
-    fun `𝕄 log UNKNOWN_ERROR only to USER 𝕎 logStatus()`() {
+    fun `𝕄 log UNKNOWN_ERROR only to USER 𝕎 logStatus()`(
+        @Forgery status: UploadStatus.UnknownError
+    ) {
         // When
-        UploadStatus.UNKNOWN_ERROR.logStatus(
+        status.logStatus(
             fakeContext,
             fakeByteSize,
             mockLogger
@@ -197,9 +214,11 @@ internal class UploadStatusTest {
     }
 
     @Test
-    fun `𝕄 log INVALID_REQUEST_ERROR only to USER 𝕎 logStatus()`() {
+    fun `𝕄 log INVALID_REQUEST_ERROR only to USER 𝕎 logStatus()`(
+        @Forgery status: UploadStatus.RequestCreationError
+    ) {
         // When
-        UploadStatus.REQUEST_CREATION_ERROR.logStatus(
+        status.logStatus(
             fakeContext,
             fakeByteSize,
             mockLogger

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnableTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnableTest.kt
@@ -9,8 +9,8 @@ package com.datadog.android.core.internal.data.upload.v2
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.NetworkInfo
-import com.datadog.android.core.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.ContextProvider
+import com.datadog.android.core.internal.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.data.upload.UploadStatus
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.persistence.BatchConfirmation
@@ -33,7 +33,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -169,8 +169,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -183,7 +183,7 @@ internal class DataUploadRunnableTest {
                 batchData,
                 batchMetadata
             )
-        ) doReturn UploadStatus.SUCCESS
+        ) doReturn forge.getForgery(UploadStatus.Success::class.java)
 
         // When
         testedRunnable.run()
@@ -224,8 +224,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -238,7 +238,7 @@ internal class DataUploadRunnableTest {
                 batchData,
                 batchMetadata
             )
-        ) doReturn UploadStatus.SUCCESS
+        ) doReturn forge.getForgery(UploadStatus.Success::class.java)
 
         // When
         testedRunnable.run()
@@ -278,8 +278,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -292,7 +292,7 @@ internal class DataUploadRunnableTest {
                 batchData,
                 batchMetadata
             )
-        ) doReturn UploadStatus.SUCCESS
+        ) doReturn forge.getForgery(UploadStatus.Success::class.java)
 
         // When
         testedRunnable.run()
@@ -447,8 +447,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -459,7 +459,7 @@ internal class DataUploadRunnableTest {
                 batchData,
                 batchMetadata
             )
-        ) doReturn UploadStatus.SUCCESS
+        ) doReturn forge.getForgery(UploadStatus.Success::class.java)
 
         // When
         testedRunnable.run()
@@ -477,11 +477,7 @@ internal class DataUploadRunnableTest {
     }
 
     @ParameterizedTest
-    @EnumSource(
-        UploadStatus::class,
-        names = ["NETWORK_ERROR", "HTTP_SERVER_ERROR", "HTTP_CLIENT_RATE_LIMITING"],
-        mode = EnumSource.Mode.INCLUDE
-    )
+    @MethodSource("retryBatchStatusValues")
     fun `batch kept on error`(
         uploadStatus: UploadStatus,
         @StringForgery batch: List<String>,
@@ -499,8 +495,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -529,11 +525,7 @@ internal class DataUploadRunnableTest {
     }
 
     @ParameterizedTest
-    @EnumSource(
-        UploadStatus::class,
-        names = ["NETWORK_ERROR", "HTTP_SERVER_ERROR", "HTTP_CLIENT_RATE_LIMITING"],
-        mode = EnumSource.Mode.INCLUDE
-    )
+    @MethodSource("retryBatchStatusValues")
     fun `batch kept after n errors`(
         uploadStatus: UploadStatus,
         @StringForgery batch: List<String>,
@@ -552,8 +544,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -583,11 +575,7 @@ internal class DataUploadRunnableTest {
     }
 
     @ParameterizedTest
-    @EnumSource(
-        UploadStatus::class,
-        names = ["INVALID_TOKEN_ERROR", "HTTP_REDIRECTION", "HTTP_CLIENT_ERROR", "UNKNOWN_ERROR"],
-        mode = EnumSource.Mode.INCLUDE
-    )
+    @MethodSource("dropBatchStatusValues")
     fun `batch dropped on error`(
         uploadStatus: UploadStatus,
         @StringForgery batch: List<String>,
@@ -605,8 +593,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -650,8 +638,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -661,7 +649,7 @@ internal class DataUploadRunnableTest {
                 batchData,
                 batchMetadata
             )
-        ) doReturn UploadStatus.SUCCESS
+        ) doReturn forge.getForgery(UploadStatus.Success::class.java)
 
         // When
         repeat(5) {
@@ -696,8 +684,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -707,7 +695,7 @@ internal class DataUploadRunnableTest {
                 batchData,
                 batchMetadata
             )
-        ) doReturn UploadStatus.SUCCESS
+        ) doReturn forge.getForgery(UploadStatus.Success::class.java)
 
         // When
         repeat(runCount) {
@@ -733,11 +721,7 @@ internal class DataUploadRunnableTest {
     }
 
     @ParameterizedTest
-    @EnumSource(
-        UploadStatus::class,
-        names = ["HTTP_REDIRECTION", "HTTP_CLIENT_ERROR", "UNKNOWN_ERROR", "INVALID_TOKEN_ERROR"],
-        mode = EnumSource.Mode.INCLUDE
-    )
+    @MethodSource("dropBatchStatusValues")
     fun `𝕄 reduce delay between runs 𝕎 batch fails and should be dropped`(
         uploadStatus: UploadStatus,
         @StringForgery batch: List<String>,
@@ -756,8 +740,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -823,8 +807,10 @@ internal class DataUploadRunnableTest {
         }
     }
 
-    @Test
+    @ParameterizedTest
+    @MethodSource("retryBatchStatusValues")
     fun `𝕄 increase delay between runs 𝕎 batch fails and should be retried`(
+        status: UploadStatus,
         @IntForgery(16, 64) runCount: Int,
         @StringForgery batch: List<String>,
         @StringForgery batchMeta: String,
@@ -841,8 +827,8 @@ internal class DataUploadRunnableTest {
         whenever(batchReader.currentMetadata()) doReturn batchMetadata
 
         whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(1).invoke(batchConfirmation)
+            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
+                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
             }
             it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
         }
@@ -852,19 +838,7 @@ internal class DataUploadRunnableTest {
                 batchData,
                 batchMetadata
             )
-        ) doAnswer {
-            forge.aValueFrom(
-                UploadStatus::class.java,
-                exclude = listOf(
-                    UploadStatus.HTTP_REDIRECTION,
-                    UploadStatus.HTTP_CLIENT_ERROR,
-                    UploadStatus.UNKNOWN_ERROR,
-                    UploadStatus.INVALID_TOKEN_ERROR,
-                    UploadStatus.SUCCESS,
-                    UploadStatus.REQUEST_CREATION_ERROR
-                )
-            )
-        }
+        ) doReturn status
 
         // When
         repeat(runCount) {
@@ -956,5 +930,32 @@ internal class DataUploadRunnableTest {
 
     companion object {
         const val TEST_BATCH_UPLOAD_WAIT_TIMEOUT_MS = 100L
+
+        @JvmStatic
+        fun retryBatchStatusValues(): List<UploadStatus> {
+            val forge = Forge().apply {
+                Configurator().configure(this)
+            }
+
+            return listOf(
+                forge.getForgery(UploadStatus.HttpServerError::class.java),
+                forge.getForgery(UploadStatus.HttpClientRateLimiting::class.java),
+                forge.getForgery(UploadStatus.NetworkError::class.java)
+            )
+        }
+
+        @JvmStatic
+        fun dropBatchStatusValues(): List<UploadStatus> {
+            val forge = Forge().apply {
+                Configurator().configure(this)
+            }
+
+            return listOf(
+                forge.getForgery(UploadStatus.HttpClientError::class.java),
+                forge.getForgery(UploadStatus.HttpRedirection::class.java),
+                forge.getForgery(UploadStatus.UnknownError::class.java),
+                forge.getForgery(UploadStatus.UnknownStatus::class.java)
+            )
+        }
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnableTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnableTest.kt
@@ -9,7 +9,7 @@ package com.datadog.android.core.internal.data.upload.v2
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.NetworkInfo
-import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.ContextProvider
 import com.datadog.android.core.internal.data.upload.UploadStatus
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
@@ -87,7 +87,7 @@ internal class DataUploadRunnableTest {
     lateinit var fakeContext: DatadogContext
 
     @Forgery
-    lateinit var fakeUploadFrequency: UploadFrequency
+    lateinit var fakeDataUploadConfiguration: DataUploadConfiguration
 
     private lateinit var testedRunnable: DataUploadRunnable
 
@@ -118,7 +118,7 @@ internal class DataUploadRunnableTest {
             mockContextProvider,
             mockNetworkInfoProvider,
             mockSystemInfoProvider,
-            fakeUploadFrequency,
+            fakeDataUploadConfiguration,
             TEST_BATCH_UPLOAD_WAIT_TIMEOUT_MS,
             mockInternalLogger
         )

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadSchedulerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadSchedulerTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.core.internal.data.upload.v2
 
-import com.datadog.android.core.configuration.DataUploadConfiguration
+import com.datadog.android.core.internal.configuration.DataUploadConfiguration
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadSchedulerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadSchedulerTest.kt
@@ -6,8 +6,10 @@
 
 package com.datadog.android.core.internal.data.upload.v2
 
-import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.configuration.DataUploadConfiguration
+import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -30,6 +32,7 @@ import java.util.concurrent.TimeUnit
     ExtendWith(ForgeExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
 internal class DataUploadSchedulerTest {
 
     lateinit var testedScheduler: DataUploadScheduler
@@ -38,7 +41,7 @@ internal class DataUploadSchedulerTest {
     lateinit var mockExecutor: ScheduledThreadPoolExecutor
 
     @Forgery
-    lateinit var fakeUploadFrequency: UploadFrequency
+    lateinit var fakeUploadConfiguration: DataUploadConfiguration
 
     @BeforeEach
     fun `set up`() {
@@ -48,7 +51,7 @@ internal class DataUploadSchedulerTest {
             mock(),
             mock(),
             mock(),
-            fakeUploadFrequency,
+            fakeUploadConfiguration,
             mockExecutor,
             mock()
         )
@@ -62,7 +65,7 @@ internal class DataUploadSchedulerTest {
         // Then
         verify(mockExecutor).schedule(
             any(),
-            eq(fakeUploadFrequency.baseStepMs * DataUploadRunnable.DEFAULT_DELAY_FACTOR),
+            eq(fakeUploadConfiguration.defaultDelayMs),
             eq(TimeUnit.MILLISECONDS)
         )
     }
@@ -79,7 +82,7 @@ internal class DataUploadSchedulerTest {
         val argumentCaptor = argumentCaptor<Runnable>()
         verify(mockExecutor).schedule(
             argumentCaptor.capture(),
-            eq(fakeUploadFrequency.baseStepMs * DataUploadRunnable.DEFAULT_DELAY_FACTOR),
+            eq(fakeUploadConfiguration.defaultDelayMs),
             eq(TimeUnit.MILLISECONDS)
         )
         verify(mockExecutor).remove(argumentCaptor.firstValue)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
@@ -1,0 +1,235 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.metrics
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.internal.configuration.DataUploadConfiguration
+import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
+import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.reset
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+import java.io.File
+import java.util.Locale
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class BatchMetricsDispatcherTest {
+
+    lateinit var testedBatchMetricsDispatcher: BatchMetricsDispatcher
+
+    lateinit var fakeFeatureName: String
+
+    @Forgery
+    lateinit var fakeUploadConfiguration: DataUploadConfiguration
+
+    @Mock
+    lateinit var mockDateTimeProvider: TimeProvider
+
+    private var currentTimeInMillis: Long = System.currentTimeMillis()
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockSampler: Sampler
+
+    @Forgery
+    lateinit var fakeFilePersistenceConfig: FilePersistenceConfig
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        whenever(mockSampler.sample()).doReturn(true)
+        fakeFeatureName = forge.anElementFrom(
+            listOf(
+                Feature.RUM_FEATURE_NAME,
+                Feature.TRACING_FEATURE_NAME,
+                Feature.LOGS_FEATURE_NAME,
+                Feature.SESSION_REPLAY_FEATURE_NAME
+            )
+        )
+        whenever(mockDateTimeProvider.getDeviceTimestamp()).doReturn(currentTimeInMillis)
+        testedBatchMetricsDispatcher = BatchMetricsDispatcher(
+            fakeFeatureName,
+            fakeUploadConfiguration,
+            fakeFilePersistenceConfig,
+            mockInternalLogger,
+            mockDateTimeProvider,
+            mockSampler
+        )
+    }
+
+    @Test
+    fun `M send metric W sendBatchDeletedMetric`(forge: Forge) {
+        // Given
+        val fakeReason = forge.forgeIncludeInMetricReason()
+        val fakeFile: File = forge.forgeValidFile()
+        val expectedAdditionalProperties = mapOf(
+            BatchMetricsDispatcher.TYPE_KEY to
+                BatchMetricsDispatcher.BATCH_DELETED_TYPE_VALUE,
+            BatchMetricsDispatcher.TRACK_KEY to
+                trackNameResolver(fakeFeatureName),
+            BatchMetricsDispatcher.BATCH_AGE_KEY to
+                (currentTimeInMillis - fakeFile.name.toLong()),
+            BatchMetricsDispatcher.UPLOADER_WINDOW_KEY to
+                fakeFilePersistenceConfig.recentDelayMs,
+            BatchMetricsDispatcher.UPLOADER_DELAY_KEY to mapOf(
+                BatchMetricsDispatcher.UPLOADER_DELAY_MIN_KEY to
+                    fakeUploadConfiguration.minDelayMs,
+                BatchMetricsDispatcher.UPLOADER_DELAY_MAX_KEY to
+                    fakeUploadConfiguration.maxDelayMs
+            ),
+            BatchMetricsDispatcher.BATCH_REMOVAL_KEY to fakeReason.toString(),
+            BatchMetricsDispatcher.IN_BACKGROUND_KEY to false
+        )
+
+        // When
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+
+        // Then
+        argumentCaptor<Map<String, Any?>> {
+            verify(mockInternalLogger).logMetric(
+                argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
+                capture()
+            )
+            assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
+        }
+    }
+
+    @Test
+    fun `M do nothing W sendBatchDeletedMetric { file name is broken }`(forge: Forge) {
+        // Given
+        val fakeReason = forge.forgeIncludeInMetricReason()
+        val fakeFile: File = mock {
+            whenever(it.name).thenReturn(forge.anAlphabeticalString())
+        }
+
+        // When
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+
+        // Then
+        verify(mockInternalLogger).log(
+            eq(InternalLogger.Level.ERROR),
+            eq(InternalLogger.Target.MAINTAINER),
+            argThat {
+                this.invoke() ==
+                    BatchMetricsDispatcher.WRONG_FILE_NAME_MESSAGE_FORMAT
+                        .format(Locale.ENGLISH, fakeFile.name)
+            },
+            argThat { this is NumberFormatException },
+            eq(false),
+            eq(null)
+        )
+        verifyNoMoreInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `M do nothing W sendBatchDeletedMetric { sampled out }`(forge: Forge) {
+        // Given
+        reset(mockSampler)
+        whenever(mockSampler.sample()).doReturn(false)
+        val fakeReason = forge.forgeIncludeInMetricReason()
+        val fakeFile: File = forge.forgeValidFile()
+
+        // When
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+
+        // Then
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `M do nothing W sendBatchDeletedMetric { reason notIncludedInMetrics }`(forge: Forge) {
+        // Given
+        reset(mockSampler)
+        whenever(mockSampler.sample()).doReturn(false)
+        val fakeReason: RemovalReason.Flushed = forge.getForgery()
+        val fakeFile: File = forge.forgeValidFile()
+
+        // When
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+
+        // Then
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `M do nothing W sendBatchDeletedMetric { feature unknown }`(forge: Forge) {
+        // Given
+        val fakeUnknownFeature = forge.anAlphabeticalString()
+        testedBatchMetricsDispatcher = BatchMetricsDispatcher(
+            fakeUnknownFeature,
+            fakeUploadConfiguration,
+            fakeFilePersistenceConfig,
+            mockInternalLogger,
+            mockDateTimeProvider,
+            mockSampler
+        )
+        val fakeReason: RemovalReason.Flushed = forge.getForgery()
+        val fakeFile: File = forge.forgeValidFile()
+
+        // When
+        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
+
+        // Then
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    private fun Forge.forgeValidFile(): File {
+        val fileNameAsLong = currentTimeInMillis - aLong(min = 1000, max = 100000)
+        val fakeFile: File = mock {
+            whenever(it.name).thenReturn(fileNameAsLong.toString())
+        }
+        return fakeFile
+    }
+
+    private fun trackNameResolver(featureName: String): String? {
+        return when (featureName) {
+            Feature.RUM_FEATURE_NAME -> BatchMetricsDispatcher.RUM_TRACK_NAME
+            Feature.LOGS_FEATURE_NAME -> BatchMetricsDispatcher.LOGS_TRACK_NAME
+            Feature.TRACING_FEATURE_NAME -> BatchMetricsDispatcher.TRACE_TRACK_NAME
+            Feature.SESSION_REPLAY_FEATURE_NAME -> BatchMetricsDispatcher.SR_TRACK_NAME
+            else -> null
+        }
+    }
+
+    private fun Forge.forgeIncludeInMetricReason(): RemovalReason {
+        while (true) {
+            val reason: RemovalReason = getForgery()
+            if (reason.includeInMetrics()) {
+                return reason
+            }
+        }
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestratorTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal.persistence.file.advanced
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.metrics.MetricsDispatcher
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileOrchestrator
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.privacy.TrackingConsent
@@ -56,6 +57,9 @@ internal class FeatureFileOrchestratorTest {
     @TempDir
     lateinit var fakeStorageDir: File
 
+    @Mock
+    lateinit var mockMetricsDispatcher: MetricsDispatcher
+
     @BeforeEach
     fun `set up`() {
         whenever(mockConsentProvider.getConsent()) doReturn fakeConsent
@@ -71,7 +75,8 @@ internal class FeatureFileOrchestratorTest {
             fakeStorageDir,
             fakeFeatureName,
             mockExecutorService,
-            mockInternalLogger
+            mockInternalLogger,
+            mockMetricsDispatcher
         )
 
         // Then
@@ -91,7 +96,8 @@ internal class FeatureFileOrchestratorTest {
             fakeStorageDir,
             fakeFeatureName,
             mockExecutorService,
-            mockInternalLogger
+            mockInternalLogger,
+            mockMetricsDispatcher
         )
 
         // Then
@@ -111,7 +117,8 @@ internal class FeatureFileOrchestratorTest {
             fakeStorageDir,
             fakeFeatureName,
             mockExecutorService,
-            mockInternalLogger
+            mockInternalLogger,
+            mockMetricsDispatcher
         )
 
         // Then

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
@@ -7,6 +7,8 @@
 package com.datadog.android.core.internal.persistence.file.batch
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.metrics.MetricsDispatcher
+import com.datadog.android.core.internal.metrics.RemovalReason
 import com.datadog.android.core.internal.persistence.file.FileOrchestrator
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.utils.forge.Configurator
@@ -29,9 +31,13 @@ import org.junit.jupiter.params.provider.ValueSource
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.argThat
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
@@ -60,6 +66,9 @@ internal class BatchFileOrchestratorTest {
 
     lateinit var fakeRootDir: File
 
+    @Mock
+    lateinit var mockMetricsDispatcher: MetricsDispatcher
+
     @BeforeEach
     fun `set up`() {
         fakeRootDir = File(tempDir, fakeRootDirName)
@@ -67,7 +76,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             fakeRootDir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
     }
 
@@ -85,7 +95,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             notADir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -111,7 +122,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             corruptedDir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -138,7 +150,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             restrictedDir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -200,6 +213,11 @@ internal class BatchFileOrchestratorTest {
         assertThat(oldFile).doesNotExist()
         assertThat(oldFileMeta).doesNotExist()
         assertThat(youngFile).exists()
+        verify(mockMetricsDispatcher).sendBatchDeletedMetric(
+            eq(oldFile),
+            argThat { this is RemovalReason.Obsolete }
+        )
+        verifyNoMoreInteractions(mockMetricsDispatcher)
     }
 
     @ParameterizedTest
@@ -240,6 +258,11 @@ internal class BatchFileOrchestratorTest {
         assertThat(oldFileMeta).doesNotExist()
         assertThat(youngFile).exists()
         assertThat(evenOlderFile).exists()
+        verify(mockMetricsDispatcher).sendBatchDeletedMetric(
+            eq(oldFile),
+            argThat { this is RemovalReason.Obsolete }
+        )
+        verifyNoMoreInteractions(mockMetricsDispatcher)
     }
 
     @ParameterizedTest
@@ -275,6 +298,15 @@ internal class BatchFileOrchestratorTest {
         assertThat(oldFile).doesNotExist()
         assertThat(oldFileMeta).doesNotExist()
         assertThat(evenOlderFile).doesNotExist()
+        verify(mockMetricsDispatcher).sendBatchDeletedMetric(
+            eq(evenOlderFile),
+            argThat { this is RemovalReason.Obsolete }
+        )
+        verify(mockMetricsDispatcher).sendBatchDeletedMetric(
+            eq(oldFile),
+            argThat { this is RemovalReason.Obsolete }
+        )
+        verifyNoMoreInteractions(mockMetricsDispatcher)
     }
 
     @ParameterizedTest
@@ -555,7 +587,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             notADir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -580,7 +613,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             corruptedDir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -606,7 +640,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             restrictedDir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -732,7 +767,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             notADir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -757,7 +793,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             corruptedDir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -783,7 +820,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             restrictedDir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -921,7 +959,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             notADir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -946,7 +985,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             corruptedDir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When
@@ -972,7 +1012,8 @@ internal class BatchFileOrchestratorTest {
         testedOrchestrator = BatchFileOrchestrator(
             restrictedDir,
             TEST_PERSISTENCE_CONFIG,
-            mockLogger
+            mockLogger,
+            mockMetricsDispatcher
         )
 
         // When

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -45,6 +45,26 @@ internal class Configurator :
         forge.addFactory(DatadogContextForgeryFactory())
         forge.addFactory(DataUploadConfigurationForgeryFactory())
 
+        // UploadStatus
+        forge.addFactory(HttpRedirectStatusForgeryFactory())
+        forge.addFactory(HttpClientRateLimitingStatusForgeryFactory())
+        forge.addFactory(HttpClientErrorForgeryFactory())
+        forge.addFactory(HttpServerErrorForgeryFactory())
+        forge.addFactory(InvalidTokenErrorStatusForgeryFactory())
+        forge.addFactory(NetworkErrorStatusForgeryFactory())
+        forge.addFactory(RequestCreationErrorStatusForgeryFactory())
+        forge.addFactory(SuccessStatusForgeryFactory())
+        forge.addFactory(UnknownErrorStatusForgeryFactory())
+        forge.addFactory(UnknownStatusForgeryFactory())
+
+        // RemovalReason
+        forge.addFactory(RemovalReasonFlushedForgeryFactory())
+        forge.addFactory(RemovalReasonPurgedForgeryFactory())
+        forge.addFactory(RemovalReasonInvalidForgeryFactory())
+        forge.addFactory(RemovalReasonObsoleteForgeryFactory())
+        forge.addFactory(RemovalReasonIntakeCodeForgeryFactory())
+        forge.addFactory(RemovalReasonForgeryFactory())
+
         forge.useJvmFactories()
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -43,6 +43,7 @@ internal class Configurator :
         forge.addFactory(ProcessInfoForgeryFactory())
         forge.addFactory(DeviceInfoForgeryFactory())
         forge.addFactory(DatadogContextForgeryFactory())
+        forge.addFactory(DataUploadConfigurationForgeryFactory())
 
         forge.useJvmFactories()
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/DataUploadConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/DataUploadConfigurationForgeryFactory.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.configuration.DataUploadConfiguration
+import com.datadog.android.core.configuration.UploadFrequency
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class DataUploadConfigurationForgeryFactory : ForgeryFactory<DataUploadConfiguration> {
+    override fun getForgery(forge: Forge): DataUploadConfiguration {
+        val frequency: UploadFrequency = forge.getForgery()
+        return DataUploadConfiguration(frequency)
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/DataUploadConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/DataUploadConfigurationForgeryFactory.kt
@@ -6,8 +6,8 @@
 
 package com.datadog.android.utils.forge
 
-import com.datadog.android.core.configuration.DataUploadConfiguration
 import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.internal.configuration.DataUploadConfiguration
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/HttpClientErrorForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/HttpClientErrorForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class HttpClientErrorForgeryFactory : ForgeryFactory<UploadStatus.HttpClientError> {
+
+    override fun getForgery(forge: Forge): UploadStatus.HttpClientError {
+        return UploadStatus.HttpClientError(responseCode = forge.aPositiveInt())
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/HttpClientRateLimitingStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/HttpClientRateLimitingStatusForgeryFactory.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class HttpClientRateLimitingStatusForgeryFactory :
+    ForgeryFactory<UploadStatus.HttpClientRateLimiting> {
+
+    override fun getForgery(forge: Forge): UploadStatus.HttpClientRateLimiting {
+        return UploadStatus.HttpClientRateLimiting(responseCode = forge.aPositiveInt())
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/HttpRedirectStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/HttpRedirectStatusForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class HttpRedirectStatusForgeryFactory : ForgeryFactory<UploadStatus.HttpRedirection> {
+
+    override fun getForgery(forge: Forge): UploadStatus.HttpRedirection {
+        return UploadStatus.HttpRedirection(responseCode = forge.aPositiveInt())
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/HttpServerErrorForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/HttpServerErrorForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class HttpServerErrorForgeryFactory : ForgeryFactory<UploadStatus.HttpServerError> {
+
+    override fun getForgery(forge: Forge): UploadStatus.HttpServerError {
+        return UploadStatus.HttpServerError(responseCode = forge.aPositiveInt())
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/InvalidTokenErrorStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/InvalidTokenErrorStatusForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class InvalidTokenErrorStatusForgeryFactory : ForgeryFactory<UploadStatus.InvalidTokenError> {
+
+    override fun getForgery(forge: Forge): UploadStatus.InvalidTokenError {
+        return UploadStatus.InvalidTokenError(responseCode = forge.aPositiveInt())
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/NetworkErrorStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/NetworkErrorStatusForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class NetworkErrorStatusForgeryFactory : ForgeryFactory<UploadStatus.NetworkError> {
+
+    override fun getForgery(forge: Forge): UploadStatus.NetworkError {
+        return UploadStatus.NetworkError
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonFlushedForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonFlushedForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.metrics.RemovalReason
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class RemovalReasonFlushedForgeryFactory : ForgeryFactory<RemovalReason.Flushed> {
+
+    override fun getForgery(forge: Forge): RemovalReason.Flushed {
+        return RemovalReason.Flushed
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonForgeryFactory.kt
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.metrics.RemovalReason
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class RemovalReasonForgeryFactory : ForgeryFactory<RemovalReason> {
+
+    override fun getForgery(forge: Forge): RemovalReason {
+        return forge.anElementFrom(
+            listOf(
+                forge.getForgery(RemovalReason.Purged::class.java),
+                forge.getForgery(RemovalReason.Obsolete::class.java),
+                forge.getForgery(RemovalReason.Flushed::class.java),
+                forge.getForgery(RemovalReason.Invalid::class.java),
+                forge.getForgery(RemovalReason.IntakeCode::class.java)
+            )
+        )
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonIntakeCodeForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonIntakeCodeForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.metrics.RemovalReason
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class RemovalReasonIntakeCodeForgeryFactory : ForgeryFactory<RemovalReason.IntakeCode> {
+
+    override fun getForgery(forge: Forge): RemovalReason.IntakeCode {
+        return RemovalReason.IntakeCode(responseCode = forge.aPositiveInt())
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonInvalidForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonInvalidForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.metrics.RemovalReason
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class RemovalReasonInvalidForgeryFactory : ForgeryFactory<RemovalReason.Invalid> {
+
+    override fun getForgery(forge: Forge): RemovalReason.Invalid {
+        return RemovalReason.Invalid
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonObsoleteForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonObsoleteForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.metrics.RemovalReason
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class RemovalReasonObsoleteForgeryFactory : ForgeryFactory<RemovalReason.Obsolete> {
+
+    override fun getForgery(forge: Forge): RemovalReason.Obsolete {
+        return RemovalReason.Obsolete
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonPurgedForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RemovalReasonPurgedForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.metrics.RemovalReason
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class RemovalReasonPurgedForgeryFactory : ForgeryFactory<RemovalReason.Purged> {
+
+    override fun getForgery(forge: Forge): RemovalReason.Purged {
+        return RemovalReason.Purged
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RequestCreationErrorStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/RequestCreationErrorStatusForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class RequestCreationErrorStatusForgeryFactory : ForgeryFactory<UploadStatus.RequestCreationError> {
+
+    override fun getForgery(forge: Forge): UploadStatus.RequestCreationError {
+        return UploadStatus.RequestCreationError
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/SuccessStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/SuccessStatusForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class SuccessStatusForgeryFactory : ForgeryFactory<UploadStatus.Success> {
+
+    override fun getForgery(forge: Forge): UploadStatus.Success {
+        return UploadStatus.Success(responseCode = forge.aPositiveInt())
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/UnknownErrorStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/UnknownErrorStatusForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class UnknownErrorStatusForgeryFactory : ForgeryFactory<UploadStatus.UnknownError> {
+
+    override fun getForgery(forge: Forge): UploadStatus.UnknownError {
+        return UploadStatus.UnknownError(responseCode = forge.aPositiveInt())
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/UnknownStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/UnknownStatusForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class UnknownStatusForgeryFactory : ForgeryFactory<UploadStatus.UnknownStatus> {
+
+    override fun getForgery(forge: Forge): UploadStatus.UnknownStatus {
+        return UploadStatus.UnknownStatus
+    }
+}


### PR DESCRIPTION
### What does this PR do?

In this PR we are following up on the already merged [PR](https://github.com/DataDog/dd-sdk-ios/pull/1384) in the `dd-sdk-ios` repository in which we are sending a special `batch_deleted` telemetry log whenever a batch was deleted in the core. More details in this [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3076063377/RFC+-+Batching+Upload+Observability). 
An upcoming PR will also add the `batch_closed` related telemetry following the details in the same RFC.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

