### PR TITLE
RUM-2245 Generate wireframe ids as 32bit Int

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -707,6 +707,7 @@ datadog:
       - "java.security.MessageDigest.update(kotlin.ByteArray?)"
       - "java.security.SecureRandom.constructor()"
       - "java.security.SecureRandom.nextFloat()"
+      - "java.security.SecureRandom.nextInt()"
       - "java.security.SecureRandom.nextLong()"
       - "java.util.HashSet.find(kotlin.Function1)"
       - "java.util.Properties.constructor()"

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/ShapeWireframeForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/ShapeWireframeForgeryFactory.kt
@@ -14,7 +14,7 @@ internal class ShapeWireframeForgeryFactory :
     ForgeryFactory<MobileSegment.Wireframe.ShapeWireframe> {
     override fun getForgery(forge: Forge): MobileSegment.Wireframe.ShapeWireframe {
         return MobileSegment.Wireframe.ShapeWireframe(
-            id = forge.aPositiveLong(),
+            id = forge.aPositiveInt().toLong(),
             x = forge.aPositiveLong(),
             y = forge.aPositiveLong(),
             width = forge.aPositiveLong(strict = true),

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/TextWireframeForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/TextWireframeForgeryFactory.kt
@@ -14,7 +14,7 @@ internal class TextWireframeForgeryFactory :
     ForgeryFactory<MobileSegment.Wireframe.TextWireframe> {
     override fun getForgery(forge: Forge): MobileSegment.Wireframe.TextWireframe {
         return MobileSegment.Wireframe.TextWireframe(
-            id = forge.aPositiveLong(),
+            id = forge.aPositiveInt().toLong(),
             x = forge.aPositiveLong(),
             y = forge.aPositiveLong(),
             width = forge.aPositiveLong(strict = true),

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/UniqueIdentifierGenerator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/UniqueIdentifierGenerator.kt
@@ -39,7 +39,7 @@ object UniqueIdentifierGenerator {
             // was a long and use that as an identifier.
             uniqueIdentifier as? Long
         } else {
-            val newUniqueIdentifier = secureRandom.nextLong()
+            val newUniqueIdentifier = secureRandom.nextInt().toLong()
             parent.setTag(key, newUniqueIdentifier)
             newUniqueIdentifier
         }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ImageWireframeForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ImageWireframeForgeryFactory.kt
@@ -14,7 +14,7 @@ internal class ImageWireframeForgeryFactory :
     ForgeryFactory<MobileSegment.Wireframe.ImageWireframe> {
     override fun getForgery(forge: Forge): MobileSegment.Wireframe.ImageWireframe {
         return MobileSegment.Wireframe.ImageWireframe(
-            id = forge.aPositiveLong(),
+            id = forge.aPositiveInt().toLong(),
             x = forge.aPositiveLong(),
             y = forge.aPositiveLong(),
             width = forge.aPositiveLong(strict = true),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/PlaceholderWireframeForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/PlaceholderWireframeForgeryFactory.kt
@@ -14,7 +14,7 @@ internal class PlaceholderWireframeForgeryFactory :
     ForgeryFactory<MobileSegment.Wireframe.PlaceholderWireframe> {
     override fun getForgery(forge: Forge): MobileSegment.Wireframe.PlaceholderWireframe {
         return MobileSegment.Wireframe.PlaceholderWireframe(
-            id = forge.aPositiveLong(),
+            id = forge.aPositiveInt().toLong(),
             x = forge.aPositiveLong(),
             y = forge.aPositiveLong(),
             width = forge.aPositiveLong(strict = true),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ShapeWireframeForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ShapeWireframeForgeryFactory.kt
@@ -14,7 +14,7 @@ internal class ShapeWireframeForgeryFactory :
     ForgeryFactory<MobileSegment.Wireframe.ShapeWireframe> {
     override fun getForgery(forge: Forge): MobileSegment.Wireframe.ShapeWireframe {
         return MobileSegment.Wireframe.ShapeWireframe(
-            id = forge.aPositiveLong(),
+            id = forge.aPositiveInt().toLong(),
             x = forge.aPositiveLong(),
             y = forge.aPositiveLong(),
             width = forge.aPositiveLong(strict = true),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ShapeWireframeMutationForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/ShapeWireframeMutationForgeryFactory.kt
@@ -15,7 +15,7 @@ internal class ShapeWireframeMutationForgeryFactory :
     override fun getForgery(forge: Forge):
         MobileSegment.WireframeUpdateMutation.ShapeWireframeUpdate {
         return MobileSegment.WireframeUpdateMutation.ShapeWireframeUpdate(
-            id = forge.aPositiveLong(),
+            id = forge.aPositiveInt().toLong(),
             x = forge.aNullable { aPositiveLong() },
             y = forge.aNullable { aPositiveLong() },
             width = forge.aNullable { aPositiveLong(strict = true) },

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/TextWireframeForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/TextWireframeForgeryFactory.kt
@@ -14,7 +14,7 @@ internal class TextWireframeForgeryFactory :
     ForgeryFactory<MobileSegment.Wireframe.TextWireframe> {
     override fun getForgery(forge: Forge): MobileSegment.Wireframe.TextWireframe {
         return MobileSegment.Wireframe.TextWireframe(
-            id = forge.aPositiveLong(),
+            id = forge.aPositiveInt().toLong(),
             x = forge.aPositiveLong(),
             y = forge.aPositiveLong(),
             width = forge.aPositiveLong(strict = true),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/TextWireframeMutationForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/TextWireframeMutationForgeryFactory.kt
@@ -15,7 +15,7 @@ internal class TextWireframeMutationForgeryFactory :
     override fun getForgery(forge: Forge):
         MobileSegment.WireframeUpdateMutation.TextWireframeUpdate {
         return MobileSegment.WireframeUpdateMutation.TextWireframeUpdate(
-            id = forge.aPositiveLong(),
+            id = forge.aPositiveInt().toLong(),
             x = forge.aNullable { aPositiveLong() },
             y = forge.aNullable { aPositiveLong() },
             width = forge.aNullable { aPositiveLong(strict = true) },

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/UniqueIdentifierGeneratorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/UniqueIdentifierGeneratorTest.kt
@@ -115,4 +115,23 @@ internal class UniqueIdentifierGeneratorTest {
 
         assertThat(generatedUniqueNumbers).isEmpty()
     }
+
+    @Test
+    fun `M always generate a 32bit Int compatible identifier W resolveChildUniqueIdentifier`(forge: Forge) {
+        // Given
+        val numberOfCalls = 1000
+
+        // When
+        val results = forge.aList<View>(numberOfCalls) { mock() }
+            .map {
+                UniqueIdentifierGenerator.resolveChildUniqueIdentifier(mock(), forge.aString())
+            }
+
+        // Then
+        results.forEach {
+            if (it != null) {
+                assertThat(it).isBetween(Int.MIN_VALUE.toLong(), Int.MAX_VALUE.toLong())
+            }
+        }
+    }
 }


### PR DESCRIPTION
### What does this PR do?
Generates wireframe IDs as `Int` instead of as `Long`. Also modify the forgery factories to do the same so that tests will reflect this change.

### Motivation
Generating the IDs as `Long` caused an issue on the backend because there the IDs are being parsed as `Int`. When the ID was out of bounds it would be rounded and this could cause problems with removals of wireframes or duplicated wireframes.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

