### PR TITLE
RUM-1187 Add more information into the batch telemetry

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestrator.kt
@@ -64,6 +64,10 @@ internal class FeatureFileOrchestrator(
     )
 
     companion object {
+        private const val BASE_DIR_NAME_REG_EX = "([a-z]+[-|_])+"
+        internal val IS_GRANTED_DIR_REG_EX = Regex("${BASE_DIR_NAME_REG_EX}v[0-9]+")
+        internal val IS_PENDING_DIR_REG_EX = Regex("${BASE_DIR_NAME_REG_EX}pending-v[0-9]+")
+
         internal const val VERSION = 2
         internal const val PENDING_DIR = "%s-pending-v$VERSION"
         internal const val GRANTED_DIR = "%s-v$VERSION"


### PR DESCRIPTION
### What does this PR do?

Following the latest discussions regarding the problem with the batch telemetry data for Android SDK we decided to add more information into the related logs:

- thread name (might be useful for potential concurrency debug)
- the batch file name 
- the tracking consent according with the batch origin folder

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

