### PR TITLE
(2/3) RUM-392 refactor shared android library build script

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/AndroidConfig.kt
@@ -7,9 +7,10 @@
 package com.datadog.gradle.config
 
 import com.android.build.api.dsl.CompileOptions
-import com.android.build.api.dsl.LibraryDefaultConfig
+import com.android.build.gradle.LibraryExtension
 import com.datadog.gradle.utils.Version
 import org.gradle.api.JavaVersion
+import org.gradle.api.Project
 
 object AndroidConfig {
 
@@ -21,7 +22,7 @@ object AndroidConfig {
     val VERSION = Version(2, 3, 0, Version.Type.Snapshot)
 }
 
-// TODO RUMM-3263 Switch to Java 17 bytecode
+// TODO RUM-628 Switch to Java 17 bytecode
 fun CompileOptions.java11() {
     sourceCompatibility = JavaVersion.VERSION_11
     targetCompatibility = JavaVersion.VERSION_11
@@ -32,11 +33,57 @@ fun CompileOptions.java17() {
     targetCompatibility = JavaVersion.VERSION_17
 }
 
-@Suppress("UnstableApiUsage")
-fun LibraryDefaultConfig.setLibraryVersion(
-    versionCode: Int = AndroidConfig.VERSION.code,
-    versionName: String = AndroidConfig.VERSION.name
-) {
-    buildConfigField("int", "SDK_VERSION_CODE", "$versionCode")
-    buildConfigField("String", "SDK_VERSION_NAME", "\"$versionName\"")
+fun Project.androidLibraryConfig() {
+    extensionConfig<LibraryExtension> {
+        compileSdk = AndroidConfig.TARGET_SDK
+        buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
+
+        defaultConfig {
+            minSdk = AndroidConfig.MIN_SDK
+        }
+
+        compileOptions {
+            java11()
+        }
+
+        sourceSets.all {
+            java.srcDir("src/$name/kotlin")
+        }
+        sourceSets.named("main") {
+            java.srcDir("build/generated/json2kotlin/main/kotlin")
+        }
+        libraryVariants.configureEach {
+            addJavaSourceFoldersToModel(
+                layout.buildDirectory.dir("generated/ksp/$name/kotlin").get().asFile
+            )
+        }
+
+        @Suppress("UnstableApiUsage")
+        testOptions {
+            unitTests.isReturnDefaultValues = true
+        }
+
+        @Suppress("UnstableApiUsage")
+        testFixtures {
+            enable = true
+        }
+
+        lint {
+            warningsAsErrors = true
+            abortOnError = true
+            checkReleaseBuilds = false
+            checkGeneratedSources = true
+            ignoreTestSources = true
+        }
+
+        packaging {
+            resources {
+                excludes += listOf(
+                    "META-INF/jvm.kotlin_module",
+                    "META-INF/LICENSE.md",
+                    "META-INF/LICENSE-notice.md"
+                )
+            }
+        }
+    }
 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/BaseExtensionConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/BaseExtensionConfig.kt
@@ -13,10 +13,8 @@ import org.gradle.kotlin.dsl.findByType
 inline fun <reified T : Any> Project.extensionConfig(
     crossinline configure: T.() -> Unit
 ) {
-    project.afterEvaluate {
-        val ext: T? = extensions.findByType(T::class)
-        ext?.configure()
-    }
+    val ext: T? = extensions.findByType(T::class)
+    ext?.configure()
 }
 
 inline fun <reified T : Task> Project.taskConfig(

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -7,13 +7,12 @@
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.BuildConfigPropertiesKeys
 import com.datadog.gradle.config.GradlePropertiesKeys
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 import com.datadog.gradle.config.publishingConfig
-import com.datadog.gradle.config.setLibraryVersion
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
@@ -50,49 +49,23 @@ fun isLogEnabledInRelease(): String {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
     defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-
         buildFeatures {
             buildConfig = true
         }
-        setLibraryVersion()
+        buildConfigField(
+            "int",
+            "SDK_VERSION_CODE",
+            "${AndroidConfig.VERSION.code}"
+        )
+        buildConfigField(
+            "String",
+            "SDK_VERSION_NAME",
+            "\"${AndroidConfig.VERSION.name}\""
+        )
     }
 
     namespace = "com.datadog.android"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("testDebug") {
-        java.srcDir("src/testDebug/kotlin")
-    }
-    sourceSets.named("testRelease") {
-        java.srcDir("src/testRelease/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.apply {
-            isReturnDefaultValues = true
-        }
-    }
-    testFixtures {
-        enable = true
-    }
 
     buildTypes {
         getByName("release") {
@@ -110,31 +83,6 @@ android {
                 "true"
             )
         }
-    }
-
-    libraryVariants.configureEach {
-        addJavaSourceFoldersToModel(
-            layout.buildDirectory
-                .dir("generated/ksp/$name/kotlin").get().asFile
-        )
-    }
-
-    packaging {
-        resources {
-            excludes += listOf(
-                "META-INF/jvm.kotlin_module",
-                "META-INF/LICENSE.md",
-                "META-INF/LICENSE-notice.md"
-            )
-        }
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
     }
 }
 
@@ -191,6 +139,7 @@ unMock {
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/features/dd-sdk-android-logs/build.gradle.kts
+++ b/features/dd-sdk-android-logs/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -40,61 +39,11 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
     defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-
         consumerProguardFiles(Paths.get(rootDir.path, "consumer-rules.pro").toString())
     }
 
     namespace = "com.datadog.android.log"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-        java.srcDir("build/generated/json2kotlin/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    libraryVariants.configureEach {
-        addJavaSourceFoldersToModel(
-            layout.buildDirectory
-                .dir("generated/ksp/$name/kotlin").get().asFile
-        )
-    }
-
-    packaging {
-        resources {
-            excludes += listOf(
-                "META-INF/jvm.kotlin_module",
-                "META-INF/LICENSE.md",
-                "META-INF/LICENSE-notice.md"
-            )
-        }
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
 
 dependencies {
@@ -117,9 +66,6 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     unmock(libs.robolectric)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 unMock {
@@ -129,6 +75,7 @@ unMock {
 apply(from = "generate_log_models.gradle.kts")
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/features/dd-sdk-android-ndk/build.gradle.kts
+++ b/features/dd-sdk-android-ndk/build.gradle.kts
@@ -5,9 +5,8 @@
  */
 
 import com.datadog.gradle.Dependencies
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -38,12 +37,8 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
         multiDexEnabled = true
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         externalNativeBuild {
@@ -55,46 +50,10 @@ android {
 
     namespace = "com.datadog.android.ndk"
 
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
-
     externalNativeBuild {
         cmake {
             path = File("$projectDir/CMakeLists.txt")
             version = Dependencies.Versions.CMake
-        }
-    }
-
-    packaging {
-        resources {
-            excludes += listOf(
-                "META-INF/jvm.kotlin_module",
-                "META-INF/LICENSE.md",
-                "META-INF/LICENSE-notice.md"
-            )
         }
     }
 
@@ -134,12 +93,10 @@ dependencies {
         // this is needed to make AssertJ working on APIs <24
         androidTestImplementation(project(":tools:javabackport"))
     }
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/features/dd-sdk-android-rum/build.gradle.kts
+++ b/features/dd-sdk-android-rum/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -40,61 +39,11 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
     defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-
         consumerProguardFiles(Paths.get(rootDir.path, "consumer-rules.pro").toString())
     }
 
     namespace = "com.datadog.android.rum"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-        java.srcDir("build/generated/json2kotlin/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    libraryVariants.configureEach {
-        addJavaSourceFoldersToModel(
-            layout.buildDirectory
-                .dir("generated/ksp/$name/kotlin").get().asFile
-        )
-    }
-
-    packaging {
-        resources {
-            excludes += listOf(
-                "META-INF/jvm.kotlin_module",
-                "META-INF/LICENSE.md",
-                "META-INF/LICENSE-notice.md"
-            )
-        }
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
 
 dependencies {
@@ -125,9 +74,6 @@ dependencies {
     testImplementation(libs.okHttpMock)
     testImplementation(libs.bundles.openTracing)
     unmock(libs.robolectric)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 unMock {
@@ -157,6 +103,7 @@ apply(from = "generate_rum_models.gradle.kts")
 apply(from = "generate_telemetry_models.gradle.kts")
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -37,49 +36,9 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.sessionreplay.material"
-
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    packaging {
-        resources {
-            excludes += listOf(
-                "META-INF/jvm.kotlin_module",
-                "META-INF/LICENSE.md",
-                "META-INF/LICENSE-notice.md"
-            )
-        }
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
+
 dependencies {
     api(project(":features:dd-sdk-android-session-replay"))
     implementation(libs.kotlin)
@@ -96,12 +55,10 @@ dependencies {
     }
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/features/dd-sdk-android-session-replay/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -38,53 +37,11 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
     defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
         consumerProguardFiles("consumer-rules.pro")
     }
 
     namespace = "com.datadog.android.sessionreplay"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-        java.srcDir("build/generated/json2kotlin/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    packaging {
-        resources {
-            excludes += listOf(
-                "META-INF/jvm.kotlin_module",
-                "META-INF/LICENSE.md",
-                "META-INF/LICENSE-notice.md"
-            )
-        }
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
 
 dependencies {
@@ -105,9 +62,6 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     unmock(libs.robolectric)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 unMock {
@@ -118,6 +72,7 @@ apply(from = "clone_session_replay_schema.gradle.kts")
 apply(from = "generate_session_replay_models.gradle.kts")
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/features/dd-sdk-android-trace/build.gradle.kts
+++ b/features/dd-sdk-android-trace/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -39,61 +38,11 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
     defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-
         consumerProguardFiles("consumer-rules.pro")
     }
 
     namespace = "com.datadog.android.trace"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-        java.srcDir("build/generated/json2kotlin/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    libraryVariants.configureEach {
-        addJavaSourceFoldersToModel(
-            layout.buildDirectory
-                .dir("generated/ksp/$name/kotlin").get().asFile
-        )
-    }
-
-    packaging {
-        resources {
-            excludes += listOf(
-                "META-INF/jvm.kotlin_module",
-                "META-INF/LICENSE.md",
-                "META-INF/LICENSE-notice.md"
-            )
-        }
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
 
 dependencies {
@@ -119,9 +68,6 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     unmock(libs.robolectric)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 unMock {
@@ -132,6 +78,7 @@ apply(from = "clone_dd_trace.gradle.kts")
 apply(from = "generate_trace_models.gradle.kts")
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/features/dd-sdk-android-webview/build.gradle.kts
+++ b/features/dd-sdk-android-webview/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -39,59 +38,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.webview"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-        java.srcDir("build/generated/json2kotlin/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    libraryVariants.configureEach {
-        addJavaSourceFoldersToModel(
-            layout.buildDirectory
-                .dir("generated/ksp/$name/kotlin").get().asFile
-        )
-    }
-
-    packaging {
-        resources {
-            excludes += listOf(
-                "META-INF/jvm.kotlin_module",
-                "META-INF/LICENSE.md",
-                "META-INF/LICENSE-notice.md"
-            )
-        }
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
 
 dependencies {
@@ -115,9 +62,6 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     unmock(libs.robolectric)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 unMock {
@@ -125,6 +69,7 @@ unMock {
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/integrations/dd-sdk-android-coil/build.gradle.kts
+++ b/integrations/dd-sdk-android-coil/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -37,40 +36,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.coil"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-    }
 }
 
 dependencies {
@@ -90,12 +56,10 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/integrations/dd-sdk-android-compose/build.gradle.kts
+++ b/integrations/dd-sdk-android-compose/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -38,47 +37,12 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.compose"
-
     buildFeatures {
         compose = true
     }
-
     composeOptions {
         kotlinCompilerExtensionVersion = libs.versions.androidXComposeRuntime.get()
-    }
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
     }
 }
 
@@ -100,9 +64,6 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     unmock(libs.robolectric)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 unMock {
@@ -113,6 +74,7 @@ unMock {
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 taskConfig<org.jetbrains.kotlin.gradle.tasks.KotlinCompile> {
     compilerOptions {
         freeCompilerArgs.add("-opt-in=kotlin.RequiresOptIn")

--- a/integrations/dd-sdk-android-fresco/build.gradle.kts
+++ b/integrations/dd-sdk-android-fresco/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -37,40 +36,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.fresco"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-    }
 }
 
 dependencies {
@@ -90,12 +56,10 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/integrations/dd-sdk-android-glide/build.gradle.kts
+++ b/integrations/dd-sdk-android-glide/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -37,41 +36,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.glide"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
 
 dependencies {
@@ -92,12 +57,10 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -39,58 +38,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.okhttp"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    libraryVariants.configureEach {
-        addJavaSourceFoldersToModel(
-            layout.buildDirectory
-                .dir("generated/ksp/$name/kotlin").get().asFile
-        )
-    }
-
-    packaging {
-        resources {
-            excludes += listOf(
-                "META-INF/jvm.kotlin_module",
-                "META-INF/LICENSE.md",
-                "META-INF/LICENSE-notice.md"
-            )
-        }
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
 
 dependencies {
@@ -115,9 +63,6 @@ dependencies {
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)
     unmock(libs.robolectric)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 unMock {
@@ -125,6 +70,7 @@ unMock {
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-rum-coroutines/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -36,41 +35,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.rum.coroutines"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
 
 dependencies {
@@ -89,12 +54,10 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/integrations/dd-sdk-android-rx/build.gradle.kts
+++ b/integrations/dd-sdk-android-rx/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -37,40 +36,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.rx"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-    }
 }
 
 dependencies {
@@ -90,12 +56,10 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/integrations/dd-sdk-android-sqldelight/build.gradle.kts
+++ b/integrations/dd-sdk-android-sqldelight/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -37,40 +36,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.sqldelight"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-    }
 }
 
 dependencies {
@@ -91,12 +57,10 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/integrations/dd-sdk-android-timber/build.gradle.kts
+++ b/integrations/dd-sdk-android-timber/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -37,41 +36,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.timber"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
 
 dependencies {
@@ -90,12 +55,10 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
+++ b/integrations/dd-sdk-android-trace-coroutines/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -36,41 +35,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.trace.coroutines"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-        ignoreTestSources = true
-    }
 }
 
 dependencies {
@@ -89,12 +54,10 @@ dependencies {
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()

--- a/integrations/dd-sdk-android-tv/build.gradle.kts
+++ b/integrations/dd-sdk-android-tv/build.gradle.kts
@@ -4,9 +4,8 @@
  * Copyright 2016-2019 Datadog, Inc.
  */
 
-import com.datadog.gradle.config.AndroidConfig
+import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -37,40 +36,7 @@ plugins {
 }
 
 android {
-    compileSdk = AndroidConfig.TARGET_SDK
-    buildToolsVersion = AndroidConfig.BUILD_TOOLS_VERSION
-
-    defaultConfig {
-        minSdk = AndroidConfig.MIN_SDK
-        targetSdk = AndroidConfig.TARGET_SDK
-    }
-
     namespace = "com.datadog.android.tv"
-
-    sourceSets.named("main") {
-        java.srcDir("src/main/kotlin")
-    }
-    sourceSets.named("test") {
-        java.srcDir("src/test/kotlin")
-    }
-    sourceSets.named("androidTest") {
-        java.srcDir("src/androidTest/kotlin")
-    }
-
-    compileOptions {
-        java11()
-    }
-
-    testOptions {
-        unitTests.isReturnDefaultValues = true
-    }
-
-    lint {
-        warningsAsErrors = true
-        abortOnError = true
-        checkReleaseBuilds = false
-        checkGeneratedSources = true
-    }
 }
 
 dependencies {
@@ -88,12 +54,10 @@ dependencies {
     }
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
-
-    // TODO MTG-12 detekt(project(":tools:detekt"))
-    // TODO MTG-12 detekt(libs.detektCli)
 }
 
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
+androidLibraryConfig()
 junitConfig()
 javadocConfig()
 dependencyUpdateConfig()


### PR DESCRIPTION
### What does this PR do?

This PR refactor the `build.gradle.kts` buildscript for all our libraries to extract shared configurations and make it easier to: 
- create new libraries
- add build features to all libraries

### Motivation

This is part of our effort on improving our test suites across the mobile teams