### PR TITLE
(3/4) RUM-2129 Implement AbstractStorage

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
@@ -1,0 +1,164 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence
+
+import androidx.annotation.AnyThread
+import androidx.annotation.WorkerThread
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.core.internal.metrics.RemovalReason
+import com.datadog.android.core.internal.privacy.ConsentProvider
+import com.datadog.android.core.internal.utils.submitSafe
+import com.datadog.android.core.persistence.NoOpPersistenceStrategy
+import com.datadog.android.core.persistence.PersistenceStrategy
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.privacy.TrackingConsentProviderCallback
+import java.util.concurrent.ExecutorService
+
+internal class AbstractStorage(
+    private val sdkCoreId: String?,
+    private val featureName: String,
+    internal val persistenceStrategyFactory: PersistenceStrategy.Factory,
+    private val executorService: ExecutorService,
+    private val internalLogger: InternalLogger,
+    internal val storageConfiguration: FeatureStorageConfiguration,
+    consentProvider: ConsentProvider
+) : Storage, TrackingConsentProviderCallback {
+
+    private val grantedPersistenceStrategy: PersistenceStrategy by lazy {
+        persistenceStrategyFactory.create(
+            "$sdkCoreId/$featureName/${TrackingConsent.GRANTED}",
+            storageConfiguration.maxItemsPerBatch,
+            storageConfiguration.maxBatchSize
+        )
+    }
+
+    private val pendingPersistenceStrategy: PersistenceStrategy by lazy {
+        persistenceStrategyFactory.create(
+            "$sdkCoreId/$featureName/${TrackingConsent.PENDING}",
+            storageConfiguration.maxItemsPerBatch,
+            storageConfiguration.maxBatchSize
+        )
+    }
+
+    private val notGrantedPersistenceStrategy: PersistenceStrategy = NoOpPersistenceStrategy()
+
+    init {
+        @Suppress("LeakingThis")
+        consentProvider.registerCallback(this)
+    }
+
+    // region Storage
+
+    @AnyThread
+    override fun writeCurrentBatch(
+        datadogContext: DatadogContext,
+        forceNewBatch: Boolean,
+        callback: (EventBatchWriter) -> Unit
+    ) {
+        val strategy = when (datadogContext.trackingConsent) {
+            TrackingConsent.GRANTED -> grantedPersistenceStrategy
+            TrackingConsent.PENDING -> pendingPersistenceStrategy
+            TrackingConsent.NOT_GRANTED -> notGrantedPersistenceStrategy
+        }
+
+        executorService.submitSafe("Data write", internalLogger) {
+            val writer = object : EventBatchWriter {
+                @WorkerThread
+                override fun currentMetadata(): ByteArray? {
+                    return strategy.currentMetadata()
+                }
+
+                @WorkerThread
+                override fun write(event: RawBatchEvent, batchMetadata: ByteArray?): Boolean {
+                    return strategy.write(event, batchMetadata)
+                }
+            }
+            callback.invoke(writer)
+        }
+    }
+
+    @WorkerThread
+    override fun readNextBatch(
+        noBatchCallback: () -> Unit,
+        readBatchCallback: (BatchId, BatchReader) -> Unit
+    ) {
+        val batch = grantedPersistenceStrategy.lockAndReadNext()
+        if (batch == null) {
+            noBatchCallback()
+        } else {
+            val batchId = BatchId(batch.batchId)
+            val reader = object : BatchReader {
+
+                @WorkerThread
+                override fun currentMetadata(): ByteArray? {
+                    return batch.metadata
+                }
+
+                @WorkerThread
+                override fun read(): List<RawBatchEvent> {
+                    return batch.events
+                }
+            }
+            readBatchCallback.invoke(batchId, reader)
+        }
+    }
+
+    @WorkerThread
+    override fun confirmBatchRead(
+        batchId: BatchId,
+        removalReason: RemovalReason,
+        callback: (BatchConfirmation) -> Unit
+    ) {
+        val confirmation = object : BatchConfirmation {
+            @WorkerThread
+            override fun markAsRead(deleteBatch: Boolean) {
+                if (deleteBatch) {
+                    grantedPersistenceStrategy.unlockAndDelete(batchId.id)
+                } else {
+                    grantedPersistenceStrategy.unlockAndKeep(batchId.id)
+                }
+            }
+        }
+        callback(confirmation)
+    }
+
+    override fun dropAll() {
+        @Suppress("ThreadSafety")
+        executorService.submitSafe("Data drop", internalLogger) {
+            grantedPersistenceStrategy.dropAll()
+            pendingPersistenceStrategy.dropAll()
+        }
+    }
+
+    // endregion
+
+    // region TrackingConsentProviderCallback
+
+    override fun onConsentUpdated(
+        previousConsent: TrackingConsent,
+        newConsent: TrackingConsent
+    ) {
+        @Suppress("ThreadSafety")
+        executorService.submitSafe("Data migration", internalLogger) {
+            if (previousConsent == TrackingConsent.PENDING) {
+                when (newConsent) {
+                    TrackingConsent.GRANTED -> pendingPersistenceStrategy.migrateData(grantedPersistenceStrategy)
+                    TrackingConsent.NOT_GRANTED -> pendingPersistenceStrategy.dropAll()
+                    TrackingConsent.PENDING -> {
+                        // Nothing to do
+                    }
+                }
+            }
+        }
+    }
+
+    // endregion
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
@@ -86,7 +86,7 @@ internal class ConsentAwareStorage(
     @WorkerThread
     override fun readNextBatch(
         noBatchCallback: () -> Unit,
-        batchCallback: (BatchId, BatchReader) -> Unit
+        readBatchCallback: (BatchId, BatchReader) -> Unit
     ) {
         val (batchFile, metaFile) = synchronized(lockedBatches) {
             val batchFile = grantedOrchestrator
@@ -116,7 +116,7 @@ internal class ConsentAwareStorage(
                 return batchEventsReaderWriter.readData(batchFile)
             }
         }
-        batchCallback(batchId, reader)
+        readBatchCallback(batchId, reader)
     }
 
     /** @inheritdoc */

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
@@ -41,13 +41,13 @@ internal interface Storage {
     /**
      * Utility to read a batch, asynchronously.
      * @param noBatchCallback an optional callback which is called when there is no batch available to read.
-     * @param batchCallback an operation to perform with a [BatchId] and [BatchReader] that will target
+     * @param readBatchCallback an operation to perform with a [BatchId] and [BatchReader] that will target
      * the next readable Batch
      */
     @WorkerThread
     fun readNextBatch(
         noBatchCallback: () -> Unit = {},
-        batchCallback: (BatchId, BatchReader) -> Unit
+        readBatchCallback: (BatchId, BatchReader) -> Unit
     )
 
     /**
@@ -66,6 +66,5 @@ internal interface Storage {
     /**
      * Removes all the files backed by this storage, synchronously.
      */
-    @WorkerThread
     fun dropAll()
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -707,12 +707,12 @@ internal class UploadWorkerTest {
 
         override fun readNextBatch(
             noBatchCallback: () -> Unit,
-            batchCallback: (BatchId, BatchReader) -> Unit
+            readBatchCallback: (BatchId, BatchReader) -> Unit
         ) {
             executor.execute {
                 delegate.readNextBatch(
                     noBatchCallback,
-                    batchCallback
+                    readBatchCallback
                 )
             }
         }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
@@ -1,0 +1,665 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.core.internal.metrics.RemovalReason
+import com.datadog.android.core.internal.privacy.ConsentProvider
+import com.datadog.android.core.persistence.PersistenceStrategy
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.BoolForgery
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argThat
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class AbstractStorageTest {
+
+    lateinit var testedStorage: AbstractStorage
+
+    @Mock
+    lateinit var mockPersistenceStrategyFactory: PersistenceStrategy.Factory
+
+    @Mock
+    lateinit var mockGrantedPersistenceStrategy: PersistenceStrategy
+
+    @Mock
+    lateinit var mockPendingPersistenceStrategy: PersistenceStrategy
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Mock
+    lateinit var mockConsentProvider: ConsentProvider
+
+    @StringForgery
+    lateinit var fakeSdkInstanceId: String
+
+    @StringForgery
+    lateinit var fakeFeatureName: String
+
+    @Forgery
+    lateinit var fakeStorageConfiguration: FeatureStorageConfiguration
+
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockPersistenceStrategyFactory.create(argThat { contains("/GRANTED") }, any(), any()))
+            .doReturn(mockGrantedPersistenceStrategy)
+        whenever(mockPersistenceStrategyFactory.create(argThat { contains("/PENDING") }, any(), any()))
+            .doReturn(mockPendingPersistenceStrategy)
+
+        testedStorage = AbstractStorage(
+            fakeSdkInstanceId,
+            fakeFeatureName,
+            mockPersistenceStrategyFactory,
+            FakeSameThreadExecutorService(),
+            mockInternalLogger,
+            fakeStorageConfiguration,
+            mockConsentProvider
+        )
+    }
+
+    // region Storage.writeCurrentBatch
+
+    @Test
+    fun `𝕄 provide writer 𝕎 writeCurrentBatch()+write() {consent=granted, batchMetadata=null}`(
+        @BoolForgery forceNewBatch: Boolean,
+        @BoolForgery fakeResult: Boolean,
+        @Forgery fakeBatchEvent: RawBatchEvent
+    ) {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
+        whenever(mockGrantedPersistenceStrategy.write(any(), anyOrNull())) doReturn fakeResult
+        var result: Boolean? = null
+        whenever(mockWriteCallback.invoke(any())) doAnswer {
+            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, null)
+        }
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+
+        // Then
+        assertThat(result).isEqualTo(fakeResult)
+        verify(mockGrantedPersistenceStrategy).write(fakeBatchEvent, null)
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide writer 𝕎 writeCurrentBatch()+write() {consent=granted, batchMetadata!=null}`(
+        @BoolForgery forceNewBatch: Boolean,
+        @BoolForgery fakeResult: Boolean,
+        @Forgery fakeBatchEvent: RawBatchEvent,
+        @StringForgery fakeBatchMetadata: String
+    ) {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
+        val batchMetadata = fakeBatchMetadata.toByteArray()
+        whenever(mockGrantedPersistenceStrategy.write(any(), anyOrNull())) doReturn fakeResult
+        var result: Boolean? = null
+        whenever(mockWriteCallback.invoke(any())) doAnswer {
+            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata)
+        }
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+
+        // Then
+        assertThat(result).isEqualTo(fakeResult)
+        verify(mockGrantedPersistenceStrategy).write(fakeBatchEvent, batchMetadata)
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide writer 𝕎 writeCurrentBatch()+currentMetadata() {consent=granted, batchMetadata=null}`(
+        @BoolForgery forceNewBatch: Boolean
+    ) {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
+        whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn null
+        var resultMetadata: ByteArray? = null
+        whenever(mockWriteCallback.invoke(any())) doAnswer {
+            resultMetadata = (it.getArgument(0) as? EventBatchWriter)?.currentMetadata()
+        }
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+
+        // Then
+        assertThat(resultMetadata).isNull()
+        verify(mockGrantedPersistenceStrategy).currentMetadata()
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide writer 𝕎 writeCurrentBatch()+currentMetadata() {consent=granted, batchMetadata!=null}`(
+        @BoolForgery forceNewBatch: Boolean,
+        @StringForgery fakeBatchMetadata: String
+    ) {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
+        val batchMetadata = fakeBatchMetadata.toByteArray()
+        whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn batchMetadata
+        var resultMetadata: ByteArray? = null
+        whenever(mockWriteCallback.invoke(any())) doAnswer {
+            resultMetadata = (it.getArgument(0) as? EventBatchWriter)?.currentMetadata()
+        }
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+
+        // Then
+        assertThat(resultMetadata).isEqualTo(batchMetadata)
+        verify(mockGrantedPersistenceStrategy).currentMetadata()
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide writer 𝕎 writeCurrentBatch()+write() {consent=pending, batchMetadata=null}`(
+        @BoolForgery forceNewBatch: Boolean,
+        @BoolForgery fakeResult: Boolean,
+        @Forgery fakeBatchEvent: RawBatchEvent
+    ) {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
+        whenever(mockPendingPersistenceStrategy.write(any(), anyOrNull())) doReturn fakeResult
+        var result: Boolean? = null
+        whenever(mockWriteCallback.invoke(any())) doAnswer {
+            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, null)
+        }
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+
+        // Then
+        assertThat(result).isEqualTo(fakeResult)
+        verify(mockPendingPersistenceStrategy).write(fakeBatchEvent, null)
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide writer 𝕎 writeCurrentBatch()+write() {consent=pending, batchMetadata!=null}`(
+        @BoolForgery forceNewBatch: Boolean,
+        @BoolForgery fakeResult: Boolean,
+        @Forgery fakeBatchEvent: RawBatchEvent,
+        @StringForgery fakeBatchMetadata: String
+    ) {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
+        val batchMetadata = fakeBatchMetadata.toByteArray()
+        whenever(mockPendingPersistenceStrategy.write(any(), anyOrNull())) doReturn fakeResult
+        var result: Boolean? = null
+        whenever(mockWriteCallback.invoke(any())) doAnswer {
+            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata)
+        }
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+
+        // Then
+        assertThat(result).isEqualTo(fakeResult)
+        verify(mockPendingPersistenceStrategy).write(fakeBatchEvent, batchMetadata)
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide writer 𝕎 writeCurrentBatch()+currentMetadata() {consent=pending, batchMetadata=null}`(
+        @BoolForgery forceNewBatch: Boolean
+    ) {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
+        var resultMetadata: ByteArray? = null
+        whenever(mockWriteCallback.invoke(any())) doAnswer {
+            resultMetadata = (it.getArgument(0) as? EventBatchWriter)?.currentMetadata()
+        }
+        whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn null
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+
+        // Then
+        assertThat(resultMetadata).isNull()
+        verify(mockPendingPersistenceStrategy).currentMetadata()
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide writer 𝕎 writeCurrentBatch()+currentMetadata() {consent=pending, batchMetadata!=null}`(
+        @BoolForgery forceNewBatch: Boolean,
+        @StringForgery fakeBatchMetadata: String
+    ) {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
+        val batchMetadata = fakeBatchMetadata.toByteArray()
+        var resultMetadata: ByteArray? = null
+        whenever(mockWriteCallback.invoke(any())) doAnswer {
+            resultMetadata = (it.getArgument(0) as? EventBatchWriter)?.currentMetadata()
+        }
+        whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn batchMetadata
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+
+        // Then
+        assertThat(resultMetadata).isEqualTo(batchMetadata)
+        verify(mockPendingPersistenceStrategy).currentMetadata()
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide no op writer 𝕎 writeCurrentBatch()+write() {consent=not_granted}`(
+        @BoolForgery forceNewBatch: Boolean,
+        @Forgery fakeBatchEvent: RawBatchEvent,
+        @StringForgery fakeBatchMetadata: String
+    ) {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
+        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
+        val batchMetadata = fakeBatchMetadata.toByteArray()
+        var result: Boolean? = null
+        whenever(mockWriteCallback.invoke(any())) doAnswer {
+            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata)
+        }
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+
+        // Then
+        assertThat(result).isFalse()
+        verifyNoInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide no op writer 𝕎 writeCurrentBatch()+currentMetadata() {consent=not_granted}`(
+        @BoolForgery forceNewBatch: Boolean
+    ) {
+        // Given
+        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
+        val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
+        var resultMetadata: ByteArray? = null
+        whenever(mockWriteCallback.invoke(any())) doAnswer {
+            resultMetadata = (it.getArgument(0) as? EventBatchWriter)?.currentMetadata()
+        }
+
+        // When
+        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+
+        // Then
+        assertThat(resultMetadata).isNull()
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    // endregion
+
+    // region Storage.readNextBatch
+
+    @Test
+    fun `𝕄 provide reader 𝕎 readNextBatch() {no batch}`() {
+        // Given
+        val mockNoBatchCallback = mock<() -> Unit>()
+        val mockReadBatchCallback = mock<(BatchId, BatchReader) -> Unit>()
+        whenever(mockGrantedPersistenceStrategy.lockAndReadNext()) doReturn null
+
+        // When
+        testedStorage.readNextBatch(mockNoBatchCallback, mockReadBatchCallback)
+
+        // Then
+        verify(mockNoBatchCallback).invoke()
+        verify(mockGrantedPersistenceStrategy).lockAndReadNext()
+        verifyNoInteractions(mockReadBatchCallback, mockPendingPersistenceStrategy)
+        verifyNoMoreInteractions(
+            mockNoBatchCallback,
+            mockGrantedPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide reader 𝕎 readNextBatch()+read() {with batch}`(
+        @Forgery fakeBatch: PersistenceStrategy.Batch
+    ) {
+        // Given
+        val mockNoBatchCallback = mock<() -> Unit>()
+        val mockReadBatchCallback = mock<(BatchId, BatchReader) -> Unit>()
+        whenever(mockGrantedPersistenceStrategy.lockAndReadNext()) doReturn fakeBatch
+        var batchId: BatchId? = null
+        var result: List<RawBatchEvent>? = null
+        whenever(mockReadBatchCallback.invoke(any(), any())) doAnswer {
+            batchId = it.getArgument(0) as? BatchId
+            result = (it.getArgument(1) as? BatchReader)?.read()
+        }
+
+        // When
+        testedStorage.readNextBatch(mockNoBatchCallback, mockReadBatchCallback)
+
+        // Then
+        assertThat(batchId).isEqualTo(BatchId(fakeBatch.batchId))
+        assertThat(result).isEqualTo(fakeBatch.events)
+        verify(mockGrantedPersistenceStrategy).lockAndReadNext()
+        verifyNoInteractions(mockPendingPersistenceStrategy)
+        verifyNoMoreInteractions(
+            mockNoBatchCallback,
+            mockGrantedPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide reader 𝕎 readNextBatch()+currentMetadata() {with batch}`(
+        @Forgery fakeBatch: PersistenceStrategy.Batch
+    ) {
+        // Given
+        val mockNoBatchCallback = mock<() -> Unit>()
+        val mockReadBatchCallback = mock<(BatchId, BatchReader) -> Unit>()
+        whenever(mockGrantedPersistenceStrategy.lockAndReadNext()) doReturn fakeBatch
+        var batchId: BatchId? = null
+        var result: ByteArray? = null
+        whenever(mockReadBatchCallback.invoke(any(), any())) doAnswer {
+            batchId = it.getArgument(0) as? BatchId
+            result = (it.getArgument(1) as? BatchReader)?.currentMetadata()
+        }
+
+        // When
+        testedStorage.readNextBatch(mockNoBatchCallback, mockReadBatchCallback)
+
+        // Then
+        assertThat(batchId).isEqualTo(BatchId(fakeBatch.batchId))
+        assertThat(result).isEqualTo(fakeBatch.metadata)
+        verify(mockGrantedPersistenceStrategy).lockAndReadNext()
+        verifyNoInteractions(mockPendingPersistenceStrategy)
+        verifyNoMoreInteractions(
+            mockNoBatchCallback,
+            mockGrantedPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    // endregion
+
+    // region Storage.readNextBatch
+
+    @Test
+    fun `𝕄 provide reader 𝕎 confirmBatchRead() {delete=true}`(
+        @StringForgery fakeBatchId: String,
+        @Forgery fakeRemovalReason: RemovalReason
+    ) {
+        // Given
+        val mockConfirmationCallback = mock<(BatchConfirmation) -> Unit>()
+        whenever(mockConfirmationCallback.invoke(any())) doAnswer {
+            (it.getArgument(0) as? BatchConfirmation)?.markAsRead(true)
+        }
+
+        // When
+        testedStorage.confirmBatchRead(BatchId(fakeBatchId), fakeRemovalReason, mockConfirmationCallback)
+
+        // Then
+        verify(mockGrantedPersistenceStrategy).unlockAndDelete(fakeBatchId)
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 provide reader 𝕎 confirmBatchRead() {delete=false}`(
+        @StringForgery fakeBatchId: String,
+        @Forgery fakeRemovalReason: RemovalReason
+    ) {
+        // Given
+        val mockConfirmationCallback = mock<(BatchConfirmation) -> Unit>()
+        whenever(mockConfirmationCallback.invoke(any())) doAnswer {
+            (it.getArgument(0) as? BatchConfirmation)?.markAsRead(false)
+        }
+
+        // When
+        testedStorage.confirmBatchRead(BatchId(fakeBatchId), fakeRemovalReason, mockConfirmationCallback)
+
+        // Then
+        verify(mockGrantedPersistenceStrategy).unlockAndKeep(fakeBatchId)
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    // endregion
+
+    // region Storage.dropAll
+
+    @Test
+    fun `𝕄 drop both granted and pending 𝕎 dropAll()`() {
+        // When
+        testedStorage.dropAll()
+
+        // Then
+        verify(mockGrantedPersistenceStrategy).dropAll()
+        verify(mockPendingPersistenceStrategy).dropAll()
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    // endregion
+
+    // region TrackingConsentProviderCallback
+
+    @Test
+    fun `𝕄 register as consent listener 𝕎 init()`() {
+        // Then
+        verify(mockConsentProvider).registerCallback(testedStorage)
+        verifyNoInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 onConsentUpdated() {not_granted to not_granted}`() {
+        // When
+        testedStorage.onConsentUpdated(TrackingConsent.NOT_GRANTED, TrackingConsent.NOT_GRANTED)
+
+        // Then
+        verifyNoInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 onConsentUpdated() {not_granted to pending}`() {
+        // When
+        testedStorage.onConsentUpdated(TrackingConsent.NOT_GRANTED, TrackingConsent.PENDING)
+
+        // Then
+        verifyNoInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 onConsentUpdated() {not_granted to granted}`() {
+        // When
+        testedStorage.onConsentUpdated(TrackingConsent.NOT_GRANTED, TrackingConsent.GRANTED)
+
+        // Then
+        verifyNoInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 drop pending data 𝕎 onConsentUpdated() {pending to not_granted}`() {
+        // When
+        testedStorage.onConsentUpdated(TrackingConsent.PENDING, TrackingConsent.NOT_GRANTED)
+
+        // Then
+        verify(mockPendingPersistenceStrategy).dropAll()
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 onConsentUpdated() {pending to pending}`() {
+        // When
+        testedStorage.onConsentUpdated(TrackingConsent.PENDING, TrackingConsent.PENDING)
+
+        // Then
+        verifyNoInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 migrate data 𝕎 onConsentUpdated() {pending to granted}`() {
+        // When
+        testedStorage.onConsentUpdated(TrackingConsent.PENDING, TrackingConsent.GRANTED)
+
+        // Then
+        verify(mockPendingPersistenceStrategy).migrateData(mockGrantedPersistenceStrategy)
+        verifyNoMoreInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 onConsentUpdated() {granted to not_granted}`() {
+        // When
+        testedStorage.onConsentUpdated(TrackingConsent.GRANTED, TrackingConsent.NOT_GRANTED)
+
+        // Then
+        verifyNoInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 onConsentUpdated() {granted to pending}`() {
+        // When
+        testedStorage.onConsentUpdated(TrackingConsent.GRANTED, TrackingConsent.PENDING)
+
+        // Then
+        verifyNoInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    @Test
+    fun `𝕄 do nothing 𝕎 onConsentUpdated() {granted to granted}`() {
+        // When
+        testedStorage.onConsentUpdated(TrackingConsent.GRANTED, TrackingConsent.GRANTED)
+
+        // Then
+        verifyNoInteractions(
+            mockGrantedPersistenceStrategy,
+            mockPendingPersistenceStrategy,
+            mockInternalLogger
+        )
+    }
+
+    // endregion
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
@@ -52,7 +52,6 @@ import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.File
 import java.util.Locale
-import java.util.concurrent.AbstractExecutorService
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.Executors
 import java.util.concurrent.RejectedExecutionException
@@ -758,30 +757,4 @@ internal class ConsentAwareStorageTest {
     }
 
     // endregion
-
-    class FakeSameThreadExecutorService : AbstractExecutorService() {
-
-        private var isShutdown = false
-
-        override fun execute(command: Runnable?) {
-            command?.run()
-        }
-
-        override fun shutdown() {
-            isShutdown = true
-        }
-
-        override fun shutdownNow(): MutableList<Runnable> {
-            isShutdown = true
-            return mutableListOf()
-        }
-
-        override fun isShutdown(): Boolean = isShutdown
-
-        override fun isTerminated(): Boolean = isShutdown
-
-        override fun awaitTermination(timeout: Long, unit: TimeUnit?): Boolean {
-            return true
-        }
-    }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FakeSameThreadExecutorService.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FakeSameThreadExecutorService.kt
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence
+
+import java.util.concurrent.AbstractExecutorService
+import java.util.concurrent.FutureTask
+import java.util.concurrent.TimeUnit
+
+internal class FakeSameThreadExecutorService : AbstractExecutorService() {
+
+    private var isShutdown = false
+
+    override fun execute(command: Runnable?) {
+        if (command is FutureTask<*>) {
+            command.run()
+            val result = command.get()
+            println("Command returned $result")
+        } else {
+            command?.run()
+        }
+    }
+
+    override fun shutdown() {
+        isShutdown = true
+    }
+
+    override fun shutdownNow(): MutableList<Runnable> {
+        isShutdown = true
+        return mutableListOf()
+    }
+
+    override fun isShutdown(): Boolean = isShutdown
+
+    override fun isTerminated(): Boolean = isShutdown
+
+    override fun awaitTermination(timeout: Long, unit: TimeUnit?): Boolean {
+        return true
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/test/elmyr/PersistenceStrategyBatchForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/test/elmyr/PersistenceStrategyBatchForgeryFactory.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.test.elmyr
+
+import com.datadog.android.core.persistence.PersistenceStrategy
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+class PersistenceStrategyBatchForgeryFactory : ForgeryFactory<PersistenceStrategy.Batch> {
+    override fun getForgery(forge: Forge): PersistenceStrategy.Batch {
+        return PersistenceStrategy.Batch(
+            batchId = forge.anAlphabeticalString(),
+            metadata = forge.aNullable { aString().toByteArray() },
+            events = forge.aList { getForgery() }
+        )
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.utils.forge
 
+import com.datadog.android.test.elmyr.PersistenceStrategyBatchForgeryFactory
 import com.datadog.android.tests.elmyr.useCoreFactories
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
@@ -62,6 +63,8 @@ internal class Configurator :
         forge.addFactory(RemovalReasonForgeryFactory())
 
         forge.addFactory(BatchClosedMetadataForgeryFactory())
+
+        forge.addFactory(PersistenceStrategyBatchForgeryFactory())
 
         forge.useJvmFactories()
     }

--- a/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/RawBatchEventForgeryFactory.kt
+++ b/dd-sdk-android-core/src/testFixtures/kotlin/com/datadog/android/tests/elmyr/RawBatchEventForgeryFactory.kt
@@ -13,14 +13,13 @@ import fr.xgouchet.elmyr.ForgeryFactory
 class RawBatchEventForgeryFactory : ForgeryFactory<RawBatchEvent> {
     override fun getForgery(forge: Forge): RawBatchEvent {
         return RawBatchEvent(
-            data = forge.aString().toByteArray(),
-            metadata = forge.aString(
-                forge.anInt(min = 0, max = DATA_SIZE_LIMIT + 1)
-            ).toByteArray()
+            data = forge.aString(forge.anInt(1, EVENT_MAX_SIZE + 1)).toByteArray(),
+            metadata = forge.aString(forge.anInt(0, METADATA_MAX_SIZE + 1)).toByteArray()
         )
     }
 
     companion object {
-        const val DATA_SIZE_LIMIT = 32
+        const val EVENT_MAX_SIZE = 512
+        const val METADATA_MAX_SIZE = 32
     }
 }


### PR DESCRIPTION
_This PR has been created automatically by splitting a large branch_

## Pull request 3 out of 4

> The overall goal is to create a feature allowing customers to store unsent data any way they want (instead of using the official disk batch files)

This PR implements our Internal `Storage` interface based on a `PersistenceStrategy`, in a _Consent Aware_ manner. This means that the tracking of consent is handled internally, and our customers don't need to worry about that part.