### PR TITLE
Enable custom mappers to return traversal strategy

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -25,6 +25,10 @@ interface com.datadog.android.sessionreplay.internal.recorder.OptionSelectorDete
   fun isOptionSelector(android.view.ViewGroup): Boolean
 data class com.datadog.android.sessionreplay.internal.recorder.SystemInformation
   constructor(GlobalBounds, Int = Configuration.ORIENTATION_UNDEFINED, Float, String? = null)
+enum com.datadog.android.sessionreplay.internal.recorder.TraversalStrategy
+  - TRAVERSE_ALL_CHILDREN
+  - STOP_AND_RETURN_NODE
+  - STOP_AND_DROP_NODE
 abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseAsyncBackgroundWireframeMapper<T: android.view.View> : BaseWireframeMapper<T, com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
   constructor(com.datadog.android.sessionreplay.utils.StringUtils = StringUtils, com.datadog.android.sessionreplay.utils.ViewUtils = ViewUtils)
   override fun map(T, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.internal.AsyncJobStatusCallback): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
@@ -44,6 +48,7 @@ open class com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMa
   constructor()
   override fun map(android.widget.TextView, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.internal.AsyncJobStatusCallback): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
 interface com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper<T: android.view.View, S: com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
+  val traversalStrategy: com.datadog.android.sessionreplay.internal.recorder.TraversalStrategy
   fun map(T, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.internal.AsyncJobStatusCallback = NoOpAsyncJobStatusCallback()): List<S>
 object com.datadog.android.sessionreplay.utils.StringUtils
   fun formatColorAndAlphaAsHexa(Int, Int): String

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -100,6 +100,18 @@ public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper
 	public fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/internal/AsyncJobStatusCallback;)Ljava/util/List;
 }
 
