### PR TITLE
Fix flaky test in DatadogContextProvider

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/DatadogContextProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/DatadogContextProviderTest.kt
@@ -161,7 +161,8 @@ internal class DatadogContextProviderTest {
         forge: Forge
     ) {
         // Given
-        val mutableFeaturesContext = forge.aMap<String, Map<String, Any?>> {
+        val mapSize = forge.anInt(4, 20)
+        val mutableFeaturesContext = forge.aMap<String, Map<String, Any?>>(mapSize) {
             aString() to forge.exhaustiveAttributes()
         }.toMutableMap()
 
@@ -188,7 +189,7 @@ internal class DatadogContextProviderTest {
             }
         }
         val keysToRemove = mutableFeaturesContext.keys
-            .take(forge.anInt(min = 0, max = mutableFeaturesContext.keys.size))
+            .take(forge.anInt(min = 1, max = mutableFeaturesContext.keys.size))
         keysToRemove.forEach {
             mutableFeaturesContext.remove(it)
         }


### PR DESCRIPTION
### What does this PR do?

Fix a flaky test in the DatadogContextProvider: 
the test tries to ensure modifying a mutable map after it being injected won't modify the underlying context. 
In some rare case, the following line would create an issue, as no data would be removed from the mutable map, making one of the assertions failed. 
 
The fix ensures that: 
- the original mutable map has at least 4 items
- at least one entry is removed