### PR TITLE
Fix batch processing level reporting in core configuration telemetry

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryCoreConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryCoreConfiguration.kt
@@ -17,7 +17,7 @@ internal data class TelemetryCoreConfiguration(
     val useProxy: Boolean,
     val useLocalEncryption: Boolean,
     // batchProcessingLevel.maxBatchesPerUploadJob
-    val batchProcessingLevel: Long
+    val batchProcessingLevel: Int
 ) {
     companion object {
         fun fromEvent(event: Map<*, *>, internalLogger: InternalLogger): TelemetryCoreConfiguration? {
@@ -26,7 +26,7 @@ internal data class TelemetryCoreConfiguration(
             val batchUploadFrequency = event["batch_upload_frequency"] as? Long
             val useProxy = event["use_proxy"] as? Boolean
             val useLocalEncryption = event["use_local_encryption"] as? Boolean
-            val batchProcessingLevel = event["batch_processing_level"] as? Long
+            val batchProcessingLevel = event["batch_processing_level"] as? Int
 
             @Suppress("ComplexCondition")
             if (trackErrors == null || batchSize == null || batchUploadFrequency == null ||

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -263,7 +263,7 @@ internal class TelemetryEventHandler(
                     sessionReplaySampleRate = sessionReplaySampleRate,
                     defaultPrivacyLevel = sessionReplayPrivacy,
                     startSessionReplayRecordingManually = startSessionReplayManually,
-                    batchProcessingLevel = coreConfiguration.batchProcessingLevel
+                    batchProcessingLevel = coreConfiguration.batchProcessingLevel.toLong()
                 )
             )
         )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -1214,7 +1214,7 @@ internal class RumFeatureTest {
         @BoolForgery useLocalEncryption: Boolean,
         @LongForgery(min = 0L) batchSize: Long,
         @LongForgery(min = 0L) batchUploadFrequency: Long,
-        @LongForgery(min = 0L) batchProcessingLevel: Long
+        @IntForgery(min = 0) batchProcessingLevel: Int
     ) {
         // Given
         testedFeature.onInitialize(appContext.mockInstance)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/TelemetryCoreConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/TelemetryCoreConfigurationForgeryFactory.kt
@@ -19,7 +19,7 @@ internal class TelemetryCoreConfigurationForgeryFactory :
             batchUploadFrequency = forge.aPositiveLong(),
             useProxy = forge.aBool(),
             useLocalEncryption = forge.aBool(),
-            batchProcessingLevel = forge.aPositiveLong()
+            batchProcessingLevel = forge.aPositiveInt()
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryConfigurationEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryConfigurationEventAssert.kt
@@ -249,13 +249,13 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
             .isEqualTo(expected)
         return this
     }
-    fun hasBatchProcessingLevel(expected: Long?): TelemetryConfigurationEventAssert {
+    fun hasBatchProcessingLevel(expected: Int?): TelemetryConfigurationEventAssert {
         assertThat(actual.telemetry.configuration.batchProcessingLevel)
             .overridingErrorMessage(
                 "Expected event data to have telemetry.configuration.batchProcessingLevel $expected " +
                     "but was ${actual.telemetry.configuration.batchProcessingLevel}"
             )
-            .isEqualTo(expected)
+            .isEqualTo(expected?.toLong())
         return this
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryCoreConfigurationTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryCoreConfigurationTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.telemetry.internal
 
 import fr.xgouchet.elmyr.annotation.AdvancedForgery
 import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.MapForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -31,7 +32,7 @@ internal class TelemetryCoreConfigurationTest {
         @BoolForgery useLocalEncryption: Boolean,
         @LongForgery(min = 0L) batchSize: Long,
         @LongForgery(min = 0L) batchUploadFrequency: Long,
-        @LongForgery(min = 0L) batchProcessingLevel: Long
+        @IntForgery(min = 0) batchProcessingLevel: Int
     ) {
         // Given
         val event = mapOf(


### PR DESCRIPTION
### What does this PR do?

`batchProcessingLevel` has type `Int` and not `Long`, this difference made it evaluate to `null` when extracted from the message bus and safe-casted to `Long`.

### Additional Notes

We probably need to come up with some approach regarding testing the things going through the message bus.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

