### PR TITLE
RUM-2568: Better handling of event write errors in RUM

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -846,6 +846,7 @@ datadog:
       - "kotlin.collections.MutableCollection.forEach(kotlin.Function1)"
       - "kotlin.collections.MutableCollection.toList()"
       - "kotlin.collections.MutableIterator.hasNext()"
+      - "kotlin.collections.MutableList.add(com.datadog.android.api.InternalLogger.Target)"
       - "kotlin.collections.MutableList.add(com.datadog.android.core.internal.persistence.Batch)"
       - "kotlin.collections.MutableList.add(com.datadog.android.plugin.DatadogPlugin)"
       - "kotlin.collections.MutableList.add(com.datadog.android.rum.internal.domain.scope.RumScope)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -230,7 +230,6 @@ internal class RumFeature constructor(
         return RumDataWriter(
             eventSerializer = MapperSerializer(
                 RumEventMapper(
-                    sdkCore,
                     viewEventMapper = configuration.viewEventMapper,
                     errorEventMapper = configuration.errorEventMapper,
                     resourceEventMapper = configuration.resourceEventMapper,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -13,14 +13,7 @@ import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.core.persistence.serializeToByteArray
-import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.internal.domain.event.RumEventMeta
-import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
-import com.datadog.android.rum.internal.monitor.StorageEvent
-import com.datadog.android.rum.model.ActionEvent
-import com.datadog.android.rum.model.ErrorEvent
-import com.datadog.android.rum.model.LongTaskEvent
-import com.datadog.android.rum.model.ResourceEvent
 import com.datadog.android.rum.model.ViewEvent
 
 internal class RumDataWriter(
@@ -70,36 +63,7 @@ internal class RumDataWriter(
     @WorkerThread
     internal fun onDataWritten(data: Any, rawData: ByteArray) {
         when (data) {
-            is ViewEvent -> persistViewEvent(rawData)
-            is ActionEvent -> notifyEventSent(
-                data.view.id,
-                StorageEvent.Action(data.action.frustration?.type?.size ?: 0)
-            )
-            is ResourceEvent -> notifyEventSent(data.view.id, StorageEvent.Resource)
-            is ErrorEvent -> {
-                if (data.error.isCrash != true) {
-                    notifyEventSent(data.view.id, StorageEvent.Error)
-                }
-            }
-            is LongTaskEvent -> {
-                if (data.longTask.isFrozenFrame == true) {
-                    notifyEventSent(data.view.id, StorageEvent.FrozenFrame)
-                } else {
-                    notifyEventSent(data.view.id, StorageEvent.LongTask)
-                }
-            }
-        }
-    }
-
-    @WorkerThread
-    private fun persistViewEvent(data: ByteArray) {
-        sdkCore.writeLastViewEvent(data)
-    }
-
-    private fun notifyEventSent(viewId: String, storageEvent: StorageEvent) {
-        val rumMonitor = GlobalRumMonitor.get(sdkCore)
-        if (rumMonitor is AdvancedRumMonitor) {
-            rumMonitor.eventSent(viewId, storageEvent)
+            is ViewEvent -> sdkCore.writeLastViewEvent(rawData)
         }
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/utils/SdkCoreExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/utils/SdkCoreExt.kt
@@ -1,0 +1,103 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.utils
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.DataWriter
+import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
+
+internal typealias EventOutcomeAction = (rumMonitor: AdvancedRumMonitor) -> Unit
+
+internal class WriteOperation(
+    private val sdkCore: FeatureSdkCore,
+    private val rumDataWriter: DataWriter<Any>,
+    private val eventSource: (DatadogContext) -> Any
+) {
+    private val advancedRumMonitor = GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor
+    private var onError: EventOutcomeAction = NO_OP_EVENT_OUTCOME_ACTION
+    private var onSuccess: EventOutcomeAction = NO_OP_EVENT_OUTCOME_ACTION
+
+    /**
+     * Invoked if write operation failed. Invocation is done on the worker thread.
+     */
+    fun onError(action: EventOutcomeAction): WriteOperation {
+        onError = action
+        return this
+    }
+
+    /**
+     * Invoked if write operation failed. Invocation is done on the worker thread.
+     */
+    fun onSuccess(action: EventOutcomeAction): WriteOperation {
+        onSuccess = action
+        return this
+    }
+
+    fun submit() {
+        sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
+            ?.withWriteContext { datadogContext, eventBatchWriter ->
+                try {
+                    val event = eventSource(datadogContext)
+
+                    @Suppress("ThreadSafety") // called in a worker thread context
+                    val isSuccess = rumDataWriter.write(eventBatchWriter, event)
+                    if (isSuccess) {
+                        advancedRumMonitor?.let {
+                            onSuccess(it)
+                        }
+                    } else {
+                        notifyEventWriteFailure()
+                    }
+                } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+                    notifyEventWriteFailure(e)
+                }
+            }
+    }
+
+    private fun notifyEventWriteFailure(exception: Exception? = null) {
+        val targets = mutableListOf(InternalLogger.Target.USER).apply {
+            // if no exception, no need to notify telemetry, probably we already handled failure
+            // internally and sent it to telemetry
+            if (exception != null) add(InternalLogger.Target.TELEMETRY)
+        }
+        sdkCore.internalLogger.log(
+            level = InternalLogger.Level.ERROR,
+            targets = targets,
+            messageBuilder = { WRITE_OPERATION_FAILED_ERROR },
+            throwable = exception
+        )
+
+        advancedRumMonitor?.let {
+            if (onError == NO_OP_EVENT_OUTCOME_ACTION) {
+                sdkCore.internalLogger.log(
+                    level = InternalLogger.Level.WARN,
+                    target = InternalLogger.Target.MAINTAINER,
+                    { NO_ERROR_CALLBACK_PROVIDED_WARNING }
+                )
+            }
+            onError(it)
+        }
+    }
+
+    internal companion object {
+        const val WRITE_OPERATION_FAILED_ERROR = "Write operation failed."
+        const val NO_ERROR_CALLBACK_PROVIDED_WARNING =
+            "Write operation failed, but no onError callback was provided."
+        val NO_OP_EVENT_OUTCOME_ACTION: EventOutcomeAction = {}
+    }
+}
+
+internal fun FeatureSdkCore.newRumEventWriteOperation(
+    rumDataWriter: DataWriter<Any>,
+    eventSource: (DatadogContext) -> Any
+): WriteOperation {
+    return WriteOperation(this, rumDataWriter, eventSource)
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/RumDataWriterTest.kt
@@ -11,8 +11,6 @@ import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.rum.internal.domain.event.RumEventMeta
-import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
-import com.datadog.android.rum.internal.monitor.StorageEvent
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
@@ -37,11 +35,8 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
-import org.mockito.kotlin.eq
-import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
@@ -233,120 +228,6 @@ internal class RumDataWriterTest {
         // Then
         verify(rumMonitor.mockSdkCore).writeLastViewEvent(fakeSerializedData)
         verifyNoInteractions(mockInternalLogger)
-    }
-
-    @Test
-    fun `𝕄 notify the RumMonitor 𝕎 onDataWritten() { ActionEvent }`(
-        @Forgery actionEvent: ActionEvent
-    ) {
-        // When
-        testedWriter.onDataWritten(actionEvent, fakeSerializedData)
-
-        // Then
-        verify(rumMonitor.mockInstance as AdvancedRumMonitor).eventSent(
-            actionEvent.view.id,
-            StorageEvent.Action(frustrationCount = actionEvent.action.frustration?.type?.size ?: 0)
-        )
-        verifyNoInteractions(rumMonitor.mockSdkCore)
-    }
-
-    @Test
-    fun `𝕄 notify the RumMonitor 𝕎 onDataWritten() { ResourceEvent }`(
-        @Forgery resourceEvent: ResourceEvent
-    ) {
-        // When
-        testedWriter.onDataWritten(resourceEvent, fakeSerializedData)
-
-        // Then
-        verify(rumMonitor.mockInstance as AdvancedRumMonitor).eventSent(
-            resourceEvent.view.id,
-            StorageEvent.Resource
-        )
-        verifyNoInteractions(rumMonitor.mockSdkCore)
-    }
-
-    @Test
-    fun `𝕄 notify the RumMonitor 𝕎 onDataWritten() { ErrorEvent isCrash=false }`(
-        @Forgery fakeEvent: ErrorEvent
-    ) {
-        // Given
-        val errorEvent = fakeEvent.copy(error = fakeEvent.error.copy(isCrash = false))
-
-        // When
-        testedWriter.onDataWritten(errorEvent, fakeSerializedData)
-
-        // Then
-        verify(rumMonitor.mockInstance as AdvancedRumMonitor).eventSent(
-            fakeEvent.view.id,
-            StorageEvent.Error
-        )
-        verifyNoInteractions(rumMonitor.mockSdkCore)
-    }
-
-    @Test
-    fun `𝕄 not notify the RumMonitor 𝕎 onDataWritten() { ErrorEvent isCrash=true }`(
-        @Forgery fakeEvent: ErrorEvent
-    ) {
-        // Given
-        val errorEvent = fakeEvent.copy(error = fakeEvent.error.copy(isCrash = true))
-
-        // When
-        testedWriter.onDataWritten(errorEvent, fakeSerializedData)
-
-        // Then
-        verify(
-            rumMonitor.mockInstance as AdvancedRumMonitor,
-            never()
-        ).eventSent(eq(fakeEvent.view.id), any())
-        verifyNoInteractions(rumMonitor.mockSdkCore)
-    }
-
-    @Test
-    fun `𝕄 notify the RumMonitor 𝕎 onDataWritten() { LongTaskEvent }`(
-        @Forgery fakeEvent: LongTaskEvent
-    ) {
-        // Given
-        val longTaskEvent = fakeEvent.copy(
-            longTask = LongTaskEvent.LongTask(
-                id = fakeEvent.longTask.id,
-                duration = fakeEvent.longTask.duration,
-                isFrozenFrame = false
-            )
-        )
-
-        // When
-        testedWriter.onDataWritten(longTaskEvent, fakeSerializedData)
-
-        // Then
-        verify(rumMonitor.mockInstance as AdvancedRumMonitor).eventSent(
-            longTaskEvent.view.id,
-            StorageEvent.LongTask
-        )
-        verifyNoInteractions(rumMonitor.mockSdkCore)
-    }
-
-    @Test
-    fun `𝕄 notify the RumMonitor 𝕎 onDataWritten() { FrozenFrame Event }`(
-        @Forgery fakeEvent: LongTaskEvent
-    ) {
-        // Given
-        val frozenFrameEvent = fakeEvent.copy(
-            longTask = LongTaskEvent.LongTask(
-                id = fakeEvent.longTask.id,
-                duration = fakeEvent.longTask.duration,
-                isFrozenFrame = true
-            )
-        )
-
-        // When
-        testedWriter.onDataWritten(frozenFrameEvent, fakeSerializedData)
-
-        // Then
-        verify(rumMonitor.mockInstance as AdvancedRumMonitor).eventSent(
-            frozenFrameEvent.view.id,
-            StorageEvent.FrozenFrame
-        )
-        verifyNoInteractions(rumMonitor.mockSdkCore)
     }
 
     // endregion

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -146,6 +146,7 @@ internal class RumContinuousActionScopeTest {
             val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any())) doReturn true
 
         testedScope = RumActionScope(
             mockParentScope,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/SdkCoreExtTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/SdkCoreExtTest.kt
@@ -1,0 +1,230 @@
+package com.datadog.android.rum.utils
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.api.storage.DataWriter
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
+import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.datadog.tools.unit.forge.anException
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.doAnswer
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class SdkCoreExtTest {
+
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
+    @Mock
+    lateinit var mockRumFeatureScope: FeatureScope
+
+    @Mock
+    lateinit var mockEventBatchWriter: EventBatchWriter
+
+    @Mock
+    lateinit var mockWriter: DataWriter<Any>
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    private val mockSdkCore
+        get() = rumMonitor.mockSdkCore
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockRumFeatureScope.withWriteContext(any(), any())) doAnswer {
+            val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
+            callback.invoke(fakeDatadogContext, mockEventBatchWriter)
+        }
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any())) doReturn true
+    }
+
+    @Test
+    fun `𝕄 write data 𝕎 submit()`() {
+        // Given
+        val fakeEvent = Any()
+
+        // When
+        mockSdkCore.newRumEventWriteOperation(mockWriter) {
+            fakeEvent
+        }
+            .submit()
+
+        // Then
+        verify(mockWriter).write(mockEventBatchWriter, fakeEvent)
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `𝕄 call onSuccess 𝕎 submit() { write succeeded } `() {
+        // Given
+        val fakeEvent = Any()
+        var invoked = false
+
+        // When
+        mockSdkCore.newRumEventWriteOperation(mockWriter) {
+            fakeEvent
+        }
+            .onSuccess {
+                invoked = true
+            }
+            .submit()
+
+        // Then
+        verifyNoInteractions(mockInternalLogger)
+        assertThat(invoked)
+            .overridingErrorMessage("Expected to invoke onSuccess callback, but it wasn't.")
+            .isTrue
+    }
+
+    @Test
+    fun `𝕄 call onError 𝕎 submit() { write was not successful }`() {
+        // Given
+        val fakeEvent = Any()
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any())) doReturn false
+        var invoked = false
+
+        // When
+        mockSdkCore.newRumEventWriteOperation(mockWriter) {
+            fakeEvent
+        }
+            .onError {
+                invoked = true
+            }
+            .submit()
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.USER),
+            message = WriteOperation.WRITE_OPERATION_FAILED_ERROR
+        )
+        assertThat(invoked)
+            .overridingErrorMessage("Expected to invoke onError callback, but it wasn't.")
+            .isTrue
+    }
+
+    @Test
+    fun `𝕄 call onError 𝕎 submit() { write throws }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeEvent = Any()
+        val fakeException = forge.anException()
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any())) doThrow fakeException
+        var invoked = false
+
+        // When
+        mockSdkCore.newRumEventWriteOperation(mockWriter) {
+            fakeEvent
+        }
+            .onError {
+                invoked = true
+            }
+            .submit()
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            message = WriteOperation.WRITE_OPERATION_FAILED_ERROR,
+            throwable = fakeException
+        )
+        assertThat(invoked)
+            .overridingErrorMessage("Expected to invoke onError callback, but it wasn't.")
+            .isTrue
+    }
+
+    @Test
+    fun `𝕄 call onError 𝕎 submit() { event creation throws }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeException = forge.anException()
+        var invoked = false
+
+        // When
+        mockSdkCore.newRumEventWriteOperation(mockWriter) {
+            throw fakeException
+        }
+            .onError {
+                invoked = true
+            }
+            .submit()
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            targets = listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            message = WriteOperation.WRITE_OPERATION_FAILED_ERROR,
+            throwable = fakeException
+        )
+        assertThat(invoked)
+            .overridingErrorMessage("Expected to invoke onError callback, but it wasn't.")
+            .isTrue
+    }
+
+    @Test
+    fun `𝕄 notify no onError provided 𝕎 submit() { write failed }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeException = forge.anException()
+
+        // When
+        mockSdkCore.newRumEventWriteOperation(mockWriter) {
+            throw fakeException
+        }
+            .submit()
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.WARN,
+            target = InternalLogger.Target.MAINTAINER,
+            message = WriteOperation.NO_ERROR_CALLBACK_PROVIDED_WARNING
+        )
+    }
+
+    companion object {
+        val rumMonitor = GlobalRumMonitorTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(rumMonitor)
+        }
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/RumEventMapperFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/RumEventMapperFactory.kt
@@ -15,7 +15,6 @@ internal class RumEventMapperFactory : ForgeryFactory<RumEventMapper> {
 
     override fun getForgery(forge: Forge): RumEventMapper {
         return RumEventMapper(
-            sdkCore = mock(),
             viewEventMapper = mock(),
             actionEventMapper = mock(),
             resourceEventMapper = mock(),


### PR DESCRIPTION
### What does this PR do?

This PR improves any error handling in the write pipeline of RUM. Before, if there was any exception thrown inside writing pipeline which wasn't caught, or if write wasn't successful, we didn't notify that event wasn't written (or dropped, in other words). This prevented to decrease `pendingXXX` counters in `RumViewScope`, thus making `isComplete` to evaluate to `false` in such cases.

This PR also centralizes the place where the notification about write success or failure is sent.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

