### PR TITLE
RUM-1924: Use tracestate header to supply vendor-specific information

### DIFF
--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -480,14 +480,25 @@ internal constructor(
 
                 TracingHeaderType.TRACECONTEXT -> {
                     requestBuilder.removeHeader(W3C_TRACEPARENT_KEY)
+                    requestBuilder.removeHeader(W3C_TRACESTATE_KEY)
+                    val traceId = span.context().toTraceId()
+                    val spanId = span.context().toSpanId()
                     requestBuilder.addHeader(
                         W3C_TRACEPARENT_KEY,
                         @Suppress("UnsafeThirdPartyFunctionCall") // Format string is static
-                        W3C_DROP_SAMPLING_DECISION.format(
-                            span.context().toTraceId(),
-                            span.context().toSpanId()
+                        W3C_TRACEPARENT_DROP_SAMPLING_DECISION.format(
+                            traceId.padStart(length = W3C_TRACE_ID_LENGTH, padChar = '0'),
+                            spanId.padStart(length = W3C_PARENT_ID_LENGTH, padChar = '0')
                         )
                     )
+                    // TODO RUM-2121 3rd party vendor information will be erased
+                    @Suppress("UnsafeThirdPartyFunctionCall") // Format string is static
+                    var traceStateHeader = W3C_TRACESTATE_DROP_SAMPLING_DECISION
+                        .format(spanId.padStart(length = W3C_PARENT_ID_LENGTH, padChar = '0'))
+                    if (traceOrigin != null) {
+                        traceStateHeader += ";o:$traceOrigin"
+                    }
+                    requestBuilder.addHeader(W3C_TRACESTATE_KEY, traceStateHeader)
                 }
             }
         }
@@ -538,7 +549,8 @@ internal constructor(
                             tracedRequestBuilder.addHeader(key, value)
                         }
 
-                        W3C_TRACEPARENT_KEY -> if (tracingHeaderTypes.contains(TracingHeaderType.TRACECONTEXT)) {
+                        W3C_TRACEPARENT_KEY,
+                        W3C_TRACESTATE_KEY -> if (tracingHeaderTypes.contains(TracingHeaderType.TRACECONTEXT)) {
                             tracedRequestBuilder.addHeader(key, value)
                         }
 
@@ -649,7 +661,13 @@ internal constructor(
 
         // taken from W3CHttpCodec
         internal const val W3C_TRACEPARENT_KEY = "traceparent"
-        internal const val W3C_DROP_SAMPLING_DECISION = "00-%s-%s-00"
+        internal const val W3C_TRACESTATE_KEY = "tracestate"
+
+        // https://www.w3.org/TR/trace-context/#traceparent-header
+        internal const val W3C_TRACEPARENT_DROP_SAMPLING_DECISION = "00-%s-%s-00"
+        internal const val W3C_TRACESTATE_DROP_SAMPLING_DECISION = "dd=p:%s;s:0"
         internal const val W3C_SAMPLING_DECISION_INDEX = 3
+        internal const val W3C_TRACE_ID_LENGTH = 32
+        internal const val W3C_PARENT_ID_LENGTH = 16
     }
 }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.okhttp.utils.config.DatadogSingletonTestConfiguration
 import com.datadog.android.okhttp.utils.verifyLog
 import com.datadog.android.trace.TracingHeaderType
@@ -148,8 +149,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     @StringForgery(type = StringForgeryType.HEXADECIMAL)
     lateinit var fakeTraceId: String
 
-    @StringForgery
-    lateinit var fakeOrigin: String
+    private var fakeOrigin: String? = null
 
     lateinit var fakeLocalHosts: Map<String, Set<TracingHeaderType>>
 
@@ -165,6 +165,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
         whenever(mockTraceSampler.sample()) doReturn true
 
+        fakeOrigin = forge.aNullable { anAlphabeticalString() }
         fakeMediaType = if (forge.aBool()) {
             val mediaType = forge.anElementFrom("application", "image", "text", "model") +
                 "/" + forge.anAlphabeticalString()
@@ -338,12 +339,16 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    fakeOrigin
                 )
         }
     }
@@ -486,12 +491,16 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    fakeOrigin
                 )
         }
     }
@@ -831,12 +840,16 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    fakeOrigin
                 )
         }
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeReso
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.okhttp.utils.config.DatadogSingletonTestConfiguration
 import com.datadog.android.okhttp.utils.verifyLog
 import com.datadog.android.trace.TracingHeaderType
@@ -143,8 +144,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     @StringForgery(type = StringForgeryType.HEXADECIMAL)
     lateinit var fakeTraceId: String
 
-    @StringForgery
-    lateinit var fakeOrigin: String
+    private var fakeOrigin: String? = null
 
     lateinit var fakeLocalHosts: Map<String, Set<TracingHeaderType>>
 
@@ -161,6 +161,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
         whenever(mockTraceSampler.sample()) doReturn true
 
+        fakeOrigin = forge.aNullable { anAlphabeticalString() }
         val mediaType = forge.anElementFrom("application", "image", "text", "model") +
             "/" + forge.anAlphabeticalString()
         fakeLocalHosts = forge.aMap {
@@ -367,12 +368,16 @@ internal open class TracingInterceptorNonDdTracerTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    fakeOrigin
                 )
         }
     }
