### PR TITLE
RUM-391 use networkInfoEnabled to serialize or not network info in spans

### DIFF
--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Trace.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/Trace.kt
@@ -29,7 +29,8 @@ object Trace {
         val tracingFeature = TracingFeature(
             sdkCore = sdkCore as FeatureSdkCore,
             customEndpointUrl = traceConfiguration.customEndpointUrl,
-            spanEventMapper = traceConfiguration.eventMapper
+            spanEventMapper = traceConfiguration.eventMapper,
+            networkInfoEnabled = traceConfiguration.networkInfoEnabled
         )
 
         sdkCore.registerFeature(tracingFeature)

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/TracingFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/TracingFeature.kt
@@ -28,7 +28,8 @@ import java.util.concurrent.atomic.AtomicBoolean
 internal class TracingFeature constructor(
     private val sdkCore: FeatureSdkCore,
     customEndpointUrl: String?,
-    internal val spanEventMapper: SpanEventMapper
+    internal val spanEventMapper: SpanEventMapper,
+    internal val networkInfoEnabled: Boolean
 ) : StorageBackedFeature {
 
     internal var dataWriter: Writer = NoOpWriter()
@@ -66,7 +67,7 @@ internal class TracingFeature constructor(
         val internalLogger = sdkCore.internalLogger
         return TraceWriter(
             sdkCore,
-            legacyMapper = DdSpanToSpanEventMapper(),
+            legacyMapper = DdSpanToSpanEventMapper(networkInfoEnabled),
             eventMapper = SpanEventMapperWrapper(spanEventMapper, internalLogger),
             serializer = SpanEventSerializer(internalLogger),
             internalLogger = internalLogger

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/TraceWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/TraceWriter.kt
@@ -22,7 +22,7 @@ import java.util.Locale
 
 internal class TraceWriter(
     private val sdkCore: FeatureSdkCore,
-    private val legacyMapper: ContextAwareMapper<DDSpan, SpanEvent>,
+    internal val legacyMapper: ContextAwareMapper<DDSpan, SpanEvent>,
     internal val eventMapper: EventMapper<SpanEvent>,
     private val serializer: ContextAwareSerializer<SpanEvent>,
     private val internalLogger: InternalLogger

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/assertj/SpanEventAssert.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/assertj/SpanEventAssert.kt
@@ -231,6 +231,16 @@ internal class SpanEventAssert(actual: SpanEvent) :
         return this
     }
 
+    fun doesntHaveNetworkInfo(): SpanEventAssert {
+        assertThat(actual.meta.network)
+            .overridingErrorMessage(
+                "Expected SpanEvent to not have network info but was: " +
+                    "${actual.meta.network}"
+            )
+            .isNull()
+        return this
+    }
+
     fun hasUserInfo(userInfo: UserInfo): SpanEventAssert {
         assertThat(actual.meta.usr.name)
             .overridingErrorMessage(

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/DdSpanToSpanEventMapperTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/DdSpanToSpanEventMapperTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.utils.forge.Configurator
 import com.datadog.opentracing.DDSpan
 import com.datadog.tools.unit.setFieldValue
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -39,9 +40,12 @@ internal class DdSpanToSpanEventMapperTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
+    @BoolForgery
+    var fakeNetworkInfoEnabled: Boolean = false
+
     @BeforeEach
     fun `set up`() {
-        testedMapper = DdSpanToSpanEventMapper()
+        testedMapper = DdSpanToSpanEventMapper(fakeNetworkInfoEnabled)
     }
 
     @RepeatedTest(4)
@@ -66,7 +70,13 @@ internal class DdSpanToSpanEventMapperTest {
             .hasSpanDuration(fakeSpan.durationNano)
             .hasTracerVersion(fakeDatadogContext.sdkVersion)
             .hasClientPackageVersion(fakeDatadogContext.version)
-            .hasNetworkInfo(fakeDatadogContext.networkInfo)
+            .apply {
+                if (fakeNetworkInfoEnabled) {
+                    hasNetworkInfo(fakeDatadogContext.networkInfo)
+                } else {
+                    doesntHaveNetworkInfo()
+                }
+            }
             .hasUserInfo(fakeDatadogContext.userInfo)
             .hasMeta(fakeSpan.meta)
             .hasMetrics(fakeSpan.metrics)


### PR DESCRIPTION
### What does this PR do?

Use the `networkInfoEnabled` to decide whether network info should be serialized or not in spans

### Motivation

This is part of several PRs to allow enabling/disabling attaching network info in spans collected in an Android app