### PR TITLE
Fix flaky test in RumEventDeserializer

### DIFF
--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/ForgeExt.kt
@@ -14,7 +14,9 @@ import java.util.Date
 import java.util.Locale
 import java.util.TimeZone
 
-fun Forge.exhaustiveAttributes(): MutableMap<String, Any?> {
+fun Forge.exhaustiveAttributes(
+    excludedKeys: Set<String> = emptySet()
+): MutableMap<String, Any?> {
     return listOf(
         aBool(),
         anInt(),
@@ -33,6 +35,7 @@ fun Forge.exhaustiveAttributes(): MutableMap<String, Any?> {
         null
     )
         .associateBy { anAlphaNumericalString() }
+        .filter { it.key !in excludedKeys }
         .toMutableMap()
 }
 

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/UserInfoForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/UserInfoForgeryFactory.kt
@@ -17,7 +17,7 @@ class UserInfoForgeryFactory : ForgeryFactory<UserInfo> {
             id = forge.aNullable { anHexadecimalString() },
             name = forge.aNullable { forge.aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
             email = forge.aNullable { forge.aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-            additionalProperties = forge.exhaustiveAttributes()
+            additionalProperties = forge.exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
         )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ActionEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ActionEventForgeryFactory.kt
@@ -68,7 +68,7 @@ internal class ActionEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-                    additionalProperties = exhaustiveAttributes()
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
             application = ActionEvent.Application(forge.getForgery<UUID>().toString()),

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ErrorEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ErrorEventForgeryFactory.kt
@@ -76,7 +76,7 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-                    additionalProperties = exhaustiveAttributes()
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
             action = forge.aNullable { ErrorEvent.Action(aList { getForgery<UUID>().toString() }) },

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/LongTaskEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/LongTaskEventForgeryFactory.kt
@@ -53,7 +53,7 @@ internal class LongTaskEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-                    additionalProperties = exhaustiveAttributes()
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
             action = forge.aNullable {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ResourceEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ResourceEventForgeryFactory.kt
@@ -90,7 +90,7 @@ internal class ResourceEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-                    additionalProperties = exhaustiveAttributes()
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
             action = forge.aNullable {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ViewEventForgeryFactory.kt
@@ -88,7 +88,7 @@ internal class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-                    additionalProperties = exhaustiveAttributes()
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
             application = ViewEvent.Application(forge.getForgery<UUID>().toString()),

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ActionEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ActionEventForgeryFactory.kt
@@ -69,7 +69,7 @@ internal class ActionEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-                    additionalProperties = exhaustiveAttributes()
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
             application = ActionEvent.Application(forge.getForgery<UUID>().toString()),

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
@@ -77,7 +77,7 @@ internal class ErrorEventForgeryFactory : ForgeryFactory<ErrorEvent> {
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-                    additionalProperties = exhaustiveAttributes()
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
             action = forge.aNullable { ErrorEvent.Action(aList { getForgery<UUID>().toString() }) },

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/LongTaskEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/LongTaskEventForgeryFactory.kt
@@ -54,7 +54,7 @@ internal class LongTaskEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-                    additionalProperties = exhaustiveAttributes()
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
             action = forge.aNullable {

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ResourceEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ResourceEventForgeryFactory.kt
@@ -101,7 +101,7 @@ internal class ResourceEventForgeryFactory :
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-                    additionalProperties = exhaustiveAttributes()
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
             action = forge.aNullable {

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ViewEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ViewEventForgeryFactory.kt
@@ -89,7 +89,7 @@ internal class ViewEventForgeryFactory : ForgeryFactory<ViewEvent> {
                     id = aNullable { anHexadecimalString() },
                     name = aNullable { aStringMatching("[A-Z][a-z]+ [A-Z]\\. [A-Z][a-z]+") },
                     email = aNullable { aStringMatching("[a-z]+\\.[a-z]+@[a-z]+\\.[a-z]{3}") },
-                    additionalProperties = exhaustiveAttributes()
+                    additionalProperties = exhaustiveAttributes(excludedKeys = setOf("id", "name", "email"))
                 )
             },
             application = ViewEvent.Application(forge.getForgery<UUID>().toString()),


### PR DESCRIPTION
### What does this PR do?

Fix a flaky test in the RumEventDeserializer.

The test generates random `usr.*` attributes in a RUM event, then serialize and deserialize it and compare with the original one. An issue can arise if one of the random attributes uses a known key name (i.e. `id`, `name`, `email`), as on serialization it would conflict and wouldn't be recoverred via deserialization. 

### Additional Notes

I also "fixed" this in other ForgeryFactory implementations that could one day cause flakyness in the tests
