### PR TITLE
Disable warning as errors locally

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
@@ -20,7 +20,8 @@ fun Project.kotlinConfig(
     taskConfig<KotlinCompile> {
         compilerOptions {
             jvmTarget.set(jvmBytecodeTarget)
-            allWarningsAsErrors.set(evaluateWarningsAsErrors)
+            val isCI = System.getenv("CI").toBoolean()
+            allWarningsAsErrors.set(evaluateWarningsAsErrors && isCI)
             apiVersion.set(KotlinVersion.KOTLIN_1_7)
             languageVersion.set(KotlinVersion.KOTLIN_1_7)
         }

--- a/local_ci.sh
+++ b/local_ci.sh
@@ -9,6 +9,7 @@ ANALYSIS=0
 COMPILE=0
 TEST=0
 UPDATE_SESSION_REPLAY_PAYLOAD=0
+export CI=true
 
 while [[ $# -gt 0 ]]; do
   case $1 in
@@ -187,4 +188,5 @@ if [[ $UPDATE_SESSION_REPLAY_PAYLOAD == 1 ]]; then
   adb pull $PAYLOAD_INPUT_DIRECTORY_PATH $PAYLOAD_OUTPUT_DIRECTORY_PATH
 fi
 
+unset CI
 echo "-- Done ✔︎"


### PR DESCRIPTION
### What does this PR do?

Use the `CI` environment variable to enable the "show warning as errors" in Kotlin compiler

### Motivation

During development, especially when doing TDD, I often find myself having variables/parameters temporarily unused, which prevent from running the tests. 
This new option allows me to to TDD without manually changing the `allWarningsAsErrors` and still keep checks in the CI. 

> [!NOTE] 
> The `local_ci.sh` script will set the environnement variable to ensure one can detect those warnings before pushing to CI
