### PR TITLE
RUM-938 Implement heuristic image classification

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageTypeResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageTypeResolver.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.GradientDrawable
+import androidx.annotation.VisibleForTesting
+
+internal class ImageTypeResolver {
+    fun isDrawablePII(drawable: Drawable, widthInDp: Int, heightInDp: Int): Boolean =
+        drawable !is GradientDrawable &&
+            (
+                widthInDp >= IMAGE_DIMEN_CONSIDERED_PII_IN_DP ||
+                    heightInDp >= IMAGE_DIMEN_CONSIDERED_PII_IN_DP
+                )
+
+    internal companion object {
+        // material design icon size is up to 48x48
+        @VisibleForTesting internal const val IMAGE_DIMEN_CONSIDERED_PII_IN_DP = 49
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageTypeResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageTypeResolverTest.kt
@@ -1,0 +1,93 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.GradientDrawable
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.recorder.base64.ImageTypeResolver.Companion.IMAGE_DIMEN_CONSIDERED_PII_IN_DP
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class ImageTypeResolverTest {
+    private lateinit var testedTypeResolver: ImageTypeResolver
+
+    @Mock
+    lateinit var mockBitmapDrawable: BitmapDrawable
+
+    @Mock
+    lateinit var mockGradientDrawable: GradientDrawable
+
+    @BeforeEach
+    fun `set up`() {
+        testedTypeResolver = ImageTypeResolver()
+    }
+
+    @Test
+    fun `M return true W isDrawablePII() { is not gradientDrawable and width above dimensions }`(
+        @IntForgery(min = IMAGE_DIMEN_CONSIDERED_PII_IN_DP) fakeWidth: Int,
+        @IntForgery(min = 0, max = IMAGE_DIMEN_CONSIDERED_PII_IN_DP) fakeHeight: Int
+    ) {
+        // When
+        val result = testedTypeResolver.isDrawablePII(mockBitmapDrawable, fakeWidth, fakeHeight)
+
+        // Then
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `M return true W isDrawablePII() { is not gradientDrawable and height is above dimensions }`(
+        @IntForgery(min = 0, max = IMAGE_DIMEN_CONSIDERED_PII_IN_DP) fakeWidth: Int,
+        @IntForgery(min = IMAGE_DIMEN_CONSIDERED_PII_IN_DP) fakeHeight: Int
+    ) {
+        // When
+        val result = testedTypeResolver.isDrawablePII(mockBitmapDrawable, fakeWidth, fakeHeight)
+
+        // Then
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `M return false W isDrawablePII() { is gradientDrawable and above dimensions }`(
+        @IntForgery(min = IMAGE_DIMEN_CONSIDERED_PII_IN_DP) fakeWidth: Int,
+        @IntForgery(min = IMAGE_DIMEN_CONSIDERED_PII_IN_DP) fakeHeight: Int
+    ) {
+        // When
+        val result = testedTypeResolver.isDrawablePII(mockGradientDrawable, fakeWidth, fakeHeight)
+
+        // Then
+        assertThat(result).isFalse
+    }
+
+    @Test
+    fun `M return false W isDrawablePII() { not gradientDrawable and dimensions are below PII limit }`(
+        @IntForgery(min = 0, max = IMAGE_DIMEN_CONSIDERED_PII_IN_DP) fakeWidth: Int,
+        @IntForgery(min = 0, max = IMAGE_DIMEN_CONSIDERED_PII_IN_DP) fakeHeight: Int
+    ) {
+        // When
+        val result = testedTypeResolver.isDrawablePII(mockBitmapDrawable, fakeWidth, fakeHeight)
+
+        // Then
+        assertThat(result).isFalse
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Implement a heuristic image classification to determine whether an image is PII or not. If the image is PII then send a placeholder wireframe identifying the image as a content image. 

The identification is by checking that the dimensions of the image do not exceed 48dp (the largest icon in the material design guidelines). In the case of GradientDrawable we ignore this check, since GradientDrawables cannot be PII and constitute the backgrounds for RippleDrawables. 

### Motivation
Avoid sending PII as part of base64.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

