### PR TITLE
RUM-1835 Lower the upload frequency and batch size enum values

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/BatchSize.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/BatchSize.kt
@@ -17,11 +17,11 @@ enum class BatchSize(
 ) {
 
     /** Prefer small batches. **/
-    SMALL(5000L),
+    SMALL(3000L),
 
     /** Prefer medium sized batches. **/
-    MEDIUM(15000L),
+    MEDIUM(10000L),
 
     /** Prefer large batches. **/
-    LARGE(60000L);
+    LARGE(35000L);
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/UploadFrequency.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/UploadFrequency.kt
@@ -15,11 +15,11 @@ enum class UploadFrequency(
 ) {
 
     /** Try to upload batch data frequently. */
-    FREQUENT(1000L),
+    FREQUENT(500L),
 
     /** Try to upload batch data with a medium frequency. */
-    AVERAGE(5000L),
+    AVERAGE(2000L),
 
     /** Try to upload batch data rarely. */
-    RARE(10000L)
+    RARE(5000L)
 }


### PR DESCRIPTION
### What does this PR do?

Following the discussions in the [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3138388946/RFC+-+Uploader+Improvements+Strategies) we are going to lower the `BatchSize` and `UploadFrequency` values in order to increase the frequency of our payload uploads.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

