### PR TITLE
RUM-1951 Improve performance with base64

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/Base64Serializer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/Base64Serializer.kt
@@ -16,13 +16,13 @@ import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.sessionreplay.internal.recorder.base64.Cache.Companion.DOES_NOT_IMPLEMENT_COMPONENTCALLBACKS
 import com.datadog.android.sessionreplay.internal.utils.Base64Utils
 import com.datadog.android.sessionreplay.internal.utils.DrawableUtils
 import com.datadog.android.sessionreplay.model.MobileSegment
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingDeque
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
@@ -49,21 +49,29 @@ internal class Base64Serializer private constructor(
         drawableWidth: Int,
         drawableHeight: Int,
         imageWireframe: MobileSegment.Wireframe.ImageWireframe,
-        callback: Base64SerializerCallback? = null
+        base64SerializerCallback: Base64SerializerCallback
     ) {
         registerCallbacks(applicationContext)
 
-        tryToGetBase64FromCache(drawable, imageWireframe, callback)
-            ?: tryToGetBitmapFromBitmapDrawable(drawable, imageWireframe, callback)
-            ?: tryToDrawNewBitmap(
-                drawable,
-                drawableWidth,
-                drawableHeight,
-                displayMetrics,
-                imageWireframe,
-                callback
+        tryToGetBase64FromCache(drawable, imageWireframe, base64SerializerCallback)
+            ?: tryToGetBitmapFromBitmapDrawable(
+                drawable = drawable,
+                displayMetrics = displayMetrics,
+                imageWireframe = imageWireframe,
+                base64SerializerCallback = base64SerializerCallback
             )
-            ?: callback?.onReady()
+            ?: tryToDrawNewBitmap(
+                drawable = drawable,
+                drawableWidth = drawableWidth,
+                drawableHeight = drawableHeight,
+                displayMetrics = displayMetrics,
+                imageWireframe = imageWireframe,
+                base64SerializerCallback = base64SerializerCallback,
+
+                // this parameter is used to avoid infinite recursion
+                // basically we only allow one attempt to recreate the bitmap
+                didCallOriginateFromFailover = false
+            )
     }
 
     // endregion
@@ -78,15 +86,31 @@ internal class Base64Serializer private constructor(
     // region private
 
     @WorkerThread
-    private fun serialiseBitmap(
+    private fun serializeBitmap(
         drawable: Drawable,
+        displayMetrics: DisplayMetrics,
         bitmap: Bitmap,
         shouldCacheBitmap: Boolean,
         imageWireframe: MobileSegment.Wireframe.ImageWireframe,
-        base64SerializerCallback: Base64SerializerCallback?
+        base64SerializerCallback: Base64SerializerCallback,
+
+        // this parameter is used to avoid infinite recursion
+        // basically we only allow one attempt to recreate the bitmap
+        didCallOriginateFromFailover: Boolean
     ) {
-        val base64String = convertBmpToBase64(drawable, bitmap, shouldCacheBitmap)
-        finalizeRecordedDataItem(base64String, imageWireframe, base64SerializerCallback)
+        val base64String = convertBitmapToBase64(
+            drawable = drawable,
+            displayMetrics = displayMetrics,
+            bitmap = bitmap,
+            shouldCacheBitmap = shouldCacheBitmap,
+            imageWireframe = imageWireframe,
+            base64SerializerCallback = base64SerializerCallback,
+            didCallOriginateFromFailover = didCallOriginateFromFailover
+        )
+
+        if (base64String.isNotEmpty()) {
+            finalizeRecordedDataItem(base64String, imageWireframe, base64SerializerCallback)
+        }
     }
 
     @MainThread
@@ -116,10 +140,37 @@ internal class Base64Serializer private constructor(
     }
 
     @WorkerThread
-    private fun convertBmpToBase64(drawable: Drawable, bitmap: Bitmap, shouldCacheBitmap: Boolean): String {
+    private fun convertBitmapToBase64(
+        drawable: Drawable,
+        displayMetrics: DisplayMetrics,
+        bitmap: Bitmap,
+        shouldCacheBitmap: Boolean,
+        imageWireframe: MobileSegment.Wireframe.ImageWireframe,
+        base64SerializerCallback: Base64SerializerCallback,
+
+        // this parameter is used to avoid infinite recursion
+        // basically we only allow one attempt to recreate the bitmap
+        didCallOriginateFromFailover: Boolean
+    ): String {
         val base64Result: String
 
         val byteArray = webPImageCompression.compressBitmap(bitmap)
+
+        // failed to get byteArray
+        // Try once to recreate bitmap from the drawable
+        if (byteArray.isEmpty() && bitmap.isRecycled && !didCallOriginateFromFailover) {
+            tryToDrawNewBitmap(
+                drawable = drawable,
+                drawableWidth = bitmap.width,
+                drawableHeight = bitmap.height,
+                displayMetrics = displayMetrics,
+                imageWireframe = imageWireframe,
+                base64SerializerCallback = base64SerializerCallback,
+                didCallOriginateFromFailover = true
+            )
+
+            return ""
+        }
 
         base64Result = base64Utils.serializeToBase64String(byteArray)
 
@@ -135,65 +186,89 @@ internal class Base64Serializer private constructor(
         return base64Result
     }
 
-    @MainThread
     private fun tryToDrawNewBitmap(
         drawable: Drawable,
         drawableWidth: Int,
         drawableHeight: Int,
         displayMetrics: DisplayMetrics,
         imageWireframe: MobileSegment.Wireframe.ImageWireframe,
-        base64SerializerCallback: Base64SerializerCallback?
-    ): Bitmap? {
+        base64SerializerCallback: Base64SerializerCallback,
+        didCallOriginateFromFailover: Boolean
+    ) {
         drawableUtils.createBitmapOfApproxSizeFromDrawable(
-            drawable,
-            drawableWidth,
-            drawableHeight,
-            displayMetrics
-        )?.let { resizedBitmap ->
-            serializeBitmapAsynchronously(
-                drawable,
-                bitmap = resizedBitmap,
-                shouldCacheBitmap = true,
-                imageWireframe,
-                base64SerializerCallback
-            )
-            return resizedBitmap
-        }
-
-        return null
+            drawable = drawable,
+            drawableWidth = drawableWidth,
+            drawableHeight = drawableHeight,
+            displayMetrics = displayMetrics,
+            base64SerializerCallback = base64SerializerCallback,
+            bitmapCreationCallback = object : BitmapCreationCallback {
+                override fun onReady(bitmap: Bitmap) {
+                    Runnable {
+                        @Suppress("ThreadSafety") // this runs inside an executor
+                        serializeBitmap(
+                            drawable = drawable,
+                            displayMetrics = displayMetrics,
+                            bitmap = bitmap,
+                            shouldCacheBitmap = true,
+                            imageWireframe = imageWireframe,
+                            base64SerializerCallback = base64SerializerCallback,
+                            didCallOriginateFromFailover = didCallOriginateFromFailover
+                        )
+                    }.let {
+                        threadPoolExecutor.executeSafe("tryToDrawNewBitmap", logger, it)
+                    }
+                }
+            }
+        )
     }
 
     @MainThread
     private fun tryToGetBitmapFromBitmapDrawable(
         drawable: Drawable,
+        displayMetrics: DisplayMetrics,
         imageWireframe: MobileSegment.Wireframe.ImageWireframe,
-        base64SerializerCallback: Base64SerializerCallback?
+        base64SerializerCallback: Base64SerializerCallback
     ): Bitmap? {
-        var result: Bitmap? = null
-        if (shouldUseDrawableBitmap(drawable)) {
-            drawableUtils.createScaledBitmap(
-                (drawable as BitmapDrawable).bitmap
-            )?.let { scaledBitmap ->
-                val shouldCacheBitmap = scaledBitmap != drawable.bitmap
+        if (drawable is BitmapDrawable && shouldUseDrawableBitmap(drawable)) {
+            val bitmap = drawable.bitmap // cannot be null - we already checked in shouldUseDrawableBitmap
+            Runnable {
+                @Suppress("ThreadSafety") // this runs inside an executor
+                drawableUtils.createScaledBitmap(
+                    bitmap
+                )?.let { scaledBitmap ->
 
-                serializeBitmapAsynchronously(
-                    drawable,
-                    scaledBitmap,
-                    shouldCacheBitmap,
-                    imageWireframe,
-                    base64SerializerCallback
-                )
+                    /**
+                     * Check whether the scaled bitmap is the same as the original.
+                     * Since Bitmap.createScaledBitmap will return the original bitmap if the
+                     * requested dimensions match the dimensions of the original
+                     */
+                    val shouldCacheBitmap = scaledBitmap != drawable.bitmap
 
-                result = scaledBitmap
+                    serializeBitmap(
+                        drawable = drawable,
+                        displayMetrics = displayMetrics,
+                        bitmap = scaledBitmap,
+                        shouldCacheBitmap = shouldCacheBitmap,
+                        imageWireframe = imageWireframe,
+                        base64SerializerCallback = base64SerializerCallback,
+                        didCallOriginateFromFailover = false
+                    )
+                }
+            }.let {
+                threadPoolExecutor.executeSafe("tryToGetBitmapFromBitmapDrawable", logger, it)
             }
+
+            // return a value to indicate that we are handling the bitmap
+            return bitmap
         }
-        return result
+
+        return null
     }
 
     private fun tryToGetBase64FromCache(
         drawable: Drawable,
         imageWireframe: MobileSegment.Wireframe.ImageWireframe,
-        base64SerializerCallback: Base64SerializerCallback?
+        base64SerializerCallback: Base64SerializerCallback
     ): String? {
         return base64LRUCache?.get(drawable)?.let { base64String ->
             finalizeRecordedDataItem(base64String, imageWireframe, base64SerializerCallback)
@@ -201,53 +276,21 @@ internal class Base64Serializer private constructor(
         }
     }
 
-    private fun serializeBitmapAsynchronously(
-        drawable: Drawable,
-        bitmap: Bitmap,
-        shouldCacheBitmap: Boolean,
-        imageWireframe: MobileSegment.Wireframe.ImageWireframe,
-        base64SerializerCallback: Base64SerializerCallback?
-    ) {
-        Runnable {
-            @Suppress("ThreadSafety") // this runs inside an executor
-            serialiseBitmap(
-                drawable,
-                bitmap,
-                shouldCacheBitmap,
-                imageWireframe,
-                base64SerializerCallback
-            )
-        }.let { executeRunnable(it) }
-    }
-
     private fun finalizeRecordedDataItem(
         base64String: String,
         wireframe: MobileSegment.Wireframe.ImageWireframe,
-        base64SerializerCallback: Base64SerializerCallback?
+        base64SerializerCallback: Base64SerializerCallback
     ) {
         if (base64String.isNotEmpty()) {
             wireframe.base64 = base64String
             wireframe.isEmpty = false
         }
 
-        base64SerializerCallback?.onReady()
+        base64SerializerCallback.onReady()
     }
 
-    private fun executeRunnable(runnable: Runnable) {
-        @Suppress("SwallowedException", "TooGenericExceptionCaught")
-        try {
-            threadPoolExecutor.submit(runnable)
-        } catch (e: RejectedExecutionException) {
-            // TODO: REPLAY-1364 Add logs here once the sdkLogger is added
-        } catch (e: NullPointerException) {
-            // TODO: REPLAY-1364 Add logs here once the sdkLogger is added
-            // should never happen since task is not null
-        }
-    }
-
-    private fun shouldUseDrawableBitmap(drawable: Drawable): Boolean {
-        return drawable is BitmapDrawable &&
-            drawable.bitmap != null &&
+    private fun shouldUseDrawableBitmap(drawable: BitmapDrawable): Boolean {
+        return drawable.bitmap != null &&
             !drawable.bitmap.isRecycled &&
             drawable.bitmap.width > 0 &&
             drawable.bitmap.height > 0
@@ -268,11 +311,14 @@ internal class Base64Serializer private constructor(
         private var threadPoolExecutor: ExecutorService = THREADPOOL_EXECUTOR,
         private var bitmapPool: BitmapPool? = null,
         private var base64LRUCache: Cache<Drawable, String>? = null,
-        private var drawableUtils: DrawableUtils = DrawableUtils(bitmapPool = bitmapPool),
+        private var drawableUtils: DrawableUtils = DrawableUtils(
+            bitmapPool = bitmapPool,
+            threadPoolExecutor = threadPoolExecutor,
+            logger = logger
+        ),
         private var base64Utils: Base64Utils = Base64Utils(),
         private var webPImageCompression: ImageCompression = WebPImageCompression()
     ) {
-
         internal fun build() =
             Base64Serializer(
                 logger = logger,
@@ -298,6 +344,10 @@ internal class Base64Serializer private constructor(
                 LinkedBlockingDeque()
             )
         }
+    }
+
+    internal interface BitmapCreationCallback {
+        fun onReady(bitmap: Bitmap)
     }
 
     // endregion

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelper.kt
@@ -47,7 +47,7 @@ internal class ImageWireframeHelper(
         drawable: Drawable? = null,
         shapeStyle: MobileSegment.ShapeStyle? = null,
         border: MobileSegment.ShapeBorder? = null,
-        callback: ImageWireframeHelperCallback? = null,
+        imageWireframeHelperCallback: ImageWireframeHelperCallback,
         prefix: String? = DRAWABLE_CHILD_NAME
     ): MobileSegment.Wireframe? {
         if (drawable == null) return null
@@ -84,7 +84,7 @@ internal class ImageWireframeHelper(
                 isEmpty = true
             )
 
-        callback?.onStart()
+        imageWireframeHelperCallback.onStart()
 
         base64Serializer.handleBitmap(
             applicationContext = applicationContext,
@@ -93,9 +93,9 @@ internal class ImageWireframeHelper(
             drawableWidth = width,
             drawableHeight = height,
             imageWireframe = imageWireframe,
-            object : Base64SerializerCallback {
+            base64SerializerCallback = object : Base64SerializerCallback {
                 override fun onReady() {
-                    callback?.onFinished()
+                    imageWireframeHelperCallback.onFinished()
                 }
             }
         )
@@ -108,7 +108,7 @@ internal class ImageWireframeHelper(
         view: TextView,
         mappingContext: MappingContext,
         prevWireframeIndex: Int,
-        callback: ImageWireframeHelperCallback?
+        imageWireframeHelperCallback: ImageWireframeHelperCallback
     ): MutableList<MobileSegment.Wireframe> {
         val result = mutableListOf<MobileSegment.Wireframe>()
         var wireframeIndex = prevWireframeIndex
@@ -147,7 +147,7 @@ internal class ImageWireframeHelper(
                     border = null,
                     usePIIPlaceholder = true,
                     clipping = MobileSegment.WireframeClip(),
-                    callback = callback
+                    imageWireframeHelperCallback = imageWireframeHelperCallback
                 )?.let { resultWireframe ->
                     result.add(resultWireframe)
                 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/WebPImageCompression.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/WebPImageCompression.kt
@@ -25,8 +25,17 @@ internal class WebPImageCompression : ImageCompression {
         // preallocate stream size
         val byteArrayOutputStream = ByteArrayOutputStream(bitmap.allocationByteCount)
         val imageFormat = getImageCompressionFormat()
-        @Suppress("UnsafeThirdPartyFunctionCall") // stream is not null and image quality is between 0 and 100
-        bitmap.compress(imageFormat, IMAGE_QUALITY, byteArrayOutputStream)
+
+        @Suppress("SwallowedException")
+        try {
+            // stream is not null and image quality is between 0 and 100
+            @Suppress("UnsafeThirdPartyFunctionCall")
+            bitmap.compress(imageFormat, IMAGE_QUALITY, byteArrayOutputStream)
+        } catch (e: IllegalStateException) {
+            // if the bitmap was recycled while we were working on it
+            return EMPTY_BYTEARRAY
+        }
+
         return byteArrayOutputStream.toByteArray()
     }
 
@@ -39,6 +48,7 @@ internal class WebPImageCompression : ImageCompression {
         }
 
     companion object {
+        private val EMPTY_BYTEARRAY = ByteArray(0)
         private const val WEBP_EXTENSION = "webp"
 
         // This is the default compression for webp when writing to the output stream -

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper.kt
@@ -137,7 +137,7 @@ abstract class BaseAsyncBackgroundWireframeMapper<T : View>(
             border = null,
             prefix = PREFIX_BACKGROUND_DRAWABLE,
             usePIIPlaceholder = false,
-            callback = object : ImageWireframeHelperCallback {
+            imageWireframeHelperCallback = object : ImageWireframeHelperCallback {
                 override fun onFinished() {
                     asyncJobStatusCallback.jobFinished()
                 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
@@ -63,7 +63,7 @@ internal class ImageViewMapper(
             border = null,
             clipping = clipping,
             prefix = ImageWireframeHelper.DRAWABLE_CHILD_NAME,
-            callback = object : ImageWireframeHelperCallback {
+            imageWireframeHelperCallback = object : ImageWireframeHelperCallback {
                 override fun onFinished() {
                     asyncJobStatusCallback.jobFinished()
                 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
@@ -12,52 +12,83 @@ import android.graphics.Bitmap.Config
 import android.graphics.Color
 import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
+import android.os.Handler
+import android.os.Looper
 import android.util.DisplayMetrics
 import androidx.annotation.MainThread
+import androidx.annotation.VisibleForTesting
+import androidx.annotation.WorkerThread
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.internal.utils.executeSafe
+import com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer
+import com.datadog.android.sessionreplay.internal.recorder.base64.Base64SerializerCallback
 import com.datadog.android.sessionreplay.internal.recorder.base64.BitmapPool
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.BitmapWrapper
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.CanvasWrapper
+import java.util.concurrent.ExecutorService
 import kotlin.math.sqrt
 
 internal class DrawableUtils(
     private val bitmapWrapper: BitmapWrapper = BitmapWrapper(),
     private val canvasWrapper: CanvasWrapper = CanvasWrapper(),
-    private val bitmapPool: BitmapPool? = null
+    private val bitmapPool: BitmapPool? = null,
+    private val threadPoolExecutor: ExecutorService,
+    private val mainThreadHandler: Handler = Handler(Looper.getMainLooper()),
+    private val logger: InternalLogger
 ) {
+
     /**
      * This method attempts to create a bitmap from a drawable, such that the bitmap file size will
      * be equal or less than a given size. It does so by modifying the dimensions of the
      * bitmap, since the file size of a bitmap can be known by the formula width*height*color depth
      */
-    @MainThread
-    @Suppress("ReturnCount")
     internal fun createBitmapOfApproxSizeFromDrawable(
         drawable: Drawable,
         drawableWidth: Int,
         drawableHeight: Int,
         displayMetrics: DisplayMetrics,
         requestedSizeInBytes: Int = MAX_BITMAP_SIZE_IN_BYTES,
-        config: Config = Config.ARGB_8888
-    ): Bitmap? {
-        val (width, height) = getScaledWidthAndHeight(
-            drawableWidth,
-            drawableHeight,
-            requestedSizeInBytes
-        )
+        config: Config = Config.ARGB_8888,
+        base64SerializerCallback: Base64SerializerCallback,
+        bitmapCreationCallback: Base64Serializer.BitmapCreationCallback
+    ) {
+        Runnable {
+            @Suppress("ThreadSafety") // this runs inside an executor
+            createScaledBitmap(
+                drawableWidth,
+                drawableHeight,
+                requestedSizeInBytes,
+                displayMetrics,
+                config,
+                resizeBitmapCallback = object :
+                    ResizeBitmapCallback {
+                    override fun onSuccess(bitmap: Bitmap) {
+                        mainThreadHandler.post {
+                            @Suppress("ThreadSafety") // this runs on the main thread
+                            drawOnCanvas(
+                                bitmap,
+                                drawable,
+                                base64SerializerCallback,
+                                bitmapCreationCallback
+                            )
+                        }
+                    }
 
-        val bitmap = getBitmapBySize(displayMetrics, width, height, config) ?: return null
-        val canvas = canvasWrapper.createCanvas(bitmap) ?: return null
-
-        // erase the canvas
-        // needed because overdrawing an already used bitmap causes unusual visual artifacts
-        canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.MULTIPLY)
-
-        drawable.setBounds(0, 0, canvas.width, canvas.height)
-        drawable.draw(canvas)
-        return bitmap
+                    override fun onFailure() {
+                        base64SerializerCallback.onReady()
+                    }
+                }
+            )
+        }.let {
+            threadPoolExecutor.executeSafe(
+                "createBitmapOfApproxSizeFromDrawable",
+                logger,
+                it
+            )
+        }
     }
 
-    @MainThread
+    @WorkerThread
     internal fun createScaledBitmap(
         bitmap: Bitmap,
         requestedSizeInBytes: Int = MAX_BITMAP_SIZE_IN_BYTES
@@ -68,6 +99,57 @@ internal class DrawableUtils(
             requestedSizeInBytes
         )
         return bitmapWrapper.createScaledBitmap(bitmap, width, height, false)
+    }
+
+    internal interface ResizeBitmapCallback {
+        fun onSuccess(bitmap: Bitmap)
+        fun onFailure()
+    }
+
+    @MainThread
+    private fun drawOnCanvas(
+        bitmap: Bitmap,
+        drawable: Drawable,
+        base64SerializerCallback: Base64SerializerCallback,
+        bitmapCreationCallback: Base64Serializer.BitmapCreationCallback
+    ) {
+        val canvas = canvasWrapper.createCanvas(bitmap)
+
+        if (canvas == null) {
+            base64SerializerCallback.onReady()
+        } else {
+            // erase the canvas
+            // needed because overdrawing an already used bitmap causes unusual visual artifacts
+            canvas.drawColor(Color.TRANSPARENT, PorterDuff.Mode.MULTIPLY)
+
+            drawable.setBounds(0, 0, canvas.width, canvas.height)
+            drawable.draw(canvas)
+            bitmapCreationCallback.onReady(bitmap)
+        }
+    }
+
+    @WorkerThread
+    private fun createScaledBitmap(
+        drawableWidth: Int,
+        drawableHeight: Int,
+        requestedSizeInBytes: Int,
+        displayMetrics: DisplayMetrics,
+        config: Config,
+        resizeBitmapCallback: ResizeBitmapCallback
+    ) {
+        val (width, height) = getScaledWidthAndHeight(
+            drawableWidth,
+            drawableHeight,
+            requestedSizeInBytes
+        )
+
+        val result = getBitmapBySize(displayMetrics, width, height, config)
+
+        if (result == null) {
+            resizeBitmapCallback.onFailure()
+        } else {
+            resizeBitmapCallback.onSuccess(result)
+        }
     }
 
     private fun getScaledWidthAndHeight(
@@ -107,7 +189,7 @@ internal class DrawableUtils(
             ?: bitmapWrapper.createBitmap(displayMetrics, width, height, config)
 
     internal companion object {
-        private const val MAX_BITMAP_SIZE_IN_BYTES = 15000 // 15kb
+        @VisibleForTesting internal const val MAX_BITMAP_SIZE_IN_BYTES = 15000 // 15kb
         private const val ARGB_8888_PIXEL_SIZE_BYTES = 4
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/ImageWireframeHelperTest.kt
@@ -69,7 +69,7 @@ internal class ImageWireframeHelperTest {
     lateinit var mockImageCompression: ImageCompression
 
     @Mock
-    lateinit var mockCallback: ImageWireframeHelperCallback
+    lateinit var mockImageWireframeHelperCallback: ImageWireframeHelperCallback
 
     @Mock
     lateinit var mockImageTypeResolver: ImageTypeResolver
@@ -183,12 +183,12 @@ internal class ImageWireframeHelperTest {
             width = 0,
             height = 0,
             usePIIPlaceholder = true,
-            callback = mockCallback
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
 
         // Then
         assertThat(wireframe).isNull()
-        verifyNoInteractions(mockCallback)
+        verifyNoInteractions(mockImageWireframeHelperCallback)
     }
 
     @Test
@@ -209,12 +209,12 @@ internal class ImageWireframeHelperTest {
             shapeStyle = null,
             border = null,
             usePIIPlaceholder = true,
-            callback = mockCallback
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
 
         // Then
         assertThat(wireframe).isNull()
-        verifyNoInteractions(mockCallback)
+        verifyNoInteractions(mockImageWireframeHelperCallback)
     }
 
     @Test
@@ -234,7 +234,7 @@ internal class ImageWireframeHelperTest {
             shapeStyle = null,
             border = null,
             usePIIPlaceholder = true,
-            callback = mockCallback
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
 
         // Then
@@ -258,7 +258,7 @@ internal class ImageWireframeHelperTest {
             shapeStyle = null,
             border = null,
             usePIIPlaceholder = true,
-            callback = mockCallback
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
 
         // Then
@@ -300,7 +300,7 @@ internal class ImageWireframeHelperTest {
             drawable = mockDrawable,
             shapeStyle = mockShapeStyle,
             border = mockBorder,
-            callback = mockCallback,
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback,
             usePIIPlaceholder = true,
             clipping = stubWireframeClip
         )
@@ -319,9 +319,9 @@ internal class ImageWireframeHelperTest {
         argumentCaptor.allValues.forEach {
             it.onReady()
         }
-        verify(mockCallback).onStart()
-        verify(mockCallback).onFinished()
-        verifyNoMoreInteractions(mockCallback)
+        verify(mockImageWireframeHelperCallback).onStart()
+        verify(mockImageWireframeHelperCallback).onFinished()
+        verifyNoMoreInteractions(mockImageWireframeHelperCallback)
         assertThat(wireframe).isEqualTo(expectedWireframe)
     }
 
@@ -340,11 +340,11 @@ internal class ImageWireframeHelperTest {
             mockTextView,
             mockMappingContext,
             0,
-            callback = mockCallback
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
 
         // Then
-        verifyNoInteractions(mockCallback)
+        verifyNoInteractions(mockImageWireframeHelperCallback)
         assertThat(wireframes).isEmpty()
     }
 
@@ -368,7 +368,7 @@ internal class ImageWireframeHelperTest {
             mockTextView,
             mockMappingContext,
             0,
-            callback = mockCallback
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
         wireframes[0] as MobileSegment.Wireframe.ImageWireframe
 
@@ -386,8 +386,8 @@ internal class ImageWireframeHelperTest {
         argumentCaptor.allValues.forEach {
             it.onReady()
         }
-        verify(mockCallback).onStart()
-        verify(mockCallback).onFinished()
+        verify(mockImageWireframeHelperCallback).onStart()
+        verify(mockImageWireframeHelperCallback).onFinished()
         assertThat(wireframes.size).isEqualTo(1)
     }
 
@@ -412,7 +412,7 @@ internal class ImageWireframeHelperTest {
             mockTextView,
             mockMappingContext,
             0,
-            callback = mockCallback
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
         wireframes[0] as MobileSegment.Wireframe.ImageWireframe
 
@@ -430,8 +430,8 @@ internal class ImageWireframeHelperTest {
         argumentCaptor.allValues.forEach {
             it.onReady()
         }
-        verify(mockCallback, times(2)).onStart()
-        verify(mockCallback, times(2)).onFinished()
+        verify(mockImageWireframeHelperCallback, times(2)).onStart()
+        verify(mockImageWireframeHelperCallback, times(2)).onFinished()
         assertThat(wireframes.size).isEqualTo(2)
     }
 
@@ -446,11 +446,11 @@ internal class ImageWireframeHelperTest {
             mockTextView,
             mockMappingContext,
             0,
-            callback = mockCallback
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
 
         // Then
-        verifyNoInteractions(mockCallback)
+        verifyNoInteractions(mockImageWireframeHelperCallback)
         assertThat(wireframes).isEmpty()
     }
 
@@ -480,7 +480,8 @@ internal class ImageWireframeHelperTest {
             drawable = mockDrawable,
             shapeStyle = null,
             border = null,
-            usePIIPlaceholder = true
+            usePIIPlaceholder = true,
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
 
         // Then
@@ -492,7 +493,7 @@ internal class ImageWireframeHelperTest {
             drawableWidth = captor.capture(),
             drawableHeight = captor.capture(),
             imageWireframe = any(),
-            callback = any()
+            base64SerializerCallback = any()
         )
         assertThat(captor.allValues).containsExactly(fakeViewWidth, fakeViewHeight)
     }
@@ -510,7 +511,8 @@ internal class ImageWireframeHelperTest {
             drawable = mockDrawable,
             shapeStyle = null,
             border = null,
-            usePIIPlaceholder = true
+            usePIIPlaceholder = true,
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
 
         // Then
@@ -522,7 +524,7 @@ internal class ImageWireframeHelperTest {
             drawableWidth = captor.capture(),
             drawableHeight = captor.capture(),
             imageWireframe = any(),
-            callback = any()
+            base64SerializerCallback = any()
 
         )
         assertThat(captor.allValues).containsExactly(fakeDrawableWidth, fakeDrawableHeight)
@@ -566,7 +568,8 @@ internal class ImageWireframeHelperTest {
             drawable = mockDrawable,
             shapeStyle = null,
             border = null,
-            usePIIPlaceholder = true
+            usePIIPlaceholder = true,
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         ) as MobileSegment.Wireframe.PlaceholderWireframe
 
         // Then
@@ -577,7 +580,7 @@ internal class ImageWireframeHelperTest {
             drawableWidth = any(),
             drawableHeight = any(),
             imageWireframe = any(),
-            callback = any()
+            base64SerializerCallback = any()
         )
 
         assertThat(isCloseTo(result.x.toInt(), fakeGlobalX)).isTrue
@@ -600,7 +603,8 @@ internal class ImageWireframeHelperTest {
             drawable = mockDrawable,
             shapeStyle = null,
             border = null,
-            usePIIPlaceholder = true
+            usePIIPlaceholder = true,
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
 
         // Then
@@ -611,7 +615,7 @@ internal class ImageWireframeHelperTest {
             drawableWidth = any(),
             drawableHeight = any(),
             imageWireframe = any(),
-            callback = any()
+            base64SerializerCallback = any()
         )
     }
 
@@ -631,7 +635,8 @@ internal class ImageWireframeHelperTest {
             drawable = mockDrawable,
             shapeStyle = null,
             border = null,
-            usePIIPlaceholder = true
+            usePIIPlaceholder = true,
+            imageWireframeHelperCallback = mockImageWireframeHelperCallback
         )
 
         // Then

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/WebPImageCompressionTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/WebPImageCompressionTest.kt
@@ -24,6 +24,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -83,6 +84,18 @@ internal class WebPImageCompressionTest {
         // Then
         @Suppress("DEPRECATION")
         assertThat(captor.firstValue).isEqualTo(Bitmap.CompressFormat.WEBP)
+    }
+
+    @Test
+    fun `M return empty bytearray W compressBitmap { bitmap was already recycled }`() {
+        // Given
+        whenever(mockBitmap.isRecycled).thenReturn(true)
+
+        // When
+        val result = testedImageCompression.compressBitmap(mockBitmap)
+
+        // Then
+        assertThat(result).isEmpty()
     }
 
     // endregion

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseTextViewWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseTextViewWireframeMapperTest.kt
@@ -350,7 +350,7 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
                 border = anyOrNull(),
                 clipping = anyOrNull(),
                 prefix = anyOrNull(),
-                callback = anyOrNull()
+                imageWireframeHelperCallback = anyOrNull()
             )
         ).thenReturn(fakeBackgroundWireframe)
 
@@ -390,7 +390,7 @@ internal abstract class BaseTextViewWireframeMapperTest : BaseWireframeMapperTes
                 shapeStyle = anyOrNull(),
                 border = anyOrNull(),
                 clipping = anyOrNull(),
-                callback = capture(),
+                imageWireframeHelperCallback = capture(),
                 prefix = anyOrNull()
             )
             allValues.forEach() {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapperTest.kt
@@ -238,7 +238,7 @@ internal class ImageViewMapperTest {
                 border = anyOrNull(),
                 clipping = anyOrNull(),
                 prefix = anyOrNull(),
-                callback = anyOrNull()
+                imageWireframeHelperCallback = anyOrNull()
             )
         ).thenReturn(expectedWireframe)
 
@@ -263,7 +263,7 @@ internal class ImageViewMapperTest {
                 shapeStyle = anyOrNull(),
                 border = anyOrNull(),
                 clipping = anyOrNull(),
-                callback = argumentCaptor.capture(),
+                imageWireframeHelperCallback = argumentCaptor.capture(),
                 prefix = anyOrNull()
             )
 
@@ -318,7 +318,7 @@ internal class ImageViewMapperTest {
             border = anyOrNull(),
             clipping = anyOrNull(),
             prefix = anyOrNull(),
-            callback = anyOrNull()
+            imageWireframeHelperCallback = anyOrNull()
         )
         val allValues = captor.allValues
         assertThat(allValues[0]).isEqualTo(0)
@@ -353,7 +353,7 @@ internal class ImageViewMapperTest {
             border = anyOrNull(),
             clipping = anyOrNull(),
             prefix = anyOrNull(),
-            callback = anyOrNull()
+            imageWireframeHelperCallback = anyOrNull()
         )
         val allValues = captor.allValues
         assertThat(allValues[0]).isEqualTo(0)
@@ -446,7 +446,7 @@ internal class ImageViewMapperTest {
                 border = anyOrNull(),
                 clipping = anyOrNull(),
                 prefix = anyOrNull(),
-                callback = anyOrNull()
+                imageWireframeHelperCallback = anyOrNull()
             )
         )
             .thenReturn(expectedFirstWireframe)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtilsTest.kt
@@ -9,8 +9,12 @@ package com.datadog.android.sessionreplay.internal.utils
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.drawable.Drawable
+import android.os.Handler
 import android.util.DisplayMetrics
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer
+import com.datadog.android.sessionreplay.internal.recorder.base64.Base64SerializerCallback
 import com.datadog.android.sessionreplay.internal.recorder.base64.BitmapPool
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.BitmapWrapper
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.CanvasWrapper
@@ -27,10 +31,14 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Future
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -65,26 +73,57 @@ internal class DrawableUtilsTest {
     @Mock
     private lateinit var mockConfig: Bitmap.Config
 
+    @Mock
+    private lateinit var mockExecutorService: ExecutorService
+
+    @Mock
+    private lateinit var mockBase64SerializerCallback: Base64SerializerCallback
+
+    @Mock
+    private lateinit var mockBitmapCreationCallback: Base64Serializer.BitmapCreationCallback
+
+    @Mock
+    private lateinit var mockMainThreadHandler: Handler
+
+    @Mock
+    private lateinit var mockLogger: InternalLogger
+
     @BeforeEach
     fun setup() {
         whenever(mockBitmapWrapper.createBitmap(any(), any(), any(), any()))
             .thenReturn(mockBitmap)
-        whenever(mockCanvasWrapper.createCanvas(mockBitmap))
+        whenever(mockCanvasWrapper.createCanvas(any()))
             .thenReturn(mockCanvas)
         whenever(mockBitmap.config).thenReturn(mockConfig)
         whenever(mockBitmapPool.getBitmapByProperties(any(), any(), any())).thenReturn(null)
 
+        doAnswer { invocation ->
+            val work = invocation.getArgument(0) as Runnable
+            work.run()
+            null
+        }.whenever(mockMainThreadHandler).post(
+            any()
+        )
+
+        whenever(mockExecutorService.execute(any())).then {
+            (it.arguments[0] as Runnable).run()
+            mock<Future<Boolean>>()
+        }
+
         testedDrawableUtils = DrawableUtils(
             bitmapWrapper = mockBitmapWrapper,
             canvasWrapper = mockCanvasWrapper,
-            bitmapPool = mockBitmapPool
+            bitmapPool = mockBitmapPool,
+            threadPoolExecutor = mockExecutorService,
+            mainThreadHandler = mockMainThreadHandler,
+            logger = mockLogger
         )
     }
 
     // region createBitmap
 
     @Test
-    fun `M set width to drawable intrinsic W createBitmapFromDrawableOfApproxSize() { no resizing }`() {
+    fun `M set width to drawable intrinsic W createBitmapOfApproxSizeFromDrawable() { no resizing }`() {
         // Given
         val requestedSize = 1000
         val edge = 10
@@ -96,12 +135,14 @@ internal class DrawableUtilsTest {
 
         // When
         testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
-            mockDrawable,
-            mockDrawable.intrinsicWidth,
-            mockDrawable.intrinsicHeight,
-            mockDisplayMetrics,
-            requestedSize,
-            mockConfig
+            drawable = mockDrawable,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            displayMetrics = mockDisplayMetrics,
+            requestedSizeInBytes = requestedSize,
+            config = mockConfig,
+            base64SerializerCallback = mockBase64SerializerCallback,
+            bitmapCreationCallback = mockBitmapCreationCallback
         )
 
         // Then
@@ -119,7 +160,7 @@ internal class DrawableUtilsTest {
     }
 
     @Test
-    fun `M set height higher W createBitmapFromDrawableOfApproxSize() { when resizing }`(
+    fun `M set height higher W createBitmapOfApproxSizeFromDrawable() { when resizing }`(
         @IntForgery(min = 0, max = 500) viewWidth: Int,
         @IntForgery(min = 501, max = 1000) viewHeight: Int
     ) {
@@ -132,10 +173,12 @@ internal class DrawableUtilsTest {
 
         // When
         testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
-            mockDrawable,
-            mockDrawable.intrinsicWidth,
-            mockDrawable.intrinsicHeight,
-            mockDisplayMetrics
+            drawable = mockDrawable,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            displayMetrics = mockDisplayMetrics,
+            base64SerializerCallback = mockBase64SerializerCallback,
+            bitmapCreationCallback = mockBitmapCreationCallback
         )
 
         // Then
@@ -164,12 +207,14 @@ internal class DrawableUtilsTest {
         val displayMetricsCaptor = argumentCaptor<DisplayMetrics>()
 
         // When
-        val result = testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
-            mockDrawable,
-            mockDrawable.intrinsicWidth,
-            mockDrawable.intrinsicHeight,
-            mockDisplayMetrics,
-            config = mockConfig
+        testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
+            drawable = mockDrawable,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            displayMetrics = mockDisplayMetrics,
+            config = mockConfig,
+            base64SerializerCallback = mockBase64SerializerCallback,
+            bitmapCreationCallback = mockBitmapCreationCallback
         )
 
         // Then
@@ -185,57 +230,12 @@ internal class DrawableUtilsTest {
         assertThat(width).isGreaterThanOrEqualTo(height)
 
         assertThat(displayMetricsCaptor.firstValue).isEqualTo(mockDisplayMetrics)
-
-        assertThat(result).isEqualTo(mockBitmap)
-    }
-
-    @Test
-    fun `M return null W createBitmapFromDrawableOfApproxSize() { failed to create bmp }`() {
-        // Given
-        val edge = 200
-        whenever(mockDrawable.intrinsicWidth).thenReturn(edge)
-        whenever(mockDrawable.intrinsicHeight).thenReturn(edge)
-        whenever(mockBitmapWrapper.createBitmap(any(), any(), any(), any()))
-            .thenReturn(null)
-
-        // When
-        val result = testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
-            mockDrawable,
-            mockDrawable.intrinsicWidth,
-            mockDrawable.intrinsicHeight,
-            mockDisplayMetrics,
-            config = mockConfig
-        )
-
-        // Then
-        assertThat(result).isNull()
-    }
-
-    @Test
-    fun `M return null W createBitmapFromDrawableOfApproxSize() { failed to create canvas }`() {
-        // Given
-        val edge = 200
-        whenever(mockDrawable.intrinsicWidth).thenReturn(edge)
-        whenever(mockDrawable.intrinsicHeight).thenReturn(edge)
-        whenever(mockCanvasWrapper.createCanvas(any()))
-            .thenReturn(null)
-
-        // When
-        val result = testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
-            mockDrawable,
-            mockDrawable.intrinsicWidth,
-            mockDrawable.intrinsicHeight,
-            mockDisplayMetrics,
-            config = mockConfig
-        )
-
-        // Then
-        assertThat(result).isNull()
     }
 
     // endregion
 
-    fun `M use bitmap from pool W createBitmapFromDrawable() { exists in pool }`(
+    @Test
+    fun `M use bitmap from pool W createBitmapOfApproxSizeFromDrawable() { exists in pool }`(
         @IntForgery(min = 1, max = 1000) viewWidth: Int,
         @IntForgery(min = 1, max = 1000) viewHeight: Int
     ) {
@@ -247,16 +247,69 @@ internal class DrawableUtilsTest {
             .thenReturn(mockBitmapFromPool)
 
         // When
-        val actualBitmap = testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
-            mockDrawable,
-            mockDrawable.intrinsicWidth,
-            mockDrawable.intrinsicHeight,
-            mockDisplayMetrics,
-            config = mockConfig
+        testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
+            drawable = mockDrawable,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            displayMetrics = mockDisplayMetrics,
+            config = mockConfig,
+            base64SerializerCallback = mockBase64SerializerCallback,
+            bitmapCreationCallback = mockBitmapCreationCallback
         )
 
         // Then
-        assertThat(actualBitmap).isEqualTo(mockBitmapFromPool)
+        verify(mockBitmapCreationCallback).onReady(mockBitmapFromPool)
+        verifyNoInteractions(mockBase64SerializerCallback)
+    }
+
+    @Test
+    fun `M call onReady W createBitmapOfApproxSizeFromDrawable { failed to create bitmap }`() {
+        // Given
+        whenever(mockDrawable.intrinsicWidth).thenReturn(1)
+        whenever(mockDrawable.intrinsicHeight).thenReturn(1)
+        whenever(mockBitmapPool.getBitmapByProperties(any(), any(), any()))
+            .thenReturn(null)
+        whenever(mockBitmapWrapper.createBitmap(any(), any(), any(), any()))
+            .thenReturn(null)
+
+        // When
+        testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
+            drawable = mockDrawable,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            displayMetrics = mockDisplayMetrics,
+            config = mockConfig,
+            base64SerializerCallback = mockBase64SerializerCallback,
+            bitmapCreationCallback = mockBitmapCreationCallback
+        )
+
+        // Then
+        verifyNoInteractions(mockBitmapCreationCallback)
+        verify(mockBase64SerializerCallback).onReady()
+    }
+
+    @Test
+    fun `M call onReady W createBitmapOfApproxSizeFromDrawable { failed to create canvas }`() {
+        // Given
+        whenever(mockDrawable.intrinsicWidth).thenReturn(1)
+        whenever(mockDrawable.intrinsicHeight).thenReturn(1)
+        whenever(mockCanvasWrapper.createCanvas(any()))
+            .thenReturn(null)
+
+        // When
+        testedDrawableUtils.createBitmapOfApproxSizeFromDrawable(
+            drawable = mockDrawable,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            displayMetrics = mockDisplayMetrics,
+            config = mockConfig,
+            base64SerializerCallback = mockBase64SerializerCallback,
+            bitmapCreationCallback = mockBitmapCreationCallback
+        )
+
+        // Then
+        verifyNoInteractions(mockBitmapCreationCallback)
+        verify(mockBase64SerializerCallback).onReady()
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Benchmarks that I've done show that performance with base64 was around 20ms on the main thread. This PR moves bitmap resizing tasks to a background thread in order to improve performance to around 7ms on the main thread. In addition the PR handles a couple of additional issues:
• Wrap the call to `bitmap.compress` in`WebPImageCompression` in try/catch to prevent an exception if the bitmap was recycled while we were working on it (can happen with the system-cached bitmaps that we take from `BitmapDrawable`)
• Rename some variables that were just called "callback" to make it clearer when reading the code what callback is involved

### Motivation
SDK should not impact the main thread more than 8ms.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

