### PR TITLE
(9/9) RUM-2127 track synthetics info from activity extras

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -315,6 +315,7 @@ datadog:
       - "android.net.ConnectivityManager.getNetworkCapabilities(android.net.Network?)"
       - "android.net.NetworkCapabilities.hasTransport(kotlin.Int)"
       - "android.os.Bundle.get(kotlin.String?)"
+      - "android.os.Bundle.getString(kotlin.String?)"
       - "android.os.Bundle.keySet()"
       - "android.os.Handler.constructor(android.os.Looper)"
       - "android.os.Handler.post(java.lang.Runnable)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -199,7 +199,7 @@ internal sealed class RumRawEvent {
 
     internal data class SetSyntheticsTestAttribute(
         val testId: String,
-        val resultId: String?,
+        val resultId: String,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -64,5 +64,5 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
 
     fun updatePerformanceMetric(metric: RumPerformanceMetric, value: Double)
 
-    fun setSyntheticsAttribute(testId: String, resultId: String?)
+    fun setSyntheticsAttribute(testId: String, resultId: String)
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -527,7 +527,7 @@ internal class DatadogRumMonitor(
 
     override fun setSyntheticsAttribute(
         testId: String,
-        resultId: String?
+        resultId: String
     ) {
         handleEvent(RumRawEvent.SetSyntheticsTestAttribute(testId, resultId))
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
@@ -15,7 +15,9 @@ import androidx.annotation.MainThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.internal.RumFeature
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 
 /**
  * The ActivityLifecycleTrackingStrategy as an [Application.ActivityLifecycleCallbacks]
@@ -89,7 +91,17 @@ abstract class ActivityLifecycleTrackingStrategy :
 
     @MainThread
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
-        // No Op
+        val intent = activity.intent
+        val extras = intent.extras
+        val testId = extras?.getString("_dd.synthetics.test_id")
+        val resultId = extras?.getString("_dd.synthetics.result_id")
+        if (!testId.isNullOrBlank() && !resultId.isNullOrBlank()) {
+            (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor)
+                ?.setSyntheticsAttribute(
+                    testId,
+                    resultId
+                )
+        }
     }
 
     @MainThread
@@ -178,5 +190,8 @@ abstract class ActivityLifecycleTrackingStrategy :
         internal const val ARGUMENT_TAG = "view.arguments"
         internal const val INTENT_ACTION_TAG = "view.intent.action"
         internal const val INTENT_URI_TAG = "view.intent.uri"
+
+        internal const val EXTRA_SYNTHETICS_TEST_ID = "_dd.synthetics.test_id"
+        internal const val EXTRA_SYNTHETICS_RESULT_ID = "_dd.synthetics.result_id"
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityLifecycleTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityLifecycleTrackingStrategyTest.kt
@@ -10,7 +10,9 @@ import android.app.Activity
 import android.app.Application
 import android.content.Context
 import android.content.Intent
+import android.os.Bundle
 import android.view.Window
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.tracking.ActivityLifecycleTrackingStrategy
 import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator
@@ -19,6 +21,7 @@ import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.BeforeEach
@@ -43,7 +46,7 @@ import org.mockito.quality.Strictness
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
 internal abstract class ActivityLifecycleTrackingStrategyTest<T> : ObjectTest<T>()
-        where T : ActivityLifecycleTrackingStrategy {
+    where T : ActivityLifecycleTrackingStrategy {
 
     lateinit var testedStrategy: T
 
@@ -103,6 +106,48 @@ internal abstract class ActivityLifecycleTrackingStrategyTest<T> : ObjectTest<T>
 
         // verify
         verifyNoInteractions(mockBadContext)
+    }
+
+    @Test
+    fun `M track synthetics info W onActivityCreated()`(
+        @StringForgery testId: String,
+        @StringForgery resultId: String
+    ) {
+        // Given
+        testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
+        val mockIntent = mock<Intent>()
+        val mockActivity = mock<Activity>()
+        val fakeExtras = Bundle(2).apply {
+            putString(ActivityLifecycleTrackingStrategy.EXTRA_SYNTHETICS_TEST_ID, testId)
+            putString(ActivityLifecycleTrackingStrategy.EXTRA_SYNTHETICS_RESULT_ID, resultId)
+        }
+        whenever(mockActivity.intent) doReturn mockIntent
+        whenever(mockIntent.extras) doReturn fakeExtras
+
+        // When
+        testedStrategy.onActivityCreated(mockActivity, null)
+
+        // verify
+        val mockRumMonitor = rumMonitor.mockInstance as AdvancedRumMonitor
+        verify(mockRumMonitor).setSyntheticsAttribute(testId, resultId)
+    }
+
+    @Test
+    fun `M do nothing W onActivityCreated() { no synthetics extra }`() {
+        // Given
+        testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
+        val mockIntent = mock<Intent>()
+        val mockActivity = mock<Activity>()
+        val fakeExtras = Bundle()
+        whenever(mockActivity.intent) doReturn mockIntent
+        whenever(mockIntent.extras) doReturn fakeExtras
+
+        // When
+        testedStrategy.onActivityCreated(mockActivity, null)
+
+        // verify
+        val mockRumMonitor = rumMonitor.mockInstance as AdvancedRumMonitor
+        verifyNoInteractions(mockRumMonitor)
     }
 
     companion object {


### PR DESCRIPTION
_This PR has been created automatically by the CI_

track synthetics info from activity extras

All the provided ViewTrackingStrategy implementation extend the ActivityLifecycleTrackingStrategy, meaning that all supports the Synthetics use case. 