### PR TITLE
Replace LogAttribute RUM tags in AndroidTracer with DDTags counterpart

### DIFF
--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -947,6 +947,10 @@ public class com/datadog/trace/api/DDTags {
 	public static final field MANUAL_DROP Ljava/lang/String;
 	public static final field MANUAL_KEEP Ljava/lang/String;
 	public static final field RESOURCE_NAME Ljava/lang/String;
+	public static final field RUM_ACTION_ID Ljava/lang/String;
+	public static final field RUM_APPLICATION_ID Ljava/lang/String;
+	public static final field RUM_SESSION_ID Ljava/lang/String;
+	public static final field RUM_VIEW_ID Ljava/lang/String;
 	public static final field SERVICE_NAME Ljava/lang/String;
 	public static final field SPAN_TYPE Ljava/lang/String;
 	public static final field THREAD_ID Ljava/lang/String;

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/api/DDTags.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/trace/api/DDTags.java
@@ -30,4 +30,10 @@ public class DDTags {
   public static final String MANUAL_KEEP = "manual.keep";
   /** Manually force tracer to be drop the trace */
   public static final String MANUAL_DROP = "manual.drop";
+
+  /** RUM Context propagation */
+  public static final String RUM_APPLICATION_ID = "_dd.application.id";
+  public static final String RUM_SESSION_ID = "_dd.session.id";
+  public static final String RUM_VIEW_ID = "_dd.view.id";
+  public static final String RUM_ACTION_ID = "_dd.action.id";
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/AndroidTracer.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/AndroidTracer.kt
@@ -12,13 +12,13 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.log.LogAttributes
 import com.datadog.android.trace.internal.TracingFeature
 import com.datadog.android.trace.internal.data.NoOpWriter
 import com.datadog.android.trace.internal.handlers.AndroidSpanLogsHandler
 import com.datadog.opentracing.DDTracer
 import com.datadog.opentracing.LogHandler
 import com.datadog.trace.api.Config
+import com.datadog.trace.api.DDTags
 import com.datadog.trace.common.writer.Writer
 import com.datadog.trace.context.ScopeListener
 import io.opentracing.Span
@@ -281,10 +281,10 @@ class AndroidTracer internal constructor(
     private fun DDSpanBuilder.withRumContext(): DDSpanBuilder {
         return if (bundleWithRum) {
             val rumContext = sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
-            withTag(LogAttributes.RUM_APPLICATION_ID, rumContext["application_id"] as? String)
-                .withTag(LogAttributes.RUM_SESSION_ID, rumContext["session_id"] as? String)
-                .withTag(LogAttributes.RUM_VIEW_ID, rumContext["view_id"] as? String)
-                .withTag(LogAttributes.RUM_ACTION_ID, rumContext["action_id"] as? String)
+            withTag(DDTags.RUM_APPLICATION_ID, rumContext["application_id"] as? String)
+                .withTag(DDTags.RUM_SESSION_ID, rumContext["session_id"] as? String)
+                .withTag(DDTags.RUM_VIEW_ID, rumContext["view_id"] as? String)
+                .withTag(DDTags.RUM_ACTION_ID, rumContext["action_id"] as? String)
         } else {
             this
         }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/AndroidTracerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/AndroidTracerTest.kt
@@ -10,7 +10,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
-import com.datadog.android.log.LogAttributes
 import com.datadog.android.trace.internal.TracingFeature
 import com.datadog.android.trace.utils.verifyLog
 import com.datadog.android.utils.forge.Configurator
@@ -18,6 +17,7 @@ import com.datadog.opentracing.DDSpan
 import com.datadog.opentracing.LogHandler
 import com.datadog.opentracing.scopemanager.ScopeTestHelper
 import com.datadog.trace.api.Config
+import com.datadog.trace.api.DDTags
 import com.datadog.trace.common.writer.Writer
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.DoubleForgery
@@ -243,21 +243,21 @@ internal class AndroidTracerTest {
 
         val span = tracer.buildSpan(operationName).start() as DDSpan
         val meta = span.meta
-        assertThat(meta[LogAttributes.RUM_APPLICATION_ID])
+        assertThat(meta[DDTags.RUM_APPLICATION_ID])
             .isEqualTo(fakeRumApplicationId)
-        assertThat(meta[LogAttributes.RUM_SESSION_ID])
+        assertThat(meta[DDTags.RUM_SESSION_ID])
             .isEqualTo(fakeRumSessionId)
         val viewId = fakeRumViewId
         if (viewId == null) {
-            assertThat(meta.containsKey(LogAttributes.RUM_VIEW_ID)).isFalse()
+            assertThat(meta.containsKey(DDTags.RUM_VIEW_ID)).isFalse()
         } else {
-            assertThat(meta[LogAttributes.RUM_VIEW_ID]).isEqualTo(viewId)
+            assertThat(meta[DDTags.RUM_VIEW_ID]).isEqualTo(viewId)
         }
         val actionId = fakeRumActionId
         if (actionId == null) {
-            assertThat(meta.containsKey(LogAttributes.RUM_ACTION_ID)).isFalse()
+            assertThat(meta.containsKey(DDTags.RUM_ACTION_ID)).isFalse()
         } else {
-            assertThat(meta[LogAttributes.RUM_ACTION_ID]).isEqualTo(actionId)
+            assertThat(meta[DDTags.RUM_ACTION_ID]).isEqualTo(actionId)
         }
     }
 
@@ -284,7 +284,7 @@ internal class AndroidTracerTest {
         val meta = span.meta
 
         // Then
-        assertThat(meta[LogAttributes.RUM_VIEW_ID]).isEqualTo(fakeViewId)
+        assertThat(meta[DDTags.RUM_VIEW_ID]).isEqualTo(fakeViewId)
     }
 
     @Test
@@ -308,7 +308,7 @@ internal class AndroidTracerTest {
         val meta = span.meta
 
         // Then
-        assertThat(meta.containsKey(LogAttributes.RUM_VIEW_ID)).isFalse()
+        assertThat(meta.containsKey(DDTags.RUM_VIEW_ID)).isFalse()
     }
 
     @Test
@@ -333,7 +333,7 @@ internal class AndroidTracerTest {
         val meta = span.meta
 
         // Then
-        assertThat(meta.containsKey(LogAttributes.RUM_VIEW_ID)).isFalse()
+        assertThat(meta.containsKey(DDTags.RUM_VIEW_ID)).isFalse()
     }
 
     @Test
@@ -359,7 +359,7 @@ internal class AndroidTracerTest {
         val meta = span.meta
 
         // Then
-        assertThat(meta[LogAttributes.RUM_ACTION_ID]).isEqualTo(fakeActionId)
+        assertThat(meta[DDTags.RUM_ACTION_ID]).isEqualTo(fakeActionId)
     }
 
     @Test
@@ -383,7 +383,7 @@ internal class AndroidTracerTest {
         val meta = span.meta
 
         // Then
-        assertThat(meta.containsKey(LogAttributes.RUM_ACTION_ID)).isFalse()
+        assertThat(meta.containsKey(DDTags.RUM_ACTION_ID)).isFalse()
     }
 
     @Test
@@ -408,7 +408,7 @@ internal class AndroidTracerTest {
         val meta = span.meta
 
         // Then
-        assertThat(meta.containsKey(LogAttributes.RUM_ACTION_ID)).isFalse()
+        assertThat(meta.containsKey(DDTags.RUM_ACTION_ID)).isFalse()
     }
 
     @Test
@@ -425,9 +425,9 @@ internal class AndroidTracerTest {
 
         // THEN
         val meta = span.meta
-        assertThat(meta[LogAttributes.RUM_APPLICATION_ID])
+        assertThat(meta[DDTags.RUM_APPLICATION_ID])
             .isNull()
-        assertThat(meta[LogAttributes.RUM_SESSION_ID])
+        assertThat(meta[DDTags.RUM_SESSION_ID])
             .isNull()
     }
 
@@ -445,9 +445,9 @@ internal class AndroidTracerTest {
 
         // THEN
         val meta = span.meta
-        assertThat(meta[LogAttributes.RUM_APPLICATION_ID])
+        assertThat(meta[DDTags.RUM_APPLICATION_ID])
             .isNull()
-        assertThat(meta[LogAttributes.RUM_SESSION_ID])
+        assertThat(meta[DDTags.RUM_SESSION_ID])
             .isNull()
     }
 


### PR DESCRIPTION
### What does this PR do?

This update the span tags pertaining RUM Context that are sent with each span. 

```
// Before
"application_id", "session_id", "view.id", "user_action.id"

//After
"_dd.application.id", "_dd.session.id", "_dd.view.id", "_dd.action.id",
```
### Motivation

Align with tags now used in span created from RUM Resources by RUM->APM.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

