### PR TITLE
RUM-971: Report ApplicationLaunch view even if first RUM event is not interaction

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -6,16 +6,22 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
+import android.app.ActivityManager
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.internal.AppStartTimeProvider
+import com.datadog.android.rum.internal.DefaultAppStartTimeProvider
 import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")
 internal class RumApplicationScope(
@@ -28,7 +34,8 @@ internal class RumApplicationScope(
     private val cpuVitalMonitor: VitalMonitor,
     private val memoryVitalMonitor: VitalMonitor,
     private val frameRateVitalMonitor: VitalMonitor,
-    private val sessionListener: RumSessionListener?
+    private val sessionListener: RumSessionListener?,
+    private val appStartTimeProvider: AppStartTimeProvider = DefaultAppStartTimeProvider()
 ) : RumScope, RumViewChangedListener {
 
     private val rumContext = RumContext(applicationId = applicationId)
@@ -55,6 +62,7 @@ internal class RumApplicationScope(
         }
 
     private var lastActiveViewInfo: RumViewInfo? = null
+    private var isSentAppStartedEvent = false
 
     // region RumScope
 
@@ -70,6 +78,10 @@ internal class RumApplicationScope(
             sdkCore.updateFeatureContext(Feature.RUM_FEATURE_NAME) {
                 it.putAll(getRumContext().toMap())
             }
+        }
+
+        if (!isSentAppStartedEvent) {
+            sendApplicationStartEvent(event.eventTime, writer)
         }
 
         delegateToChildren(event, writer)
@@ -92,6 +104,8 @@ internal class RumApplicationScope(
             lastActiveViewInfo = viewInfo
         }
     }
+
+    // region Internal
 
     @WorkerThread
     private fun delegateToChildren(
@@ -154,6 +168,34 @@ internal class RumApplicationScope(
             )
         }
     }
+
+    @WorkerThread
+    private fun sendApplicationStartEvent(eventTime: Time, writer: DataWriter<Any>) {
+        val processImportance = DdRumContentProvider.processImportance
+        val isForegroundProcess = processImportance ==
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+        if (isForegroundProcess) {
+            val processStartTimeNs = appStartTimeProvider.appStartTimeNs
+            // processStartTime is the time in nanoseconds since VM start. To get a timestamp, we want
+            // to convert it to milliseconds since epoch provided by System.currentTimeMillis.
+            // To do so, we take the offset of those times in the event time, which should be consistent,
+            // then add that to our processStartTime to get the correct value.
+            val timestampNs = (
+                TimeUnit.MILLISECONDS.toNanos(eventTime.timestamp) - eventTime.nanoTime
+                ) + processStartTimeNs
+            val applicationLaunchViewTime = Time(
+                timestamp = TimeUnit.NANOSECONDS.toMillis(timestampNs),
+                nanoTime = processStartTimeNs
+            )
+            val startupTime = eventTime.nanoTime - processStartTimeNs
+            val appStartedEvent =
+                RumRawEvent.ApplicationStarted(applicationLaunchViewTime, startupTime)
+            delegateToChildren(appStartedEvent, writer)
+            isSentAppStartedEvent = true
+        }
+    }
+
+    // endregion
 
     companion object {
         internal const val LAST_ACTIVE_VIEW_GONE_WARNING_MESSAGE = "Attempting to start a new " +

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -116,6 +116,14 @@ internal fun Forge.addLongTaskEvent(): RumRawEvent.AddLongTask {
     )
 }
 
+internal fun Forge.applicationStartedEvent(): RumRawEvent.ApplicationStarted {
+    val time = Time()
+    return RumRawEvent.ApplicationStarted(
+        eventTime = time,
+        applicationStartupNanos = aLong(min = 0L, max = time.nanoTime)
+    )
+}
+
 internal fun Forge.validBackgroundEvent(): RumRawEvent {
     return this.anElementFrom(
         listOf(


### PR DESCRIPTION
### What does this PR do?

Fixes #1582 and maybe fixes #1523.

This PR fixes the issue when `ApplicationLaunch` is not reported in case if first RUM event coming is not interaction event. In this case session is not yet active, so we create `ApplicationLaunch` and `ApplicationStarted` action for nothing - they won't be written, because writer is no-op.

This PR moves the logic of creating `ApplicationStarted` event up to the application scope, which makes sense - we have to report it only once in the application lifecycle. Also session we be activated once `ApplicationStarted` event is received by the session scope, meaning that session is created not only by start view or start action events (which makes sense, because we introduced `ApplicationLaunch` view to be independent from background tracking feature).

There is one leftover which I don't personally enjoy - having `applicationDisplayed` property in the scopes (I think this property is vague), but getting rid of it is tricky.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

