### PR TITLE
(1/4) RUM-2129 Create PersistenceStrategy interface

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -234,6 +234,18 @@ fun Int.toHexString(): String
 fun Long.toHexString(): String
 fun java.math.BigInteger.toHexString(): String
 fun Throwable.loggableStackTrace(): String
+interface com.datadog.android.core.persistence.PersistenceStrategy
+  interface Factory
+    fun create(String, Int, Long): PersistenceStrategy
+  data class Batch
+    constructor(String, ByteArray? = null, List<com.datadog.android.api.storage.RawBatchEvent> = mutableListOf())
+  fun currentMetadata(): ByteArray?
+  fun write(com.datadog.android.api.storage.RawBatchEvent, ByteArray?): Boolean
+  fun lockAndReadNext(): Batch?
+  fun unlockAndKeep(String)
+  fun unlockAndDelete(String)
+  fun dropAll()
+  fun migrateData(PersistenceStrategy)
 interface com.datadog.android.core.persistence.Serializer<T: Any>
   fun serialize(T): String?
   companion object 

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -612,6 +612,36 @@ public final class com/datadog/android/core/internal/utils/ThrowableExtKt {
 	public static final fun loggableStackTrace (Ljava/lang/Throwable;)Ljava/lang/String;
 }
 
+public abstract interface class com/datadog/android/core/persistence/PersistenceStrategy {
+	public abstract fun currentMetadata ()[B
+	public abstract fun dropAll ()V
+	public abstract fun lockAndReadNext ()Lcom/datadog/android/core/persistence/PersistenceStrategy$Batch;
+	public abstract fun migrateData (Lcom/datadog/android/core/persistence/PersistenceStrategy;)V
+	public abstract fun unlockAndDelete (Ljava/lang/String;)V
+	public abstract fun unlockAndKeep (Ljava/lang/String;)V
+	public abstract fun write (Lcom/datadog/android/api/storage/RawBatchEvent;[B)Z
+}
+
+public final class com/datadog/android/core/persistence/PersistenceStrategy$Batch {
+	public fun <init> (Ljava/lang/String;[BLjava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;[BLjava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()[B
+	public final fun component3 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;[BLjava/util/List;)Lcom/datadog/android/core/persistence/PersistenceStrategy$Batch;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/persistence/PersistenceStrategy$Batch;Ljava/lang/String;[BLjava/util/List;ILjava/lang/Object;)Lcom/datadog/android/core/persistence/PersistenceStrategy$Batch;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getBatchId ()Ljava/lang/String;
+	public final fun getEvents ()Ljava/util/List;
+	public final fun getMetadata ()[B
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/datadog/android/core/persistence/PersistenceStrategy$Factory {
+	public abstract fun create (Ljava/lang/String;IJ)Lcom/datadog/android/core/persistence/PersistenceStrategy;
+}
+
 public abstract interface class com/datadog/android/core/persistence/Serializer {
 	public static final field Companion Lcom/datadog/android/core/persistence/Serializer$Companion;
 	public abstract fun serialize (Ljava/lang/Object;)Ljava/lang/String;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/EventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/EventBatchWriter.kt
@@ -14,7 +14,7 @@ import androidx.annotation.WorkerThread
 interface EventBatchWriter {
 
     /**
-     * @return the metadata of the current writeable file
+     * @return the metadata of the current writeable batch
      */
     @WorkerThread
     fun currentMetadata(): ByteArray?

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/persistence/PersistenceStrategy.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/persistence/PersistenceStrategy.kt
@@ -1,0 +1,103 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.persistence
+
+import androidx.annotation.WorkerThread
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.tools.annotation.NoOpImplementation
+
+/**
+ * The main strategy used to persist data between the moment it's tracked and created,
+ * and the moment it's uploaded to the intake.
+ */
+@NoOpImplementation
+interface PersistenceStrategy {
+
+    /**
+     * A factory used to create an instance of a [PersistenceStrategy].
+     *
+     * Each instance of a persistence strategy should have independent storage.
+     * Data written to one instance must not be readable from another one.
+     */
+    interface Factory {
+
+        /**
+         * Creates an instance of a [PersistenceStrategy].
+         *
+         * @param identifier the identifier for the persistence strategy.
+         * @param maxItemsPerBatch the maximum number of individual events in a batch
+         * @param maxBatchSize the maximum size (in bytes) of a complete batch
+         */
+        fun create(
+            identifier: String,
+            maxItemsPerBatch: Int,
+            maxBatchSize: Long
+        ): PersistenceStrategy
+    }
+
+    /**
+     * Describes the content of event batch.
+     * @property batchId the unique identifier for a batch
+     * @property metadata the metadata attached to the batch
+     * @property events the list of events in the batch
+     */
+    data class Batch(
+        val batchId: String,
+        val metadata: ByteArray? = null,
+        val events: List<RawBatchEvent> = mutableListOf()
+    )
+
+    /**
+     * @return the metadata of the current writeable batch
+     */
+    @WorkerThread
+    fun currentMetadata(): ByteArray?
+
+    /**
+     * Writes the content of the event to the current available batch.
+     * @param event the event to write (content + metadata)
+     * @param batchMetadata the optional updated batch metadata
+     *
+     * @return true if event was written, false otherwise.
+     */
+    @WorkerThread
+    fun write(
+        event: RawBatchEvent,
+        batchMetadata: ByteArray?
+    ): Boolean
+
+    /**
+     * Reads the next batch of data and lock it so that it can't be read or written to by anyone.
+     */
+    @WorkerThread
+    fun lockAndReadNext(): Batch?
+
+    /**
+     * Marks the batch as unlocked and to be kept to be read again later.
+     */
+    @WorkerThread
+    fun unlockAndKeep(batchId: String)
+
+    /**
+     *  Marks the batch as unlocked and to be deleted.
+     *  The corresponding batch should not be returned in any call to [lockAndReadNext].
+     */
+    @WorkerThread
+    fun unlockAndDelete(batchId: String)
+
+    /**
+     * Drop all data.
+     */
+    @WorkerThread
+    fun dropAll()
+
+    /**
+     * Migrate the data to a different [PersistenceStrategy].
+     * All readable and ongoing batches must be transferred to the given strategy.
+     */
+    fun migrateData(targetStrategy: PersistenceStrategy)
+}


### PR DESCRIPTION
_This PR has been created automatically by splitting a large branch_

## Pull request 1 out of 4

> The overall goal is to create a feature allowing customers to store unsent data any way they want (instead of using the official disk batch files)

This first PR creates a "public" `PersistenceStrategy` interface that customers would need to implement to use this new feature.