### PR TITLE
RUM-1517 create Stub Core module

### DIFF
--- a/reliability/single-fit/logs/src/test/kotlin/com/datadog/android/logs/integration/LoggerTest.kt
+++ b/reliability/single-fit/logs/src/test/kotlin/com/datadog/android/logs/integration/LoggerTest.kt
@@ -7,10 +7,9 @@
 package com.datadog.android.logs.integration
 
 import android.util.Log
-import com.datadog.android.api.StubEvent
-import com.datadog.android.api.StubSDKCore
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.core.stub.StubSDKCore
 import com.datadog.android.log.Logger
 import com.datadog.android.log.Logs
 import com.datadog.android.log.LogsConfiguration
@@ -36,7 +35,6 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.quality.Strictness
-import java.lang.Exception
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -69,7 +67,7 @@ class LoggerTest {
         logger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -88,7 +86,7 @@ class LoggerTest {
         logger.v(fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -107,7 +105,7 @@ class LoggerTest {
         logger.d(fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -126,7 +124,7 @@ class LoggerTest {
         logger.i(fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -145,7 +143,7 @@ class LoggerTest {
         logger.w(fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -164,7 +162,7 @@ class LoggerTest {
         logger.e(fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -183,7 +181,7 @@ class LoggerTest {
         logger.wtf(fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -204,7 +202,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(fakeServiceName)
@@ -225,7 +223,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -250,7 +248,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -276,7 +274,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -299,7 +297,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -325,7 +323,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -350,7 +348,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -372,7 +370,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).isEmpty()
     }
 
@@ -394,7 +392,7 @@ class LoggerTest {
 
         // Then
         val expectedCount = (repeatCount * fakeSampleRate / 100f).toInt()
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten.size).isCloseTo(expectedCount, offset(offsetMargin))
     }
 
@@ -420,7 +418,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -452,7 +450,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -476,7 +474,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage, null, mapOf(fakeKey to fakeValue))
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -498,7 +496,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage, fakeException)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
@@ -525,7 +523,7 @@ class LoggerTest {
         testedLogger.log(fakeLevel, fakeMessage, fakeErrorKind, fakeErrorMessage, fakeErrorStack)
 
         // Then
-        val eventsWritten: List<StubEvent> = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
         assertThat(eventsWritten).hasSize(1)
         val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
         assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)

--- a/reliability/stub-core/build.gradle.kts
+++ b/reliability/stub-core/build.gradle.kts
@@ -6,8 +6,6 @@
 
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.javadocConfig
-import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -26,21 +24,15 @@ plugins {
 }
 
 android {
-    namespace = "com.datadog.android.logs.integration"
-
-    sourceSets.named("test") {
-        // Required because AGP doesn't support kotlin test fixtures :/
-        java.srcDir("${project.rootDir.path}/dd-sdk-android-core/src/testFixtures/kotlin")
-    }
+    namespace = "com.datadog.android.core.stub"
 }
 
 dependencies {
     implementation(project(":dd-sdk-android-core"))
-    implementation(project(":features:dd-sdk-android-logs"))
     implementation(libs.kotlin)
 
     // Testing
-    testImplementation(project(":tools:unit")) {
+    implementation(project(":tools:unit")) {
         attributes {
             attribute(
                 com.android.build.api.attributes.ProductFlavorAttr.of("platform"),
@@ -48,22 +40,12 @@ dependencies {
             )
         }
     }
-    testImplementation(testFixtures(project(":dd-sdk-android-core")))
-    testImplementation(project(":reliability:stub-core"))
-    testImplementation(libs.bundles.jUnit5)
-    testImplementation(libs.bundles.testTools)
-    testImplementation(libs.okHttp)
-    testImplementation(libs.gson)
-    unmock(libs.robolectric)
-}
-
-unMock {
-    keepStartingWith("android.os")
-    keepStartingWith("org.json")
+    implementation(libs.bundles.jUnit5)
+    implementation(libs.bundles.testTools)
+    implementation(libs.okHttp)
+    implementation(libs.gson)
 }
 
 androidLibraryConfig()
 kotlinConfig(jvmBytecodeTarget = JvmTarget.JVM_11)
-junitConfig()
-javadocConfig()
 dependencyUpdateConfig()

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubEvent.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubEvent.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.api
+package com.datadog.android.core.stub
 
 /**
  * Holds the data and metadata of an event written via the [StubSDKCore].

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
@@ -4,7 +4,7 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.api
+package com.datadog.android.core.stub
 
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
@@ -14,6 +14,7 @@ import com.datadog.android.api.storage.RawBatchEvent
 import org.mockito.Mockito.mock
 import org.mockito.Mockito.mockingDetails
 
+@Suppress("CheckInternal", "UnsafeThirdPartyFunctionCall")
 internal class StubFeatureScope(
     private val feature: Feature,
     private val datadogContextProvider: () -> DatadogContext,

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFirstPartyHostHeaderTypeResolver.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFirstPartyHostHeaderTypeResolver.kt
@@ -4,12 +4,16 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.api
+package com.datadog.android.core.stub
 
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.trace.TracingHeaderType
 import okhttp3.HttpUrl
 
+/**
+ * Stubbed implementation of [FirstPartyHostHeaderTypeResolver], which is an
+ * allow all, trace all implementation (using the W3C TraceContext headers).
+ */
 class StubFirstPartyHostHeaderTypeResolver :
     FirstPartyHostHeaderTypeResolver {
 

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubInternalLogger.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubInternalLogger.kt
@@ -4,8 +4,11 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.api
+package com.datadog.android.core.stub
 
+import com.datadog.android.api.InternalLogger
+
+@Suppress("UnsafeThirdPartyFunctionCall")
 internal class StubInternalLogger : InternalLogger {
     override fun log(
         level: InternalLogger.Level,

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -4,9 +4,10 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.api
+package com.datadog.android.core.stub
 
 import android.content.Context
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.context.TimeInfo
@@ -26,9 +27,10 @@ import org.mockito.kotlin.whenever
  * It adds several functions to get info about internal state and usage:
  * [eventsWritten], …
  */
+@Suppress("UnsafeThirdPartyFunctionCall")
 class StubSDKCore(
     private val forge: Forge,
-    val mockContext: Context = mock(),
+    private val mockContext: Context = mock(),
     private val mockSdkCore: InternalSdkCore = mock()
 ) : InternalSdkCore by mockSdkCore {
 
@@ -51,10 +53,18 @@ class StubSDKCore(
         return featureScopes[featureName]?.eventsWritten() ?: emptyList()
     }
 
+    /**
+     * Stubs the network info visible via the SDK Core.
+     * @param networkInfo the network info
+     */
     fun stubNetworkInfo(networkInfo: NetworkInfo) {
         datadogContext = datadogContext.copy(networkInfo = networkInfo)
     }
 
+    /**
+     * Stubs the user info visible via the SDK Core.
+     * @param userInfo the user info
+     */
     fun stubUserInfo(userInfo: UserInfo) {
         networkInfo
         datadogContext = datadogContext.copy(userInfo = userInfo)
@@ -125,7 +135,7 @@ class StubSDKCore(
         email: String?,
         extraInfo: Map<String, Any?>
     ) {
-        datadogContext = datadogContext.copy(userInfo = UserInfo(id, name, email, extraInfo))
+        stubUserInfo(UserInfo(id, name, email, extraInfo))
     }
 
     // endregion

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/tests/ktx/JsonObjectExt.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/tests/ktx/JsonObjectExt.kt
@@ -21,6 +21,7 @@ import com.google.gson.JsonObject
  *   }
  * }
  */
+@Suppress("UnsafeThirdPartyFunctionCall")
 fun JsonObject.getString(path: String): String? {
     return if (has(path)) {
         getAsJsonPrimitive(path)?.asString

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -29,6 +29,9 @@ include(":integrations:dd-sdk-android-okhttp")
 include(":integrations:dd-sdk-android-rum-coroutines")
 include(":integrations:dd-sdk-android-trace-coroutines")
 
+// TESTING UTILS
+include(":reliability:stub-core")
+
 // SINGLE FEATURE INTEGRATION TESTS
 include(":reliability:single-fit:logs")
 include(":reliability:single-fit:rum")


### PR DESCRIPTION
### What does this PR do?

Because AndroidStudio doesn't deal well with `testFixtures` source sets, the Stubbed SDKCore (and linked classes) were moved to an independent module which allows code completion and make the IDE happy.
