### PR TITLE
Fix RegEx in FeatureFileOrchestrator to resolve file consent type

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/FeatureFileOrchestrator.kt
@@ -65,7 +65,7 @@ internal class FeatureFileOrchestrator(
     )
 
     companion object {
-        private const val BASE_DIR_NAME_REG_EX = "([a-z]+[-|_])+"
+        private const val BASE_DIR_NAME_REG_EX = "([a-z]+-)+"
         internal val IS_GRANTED_DIR_REG_EX = Regex("${BASE_DIR_NAME_REG_EX}v[0-9]+")
         internal val IS_PENDING_DIR_REG_EX = Regex("${BASE_DIR_NAME_REG_EX}pending-v[0-9]+")
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
@@ -608,13 +608,13 @@ internal class BatchMetricsDispatcherTest {
     }
 
     private fun Forge.forgeAGrantedDirName(): String {
-        val separator = if (aBool()) "_" else "-"
+        val separator = "-"
         return aList(anInt(min = 1, max = 10)) { anAlphabeticalString() }
             .joinToString(separator) + "-v" + aNumericalString()
     }
 
     private fun Forge.forgeAPendingDirName(): String {
-        val separator = if (aBool()) "_" else "-"
+        val separator = "-"
         return aList(anInt(min = 1, max = 10)) { anAlphabeticalString() }
             .joinToString(separator) + "-pending-v" + aNumericalString()
     }


### PR DESCRIPTION
### What does this PR do?

The NDK folders do not produce batching telemetry so we had to simplify the rules a bit by removing the `|` separator case.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

