### PR TITLE
(4/4) RUM-2129 Use AbstractStorage when custom persistence strategy provided

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
@@ -131,7 +131,7 @@ internal class DatadogCore(
             internalLogger
         )
         features[feature.name] = sdkFeature
-        sdkFeature.initialize(context)
+        sdkFeature.initialize(context, instanceId)
 
         when (feature.name) {
             Feature.LOGS_FEATURE_NAME -> {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -31,6 +31,7 @@ import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.metrics.BatchMetricsDispatcher
 import com.datadog.android.core.internal.metrics.MetricsDispatcher
 import com.datadog.android.core.internal.metrics.NoOpMetricsDispatcher
+import com.datadog.android.core.internal.persistence.AbstractStorage
 import com.datadog.android.core.internal.persistence.ConsentAwareStorage
 import com.datadog.android.core.internal.persistence.NoOpStorage
 import com.datadog.android.core.internal.persistence.Storage
@@ -41,6 +42,7 @@ import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.NoOpFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
+import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.privacy.TrackingConsentProviderCallback
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
@@ -77,18 +79,12 @@ internal class SdkFeature(
                 uploadFrequency,
                 batchProcessingLevel.maxBatchesPerUploadJob
             )
-            val storageConfiguration = wrappedFeature.storageConfiguration
-            val recentDelayMs = resolveBatchingDelay(coreFeature, storageConfiguration)
-            val filePersistenceConfig = coreFeature.buildFilePersistenceConfig().copy(
-                maxBatchSize = storageConfiguration.maxBatchSize,
-                maxItemSize = storageConfiguration.maxItemSize,
-                maxItemsPerBatch = storageConfiguration.maxItemsPerBatch,
-                oldFileThreshold = storageConfiguration.oldBatchThreshold,
-                recentDelayMs = recentDelayMs
+            storage = prepareStorage(
+                dataUploadConfiguration,
+                wrappedFeature,
+                context,
+                coreFeature.persistenceStrategyFactory
             )
-            setupMetricsDispatcher(dataUploadConfiguration, filePersistenceConfig, context)
-
-            storage = createStorage(wrappedFeature.name, filePersistenceConfig)
         }
 
         wrappedFeature.onInitialize(context)
@@ -209,6 +205,7 @@ internal class SdkFeature(
             coreFeature.uploadFrequency
         }
     }
+
     private fun resolveBatchProcessingLevel(): BatchProcessingLevel {
         return if (wrappedFeature is StorageBackedFeature) {
             wrappedFeature.storageConfiguration.batchProcessingLevel
@@ -242,7 +239,47 @@ internal class SdkFeature(
 
     // region Feature setup
 
-    private fun createStorage(
+    private fun prepareStorage(
+        dataUploadConfiguration: DataUploadConfiguration,
+        wrappedFeature: StorageBackedFeature,
+        context: Context,
+        persistenceStrategyFactory: PersistenceStrategy.Factory?
+    ): Storage {
+        val storageConfiguration = wrappedFeature.storageConfiguration
+        return if (persistenceStrategyFactory == null) {
+            val recentDelayMs = resolveBatchingDelay(coreFeature, storageConfiguration)
+            val filePersistenceConfig = coreFeature.buildFilePersistenceConfig().copy(
+                maxBatchSize = storageConfiguration.maxBatchSize,
+                maxItemSize = storageConfiguration.maxItemSize,
+                maxItemsPerBatch = storageConfiguration.maxItemsPerBatch,
+                oldFileThreshold = storageConfiguration.oldBatchThreshold,
+                recentDelayMs = recentDelayMs
+            )
+            setupMetricsDispatcher(dataUploadConfiguration, filePersistenceConfig, context)
+
+            createFileStorage(wrappedFeature.name, filePersistenceConfig)
+        } else {
+            createCustomStorage(wrappedFeature.name, storageConfiguration, persistenceStrategyFactory)
+        }
+    }
+
+    private fun createCustomStorage(
+        featureName: String,
+        storageConfiguration: FeatureStorageConfiguration,
+        persistenceStrategyFactory: PersistenceStrategy.Factory
+    ): Storage {
+        return AbstractStorage(
+            coreFeature.variant,
+            featureName,
+            persistenceStrategyFactory,
+            coreFeature.persistenceExecutorService,
+            internalLogger,
+            storageConfiguration,
+            coreFeature.trackingConsentProvider
+        )
+    }
+
+    private fun createFileStorage(
         featureName: String,
         filePersistenceConfig: FilePersistenceConfig
     ): Storage {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -66,7 +66,7 @@ internal class SdkFeature(
 
     // region SdkFeature
 
-    fun initialize(context: Context) {
+    fun initialize(context: Context, instanceId: String) {
         if (initialized.get()) {
             return
         }
@@ -83,6 +83,7 @@ internal class SdkFeature(
                 dataUploadConfiguration,
                 wrappedFeature,
                 context,
+                instanceId,
                 coreFeature.persistenceStrategyFactory
             )
         }
@@ -243,6 +244,7 @@ internal class SdkFeature(
         dataUploadConfiguration: DataUploadConfiguration,
         wrappedFeature: StorageBackedFeature,
         context: Context,
+        instanceId: String,
         persistenceStrategyFactory: PersistenceStrategy.Factory?
     ): Storage {
         val storageConfiguration = wrappedFeature.storageConfiguration
@@ -259,17 +261,18 @@ internal class SdkFeature(
 
             createFileStorage(wrappedFeature.name, filePersistenceConfig)
         } else {
-            createCustomStorage(wrappedFeature.name, storageConfiguration, persistenceStrategyFactory)
+            createCustomStorage(instanceId, wrappedFeature.name, storageConfiguration, persistenceStrategyFactory)
         }
     }
 
     private fun createCustomStorage(
+        instanceId: String,
         featureName: String,
         storageConfiguration: FeatureStorageConfiguration,
         persistenceStrategyFactory: PersistenceStrategy.Factory
     ): Storage {
         return AbstractStorage(
-            coreFeature.variant,
+            instanceId,
             featureName,
             persistenceStrategyFactory,
             coreFeature.persistenceExecutorService,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
@@ -23,7 +23,7 @@ import com.datadog.android.privacy.TrackingConsentProviderCallback
 import java.util.concurrent.ExecutorService
 
 internal class AbstractStorage(
-    private val sdkCoreId: String?,
+    internal val sdkCoreId: String?,
     private val featureName: String,
     internal val persistenceStrategyFactory: PersistenceStrategy.Factory,
     private val executorService: ExecutorService,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -101,6 +101,9 @@ internal class SdkFeatureTest {
     lateinit var fakeStorageConfiguration: FeatureStorageConfiguration
 
     @StringForgery
+    lateinit var fakeInstanceId: String
+
+    @StringForgery
     lateinit var fakeFeatureName: String
 
     private lateinit var fakeCoreUploadFrequency: UploadFrequency
@@ -138,7 +141,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 mark itself as initialized 𝕎 initialize()`() {
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         assertThat(testedFeature.isInitialized()).isTrue()
@@ -147,7 +150,7 @@ internal class SdkFeatureTest {
     @Test
     fun `M register ProcessLifecycleMonitor for MetricsDispatcher W initialize()`() {
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         argumentCaptor<Application.ActivityLifecycleCallbacks>() {
@@ -162,7 +165,7 @@ internal class SdkFeatureTest {
     fun `M not throw W initialize(){ no app context }`() {
         // When
         assertDoesNotThrow {
-            testedFeature.initialize(mock())
+            testedFeature.initialize(mock(), fakeInstanceId)
         }
     }
 
@@ -175,7 +178,7 @@ internal class SdkFeatureTest {
         )
 
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         assertThat(testedFeature.uploadScheduler)
@@ -209,7 +212,7 @@ internal class SdkFeatureTest {
             .thenReturn(fakeStorageConfig)
 
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         assertThat(testedFeature.uploadScheduler)
@@ -231,7 +234,7 @@ internal class SdkFeatureTest {
             .thenReturn(fakeStorageConfig)
 
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         assertThat(testedFeature.uploadScheduler)
@@ -249,7 +252,7 @@ internal class SdkFeatureTest {
             .thenReturn(fakeCorePersistenceConfig)
 
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         assertThat(testedFeature.storage).isInstanceOf(ConsentAwareStorage::class.java)
@@ -279,11 +282,12 @@ internal class SdkFeatureTest {
         whenever(coreFeature.mockInstance.persistenceStrategyFactory) doReturn mockPersistenceStrategy
 
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         assertThat(testedFeature.storage).isInstanceOf(AbstractStorage::class.java)
         val abstractStorage = testedFeature.storage as AbstractStorage
+        assertThat(abstractStorage.sdkCoreId).isEqualTo(fakeInstanceId)
         assertThat(abstractStorage.persistenceStrategyFactory)
             .isEqualTo(mockPersistenceStrategy)
     }
@@ -298,7 +302,7 @@ internal class SdkFeatureTest {
             .thenReturn(fakeStorageConfig)
 
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         assertThat(testedFeature.storage).isInstanceOf(ConsentAwareStorage::class.java)
@@ -318,7 +322,7 @@ internal class SdkFeatureTest {
         )
 
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         verify(coreFeature.mockInstance.trackingConsentProvider)
@@ -338,7 +342,7 @@ internal class SdkFeatureTest {
         )
 
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         assertThat(testedFeature.isInitialized()).isTrue
@@ -356,7 +360,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 stop scheduler 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
         val mockUploadScheduler: UploadScheduler = mock()
         testedFeature.uploadScheduler = mockUploadScheduler
 
@@ -370,7 +374,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 unregister ProcessLifecycleMonitor 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // When
         testedFeature.stop()
@@ -384,7 +388,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 cleanup data 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // When
         testedFeature.stop()
@@ -405,7 +409,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 mark itself as not initialized 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // When
         testedFeature.stop()
@@ -417,7 +421,7 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 call wrapped feature onStop 𝕎 stop()`() {
         // Given
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // When
         testedFeature.stop()
@@ -437,7 +441,7 @@ internal class SdkFeatureTest {
             wrappedFeature = mockFeature,
             internalLogger = mockInternalLogger
         )
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // When
         testedFeature.stop()
@@ -449,14 +453,14 @@ internal class SdkFeatureTest {
     @Test
     fun `𝕄 initialize only once 𝕎 initialize() twice`() {
         // Given
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
         val uploadScheduler = testedFeature.uploadScheduler
         val uploader = testedFeature.uploader
         val storage = testedFeature.storage
         val fileOrchestrator = testedFeature.fileOrchestrator
 
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         assertThat(testedFeature.uploadScheduler).isSameAs(uploadScheduler)
@@ -471,7 +475,7 @@ internal class SdkFeatureTest {
         whenever(testedFeature.coreFeature.isMainProcess) doReturn false
 
         // When
-        testedFeature.initialize(appContext.mockInstance)
+        testedFeature.initialize(appContext.mockInstance, fakeInstanceId)
 
         // Then
         assertThat(testedFeature.uploadScheduler).isInstanceOf(NoOpUploadScheduler::class.java)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -27,12 +27,14 @@ import com.datadog.android.core.internal.data.upload.v2.NoOpDataUploader
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.metrics.BatchMetricsDispatcher
 import com.datadog.android.core.internal.metrics.NoOpMetricsDispatcher
+import com.datadog.android.core.internal.persistence.AbstractStorage
 import com.datadog.android.core.internal.persistence.ConsentAwareStorage
 import com.datadog.android.core.internal.persistence.NoOpStorage
 import com.datadog.android.core.internal.persistence.Storage
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.NoOpFileOrchestrator
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileOrchestrator
+import com.datadog.android.core.persistence.PersistenceStrategy
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.privacy.TrackingConsentProviderCallback
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
@@ -268,6 +270,22 @@ internal class SdkFeatureTest {
         )
         assertThat(pendingFileOrchestrator.config).isEqualTo(expectedFilePersistenceConfig)
         assertThat(grantedFileOrchestrator.config).isEqualTo(expectedFilePersistenceConfig)
+    }
+
+    @Test
+    fun `𝕄 initialize the storage 𝕎 initialize() {custom persistence strategy}`() {
+        // Given
+        val mockPersistenceStrategy = mock<PersistenceStrategy.Factory>()
+        whenever(coreFeature.mockInstance.persistenceStrategyFactory) doReturn mockPersistenceStrategy
+
+        // When
+        testedFeature.initialize(appContext.mockInstance)
+
+        // Then
+        assertThat(testedFeature.storage).isInstanceOf(AbstractStorage::class.java)
+        val abstractStorage = testedFeature.storage as AbstractStorage
+        assertThat(abstractStorage.persistenceStrategyFactory)
+            .isEqualTo(mockPersistenceStrategy)
     }
 
     @Test


### PR DESCRIPTION
_This PR has been created automatically by splitting a large branch_

## Pull request 4 out of 4

> The overall goal is to create a feature allowing customers to store unsent data any way they want (instead of using the official disk batch files)

This final PR updates the SDK Feature initialisation by choosing the default storage or the new `AbstractStorage` one depending on the provided `PersistenceStrategy.Factory`