### PR TITLE
(8/9) RUM-2127 Add synthetics info to RUM Long Tasks

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -968,6 +968,22 @@ internal open class RumViewScope(
                     datadogContext,
                     rumContext.viewId.orEmpty()
                 )
+                val syntheticsAttribute = if (
+                    rumContext.syntheticsTestId.isNullOrBlank() ||
+                    rumContext.syntheticsResultId.isNullOrBlank()
+                ) {
+                    null
+                } else {
+                    LongTaskEvent.Synthetics(
+                        testId = rumContext.syntheticsTestId,
+                        resultId = rumContext.syntheticsResultId
+                    )
+                }
+                val sessionType = if (syntheticsAttribute == null) {
+                    LongTaskEvent.LongTaskEventSessionType.USER
+                } else {
+                    LongTaskEvent.LongTaskEventSessionType.SYNTHETICS
+                }
                 val longTaskEvent = LongTaskEvent(
                     date = timestamp - TimeUnit.NANOSECONDS.toMillis(event.durationNs),
                     longTask = LongTaskEvent.LongTask(
@@ -994,9 +1010,10 @@ internal open class RumViewScope(
                     application = LongTaskEvent.Application(rumContext.applicationId),
                     session = LongTaskEvent.LongTaskEventSession(
                         id = rumContext.sessionId,
-                        type = LongTaskEvent.LongTaskEventSessionType.USER,
+                        type = sessionType,
                         hasReplay = hasReplay
                     ),
+                    synthetics = syntheticsAttribute,
                     source = LongTaskEvent.Source.tryFromSource(
                         datadogContext.source,
                         sdkCore.internalLogger

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/LongTaskEventAssert.kt
@@ -164,7 +164,7 @@ internal class LongTaskEventAssert(actual: LongTaskEvent) :
     fun hasApplicationId(expected: String): LongTaskEventAssert {
         assertThat(actual.application.id)
             .overridingErrorMessage(
-                "Expected context to have application.id $expected but was ${actual.application.id}"
+                "Expected event to have application.id $expected but was ${actual.application.id}"
             )
             .isEqualTo(expected)
         return this
@@ -173,9 +173,49 @@ internal class LongTaskEventAssert(actual: LongTaskEvent) :
     fun hasSessionId(expected: String): LongTaskEventAssert {
         assertThat(actual.session.id)
             .overridingErrorMessage(
-                "Expected context to have session.id $expected but was ${actual.session.id}"
+                "Expected event to have session.id $expected but was ${actual.session.id}"
             )
             .isEqualTo(expected)
+        return this
+    }
+
+    fun hasUserSession(): LongTaskEventAssert {
+        assertThat(actual.session.type)
+            .overridingErrorMessage(
+                "Expected event to have session.type:user but was ${actual.session.type}"
+            ).isEqualTo(LongTaskEvent.LongTaskEventSessionType.USER)
+        return this
+    }
+
+    fun hasSyntheticsSession(): LongTaskEventAssert {
+        assertThat(actual.session.type)
+            .overridingErrorMessage(
+                "Expected event to have session.type:synthetics but was ${actual.session.type}"
+            ).isEqualTo(LongTaskEvent.LongTaskEventSessionType.SYNTHETICS)
+        return this
+    }
+
+    fun hasNoSyntheticsTest(): LongTaskEventAssert {
+        assertThat(actual.synthetics?.testId)
+            .overridingErrorMessage(
+                "Expected event to have no synthetics.testId but was ${actual.synthetics?.testId}"
+            ).isNull()
+        assertThat(actual.synthetics?.resultId)
+            .overridingErrorMessage(
+                "Expected event to have no synthetics.resultId but was ${actual.synthetics?.resultId}"
+            ).isNull()
+        return this
+    }
+
+    fun hasSyntheticsTest(testId: String, resultId: String): LongTaskEventAssert {
+        assertThat(actual.synthetics?.testId)
+            .overridingErrorMessage(
+                "Expected event to have synthetics.testId $testId but was ${actual.synthetics?.testId}"
+            ).isEqualTo(testId)
+        assertThat(actual.synthetics?.resultId)
+            .overridingErrorMessage(
+                "Expected event to have synthetics.resultId $resultId but was ${actual.synthetics?.resultId}"
+            ).isEqualTo(resultId)
         return this
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -5783,6 +5783,8 @@ internal class RumViewScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasLiteSessionPlan()
+                    hasUserSession()
+                    hasNoSyntheticsTest()
                     hasReplay(fakeHasReplay)
                     hasSource(fakeSourceLongTaskEvent)
                     hasDeviceInfo(
@@ -5835,6 +5837,134 @@ internal class RumViewScopeTest {
                     hasApplicationId(fakeParentContext.applicationId)
                     hasSessionId(fakeParentContext.sessionId)
                     hasLiteSessionPlan()
+                    hasUserSession()
+                    hasNoSyntheticsTest()
+                    hasReplay(fakeHasReplay)
+                    hasSource(fakeSourceLongTaskEvent)
+                    hasDeviceInfo(
+                        fakeDatadogContext.deviceInfo.deviceName,
+                        fakeDatadogContext.deviceInfo.deviceModel,
+                        fakeDatadogContext.deviceInfo.deviceBrand,
+                        fakeDatadogContext.deviceInfo.deviceType.toLongTaskSchemaType(),
+                        fakeDatadogContext.deviceInfo.architecture
+                    )
+                    hasOsInfo(
+                        fakeDatadogContext.deviceInfo.osName,
+                        fakeDatadogContext.deviceInfo.osVersion,
+                        fakeDatadogContext.deviceInfo.osMajorVersion
+                    )
+                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasServiceName(fakeDatadogContext.service)
+                    hasVersion(fakeDatadogContext.version)
+                    hasSampleRate(fakeSampleRate)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
+    fun `𝕄 send event synthetics info 𝕎 handleEvent(AddLongTask) on active view {not frozen}`(
+        @StringForgery fakeTestId: String,
+        @StringForgery fakeResultId: String,
+        @LongForgery(0L, 700_000_000L) durationNs: Long,
+        @StringForgery target: String
+    ) {
+        // Given
+        testedScope.activeActionScope = null
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        val durationMs = TimeUnit.NANOSECONDS.toMillis(durationNs)
+        fakeParentContext = fakeParentContext.copy(
+            syntheticsTestId = fakeTestId,
+            syntheticsResultId = fakeResultId
+        )
+        whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        argumentCaptor<LongTaskEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+
+            assertThat(firstValue)
+                .apply {
+                    hasTimestamp(
+                        resolveExpectedTimestamp(fakeEvent.eventTime.timestamp) - durationMs
+                    )
+                    hasDuration(durationNs)
+                    isFrozenFrame(false)
+                    hasUserInfo(fakeDatadogContext.userInfo)
+                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasView(testedScope.viewId, testedScope.url)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasLiteSessionPlan()
+                    hasSyntheticsSession()
+                    hasSyntheticsTest(fakeTestId, fakeResultId)
+                    hasReplay(fakeHasReplay)
+                    hasSource(fakeSourceLongTaskEvent)
+                    hasDeviceInfo(
+                        fakeDatadogContext.deviceInfo.deviceName,
+                        fakeDatadogContext.deviceInfo.deviceModel,
+                        fakeDatadogContext.deviceInfo.deviceBrand,
+                        fakeDatadogContext.deviceInfo.deviceType.toLongTaskSchemaType(),
+                        fakeDatadogContext.deviceInfo.architecture
+                    )
+                    hasOsInfo(
+                        fakeDatadogContext.deviceInfo.osName,
+                        fakeDatadogContext.deviceInfo.osVersion,
+                        fakeDatadogContext.deviceInfo.osMajorVersion
+                    )
+                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasServiceName(fakeDatadogContext.service)
+                    hasVersion(fakeDatadogContext.version)
+                    hasSampleRate(fakeSampleRate)
+                }
+        }
+        verifyNoMoreInteractions(mockWriter)
+        assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
+    fun `𝕄 send event with synthetics info 𝕎 handleEvent(AddLongTask) on active view {frozen}`(
+        @StringForgery fakeTestId: String,
+        @StringForgery fakeResultId: String,
+        @LongForgery(700_000_000L, 10_000_000_000L) durationNs: Long,
+        @StringForgery target: String
+    ) {
+        // Given
+        testedScope.activeActionScope = null
+        fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
+        val durationMs = TimeUnit.NANOSECONDS.toMillis(durationNs)
+        fakeParentContext = fakeParentContext.copy(
+            syntheticsTestId = fakeTestId,
+            syntheticsResultId = fakeResultId
+        )
+        whenever(mockParentScope.getRumContext()) doReturn fakeParentContext
+
+        // When
+        val result = testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        argumentCaptor<LongTaskEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+
+            assertThat(firstValue)
+                .apply {
+                    hasTimestamp(
+                        resolveExpectedTimestamp(fakeEvent.eventTime.timestamp) - durationMs
+                    )
+                    hasDuration(durationNs)
+                    isFrozenFrame(true)
+                    hasUserInfo(fakeDatadogContext.userInfo)
+                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasView(testedScope.viewId, testedScope.url)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasLiteSessionPlan()
+                    hasSyntheticsSession()
+                    hasSyntheticsTest(fakeTestId, fakeResultId)
                     hasReplay(fakeHasReplay)
                     hasSource(fakeSourceLongTaskEvent)
                     hasDeviceInfo(
@@ -5896,6 +6026,8 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasLiteSessionPlan()
+                    hasUserSession()
+                    hasNoSyntheticsTest()
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(expectedAttributes)
                     hasSource(fakeSourceLongTaskEvent)
@@ -5958,6 +6090,8 @@ internal class RumViewScopeTest {
                     hasSessionId(fakeParentContext.sessionId)
                     hasActionId(fakeActionId)
                     hasLiteSessionPlan()
+                    hasUserSession()
+                    hasNoSyntheticsTest()
                     hasReplay(fakeHasReplay)
                     containsExactlyContextAttributes(expectedAttributes)
                     hasSource(fakeSourceLongTaskEvent)


### PR DESCRIPTION
_This PR has been created automatically by the CI_

Add synthetics info to RUM Long Tasks
The info is read from the RUM context and converted into the relevant attributes at write time.