### PR TITLE
RUM-1042 Fix base64 issues with multithreading

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
@@ -91,7 +91,7 @@ internal class RecordedDataQueueHandler {
             ?: return null
 
         val item = TouchEventRecordedDataQueueItem(
-            rumContextData = rumContextData,
+            recordedQueuedItemContext = rumContextData,
             touchData = pointerInteractions
         )
 
@@ -108,7 +108,7 @@ internal class RecordedDataQueueHandler {
             ?: return null
 
         val item = SnapshotRecordedDataQueueItem(
-            rumContextData = rumContextData,
+            recordedQueuedItemContext = rumContextData,
             systemInformation = systemInformation
         )
 
@@ -198,7 +198,7 @@ internal class RecordedDataQueueHandler {
         !recordedDataQueueItem.isValid() || isTooOld(currentTime, recordedDataQueueItem)
 
     private fun isTooOld(currentTime: Long, recordedDataQueueItem: RecordedDataQueueItem): Boolean =
-        (currentTime - recordedDataQueueItem.rumContextData.timestamp) > MAX_DELAY_MS
+        (currentTime - recordedDataQueueItem.recordedQueuedItemContext.timestamp) > MAX_DELAY_MS
 
     private fun insertIntoRecordedDataQueue(recordedDataQueueItem: RecordedDataQueueItem) {
         @Suppress("SwallowedException", "TooGenericExceptionCaught")

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueItem.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueItem.kt
@@ -6,10 +6,10 @@
 
 package com.datadog.android.sessionreplay.internal.async
 
-import com.datadog.android.sessionreplay.internal.processor.RumContextData
+import com.datadog.android.sessionreplay.internal.processor.RecordedQueuedItemContext
 
 internal abstract class RecordedDataQueueItem(
-    internal val rumContextData: RumContextData
+    internal val recordedQueuedItemContext: RecordedQueuedItemContext
 ) {
     internal abstract fun isValid(): Boolean
     internal abstract fun isReady(): Boolean

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/SnapshotRecordedDataQueueItem.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/SnapshotRecordedDataQueueItem.kt
@@ -6,15 +6,15 @@
 
 package com.datadog.android.sessionreplay.internal.async
 
-import com.datadog.android.sessionreplay.internal.processor.RumContextData
+import com.datadog.android.sessionreplay.internal.processor.RecordedQueuedItemContext
 import com.datadog.android.sessionreplay.internal.recorder.Node
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import java.util.concurrent.atomic.AtomicInteger
 
 internal class SnapshotRecordedDataQueueItem(
-    rumContextData: RumContextData,
+    recordedQueuedItemContext: RecordedQueuedItemContext,
     internal val systemInformation: SystemInformation
-) : RecordedDataQueueItem(rumContextData) {
+) : RecordedDataQueueItem(recordedQueuedItemContext) {
     internal var nodes = emptyList<Node>()
     internal var pendingImages = AtomicInteger(0)
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/TouchEventRecordedDataQueueItem.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/TouchEventRecordedDataQueueItem.kt
@@ -6,13 +6,13 @@
 
 package com.datadog.android.sessionreplay.internal.async
 
-import com.datadog.android.sessionreplay.internal.processor.RumContextData
+import com.datadog.android.sessionreplay.internal.processor.RecordedQueuedItemContext
 import com.datadog.android.sessionreplay.model.MobileSegment
 
 internal class TouchEventRecordedDataQueueItem(
-    rumContextData: RumContextData,
+    recordedQueuedItemContext: RecordedQueuedItemContext,
     internal val touchData: List<MobileSegment.MobileRecord> = emptyList()
-) : RecordedDataQueueItem(rumContextData) {
+) : RecordedDataQueueItem(recordedQueuedItemContext) {
 
     override fun isValid(): Boolean {
         return touchData.isNotEmpty()

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedQueuedItemContext.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RecordedQueuedItemContext.kt
@@ -8,8 +8,7 @@ package com.datadog.android.sessionreplay.internal.processor
 
 import com.datadog.android.sessionreplay.internal.utils.SessionReplayRumContext
 
-internal data class RumContextData(
+internal data class RecordedQueuedItemContext(
     internal val timestamp: Long,
-    internal val newRumContext: SessionReplayRumContext,
-    internal val prevRumContext: SessionReplayRumContext
+    internal val newRumContext: SessionReplayRumContext
 )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RumContextDataHandler.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/RumContextDataHandler.kt
@@ -9,7 +9,6 @@ package com.datadog.android.sessionreplay.internal.processor
 import androidx.annotation.MainThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.utils.RumContextProvider
-import com.datadog.android.sessionreplay.internal.utils.SessionReplayRumContext
 import com.datadog.android.sessionreplay.internal.utils.TimeProvider
 import java.util.Locale
 
@@ -18,10 +17,9 @@ internal class RumContextDataHandler(
     private val timeProvider: TimeProvider,
     private val internalLogger: InternalLogger
 ) {
-    private var prevRumContext = SessionReplayRumContext()
 
     @MainThread
-    internal fun createRumContextData(): RumContextData? {
+    internal fun createRumContextData(): RecordedQueuedItemContext? {
         // we will make sure we get the timestamp on the UI thread to avoid time skewing
         val timestamp = timeProvider.getDeviceTimestamp()
 
@@ -42,11 +40,7 @@ internal class RumContextDataHandler(
             return null
         }
 
-        val rumContextData = RumContextData(timestamp, newRumContext.copy(), prevRumContext.copy())
-
-        prevRumContext = newRumContext
-
-        return rumContextData
+        return RecordedQueuedItemContext(timestamp, newRumContext.copy())
     }
 
     companion object {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelper.kt
@@ -14,6 +14,7 @@ import android.view.View
 import android.widget.TextView
 import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
+import com.datadog.android.sessionreplay.internal.AsyncImageProcessingCallback
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.ViewUtilsInternal
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
@@ -38,7 +39,8 @@ internal class ImageWireframeHelper(
         drawable: Drawable? = null,
         shapeStyle: MobileSegment.ShapeStyle? = null,
         border: MobileSegment.ShapeBorder? = null,
-        prefix: String = DRAWABLE_CHILD_NAME
+        prefix: String = DRAWABLE_CHILD_NAME,
+        asyncImageProcessingCallback: AsyncImageProcessingCallback?
     ): MobileSegment.Wireframe.ImageWireframe? {
         val id = uniqueIdentifierGenerator.resolveChildUniqueIdentifier(view, prefix + currentWireframeIndex)
         val drawableProperties = resolveDrawableProperties(view, drawable)
@@ -70,7 +72,8 @@ internal class ImageWireframeHelper(
             drawable = drawableProperties.drawable!!,
             drawableWidth = drawableProperties.drawableWidth,
             drawableHeight = drawableProperties.drawableHeight,
-            imageWireframe = imageWireframe
+            imageWireframe = imageWireframe,
+            asyncImageProcessingCallback = asyncImageProcessingCallback
         )
 
         return imageWireframe
@@ -80,7 +83,8 @@ internal class ImageWireframeHelper(
     internal fun createCompoundDrawableWireframes(
         view: TextView,
         mappingContext: MappingContext,
-        prevWireframeIndex: Int
+        prevWireframeIndex: Int,
+        asyncImageProcessingCallback: AsyncImageProcessingCallback?
     ): MutableList<MobileSegment.Wireframe> {
         val result = mutableListOf<MobileSegment.Wireframe>()
         var wireframeIndex = prevWireframeIndex
@@ -119,7 +123,8 @@ internal class ImageWireframeHelper(
                         .densityNormalized(density).toLong(),
                     drawable = drawable,
                     shapeStyle = null,
-                    border = null
+                    border = null,
+                    asyncImageProcessingCallback = asyncImageProcessingCallback
                 )?.let { resultWireframe ->
                     result.add(resultWireframe)
                 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
@@ -32,6 +32,7 @@ abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wireframe>(
     private var base64Serializer: Base64Serializer? = null
     private var imageWireframeHelper: ImageWireframeHelper? = null
     private var uniqueIdentifierGenerator = UniqueIdentifierGenerator
+    internal var asyncImageProcessingCallback: AsyncImageProcessingCallback? = null
 
     internal constructor(
         base64Serializer: Base64Serializer,
@@ -111,7 +112,7 @@ abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wireframe>(
     internal fun registerAsyncImageProcessingCallback(
         asyncImageProcessingCallback: AsyncImageProcessingCallback
     ) {
-        base64Serializer?.registerAsyncLoadingCallback(asyncImageProcessingCallback)
+        this.asyncImageProcessingCallback = asyncImageProcessingCallback
     }
 
     private fun resolveViewBackground(
@@ -186,7 +187,8 @@ abstract class BaseWireframeMapper<T : View, S : MobileSegment.Wireframe>(
             view.background?.constantState?.newDrawable(resources),
             shapeStyle = null,
             border = null,
-            prefix = PREFIX_BACKGROUND_DRAWABLE
+            prefix = PREFIX_BACKGROUND_DRAWABLE,
+            asyncImageProcessingCallback = asyncImageProcessingCallback
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapper.kt
@@ -54,7 +54,8 @@ internal class ImageButtonMapper(
             height = scaledDrawableHeight,
             drawable = drawable.constantState?.newDrawable(resources),
             shapeStyle = null,
-            border = null
+            border = null,
+            asyncImageProcessingCallback = asyncImageProcessingCallback
         )?.let {
             wireframes.add(it)
         }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper.kt
@@ -95,7 +95,8 @@ open class TextViewMapper :
         imageWireframeHelper?.createCompoundDrawableWireframes(
             view,
             mappingContext,
-            currentIndex
+            currentIndex,
+            asyncImageProcessingCallback = asyncImageProcessingCallback
         )?.let { result ->
             wireframes.addAll(result)
         }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/RumContextDataForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/RumContextDataForgeryFactory.kt
@@ -6,15 +6,14 @@
 
 package com.datadog.android.sessionreplay.forge
 
-import com.datadog.android.sessionreplay.internal.processor.RumContextData
+import com.datadog.android.sessionreplay.internal.processor.RecordedQueuedItemContext
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-internal class RumContextDataForgeryFactory : ForgeryFactory<RumContextData> {
-    override fun getForgery(forge: Forge): RumContextData {
-        return RumContextData(
+internal class RumContextDataForgeryFactory : ForgeryFactory<RecordedQueuedItemContext> {
+    override fun getForgery(forge: Forge): RecordedQueuedItemContext {
+        return RecordedQueuedItemContext(
             forge.aLong(),
-            forge.getForgery(),
             forge.getForgery()
         )
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SnapshotRecordedDataQueueItemForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SnapshotRecordedDataQueueItemForgeryFactory.kt
@@ -14,7 +14,7 @@ import java.util.concurrent.atomic.AtomicInteger
 internal class SnapshotRecordedDataQueueItemForgeryFactory : ForgeryFactory<SnapshotRecordedDataQueueItem> {
     override fun getForgery(forge: Forge): SnapshotRecordedDataQueueItem {
         val item = SnapshotRecordedDataQueueItem(
-            rumContextData = forge.getForgery(),
+            recordedQueuedItemContext = forge.getForgery(),
             systemInformation = forge.getForgery()
         )
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/TouchEventRecordedDataQueueItemForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/TouchEventRecordedDataQueueItemForgeryFactory.kt
@@ -13,7 +13,7 @@ import fr.xgouchet.elmyr.ForgeryFactory
 internal class TouchEventRecordedDataQueueItemForgeryFactory : ForgeryFactory<TouchEventRecordedDataQueueItem> {
     override fun getForgery(forge: Forge): TouchEventRecordedDataQueueItem {
         return TouchEventRecordedDataQueueItem(
-            rumContextData = forge.getForgery(),
+            recordedQueuedItemContext = forge.getForgery(),
             touchData = listOf(forge.getForgery())
         )
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/TouchEventRecordedDataQueueItemTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/TouchEventRecordedDataQueueItemTest.kt
@@ -41,7 +41,7 @@ internal class TouchEventRecordedDataQueueItemTest {
     fun `M return false W isValid() { Touch Event with empty touchData }`() {
         // Given
         testedItem = TouchEventRecordedDataQueueItem(
-            rumContextData = fakeTouchEventRecordedDataQueueItem.rumContextData,
+            recordedQueuedItemContext = fakeTouchEventRecordedDataQueueItem.recordedQueuedItemContext,
             touchData = emptyList()
         )
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/Base64SerializerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/Base64SerializerTest.kt
@@ -45,6 +45,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Future
 
@@ -73,7 +74,7 @@ internal class Base64SerializerTest {
     lateinit var mockApplicationContext: Context
 
     @Mock
-    lateinit var mockCallback: AsyncImageProcessingCallback
+    lateinit var mockAsyncImageProcessingCallback: AsyncImageProcessingCallback
 
     private lateinit var fakeBase64String: String
 
@@ -152,7 +153,6 @@ internal class Base64SerializerTest {
         whenever(mockBitmapDrawable.bitmap).thenReturn(mockBitmap)
 
         testedBase64Serializer = createBase64Serializer()
-        testedBase64Serializer.registerAsyncLoadingCallback(mockCallback)
     }
 
     @Test
@@ -164,11 +164,12 @@ internal class Base64SerializerTest {
             drawable = mockDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
-        verify(mockCallback).startProcessingImage()
+        verify(mockAsyncImageProcessingCallback).startProcessingImage()
     }
 
     @Test
@@ -192,11 +193,12 @@ internal class Base64SerializerTest {
             drawable = mockDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
-        verify(mockCallback).finishProcessingImage()
+        verify(mockAsyncImageProcessingCallback).finishProcessingImage()
     }
 
     @Test
@@ -220,13 +222,14 @@ internal class Base64SerializerTest {
             drawable = mockDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
         assertThat(fakeImageWireframe.base64).isEqualTo(fakeBase64String)
         assertThat(fakeImageWireframe.isEmpty).isFalse
-        verify(mockCallback).finishProcessingImage()
+        verify(mockAsyncImageProcessingCallback).finishProcessingImage()
     }
 
     @Test
@@ -256,7 +259,8 @@ internal class Base64SerializerTest {
             drawable = mockDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -273,7 +277,8 @@ internal class Base64SerializerTest {
                 drawable = mockDrawable,
                 drawableWidth = mockDrawable.intrinsicWidth,
                 drawableHeight = mockDrawable.intrinsicHeight,
-                imageWireframe = fakeImageWireframe
+                imageWireframe = fakeImageWireframe,
+                asyncImageProcessingCallback = mockAsyncImageProcessingCallback
             )
         }
 
@@ -302,7 +307,8 @@ internal class Base64SerializerTest {
             drawable = mockDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -330,7 +336,8 @@ internal class Base64SerializerTest {
                 drawable = mockDrawable,
                 drawableWidth = mockDrawable.intrinsicWidth,
                 drawableHeight = mockDrawable.intrinsicHeight,
-                imageWireframe = fakeImageWireframe
+                imageWireframe = fakeImageWireframe,
+                asyncImageProcessingCallback = mockAsyncImageProcessingCallback
             )
         }
 
@@ -350,7 +357,8 @@ internal class Base64SerializerTest {
             drawable = mockDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -385,7 +393,8 @@ internal class Base64SerializerTest {
             drawable = mockStateListDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -404,7 +413,8 @@ internal class Base64SerializerTest {
             drawable = mockStateListDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -423,7 +433,8 @@ internal class Base64SerializerTest {
             drawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -449,7 +460,8 @@ internal class Base64SerializerTest {
             drawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -472,7 +484,8 @@ internal class Base64SerializerTest {
             drawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -494,7 +507,8 @@ internal class Base64SerializerTest {
             drawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -524,7 +538,8 @@ internal class Base64SerializerTest {
             drawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -555,7 +570,8 @@ internal class Base64SerializerTest {
             drawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -577,7 +593,8 @@ internal class Base64SerializerTest {
             drawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -596,7 +613,8 @@ internal class Base64SerializerTest {
             drawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -615,7 +633,8 @@ internal class Base64SerializerTest {
             drawable = mockLayerDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
-            imageWireframe = fakeImageWireframe
+            imageWireframe = fakeImageWireframe,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -637,6 +656,51 @@ internal class Base64SerializerTest {
             drawable = mockDrawable,
             density = mockDensity
         )
+    }
+
+    @Test
+    fun `M return correct callback W handleBitmap() { multiple threads, first takes longer }`(
+        @Mock mockFirstCallback: AsyncImageProcessingCallback,
+        @Mock mockSecondCallback: AsyncImageProcessingCallback
+    ) {
+        // Given
+        val countDownLatch = CountDownLatch(2)
+
+        val thread1 = Thread {
+            testedBase64Serializer.handleBitmap(
+                applicationContext = mockApplicationContext,
+                displayMetrics = mockDisplayMetrics,
+                drawable = mockDrawable,
+                drawableWidth = fakeBitmapWidth,
+                drawableHeight = fakeBitmapHeight,
+                imageWireframe = fakeImageWireframe,
+                asyncImageProcessingCallback = mockFirstCallback
+            )
+            Thread.sleep(1500)
+            countDownLatch.countDown()
+        }
+        val thread2 = Thread {
+            testedBase64Serializer.handleBitmap(
+                applicationContext = mockApplicationContext,
+                displayMetrics = mockDisplayMetrics,
+                drawable = mockDrawable,
+                drawableWidth = fakeBitmapWidth,
+                drawableHeight = fakeBitmapHeight,
+                imageWireframe = fakeImageWireframe,
+                asyncImageProcessingCallback = mockSecondCallback
+            )
+            Thread.sleep(500)
+            countDownLatch.countDown()
+        }
+
+        // When
+        thread1.start()
+        thread2.start()
+
+        // Then
+        countDownLatch.await()
+        verify(mockFirstCallback).finishProcessingImage()
+        verify(mockSecondCallback).finishProcessingImage()
     }
 
     private fun createBase64Serializer(): Base64Serializer {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelperTest.kt
@@ -16,6 +16,7 @@ import android.util.DisplayMetrics
 import android.view.View
 import android.widget.TextView
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.AsyncImageProcessingCallback
 import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
@@ -38,6 +39,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -60,6 +62,9 @@ internal class ImageWireframeHelperTest {
 
     @Mock
     lateinit var mockImageCompression: ImageCompression
+
+    @Mock
+    lateinit var mockAsyncImageProcessingCallback: AsyncImageProcessingCallback
 
     @Mock
     lateinit var mockView: View
@@ -167,7 +172,8 @@ internal class ImageWireframeHelperTest {
             x = 0,
             y = 0,
             width = 0,
-            height = 0
+            height = 0,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -190,7 +196,8 @@ internal class ImageWireframeHelperTest {
             height = 0,
             drawable = mockDrawable,
             shapeStyle = null,
-            border = null
+            border = null,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -212,7 +219,8 @@ internal class ImageWireframeHelperTest {
             height = 0,
             drawable = mockDrawable,
             shapeStyle = null,
-            border = null
+            border = null,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -234,7 +242,8 @@ internal class ImageWireframeHelperTest {
             height = 0,
             drawable = mockDrawable,
             shapeStyle = null,
-            border = null
+            border = null,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -276,8 +285,8 @@ internal class ImageWireframeHelperTest {
             height = fakeDrawableHeight,
             drawable = mockDrawable,
             shapeStyle = mockShapeStyle,
-            border = mockBorder
-
+            border = mockBorder,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -298,7 +307,8 @@ internal class ImageWireframeHelperTest {
         val wireframes = testedHelper.createCompoundDrawableWireframes(
             mockTextView,
             mockMappingContext,
-            0
+            0,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -324,7 +334,8 @@ internal class ImageWireframeHelperTest {
         val wireframes = testedHelper.createCompoundDrawableWireframes(
             mockTextView,
             mockMappingContext,
-            0
+            0,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
         wireframes[0] as MobileSegment.Wireframe.ImageWireframe
 
@@ -351,7 +362,8 @@ internal class ImageWireframeHelperTest {
         val wireframes = testedHelper.createCompoundDrawableWireframes(
             mockTextView,
             mockMappingContext,
-            0
+            0,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
         wireframes[0] as MobileSegment.Wireframe.ImageWireframe
 
@@ -369,7 +381,8 @@ internal class ImageWireframeHelperTest {
         val wireframes = testedHelper.createCompoundDrawableWireframes(
             mockTextView,
             mockMappingContext,
-            0
+            0,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -401,7 +414,8 @@ internal class ImageWireframeHelperTest {
             height = 0,
             drawable = mockDrawable,
             shapeStyle = null,
-            border = null
+            border = null,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -412,7 +426,8 @@ internal class ImageWireframeHelperTest {
             drawable = any(),
             drawableWidth = captor.capture(),
             drawableHeight = captor.capture(),
-            imageWireframe = any()
+            imageWireframe = any(),
+            asyncImageProcessingCallback = anyOrNull()
         )
         assertThat(captor.allValues).containsExactly(fakeViewWidth, fakeViewHeight)
     }
@@ -429,7 +444,8 @@ internal class ImageWireframeHelperTest {
             height = 0,
             drawable = mockDrawable,
             shapeStyle = null,
-            border = null
+            border = null,
+            asyncImageProcessingCallback = mockAsyncImageProcessingCallback
         )
 
         // Then
@@ -440,7 +456,8 @@ internal class ImageWireframeHelperTest {
             drawable = any(),
             drawableWidth = captor.capture(),
             drawableHeight = captor.capture(),
-            imageWireframe = any()
+            imageWireframe = any(),
+            asyncImageProcessingCallback = anyOrNull()
         )
         assertThat(captor.allValues).containsExactly(fakeDrawableWidth.toInt(), fakeDrawableHeight.toInt())
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseTextViewWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseTextViewWireframeMapperTest.kt
@@ -30,6 +30,7 @@ import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
 import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.whenever
 
@@ -413,7 +414,7 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
         }
         val mockImageWireframe: MobileSegment.Wireframe.ImageWireframe = mock()
 
-        whenever(mockImageWireframeHelper.createCompoundDrawableWireframes(any(), any(), any()))
+        whenever(mockImageWireframeHelper.createCompoundDrawableWireframes(any(), any(), any(), anyOrNull()))
             .thenReturn(mutableListOf(mockImageWireframe))
 
         whenever(mockObfuscationRule.resolveObfuscatedValue(mockTextView, fakeMappingContext))

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapperTest.kt
@@ -14,6 +14,7 @@ import android.graphics.drawable.Drawable.ConstantState
 import android.util.DisplayMetrics
 import android.widget.ImageButton
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.AsyncImageProcessingCallback
 import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
@@ -83,6 +84,9 @@ internal class ImageButtonMapperTest {
 
     @Mock
     lateinit var mockBase64Serializer: Base64Serializer
+
+    @Mock
+    lateinit var mockAsyncImageProcessingCallback: AsyncImageProcessingCallback
 
     @Mock
     lateinit var mockViewUtils: ViewUtils
@@ -155,6 +159,8 @@ internal class ImageButtonMapperTest {
             imageWireframeHelper = mockImageWireframeHelper,
             uniqueIdentifierGenerator = mockUniqueIdentifierGenerator
         )
+
+        testedMapper.registerAsyncImageProcessingCallback(mockAsyncImageProcessingCallback)
     }
 
     @Test
@@ -172,7 +178,8 @@ internal class ImageButtonMapperTest {
                 mockImageButton.height.toLong(),
                 mockDrawable.constantState?.newDrawable(mockResources),
                 null,
-                null
+                null,
+                asyncImageProcessingCallback = mockAsyncImageProcessingCallback
             )
         ).thenReturn(expectedWireframe)
 
@@ -256,6 +263,7 @@ internal class ImageButtonMapperTest {
             anyOrNull(),
             anyOrNull(),
             anyOrNull(),
+            anyOrNull(),
             anyOrNull()
         )
         val allValues = captor.allValues
@@ -285,6 +293,7 @@ internal class ImageButtonMapperTest {
             any(),
             any(),
             any(),
+            anyOrNull(),
             anyOrNull(),
             anyOrNull(),
             anyOrNull(),
@@ -375,6 +384,7 @@ internal class ImageButtonMapperTest {
                 any(),
                 any(),
                 any(),
+                anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),
                 anyOrNull(),


### PR DESCRIPTION
### What does this PR do?
Fixes two issues that were discovered during functional tests. 

The first issue is having the `AsyncImageProcessingCallback` held by the `Base64Serializer` instance, and this can lead to the next bitmap replacing the callback before the first one has completed. This can lead to the decrement of pending images happening on the wrong node. Solution: passing the asyncCallback in every call to handleBitmap.

The second issue is having the previous `RumContext` held by the `RumContextData` object. This can lead to an item being removed from the queue (lost - not processed) with prevContext A and newContext B, and the next item with prevContext B newContext B will no longer be seen as a new view - so no meta data. Solution: the RecordedDataProcessor now holds it's own prevRumContext variable and replaces it only after processing an item. 

### Motivation
Issues found during functional tests.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