@@ -515,12 +520,16 @@ internal open class TracingInterceptorNonDdTracerTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    fakeOrigin
                 )
         }
     }
@@ -948,12 +957,16 @@ internal open class TracingInterceptorNonDdTracerTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    fakeOrigin
                 )
         }
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.okhttp.utils.config.DatadogSingletonTestConfiguration
 import com.datadog.android.okhttp.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.okhttp.utils.verifyLog
@@ -147,8 +148,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     @StringForgery(type = StringForgeryType.HEXADECIMAL)
     lateinit var fakeTraceId: String
 
-    @StringForgery
-    lateinit var fakeOrigin: String
+    private var fakeOrigin: String? = null
 
     lateinit var fakeLocalHosts: Map<String, Set<TracingHeaderType>>
 
@@ -164,6 +164,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
         whenever(mockTraceSampler.sample()) doReturn true
 
+        fakeOrigin = forge.aNullable { anAlphabeticalString() }
         fakeMediaType = if (forge.aBool()) {
             val mediaType = forge.anElementFrom("application", "image", "text", "model") +
                 "/" + forge.anAlphabeticalString()
@@ -212,7 +213,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         }
     }
 
-    open fun getExpectedOrigin(): String {
+    open fun getExpectedOrigin(): String? {
         return fakeOrigin
     }
 
@@ -354,12 +355,16 @@ internal open class TracingInterceptorNotSendingSpanTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    getExpectedOrigin()
                 )
         }
     }
@@ -399,12 +404,16 @@ internal open class TracingInterceptorNotSendingSpanTest {
             assertThat(lastValue.header(TracingInterceptor.B3M_TRACE_ID_KEY)).isNull()
             assertThat(lastValue.header(TracingInterceptor.B3_HEADER_KEY))
                 .isEqualTo("0")
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    getExpectedOrigin()
                 )
         }
     }
@@ -547,12 +556,16 @@ internal open class TracingInterceptorNotSendingSpanTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    getExpectedOrigin()
                 )
         }
     }
@@ -890,12 +903,16 @@ internal open class TracingInterceptorNotSendingSpanTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    getExpectedOrigin()
                 )
         }
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeReso
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.okhttp.utils.config.DatadogSingletonTestConfiguration
 import com.datadog.android.okhttp.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.okhttp.utils.verifyLog
@@ -143,8 +144,7 @@ internal open class TracingInterceptorTest {
     @StringForgery(type = StringForgeryType.HEXADECIMAL)
     lateinit var fakeTraceId: String
 
-    @StringForgery
-    lateinit var fakeOrigin: String
+    private var fakeOrigin: String? = null
 
     lateinit var fakeLocalHosts: Map<String, Set<TracingHeaderType>>
 
@@ -162,6 +162,7 @@ internal open class TracingInterceptorTest {
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
         whenever(mockTraceSampler.sample()) doReturn true
 
+        fakeOrigin = forge.aNullable { anAlphabeticalString() }
         val mediaType = forge.anElementFrom("application", "image", "text", "model") +
             "/" + forge.anAlphabeticalString()
         fakeLocalHosts =
@@ -193,7 +194,7 @@ internal open class TracingInterceptorTest {
         )
     }
 
-    open fun getExpectedOrigin(): String {
+    open fun getExpectedOrigin(): String? {
         return fakeOrigin
     }
 
@@ -384,12 +385,16 @@ internal open class TracingInterceptorTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    getExpectedOrigin()
                 )
         }
     }
@@ -429,12 +434,16 @@ internal open class TracingInterceptorTest {
             assertThat(lastValue.header(TracingInterceptor.B3M_TRACE_ID_KEY)).isNull()
             assertThat(lastValue.header(TracingInterceptor.B3_HEADER_KEY))
                 .isEqualTo("0")
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    getExpectedOrigin()
                 )
         }
     }
@@ -572,12 +581,16 @@ internal open class TracingInterceptorTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    getExpectedOrigin()
                 )
         }
     }
@@ -623,12 +636,16 @@ internal open class TracingInterceptorTest {
             assertThat(lastValue.header(TracingInterceptor.B3M_TRACE_ID_KEY)).isNull()
             assertThat(lastValue.header(TracingInterceptor.B3_HEADER_KEY))
                 .isEqualTo("0")
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    getExpectedOrigin()
                 )
         }
     }
