### PR TITLE
RUM-986: Fix crash when disabling JankStats tracking

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListener.kt
@@ -75,6 +75,7 @@ internal class JankStatsActivityLifecycleListener(
     override fun onActivityPaused(activity: Activity) {
     }
 
+    @Suppress("NestedBlockDepth")
     @MainThread
     override fun onActivityStopped(activity: Activity) {
         val window = activity.window
@@ -96,7 +97,30 @@ internal class JankStatsActivityLifecycleListener(
                 InternalLogger.Target.MAINTAINER,
                 { "Disabling jankStats for window $window" }
             )
-            activeWindowsListener[window]?.isTrackingEnabled = false
+            try {
+                activeWindowsListener[window]?.let {
+                    if (it.isTrackingEnabled) {
+                        it.isTrackingEnabled = false
+                    } else {
+                        internalLogger.log(
+                            InternalLogger.Level.ERROR,
+                            InternalLogger.Target.TELEMETRY,
+                            { JANK_STATS_TRACKING_ALREADY_DISABLED_ERROR }
+                        )
+                    }
+                }
+            } catch (iae: IllegalArgumentException) {
+                // android.view.View.removeFrameMetricsListener may throw it (attempt to remove
+                // OnFrameMetricsAvailableListener that was never added). Unclear why, because
+                // JankStats registers listener in the constructor, so if we have the instance,
+                // listener should be there.
+                internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.TELEMETRY,
+                    { JANK_STATS_TRACKING_DISABLE_ERROR },
+                    iae
+                )
+            }
         }
     }
 
@@ -139,6 +163,13 @@ internal class JankStatsActivityLifecycleListener(
     // endregion
 
     companion object {
+
+        internal const val JANK_STATS_TRACKING_ALREADY_DISABLED_ERROR =
+            "Trying to disable JankStats instance which was already disabled before, this" +
+                " shouldn't happen."
+        internal const val JANK_STATS_TRACKING_DISABLE_ERROR =
+            "Failed to disable JankStats tracking"
+
         private val ONE_SECOND_NS: Double = TimeUnit.SECONDS.toNanos(1).toDouble()
 
         private const val MIN_FPS: Double = 1.0


### PR DESCRIPTION
### What does this PR do?

The following crash was reported by the customer:

```
java.lang.IllegalArgumentException: attempt to remove OnFrameMetricsAvailableListener that was never added
        at android.view.View.removeFrameMetricsListener(View.java:7797)
        at android.view.Window.removeOnFrameMetricsAvailableListener(Window.java:995)
        at androidx.metrics.performance.DelegatingFrameMetricsListener.remove(JankStatsApi24Impl.kt:253)
        at androidx.metrics.performance.JankStatsApi24Impl.removeFrameMetricsListenerDelegate(JankStatsApi24Impl.kt:126)
        at androidx.metrics.performance.JankStatsApi24Impl.setupFrameTimer(JankStatsApi24Impl.kt:107)
        at androidx.metrics.performance.JankStats.setTrackingEnabled(JankStats.kt:129)
        at com.datadog.android.rum.internal.vitals.JankStatsActivityLifecycleListener.onActivityStopped(JankStatsActivityLifecycleListener.kt:99)
        ....
```

This PR does the following:

* Checks that tracking is enabled before disabling it. If it is already disabled - we report it to the telemetry, because probably the issue is on our side.
* If still there is a crash when we disabling jank stats even in a proper state (when it is enabled) - we still report it to the telemetry, but in this case the problem is in the `JankStats` class itself probably.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