+public final class com/datadog/android/sessionreplay/internal/recorder/TraversalStrategy : java/lang/Enum {
+	public static final field STOP_AND_DROP_NODE Lcom/datadog/android/sessionreplay/internal/recorder/TraversalStrategy;
+	public static final field STOP_AND_RETURN_NODE Lcom/datadog/android/sessionreplay/internal/recorder/TraversalStrategy;
+	public static final field TRAVERSE_ALL_CHILDREN Lcom/datadog/android/sessionreplay/internal/recorder/TraversalStrategy;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/internal/recorder/TraversalStrategy;
+	public static fun values ()[Lcom/datadog/android/sessionreplay/internal/recorder/TraversalStrategy;
+}
+
+public final class com/datadog/android/sessionreplay/internal/recorder/base64/Base64Serializer {
+	public synthetic fun <init> (Ljava/util/concurrent/ExecutorService;Lcom/datadog/android/sessionreplay/internal/utils/DrawableUtils;Lcom/datadog/android/sessionreplay/internal/utils/Base64Utils;Lcom/datadog/android/sessionreplay/internal/recorder/base64/ImageCompression;Lkotlin/jvm/internal/DefaultConstructorMarker;)V
+}
+
 public final class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper$Companion {
 }
 
@@ -109,6 +121,11 @@ public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper
 	public fun <init> (Lcom/datadog/android/sessionreplay/utils/StringUtils;Lcom/datadog/android/sessionreplay/utils/ViewUtils;)V
 	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/utils/StringUtils;Lcom/datadog/android/sessionreplay/utils/ViewUtils;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected final fun colorAndAlphaAsStringHexa (II)Ljava/lang/String;
+	public fun finishProcessingImage ()V
+	public fun getTraversalStrategy ()Lcom/datadog/android/sessionreplay/internal/recorder/TraversalStrategy;
+	protected final fun getWebPMimeType ()Ljava/lang/String;
+	protected final fun handleBitmap (Landroid/util/DisplayMetrics;Landroid/graphics/drawable/Drawable;Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;)V
+	protected final fun resolveChildDrawableUniqueIdentifier (Landroid/view/View;)Ljava/lang/Long;
 	protected final fun resolveShapeStyleAndBorder (Landroid/graphics/drawable/Drawable;F)Lkotlin/Pair;
 	protected final fun resolveViewGlobalBounds (Landroid/view/View;F)Lcom/datadog/android/sessionreplay/internal/recorder/GlobalBounds;
 	protected final fun resolveViewId (Landroid/view/View;)J
@@ -132,11 +149,16 @@ public class com/datadog/android/sessionreplay/internal/recorder/mapper/TextView
 }
 
 public abstract interface class com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper {
+	public abstract fun getTraversalStrategy ()Lcom/datadog/android/sessionreplay/internal/recorder/TraversalStrategy;
 	public abstract fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/internal/AsyncJobStatusCallback;)Ljava/util/List;
 }
 
 public final class com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper$DefaultImpls {
-	public static synthetic fun map$default (Lcom/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper;Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/internal/AsyncJobStatusCallback;ILjava/lang/Object;)Ljava/util/List;
+	public abstract fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;)Ljava/util/List;
+}
+
+public final class com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper$DefaultImpls {
+	public static fun getTraversalStrategy (Lcom/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper;)Lcom/datadog/android/sessionreplay/internal/recorder/TraversalStrategy;
 }
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -41,17 +41,17 @@ internal class SnapshotProducer(
         val traversedTreeView = treeViewTraversal.traverse(view, mappingContext, recordedDataQueueRefs)
         val nextTraversalStrategy = traversedTreeView.nextActionStrategy
         val resolvedWireframes = traversedTreeView.mappedWireframes
-        if (nextTraversalStrategy == TreeViewTraversal.TraversalStrategy.STOP_AND_DROP_NODE) {
+        if (nextTraversalStrategy == TraversalStrategy.STOP_AND_DROP_NODE) {
             return null
         }
-        if (nextTraversalStrategy == TreeViewTraversal.TraversalStrategy.STOP_AND_RETURN_NODE) {
+        if (nextTraversalStrategy == TraversalStrategy.STOP_AND_RETURN_NODE) {
             return Node(wireframes = resolvedWireframes, parents = parents)
         }
 
         val childNodes = LinkedList<Node>()
         if (view is ViewGroup &&
             view.childCount > 0 &&
-            nextTraversalStrategy == TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            nextTraversalStrategy == TraversalStrategy.TRAVERSE_ALL_CHILDREN
         ) {
             val childMappingContext = resolveChildMappingContext(view, mappingContext)
             val parentsCopy = LinkedList(parents).apply { addAll(resolvedWireframes) }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt
@@ -42,7 +42,7 @@ internal class TreeViewTraversal(
 
         if (exhaustiveTypeMapper != null) {
             val queueableViewMapper = QueueableViewMapper(exhaustiveTypeMapper, recordedDataQueueRefs)
-            traversalStrategy = TraversalStrategy.STOP_AND_RETURN_NODE
+            traversalStrategy = exhaustiveTypeMapper.traversalStrategy
             resolvedWireframes = queueableViewMapper.map(view, mappingContext)
         } else if (isDecorView(view)) {
             traversalStrategy = TraversalStrategy.TRAVERSE_ALL_CHILDREN
@@ -71,10 +71,10 @@ internal class TreeViewTraversal(
         val mappedWireframes: List<MobileSegment.Wireframe>,
         val nextActionStrategy: TraversalStrategy
     )
+}
 
-    enum class TraversalStrategy {
-        TRAVERSE_ALL_CHILDREN,
-        STOP_AND_RETURN_NODE,
-        STOP_AND_DROP_NODE
-    }
+enum class TraversalStrategy {
+    TRAVERSE_ALL_CHILDREN,
+    STOP_AND_RETURN_NODE,
+    STOP_AND_DROP_NODE
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper.kt
@@ -11,6 +11,7 @@ import com.datadog.android.sessionreplay.internal.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.internal.NoOpAsyncJobStatusCallback
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
+import com.datadog.android.sessionreplay.internal.recorder.TraversalStrategy
 import com.datadog.android.sessionreplay.model.MobileSegment
 
 /**
@@ -19,6 +20,8 @@ import com.datadog.android.sessionreplay.model.MobileSegment
  * Session Replay representation for a specific View type you can implement this on your end.
  */
 interface WireframeMapper<in T : View, out S : MobileSegment.Wireframe> {
+    val traversalStrategy: TraversalStrategy
+        get() = TraversalStrategy.STOP_AND_RETURN_NODE
 
     /**
      * Maps a [View] to a [List<Wireframe>] in order to be rendered in the Session Replay player.

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
@@ -69,7 +69,7 @@ internal class SnapshotProducerTest {
         val mockRoot: View = mock()
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.STOP_AND_DROP_NODE
+            TraversalStrategy.STOP_AND_DROP_NODE
         )
         whenever(mockTreeViewTraversal.traverse(eq(mockRoot), any(), any()))
             .thenReturn(fakeTraversedTreeView)
@@ -93,7 +93,7 @@ internal class SnapshotProducerTest {
         val fakeRoot = forge.aMockView<View>()
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.STOP_AND_RETURN_NODE
+            TraversalStrategy.STOP_AND_RETURN_NODE
         )
         whenever(mockTreeViewTraversal.traverse(eq(fakeRoot), any(), any()))
             .thenReturn(fakeTraversedTreeView)
@@ -118,7 +118,7 @@ internal class SnapshotProducerTest {
         val fakeRoot = forge.aMockViewWithChildren(2, 0, 2)
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.STOP_AND_RETURN_NODE
+            TraversalStrategy.STOP_AND_RETURN_NODE
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any()))
             .thenReturn(fakeTraversedTreeView)
@@ -143,7 +143,7 @@ internal class SnapshotProducerTest {
         val fakeRoot = forge.aMockViewWithChildren(2, 0, 2)
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any()))
             .thenReturn(fakeTraversedTreeView)
@@ -172,7 +172,7 @@ internal class SnapshotProducerTest {
         }
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any())).thenReturn(fakeTraversedTreeView)
 
@@ -204,7 +204,7 @@ internal class SnapshotProducerTest {
         }
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any())).thenReturn(fakeTraversedTreeView)
         whenever(mockOptionSelectorDetector.isOptionSelector(mockRoot)).thenReturn(true)
@@ -237,7 +237,7 @@ internal class SnapshotProducerTest {
         }
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any())).thenReturn(fakeTraversedTreeView)
         whenever(mockOptionSelectorDetector.isOptionSelector(mockRoot)).thenReturn(false)
@@ -267,14 +267,14 @@ internal class SnapshotProducerTest {
         val fakeRoot = forge.aMockViewWithChildren(2, 0, 2)
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any()))
             .thenReturn(fakeTraversedTreeView)
             .thenReturn(
                 fakeTraversedTreeView.copy(
                     nextActionStrategy =
-                    TreeViewTraversal.TraversalStrategy.STOP_AND_RETURN_NODE
+                    TraversalStrategy.STOP_AND_RETURN_NODE
                 )
             )
         var expectedSnapshot = fakeRoot.toNode(viewMappedWireframes = fakeViewWireframes)
@@ -303,14 +303,14 @@ internal class SnapshotProducerTest {
         val fakeRoot = forge.aMockViewWithChildren(2, 0, 2)
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any()))
             .thenReturn(fakeTraversedTreeView)
             .thenReturn(
                 fakeTraversedTreeView.copy(
                     nextActionStrategy =
-                    TreeViewTraversal.TraversalStrategy.STOP_AND_DROP_NODE
+                    TraversalStrategy.STOP_AND_DROP_NODE
                 )
             )
         val expectedSnapshot = fakeRoot.toNode(viewMappedWireframes = fakeViewWireframes)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversalTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversalTest.kt
@@ -121,7 +121,7 @@ internal class TreeViewTraversalTest {
         // Then
         assertThat(traversedTreeView.mappedWireframes).isEqualTo(fakeViewMappedWireframes)
         assertThat(traversedTreeView.nextActionStrategy)
-            .isEqualTo(TreeViewTraversal.TraversalStrategy.STOP_AND_RETURN_NODE)
+            .isEqualTo(TraversalStrategy.STOP_AND_RETURN_NODE)
     }
 
     @Test
@@ -161,7 +161,7 @@ internal class TreeViewTraversalTest {
         // Then
         assertThat(traversedTreeView.mappedWireframes).isEqualTo(fakeViewMappedWireframes)
         assertThat(traversedTreeView.nextActionStrategy)
-            .isEqualTo(TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN)
+            .isEqualTo(TraversalStrategy.TRAVERSE_ALL_CHILDREN)
     }
 
     @Test
@@ -193,7 +193,7 @@ internal class TreeViewTraversalTest {
         // Then
         assertThat(traversedTreeView.mappedWireframes).isEqualTo(fakeViewMappedWireframes)
         assertThat(traversedTreeView.nextActionStrategy)
-            .isEqualTo(TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN)
+            .isEqualTo(TraversalStrategy.TRAVERSE_ALL_CHILDREN)
     }
 
     @Test
@@ -226,7 +226,7 @@ internal class TreeViewTraversalTest {
         // Then
         assertThat(traversedTreeView.mappedWireframes).isEqualTo(fakeViewMappedWireframes)
         assertThat(traversedTreeView.nextActionStrategy)
-            .isEqualTo(TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN)
+            .isEqualTo(TraversalStrategy.TRAVERSE_ALL_CHILDREN)
     }
 
     // endregion
@@ -250,7 +250,7 @@ internal class TreeViewTraversalTest {
         // Then
         assertThat(traversedTreeView.mappedWireframes).isEmpty()
         assertThat(traversedTreeView.nextActionStrategy)
-            .isEqualTo(TreeViewTraversal.TraversalStrategy.STOP_AND_DROP_NODE)
+            .isEqualTo(TraversalStrategy.STOP_AND_DROP_NODE)
     }
 
     // endregion
@@ -274,7 +274,7 @@ internal class TreeViewTraversalTest {
         // Then
         assertThat(traversedTreeView.mappedWireframes).isEmpty()
         assertThat(traversedTreeView.nextActionStrategy)
-            .isEqualTo(TreeViewTraversal.TraversalStrategy.STOP_AND_DROP_NODE)
+            .isEqualTo(TraversalStrategy.STOP_AND_DROP_NODE)
     }
 
     // endregion


### PR DESCRIPTION
### What and why?

_This is a draft PR to get feedback on the implementation and possible improvements._

Currently `customMappers` will always return with a `TraversalStrategy.STOP_AND_RETURN_NODE`. This is a problem when mapping View-like elements in a custom mapper, we want to instead traverse all children:

```kotlin
// features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt

// try to resolve from the exhaustive type mappers
val exhaustiveTypeMapper = mappers.findFirstForType(view::class.java)

if (exhaustiveTypeMapper != null) {
    val queueableViewMapper = QueueableViewMapper(exhaustiveTypeMapper, recordedDataQueueRefs)
    traversalStrategy = TraversalStrategy.STOP_AND_RETURN_NODE
    resolvedWireframes = queueableViewMapper.map(view, mappingContext)
} else if (isDecorView(view)) {
    traversalStrategy = TraversalStrategy.TRAVERSE_ALL_CHILDREN
    resolvedWireframes = decorViewMapper.map(view, mappingContext)
} else {
    traversalStrategy = TraversalStrategy.TRAVERSE_ALL_CHILDREN
    resolvedWireframes = viewMapper.map(view, mappingContext)
}
```

The idea applied here is to add a `traversalStrategy` property to mappers (`STOP_AND_RETURN_NODE` by default) to be able to override it in case of custom view mappers.

There are a few options I did not explore yet:
- add customViewMapper option for viewMappers that would set a TRAVERSE_ALL_CHILDREN traversal strategy
- add a parameter to specify the type of custom mappers

I think this solution is the easiest one to implement, and the easiest one to refactor if we ever change the way the mappers are applied.

