### PR TITLE
Revert "RUM-1002 Implement base64 for imageviews"

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacy.kt
@@ -11,6 +11,8 @@ import android.view.View
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.CheckedTextView
+import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.NumberPicker
 import android.widget.RadioButton
@@ -26,7 +28,8 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.BasePickerMapp
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckedTextViewMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.ImageViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.EditTextViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ImageButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MapperTypeWrapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckedTextViewMapper
@@ -42,6 +45,8 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.SeekBarWirefra
 import com.datadog.android.sessionreplay.internal.recorder.mapper.SwitchCompatMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.UnsupportedViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ViewScreenshotWireframeMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ViewWireframeMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 import androidx.appcompat.widget.Toolbar as AppCompatToolbar
@@ -81,14 +86,17 @@ enum class SessionReplayPrivacy {
         val imageWireframeHelper = ImageWireframeHelper(base64Serializer = base64Serializer)
         val uniqueIdentifierGenerator = UniqueIdentifierGenerator
 
+        val viewWireframeMapper = ViewWireframeMapper()
         val unsupportedViewMapper = UnsupportedViewMapper()
-        val imageViewMapper = ImageViewMapper(
+        val imageButtonMapper = ImageButtonMapper(
             base64Serializer = base64Serializer,
             imageWireframeHelper = imageWireframeHelper,
             uniqueIdentifierGenerator = uniqueIdentifierGenerator
         )
+        val imageMapper: ViewScreenshotWireframeMapper
         val textMapper: TextViewMapper
         val buttonMapper: ButtonMapper
+        val editTextViewMapper: EditTextViewMapper
         val checkedTextViewMapper: CheckedTextViewMapper
         val checkBoxMapper: CheckBoxMapper
         val radioButtonMapper: RadioButtonMapper
@@ -97,11 +105,13 @@ enum class SessionReplayPrivacy {
         val numberPickerMapper: BasePickerMapper?
         when (this) {
             ALLOW -> {
+                imageMapper = ViewScreenshotWireframeMapper(viewWireframeMapper)
                 textMapper = TextViewMapper(
                     imageWireframeHelper = imageWireframeHelper,
                     uniqueIdentifierGenerator = uniqueIdentifierGenerator
                 )
                 buttonMapper = ButtonMapper(textMapper)
+                editTextViewMapper = EditTextViewMapper(textMapper)
                 checkedTextViewMapper = CheckedTextViewMapper(textMapper)
                 checkBoxMapper = CheckBoxMapper(textMapper)
                 radioButtonMapper = RadioButtonMapper(textMapper)
@@ -110,11 +120,13 @@ enum class SessionReplayPrivacy {
                 numberPickerMapper = getNumberPickerMapper()
             }
             MASK -> {
+                imageMapper = ViewScreenshotWireframeMapper(viewWireframeMapper)
                 textMapper = MaskTextViewMapper(
                     imageWireframeHelper = imageWireframeHelper,
                     uniqueIdentifierGenerator = uniqueIdentifierGenerator
                 )
                 buttonMapper = ButtonMapper(textMapper)
+                editTextViewMapper = EditTextViewMapper(textMapper)
                 checkedTextViewMapper = MaskCheckedTextViewMapper(textMapper)
                 checkBoxMapper = MaskCheckBoxMapper(textMapper)
                 radioButtonMapper = MaskRadioButtonMapper(textMapper)
@@ -123,11 +135,13 @@ enum class SessionReplayPrivacy {
                 numberPickerMapper = getMaskNumberPickerMapper()
             }
             MASK_USER_INPUT -> {
+                imageMapper = ViewScreenshotWireframeMapper(viewWireframeMapper)
                 textMapper = MaskInputTextViewMapper(
                     imageWireframeHelper = imageWireframeHelper,
                     uniqueIdentifierGenerator = uniqueIdentifierGenerator
                 )
                 buttonMapper = ButtonMapper(textMapper)
+                editTextViewMapper = EditTextViewMapper(textMapper)
                 checkedTextViewMapper = MaskCheckedTextViewMapper(textMapper)
                 checkBoxMapper = MaskCheckBoxMapper(textMapper)
                 radioButtonMapper = MaskRadioButtonMapper(textMapper)
@@ -142,8 +156,10 @@ enum class SessionReplayPrivacy {
             MapperTypeWrapper(CheckBox::class.java, checkBoxMapper.toGenericMapper()),
             MapperTypeWrapper(CheckedTextView::class.java, checkedTextViewMapper.toGenericMapper()),
             MapperTypeWrapper(Button::class.java, buttonMapper.toGenericMapper()),
+            MapperTypeWrapper(ImageButton::class.java, imageButtonMapper.toGenericMapper()),
+            MapperTypeWrapper(EditText::class.java, editTextViewMapper.toGenericMapper()),
             MapperTypeWrapper(TextView::class.java, textMapper.toGenericMapper()),
-            MapperTypeWrapper(ImageView::class.java, imageViewMapper.toGenericMapper()),
+            MapperTypeWrapper(ImageView::class.java, imageMapper.toGenericMapper()),
             MapperTypeWrapper(AppCompatToolbar::class.java, unsupportedViewMapper.toGenericMapper())
         )
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/EditTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/EditTextViewMapper.kt
@@ -1,0 +1,86 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.mapper
+
+import android.widget.EditText
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.internal.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.internal.recorder.MappingContext
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.StringUtils
+import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
+import com.datadog.android.sessionreplay.utils.ViewUtils
+
+/**
+ * A [WireframeMapper] implementation to map a [EditText] component in case the
+ * [SessionReplayPrivacy.ALLOW] rule was used in the configuration.
+ * In this case the mapper will use the provided [textViewMapper] used for the current privacy
+ * level and will only mask the [EditText] for which the input type is considered sensible
+ * (password, email, address, postal address, numeric password) with the static mask: [***].
+ */
+internal open class EditTextViewMapper(
+    internal val textViewMapper: TextViewMapper,
+    private val uniqueIdentifierGenerator: UniqueIdentifierGenerator = UniqueIdentifierGenerator,
+    viewUtils: ViewUtils = ViewUtils,
+    stringUtils: StringUtils = StringUtils
+) : BaseWireframeMapper<EditText, MobileSegment.Wireframe>(
+    viewUtils = viewUtils,
+    stringUtils = stringUtils
+) {
+
+    override fun map(
+        view: EditText,
+        mappingContext: MappingContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback
+    ):
+        List<MobileSegment.Wireframe> {
+        val mainWireframeList = textViewMapper.map(view, mappingContext, asyncJobStatusCallback)
+        resolveUnderlineWireframe(view, mappingContext.systemInformation.screenDensity)
+            ?.let { wireframe ->
+                return mainWireframeList + wireframe
+            }
+        return mainWireframeList
+    }
+
+    private fun resolveUnderlineWireframe(
+        parent: EditText,
+        pixelsDensity: Float
+    ): MobileSegment.Wireframe? {
+        val identifier = uniqueIdentifierGenerator.resolveChildUniqueIdentifier(
+            parent,
+            UNDERLINE_KEY_NAME
+        ) ?: return null
+        val viewGlobalBounds = resolveViewGlobalBounds(parent, pixelsDensity)
+        val fieldUnderlineColor = resolveUnderlineColor(parent)
+        return MobileSegment.Wireframe.ShapeWireframe(
+            identifier,
+            viewGlobalBounds.x,
+            viewGlobalBounds.y + viewGlobalBounds.height - UNDERLINE_HEIGHT_IN_PIXELS,
+            viewGlobalBounds.width,
+            UNDERLINE_HEIGHT_IN_PIXELS,
+            shapeStyle = MobileSegment.ShapeStyle(
+                backgroundColor = fieldUnderlineColor,
+                opacity = parent.alpha
+            )
+        )
+    }
+
+    private fun resolveUnderlineColor(view: EditText): String {
+        view.backgroundTintList?.let {
+            return colorAndAlphaAsStringHexa(
+                it.defaultColor,
+                OPAQUE_ALPHA_VALUE
+            )
+        }
+        return colorAndAlphaAsStringHexa(view.currentTextColor, OPAQUE_ALPHA_VALUE)
+    }
+
+    companion object {
+        internal const val UNDERLINE_HEIGHT_IN_PIXELS = 1L
+        internal const val UNDERLINE_KEY_NAME = "underline"
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapper.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
-import android.widget.ImageView
+import android.widget.ImageButton
 import com.datadog.android.sessionreplay.internal.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer
@@ -16,16 +16,16 @@ import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
 
-internal class ImageViewMapper(
+internal class ImageButtonMapper(
     private val base64Serializer: Base64Serializer,
     private val imageWireframeHelper: ImageWireframeHelper,
     uniqueIdentifierGenerator: UniqueIdentifierGenerator
-) : BaseAsyncBackgroundWireframeMapper<ImageView>(
+) : BaseAsyncBackgroundWireframeMapper<ImageButton>(
     imageWireframeHelper = imageWireframeHelper,
     uniqueIdentifierGenerator = uniqueIdentifierGenerator
 ) {
     override fun map(
-        view: ImageView,
+        view: ImageButton,
         mappingContext: MappingContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
     ): List<MobileSegment.Wireframe> {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayPrivacyTest.kt
@@ -11,6 +11,8 @@ import android.view.View
 import android.widget.Button
 import android.widget.CheckBox
 import android.widget.CheckedTextView
+import android.widget.EditText
+import android.widget.ImageButton
 import android.widget.ImageView
 import android.widget.NumberPicker
 import android.widget.RadioButton
@@ -21,7 +23,8 @@ import androidx.appcompat.widget.SwitchCompat
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckedTextViewMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.ImageViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.EditTextViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ImageButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MapperTypeWrapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.MaskCheckedTextViewMapper
@@ -37,6 +40,7 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.SeekBarWirefra
 import com.datadog.android.sessionreplay.internal.recorder.mapper.SwitchCompatMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.UnsupportedViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ViewScreenshotWireframeMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
 import com.datadog.tools.unit.setStaticValue
 import org.assertj.core.api.Assertions.assertThat
@@ -106,12 +110,16 @@ internal class SessionReplayPrivacyTest {
 
         // BASE
         private val mockButtonMapper: ButtonMapper = mock()
+        private val mockEditTextViewMapper: EditTextViewMapper = mock()
+        private val mockImageMapper: ViewScreenshotWireframeMapper = mock()
         private val mockUnsupportedViewMapper: UnsupportedViewMapper = mock()
-        private val mockImageViewMapper: ImageViewMapper = mock()
+        private val mockImageButtonViewMapper: ImageButtonMapper = mock()
 
         private val baseMappers = listOf(
             MapperTypeWrapper(Button::class.java, mockButtonMapper.toGenericMapper()),
-            MapperTypeWrapper(ImageView::class.java, mockImageViewMapper.toGenericMapper()),
+            MapperTypeWrapper(EditText::class.java, mockEditTextViewMapper.toGenericMapper()),
+            MapperTypeWrapper(ImageView::class.java, mockImageMapper.toGenericMapper()),
+            MapperTypeWrapper(ImageButton::class.java, mockImageButtonViewMapper.toGenericMapper()),
             MapperTypeWrapper(AppCompatToolbar::class.java, mockUnsupportedViewMapper.toGenericMapper())
         )
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseEditTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseEditTextViewMapperTest.kt
@@ -1,0 +1,167 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.mapper
+
+import android.content.res.ColorStateList
+import android.widget.EditText
+import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.StringUtils
+import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
+import com.datadog.android.sessionreplay.utils.ViewUtils
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.mockito.Mock
+import org.mockito.kotlin.any
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.whenever
+
+internal abstract class BaseEditTextViewMapperTest : BaseWireframeMapperTest() {
+
+    private lateinit var testedEditTextViewMapper: EditTextViewMapper
+
+    @Mock
+    lateinit var mockuniqueIdentifierGenerator: UniqueIdentifierGenerator
+
+    @Mock
+    lateinit var mockTextWireframeMapper: TextViewMapper
+
+    @Forgery
+    lateinit var fakeTextWireframes: List<MobileSegment.Wireframe.TextWireframe>
+
+    @Mock
+    lateinit var mockEditText: EditText
+
+    @Mock
+    lateinit var mockBackgroundTintList: ColorStateList
+
+    @LongForgery
+    var fakeGeneratedIdentifier: Long = 0L
+
+    @IntForgery
+    var fakeBackgroundTintColor: Int = 0
+
+    @IntForgery
+    var fakeTextColor: Int = 0
+
+    @Mock
+    lateinit var mockViewUtils: ViewUtils
+
+    @Forgery
+    lateinit var fakeViewGlobalBounds: GlobalBounds
+
+    @Mock
+    lateinit var mockStringUtils: StringUtils
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockEditText.currentTextColor).thenReturn(fakeTextColor)
+        whenever(mockBackgroundTintList.defaultColor).thenReturn(fakeBackgroundTintColor)
+        whenever(
+            mockuniqueIdentifierGenerator.resolveChildUniqueIdentifier(
+                mockEditText,
+                EditTextViewMapper.UNDERLINE_KEY_NAME
+            )
+        ).thenReturn(fakeGeneratedIdentifier)
+        whenever(mockEditText.backgroundTintList).thenReturn(mockBackgroundTintList)
+        whenever(mockTextWireframeMapper.map(eq(mockEditText), eq(fakeMappingContext), any()))
+            .thenReturn(fakeTextWireframes)
+        whenever(
+            mockViewUtils.resolveViewGlobalBounds(
+                mockEditText,
+                fakeMappingContext.systemInformation.screenDensity
+            )
+        )
+            .thenReturn(fakeViewGlobalBounds)
+        testedEditTextViewMapper = initTestInstance()
+    }
+
+    abstract fun initTestInstance(): EditTextViewMapper
+
+    @Test
+    fun `M resolve the underline as ShapeWireframe W map()`(forge: Forge) {
+        // Given
+        val fakeExpectedUnderlineColor = forge.aStringMatching("#[0-9A-Fa-f]{8}")
+        whenever(
+            mockStringUtils.formatColorAndAlphaAsHexa(
+                fakeBackgroundTintColor,
+                OPAQUE_ALPHA_VALUE
+            )
+        )
+            .thenReturn(fakeExpectedUnderlineColor)
+        val expectedUnderlineShapeWireframe = MobileSegment.Wireframe.ShapeWireframe(
+            id = fakeGeneratedIdentifier,
+            x = fakeViewGlobalBounds.x,
+            y = fakeViewGlobalBounds.y +
+                fakeViewGlobalBounds.height -
+                EditTextViewMapper.UNDERLINE_HEIGHT_IN_PIXELS,
+            width = fakeViewGlobalBounds.width,
+            height = EditTextViewMapper.UNDERLINE_HEIGHT_IN_PIXELS,
+            shapeStyle = MobileSegment.ShapeStyle(
+                backgroundColor = fakeExpectedUnderlineColor,
+                opacity = mockEditText.alpha
+            )
+        )
+
+        // When
+        assertThat(testedEditTextViewMapper.map(mockEditText, fakeMappingContext))
+            .isEqualTo(fakeTextWireframes + expectedUnderlineShapeWireframe)
+    }
+
+    @Test
+    fun `M resolve the underline color from textColor W map{backgroundTint is null}`(
+        forge: Forge
+    ) {
+        // Given
+        whenever(mockEditText.backgroundTintList).thenReturn(null)
+        val fakeExpectedUnderlineColor = forge.aStringMatching("#[0-9A-Fa-f]{8}")
+        whenever(
+            mockStringUtils.formatColorAndAlphaAsHexa(
+                fakeTextColor,
+                OPAQUE_ALPHA_VALUE
+            )
+        )
+            .thenReturn(fakeExpectedUnderlineColor)
+        val expectedUnderlineShapeWireframe = MobileSegment.Wireframe.ShapeWireframe(
+            id = fakeGeneratedIdentifier,
+            x = fakeViewGlobalBounds.x,
+            y = fakeViewGlobalBounds.y +
+                fakeViewGlobalBounds.height -
+                EditTextViewMapper.UNDERLINE_HEIGHT_IN_PIXELS,
+            width = fakeViewGlobalBounds.width,
+            height = EditTextViewMapper.UNDERLINE_HEIGHT_IN_PIXELS,
+            shapeStyle = MobileSegment.ShapeStyle(
+                backgroundColor = fakeExpectedUnderlineColor,
+                opacity = mockEditText.alpha
+            )
+        )
+
+        // When
+        assertThat(testedEditTextViewMapper.map(mockEditText, fakeMappingContext))
+            .isEqualTo(fakeTextWireframes + expectedUnderlineShapeWireframe)
+    }
+
+    @Test
+    fun `M ignore the underline W map() { unique id could not be generated }`() {
+        // Given
+        whenever(
+            mockuniqueIdentifierGenerator.resolveChildUniqueIdentifier(
+                mockEditText,
+                EditTextViewMapper.UNDERLINE_KEY_NAME
+            )
+        ).thenReturn(null)
+
+        // Then
+        assertThat(testedEditTextViewMapper.map(mockEditText, fakeMappingContext))
+            .isEqualTo(fakeTextWireframes)
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/EditTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/EditTextViewMapperTest.kt
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.mapper
+
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class EditTextViewMapperTest : BaseEditTextViewMapperTest() {
+
+    override fun initTestInstance(): EditTextViewMapper {
+        return EditTextViewMapper(
+            mockTextWireframeMapper,
+            mockuniqueIdentifierGenerator,
+            mockViewUtils,
+            mockStringUtils
+        )
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageButtonMapperTest.kt
@@ -12,7 +12,7 @@ import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.Drawable.ConstantState
 import android.util.DisplayMetrics
-import android.widget.ImageView
+import android.widget.ImageButton
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
@@ -56,12 +56,12 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
-internal class ImageViewMapperTest {
+internal class ImageButtonMapperTest {
 
-    private lateinit var testedMapper: ImageViewMapper
+    private lateinit var testedMapper: ImageButtonMapper
 
     @Mock
-    lateinit var mockImageView: ImageView
+    lateinit var mockImageButton: ImageButton
 
     @Mock
     lateinit var mockImageWireframeHelper: ImageWireframeHelper
@@ -116,15 +116,15 @@ internal class ImageViewMapperTest {
 
     @BeforeEach
     fun setup(forge: Forge) {
-        whenever(mockImageView.background).thenReturn(null)
+        whenever(mockImageButton.background).thenReturn(null)
 
         whenever(mockUniqueIdentifierGenerator.resolveChildUniqueIdentifier(any(), any()))
             .thenReturn(fakeId)
 
         whenever(mockConstantState.newDrawable(any())).thenReturn(mockDrawable)
         whenever(mockDrawable.constantState).thenReturn(mockConstantState)
-        whenever(mockImageView.drawable).thenReturn(mockDrawable)
-        whenever(mockImageView.drawable.current).thenReturn(mockDrawable)
+        whenever(mockImageButton.drawable).thenReturn(mockDrawable)
+        whenever(mockImageButton.drawable.current).thenReturn(mockDrawable)
 
         whenever(mockDrawable.intrinsicWidth).thenReturn(forge.aPositiveInt())
         whenever(mockDrawable.intrinsicHeight).thenReturn(forge.aPositiveInt())
@@ -135,10 +135,10 @@ internal class ImageViewMapperTest {
         whenever(mockMappingContext.systemInformation).thenReturn(mockSystemInformation)
 
         whenever(mockResources.displayMetrics).thenReturn(mockDisplayMetrics)
-        whenever(mockImageView.resources).thenReturn(mockResources)
+        whenever(mockImageButton.resources).thenReturn(mockResources)
 
         whenever(mockContext.applicationContext).thenReturn(mockContext)
-        whenever(mockImageView.context).thenReturn(mockContext)
+        whenever(mockImageButton.context).thenReturn(mockContext)
         whenever(mockBackground.current).thenReturn(mockBackground)
 
         whenever(mockViewUtils.resolveViewGlobalBounds(any(), any())).thenReturn(mockGlobalBounds)
@@ -147,8 +147,8 @@ internal class ImageViewMapperTest {
             id = fakeId,
             x = mockGlobalBounds.x,
             y = mockGlobalBounds.y,
-            width = mockImageView.width.toLong(),
-            height = mockImageView.height.toLong(),
+            width = mockImageButton.width.toLong(),
+            height = mockImageButton.height.toLong(),
             shapeStyle = null,
             border = null,
             base64 = "",
@@ -159,7 +159,7 @@ internal class ImageViewMapperTest {
         whenever(mockBase64Serializer.getDrawableScaledDimensions(any(), any(), any()))
             .thenReturn(DrawableDimensions(0, 0))
 
-        testedMapper = ImageViewMapper(
+        testedMapper = ImageButtonMapper(
             base64Serializer = mockBase64Serializer,
             imageWireframeHelper = mockImageWireframeHelper,
             uniqueIdentifierGenerator = mockUniqueIdentifierGenerator
@@ -169,11 +169,11 @@ internal class ImageViewMapperTest {
     @Test
     fun `M return foreground wireframe W map() { no background }`() {
         // Given
-        whenever(mockImageView.background).thenReturn(null)
+        whenever(mockImageButton.background).thenReturn(null)
         val fakeViewDrawable = mockDrawable.constantState?.newDrawable(mockResources)
         whenever(
             mockImageWireframeHelper.createImageWireframe(
-                eq(mockImageView),
+                eq(mockImageButton),
                 any(),
                 any(),
                 any(),
@@ -188,7 +188,7 @@ internal class ImageViewMapperTest {
         ).thenReturn(expectedWireframe)
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext)
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
 
         // Then
         assertThat(wireframes.size).isEqualTo(1)
@@ -204,8 +204,8 @@ internal class ImageViewMapperTest {
             id = id,
             x = mockGlobalBounds.x,
             y = mockGlobalBounds.y,
-            width = mockImageView.width.toLong(),
-            height = mockImageView.height.toLong(),
+            width = mockImageButton.width.toLong(),
+            height = mockImageButton.height.toLong(),
             shapeStyle = null,
             border = null,
             base64 = "",
@@ -213,14 +213,14 @@ internal class ImageViewMapperTest {
             isEmpty = true
         )
 
-        whenever(mockImageView.background).thenReturn(mockBackground)
+        whenever(mockImageButton.background).thenReturn(mockBackground)
         mockCreateImageWireframe(
             expectedBackgroundWireframe,
             expectedWireframe
         )
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext)
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
 
         // Then
         assertThat(wireframes.size).isEqualTo(2)
@@ -231,7 +231,7 @@ internal class ImageViewMapperTest {
     @Test
     fun `M call async callback W map() { }`() {
         // Given
-        whenever(mockImageView.background).thenReturn(mockBackground)
+        whenever(mockImageButton.background).thenReturn(mockBackground)
 
         val argumentCaptor = argumentCaptor<ImageWireframeHelperCallback>()
         whenever(
@@ -251,7 +251,7 @@ internal class ImageViewMapperTest {
         ).thenReturn(expectedWireframe)
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext, mockCallback)
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext, mockCallback)
 
         // Then
         assertThat(wireframes.size).isEqualTo(2)
@@ -287,15 +287,15 @@ internal class ImageViewMapperTest {
             id = id,
             x = mockGlobalBounds.x,
             y = mockGlobalBounds.y,
-            width = mockImageView.width.toLong(),
-            height = mockImageView.height.toLong(),
+            width = mockImageButton.width.toLong(),
+            height = mockImageButton.height.toLong(),
             shapeStyle = null,
             border = null,
             base64 = "",
             mimeType = fakeMimeType,
             isEmpty = true
         )
-        whenever(mockImageView.background).thenReturn(mockBackground)
+        whenever(mockImageButton.background).thenReturn(mockBackground)
 
         mockCreateImageWireframe(
             expectedBackgroundWireframe,
@@ -303,7 +303,7 @@ internal class ImageViewMapperTest {
         )
 
         // When
-        testedMapper.map(mockImageView, mockMappingContext)
+        testedMapper.map(mockImageButton, mockMappingContext)
 
         // Then
         val captor = argumentCaptor<Int>()
@@ -328,7 +328,7 @@ internal class ImageViewMapperTest {
     @Test
     fun `M set index to 0 W map() { no background wireframe }`() {
         // Given
-        whenever(mockImageView.background).thenReturn(mockBackground)
+        whenever(mockImageButton.background).thenReturn(mockBackground)
 
         mockCreateImageWireframe(
             null,
@@ -336,7 +336,7 @@ internal class ImageViewMapperTest {
         )
 
         // When
-        testedMapper.map(mockImageView, mockMappingContext)
+        testedMapper.map(mockImageButton, mockMappingContext)
 
         // Then
         val captor = argumentCaptor<Int>()
@@ -363,14 +363,14 @@ internal class ImageViewMapperTest {
         @LongForgery id: Long
     ) {
         // Given
-        whenever(mockImageView.background).thenReturn(mockBackground)
+        whenever(mockImageButton.background).thenReturn(mockBackground)
 
         val expectedBackgroundWireframe = MobileSegment.Wireframe.ImageWireframe(
             id = id,
             x = mockGlobalBounds.x,
             y = mockGlobalBounds.y,
-            width = mockImageView.width.toLong(),
-            height = mockImageView.height.toLong(),
+            width = mockImageButton.width.toLong(),
+            height = mockImageButton.height.toLong(),
             shapeStyle = null,
             border = null,
             base64 = "",
@@ -384,7 +384,7 @@ internal class ImageViewMapperTest {
         )
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext)
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
 
         // Then
         assertThat(wireframes[0]::class.java).isEqualTo(MobileSegment.Wireframe.ImageWireframe::class.java)
@@ -395,10 +395,10 @@ internal class ImageViewMapperTest {
         @Mock mockColorDrawable: ColorDrawable
     ) {
         // Given
-        whenever(mockImageView.background).thenReturn(mockColorDrawable)
+        whenever(mockImageButton.background).thenReturn(mockColorDrawable)
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext)
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
 
         // Then
         assertThat(wireframes[0]::class.java).isEqualTo(MobileSegment.Wireframe.ShapeWireframe::class.java)
@@ -409,7 +409,7 @@ internal class ImageViewMapperTest {
         @Mock mockColorDrawable: ColorDrawable
     ) {
         // Given
-        whenever(mockImageView.background).thenReturn(mockColorDrawable)
+        whenever(mockImageButton.background).thenReturn(mockColorDrawable)
 
         whenever(mockUniqueIdentifierGenerator.resolveChildUniqueIdentifier(any(), any()))
             .thenReturn(null)
@@ -420,7 +420,7 @@ internal class ImageViewMapperTest {
         )
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext)
+        val wireframes = testedMapper.map(mockImageButton, mockMappingContext)
 
         // Then
         assertThat(wireframes.size).isEqualTo(1)


### PR DESCRIPTION
This reverts commit 3100b414e02641ba8e53f0a84051d8cf5e3bafd4.
Reverts base64 imageview support due to an issue discovered where the "content image" square size would change between when the image begins to download and finishes downloading remotely (the image is resized for centercrop). We will need to implement wireframe cropping and keep the image at a constant size.

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

