### PR TITLE
Fix Android Studio 'Rebuild Project'

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/ApiSurfacePlugin.kt
@@ -19,12 +19,11 @@ class ApiSurfacePlugin : Plugin<Project> {
         val genDir = File(File(target.buildDir, "generated"), "json2kotlin")
         val apiDir = File(target.projectDir, "api")
         val surfaceFile = File(apiDir, FILE_NAME)
-        genDir.mkdirs()
 
         target.tasks
             .register(TASK_GEN_KOTLIN_API_SURFACE, GenerateApiSurfaceTask::class.java) {
-                this.srcDir = srcDir
-                this.genDir = genDir
+                this.srcDirPath = srcDir.absolutePath
+                this.genDirPath = genDir.absolutePath
                 this.surfaceFile = surfaceFile
             }
         target.tasks

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateApiSurfaceTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateApiSurfaceTask.kt
@@ -7,20 +7,21 @@
 package com.datadog.gradle.plugin.apisurface
 
 import org.gradle.api.DefaultTask
-import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
 open class GenerateApiSurfaceTask : DefaultTask() {
-    @get:InputDirectory
-    lateinit var srcDir: File
+    @get:Input
+    lateinit var srcDirPath: String
 
-    @get:InputDirectory
-    lateinit var genDir: File
+    @get:Input
+    lateinit var genDirPath: String
 
     @get: OutputFile
     lateinit var surfaceFile: File
+
     private lateinit var visitor: KotlinFileVisitor
 
     init {
@@ -33,8 +34,8 @@ open class GenerateApiSurfaceTask : DefaultTask() {
     @TaskAction
     fun applyTask() {
         visitor = KotlinFileVisitor()
-        visitDirectoryRecursively(srcDir)
-        visitDirectoryRecursively(genDir)
+        visitDirectoryRecursively(File(srcDirPath))
+        visitDirectoryRecursively(File(genDirPath))
 
         surfaceFile.printWriter().use {
             it.print(visitor.description.toString())
@@ -45,12 +46,13 @@ open class GenerateApiSurfaceTask : DefaultTask() {
 
     private fun visitDirectoryRecursively(file: File) {
         when {
+            !file.exists() -> logger.warn("File $file doesn't exist, ignoring")
             file.isDirectory ->
                 file.listFiles().orEmpty()
                     .sortedBy { it.absolutePath }
                     .forEach { visitDirectoryRecursively(it) }
             file.isFile -> visitFile(file)
-            else -> System.err.println("${file.path} is neither file nor directory")
+            else -> logger.error("${file.path} is neither file nor directory")
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

Android Studio's `Rebuild Project` button performs the equivalent of `./gradlew clean assemble`. Because of that the `genDir` folder used to store `json2kotlin` generated files is cleared and doesn't exists when the `GenerateApiSurfaceTask`is ran. 

The recommended way is to store path instead of actual files when the file is not guaranteed to exists when the task is ran.

### Motivation

Being able to use the `Rebuild Project` feature in AS.

