### PR TITLE
Remove resourceId field from e2e payloads

### DIFF
--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayTest.kt
@@ -241,7 +241,7 @@ internal abstract class BaseSessionReplayTest<R : Activity> {
         // will be executed in Bitrise and currently Bitrise does not own a specific model for the
         // API 33. They only have a standard emulator for this API with the required screen size and
         // X,Y positions are different from the ones we have in our local emulator.
-        // Also the base64 encoded images values are inconsistent from one run to another so will
+        // Also the base64 and resourceId encoded images values are inconsistent from one run to another so will
         // be removed from the payload.
 
         return this.asJsonObject.apply {
@@ -254,6 +254,7 @@ internal abstract class BaseSessionReplayTest<R : Activity> {
                         wireframeJson.remove("x")
                         wireframeJson.remove("y")
                         wireframeJson.remove("base64")
+                        wireframeJson.remove("resourceId")
                         wireframeJson
                     }?.fold(JsonArray()) { acc, jsonObject ->
                         acc.add(jsonObject)


### PR DESCRIPTION
### What does this PR do?
Adds resourceIds to the e2e payloads

### Motivation
We now send resourceIds as part of the ImageWireframes

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

