### PR TITLE
RUM-2446: Open text masking classes for extension

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -36,9 +36,9 @@ abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseWi
   protected fun resolveViewGlobalBounds(android.view.View, Float): com.datadog.android.sessionreplay.internal.recorder.GlobalBounds
   protected fun android.graphics.drawable.Drawable.resolveShapeStyleAndBorder(Float): Pair<com.datadog.android.sessionreplay.model.MobileSegment.ShapeStyle?, com.datadog.android.sessionreplay.model.MobileSegment.ShapeBorder?>?
   companion object 
-class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskInputTextViewMapper : TextViewMapper
+open class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskInputTextViewMapper : TextViewMapper
   constructor()
-class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskTextViewMapper : TextViewMapper
+open class com.datadog.android.sessionreplay.internal.recorder.mapper.MaskTextViewMapper : TextViewMapper
   constructor()
 open class com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper : BaseAsyncBackgroundWireframeMapper<android.widget.TextView>
   constructor()

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -117,11 +117,11 @@ public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper
 public final class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper$Companion {
 }
 
-public final class com/datadog/android/sessionreplay/internal/recorder/mapper/MaskInputTextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper {
+public class com/datadog/android/sessionreplay/internal/recorder/mapper/MaskInputTextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper {
 	public fun <init> ()V
 }
 
-public final class com/datadog/android/sessionreplay/internal/recorder/mapper/MaskTextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper {
+public class com/datadog/android/sessionreplay/internal/recorder/mapper/MaskTextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper {
 	public fun <init> ()V
 }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskInputTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskInputTextViewMapper.kt
@@ -16,7 +16,7 @@ import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
  * A [WireframeMapper] implementation to map a [TextView] component and apply the
  * [SessionReplayPrivacy.MASK_USER_INPUT] masking rule.
  */
-class MaskInputTextViewMapper : TextViewMapper {
+open class MaskInputTextViewMapper : TextViewMapper {
     constructor() : super(textValueObfuscationRule = MaskInputObfuscationRule())
 
     internal constructor(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/MaskTextViewMapper.kt
@@ -18,7 +18,7 @@ import com.datadog.android.sessionreplay.utils.UniqueIdentifierGenerator
  * A [WireframeMapper] implementation to map a [TextView] component and apply the
  * [SessionReplayPrivacy.MASK] masking rule.
  */
-class MaskTextViewMapper : TextViewMapper {
+open class MaskTextViewMapper : TextViewMapper {
     constructor() : super(textValueObfuscationRule = MaskObfuscationRule())
 
     internal constructor(


### PR DESCRIPTION
### What does this PR do?
Modify `MaskTextViewMapper` and `MaskInputTextViewMapper` to be open for extension.

### Motivation
Necessary for React Native Session Replay, in order to support masking for text elements.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

