### PR TITLE
RUM-2104: Fix the issue of missing cpu/memory info with RUM view events

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/VitalReaderRunnable.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/vitals/VitalReaderRunnable.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.vitals
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.scheduleSafe
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -22,8 +23,9 @@ internal class VitalReaderRunnable(
 ) : Runnable {
 
     override fun run() {
-        val rumContext = sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
-        val rumViewType = rumContext["view_type"] as? RumViewScope.RumViewType
+        val rumContext =
+            RumContext.fromFeatureContext(sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME))
+        val rumViewType = rumContext.viewType
         if (rumViewType == RumViewScope.RumViewType.FOREGROUND) {
             val data = reader.readVitalData()
             if (data != null) {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/VitalReaderRunnableTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/VitalReaderRunnableTest.kt
@@ -9,9 +9,11 @@ package com.datadog.android.rum.internal.vitals
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.rum.utils.verifyLog
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.DoubleForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -46,7 +48,7 @@ import java.util.concurrent.TimeUnit
 @ForgeConfiguration(Configurator::class)
 internal class VitalReaderRunnableTest {
 
-    lateinit var testedRunnable: VitalReaderRunnable
+    private lateinit var testedRunnable: VitalReaderRunnable
 
     @Mock
     lateinit var mockReader: VitalReader
@@ -67,10 +69,9 @@ internal class VitalReaderRunnableTest {
     var fakeValue: Double = 0.0
 
     @BeforeEach
-    fun `set up`() {
-        val rumContext = mapOf<String, Any?>(
-            "view_type" to RumViewScope.RumViewType.FOREGROUND
-        )
+    fun `set up`(forge: Forge) {
+        val rumContext = forge.getForgery<RumContext>()
+            .copy(viewType = RumViewScope.RumViewType.FOREGROUND).toMap()
         whenever(mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)) doReturn rumContext
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
         testedRunnable = VitalReaderRunnable(
@@ -104,12 +105,12 @@ internal class VitalReaderRunnableTest {
         mode = EnumSource.Mode.EXCLUDE
     )
     fun `𝕄 not read data, not notify observer but schedule 𝕎 run { viewType != FOREGROUND }()`(
-        viewType: RumViewScope.RumViewType
+        viewType: RumViewScope.RumViewType,
+        forge: Forge
     ) {
         // Given
-        val rumContext = mapOf<String, Any?>(
-            "view_type" to viewType
-        )
+        val rumContext = forge.getForgery<RumContext>()
+            .copy(viewType = viewType).toMap()
         whenever(mockSdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)) doReturn rumContext
 
         // When


### PR DESCRIPTION
### What does this PR do?

RUM data was missing cpu/memory info since SDK v2, because we were safe-casting the property of RUM context to the wrong type.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

