### PR TITLE
RUM-1017: Unregister RUM monitor when associated RUM feature is stopped

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -902,6 +902,7 @@ datadog:
       - "kotlin.collections.MutableMap.put(kotlin.String, kotlin.String)"
       - "kotlin.collections.MutableMap.putAll(kotlin.collections.Map)"
       - "kotlin.collections.MutableMap.remove(androidx.compose.foundation.interaction.DragInteraction.Start)"
+      - "kotlin.collections.MutableMap.remove(com.datadog.android.api.SdkCore)"
       - "kotlin.collections.MutableMap.remove(com.datadog.android.rum.internal.vitals.VitalListener)"
       - "kotlin.collections.MutableMap.remove(kotlin.Int)"
       - "kotlin.collections.MutableMap.remove(kotlin.Long)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -217,6 +217,8 @@ internal class RumFeature constructor(
         anrDetectorRunnable.stop()
         vitalExecutorService = NoOpScheduledExecutorService()
         sessionListener = NoOpRumSessionListener()
+
+        GlobalRumMonitor.unregister(sdkCore)
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.MapperSerializer
 import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.NoOpRumMonitor
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.assertj.RumFeatureAssert
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
@@ -570,6 +571,20 @@ internal class RumFeatureTest {
 
         // Then
         assertThat(testedFeature.dataWriter).isInstanceOf(NoOpDataWriter::class.java)
+    }
+
+    @Test
+    fun `𝕄 remove associated monitor 𝕎 onStop()`() {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+        GlobalRumMonitor.registerIfAbsent(mockRumMonitor, mockSdkCore)
+
+        // When
+        testedFeature.onStop()
+
+        // Then
+        assertThat(GlobalRumMonitor.isRegistered(mockSdkCore)).isFalse
+        assertThat(GlobalRumMonitor.get(mockSdkCore)).isInstanceOf(NoOpRumMonitor::class.java)
     }
 
     @ParameterizedTest

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -205,10 +205,6 @@ internal class EncryptionTest {
     private fun stopSdk() {
         Datadog.stopInstance()
         GlobalTracer::class.java.setStaticValue("isRegistered", false)
-        GlobalRumMonitor::class.java.getDeclaredMethod("reset").apply {
-            isAccessible = true
-            invoke(null)
-        }
     }
 
     private fun flushAndShutdownExecutors() {

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayTest.kt
@@ -40,10 +40,6 @@ internal abstract class BaseSessionReplayTest<R : Activity> {
     fun tearDown() {
         GlobalRumMonitor.get().stopSession()
         Datadog.stopInstance()
-        GlobalRumMonitor::class.java.getDeclaredMethod("reset").apply {
-            isAccessible = true
-            invoke(null)
-        }
     }
 
     protected fun assessSrPayload(payloadFileName: String, rule: SessionReplayTestRule<R>) {

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
@@ -105,10 +105,6 @@ internal open class MockServerActivityTestRule<T : Activity>(
             .cacheDir.deleteRecursively()
         GlobalRumMonitor.get().stopSession()
         Datadog.stopInstance()
-        GlobalRumMonitor::class.java.getDeclaredMethod("reset").apply {
-            isAccessible = true
-            invoke(null)
-        }
 
         super.afterActivityFinished()
     }

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/utils/MiscUtils.kt
@@ -80,10 +80,6 @@ fun stopSdk() {
 
     // Reset Global states
     GlobalTracer::class.java.setStaticValue("isRegistered", false)
-    GlobalRumMonitor::class.java.getDeclaredMethod("reset").apply {
-        isAccessible = true
-        invoke(null)
-    }
 }
 
 fun flushAndShutdownExecutors() {


### PR DESCRIPTION
### What does this PR do?

This change removes RUM monitor for the given RUM feature (or SDK instance in other words), when the feature is stopped.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

