### PR TITLE
RUM-501 Handle Android Strict Mode

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -148,6 +148,7 @@ interface com.datadog.android.core.InternalSdkCore : com.datadog.android.api.fea
 class com.datadog.android.core.SdkReference
   constructor(String? = null, (com.datadog.android.api.SdkCore) -> Unit = {})
   fun get(): com.datadog.android.api.SdkCore?
+fun <T> allowThreadDiskReads(() -> T): T
 enum com.datadog.android.core.configuration.BatchSize
   constructor(Long)
   - SMALL

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -439,6 +439,10 @@ public final class com/datadog/android/core/SdkReference {
 	public final fun get ()Lcom/datadog/android/api/SdkCore;
 }
 
+public final class com/datadog/android/core/StrictModeExtKt {
+	public static final fun allowThreadDiskReads (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
+}
+
 public final class com/datadog/android/core/configuration/BatchSize : java/lang/Enum {
 	public static final field LARGE Lcom/datadog/android/core/configuration/BatchSize;
 	public static final field MEDIUM Lcom/datadog/android/core/configuration/BatchSize;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/StrictModeExt.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/StrictModeExt.kt
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core
+
+import android.os.StrictMode
+import com.datadog.android.lint.InternalApi
+
+/**
+ * This utility function wraps a call to a method that needs to perform a disk read operation
+ * on the main thread.
+ * This prevents adding LogCat noise when customer enable StrictMode logging.
+ * @param T the type returned by the operation
+ * @param operation the operation
+ * @return the value returned by the operation
+ */
+@InternalApi
+fun <T> allowThreadDiskReads(
+    operation: () -> T
+): T {
+    val oldPolicy = StrictMode.allowThreadDiskReads()
+    try {
+        return operation()
+    } finally {
+        StrictMode.setThreadPolicy(oldPolicy)
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -17,6 +17,7 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.BuildConfig
 import com.datadog.android.DatadogSite
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.allowThreadDiskReads
 import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.UploadFrequency
@@ -161,10 +162,14 @@ internal class CoreFeature(
         firstPartyHostHeaderTypeResolver
             .addKnownHostsWithHeaderTypes(configuration.coreConfig.firstPartyHostsWithHeaderTypes)
         androidInfoProvider = DefaultAndroidInfoProvider(appContext)
-        storageDir = File(
-            appContext.cacheDir,
-            DATADOG_STORAGE_DIR_NAME.format(Locale.US, sdkInstanceId)
-        )
+
+        storageDir = allowThreadDiskReads {
+            File(
+                appContext.cacheDir,
+                DATADOG_STORAGE_DIR_NAME.format(Locale.US, sdkInstanceId)
+            )
+        }
+
         // BIG NOTE !!
         // Please do not move the block bellow.
         // The NDK crash handler `prepareData` function needs to be called exactly at this moment

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -316,6 +316,8 @@ datadog:
       - "android.os.Process.getStartElapsedRealtime()"
       - "android.os.Process.myPid()"
       - "android.os.SystemClock.elapsedRealtime()"
+      - "android.os.StrictMode.allowThreadDiskReads()"
+      - "android.os.StrictMode.setThreadPolicy(android.os.StrictMode.ThreadPolicy)"
       - "android.util.Log.i(kotlin.String?, kotlin.String)"
       - "android.util.Log.e(kotlin.String?, kotlin.String)"
       - "android.util.Log.e(kotlin.String?, kotlin.String?, kotlin.Throwable?)"

--- a/features/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/internal/NdkCrashReportsFeature.kt
+++ b/features/dd-sdk-android-ndk/src/main/kotlin/com/datadog/android/ndk/internal/NdkCrashReportsFeature.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.allowThreadDiskReads
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.privacy.TrackingConsentProviderCallback
 import java.io.File
@@ -49,7 +50,9 @@ internal class NdkCrashReportsFeature(private val sdkCore: FeatureSdkCore) :
             NDK_CRASH_REPORTS_FOLDER
         )
         try {
-            ndkCrashesDirs.mkdirs()
+            allowThreadDiskReads {
+                ndkCrashesDirs.mkdirs()
+            }
         } catch (e: SecurityException) {
             sdkCore.internalLogger.log(
                 InternalLogger.Level.ERROR,
@@ -98,7 +101,9 @@ internal class NdkCrashReportsFeature(private val sdkCore: FeatureSdkCore) :
     private fun loadNativeLibrary(internalLogger: InternalLogger) {
         var exception: Throwable? = null
         try {
-            System.loadLibrary("datadog-native-lib")
+            allowThreadDiskReads {
+                System.loadLibrary("datadog-native-lib")
+            }
             nativeLibraryLoaded = true
         } catch (e: SecurityException) {
             exception = e

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/DDTracer.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/opentracing/DDTracer.java
@@ -6,6 +6,8 @@
 
 package com.datadog.opentracing;
 
+import android.os.StrictMode;
+
 import com.datadog.opentracing.decorators.AbstractDecorator;
 import com.datadog.opentracing.decorators.DDDecoratorsFactory;
 import com.datadog.opentracing.jfr.DDNoopScopeEventFactory;
@@ -240,10 +242,12 @@ public class DDTracer implements io.opentracing.Tracer, Closeable, Tracer {
      */
     public void registerClassLoader(final ClassLoader classLoader) {
         try {
-            for (final TraceInterceptor interceptor :
-                    ServiceLoader.load(TraceInterceptor.class, classLoader)) {
+            StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskReads();
+            ServiceLoader<TraceInterceptor> serviceLoader = ServiceLoader.load(TraceInterceptor.class, classLoader);
+            for (final TraceInterceptor interceptor : serviceLoader) {
                 addTraceInterceptor(interceptor);
             }
+            StrictMode.setThreadPolicy(oldPolicy);
         } catch (final ServiceConfigurationError e) {
         }
     }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/core/StrictModeTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/core/StrictModeTest.kt
@@ -1,0 +1,77 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.core
+
+import android.os.StrictMode
+import android.os.StrictMode.ThreadPolicy
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.filters.MediumTest
+import com.datadog.android.core.allowThreadDiskReads
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@Suppress("TestFunctionName")
+@MediumTest
+@RunWith(AndroidJUnit4::class)
+class StrictModeTest {
+    @Test
+    fun M_disable_disk_read_checks_W_allowThreadDiskReads() {
+        // Given
+        StrictMode.setThreadPolicy(
+            ThreadPolicy.Builder()
+                .detectAll()
+                .penaltyDeath()
+                .build()
+        )
+
+        // When
+        var error: RuntimeException? = null
+        val sdcardExists = try {
+            allowThreadDiskReads {
+                val sdcard = File("/sdcard")
+                sdcard.exists()
+            }
+        } catch (e: RuntimeException) {
+            error = e
+            false
+        }
+
+        // Then
+        assertThat(error).isNull()
+        assertThat(sdcardExists).isTrue()
+    }
+
+    @Test
+    fun M_disable_disk_read_checks_temporarily_W_allowThreadDiskReads() {
+        // Given
+        StrictMode.setThreadPolicy(
+            ThreadPolicy.Builder()
+                .detectAll()
+                .penaltyDeath()
+                .build()
+        )
+
+        // When
+        var error: RuntimeException? = null
+        val sdcardExists = try {
+            allowThreadDiskReads {
+                // do nothing
+            }
+            val sdcard = File("/sdcard")
+            sdcard.exists()
+        } catch (e: RuntimeException) {
+            error = e
+            null
+        }
+
+        // Then
+        assertThat(error).isNotNull()
+        assertThat(sdcardExists).isNull()
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This tries to handle some StrictMode warnings happening during the SDK initialization, which can't easily be deferred to background threads. 

### Motivation

Prevent the SDK from spamming warnings in host application when StrictMode feature is enabled. 