### PR TITLE
RUM-985 propagate session state and view type as Strings

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumContext.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumContext.kt
@@ -26,11 +26,11 @@ internal data class RumContext(
         return mapOf(
             APPLICATION_ID to applicationId,
             SESSION_ID to sessionId,
-            SESSION_STATE to sessionState,
+            SESSION_STATE to sessionState.asString,
             VIEW_ID to viewId,
             VIEW_NAME to viewName,
             VIEW_URL to viewUrl,
-            VIEW_TYPE to viewType,
+            VIEW_TYPE to viewType.asString,
             ACTION_ID to actionId
         )
     }
@@ -52,23 +52,21 @@ internal data class RumContext(
         fun fromFeatureContext(featureContext: Map<String, Any?>): RumContext {
             val applicationId = featureContext[APPLICATION_ID] as? String
             val sessionId = featureContext[SESSION_ID] as? String
-            val sessionState = featureContext[SESSION_STATE] as? RumSessionScope.State
-                ?: RumSessionScope.State.NOT_TRACKED
+            val sessionState = RumSessionScope.State.fromString(featureContext[SESSION_STATE] as? String)
             val viewId = featureContext[VIEW_ID] as? String
             val viewName = featureContext[VIEW_NAME] as? String
             val viewUrl = featureContext[VIEW_URL] as? String
-            val viewType = featureContext[VIEW_TYPE] as? RumViewScope.RumViewType
-                ?: RumViewScope.RumViewType.NONE
+            val viewType = RumViewScope.RumViewType.fromString(featureContext[VIEW_TYPE] as? String)
             val actionId = featureContext[ACTION_ID] as? String
 
             return RumContext(
                 applicationId = applicationId ?: NULL_UUID,
                 sessionId = sessionId ?: NULL_UUID,
-                sessionState = sessionState,
+                sessionState = sessionState ?: RumSessionScope.State.NOT_TRACKED,
                 viewId = viewId,
                 viewName = viewName,
                 viewUrl = viewUrl,
-                viewType = viewType,
+                viewType = viewType ?: RumViewScope.RumViewType.NONE,
                 actionId = actionId
             )
         }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -70,10 +70,16 @@ internal class RumSessionScope(
         }
     }
 
-    enum class State {
-        NOT_TRACKED,
-        TRACKED,
-        EXPIRED
+    enum class State(val asString: String) {
+        NOT_TRACKED("NOT_TRACKED"),
+        TRACKED("TRACKED"),
+        EXPIRED("EXPIRED");
+
+        companion object {
+            fun fromString(string: String?): State? {
+                return values().firstOrNull { it.asString == string }
+            }
+        }
     }
 
     // region RumScope

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -1014,11 +1014,17 @@ internal open class RumViewScope(
         return stopped && activeResourceScopes.isEmpty() && (pending <= 0L)
     }
 
-    enum class RumViewType {
-        NONE,
-        FOREGROUND,
-        BACKGROUND,
-        APPLICATION_LAUNCH
+    enum class RumViewType(val asString: String) {
+        NONE("NONE"),
+        FOREGROUND("FOREGROUND"),
+        BACKGROUND("BACKGROUND"),
+        APPLICATION_LAUNCH("APPLICATION_LAUNCH");
+
+        companion object {
+            fun fromString(string: String?): RumViewType? {
+                return values().firstOrNull { it.asString == string }
+            }
+        }
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -130,7 +130,7 @@ internal class RumSessionScopeTest {
 
             assertThat(rumContext["application_id"]).isEqualTo(expectedContext.applicationId)
             assertThat(rumContext["session_id"]).isEqualTo(expectedContext.sessionId)
-            assertThat(rumContext["session_state"]).isEqualTo(expectedContext.sessionState)
+            assertThat(rumContext["session_state"]).isEqualTo(expectedContext.sessionState.asString)
         }
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -388,7 +388,7 @@ internal class RumViewScopeTest {
                 function.invoke(acc)
                 acc
             }
-            assertThat(rumContext["view_type"]).isEqualTo(fakeViewEventType)
+            assertThat(rumContext["view_type"]).isEqualTo(fakeViewEventType.asString)
         }
     }
 
@@ -432,8 +432,7 @@ internal class RumViewScopeTest {
                 function.invoke(acc)
                 acc
             }
-            assertThat(rumContext["view_type"])
-                .isEqualTo(RumViewScope.RumViewType.NONE)
+            assertThat(rumContext["view_type"]).isEqualTo(RumViewScope.RumViewType.NONE.asString)
         }
     }
 
