### PR TITLE
Fix flaky test in BatchFileOrchestratorTest

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/batch/BatchFileOrchestratorTest.kt
@@ -1207,7 +1207,7 @@ internal class BatchFileOrchestratorTest {
         repeat(repeatCount) {
             Thread {
                 val result = testedOrchestrator.getRootDir()
-                results.add(result)
+                synchronized(results) { results.add(result) }
                 countDownLatch.countDown()
             }.start()
         }
@@ -1215,7 +1215,9 @@ internal class BatchFileOrchestratorTest {
 
         // Then
         assertThat(countDownLatch.count).isZero()
-        assertThat(results).containsExactlyElementsOf(List(repeatCount) { fakeRootDir })
+        assertThat(results)
+            .hasSize(repeatCount)
+            .containsOnly(fakeRootDir)
         verifyNoInteractions(mockLogger)
     }
 


### PR DESCRIPTION
### What does this PR do?

Fix flaky test in BatchFileOrchestratorTest

The main issue here is that were using Kotlin's `mutableListOf()` which is inherently not thread safe, and try to insert elements from multiple concurrent threads. What happens 10% of the time (locally) is that two thread end up appending at the same time, and one of the value is overridden, resulting in one less value in the list than expected.