### PR TITLE
RUM-985 fix the WebView fragment in sample app

### DIFF
--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/WebFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/WebFragment.kt
@@ -15,6 +15,7 @@ import android.webkit.WebViewClient
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProviders
 import com.datadog.android.sample.R
+import com.datadog.android.sample.SampleApplication
 import com.datadog.android.webview.WebViewTracking
 
 internal class WebFragment : Fragment() {
@@ -44,7 +45,8 @@ internal class WebFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        viewModel = ViewModelProviders.of(this).get(WebViewModel::class.java)
+        val factory = SampleApplication.getViewModelFactory(requireContext())
+        viewModel = ViewModelProviders.of(this, factory).get(WebViewModel::class.java)
     }
 
     override fun onResume() {


### PR DESCRIPTION
### What does this PR do?

A quick fix for the Webview page in the sample app: it would crash systematically because it used a generic ViewModelFactory instead of the app's one which can generate a WebviewViewModel. 