### PR TITLE
(2/16) Include rum-mobile-android as codeowner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,6 @@
 # Global code owners - RUM Mobile Team
 
-* @DataDog/rum-mobile
+* @DataDog/rum-mobile @DataDog/rum-mobile-android
 
 ## Docs
 


### PR DESCRIPTION
_This PR has been created automatically by the CI_

Include rum-mobile-android as codeowner