### PR TITLE
RUM-1654 Add resourceId to ImageWireframe

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -197,7 +197,7 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
         fun fromJson(kotlin.String): TextWireframe
         fun fromJsonObject(com.google.gson.JsonObject): TextWireframe
     data class ImageWireframe : Wireframe
-      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, WireframeClip? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Boolean? = null)
+      constructor(kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, kotlin.Long, WireframeClip? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Boolean? = null)
       val type: kotlin.String
       override fun toJson(): com.google.gson.JsonElement
       companion object 
@@ -242,7 +242,7 @@ data class com.datadog.android.sessionreplay.model.MobileSegment
         fun fromJson(kotlin.String): ShapeWireframeUpdate
         fun fromJsonObject(com.google.gson.JsonObject): ShapeWireframeUpdate
     data class ImageWireframeUpdate : WireframeUpdateMutation
-      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, WireframeClip? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Boolean? = null)
+      constructor(kotlin.Long, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, WireframeClip? = null, ShapeStyle? = null, ShapeBorder? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Boolean? = null)
       val type: kotlin.String
       override fun toJson(): com.google.gson.JsonElement
       companion object 

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -907,11 +907,12 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Wirefra
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe : com/datadog/android/sessionreplay/model/MobileSegment$Wireframe {
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe$Companion;
-	public fun <init> (JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/Boolean;
 	public final fun component2 ()J
 	public final fun component3 ()J
 	public final fun component4 ()J
@@ -920,8 +921,8 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Wirefra
 	public final fun component7 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;
 	public final fun component8 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;
+	public final fun copy (JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;JJJJJLcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe$ImageWireframe;
@@ -931,6 +932,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Wirefra
 	public final fun getHeight ()J
 	public final fun getId ()J
 	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getResourceId ()Ljava/lang/String;
 	public final fun getShapeStyle ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getWidth ()J
@@ -941,6 +943,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Wirefra
 	public final fun setBase64 (Ljava/lang/String;)V
 	public final fun setEmpty (Ljava/lang/Boolean;)V
 	public final fun setMimeType (Ljava/lang/String;)V
+	public final fun setResourceId (Ljava/lang/String;)V
 	public fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }
@@ -1106,11 +1109,12 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Wirefra
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate : com/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation {
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate$Companion;
-	public fun <init> (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
-	public synthetic fun <init> (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)V
+	public synthetic fun <init> (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()J
 	public final fun component10 ()Ljava/lang/String;
-	public final fun component11 ()Ljava/lang/Boolean;
+	public final fun component11 ()Ljava/lang/String;
+	public final fun component12 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/Long;
 	public final fun component3 ()Ljava/lang/Long;
 	public final fun component4 ()Ljava/lang/Long;
@@ -1119,8 +1123,8 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Wirefra
 	public final fun component7 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;
 	public final fun component8 ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;
 	public final fun component9 ()Ljava/lang/String;
-	public final fun copy (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate;
+	public final fun copy (JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate;JLjava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Boolean;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeUpdateMutation$ImageWireframeUpdate;
@@ -1130,6 +1134,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Wirefra
 	public final fun getHeight ()Ljava/lang/Long;
 	public final fun getId ()J
 	public final fun getMimeType ()Ljava/lang/String;
+	public final fun getResourceId ()Ljava/lang/String;
 	public final fun getShapeStyle ()Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;
 	public final fun getType ()Ljava/lang/String;
 	public final fun getWidth ()Ljava/lang/Long;
@@ -1140,6 +1145,7 @@ public final class com/datadog/android/sessionreplay/model/MobileSegment$Wirefra
 	public final fun setBase64 (Ljava/lang/String;)V
 	public final fun setEmpty (Ljava/lang/Boolean;)V
 	public final fun setMimeType (Ljava/lang/String;)V
+	public final fun setResourceId (Ljava/lang/String;)V
 	public fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
 }

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/image-wireframe-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/image-wireframe-schema.json
@@ -22,6 +22,11 @@
           "description": "base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64",
           "readOnly": false
         },
+        "resourceId": {
+          "type": "string",
+          "description": "Unique identifier of the image resource",
+          "readOnly": false
+        },
         "mimeType": {
           "type": "string",
           "description": "MIME type of the image file",

--- a/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/image-wireframe-update-schema.json
+++ b/features/dd-sdk-android-session-replay/src/main/json/schemas/session-replay/mobile/image-wireframe-update-schema.json
@@ -22,6 +22,11 @@
           "description": "base64 representation of the image. Not required as the ImageWireframe can be initialised without any base64",
           "readOnly": false
         },
+        "resourceId": {
+          "type": "string",
+          "description": "Unique identifier of the image resource",
+          "readOnly": false
+        },
         "mimeType": {
           "type": "string",
           "description": "MIME type of the image file",

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/MutationResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/MutationResolver.kt
@@ -291,8 +291,8 @@ internal class MutationResolver(private val internalLogger: InternalLogger) {
                     ?: MobileSegment.WireframeClip(0, 0, 0, 0)
             )
         }
-        if (prevWireframe.base64 != currentWireframe.base64) {
-            mutation = mutation.copy(base64 = currentWireframe.base64)
+        if (prevWireframe.resourceId != currentWireframe.resourceId) {
+            mutation = mutation.copy(resourceId = currentWireframe.resourceId)
         }
         if (prevWireframe.mimeType != currentWireframe.mimeType) {
             mutation = mutation.copy(mimeType = currentWireframe.mimeType)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/HashGenerator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/HashGenerator.kt
@@ -1,0 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+internal interface HashGenerator {
+    fun generate(input: ByteArray): String?
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/MD5HashGenerator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/MD5HashGenerator.kt
@@ -1,0 +1,39 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+import com.datadog.android.api.InternalLogger
+import java.security.MessageDigest
+import java.security.NoSuchAlgorithmException
+import java.util.Locale
+
+internal class MD5HashGenerator(
+    private val logger: InternalLogger
+) : HashGenerator {
+    override fun generate(input: ByteArray): String? {
+        return try {
+            val messageDigest = MessageDigest.getInstance("MD5")
+            messageDigest.update(input)
+
+            val hashBytes = messageDigest.digest()
+
+            hashBytes.joinToString(separator = "") { "%02x".format(Locale.US, it) }
+        } catch (e: NoSuchAlgorithmException) {
+            logger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.USER,
+                { MD5_HASH_GENERATION_ERROR },
+                e
+            )
+            null
+        }
+    }
+
+    private companion object {
+        private const val MD5_HASH_GENERATION_ERROR = "Cannot generate MD5 hash."
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
@@ -21,7 +21,6 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.utils.executeSafe
 import com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer
-import com.datadog.android.sessionreplay.internal.recorder.base64.Base64SerializerCallback
 import com.datadog.android.sessionreplay.internal.recorder.base64.BitmapPool
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.BitmapWrapper
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.CanvasWrapper
@@ -49,7 +48,6 @@ internal class DrawableUtils(
         displayMetrics: DisplayMetrics,
         requestedSizeInBytes: Int = MAX_BITMAP_SIZE_IN_BYTES,
         config: Config = Config.ARGB_8888,
-        base64SerializerCallback: Base64SerializerCallback,
         bitmapCreationCallback: Base64Serializer.BitmapCreationCallback
     ) {
         Runnable {
@@ -68,14 +66,13 @@ internal class DrawableUtils(
                             drawOnCanvas(
                                 bitmap,
                                 drawable,
-                                base64SerializerCallback,
                                 bitmapCreationCallback
                             )
                         }
                     }
 
                     override fun onFailure() {
-                        base64SerializerCallback.onReady()
+                        bitmapCreationCallback.onFailure()
                     }
                 }
             )
@@ -110,13 +107,12 @@ internal class DrawableUtils(
     private fun drawOnCanvas(
         bitmap: Bitmap,
         drawable: Drawable,
-        base64SerializerCallback: Base64SerializerCallback,
         bitmapCreationCallback: Base64Serializer.BitmapCreationCallback
     ) {
         val canvas = canvasWrapper.createCanvas(bitmap)
 
         if (canvas == null) {
-            base64SerializerCallback.onReady()
+            bitmapCreationCallback.onFailure()
         } else {
             // erase the canvas
             // needed because overdrawing an already used bitmap causes unusual visual artifacts

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ImageWireframeForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ImageWireframeForgeryFactory.kt
@@ -27,6 +27,7 @@ internal class ImageWireframeForgeryFactory :
                 )
             },
             base64 = forge.aNullable { aString() },
+            resourceId = forge.aNullable() { aString() },
             clip = forge.aNullable {
                 getForgery()
             }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/MutationResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/MutationResolverTest.kt
@@ -458,7 +458,7 @@ internal class MutationResolverTest {
     // region ImageWireframe update mutations
 
     @Test
-    fun `M identify the updated wireframes W resolveMutations {Image, valid base64}`(forge: Forge) {
+    fun `M identify the updated wireframes W resolveMutations {Image, valid resourceId}`(forge: Forge) {
         // Given
         val fakePrevSnapshot = forge.aList(size = forge.anInt(min = 2, max = 10)) {
             forge.getForgery(MobileSegment.Wireframe.ImageWireframe::class.java)
@@ -466,12 +466,12 @@ internal class MutationResolverTest {
         val fakeUpdateSize = forge.anInt(min = 1, max = fakePrevSnapshot.size)
         val fakeUpdatedWireframes = fakePrevSnapshot
             .take(fakeUpdateSize)
-            .map { it.copy(base64 = forge.aString()) }
+            .map { it.copy(resourceId = forge.aString()) }
         val fakeCurrentSnapshot = fakeUpdatedWireframes + fakePrevSnapshot.drop(fakeUpdateSize)
         val expectedUpdates = fakeUpdatedWireframes.map {
             MobileSegment.WireframeUpdateMutation.ImageWireframeUpdate(
                 id = it.id(),
-                base64 = it.base64
+                resourceId = it.resourceId
             )
         }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/MD5HashGeneratorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/MD5HashGeneratorTest.kt
@@ -1,0 +1,71 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.base64
+
+import com.datadog.android.api.InternalLogger
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(ExtendWith(ForgeExtension::class))
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class MD5HashGeneratorTest {
+
+    @Mock
+    private lateinit var mockLogger: InternalLogger
+
+    private lateinit var testedGenerator: HashGenerator
+
+    @BeforeEach
+    fun setup() {
+        testedGenerator = MD5HashGenerator(mockLogger)
+    }
+
+    @Test
+    fun `𝕄 generate hash of expected format 𝕎 generate()`(
+        @StringForgery fakeInput: String
+    ) {
+        // When
+        val hash = testedGenerator.generate(fakeInput.toByteArray())
+
+        // Then
+        Assertions.assertThat(hash).isNotNull()
+        Assertions.assertThat(hash).matches("[0-9a-z]+")
+    }
+
+    @Test
+    fun `𝕄 generate same hash 𝕎 generate() { same input }`(
+        @StringForgery fakeInput: String
+    ) {
+        // When
+        val hash1 = testedGenerator.generate(fakeInput.toByteArray())
+        val hash2 = testedGenerator.generate(fakeInput.toByteArray())
+
+        // Then
+        Assertions.assertThat(hash1).isEqualTo(hash2)
+    }
+
+    @Test
+    fun `𝕄 generate different hash 𝕎 generate() { different input }`(
+        @StringForgery fakeInput1: String,
+        @StringForgery fakeInput2: String
+    ) {
+        // When
+        val hash1 = testedGenerator.generate(fakeInput1.toByteArray())
+        val hash2 = testedGenerator.generate(fakeInput2.toByteArray())
+
+        // Then
+        Assertions.assertThat(hash1).isNotEqualTo(hash2)
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtilsTest.kt
@@ -14,7 +14,6 @@ import android.util.DisplayMetrics
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.base64.Base64Serializer
-import com.datadog.android.sessionreplay.internal.recorder.base64.Base64SerializerCallback
 import com.datadog.android.sessionreplay.internal.recorder.base64.BitmapPool
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.BitmapWrapper
 import com.datadog.android.sessionreplay.internal.recorder.wrappers.CanvasWrapper
@@ -34,7 +33,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
-import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.ExecutorService
@@ -75,9 +73,6 @@ internal class DrawableUtilsTest {
 
     @Mock
     private lateinit var mockExecutorService: ExecutorService
-
-    @Mock
-    private lateinit var mockBase64SerializerCallback: Base64SerializerCallback
 
     @Mock
     private lateinit var mockBitmapCreationCallback: Base64Serializer.BitmapCreationCallback
@@ -141,7 +136,6 @@ internal class DrawableUtilsTest {
             displayMetrics = mockDisplayMetrics,
             requestedSizeInBytes = requestedSize,
             config = mockConfig,
-            base64SerializerCallback = mockBase64SerializerCallback,
             bitmapCreationCallback = mockBitmapCreationCallback
         )
 
@@ -177,7 +171,6 @@ internal class DrawableUtilsTest {
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             displayMetrics = mockDisplayMetrics,
-            base64SerializerCallback = mockBase64SerializerCallback,
             bitmapCreationCallback = mockBitmapCreationCallback
         )
 
@@ -213,7 +206,6 @@ internal class DrawableUtilsTest {
             drawableHeight = mockDrawable.intrinsicHeight,
             displayMetrics = mockDisplayMetrics,
             config = mockConfig,
-            base64SerializerCallback = mockBase64SerializerCallback,
             bitmapCreationCallback = mockBitmapCreationCallback
         )
 
@@ -253,17 +245,15 @@ internal class DrawableUtilsTest {
             drawableHeight = mockDrawable.intrinsicHeight,
             displayMetrics = mockDisplayMetrics,
             config = mockConfig,
-            base64SerializerCallback = mockBase64SerializerCallback,
             bitmapCreationCallback = mockBitmapCreationCallback
         )
 
         // Then
         verify(mockBitmapCreationCallback).onReady(mockBitmapFromPool)
-        verifyNoInteractions(mockBase64SerializerCallback)
     }
 
     @Test
-    fun `M call onReady W createBitmapOfApproxSizeFromDrawable { failed to create bitmap }`() {
+    fun `M call onFailure W createBitmapOfApproxSizeFromDrawable { failed to create bitmap }`() {
         // Given
         whenever(mockDrawable.intrinsicWidth).thenReturn(1)
         whenever(mockDrawable.intrinsicHeight).thenReturn(1)
@@ -279,17 +269,15 @@ internal class DrawableUtilsTest {
             drawableHeight = mockDrawable.intrinsicHeight,
             displayMetrics = mockDisplayMetrics,
             config = mockConfig,
-            base64SerializerCallback = mockBase64SerializerCallback,
             bitmapCreationCallback = mockBitmapCreationCallback
         )
 
         // Then
-        verifyNoInteractions(mockBitmapCreationCallback)
-        verify(mockBase64SerializerCallback).onReady()
+        verify(mockBitmapCreationCallback).onFailure()
     }
 
     @Test
-    fun `M call onReady W createBitmapOfApproxSizeFromDrawable { failed to create canvas }`() {
+    fun `M call onFailure W createBitmapOfApproxSizeFromDrawable { failed to create canvas }`() {
         // Given
         whenever(mockDrawable.intrinsicWidth).thenReturn(1)
         whenever(mockDrawable.intrinsicHeight).thenReturn(1)
@@ -303,13 +291,11 @@ internal class DrawableUtilsTest {
             drawableHeight = mockDrawable.intrinsicHeight,
             displayMetrics = mockDisplayMetrics,
             config = mockConfig,
-            base64SerializerCallback = mockBase64SerializerCallback,
             bitmapCreationCallback = mockBitmapCreationCallback
         )
 
         // Then
-        verifyNoInteractions(mockBitmapCreationCallback)
-        verify(mockBase64SerializerCallback).onReady()
+        verify(mockBitmapCreationCallback).onFailure()
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?
Adds the resourceId property to ImageWireframe, and additionally removes base64 from the MutationResolver diffing.  

### Motivation
Removing base64 from diffing improved performance on ios and in this PR we align on this change. Additionally, resourceId is a necessary prerequisite for the resource endpoint change.

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

