### PR TITLE
Reduce noise in logs when building the project

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/FlavorBuildConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/FlavorBuildConfig.kt
@@ -8,6 +8,7 @@ package com.datadog.gradle.config
 
 import com.android.build.api.dsl.ApplicationProductFlavor
 import com.google.gson.Gson
+import org.gradle.api.Project
 import java.io.File
 import java.util.Locale
 
@@ -23,9 +24,13 @@ fun sampleAppConfig(filePath: String): SampleAppConfig {
 }
 
 @Suppress("UnstableApiUsage")
-fun configureFlavorForSampleApp(flavor: ApplicationProductFlavor, rootDir: File) {
+fun configureFlavorForSampleApp(
+    project: Project,
+    flavor: ApplicationProductFlavor,
+    rootDir: File
+) {
     val config = sampleAppConfig("${rootDir.absolutePath}/config/${flavor.name}.json")
-    println("Configuring flavor: [${flavor.name}] with config: [$config]")
+    project.logger.info("Configuring flavor: [${flavor.name}] with config: [$config]")
     flavor.buildConfigField(
         "String",
         "DD_OVERRIDE_LOGS_URL",

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateApiSurfaceTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/apisurface/GenerateApiSurfaceTask.kt
@@ -46,7 +46,7 @@ open class GenerateApiSurfaceTask : DefaultTask() {
 
     private fun visitDirectoryRecursively(file: File) {
         when {
-            !file.exists() -> logger.warn("File $file doesn't exist, ignoring")
+            !file.exists() -> logger.info("File $file doesn't exist, ignoring")
             file.isDirectory ->
                 file.listFiles().orEmpty()
                     .sortedBy { it.absolutePath }

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -84,7 +84,7 @@ android {
             register(region) {
                 isDefault = index == 0
                 dimension = "site"
-                configureFlavorForSampleApp(this, project.rootDir)
+                configureFlavorForSampleApp(project, this, project.rootDir)
             }
         }
     }

--- a/sample/wear/build.gradle.kts
+++ b/sample/wear/build.gradle.kts
@@ -43,7 +43,7 @@ android {
             register(region) {
                 isDefault = index == 0
                 dimension = "site"
-                configureFlavorForSampleApp(this, project.rootDir)
+                configureFlavorForSampleApp(project, this, project.rootDir)
             }
         }
     }


### PR DESCRIPTION
### What does this PR do?

Replace a `println` with gradle's logger to reduce the noise in our build output
