### PR TITLE
RUM-1930 Add regression test for Gson toString method

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/serializer/GsonCompatibilityTests.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/serializer/GsonCompatibilityTests.kt
@@ -1,0 +1,72 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.serializer
+
+import com.google.gson.JsonObject
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+
+/**
+ * This class is used to test the compatibility of the Gson serializer with our current `.`
+ * keys in the JSON payloads. This should make sure that Json properties are added into the
+ * `toString` representation in the order they were added in the JSON object.
+ */
+
+@Extensions(ExtendWith(ForgeExtension::class))
+internal class GsonCompatibilityTests {
+
+    @RepeatedTest(5)
+    fun `M add the properties in order in the string W toString()`(forge: Forge) {
+        val propertiesKeysValues = forge.aMap(size = forge.anInt(min = 5, max = 50)) {
+            val key = forge.aList(size = forge.anInt(min = 1, max = 10)) {
+                anAlphabeticalString()
+            }.joinToString(".")
+            val values = listOf<Any>(
+                anInt(),
+                aBool(),
+                aNumericalString(),
+                anHexadecimalString(),
+                anAlphabeticalString()
+            )
+            val value = forge.anElementFrom(values)
+
+            key to value
+        }
+        val expectedJsonRepresentation = buildString {
+            append("{")
+            propertiesKeysValues.entries.forEachIndexed { index, entry ->
+                when (entry.value) {
+                    is Int, is Boolean -> append("\"${entry.key}\":${entry.value}")
+                    else -> append("\"${entry.key}\":\"${entry.value}\"")
+                }
+                if (index < propertiesKeysValues.size - 1) {
+                    append(",")
+                }
+            }
+            append("}")
+        }
+        val jsonObject = JsonObject().apply {
+            propertiesKeysValues.forEach { (key, value) ->
+                when (value) {
+                    is Int -> addProperty(key, value)
+                    is Boolean -> addProperty(key, value)
+                    is String -> addProperty(key, value)
+                }
+            }
+        }
+
+        // When
+        val actualJsonRepresentation = jsonObject.toString()
+
+        // Then
+        assertThat(actualJsonRepresentation).isEqualTo(expectedJsonRepresentation)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

As a followup on the previous action taken on iOS: https://datadoghq.atlassian.net/browse/RUM-1929, I investigated all the potential issues on our end regarding this topic and came to the following conclusions:

- we are using indeed `.` attributes on our end but most of them are correctly handled in our serializers. 
- it will be quite hard and very intrusive to try to remove all these attributes in the sdk and for no reason momentarily because the serializers are handling this. There is only one problem that could appear if by any chance we adopt a new `Gson` version which changes the implementation in adding the properties into the `toString` method. Right now they are using a `LinkedList` which suites us very well.

In this PR I added a regression test for our Gson dependency to make sure it will always add the properties in the order they were added in the Json object when using the `toString` method.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

