### PR TITLE
Fix flaky test in TelemetryEventHandlerTest

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -718,11 +718,13 @@ internal class TelemetryEventHandlerTest {
     @Test
     fun `𝕄 continue writing events after new session 𝕎 handleEvent(SendTelemetry)`(forge: Forge) {
         // Given
-        val eventsInOldSession = forge.aList(
-            size = forge.anInt(MAX_EVENTS_PER_SESSION_TEST * 2, MAX_EVENTS_PER_SESSION_TEST * 4)
-        ) { createRumRawTelemetryEvent() }
-            // remove unwanted identity collisions
-            .groupBy { it.identity }.map { it.value.first() }
+        val eventMap = mutableMapOf<TelemetryEventId, RumRawEvent.SendTelemetry>()
+        while (eventMap.size <= MAX_EVENTS_PER_SESSION_TEST) {
+            val candidate = forge.createRumRawTelemetryEvent()
+            val id = candidate.identity
+            eventMap[id] = candidate
+        }
+        val eventsInOldSession = eventMap.map { it.value }
         val extraNumber = eventsInOldSession.size - MAX_EVENTS_PER_SESSION_TEST
 
         val eventsInNewSession = forge.aList(


### PR DESCRIPTION
### What does this PR do?

This PR fixes a flaky test in TelemetryEventHandlerTest

The test generates a list of events, and then filters it to ensure to keep only one event per fingerprint. If the number of filtered event is lower than the `MAX_EVENTS_PER_SESSION_TEST` value, the test eventually tries to verify that a warning log is printed a negative amount of times. 

The fix ensures that the filtered list has enough entries to trigger the log at least once.
