### PR TITLE
RUM-1983 Introduce the BatchProcessingLevel API

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,7 +131,7 @@ tasks.register("buildNdkIntegrationTestsArtifacts") {
     dependsOn(":instrumented:integration:assembleDebug")
 }
 
-nightlyTestsCoverageConfig(threshold = 0.86f)
+nightlyTestsCoverageConfig(threshold = 0.85f)
 
 tasks.register("printSdkDebugRuntimeClasspath") {
     val fileTreeClassPathCollector = UnionFileTree(

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -132,7 +132,7 @@ interface com.datadog.android.api.storage.EventBatchWriter
   fun currentMetadata(): ByteArray?
   fun write(RawBatchEvent, ByteArray?): Boolean
 data class com.datadog.android.api.storage.FeatureStorageConfiguration
-  constructor(Long, Int, Long, Long, com.datadog.android.core.configuration.UploadFrequency?, com.datadog.android.core.configuration.BatchSize?)
+  constructor(Long, Int, Long, Long, com.datadog.android.core.configuration.UploadFrequency?, com.datadog.android.core.configuration.BatchSize?, com.datadog.android.core.configuration.BatchProcessingLevel?)
   companion object 
     val DEFAULT: FeatureStorageConfiguration
 data class com.datadog.android.api.storage.RawBatchEvent
@@ -153,6 +153,11 @@ class com.datadog.android.core.SdkReference
   constructor(String? = null, (com.datadog.android.api.SdkCore) -> Unit = {})
   fun get(): com.datadog.android.api.SdkCore?
 fun <T> allowThreadDiskReads(() -> T): T
+enum com.datadog.android.core.configuration.BatchProcessingLevel
+  constructor(Int)
+  - LOW
+  - MEDIUM
+  - HIGH
 enum com.datadog.android.core.configuration.BatchSize
   constructor(Long)
   - SMALL
@@ -168,6 +173,7 @@ data class com.datadog.android.core.configuration.Configuration
     fun useSite(com.datadog.android.DatadogSite): Builder
     fun setBatchSize(BatchSize): Builder
     fun setUploadFrequency(UploadFrequency): Builder
+    fun setBatchProcessingLevel(BatchProcessingLevel): Builder
     fun setAdditionalConfiguration(Map<String, Any>): Builder
     fun setProxy(java.net.Proxy, okhttp3.Authenticator?): Builder
     fun setEncryption(com.datadog.android.security.Encryption): Builder

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -395,16 +395,18 @@ public abstract interface class com/datadog/android/api/storage/EventBatchWriter
 
 public final class com/datadog/android/api/storage/FeatureStorageConfiguration {
 	public static final field Companion Lcom/datadog/android/api/storage/FeatureStorageConfiguration$Companion;
-	public fun <init> (JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;)V
+	public fun <init> (JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;Lcom/datadog/android/core/configuration/BatchProcessingLevel;)V
 	public final fun component1 ()J
 	public final fun component2 ()I
 	public final fun component3 ()J
 	public final fun component4 ()J
 	public final fun component5 ()Lcom/datadog/android/core/configuration/UploadFrequency;
 	public final fun component6 ()Lcom/datadog/android/core/configuration/BatchSize;
-	public final fun copy (JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/api/storage/FeatureStorageConfiguration;JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;ILjava/lang/Object;)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
+	public final fun component7 ()Lcom/datadog/android/core/configuration/BatchProcessingLevel;
+	public final fun copy (JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;Lcom/datadog/android/core/configuration/BatchProcessingLevel;)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/api/storage/FeatureStorageConfiguration;JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;Lcom/datadog/android/core/configuration/BatchProcessingLevel;ILjava/lang/Object;)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBatchProcessingLevel ()Lcom/datadog/android/core/configuration/BatchProcessingLevel;
 	public final fun getBatchSize ()Lcom/datadog/android/core/configuration/BatchSize;
 	public final fun getMaxBatchSize ()J
 	public final fun getMaxItemSize ()J
@@ -457,6 +459,15 @@ public final class com/datadog/android/core/StrictModeExtKt {
 	public static final fun allowThreadDiskReads (Lkotlin/jvm/functions/Function0;)Ljava/lang/Object;
 }
 
+public final class com/datadog/android/core/configuration/BatchProcessingLevel : java/lang/Enum {
+	public static final field HIGH Lcom/datadog/android/core/configuration/BatchProcessingLevel;
+	public static final field LOW Lcom/datadog/android/core/configuration/BatchProcessingLevel;
+	public static final field MEDIUM Lcom/datadog/android/core/configuration/BatchProcessingLevel;
+	public final fun getMaxBatchesPerUploadJob ()I
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/configuration/BatchProcessingLevel;
+	public static fun values ()[Lcom/datadog/android/core/configuration/BatchProcessingLevel;
+}
+
 public final class com/datadog/android/core/configuration/BatchSize : java/lang/Enum {
 	public static final field LARGE Lcom/datadog/android/core/configuration/BatchSize;
 	public static final field MEDIUM Lcom/datadog/android/core/configuration/BatchSize;
@@ -481,6 +492,7 @@ public final class com/datadog/android/core/configuration/Configuration$Builder 
 	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun build ()Lcom/datadog/android/core/configuration/Configuration;
 	public final fun setAdditionalConfiguration (Ljava/util/Map;)Lcom/datadog/android/core/configuration/Configuration$Builder;
+	public final fun setBatchProcessingLevel (Lcom/datadog/android/core/configuration/BatchProcessingLevel;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setBatchSize (Lcom/datadog/android/core/configuration/BatchSize;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setCrashReportsEnabled (Z)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setEncryption (Lcom/datadog/android/security/Encryption;)Lcom/datadog/android/core/configuration/Configuration$Builder;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/FeatureStorageConfiguration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/FeatureStorageConfiguration.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.api.storage
 
+import com.datadog.android.core.configuration.BatchProcessingLevel
 import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.UploadFrequency
 
@@ -18,8 +19,10 @@ import com.datadog.android.core.configuration.UploadFrequency
  * old to be uploaded (usually because it'll be discarded at ingestion by the backend)
  * @property uploadFrequency the desired upload frequency policy. If not explicitly provided this
  * value will be taken from core configuration.
- * @property batchSize the desired batch size policy.If not explicitly provided this
+ * @property batchSize the desired batch size policy. If not explicitly provided this
  * value will be taken from core configuration.
+ * @property batchProcessingLevel the desired batch processing level policy.
+ * If not explicitly provided this value will be taken from core configuration.
  */
 data class FeatureStorageConfiguration(
     val maxItemSize: Long,
@@ -27,7 +30,8 @@ data class FeatureStorageConfiguration(
     val maxBatchSize: Long,
     val oldBatchThreshold: Long,
     val uploadFrequency: UploadFrequency?,
-    val batchSize: BatchSize?
+    val batchSize: BatchSize?,
+    val batchProcessingLevel: BatchProcessingLevel?
 ) {
     companion object {
 
@@ -47,7 +51,8 @@ data class FeatureStorageConfiguration(
             // 18 hours
             oldBatchThreshold = 18L * 60L * 60L * 1000L,
             uploadFrequency = null,
-            batchSize = null
+            batchSize = null,
+            batchProcessingLevel = null
         )
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/BatchProcessingLevel.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/BatchProcessingLevel.kt
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.configuration
+
+/**
+ * Defines the policy for sending the batches.
+ * High level will mean that more data will be sent in a single upload cycle but more CPU and memory
+ * will be used to process the data.
+ * Low level will mean that less data will be sent in a single upload cycle but less CPU and memory
+ * will be used to process the data.
+ * @param maxBatchesPerUploadJob the maximum number of batches that will be sent in a single upload
+ * cycle.
+ */
+@Suppress("MagicNumber")
+enum class BatchProcessingLevel(val maxBatchesPerUploadJob: Int) {
+    /**
+     * Only 1 batch will be sent in a single upload cycle.
+     */
+    LOW(maxBatchesPerUploadJob = 1),
+
+    /**
+     * 10 batches will be sent in a single upload cycle.
+     */
+    MEDIUM(maxBatchesPerUploadJob = 10),
+
+    /**
+     * 100 batches will be sent in a single upload cycle.
+     */
+    HIGH(maxBatchesPerUploadJob = 100)
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -38,7 +38,8 @@ internal constructor(
         val proxy: Proxy?,
         val proxyAuth: Authenticator,
         val encryption: Encryption?,
-        val site: DatadogSite
+        val site: DatadogSite,
+        val batchProcessingLevel: BatchProcessingLevel
     )
 
     // region Builder
@@ -167,6 +168,18 @@ internal constructor(
         }
 
         /**
+         * Defines the Batch processing level, defining the maximum number of batches processed
+         * sequentially without a delay within one reading/uploading cycle.
+         * @param batchProcessingLevel the desired batch processing level. By default it's set to
+         * [BatchProcessingLevel.MEDIUM].
+         * @see BatchProcessingLevel
+         */
+        fun setBatchProcessingLevel(batchProcessingLevel: BatchProcessingLevel): Builder {
+            coreConfig = coreConfig.copy(batchProcessingLevel = batchProcessingLevel)
+            return this
+        }
+
+        /**
          * Allows to provide additional configuration values which can be used by the SDK.
          * @param additionalConfig Additional configuration values.
          */
@@ -238,7 +251,8 @@ internal constructor(
             proxy = null,
             proxyAuth = Authenticator.NONE,
             encryption = null,
-            site = DatadogSite.US1
+            site = DatadogSite.US1,
+            batchProcessingLevel = BatchProcessingLevel.MEDIUM
         )
 
         internal const val NETWORK_REQUESTS_TRACKING_FEATURE_NAME = "Network requests"

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -18,6 +18,7 @@ import com.datadog.android.BuildConfig
 import com.datadog.android.DatadogSite
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.allowThreadDiskReads
+import com.datadog.android.core.configuration.BatchProcessingLevel
 import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.configuration.UploadFrequency
@@ -129,6 +130,7 @@ internal class CoreFeature(
     internal var variant: String = ""
     internal var batchSize: BatchSize = BatchSize.MEDIUM
     internal var uploadFrequency: UploadFrequency = UploadFrequency.AVERAGE
+    internal var batchProcessingLevel: BatchProcessingLevel = BatchProcessingLevel.MEDIUM
     internal var ndkCrashHandler: NdkCrashHandler = NoOpNdkCrashHandler()
     internal var site: DatadogSite = DatadogSite.US1
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/configuration/DataUploadConfiguration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/configuration/DataUploadConfiguration.kt
@@ -8,10 +8,14 @@ package com.datadog.android.core.internal.configuration
 
 import com.datadog.android.core.configuration.UploadFrequency
 
-internal data class DataUploadConfiguration(internal val frequency: UploadFrequency) {
+internal data class DataUploadConfiguration(
+    internal val frequency: UploadFrequency,
+    internal val maxBatchesPerUploadJob: Int
+) {
     internal val minDelayMs = MIN_DELAY_FACTOR * frequency.baseStepMs
     internal val maxDelayMs = MAX_DELAY_FACTOR * frequency.baseStepMs
     internal val defaultDelayMs = DEFAULT_DELAY_FACTOR * frequency.baseStepMs
+
     companion object {
         internal const val MIN_DELAY_FACTOR = 1
         internal const val MAX_DELAY_FACTOR = 10

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnable.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnable.kt
@@ -44,38 +44,31 @@ internal class DataUploadRunnable(
     internal var currentDelayIntervalMs = uploadConfiguration.defaultDelayMs
     internal val minDelayMs = uploadConfiguration.minDelayMs
     internal val maxDelayMs = uploadConfiguration.maxDelayMs
+    internal val maxBatchesPerJob = uploadConfiguration.maxBatchesPerUploadJob
 
     //  region Runnable
 
     @WorkerThread
-    @Suppress("UnsafeThirdPartyFunctionCall") // called inside a dedicated executor
     override fun run() {
         if (isNetworkAvailable() && isSystemReady()) {
             val context = contextProvider.context
             // TODO RUMM-0000 it should be already on the worker thread and if readNextBatch is async,
             //  we should wait until it completes before scheduling further
-            val lock = CountDownLatch(1)
-            storage.readNextBatch(
-                noBatchCallback = {
-                    increaseInterval()
-                    lock.countDown()
-                }
-            ) { batchId, reader ->
-                try {
-                    val batch = reader.read()
-                    val batchMeta = reader.currentMetadata()
-
-                    consumeBatch(
-                        context,
-                        batchId,
-                        batch,
-                        batchMeta
-                    )
-                } finally {
-                    lock.countDown()
-                }
+            var batchConsumerAvailableAttempts = maxBatchesPerJob
+            var lastBatchUploadStatus: UploadStatus?
+            do {
+                batchConsumerAvailableAttempts--
+                lastBatchUploadStatus = handleNextBatch(context)
+            } while (batchConsumerAvailableAttempts > 0 &&
+                lastBatchUploadStatus is UploadStatus.Success
+            )
+            if (lastBatchUploadStatus != null) {
+                handleBatchConsumingJobFrequency(lastBatchUploadStatus)
+            } else {
+                // there was no batch left or there was a problem reading the next batch
+                // in the storage so we increase the interval
+                increaseInterval()
             }
-            lock.await(batchUploadWaitTimeoutMs, TimeUnit.MILLISECONDS)
         }
 
         scheduleNextUpload()
@@ -84,6 +77,42 @@ internal class DataUploadRunnable(
     // endregion
 
     // region Internal
+
+    private fun handleBatchConsumingJobFrequency(lastBatchUploadStatus: UploadStatus) {
+        if (lastBatchUploadStatus.shouldRetry) {
+            increaseInterval()
+        } else {
+            decreaseInterval()
+        }
+    }
+
+    @WorkerThread
+    @Suppress("UnsafeThirdPartyFunctionCall") // called inside a dedicated executor
+    private fun handleNextBatch(context: DatadogContext): UploadStatus? {
+        var uploadStatus: UploadStatus? = null
+        val lock = CountDownLatch(1)
+        storage.readNextBatch(
+            noBatchCallback = {
+                lock.countDown()
+            }
+        ) { batchId, reader ->
+            try {
+                val batch = reader.read()
+                val batchMeta = reader.currentMetadata()
+
+                uploadStatus = consumeBatch(
+                    context,
+                    batchId,
+                    batch,
+                    batchMeta
+                )
+            } finally {
+                lock.countDown()
+            }
+        }
+        lock.await(batchUploadWaitTimeoutMs, TimeUnit.MILLISECONDS)
+        return uploadStatus
+    }
 
     private fun isNetworkAvailable(): Boolean {
         val networkInfo = networkInfoProvider.getLatestNetworkInfo()
@@ -115,7 +144,7 @@ internal class DataUploadRunnable(
         batchId: BatchId,
         batch: List<RawBatchEvent>,
         batchMeta: ByteArray?
-    ) {
+    ): UploadStatus {
         val status = dataUploader.upload(context, batch, batchMeta)
         val removalReason = if (status is UploadStatus.RequestCreationError) {
             RemovalReason.Invalid
@@ -123,14 +152,9 @@ internal class DataUploadRunnable(
             RemovalReason.IntakeCode(status.code)
         }
         storage.confirmBatchRead(batchId, removalReason) {
-            if (status.shouldRetry) {
-                it.markAsRead(false)
-                increaseInterval()
-            } else {
-                it.markAsRead(true)
-                decreaseInterval()
-            }
+            it.markAsRead(deleteBatch = !status.shouldRetry)
         }
+        return status
     }
 
     @Suppress("UnsafeThirdPartyFunctionCall") // rounded Double isn't NaN

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -72,7 +72,8 @@ internal class ConfigurationBuilderTest {
                 proxy = null,
                 proxyAuth = Authenticator.NONE,
                 encryption = null,
-                site = DatadogSite.US1
+                site = DatadogSite.US1,
+                batchProcessingLevel = BatchProcessingLevel.MEDIUM
             )
         )
         assertThat(config.crashReportsEnabled).isTrue

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/configuration/DataUploadConfigurationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/configuration/DataUploadConfigurationTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal.configuration
 
 import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -34,8 +35,11 @@ internal class DataUploadConfigurationTest {
     lateinit var testedConfiguration: DataUploadConfiguration
 
     @BeforeEach
-    fun `set up`() {
-        testedConfiguration = DataUploadConfiguration(fakeUploadFrequency)
+    fun `set up`(forge: Forge) {
+        testedConfiguration = DataUploadConfiguration(
+            fakeUploadFrequency,
+            forge.anInt()
+        )
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnableTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/v2/DataUploadRunnableTest.kt
@@ -36,12 +36,14 @@ import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.MethodSource
 import org.mockito.Mock
+import org.mockito.invocation.InvocationOnMock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doReturnConsecutively
 import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -52,9 +54,12 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import org.mockito.stubbing.Answer
 import java.util.concurrent.ScheduledThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
+// TODO: RUM-2014 Simplify / Refactor these tests when we're going to switch to the
+// sync API for uploading data
 @Extensions(
     ExtendWith(MockitoExtension::class),
     ExtendWith(ForgeExtension::class)
@@ -90,10 +95,14 @@ internal class DataUploadRunnableTest {
     @Forgery
     lateinit var fakeDataUploadConfiguration: DataUploadConfiguration
 
+    private var expectedBatchesHandled: Int = 0
+
     private lateinit var testedRunnable: DataUploadRunnable
 
     @BeforeEach
     fun `set up`(forge: Forge) {
+        // to make sure the existing tests based only on 1 batch are not broken
+        fakeDataUploadConfiguration = fakeDataUploadConfiguration.copy(maxBatchesPerUploadJob = 1)
         val fakeNetworkInfo =
             NetworkInfo(
                 forge.aValueFrom(
@@ -101,6 +110,7 @@ internal class DataUploadRunnableTest {
                     exclude = listOf(NetworkInfo.Connectivity.NETWORK_NOT_CONNECTED)
                 )
             )
+        expectedBatchesHandled = fakeDataUploadConfiguration.maxBatchesPerUploadJob
         whenever(mockNetworkInfoProvider.getLatestNetworkInfo()) doReturn fakeNetworkInfo
         val fakeSystemInfo = SystemInfo(
             batteryFullOrCharging = true,
@@ -191,8 +201,8 @@ internal class DataUploadRunnableTest {
         // Then
         verify(batchConfirmation).markAsRead(true)
         verifyNoMoreInteractions(batchConfirmation)
-        verify(batchReader).read()
-        verify(mockDataUploader).upload(fakeContext, batch, batchMetadata)
+        verify(batchReader, times(expectedBatchesHandled)).read()
+        verify(mockDataUploader, times(expectedBatchesHandled)).upload(fakeContext, batch, batchMetadata)
         verify(mockThreadPoolExecutor).schedule(
             same(testedRunnable),
             any(),
@@ -243,10 +253,11 @@ internal class DataUploadRunnableTest {
         testedRunnable.run()
 
         // Then
-        verify(batchConfirmation).markAsRead(true)
+        verify(batchConfirmation, times(expectedBatchesHandled)).markAsRead(true)
         verifyNoMoreInteractions(batchConfirmation)
-        verify(batchReader).read()
-        verify(mockDataUploader).upload(fakeContext, batch, batchMetadata)
+        verify(batchReader, times(expectedBatchesHandled)).read()
+        verify(mockDataUploader, times(expectedBatchesHandled))
+            .upload(fakeContext, batch, batchMetadata)
         verify(mockThreadPoolExecutor).schedule(
             same(testedRunnable),
             any(),
@@ -296,10 +307,11 @@ internal class DataUploadRunnableTest {
         testedRunnable.run()
 
         // Then
-        verify(batchConfirmation).markAsRead(true)
+        verify(batchConfirmation, times(expectedBatchesHandled)).markAsRead(true)
         verifyNoMoreInteractions(batchConfirmation)
-        verify(batchReader).read()
-        verify(mockDataUploader).upload(fakeContext, batch, batchMetadata)
+        verify(batchReader, times(expectedBatchesHandled)).read()
+        verify(mockDataUploader, times(expectedBatchesHandled))
+            .upload(fakeContext, batch, batchMetadata)
         verify(mockThreadPoolExecutor).schedule(
             same(testedRunnable),
             any(),
@@ -462,10 +474,11 @@ internal class DataUploadRunnableTest {
         testedRunnable.run()
 
         // Then
-        verify(batchConfirmation).markAsRead(true)
+        verify(batchConfirmation, times(expectedBatchesHandled)).markAsRead(true)
         verifyNoMoreInteractions(batchConfirmation)
-        verify(batchReader).read()
-        verify(mockDataUploader).upload(fakeContext, batch, batchMetadata)
+        verify(batchReader, times(expectedBatchesHandled)).read()
+        verify(mockDataUploader, times(expectedBatchesHandled))
+            .upload(fakeContext, batch, batchMetadata)
         verify(mockThreadPoolExecutor).schedule(
             same(testedRunnable),
             any(),
@@ -509,10 +522,11 @@ internal class DataUploadRunnableTest {
         testedRunnable.run()
 
         // Then
-        verify(batchConfirmation).markAsRead(false)
+        verify(batchConfirmation, times(expectedBatchesHandled)).markAsRead(false)
         verifyNoMoreInteractions(batchConfirmation)
-        verify(batchReader).read()
-        verify(mockDataUploader).upload(fakeContext, batch, batchMetadata)
+        verify(batchReader, times(expectedBatchesHandled)).read()
+        verify(mockDataUploader, times(expectedBatchesHandled))
+            .upload(fakeContext, batch, batchMetadata)
         verify(mockThreadPoolExecutor).schedule(
             same(testedRunnable),
             any(),
@@ -558,10 +572,12 @@ internal class DataUploadRunnableTest {
         }
 
         // Then
-        verify(batchConfirmation, times(runCount)).markAsRead(false)
+        verify(batchConfirmation, times(runCount))
+            .markAsRead(false)
         verifyNoMoreInteractions(batchConfirmation)
-        verify(batchReader, times(runCount)).read()
-        verify(mockDataUploader, times(runCount)).upload(fakeContext, batch, batchMetadata)
+        verify(batchReader, times(runCount * expectedBatchesHandled)).read()
+        verify(mockDataUploader, times(runCount * expectedBatchesHandled))
+            .upload(fakeContext, batch, batchMetadata)
         verify(mockThreadPoolExecutor, times(runCount)).schedule(
             same(testedRunnable),
             any(),
@@ -604,10 +620,11 @@ internal class DataUploadRunnableTest {
         testedRunnable.run()
 
         // Then
-        verify(batchConfirmation).markAsRead(true)
+        verify(batchConfirmation, times(expectedBatchesHandled)).markAsRead(true)
         verifyNoMoreInteractions(batchConfirmation)
-        verify(batchReader).read()
-        verify(mockDataUploader).upload(fakeContext, batch, batchMetadata)
+        verify(batchReader, times(expectedBatchesHandled)).read()
+        verify(mockDataUploader, times(expectedBatchesHandled))
+            .upload(fakeContext, batch, batchMetadata)
         verify(mockThreadPoolExecutor).schedule(
             same(testedRunnable),
             any(),
@@ -651,7 +668,10 @@ internal class DataUploadRunnableTest {
 
         // Then
         val captor = argumentCaptor<Long>()
-        verify(mockThreadPoolExecutor, times(5))
+        verify(
+            mockThreadPoolExecutor,
+            times(5 * expectedBatchesHandled)
+        )
             .schedule(same(testedRunnable), captor.capture(), eq(TimeUnit.MILLISECONDS))
         captor.allValues.reduce { previous, next ->
             assertThat(next).isLessThan(previous)
@@ -716,33 +736,50 @@ internal class DataUploadRunnableTest {
     @MethodSource("dropBatchStatusValues")
     fun `𝕄 reduce delay between runs 𝕎 batch fails and should be dropped`(
         uploadStatus: UploadStatus,
-        @Forgery batch: List<RawBatchEvent>,
-        @StringForgery batchMeta: String,
         @IntForgery(16, 64) runCount: Int,
-        forge: Forge
+        forge: Forge,
+        @Forgery fakeConfiguration: DataUploadConfiguration
     ) {
         // Given
-        val batchId = mock<BatchId>()
+        testedRunnable = DataUploadRunnable(
+            mockThreadPoolExecutor,
+            mockStorage,
+            mockDataUploader,
+            mockContextProvider,
+            mockNetworkInfoProvider,
+            mockSystemInfoProvider,
+            fakeConfiguration,
+            TEST_BATCH_UPLOAD_WAIT_TIMEOUT_MS,
+            mockInternalLogger
+        )
+        // extra batches to make sure we are not reaching the limit as this will fall into the
+        // else branch and increase the interval making the test to fail
+        val batches = forge.aList(size = runCount * fakeConfiguration.maxBatchesPerUploadJob + 10) {
+            aList { getForgery<RawBatchEvent>() }
+        }
+        val randomFailIndex = forge.anInt(min = 0, max = batches.size)
         val batchReader = mock<BatchReader>()
         val batchConfirmation = mock<BatchConfirmation>()
-        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
-
-        whenever(batchReader.read()) doReturn batch
-        whenever(batchReader.currentMetadata()) doReturn batchMetadata
-
-        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
-            }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        val batchMetadata = forge.aList(size = batches.size) {
+            aNullable { aString().toByteArray() }
         }
-        whenever(
-            mockDataUploader.upload(
-                fakeContext,
-                batch,
-                batchMetadata
-            )
-        ) doReturn uploadStatus
+
+        stubBatchReader(batchReader, batches, batchMetadata, batchConfirmation)
+
+        batches.forEachIndexed { index, batch ->
+            val expectedStatus = if (index == randomFailIndex) {
+                uploadStatus
+            } else {
+                forge.getForgery(UploadStatus.Success::class.java)
+            }
+            whenever(
+                mockDataUploader.upload(
+                    fakeContext,
+                    batch,
+                    batchMetadata[index]
+                )
+            ) doReturn expectedStatus
+        }
 
         // When
         repeat(runCount) {
@@ -802,33 +839,53 @@ internal class DataUploadRunnableTest {
     @MethodSource("retryBatchStatusValues")
     fun `𝕄 increase delay between runs 𝕎 batch fails and should be retried`(
         status: UploadStatus,
-        @IntForgery(16, 64) runCount: Int,
-        @Forgery batch: List<RawBatchEvent>,
-        @StringForgery batchMeta: String,
-        forge: Forge
+        @IntForgery(1, 10) runCount: Int,
+        forge: Forge,
+        @Forgery fakeConfiguration: DataUploadConfiguration
     ) {
         // Given
-        val batchId = mock<BatchId>()
+        testedRunnable = DataUploadRunnable(
+            mockThreadPoolExecutor,
+            mockStorage,
+            mockDataUploader,
+            mockContextProvider,
+            mockNetworkInfoProvider,
+            mockSystemInfoProvider,
+            fakeConfiguration,
+            TEST_BATCH_UPLOAD_WAIT_TIMEOUT_MS,
+            mockInternalLogger
+        )
+        val batches = forge.aList(size = runCount * fakeConfiguration.maxBatchesPerUploadJob) {
+            aList { getForgery<RawBatchEvent>() }
+        }
+        val failIndexesSet = mutableSetOf<Int>().apply {
+            var index = 0
+            repeat(runCount) {
+                add(index)
+                index += fakeConfiguration.maxBatchesPerUploadJob
+            }
+        }
         val batchReader = mock<BatchReader>()
         val batchConfirmation = mock<BatchConfirmation>()
-        val batchMetadata = forge.aNullable { batchMeta.toByteArray() }
-
-        whenever(batchReader.read()) doReturn batch
-        whenever(batchReader.currentMetadata()) doReturn batchMetadata
-
-        whenever(mockStorage.readNextBatch(any(), any())) doAnswer {
-            whenever(mockStorage.confirmBatchRead(eq(batchId), any(), any())) doAnswer {
-                it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
-            }
-            it.getArgument<(BatchId, BatchReader) -> Unit>(1).invoke(batchId, batchReader)
+        val batchMetadata = forge.aList(size = batches.size) {
+            aNullable { aString().toByteArray() }
         }
-        whenever(
-            mockDataUploader.upload(
-                fakeContext,
-                batch,
-                batchMetadata
-            )
-        ) doReturn status
+
+        stubBatchReader(batchReader, batches, batchMetadata, batchConfirmation)
+        batches.forEachIndexed { index, batch ->
+            val expectedStatus = if (index in failIndexesSet) {
+                status
+            } else {
+                forge.getForgery(UploadStatus.Success::class.java)
+            }
+            whenever(
+                mockDataUploader.upload(
+                    fakeContext,
+                    batch,
+                    batchMetadata[index]
+                )
+            ) doReturn expectedStatus
+        }
 
         // When
         repeat(runCount) {
@@ -913,6 +970,156 @@ internal class DataUploadRunnableTest {
             any(),
             eq(TimeUnit.MILLISECONDS)
         )
+    }
+
+    // endregion
+
+    // region maxBatchesPerJob
+
+    @Test
+    fun `𝕄 handle the maxBatchesPerJob W run{maxBatchesPerJob smaller availableBatches}`(
+        forge: Forge,
+        @Forgery fakeConfiguration: DataUploadConfiguration
+    ) {
+        // Given
+        testedRunnable = DataUploadRunnable(
+            mockThreadPoolExecutor,
+            mockStorage,
+            mockDataUploader,
+            mockContextProvider,
+            mockNetworkInfoProvider,
+            mockSystemInfoProvider,
+            fakeConfiguration,
+            TEST_BATCH_UPLOAD_WAIT_TIMEOUT_MS,
+            mockInternalLogger
+        )
+        val batches = forge.aList(
+            size = forge.anInt(
+                min = fakeConfiguration.maxBatchesPerUploadJob + 1,
+                max = fakeConfiguration.maxBatchesPerUploadJob + 1000
+            )
+        ) {
+            aList { getForgery<RawBatchEvent>() }
+        }
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchMetadata = forge.aList(size = batches.size) { aNullable { aString().toByteArray() } }
+        stubBatchReader(batchReader, batches, batchMetadata, batchConfirmation)
+        batches.forEachIndexed { index, batch ->
+            whenever(
+                mockDataUploader.upload(
+                    fakeContext,
+                    batch,
+                    batchMetadata[index]
+                )
+            ) doReturn forge.getForgery(UploadStatus.Success::class.java)
+        }
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        verify(batchConfirmation, times(fakeConfiguration.maxBatchesPerUploadJob))
+            .markAsRead(true)
+        verifyNoMoreInteractions(batchConfirmation)
+        verify(batchReader, times(fakeConfiguration.maxBatchesPerUploadJob)).read()
+        batches.take(fakeConfiguration.maxBatchesPerUploadJob).forEachIndexed { index, batch ->
+            verify(mockDataUploader).upload(fakeContext, batch, batchMetadata[index])
+        }
+        verifyNoMoreInteractions(mockDataUploader)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    @Test
+    fun `𝕄 exhaust the available batches W run {maxBatchesPerJob higher or equal availableBatches}`(
+        forge: Forge,
+        @Forgery fakeConfiguration: DataUploadConfiguration
+    ) {
+        // Given
+        testedRunnable = DataUploadRunnable(
+            mockThreadPoolExecutor,
+            mockStorage,
+            mockDataUploader,
+            mockContextProvider,
+            mockNetworkInfoProvider,
+            mockSystemInfoProvider,
+            fakeConfiguration,
+            TEST_BATCH_UPLOAD_WAIT_TIMEOUT_MS,
+            mockInternalLogger
+        )
+        val fakeBatchesCount = forge.anInt(
+            min = 1,
+            max = fakeConfiguration.maxBatchesPerUploadJob + 1
+        )
+        val batches = forge.aList(
+            size = fakeBatchesCount
+        ) { aList { getForgery<RawBatchEvent>() } }
+        val batchReader = mock<BatchReader>()
+        val batchConfirmation = mock<BatchConfirmation>()
+        val batchMetadata = forge.aList(size = batches.size) { aNullable { aString().toByteArray() } }
+        stubBatchReader(batchReader, batches, batchMetadata, batchConfirmation)
+        batches.forEachIndexed { index, batch ->
+            whenever(
+                mockDataUploader.upload(
+                    fakeContext,
+                    batch,
+                    batchMetadata[index]
+                )
+            ) doReturn forge.getForgery(UploadStatus.Success::class.java)
+        }
+
+        // When
+        testedRunnable.run()
+
+        // Then
+        val batchesCount = batches.size
+        verify(batchConfirmation, times(batchesCount)).markAsRead(true)
+        verifyNoMoreInteractions(batchConfirmation)
+        verify(batchReader, times(batchesCount)).read()
+        batches.forEachIndexed { index, batch ->
+            verify(mockDataUploader).upload(fakeContext, batch, batchMetadata[index])
+        }
+        verifyNoMoreInteractions(mockDataUploader)
+        verify(mockThreadPoolExecutor).schedule(
+            same(testedRunnable),
+            any(),
+            eq(TimeUnit.MILLISECONDS)
+        )
+    }
+
+    // region Internal
+
+    private fun stubBatchReader(
+        mockBatchReader: BatchReader,
+        batches: List<List<RawBatchEvent>>,
+        batchMeta: List<ByteArray?>,
+        batchConfirmation: BatchConfirmation
+    ) {
+        whenever(mockBatchReader.read()).doReturnConsecutively(batches)
+            .thenReturn(null)
+        whenever(mockBatchReader.currentMetadata()).doReturnConsecutively(batchMeta)
+            .thenReturn(null)
+        val batchId = mock<BatchId>()
+        whenever(mockStorage.readNextBatch(any(), any())) doAnswer object : Answer<Unit> {
+            var count = 0
+
+            override fun answer(invocation: InvocationOnMock) {
+                if (count >= batches.size) {
+                    invocation.getArgument<() -> Unit>(0).invoke()
+                } else {
+                    whenever(mockStorage.confirmBatchRead(any(), any(), any())) doAnswer {
+                        it.getArgument<(BatchConfirmation) -> Unit>(2).invoke(batchConfirmation)
+                    }
+                    invocation.getArgument<(BatchId, BatchReader) -> Unit>(1)
+                        .invoke(batchId, mockBatchReader)
+                }
+                count++
+            }
+        }
     }
 
     // endregion

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
@@ -41,7 +41,8 @@ internal class ConfigurationCoreForgeryFactory :
             proxy = proxy,
             proxyAuth = auth,
             encryption = forge.aNullable { NoOpEncryption() },
-            site = forge.aValueFrom(DatadogSite::class.java)
+            site = forge.aValueFrom(DatadogSite::class.java),
+            batchProcessingLevel = forge.getForgery()
         )
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/DataUploadConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/DataUploadConfigurationForgeryFactory.kt
@@ -14,6 +14,7 @@ import fr.xgouchet.elmyr.ForgeryFactory
 internal class DataUploadConfigurationForgeryFactory : ForgeryFactory<DataUploadConfiguration> {
     override fun getForgery(forge: Forge): DataUploadConfiguration {
         val frequency: UploadFrequency = forge.getForgery()
-        return DataUploadConfiguration(frequency)
+        // we limit the size to avoid OOM errors inside our tests
+        return DataUploadConfiguration(frequency, forge.anInt(min = 1, max = 200))
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/FeatureStorageConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/FeatureStorageConfigurationForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.core.configuration.BatchProcessingLevel
 import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.UploadFrequency
 import fr.xgouchet.elmyr.Forge
@@ -21,7 +22,8 @@ internal class FeatureStorageConfigurationForgeryFactory :
             maxItemSize = forge.aPositiveLong(),
             oldBatchThreshold = forge.aPositiveLong(),
             uploadFrequency = forge.aNullable { forge.aValueFrom(UploadFrequency::class.java) },
-            batchSize = forge.aNullable { forge.aValueFrom(BatchSize::class.java) }
+            batchSize = forge.aNullable { forge.aValueFrom(BatchSize::class.java) },
+            batchProcessingLevel = forge.aNullable { forge.aValueFrom(BatchProcessingLevel::class.java) }
         )
     }
 }


### PR DESCRIPTION
### What does this PR do?

Modifies the core logic to get a list of batches instead of single batch. It's done through a new configuration called BatchProcessingLevel that allows controlling the amount of batches processed sequentially without a delay within one reading/uploading cycle. Currently it exposed 3 levels: low, medium and high that translate to 1, 10 and 100 of batches processed. By default it's taking up to 10 batches in a cycle.

This logic improves the data upload when batch back pressure occurs.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

