### PR TITLE
RUM-1095 Fix the batch duration value in batch_close telemetry event

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
@@ -201,11 +201,12 @@ internal class BatchFileOrchestrator(
         val newFileName = System.currentTimeMillis().toString()
         val newFile = File(rootDir, newFileName)
         val closedFile = previousFile
+        val closedFileLastAccessTimestamp = lastFileAccessTimestamp
         if (closedFile != null) {
             metricsDispatcher.sendBatchClosedMetric(
                 closedFile,
                 BatchClosedMetadata(
-                    lastTimeWasUsedInMs = lastFileAccessTimestamp,
+                    lastTimeWasUsedInMs = closedFileLastAccessTimestamp,
                     eventsCount = previousFileItemCount,
                     forcedNew = wasForced
                 )


### PR DESCRIPTION
### What does this PR do?

Before we were computing the batch duration value for the `batch_close` telemetry event as: `System.currentTimeInMillis - lastTimeBatchWasAccessed` which was completely wrong. In this PR we are addressing this issue.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

