### PR TITLE
(1/9) RUM-2127 Create a SetSyntheticsTestAttribute event

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -197,6 +197,12 @@ internal sealed class RumRawEvent {
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
+    internal data class SetSyntheticsTestAttribute(
+        val testId: String,
+        val resultId: String?,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
     internal data class WebViewEvent(override val eventTime: Time = Time()) : RumRawEvent()
 
     internal data class SendTelemetry(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -63,4 +63,6 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
     fun sendConfigurationTelemetryEvent(coreConfiguration: TelemetryCoreConfiguration)
 
     fun updatePerformanceMetric(metric: RumPerformanceMetric, value: Double)
+
+    fun setSyntheticsAttribute(testId: String, resultId: String?)
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -525,6 +525,13 @@ internal class DatadogRumMonitor(
         handleEvent(RumRawEvent.UpdatePerformanceMetric(metric, value))
     }
 
+    override fun setSyntheticsAttribute(
+        testId: String,
+        resultId: String?
+    ) {
+        handleEvent(RumRawEvent.SetSyntheticsTestAttribute(testId, resultId))
+    }
+
     override fun _getInternal(): _RumInternalProxy {
         return internalProxy
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1621,6 +1621,26 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
+    fun `M handle synthetics test attributes W setSyntheticsTestAttribute()`(
+        @StringForgery fakeTestId: String,
+        @StringForgery fakeResultId: String
+    ) {
+        // When
+        testedMonitor.setSyntheticsAttribute(fakeTestId, fakeResultId)
+        Thread.sleep(PROCESSING_DELAY)
+
+        // Then
+        argumentCaptor<RumRawEvent.SetSyntheticsTestAttribute> {
+            verify(mockScope).handleEvent(
+                capture(),
+                eq(mockWriter)
+            )
+            assertThat(lastValue.testId).isEqualTo(fakeTestId)
+            assertThat(lastValue.resultId).isEqualTo(fakeResultId)
+        }
+    }
+
+    @Test
     fun `M allow only one thread inside rootScope#handleEvent at the time W handleEvent()`(
         forge: Forge
     ) {


### PR DESCRIPTION
_This PR has been created automatically by the CI_

Create a SetSyntheticsTestAttribute event.
The event will be used to attach Synthetics test run information to the RUM Events