### PR TITLE
(1/3) RUM-392 create core testFixtures source set

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -66,7 +66,7 @@ static-analysis:
     DETEKT_CLASSPATH_FILE_PATH: "sdk_classpath"
     FLAVORED_ANDROID_LINT: ":tools:lint:lint :sample:kotlin:lintUs1Release :sample:wear:lintUs1Release"
   trigger:
-    include: "https://gitlab-templates.ddbuild.io/mobile/v20132793-918be90a/static-analysis.yml"
+    include: "https://gitlab-templates.ddbuild.io/mobile/v21503284-abb6cabb/static-analysis.yml"
     strategy: depend
 
 analysis:licenses:

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -170,9 +170,11 @@ dependencies {
     testImplementation(libs.bundles.testTools)
     unmock(libs.robolectric)
 
-    // Static Analysis
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
+    // Test Fixtures
+    testFixturesImplementation(libs.kotlin)
+    testFixturesImplementation(libs.bundles.jUnit5)
+    testFixturesImplementation(libs.okHttp)
+    testFixturesImplementation(libs.bundles.testTools)
 }
 
 unMock {

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/DatadogContextForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/DatadogContextForgeryFactory.kt
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.tests.elmyr
+
+import com.datadog.android.DatadogSite
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.privacy.TrackingConsent
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.Locale
+
+class DatadogContextForgeryFactory : ForgeryFactory<DatadogContext> {
+
+    override fun getForgery(forge: Forge): DatadogContext {
+        return DatadogContext(
+            site = forge.aValueFrom(DatadogSite::class.java),
+            clientToken = forge.anHexadecimalString().lowercase(Locale.US),
+            service = forge.anAlphabeticalString(),
+            version = forge.aStringMatching("[0-9](\\.[0-9]{1,3}){2,3}"),
+            variant = forge.anAlphabeticalString(),
+            env = forge.anAlphabeticalString(),
+            source = forge.anAlphabeticalString(),
+            sdkVersion = forge.aStringMatching("[0-9](\\.[0-9]{1,2}){1,3}"),
+            time = forge.getForgery(),
+            processInfo = forge.getForgery(),
+            networkInfo = forge.getForgery(),
+            deviceInfo = forge.getForgery(),
+            userInfo = forge.getForgery(),
+            trackingConsent = forge.aValueFrom(TrackingConsent::class.java),
+            // building nested maps with default size slows down tests quite a lot, so will use
+            // an explicit small size
+            featuresContext = forge.aMap(size = 2) {
+                forge.anAlphabeticalString() to forge.exhaustiveAttributes()
+            }
+        )
+    }
+}

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/DeviceInfoForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/DeviceInfoForgeryFactory.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.tests.elmyr
+
+import com.datadog.android.api.context.DeviceInfo
+import com.datadog.android.api.context.DeviceType
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class DeviceInfoForgeryFactory : ForgeryFactory<DeviceInfo> {
+    override fun getForgery(forge: Forge): DeviceInfo {
+        return DeviceInfo(
+            deviceName = forge.anAlphabeticalString(),
+            deviceBrand = forge.anAlphabeticalString(),
+            deviceModel = forge.anAlphabeticalString(),
+            deviceType = forge.aValueFrom(DeviceType::class.java),
+            deviceBuildId = forge.anAlphaNumericalString(),
+            osName = forge.aString(),
+            osVersion = forge.aString(),
+            osMajorVersion = forge.aString(),
+            architecture = forge.aString()
+        )
+    }
+}

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
@@ -1,0 +1,48 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.tests.elmyr
+
+import fr.xgouchet.elmyr.Forge
+import org.json.JSONArray
+import org.json.JSONObject
+import java.io.File
+import java.util.Date
+import java.util.Locale
+import java.util.TimeZone
+
+fun Forge.exhaustiveAttributes(): MutableMap<String, Any?> {
+    return listOf(
+        aBool(),
+        anInt(),
+        aLong(),
+        aFloat(),
+        aDouble(),
+        anAsciiString(),
+        getForgery<Date>(),
+        getForgery<Locale>(),
+        getForgery<TimeZone>(),
+        getForgery<File>(),
+        getForgery<JSONObject>(),
+        getForgery<JSONArray>(),
+        aList { anAlphabeticalString() },
+        aList { aDouble() },
+        null
+    )
+        .associateBy { anAlphaNumericalString() }
+        .toMutableMap()
+}
+
+fun <T : Forge> T.useCoreFactories(): T {
+    addFactory(DatadogContextForgeryFactory())
+    addFactory(DeviceInfoForgeryFactory())
+    addFactory(NetworkInfoForgeryFactory())
+    addFactory(ProcessInfoForgeryFactory())
+    addFactory(TimeInfoForgeryFactory())
+    addFactory(UserInfoForgeryFactory())
+
+    return this
+}

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/NetworkInfoForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/NetworkInfoForgeryFactory.kt
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.tests.elmyr
+
+import com.datadog.android.api.context.NetworkInfo
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class NetworkInfoForgeryFactory : ForgeryFactory<NetworkInfo> {
+
+    override fun getForgery(forge: Forge): NetworkInfo {
+        return NetworkInfo(
+            connectivity = forge.aValueFrom(NetworkInfo.Connectivity::class.java),
+            carrierName = forge.anElementFrom(
+                forge.anAlphabeticalString(),
+                forge.aWhitespaceString(),
+                null
+            ),
+            carrierId = forge.aNullable { forge.aLong(0, 10000) },
+            upKbps = forge.aNullable { forge.aLong(1, Long.MAX_VALUE) },
+            downKbps = forge.aNullable { forge.aLong(1, Long.MAX_VALUE) },
+            strength = forge.aNullable { forge.aLong(-100, -30) }, // dBm for wifi signal
+            cellularTechnology = forge.aNullable { anAlphabeticalString() }
+        )
+    }
+}

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ProcessInfoForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ProcessInfoForgeryFactory.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.tests.elmyr
+
+import com.datadog.android.api.context.ProcessInfo
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class ProcessInfoForgeryFactory : ForgeryFactory<ProcessInfo> {
+    override fun getForgery(forge: Forge): ProcessInfo {
+        return ProcessInfo(
+            isMainProcess = forge.aBool()
+        )
+    }
+}

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/TimeInfoForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/TimeInfoForgeryFactory.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.tests.elmyr
+
+import com.datadog.android.api.context.TimeInfo
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class TimeInfoForgeryFactory : ForgeryFactory<TimeInfo> {
+    override fun getForgery(forge: Forge): TimeInfo {
+        return TimeInfo(
+            deviceTimeNs = forge.aLong(min = 0),
+            serverTimeNs = forge.aLong(min = 0),
+            serverTimeOffsetNs = forge.aLong(),
+            serverTimeOffsetMs = forge.aLong()
+        )
+    }
+}

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/UserInfoForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/UserInfoForgeryFactory.kt
@@ -1,0 +1,23 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.tests.elmyr
+
+import com.datadog.android.api.context.UserInfo
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class UserInfoForgeryFactory : ForgeryFactory<UserInfo> {
+
+    override fun getForgery(forge: Forge): UserInfo {
+        return UserInfo(
+            id = forge.aNullable { anHexadecimalString() },
+            name = forge.aNullable { forge.aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
+            email = forge.aNullable { forge.aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
+            additionalProperties = forge.exhaustiveAttributes()
+        )
+    }
+}

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -77,7 +77,7 @@ style:
 
 datadog:
   active: true
-  excludes: ['**/build/**', '**/test/**', '**/testDebug/**','**/testRelease/**', '**/androidTest/**', '**/buildSrc/**', '**/*.kts', '**/instrumented/**', '**/sample/**', '**/tools/**']
+  excludes: ['**/build/**', '**/test/**', '**/testDebug/**','**/testRelease/**', '**/androidTest/**', '**/testFixtures/**', '**/buildSrc/**', '**/*.kts', '**/instrumented/**', '**/sample/**', '**/tools/**']
   UnsafeThirdPartyFunctionCall:
     active: true
     internalPackagePrefix: 'com.datadog'


### PR DESCRIPTION
### What does this PR do?

This PR adds a `testFixtures` source set to the Core module, and adds test fixture classes that will be shared with other modues (in the next PR)

### Motivation

This is part of our effort on improving our test suites across the mobile teams