### PR TITLE
RUM-1189 fix duplicate views in MixedViewTrackingStrategy

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -220,12 +220,6 @@ class com.datadog.android.rum.tracking.MixedViewTrackingStrategy : ActivityLifec
   constructor(Boolean, ComponentPredicate<android.app.Activity> = AcceptAllActivities(), ComponentPredicate<androidx.fragment.app.Fragment> = AcceptAllSupportFragments(), ComponentPredicate<android.app.Fragment> = AcceptAllDefaultFragment())
   override fun register(com.datadog.android.api.SdkCore, android.content.Context)
   override fun unregister(android.content.Context?)
-  override fun onActivityCreated(android.app.Activity, android.os.Bundle?)
-  override fun onActivityStarted(android.app.Activity)
-  override fun onActivityResumed(android.app.Activity)
-  override fun onActivityPaused(android.app.Activity)
-  override fun onActivityStopped(android.app.Activity)
-  override fun onActivityDestroyed(android.app.Activity)
   override fun equals(Any?): Boolean
   override fun hashCode(): Int
 class com.datadog.android.rum.tracking.NavigationViewTrackingStrategy : ActivityLifecycleTrackingStrategy, ViewTrackingStrategy, androidx.navigation.NavController.OnDestinationChangedListener

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -4591,12 +4591,6 @@ public final class com/datadog/android/rum/tracking/MixedViewTrackingStrategy : 
 	public synthetic fun <init> (ZLcom/datadog/android/rum/tracking/ComponentPredicate;Lcom/datadog/android/rum/tracking/ComponentPredicate;Lcom/datadog/android/rum/tracking/ComponentPredicate;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
-	public fun onActivityCreated (Landroid/app/Activity;Landroid/os/Bundle;)V
-	public fun onActivityDestroyed (Landroid/app/Activity;)V
-	public fun onActivityPaused (Landroid/app/Activity;)V
-	public fun onActivityResumed (Landroid/app/Activity;)V
-	public fun onActivityStarted (Landroid/app/Activity;)V
-	public fun onActivityStopped (Landroid/app/Activity;)V
 	public fun register (Lcom/datadog/android/api/SdkCore;Landroid/content/Context;)V
 	public fun unregister (Landroid/content/Context;)V
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/MixedViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/MixedViewTrackingStrategy.kt
@@ -8,8 +8,6 @@ package com.datadog.android.rum.tracking
 
 import android.app.Activity
 import android.content.Context
-import android.os.Bundle
-import androidx.annotation.MainThread
 import androidx.fragment.app.Fragment
 import com.datadog.android.api.SdkCore
 
@@ -50,6 +48,8 @@ class MixedViewTrackingStrategy internal constructor(
         )
     )
 
+    // region ActivityLifecycleTrackingStrategy
+
     override fun register(sdkCore: SdkCore, context: Context) {
         super.register(sdkCore, context)
         activityViewTrackingStrategy.register(sdkCore, context)
@@ -60,50 +60,6 @@ class MixedViewTrackingStrategy internal constructor(
         activityViewTrackingStrategy.unregister(context)
         fragmentViewTrackingStrategy.unregister(context)
         super.unregister(context)
-    }
-
-    // region ActivityLifecycleTrackingStrategy
-
-    @MainThread
-    override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        super.onActivityCreated(activity, savedInstanceState)
-        activityViewTrackingStrategy.onActivityCreated(activity, savedInstanceState)
-        fragmentViewTrackingStrategy.onActivityCreated(activity, savedInstanceState)
-    }
-
-    @MainThread
-    override fun onActivityStarted(activity: Activity) {
-        super.onActivityStarted(activity)
-        activityViewTrackingStrategy.onActivityStarted(activity)
-        fragmentViewTrackingStrategy.onActivityStarted(activity)
-    }
-
-    @MainThread
-    override fun onActivityResumed(activity: Activity) {
-        super.onActivityResumed(activity)
-        activityViewTrackingStrategy.onActivityResumed(activity)
-        fragmentViewTrackingStrategy.onActivityResumed(activity)
-    }
-
-    @MainThread
-    override fun onActivityPaused(activity: Activity) {
-        super.onActivityPaused(activity)
-        activityViewTrackingStrategy.onActivityPaused(activity)
-        fragmentViewTrackingStrategy.onActivityPaused(activity)
-    }
-
-    @MainThread
-    override fun onActivityStopped(activity: Activity) {
-        super.onActivityStopped(activity)
-        activityViewTrackingStrategy.onActivityStopped(activity)
-        fragmentViewTrackingStrategy.onActivityStopped(activity)
-    }
-
-    @MainThread
-    override fun onActivityDestroyed(activity: Activity) {
-        super.onActivityDestroyed(activity)
-        activityViewTrackingStrategy.onActivityDestroyed(activity)
-        fragmentViewTrackingStrategy.onActivityDestroyed(activity)
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/MixedViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/MixedViewTrackingStrategyTest.kt
@@ -23,8 +23,8 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -81,75 +81,57 @@ internal class MixedViewTrackingStrategyTest :
     }
 
     @Test
