### PR TITLE
RUM-1202: Make `FeatureFileOrchesrator` use file persistence config created from user/feature settings

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -238,6 +238,7 @@ internal class SdkFeature(
             storageDir = coreFeature.storageDir,
             featureName = featureName,
             executorService = coreFeature.persistenceExecutorService,
+            filePersistenceConfig = filePersistenceConfig,
             internalLogger = internalLogger,
             metricsDispatcher = metricsDispatcher
         )

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
@@ -26,8 +26,8 @@ import java.util.concurrent.ExecutorService
 
 internal class ConsentAwareStorage(
     private val executorService: ExecutorService,
-    private val grantedOrchestrator: FileOrchestrator,
-    private val pendingOrchestrator: FileOrchestrator,
+    internal val grantedOrchestrator: FileOrchestrator,
+    internal val pendingOrchestrator: FileOrchestrator,
     private val batchEventsReaderWriter: BatchFileReaderWriter,
     private val batchMetadataReaderWriter: FileReaderWriter,
     private val fileMover: FileMover,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestrator.kt
@@ -39,19 +39,20 @@ internal class FeatureFileOrchestrator(
         storageDir: File,
         featureName: String,
         executorService: ExecutorService,
+        filePersistenceConfig: FilePersistenceConfig,
         internalLogger: InternalLogger,
         metricsDispatcher: MetricsDispatcher
     ) : this(
         consentProvider,
         BatchFileOrchestrator(
             File(storageDir, PENDING_DIR.format(Locale.US, featureName)),
-            PERSISTENCE_CONFIG,
+            filePersistenceConfig,
             internalLogger,
             metricsDispatcher
         ),
         BatchFileOrchestrator(
             File(storageDir, GRANTED_DIR.format(Locale.US, featureName)),
-            PERSISTENCE_CONFIG,
+            filePersistenceConfig,
             internalLogger,
             metricsDispatcher
         ),
@@ -67,7 +68,5 @@ internal class FeatureFileOrchestrator(
         internal const val VERSION = 2
         internal const val PENDING_DIR = "%s-pending-v$VERSION"
         internal const val GRANTED_DIR = "%s-v$VERSION"
-
-        private val PERSISTENCE_CONFIG = FilePersistenceConfig()
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestrator.kt
@@ -30,7 +30,7 @@ import kotlin.math.roundToLong
 //  system in order to reduce the number of syscalls (which are expensive) for files already seen
 internal class BatchFileOrchestrator(
     private val rootDir: File,
-    private val config: FilePersistenceConfig,
+    internal val config: FilePersistenceConfig,
     private val internalLogger: InternalLogger,
     private val metricsDispatcher: MetricsDispatcher
 ) : FileOrchestrator {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -31,6 +31,7 @@ import com.datadog.android.core.internal.persistence.NoOpStorage
 import com.datadog.android.core.internal.persistence.Storage
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.NoOpFileOrchestrator
+import com.datadog.android.core.internal.persistence.file.batch.BatchFileOrchestrator
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.privacy.TrackingConsentProviderCallback
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
@@ -220,6 +221,20 @@ internal class SdkFeatureTest {
         val consentAwareStorage = testedFeature.storage as ConsentAwareStorage
         assertThat(consentAwareStorage.filePersistenceConfig.recentDelayMs)
             .isEqualTo(fakeCoreBatchSize.windowDurationMs)
+        val pendingFileOrchestrator =
+            consentAwareStorage.pendingOrchestrator as BatchFileOrchestrator
+        val grantedFileOrchestrator =
+            consentAwareStorage.grantedOrchestrator as BatchFileOrchestrator
+        val expectedFilePersistenceConfig = fakeCorePersistenceConfig.copy(
+            maxBatchSize = fakeStorageConfiguration.maxBatchSize,
+            maxItemSize = fakeStorageConfiguration.maxItemSize,
+            maxItemsPerBatch = fakeStorageConfiguration.maxItemsPerBatch,
+            oldFileThreshold = fakeStorageConfiguration.oldBatchThreshold,
+            recentDelayMs = fakeStorageConfiguration.batchSize?.windowDurationMs
+                ?: fakeCoreBatchSize.windowDurationMs
+        )
+        assertThat(pendingFileOrchestrator.config).isEqualTo(expectedFilePersistenceConfig)
+        assertThat(grantedFileOrchestrator.config).isEqualTo(expectedFilePersistenceConfig)
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestratorTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal.persistence.file.advanced
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.metrics.MetricsDispatcher
+import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileOrchestrator
 import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.privacy.TrackingConsent
@@ -57,6 +58,9 @@ internal class FeatureFileOrchestratorTest {
     @TempDir
     lateinit var fakeStorageDir: File
 
+    @Forgery
+    lateinit var fakeFilePersistenceConfig: FilePersistenceConfig
+
     @Mock
     lateinit var mockMetricsDispatcher: MetricsDispatcher
 
@@ -75,6 +79,7 @@ internal class FeatureFileOrchestratorTest {
             fakeStorageDir,
             fakeFeatureName,
             mockExecutorService,
+            fakeFilePersistenceConfig,
             mockInternalLogger,
             mockMetricsDispatcher
         )
@@ -96,6 +101,7 @@ internal class FeatureFileOrchestratorTest {
             fakeStorageDir,
             fakeFeatureName,
             mockExecutorService,
+            fakeFilePersistenceConfig,
             mockInternalLogger,
             mockMetricsDispatcher
         )
@@ -117,6 +123,7 @@ internal class FeatureFileOrchestratorTest {
             fakeStorageDir,
             fakeFeatureName,
             mockExecutorService,
+            fakeFilePersistenceConfig,
             mockInternalLogger,
             mockMetricsDispatcher
         )


### PR DESCRIPTION
### What does this PR do?

It turns out that `FeatureFileOrchesrator` was using default file persistence config which didn't reflect user settings and feature settings for batch size, max item size, etc. This PR fixes it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

