### PR TITLE
RUM-1330 Make sure we use try-locks in our NDK signal catcher

### DIFF
--- a/features/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.h
+++ b/features/dd-sdk-android-ndk/src/main/cpp/datadog-native-lib.h
@@ -24,6 +24,11 @@ void write_crash_report(int signum,
                         const char *error_message,
                         const char *error_stacktrace);
 
+#ifndef NDEBUG
+void lockMutex();
+void unlockMutex();
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/features/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
+++ b/features/dd-sdk-android-ndk/src/main/cpp/utils/signal-monitor.c
@@ -93,7 +93,12 @@ void free_up_memory() {
 void invoke_previous_handler(int signum, siginfo_t *info, void *user_context) {
     // It may happen that the process is killed during this function execution.
     // Therefore this function may never return.
-    pthread_mutex_lock(&mutex);
+
+    if(pthread_mutex_trylock(&mutex) != 0){
+        // There is no action to take if the mutex cannot be acquired.
+        // In this case will just return here in order not to block the process.
+        return;
+    }
 
     const size_t signals_array_size = handled_signals_size();
     for (int i = 0; i < signals_array_size; ++i) {


### PR DESCRIPTION
### What does this PR do?

We recently had some reported issues in the flutter sdk regarding some ANRs caused by our signal catcher. Basically what was happening is that our code inside the signal catcher was trying to acquire a `mutex` lock which was already acquired by another thread (we could not really reproduce this). We chose to go with the safest mechanism here in order to avoid any other issues and use `try locks` instead of simple `locks`.

https://github.com/DataDog/dd-sdk-flutter/issues/487

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

