### PR TITLE
feat: Add `isEnabled` to Logs

### DIFF
--- a/features/dd-sdk-android-logs/api/apiSurface
+++ b/features/dd-sdk-android-logs/api/apiSurface
@@ -26,6 +26,7 @@ class com.datadog.android.log.Logger
   fun removeTagsWithKey(String)
 object com.datadog.android.log.Logs
   fun enable(LogsConfiguration, com.datadog.android.api.SdkCore = Datadog.getInstance())
+  fun isEnabled(com.datadog.android.api.SdkCore = Datadog.getInstance()): Boolean
 data class com.datadog.android.log.LogsConfiguration
   class Builder
     fun useCustomEndpoint(String): Builder

--- a/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
+++ b/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
@@ -58,6 +58,9 @@ public final class com/datadog/android/log/Logs {
 	public static final fun enable (Lcom/datadog/android/log/LogsConfiguration;)V
 	public static final fun enable (Lcom/datadog/android/log/LogsConfiguration;Lcom/datadog/android/api/SdkCore;)V
 	public static synthetic fun enable$default (Lcom/datadog/android/log/LogsConfiguration;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
+	public static final fun isEnabled ()Z
+	public static final fun isEnabled (Lcom/datadog/android/api/SdkCore;)Z
+	public static synthetic fun isEnabled$default (Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)Z
 }
 
 public final class com/datadog/android/log/LogsConfiguration {

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/Logs.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/Logs.kt
@@ -8,6 +8,7 @@ package com.datadog.android.log
 
 import com.datadog.android.Datadog
 import com.datadog.android.api.SdkCore
+import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.log.internal.LogsFeature
 
@@ -33,5 +34,21 @@ object Logs {
         )
 
         sdkCore.registerFeature(logsFeature)
+    }
+
+    /**
+     * Identify whether a [Logs] has been enabled for the given SDK instance.
+     *
+     * This check is useful in scenarios where more than one component may be responsible
+     * for enabling the feature
+     *
+     * @param sdkCore the [SdkCore] instance to check against. If not provided, default instance
+     * will be checked.
+     * @return whether Logs has been enabled
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun isEnabled(sdkCore: SdkCore = Datadog.getInstance()): Boolean {
+        return (sdkCore as FeatureSdkCore).getFeature(Feature.LOGS_FEATURE_NAME) != null
     }
 }

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.log
 
+import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.log.internal.net.LogsRequestFactory
@@ -64,5 +65,29 @@ internal class LogsTest {
             assertThat((lastValue.requestFactory as LogsRequestFactory).customEndpointUrl)
                 .isEqualTo(fakeLogsConfiguration.customEndpointUrl)
         }
+    }
+
+    @Test
+    fun `M return true W isEnabled() { core returns feature }`() {
+        // Given
+        whenever(mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)) doReturn mock()
+
+        // When
+        val result = Logs.isEnabled(mockSdkCore)
+
+        // Then
+        assertThat(result).isTrue
+    }
+
+    @Test
+    fun `M return false W isEnabled() { core returns null }`() {
+        // Given
+        whenever(mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)) doReturn null
+
+        // When
+        val result = Logs.isEnabled(mockSdkCore)
+
+        // Then
+        assertThat(result).isFalse
     }
 }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -17,6 +17,7 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.Datadog#fun setVerbosity(Int)
  * apiMethodSignature: com.datadog.android.Datadog#fun stopInstance(String? = null)
  * apiMethodSignature: com.datadog.android.Datadog#fun stopSession()
+ * apiMethodSignature: com.datadog.android.Datadog#fun _internalProxy(String? = null): _InternalProxy
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setAdditionalConfiguration(Map<String, Any>): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setProxy(java.net.Proxy, okhttp3.Authenticator?): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setUploadFrequency(UploadFrequency): Builder
@@ -28,6 +29,7 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.core.sampling.RateBasedSampler#constructor(Float)
  * apiMethodSignature: com.datadog.android.event.MapperSerializer<T#constructor(EventMapper<T>, com.datadog.android.core.persistence.Serializer<T>)
  * apiMethodSignature: com.datadog.android.log.Logs#fun enable(LogsConfiguration, com.datadog.android.api.SdkCore = Datadog.getInstance())
+ * apiMethodSignature: com.datadog.android.log.Logs#fun isEnabled(com.datadog.android.api.SdkCore = Datadog.getInstance()): Boolean
  * apiMethodSignature: com.datadog.android.log.Logger#fun log(Int, String, Throwable? = null, Map<String, Any?> = emptyMap())
  * apiMethodSignature: com.datadog.android.log.Logger$Builder#fun setLogcatLogsEnabled(Boolean): Builder
  * apiMethodSignature: com.datadog.android.log.LogsConfiguration$Builder#fun useCustomEndpoint(String): Builder


### PR DESCRIPTION
### What does this PR do?

Added a static method to Logs for checking if the feature had been enabled in a core.  This method is needed to properly setup Flutter when using `attachToExisting`.

refs: RUM-1066

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

