### PR TITLE
RUM-1492 Have more consistent results when using the load picture sample screen

### DIFF
--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/picture/PictureViewModel.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/picture/PictureViewModel.kt
@@ -8,20 +8,20 @@ package com.datadog.android.sample.picture
 
 import android.widget.ImageView
 import androidx.lifecycle.ViewModel
-import java.security.SecureRandom
 
 internal class PictureViewModel : ViewModel() {
 
-    val random = SecureRandom()
-    var loader: ImageLoader = GlideImageLoader()
+    private var loader: ImageLoader = GlideImageLoader()
+    private var useFailingUrl = false
 
     fun loadPictureInto(picture: ImageView) {
-        val url = if (random.nextBoolean()) {
+        val url = if (useFailingUrl) {
             RANDOM_URL
         } else {
             FAILING_URL
         }
         loader.load(url, picture)
+        useFailingUrl = !useFailingUrl
     }
 
     fun selectImageLoader(type: ImageLoaderType) {


### PR DESCRIPTION


### What does this PR do?

To ensure our E2E tests have a consistent number of event, while having some picture load failure, we replace the "pure" random logic with alternating loading failure and success