### PR TITLE
(3/9) RUM-2127 store the synthetics test info in the RUM Context

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -38,7 +38,8 @@ internal class RumApplicationScope(
     private val appStartTimeProvider: AppStartTimeProvider = DefaultAppStartTimeProvider()
 ) : RumScope, RumViewChangedListener {
 
-    private val rumContext = RumContext(applicationId = applicationId)
+    private var rumContext = RumContext(applicationId = applicationId)
+
     internal val childScopes: MutableList<RumScope> = mutableListOf(
         RumSessionScope(
             this,
@@ -71,6 +72,13 @@ internal class RumApplicationScope(
         event: RumRawEvent,
         writer: DataWriter<Any>
     ): RumScope {
+        if (event is RumRawEvent.SetSyntheticsTestAttribute) {
+            rumContext = rumContext.copy(
+                syntheticsTestId = event.testId,
+                syntheticsResultId = event.resultId
+            )
+        }
+
         val isInteraction = (event is RumRawEvent.StartView) || (event is RumRawEvent.StartAction)
         if (activeSession == null && isInteraction) {
             startNewSession(event, writer)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -144,10 +144,37 @@ internal class RumApplicationScopeTest {
     }
 
     @Test
-    fun `always returns the same applicationId`() {
+    fun `M always return the same applicationId W getRumContext()`() {
         val context = testedScope.getRumContext()
 
         assertThat(context.applicationId).isEqualTo(fakeApplicationId)
+    }
+
+    @Test
+    fun `M return null synthetics info W getRumContext()`() {
+        val context = testedScope.getRumContext()
+
+        assertThat(context.syntheticsTestId).isNull()
+        assertThat(context.syntheticsResultId).isNull()
+    }
+
+    @Test
+    fun `M return synthetics test attributes W handleEvent() + getRumContext()`(
+        @StringForgery fakeTestId: String,
+        @StringForgery fakeResultId: String
+    ) {
+        // Given
+        val event = RumRawEvent.SetSyntheticsTestAttribute(fakeTestId, fakeResultId)
+
+        // When
+        val result = testedScope.handleEvent(event, mockWriter)
+        val context = testedScope.getRumContext()
+
+        // Then
+        assertThat(result).isSameAs(testedScope)
+        assertThat(context.syntheticsTestId).isEqualTo(fakeTestId)
+        assertThat(context.syntheticsResultId).isEqualTo(fakeResultId)
+        verifyNoInteractions(mockWriter)
     }
 
     @Test


### PR DESCRIPTION
_This PR has been created automatically by the CI_

Store the synthetics test info in the RUM Context.
We store the info directly at the application level, as it will be the same for a given run in Synthetics. If a Synthetics run creates multiple session for any reason, we want  the info to stay available. 