### PR TITLE
RUM-391 add networkInfoEnabled option in TraceConfiguration

### DIFF
--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -41,7 +41,7 @@ data class com.datadog.android.trace.model.SpanEvent
       fun fromJson(kotlin.String): Metrics
       fun fromJsonObject(com.google.gson.JsonObject): Metrics
   data class Meta
-    constructor(kotlin.String, Dd, Span, Tracer, Usr, Network, kotlin.collections.MutableMap<kotlin.String, kotlin.String> = mutableMapOf())
+    constructor(kotlin.String, Dd, Span, Tracer, Usr, Network? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.String> = mutableMapOf())
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Meta
@@ -68,13 +68,13 @@ data class com.datadog.android.trace.model.SpanEvent
       fun fromJson(kotlin.String): Usr
       fun fromJsonObject(com.google.gson.JsonObject): Usr
   data class Network
-    constructor(Client)
+    constructor(Client? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Network
       fun fromJsonObject(com.google.gson.JsonObject): Network
   data class Client
-    constructor(SimCarrier? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String)
+    constructor(SimCarrier? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Client

--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -23,6 +23,7 @@ data class com.datadog.android.trace.TraceConfiguration
   class Builder
     fun useCustomEndpoint(String): Builder
     fun setEventMapper(com.datadog.android.trace.event.SpanEventMapper): Builder
+    fun setNetworkInfoEnabled(Boolean): Builder
     fun build(): TraceConfiguration
 interface com.datadog.android.trace.event.SpanEventMapper : com.datadog.android.event.EventMapper<com.datadog.android.trace.model.SpanEvent>
   override fun map(com.datadog.android.trace.model.SpanEvent): com.datadog.android.trace.model.SpanEvent

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -41,8 +41,8 @@ public final class com/datadog/android/trace/Trace {
 }
 
 public final class com/datadog/android/trace/TraceConfiguration {
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;)Lcom/datadog/android/trace/TraceConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/trace/TraceConfiguration;Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ILjava/lang/Object;)Lcom/datadog/android/trace/TraceConfiguration;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;Z)Lcom/datadog/android/trace/TraceConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/trace/TraceConfiguration;Ljava/lang/String;Lcom/datadog/android/trace/event/SpanEventMapper;ZILjava/lang/Object;)Lcom/datadog/android/trace/TraceConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -52,6 +52,7 @@ public final class com/datadog/android/trace/TraceConfiguration$Builder {
 	public fun <init> ()V
 	public final fun build ()Lcom/datadog/android/trace/TraceConfiguration;
 	public final fun setEventMapper (Lcom/datadog/android/trace/event/SpanEventMapper;)Lcom/datadog/android/trace/TraceConfiguration$Builder;
+	public final fun setNetworkInfoEnabled (Z)Lcom/datadog/android/trace/TraceConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/trace/TraceConfiguration$Builder;
 }
 

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -100,6 +100,7 @@ public final class com/datadog/android/trace/model/SpanEvent {
 
 public final class com/datadog/android/trace/model/SpanEvent$Client {
 	public static final field Companion Lcom/datadog/android/trace/model/SpanEvent$Client$Companion;
+	public fun <init> ()V
 	public fun <init> (Lcom/datadog/android/trace/model/SpanEvent$SimCarrier;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
 	public synthetic fun <init> (Lcom/datadog/android/trace/model/SpanEvent$SimCarrier;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/trace/model/SpanEvent$SimCarrier;
@@ -213,7 +214,9 @@ public final class com/datadog/android/trace/model/SpanEvent$Metrics$Companion {
 
 public final class com/datadog/android/trace/model/SpanEvent$Network {
 	public static final field Companion Lcom/datadog/android/trace/model/SpanEvent$Network$Companion;
+	public fun <init> ()V
 	public fun <init> (Lcom/datadog/android/trace/model/SpanEvent$Client;)V
+	public synthetic fun <init> (Lcom/datadog/android/trace/model/SpanEvent$Client;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/trace/model/SpanEvent$Client;
 	public final fun copy (Lcom/datadog/android/trace/model/SpanEvent$Client;)Lcom/datadog/android/trace/model/SpanEvent$Network;
 	public static synthetic fun copy$default (Lcom/datadog/android/trace/model/SpanEvent$Network;Lcom/datadog/android/trace/model/SpanEvent$Client;ILjava/lang/Object;)Lcom/datadog/android/trace/model/SpanEvent$Network;

--- a/features/dd-sdk-android-trace/src/main/json/trace/span-schema.json
+++ b/features/dd-sdk-android-trace/src/main/json/trace/span-schema.json
@@ -195,16 +195,10 @@
                   "readOnly": true
                 }
               },
-              "readOnly": true,
-              "required": [
-                "connectivity"
-              ]
+              "readOnly": true
             }
           },
-          "readOnly": true,
-          "required": [
-            "client"
-          ]
+          "readOnly": true
         }
       },
       "required": [
@@ -212,8 +206,7 @@
         "_dd",
         "span",
         "tracer",
-        "usr",
-        "network"
+        "usr"
       ],
       "additionalProperties": {
         "type": "string",

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/TraceConfiguration.kt
@@ -14,7 +14,8 @@ import com.datadog.android.trace.event.SpanEventMapper
  */
 data class TraceConfiguration internal constructor(
     internal val customEndpointUrl: String?,
-    internal val eventMapper: SpanEventMapper
+    internal val eventMapper: SpanEventMapper,
+    internal val networkInfoEnabled: Boolean
 ) {
 
     /**
@@ -23,6 +24,7 @@ data class TraceConfiguration internal constructor(
     class Builder {
         private var customEndpointUrl: String? = null
         private var spanEventMapper: SpanEventMapper = NoOpSpanEventMapper()
+        private var networkInfoEnabled: Boolean = true
 
         /**
          * Let the Tracing feature target a custom server.
@@ -45,12 +47,22 @@ data class TraceConfiguration internal constructor(
         }
 
         /**
+         * Enables network information to be automatically added in your logs.
+         * @param enabled true by default
+         */
+        fun setNetworkInfoEnabled(enabled: Boolean): Builder {
+            networkInfoEnabled = enabled
+            return this
+        }
+
+        /**
          * Builds a [TraceConfiguration] based on the current state of this Builder.
          */
         fun build(): TraceConfiguration {
             return TraceConfiguration(
                 customEndpointUrl = customEndpointUrl,
-                eventMapper = spanEventMapper
+                eventMapper = spanEventMapper,
+                networkInfoEnabled = networkInfoEnabled
             )
         }
     }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/assertj/SpanEventAssert.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/assertj/SpanEventAssert.kt
@@ -186,46 +186,46 @@ internal class SpanEventAssert(actual: SpanEvent) :
     }
 
     fun hasNetworkInfo(networkInfo: NetworkInfo): SpanEventAssert {
-        assertThat(actual.meta.network.client.connectivity)
+        assertThat(actual.meta.network?.client?.connectivity)
             .overridingErrorMessage(
                 "Expected SpanEvent to have connectivity: " +
                     "${networkInfo.connectivity} but " +
-                    "instead was: ${actual.meta.network.client.connectivity}"
+                    "instead was: ${actual.meta.network?.client?.connectivity}"
             )
             .isEqualTo(networkInfo.connectivity.toString())
-        assertThat(actual.meta.network.client.downlinkKbps)
+        assertThat(actual.meta.network?.client?.downlinkKbps)
             .overridingErrorMessage(
                 "Expected SpanEvent to have downlinkKbps: " +
                     "${networkInfo.downKbps?.toString()} but " +
-                    "instead was: ${actual.meta.network.client.downlinkKbps}"
+                    "instead was: ${actual.meta.network?.client?.downlinkKbps}"
             )
             .isEqualTo(networkInfo.downKbps?.toString())
-        assertThat(actual.meta.network.client.uplinkKbps)
+        assertThat(actual.meta.network?.client?.uplinkKbps)
             .overridingErrorMessage(
                 "Expected SpanEvent to have uplinkKbps: " +
                     "${networkInfo.upKbps?.toString()} but " +
-                    "instead was: ${actual.meta.network.client.uplinkKbps}"
+                    "instead was: ${actual.meta.network?.client?.uplinkKbps}"
             )
             .isEqualTo(networkInfo.upKbps?.toString())
-        assertThat(actual.meta.network.client.signalStrength)
+        assertThat(actual.meta.network?.client?.signalStrength)
             .overridingErrorMessage(
                 "Expected SpanEvent to have signal strength: " +
                     "${networkInfo.strength?.toString()} but " +
-                    "instead was: ${actual.meta.network.client.signalStrength}"
+                    "instead was: ${actual.meta.network?.client?.signalStrength}"
             )
             .isEqualTo(networkInfo.strength?.toString())
-        assertThat(actual.meta.network.client.simCarrier?.id)
+        assertThat(actual.meta.network?.client?.simCarrier?.id)
             .overridingErrorMessage(
                 "Expected SpanEvent to have carrier id: " +
                     "${networkInfo.carrierId?.toString()} but " +
-                    "instead was: ${actual.meta.network.client.simCarrier?.id}"
+                    "instead was: ${actual.meta.network?.client?.simCarrier?.id}"
             )
             .isEqualTo(networkInfo.carrierId?.toString())
-        assertThat(actual.meta.network.client.simCarrier?.name)
+        assertThat(actual.meta.network?.client?.simCarrier?.name)
             .overridingErrorMessage(
                 "Expected SpanEvent to have carrier name: " +
                     "${networkInfo.carrierName} but " +
-                    "instead was: ${actual.meta.network.client.simCarrier?.name}"
+                    "instead was: ${actual.meta.network?.client?.simCarrier?.name}"
             )
             .isEqualTo(networkInfo.carrierName)
         return this

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/SpanEventSerializerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/SpanEventSerializerTest.kt
@@ -220,11 +220,13 @@ internal class SpanEventSerializerTest {
         spanEvent: SpanEvent
     ) {
         val network = spanEvent.meta.network
-        hasField(
-            KEY_NETWORK_CONNECTIVITY,
-            network.client.connectivity
-        )
-        val simCarrier = network.client.simCarrier
+        val connectivity = network?.client?.connectivity
+        if (connectivity != null) {
+            hasField(KEY_NETWORK_CONNECTIVITY, connectivity)
+        } else {
+            doesNotHaveField(KEY_NETWORK_CONNECTIVITY)
+        }
+        val simCarrier = network?.client?.simCarrier
         if (simCarrier != null) {
             hasField(KEY_SIM_CARRIER) {
                 val simCarrierName = simCarrier.name
@@ -246,13 +248,13 @@ internal class SpanEventSerializerTest {
         } else {
             doesNotHaveField(KEY_SIM_CARRIER)
         }
-        val uplinkKbps = network.client.uplinkKbps
+        val uplinkKbps = network?.client?.uplinkKbps
         if (uplinkKbps != null) {
             hasField(KEY_NETWORK_UP_KBPS, uplinkKbps)
         } else {
             doesNotHaveField(KEY_NETWORK_UP_KBPS)
         }
-        val downlinkKbps = network.client.downlinkKbps
+        val downlinkKbps = network?.client?.downlinkKbps
         if (downlinkKbps != null) {
             hasField(
                 KEY_NETWORK_DOWN_KBPS,
@@ -261,7 +263,7 @@ internal class SpanEventSerializerTest {
         } else {
             doesNotHaveField(KEY_NETWORK_DOWN_KBPS)
         }
-        val signalStrength = network.client.signalStrength
+        val signalStrength = network?.client?.signalStrength
         if (signalStrength != null) {
             hasField(
                 KEY_NETWORK_SIGNAL_STRENGTH,

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/TraceConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/utils/forge/TraceConfigurationForgeryFactory.kt
@@ -15,7 +15,8 @@ class TraceConfigurationForgeryFactory : ForgeryFactory<TraceConfiguration> {
     override fun getForgery(forge: Forge): TraceConfiguration {
         return TraceConfiguration(
             customEndpointUrl = forge.aNullable { aStringMatching("https://[a-z]+\\.com") },
-            eventMapper = mock()
+            eventMapper = mock(),
+            networkInfoEnabled = forge.aBool()
         )
     }
 }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -43,6 +43,7 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.rum.tracking.NavigationViewTrackingStrategy#fun stopTracking()
  * apiMethodSignature: com.datadog.android.trace.Trace#fun enable(TraceConfiguration, com.datadog.android.api.SdkCore = Datadog.getInstance())
  * apiMethodSignature: com.datadog.android.trace.TraceConfiguration$Builder#fun useCustomEndpoint(String): Builder
+ * apiMethodSignature: com.datadog.android.trace.TraceConfiguration$Builder#fun setNetworkInfoEnabled(Boolean): Builder
  * apiMethodSignature: com.datadog.android.core.SdkReference#constructor(String? = null, (com.datadog.android.api.SdkCore) -> Unit = {})
  * apiMethodSignature: com.datadog.android.core.SdkReference#fun get(): com.datadog.android.api.SdkCore?
  * apiMethodSignature: com.datadog.android.sessionreplay.SessionReplay#fun enable(SessionReplayConfiguration, com.datadog.android.api.SdkCore = Datadog.getInstance())


### PR DESCRIPTION
### What does this PR do?

Add a `setNetworkInfoEnabled` option in the TraceConfiguration used to enable the feature

### Motivation

This is part of several PRs to allow enabling/disabling attaching network info in spans collected in an Android app