### PR TITLE
RUM-1613 Add mapper interface for traversing all children

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -43,6 +43,7 @@ class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskTextViewMap
 open class com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper : BaseAsyncBackgroundWireframeMapper<android.widget.TextView>
   constructor()
   override fun map(android.widget.TextView, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.internal.AsyncJobStatusCallback): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
+interface com.datadog.android.sessionreplay.internal.recorder.mapper.TraverseAllChildrenMapper<T: android.view.View, S: com.datadog.android.sessionreplay.model.MobileSegment.Wireframe> : WireframeMapper<T, S>
 interface com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper<T: android.view.View, S: com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
   fun map(T, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.internal.AsyncJobStatusCallback = NoOpAsyncJobStatusCallback()): List<S>
 object com.datadog.android.sessionreplay.utils.StringUtils

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -131,6 +131,9 @@ public class com/datadog/android/sessionreplay/internal/recorder/mapper/TextView
 	public fun map (Landroid/widget/TextView;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/internal/AsyncJobStatusCallback;)Ljava/util/List;
 }
 
+public abstract interface class com/datadog/android/sessionreplay/internal/recorder/mapper/TraverseAllChildrenMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper {
+}
+
 public abstract interface class com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper {
 	public abstract fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/internal/AsyncJobStatusCallback;)Ljava/util/List;
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -41,17 +41,17 @@ internal class SnapshotProducer(
         val traversedTreeView = treeViewTraversal.traverse(view, mappingContext, recordedDataQueueRefs)
         val nextTraversalStrategy = traversedTreeView.nextActionStrategy
         val resolvedWireframes = traversedTreeView.mappedWireframes
-        if (nextTraversalStrategy == TreeViewTraversal.TraversalStrategy.STOP_AND_DROP_NODE) {
+        if (nextTraversalStrategy == TraversalStrategy.STOP_AND_DROP_NODE) {
             return null
         }
-        if (nextTraversalStrategy == TreeViewTraversal.TraversalStrategy.STOP_AND_RETURN_NODE) {
+        if (nextTraversalStrategy == TraversalStrategy.STOP_AND_RETURN_NODE) {
             return Node(wireframes = resolvedWireframes, parents = parents)
         }
 
         val childNodes = LinkedList<Node>()
         if (view is ViewGroup &&
             view.childCount > 0 &&
-            nextTraversalStrategy == TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            nextTraversalStrategy == TraversalStrategy.TRAVERSE_ALL_CHILDREN
         ) {
             val childMappingContext = resolveChildMappingContext(view, mappingContext)
             val parentsCopy = LinkedList(parents).apply { addAll(resolvedWireframes) }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TraverseAllChildrenMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TraverseAllChildrenMapper.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.mapper
+
+import android.view.View
+import com.datadog.android.sessionreplay.model.MobileSegment
+
+/**
+ * Maps a View to a [List] of [MobileSegment.Wireframe].
+ * This is mainly used internally by the SDK but if you want to provide a different
+ * Session Replay representation for a specific View type you can implement this on your end.
+ * Note that mappers using this interface also traverse all the children of the view
+ * instead of just the immediate one. This means that you will need to have mappers
+ * for all child views of the view the mapper is traversing.
+ */
+interface TraverseAllChildrenMapper<in T : View, out S : MobileSegment.Wireframe> :
+    WireframeMapper<T, S>

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
@@ -69,7 +69,7 @@ internal class SnapshotProducerTest {
         val mockRoot: View = mock()
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.STOP_AND_DROP_NODE
+            TraversalStrategy.STOP_AND_DROP_NODE
         )
         whenever(mockTreeViewTraversal.traverse(eq(mockRoot), any(), any()))
             .thenReturn(fakeTraversedTreeView)
@@ -93,7 +93,7 @@ internal class SnapshotProducerTest {
         val fakeRoot = forge.aMockView<View>()
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.STOP_AND_RETURN_NODE
+            TraversalStrategy.STOP_AND_RETURN_NODE
         )
         whenever(mockTreeViewTraversal.traverse(eq(fakeRoot), any(), any()))
             .thenReturn(fakeTraversedTreeView)
@@ -118,7 +118,7 @@ internal class SnapshotProducerTest {
         val fakeRoot = forge.aMockViewWithChildren(2, 0, 2)
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.STOP_AND_RETURN_NODE
+            TraversalStrategy.STOP_AND_RETURN_NODE
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any()))
             .thenReturn(fakeTraversedTreeView)
@@ -143,7 +143,7 @@ internal class SnapshotProducerTest {
         val fakeRoot = forge.aMockViewWithChildren(2, 0, 2)
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any()))
             .thenReturn(fakeTraversedTreeView)
@@ -172,7 +172,7 @@ internal class SnapshotProducerTest {
         }
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any())).thenReturn(fakeTraversedTreeView)
 
@@ -204,7 +204,7 @@ internal class SnapshotProducerTest {
         }
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any())).thenReturn(fakeTraversedTreeView)
         whenever(mockOptionSelectorDetector.isOptionSelector(mockRoot)).thenReturn(true)
@@ -237,7 +237,7 @@ internal class SnapshotProducerTest {
         }
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any())).thenReturn(fakeTraversedTreeView)
         whenever(mockOptionSelectorDetector.isOptionSelector(mockRoot)).thenReturn(false)
@@ -267,14 +267,14 @@ internal class SnapshotProducerTest {
         val fakeRoot = forge.aMockViewWithChildren(2, 0, 2)
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any()))
             .thenReturn(fakeTraversedTreeView)
             .thenReturn(
                 fakeTraversedTreeView.copy(
                     nextActionStrategy =
-                    TreeViewTraversal.TraversalStrategy.STOP_AND_RETURN_NODE
+                    TraversalStrategy.STOP_AND_RETURN_NODE
                 )
             )
         var expectedSnapshot = fakeRoot.toNode(viewMappedWireframes = fakeViewWireframes)
@@ -303,14 +303,14 @@ internal class SnapshotProducerTest {
         val fakeRoot = forge.aMockViewWithChildren(2, 0, 2)
         val fakeTraversedTreeView = TreeViewTraversal.TraversedTreeView(
             fakeViewWireframes,
-            TreeViewTraversal.TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            TraversalStrategy.TRAVERSE_ALL_CHILDREN
         )
         whenever(mockTreeViewTraversal.traverse(any(), any(), any()))
             .thenReturn(fakeTraversedTreeView)
             .thenReturn(
                 fakeTraversedTreeView.copy(
                     nextActionStrategy =
-                    TreeViewTraversal.TraversalStrategy.STOP_AND_DROP_NODE
+                    TraversalStrategy.STOP_AND_DROP_NODE
                 )
             )
         val expectedSnapshot = fakeRoot.toNode(viewMappedWireframes = fakeViewWireframes)


### PR DESCRIPTION
### What does this PR do?
Add an internal interface for mappers that need to traverse all children during tree traversal.

### Motivation
This interface is to be used by React Native for traversing RN view groups, as preparation for implementing Session Replay there.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

