### PR TITLE
RUM-700 prevent NPE in GestureListener

### DIFF
--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -252,6 +252,12 @@ public final class com/datadog/android/rum/internal/domain/event/ResourceTiming 
 	public fun toString ()Ljava/lang/String;
 }
 
+public abstract class com/datadog/android/rum/internal/instrumentation/gestures/GestureListenerCompat : android/view/GestureDetector$OnGestureListener {
+	public fun <init> ()V
+	public fun onFling (Landroid/view/MotionEvent;Landroid/view/MotionEvent;FF)Z
+	public fun onScroll (Landroid/view/MotionEvent;Landroid/view/MotionEvent;FF)Z
+}
+
 public abstract interface class com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor {
 	public abstract fun addResourceTiming (Ljava/lang/String;Lcom/datadog/android/rum/internal/domain/event/ResourceTiming;)V
 	public abstract fun notifyInterceptorInstantiated ()V

--- a/features/dd-sdk-android-rum/src/main/java/com/datadog/android/rum/internal/instrumentation/gestures/GestureListenerCompat.java
+++ b/features/dd-sdk-android-rum/src/main/java/com/datadog/android/rum/internal/instrumentation/gestures/GestureListenerCompat.java
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.instrumentation.gestures;
+
+import android.view.GestureDetector;
+import android.view.MotionEvent;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+public abstract class GestureListenerCompat implements GestureDetector.OnGestureListener {
+
+    @Override
+    public boolean onScroll(@Nullable MotionEvent e1, @NonNull MotionEvent e2, float distanceX, float distanceY) {
+        // This implementation is no op, and just there to be able to accept nullable e1 param
+        // in our Kotlin implementation.
+        // Since Android API 33, the param was annotated with @NonNull, but older versions of Android
+        // can still call it with null values. Our Kotlin implementation throws NPEs because of this.
+        return false;
+    }
+
+    @Override
+    public boolean onFling(@Nullable MotionEvent e1, @NonNull MotionEvent e2, float velocityX, float velocityY) {
+        // This implementation is no op, and just there to be able to accept nullable e1 param
+        // in our Kotlin implementation.
+        // Since Android API 33, the param was annotated with @NonNull, but older versions of Android
+        // can still call it with null values. Our Kotlin implementation throws NPEs because of this.
+        return false;
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.rum.internal.instrumentation.gestures
 
 import android.content.Context
-import android.view.GestureDetector
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -36,7 +35,7 @@ internal class GesturesListener(
     private val interactionPredicate: InteractionPredicate = NoOpInteractionPredicate(),
     private val contextRef: Reference<Context>,
     private val internalLogger: InternalLogger
-) : GestureDetector.OnGestureListener {
+) : GestureListenerCompat() {
 
     private val coordinatesContainer = IntArray(2)
     private var scrollEventType: RumActionType? = null
@@ -71,7 +70,7 @@ internal class GesturesListener(
     }
 
     override fun onFling(
-        startDownEvent: MotionEvent,
+        startDownEvent: MotionEvent?,
         endUpEvent: MotionEvent,
         velocityX: Float,
         velocityY: Float
@@ -82,7 +81,7 @@ internal class GesturesListener(
 
     @Suppress("ReturnCount")
     override fun onScroll(
-        startDownEvent: MotionEvent,
+        startDownEvent: MotionEvent?,
         currentMoveEvent: MotionEvent,
         distanceX: Float,
         distanceY: Float
@@ -93,7 +92,7 @@ internal class GesturesListener(
         // we only start the user action once
         if (scrollEventType == null) {
             // check if we find a valid target
-            val scrollTarget = findTargetForScroll(decorView, startDownEvent.x, startDownEvent.y)
+            val scrollTarget = startDownEvent?.let { findTargetForScroll(decorView, it.x, startDownEvent.y) }
             if (scrollTarget != null) {
                 scrollTargetReference = WeakReference(scrollTarget)
                 val targetId: String = contextRef.get().resourceIdName(scrollTarget.id)


### PR DESCRIPTION
### What does this PR do?

Create a custom Java version of `GestureDetector.OnGestureListener` class to keep compatibility with older versions of Android

### Motivation

Our telemetry is reporting a lot of exception similar to: 
```
java.lang.NullPointerException: Parameter specified as non-null is null: method kotlin.jvm.internal.Intrinsics.checkNotNullParameter, parameter startDownEvent
	at com.datadog.android.rum.internal.instrumentation.gestures.GesturesListener.onScroll(Unknown Source:2)
	at android.view.GestureDetector.onTouchEvent(GestureDetector.java:791)
```

On Android pre API 32, the `onScroll` method could be called with a null `startDownEvent` value. Starting in API 33, this parameter is marked as `@NonNull`, meaning that our Kotlin implementation must accept non-null parameters (trying to force the type as nullable `MotionEvent?` cause a compilation error. 

This PR uses a custom Java override where the annotation is replaced with `@Nullable` to make Kotlin happy. 

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