@@ -1036,12 +1053,16 @@ internal open class TracingInterceptorTest {
         assertThat(response).isSameAs(fakeResponse)
         argumentCaptor<Request> {
             verify(mockChain).proceed(capture())
-            assertThat(lastValue.header(TracingInterceptor.W3C_TRACEPARENT_KEY))
-                .isEqualTo(
-                    "00-%s-%s-00".format(
-                        mockSpan.context().toTraceId(),
-                        mockSpan.context().toSpanId()
-                    )
+            assertThat(lastValue.headers)
+                .hasTraceParentHeader(
+                    mockSpan.context().toTraceId(),
+                    mockSpan.context().toSpanId(),
+                    isSampled = false
+                )
+                .hasTraceStateHeaderWithOnlyDatadogVendorValues(
+                    mockSpan.context().toSpanId(),
+                    isSampled = false,
+                    getExpectedOrigin()
                 )
         }
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/assertj/HeadersAssert.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/utils/assertj/HeadersAssert.kt
@@ -1,0 +1,124 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp.utils.assertj
+
+import okhttp3.Headers
+import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.Assertions.assertThat
+
+internal class HeadersAssert(actual: Headers) :
+    AbstractAssert<HeadersAssert, Headers>(actual, HeadersAssert::class.java) {
+
+    fun hasTraceParentHeader(traceId: String, spanId: String, isSampled: Boolean): HeadersAssert {
+        val expected = createTraceParentHeader(traceId, spanId, isSampled)
+        return hasHeader(TRACEPARENT_HEADER_NAME, expected)
+    }
+
+    fun hasHeader(name: String, expectedValue: String): HeadersAssert {
+        val actualValue = actual[name]
+        if (actualValue == null) {
+            failWithMessage(
+                "We were expecting to have header [$name] but it was missing."
+            )
+        } else {
+            assertThat(actualValue)
+                .overridingErrorMessage(
+                    "We were expecting to have value [$expectedValue] for" +
+                        " header [$name], but it was [$actualValue]."
+                )
+                .isEqualTo(expectedValue)
+        }
+        return this
+    }
+
+    fun hasTraceStateHeaderWithOnlyDatadogVendorValues(
+        spanId: String,
+        isSampled: Boolean,
+        origin: String? = null
+    ): HeadersAssert {
+        val headerValue = actual[TRACESTATE_HEADER_NAME]
+        if (headerValue == null) {
+            failWithMessage(
+                "We were expecting to have header [$TRACESTATE_HEADER_NAME] but it was missing."
+            )
+        } else {
+            val vendorTags = headerValue.split(",")
+            assertThat(vendorTags)
+                .overridingErrorMessage(
+                    "We were expecting to have only one vendor for" +
+                        " [$TRACESTATE_HEADER_NAME] header, but the actual header value is [$headerValue]"
+                )
+                .hasSize(1)
+            val vendor = vendorTags[0]
+            assertThat(vendor)
+                .overridingErrorMessage(
+                    "We were expecting to have Datadog vendor for" +
+                        " [$TRACESTATE_HEADER_NAME] header, but the actual header value is [$headerValue]"
+                )
+                .startsWith("dd=")
+
+            val rawActualTags = vendor.substringAfter("dd=")
+                .split(";")
+                .map { it.split(":").let { it[0] to it[1] } }
+                .groupBy { it.first }
+                .mapValues { it.value.map { it.second } }
+
+            rawActualTags.forEach {
+                assertThat(it.value)
+                    .overridingErrorMessage(
+                        "We were expecting to not have duplicated or empty tags for" +
+                            " Datadog vendor of [$TRACESTATE_HEADER_NAME] header, but" +
+                            " the actual tags were $vendor"
+                    )
+                    .hasSize(1)
+            }
+
+            val expectedTags = mutableMapOf(
+                "s" to if (isSampled) "1" else "0",
+                "p" to spanId.padStart(length = 16, padChar = '0')
+            ).apply {
+                if (origin != null) put("o", origin)
+            }
+
+            val actualTags = rawActualTags.mapValues { it.value.first() }
+
+            assertThat(actualTags)
+                .overridingErrorMessage(
+                    "We were expecting to have the following tags for" +
+                        " Datadog vendor of [$TRACESTATE_HEADER_NAME] header [$expectedTags], but" +
+                        " the actual tags were [$actualTags]"
+                )
+                .isEqualTo(expectedTags)
+        }
+        return this
+    }
+
+    private fun createTraceParentHeader(
+        traceId: String,
+        spanId: String,
+        isSampled: Boolean
+    ): String {
+        // https://www.w3.org/TR/trace-context/#traceparent-header
+        val paddedTraceId = traceId.padStart(length = 32, padChar = '0')
+        val paddedSpanId = spanId.padStart(length = 16, padChar = '0')
+        val flags = if (isSampled) "01" else "00"
+        return "00-$paddedTraceId-$paddedSpanId-$flags"
+    }
+
+    companion object {
+
+        private const val TRACEPARENT_HEADER_NAME = "traceparent"
+        private const val TRACESTATE_HEADER_NAME = "tracestate"
+
+        /**
+         * Create assertion for [Headers].
+         * @param actual the actual element to assert on
+         * @return the created assertion object.
+         */
+        fun assertThat(actual: Headers): HeadersAssert = HeadersAssert(actual)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds `tracestate` header with Datadog-specific information in case of `TRACECONTEXT` tracing. This header will contain the following Datadog-specific tags:

* `p` - parent ID
* `s` - sampling decision
* `o` - origin, if exists. In case of instrumentation with RUM, it will have `rum` value.

Full spec https://www.w3.org/TR/trace-context/#tracestate-header

iOS counterpart https://github.com/DataDog/dd-sdk-ios/pull/1536

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

