### PR TITLE
RUM-2376: Fix duplicate wireframes issue

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
@@ -22,9 +22,7 @@ internal class WindowsOnDrawListener(
     private val recordedDataQueueHandler: RecordedDataQueueHandler,
     private val snapshotProducer: SnapshotProducer,
     private val debouncer: Debouncer = Debouncer(),
-    private val miscUtils: MiscUtils = MiscUtils,
-    private val recordedDataQueueRefs: RecordedDataQueueRefs =
-        RecordedDataQueueRefs(recordedDataQueueHandler)
+    private val miscUtils: MiscUtils = MiscUtils
 ) : ViewTreeObserver.OnDrawListener {
 
     internal val weakReferencedDecorViews: List<WeakReference<View>>
@@ -56,6 +54,8 @@ internal class WindowsOnDrawListener(
         val item = recordedDataQueueHandler.addSnapshotItem(systemInformation)
             ?: return@Runnable
 
+        val recordedDataQueueRefs =
+            RecordedDataQueueRefs(recordedDataQueueHandler)
         recordedDataQueueRefs.recordedDataQueueItem = item
 
         val nodes = views

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.async
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler.Companion.ITEM_DROPPED_FROM_QUEUE_ERROR_MESSAGE
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler.Companion.MAX_DELAY_MS
 import com.datadog.android.sessionreplay.internal.processor.RecordedDataProcessor
 import com.datadog.android.sessionreplay.internal.processor.RecordedQueuedItemContext
@@ -45,6 +46,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.Locale
 import java.util.Queue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
@@ -315,6 +317,16 @@ internal class RecordedDataQueueHandlerTest {
 
         // Then
         assertThat(testedHandler.recordedDataQueue.isEmpty()).isTrue
+        val expectedLogMessage = ITEM_DROPPED_FROM_QUEUE_ERROR_MESSAGE
+            .format(Locale.US, true)
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            listOf(
+                InternalLogger.Target.MAINTAINER,
+                InternalLogger.Target.TELEMETRY
+            ),
+            expectedLogMessage
+        )
         verifyNoMoreInteractions(mockProcessor)
     }
 
@@ -336,7 +348,16 @@ internal class RecordedDataQueueHandlerTest {
         spyExecutorService.awaitTermination(1, TimeUnit.SECONDS)
 
         // Then
-        assertThat(testedHandler.recordedDataQueue.size).isEqualTo(0)
+        assertThat(testedHandler.recordedDataQueue).isEmpty()
+        val expectedLogMessage = ITEM_DROPPED_FROM_QUEUE_ERROR_MESSAGE.format(Locale.US, false)
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            listOf(
+                InternalLogger.Target.MAINTAINER,
+                InternalLogger.Target.TELEMETRY
+            ),
+            expectedLogMessage
+        )
         verifyNoMoreInteractions(mockProcessor)
     }
 
@@ -358,7 +379,17 @@ internal class RecordedDataQueueHandlerTest {
         spyExecutorService.awaitTermination(1, TimeUnit.SECONDS)
 
         // Then
-        assertThat(testedHandler.recordedDataQueue.size).isEqualTo(0)
+        assertThat(testedHandler.recordedDataQueue).isEmpty()
+        val expectedLogMessage = ITEM_DROPPED_FROM_QUEUE_ERROR_MESSAGE
+            .format(Locale.US, false)
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            listOf(
+                InternalLogger.Target.MAINTAINER,
+                InternalLogger.Target.TELEMETRY
+            ),
+            expectedLogMessage
+        )
         verifyNoMoreInteractions(mockProcessor)
     }
 


### PR DESCRIPTION
### What does this PR do?
This pr fixes the issue of duplicate wireframes appearing in the replays, and also adds in telemetry so that we'll know if items are dropped in future from the `RecordedDataQueue`. 

What was happening was that `RecordedDataQueueRefs` was held as a class-level variable inside `RecordedDataQueueHandler`. As a result, for every traversal the value of the `SnapshotRecordedDataQueueItem` held by the ref object was mutating, and this caused asynchronous tasks to occasionally return their callback to the wrong `SnapshotRecordedDataQueueItem`. This further led to the number of pending asynchronous tasks on the previous item never reaching zero, so it became stuck in the queue and eventually cleaned after exceeding the 200ms timeout. 

### Motivation
To handle the issue of duplicate wireframes. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