@@ -458,8 +457,7 @@ internal class RumViewScopeTest {
             )
             val rumContext = mutableMapOf<String, Any?>()
             lastValue.invoke(rumContext)
-            assertThat(rumContext["view_type"])
-                .isEqualTo(RumViewScope.RumViewType.FOREGROUND)
+            assertThat(rumContext["view_type"]).isEqualTo(RumViewScope.RumViewType.FOREGROUND.asString)
         }
     }
 
@@ -511,16 +509,11 @@ internal class RumViewScopeTest {
                 acc
             }
 
-            assertThat(rumContext["view_type"])
-                .isEqualTo(expectedViewType)
-            assertThat(rumContext["view_name"])
-                .isEqualTo(anotherScope.getRumContext().viewName)
-            assertThat(rumContext["view_id"])
-                .isEqualTo(anotherScope.getRumContext().viewId)
-            assertThat(rumContext["view_url"])
-                .isEqualTo(anotherScope.getRumContext().viewUrl)
-            assertThat(rumContext["action_id"])
-                .isEqualTo(anotherScope.getRumContext().actionId)
+            assertThat(rumContext["view_type"]).isEqualTo(expectedViewType.asString)
+            assertThat(rumContext["view_name"]).isEqualTo(anotherScope.getRumContext().viewName)
+            assertThat(rumContext["view_id"]).isEqualTo(anotherScope.getRumContext().viewId)
+            assertThat(rumContext["view_url"]).isEqualTo(anotherScope.getRumContext().viewUrl)
+            assertThat(rumContext["action_id"]).isEqualTo(anotherScope.getRumContext().actionId)
         }
         mockInternalLogger.verifyLog(
             InternalLogger.Level.DEBUG,
@@ -560,8 +553,7 @@ internal class RumViewScopeTest {
                 acc
             }
 
-            assertThat(rumContext["view_type"])
-                .isEqualTo(RumViewScope.RumViewType.NONE)
+            assertThat(rumContext["view_type"]).isEqualTo(RumViewScope.RumViewType.NONE.asString)
             assertThat(rumContext["view_name"]).isNull()
             assertThat(rumContext["view_id"]).isNull()
             assertThat(rumContext["view_url"]).isNull()
@@ -603,16 +595,11 @@ internal class RumViewScopeTest {
                 acc
             }
 
-            assertThat(rumContext["view_type"])
-                .isEqualTo(RumViewScope.RumViewType.NONE)
-            assertThat(rumContext["view_name"])
-                .isNull()
-            assertThat(rumContext["view_id"])
-                .isNull()
-            assertThat(rumContext["view_url"])
-                .isNull()
-            assertThat(rumContext["action_id"])
-                .isNull()
+            assertThat(rumContext["view_type"]).isEqualTo(RumViewScope.RumViewType.NONE.asString)
+            assertThat(rumContext["view_name"]).isNull()
+            assertThat(rumContext["view_id"]).isNull()
+            assertThat(rumContext["view_url"]).isNull()
+            assertThat(rumContext["action_id"]).isNull()
         }
 
         mockInternalLogger.verifyLog(
@@ -707,7 +694,7 @@ internal class RumViewScopeTest {
                 function.invoke(acc)
                 acc
             }
-            assertThat(rumContext["view_type"]).isEqualTo(viewType)
+            assertThat(rumContext["view_type"]).isEqualTo(viewType.asString)
         }
     }
 
@@ -764,7 +751,7 @@ internal class RumViewScopeTest {
                 function.invoke(acc)
                 acc
             }
-            assertThat(rumContext["view_type"]).isEqualTo(viewType)
+            assertThat(rumContext["view_type"]).isEqualTo(viewType.asString)
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

The RUM `session_state` and `view_type` were propagated as internal enums in the shared RUM feature context. This means that other modules could not use those values (except with a call to `toString()`, which could have resulted in obfuscated results). 

This PR ensures the data is shared as a String, to be manipulated unobfuscated from any module using it. 

### Motivation

Part of the work done to make the RUM sampling consistent between Webviews and the native app.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

