### PR TITLE
RUM-2467: Fix `ConcurrentModificationException` during `ConsentAwareStorage.dropAll` call

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
@@ -149,8 +149,8 @@ internal class ConsentAwareStorage(
         synchronized(lockedBatches) {
             lockedBatches.forEach {
                 deleteBatch(it, RemovalReason.Flushed)
-                lockedBatches.remove(it)
             }
+            lockedBatches.clear()
         }
 
         arrayOf(pendingOrchestrator, grantedOrchestrator).forEach { orchestrator ->


### PR DESCRIPTION
### What does this PR do?

We were removing items from collection during its traversal, this PR fixes that.

The issue doesn't reproduce with only single item in the collection, because modification check it done on the next iteration, so I also updated test to have multiple locked batches.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

