### PR TITLE
Fix WeakReference leak

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -244,8 +244,7 @@ internal open class RumViewScope(
         writer: DataWriter<Any>
     ) {
         delegateEventToChildren(event, writer)
-        val startedKey = keyRef.get()
-        val shouldStop = (event.key == startedKey) || (startedKey == null)
+        val shouldStop = (keyRef.refersTo(event.key) || keyRef.refersTo(null))
         if (shouldStop && !stopped) {
             val newRumContext = getRumContext().copy(
                 viewType = RumViewType.NONE,


### PR DESCRIPTION
See https://github.com/DataDog/dd-sdk-android/issues/1762 for details. According to https://developer.android.com/reference/java/lang/ref/Reference#refersTo(T) we should prefer using refersTo over a comparison with the result of get. refersTo avoids creating a strong ref even temporarily, thereby avoiding this leak.