### PR TITLE
RUM-1194 DataUploadWorker is scheduled every time and on non - roaming network

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
@@ -362,7 +362,6 @@ internal class DatadogCore(
         if (appContext is Application) {
             processLifecycleMonitor = ProcessLifecycleMonitor(
                 ProcessLifecycleCallback(
-                    coreFeature.networkInfoProvider,
                     appContext,
                     internalLogger
                 )

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
@@ -9,15 +9,12 @@ package com.datadog.android.core.internal.lifecycle
 import android.content.Context
 import androidx.work.WorkManager
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.api.context.NetworkInfo
-import com.datadog.android.core.internal.net.info.NetworkInfoProvider
 import com.datadog.android.core.internal.utils.cancelUploadWorker
 import com.datadog.android.core.internal.utils.triggerUploadWorker
 import java.lang.ref.Reference
 import java.lang.ref.WeakReference
 
 internal class ProcessLifecycleCallback(
-    val networkInfoProvider: NetworkInfoProvider,
     appContext: Context,
     private val internalLogger: InternalLogger
 ) :
@@ -38,15 +35,9 @@ internal class ProcessLifecycleCallback(
     }
 
     override fun onStopped() {
-        val isOffline = (
-            networkInfoProvider.getLatestNetworkInfo().connectivity
-                == NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED
-            )
-        if (isOffline) {
-            contextWeakRef.get()?.let {
-                if (WorkManager.isInitialized()) {
-                    triggerUploadWorker(it, internalLogger)
-                }
+        contextWeakRef.get()?.let {
+            if (WorkManager.isInitialized()) {
+                triggerUploadWorker(it, internalLogger)
             }
         }
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
@@ -33,7 +33,7 @@ internal class BatchMetricsDispatcher(
 ) : MetricsDispatcher, ProcessLifecycleMonitor.Callback {
 
     private val trackName: String? = resolveTrackName(featureName)
-    private val isInBackground = AtomicBoolean(false)
+    private val isInBackground = AtomicBoolean(true)
 
     // region MetricsDispatcher
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
@@ -44,7 +44,7 @@ internal fun triggerUploadWorker(context: Context, internalLogger: InternalLogge
     try {
         val workManager = WorkManager.getInstance(context)
         val constraints = Constraints.Builder()
-            .setRequiredNetworkType(NetworkType.CONNECTED)
+            .setRequiredNetworkType(NetworkType.NOT_ROAMING)
             .build()
         val uploadWorkRequest = OneTimeWorkRequest.Builder(UploadWorker::class.java)
             .setConstraints(constraints)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
@@ -144,6 +144,7 @@ internal class BatchMetricsDispatcherTest {
         val fakeFile: File = forge.forgeValidFile()
         val expectedAdditionalProperties = resolveDefaultDeleteExtraProperties(fakeFile).apply {
             put(BatchMetricsDispatcher.BATCH_REMOVAL_KEY, fakeReason.toString())
+            put(BatchMetricsDispatcher.IN_BACKGROUND_KEY, false)
         }
         // When
         testedBatchMetricsDispatcher.onResumed()
@@ -173,7 +174,6 @@ internal class BatchMetricsDispatcherTest {
             put(BatchMetricsDispatcher.TRACKING_CONSENT_KEY, "pending")
         }
         // When
-        testedBatchMetricsDispatcher.onResumed()
         testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
 
         // Then
@@ -199,7 +199,6 @@ internal class BatchMetricsDispatcherTest {
             put(BatchMetricsDispatcher.TRACKING_CONSENT_KEY, null)
         }
         // When
-        testedBatchMetricsDispatcher.onResumed()
         testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
 
         // Then
@@ -225,7 +224,6 @@ internal class BatchMetricsDispatcherTest {
             put(BatchMetricsDispatcher.TRACKING_CONSENT_KEY, null)
         }
         // When
-        testedBatchMetricsDispatcher.onResumed()
         testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
 
         // Then
@@ -564,7 +562,7 @@ internal class BatchMetricsDispatcherTest {
             BatchMetricsDispatcher.FILE_NAME to file.name,
             BatchMetricsDispatcher.THREAD_NAME to Thread.currentThread().name,
             BatchMetricsDispatcher.TRACKING_CONSENT_KEY to "granted",
-            BatchMetricsDispatcher.IN_BACKGROUND_KEY to false
+            BatchMetricsDispatcher.IN_BACKGROUND_KEY to true
         )
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal.utils
 
 import android.app.Application
 import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.impl.WorkManagerImpl
 import com.datadog.android.api.InternalLogger
@@ -109,7 +110,8 @@ internal class WorkManagerUtilsTest {
             eq(ExistingWorkPolicy.REPLACE),
             argThat<OneTimeWorkRequest> {
                 this.workSpec.workerClassName == UploadWorker::class.java.canonicalName &&
-                    this.tags.contains(TAG_DATADOG_UPLOAD)
+                    this.tags.contains(TAG_DATADOG_UPLOAD) &&
+                    this.workSpec.constraints.requiredNetworkType == NetworkType.NOT_ROAMING
             }
         )
     }


### PR DESCRIPTION
### What does this PR do?

Previously our data upload worker was scheduled only if the device was offline and on any type of network. We are currently scheduling this all the time and only if the network is unmetered (WIFI or any other form of unmetered network)
We also updated the default `inBackground` state in the `BatchMetricsDispatcher` as `true` to handle correctly the metrics sent from the scheduled upload worker.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

