### PR TITLE
(2/4) RUM-2129 let customer set custom persistence strategy in configuration

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -177,6 +177,7 @@ data class com.datadog.android.core.configuration.Configuration
     fun setAdditionalConfiguration(Map<String, Any>): Builder
     fun setProxy(java.net.Proxy, okhttp3.Authenticator?): Builder
     fun setEncryption(com.datadog.android.security.Encryption): Builder
+    fun setPersistenceStrategyFactory(com.datadog.android.core.persistence.PersistenceStrategy.Factory?): Builder
     fun setCrashReportsEnabled(Boolean): Builder
   companion object 
 class com.datadog.android.core.configuration.HostsSanitizer

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -498,6 +498,7 @@ public final class com/datadog/android/core/configuration/Configuration$Builder 
 	public final fun setEncryption (Lcom/datadog/android/security/Encryption;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setFirstPartyHosts (Ljava/util/List;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setFirstPartyHostsWithHeaderType (Ljava/util/Map;)Lcom/datadog/android/core/configuration/Configuration$Builder;
+	public final fun setPersistenceStrategyFactory (Lcom/datadog/android/core/persistence/PersistenceStrategy$Factory;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setProxy (Ljava/net/Proxy;Lokhttp3/Authenticator;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUploadFrequency (Lcom/datadog/android/core/configuration/UploadFrequency;)Lcom/datadog/android/core/configuration/Configuration$Builder;
 	public final fun setUseDeveloperModeWhenDebuggable (Z)Lcom/datadog/android/core/configuration/Configuration$Builder;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
@@ -428,8 +428,8 @@ internal class DatadogCore(
                 "batch_upload_frequency" to configuration.coreConfig.uploadFrequency.baseStepMs,
                 "use_proxy" to (configuration.coreConfig.proxy != null),
                 "use_local_encryption" to (configuration.coreConfig.encryption != null),
-                "batch_processing_level" to
-                    configuration.coreConfig.batchProcessingLevel.maxBatchesPerUploadJob
+                "batch_processing_level" to configuration.coreConfig.batchProcessingLevel.maxBatchesPerUploadJob,
+                "use_persistence_strategy_factory" to (configuration.coreConfig.persistenceStrategyFactory != null)
             )
             rumFeature.sendEvent(coreConfigurationEvent)
         }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/configuration/Configuration.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.configuration
 
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
+import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.security.Encryption
 import com.datadog.android.trace.TracingHeaderType
 import okhttp3.Authenticator
@@ -39,7 +40,8 @@ internal constructor(
         val proxyAuth: Authenticator,
         val encryption: Encryption?,
         val site: DatadogSite,
-        val batchProcessingLevel: BatchProcessingLevel
+        val batchProcessingLevel: BatchProcessingLevel,
+        val persistenceStrategyFactory: PersistenceStrategy.Factory?
     )
 
     // region Builder
@@ -221,6 +223,17 @@ internal constructor(
         }
 
         /**
+         * Allows to use a custom persistence strategy.
+         * @param persistenceStrategyFactory the persistence strategy to use (or null to use the default one)
+         */
+        fun setPersistenceStrategyFactory(persistenceStrategyFactory: PersistenceStrategy.Factory?): Builder {
+            coreConfig = coreConfig.copy(
+                persistenceStrategyFactory = persistenceStrategyFactory
+            )
+            return this
+        }
+
+        /**
          * Allows to control if JVM crashes are tracked or not. Default value is [true].
          *
          * @param crashReportsEnabled whether crashes are tracked and sent to Datadog
@@ -257,7 +270,8 @@ internal constructor(
             proxyAuth = Authenticator.NONE,
             encryption = null,
             site = DatadogSite.US1,
-            batchProcessingLevel = BatchProcessingLevel.MEDIUM
+            batchProcessingLevel = BatchProcessingLevel.MEDIUM,
+            persistenceStrategyFactory = null
         )
 
         internal const val NETWORK_REQUESTS_TRACKING_FEATURE_NAME = "Network requests"

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -62,6 +62,7 @@ import com.datadog.android.core.internal.user.NoOpMutableUserInfoProvider
 import com.datadog.android.core.internal.user.UserInfoDeserializer
 import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.core.internal.utils.unboundInternalLogger
+import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.ndk.internal.DatadogNdkCrashHandler
 import com.datadog.android.ndk.internal.NdkCrashHandler
 import com.datadog.android.ndk.internal.NdkCrashLogDeserializer
@@ -137,6 +138,7 @@ internal class CoreFeature(
     internal lateinit var uploadExecutorService: ScheduledThreadPoolExecutor
     internal lateinit var persistenceExecutorService: ExecutorService
     internal var localDataEncryption: Encryption? = null
+    internal var persistenceStrategyFactory: PersistenceStrategy.Factory? = null
     internal lateinit var storageDir: File
     internal lateinit var androidInfoProvider: AndroidInfoProvider
 
@@ -358,6 +360,7 @@ internal class CoreFeature(
         batchSize = configuration.batchSize
         uploadFrequency = configuration.uploadFrequency
         localDataEncryption = configuration.encryption
+        persistenceStrategyFactory = configuration.persistenceStrategyFactory
         site = configuration.site
     }
 
@@ -455,8 +458,7 @@ internal class CoreFeature(
 
     private fun setupExecutors() {
         @Suppress("UnsafeThirdPartyFunctionCall") // pool size can't be <= 0
-        uploadExecutorService =
-            LoggingScheduledThreadPoolExecutor(CORE_DEFAULT_POOL_SIZE, internalLogger)
+        uploadExecutorService = LoggingScheduledThreadPoolExecutor(CORE_DEFAULT_POOL_SIZE, internalLogger)
         @Suppress("UnsafeThirdPartyFunctionCall") // workQueue can't be null
         persistenceExecutorService = persistenceExecutorServiceFactory(internalLogger)
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
@@ -319,6 +319,7 @@ internal class DatadogCoreInitializationTest {
         val trackErrors = forge.aBool()
         val useProxy = forge.aBool()
         val useLocalEncryption = forge.aBool()
+        val usePersistenceStrategyFactory = forge.aBool()
         val batchSize = forge.aValueFrom(BatchSize::class.java)
         val uploadFrequency = forge.aValueFrom(UploadFrequency::class.java)
         val batchProcessingLevel = forge.aValueFrom(BatchProcessingLevel::class.java)
@@ -337,6 +338,9 @@ internal class DatadogCoreInitializationTest {
                 whenever(mockEncryption.encrypt(any())) doAnswer { it.getArgument<ByteArray>(0) }
                 whenever(mockEncryption.decrypt(any())) doAnswer { it.getArgument<ByteArray>(0) }
                 setEncryption(mockEncryption)
+            }
+            if (usePersistenceStrategyFactory) {
+                setPersistenceStrategyFactory(mock())
             }
         }
             .setBatchSize(batchSize)
@@ -375,7 +379,8 @@ internal class DatadogCoreInitializationTest {
                     "batch_size" to batchSize.windowDurationMs,
                     "batch_upload_frequency" to uploadFrequency.baseStepMs,
                     "track_errors" to trackErrors,
-                    "batch_processing_level" to batchProcessingLevel.maxBatchesPerUploadJob
+                    "batch_processing_level" to batchProcessingLevel.maxBatchesPerUploadJob,
+                    "use_persistence_strategy_factory" to usePersistenceStrategyFactory
                 )
             )
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/configuration/ConfigurationBuilderTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.configuration
 
 import com.datadog.android.DatadogSite
+import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.security.Encryption
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.android.utils.config.InternalLoggerTestConfiguration
@@ -73,7 +74,8 @@ internal class ConfigurationBuilderTest {
                 proxyAuth = Authenticator.NONE,
                 encryption = null,
                 site = DatadogSite.US1,
-                batchProcessingLevel = BatchProcessingLevel.MEDIUM
+                batchProcessingLevel = BatchProcessingLevel.MEDIUM,
+                persistenceStrategyFactory = null
             )
         )
         assertThat(config.crashReportsEnabled).isTrue
@@ -366,6 +368,24 @@ internal class ConfigurationBuilderTest {
         assertThat(config.coreConfig).isEqualTo(
             Configuration.DEFAULT_CORE_CONFIG.copy(
                 encryption = mockEncryption
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with persistence strategy 𝕎 setPersistenceStrategyFactory() and build()`() {
+        // Given
+        val mockFactory = mock<PersistenceStrategy.Factory>()
+
+        // When
+        val config = testedBuilder
+            .setPersistenceStrategyFactory(mockFactory)
+            .build()
+
+        // Then
+        assertThat(config.coreConfig).isEqualTo(
+            Configuration.DEFAULT_CORE_CONFIG.copy(
+                persistenceStrategyFactory = mockFactory
             )
         )
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/ConfigurationCoreForgeryFactory.kt
@@ -8,12 +8,16 @@ package com.datadog.android.utils.forge
 
 import com.datadog.android.DatadogSite
 import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.security.NoOpEncryption
 import com.datadog.android.trace.TracingHeaderType
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 import okhttp3.Authenticator
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
 import java.net.Proxy
 import java.net.URL
 
@@ -42,7 +46,12 @@ internal class ConfigurationCoreForgeryFactory :
             proxyAuth = auth,
             encryption = forge.aNullable { NoOpEncryption() },
             site = forge.aValueFrom(DatadogSite::class.java),
-            batchProcessingLevel = forge.getForgery()
+            batchProcessingLevel = forge.getForgery(),
+            persistenceStrategyFactory = forge.aNullable {
+                mock<PersistenceStrategy.Factory>().apply {
+                    whenever(create(any(), any(), any())) doReturn mock()
+                }
+            }
         )
     }
 }


### PR DESCRIPTION
_This PR has been created automatically by splitting a large branch_

## Pull request 2 out of 4

> The overall goal is to create a feature allowing customers to store unsent data any way they want (instead of using the official disk batch files)

This PR adds the necessary methods to set a custom `PersistenceStrategy.Factory` in the core configuration.

When set, this will be reported in the configuration telemetry, and
the persistenceStrategyFactory will be stored in the CoreFeature instance