-    fun `when activity created will delegate to the bundled strategies`() {
+    fun `when activity created will not delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityCreated(mockActivity, mockBundle)
 
         // Then
-        inOrder(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy) {
-            verify(mockActivityViewTrackingStrategy).onActivityCreated(mockActivity, mockBundle)
-            verify(mockFragmentViewTrackingStrategy).onActivityCreated(mockActivity, mockBundle)
-        }
+        verifyNoInteractions(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy)
     }
 
     @Test
-    fun `when activity destroyed will delegate to the bundled strategies`() {
+    fun `when activity destroyed will not delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityDestroyed(mockActivity)
 
         // Then
-        inOrder(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy) {
-            verify(mockActivityViewTrackingStrategy).onActivityDestroyed(mockActivity)
-            verify(mockFragmentViewTrackingStrategy).onActivityDestroyed(mockActivity)
-        }
+        verifyNoInteractions(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy)
     }
 
     @Test
-    fun `when activity started will delegate to the bundled strategies`() {
+    fun `when activity started will not delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityStarted(mockActivity)
 
         // Then
-        inOrder(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy) {
-            verify(mockActivityViewTrackingStrategy).onActivityStarted(mockActivity)
-            verify(mockFragmentViewTrackingStrategy).onActivityStarted(mockActivity)
-        }
+        verifyNoInteractions(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy)
     }
 
     @Test
-    fun `when activity stopped will delegate to the bundled strategies`() {
+    fun `when activity stopped will not delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityStopped(mockActivity)
 
         // Then
-        inOrder(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy) {
-            verify(mockActivityViewTrackingStrategy).onActivityStopped(mockActivity)
-            verify(mockFragmentViewTrackingStrategy).onActivityStopped(mockActivity)
-        }
+        verifyNoInteractions(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy)
     }
 
     @Test
-    fun `when activity resumed will delegate to the bundled strategies`() {
+    fun `when activity resumed will not delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityResumed(mockActivity)
 
         // Then
-        inOrder(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy) {
-            verify(mockActivityViewTrackingStrategy).onActivityResumed(mockActivity)
-            verify(mockFragmentViewTrackingStrategy).onActivityResumed(mockActivity)
-        }
+        verifyNoInteractions(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy)
     }
 
     @Test
-    fun `when activity paused will delegate to the bundled strategies`() {
+    fun `when activity paused will not delegate to the bundled strategies`() {
         // Whenever
         testedStrategy.onActivityPaused(mockActivity)
 
         // Then
-        inOrder(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy) {
-            verify(mockActivityViewTrackingStrategy).onActivityPaused(mockActivity)
-            verify(mockFragmentViewTrackingStrategy).onActivityPaused(mockActivity)
-        }
+        verifyNoInteractions(mockActivityViewTrackingStrategy, mockFragmentViewTrackingStrategy)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

Fix #1614

Because the inner Activity and Fragment ViewTrackingStrategies used by the `MixedViewTrackingStrategy` also listen to activity lifecycle callbacks, RUM start view events are called twice, resulting in duplicated events. 
