### PR TITLE
RUM-2014 Add the synchronous equivalent of readNextBatch and confirmBatchRead in Storage API

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadWorker.kt
@@ -22,8 +22,6 @@ import com.datadog.android.core.internal.metrics.RemovalReason
 import com.datadog.android.core.internal.utils.unboundInternalLogger
 import java.util.LinkedList
 import java.util.Queue
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
 
 internal class UploadWorker(
     appContext: Context,
@@ -87,32 +85,22 @@ internal class UploadWorker(
 
             val storage = feature.storage
             val uploader = feature.uploader
-
-            // storage APIs may be async, so we need to block current thread to keep Worker alive
-            @Suppress("UnsafeThirdPartyFunctionCall") // safe to create, argument is not negative
-            val lock = CountDownLatch(1)
-
-            storage.readNextBatch(noBatchCallback = {
-                lock.countDown()
-            }) { batchId, reader ->
-                val batch = reader.read()
-                val batchMeta = reader.currentMetadata()
-
-                val uploadStatus = consumeBatch(context, batch, batchMeta, uploader)
+            val nextBatchData = storage.readNextBatch()
+            if (nextBatchData != null) {
+                val uploadStatus = consumeBatch(
+                    context,
+                    nextBatchData.data,
+                    nextBatchData.metadata,
+                    uploader
+                )
                 storage.confirmBatchRead(
-                    batchId,
-                    RemovalReason.IntakeCode(uploadStatus.code)
-                ) { confirmation ->
-                    confirmation.markAsRead(deleteBatch = !uploadStatus.shouldRetry)
-                    @Suppress("UnsafeThirdPartyFunctionCall") // safe to add
-                    taskQueue.offer(UploadNextBatchTask(taskQueue, sdkCore, feature))
-                    lock.countDown()
-                }
+                    nextBatchData.id,
+                    RemovalReason.IntakeCode(uploadStatus.code),
+                    deleteBatch = !uploadStatus.shouldRetry
+                )
+                @Suppress("UnsafeThirdPartyFunctionCall") // safe to add
+                taskQueue.offer(UploadNextBatchTask(taskQueue, sdkCore, feature))
             }
-
-            @Suppress("UnsafeThirdPartyFunctionCall") // if interrupt happens, WorkManager
-            // will handle it
-            lock.await(LOCK_AWAIT_SECONDS, TimeUnit.SECONDS)
         }
 
         private fun consumeBatch(
@@ -128,7 +116,6 @@ internal class UploadWorker(
     // endregion
 
     companion object {
-        const val LOCK_AWAIT_SECONDS = 30L
 
         const val MESSAGE_NOT_INITIALIZED = "Datadog has not been initialized."
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/BatchData.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/BatchData.kt
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence
+
+import com.datadog.android.api.storage.RawBatchEvent
+
+internal data class BatchData(
+    val id: BatchId,
+    val data: List<RawBatchEvent>,
+    val metadata: ByteArray? = null
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as BatchData
+
+        if (id != other.id) return false
+        if (data != other.data) return false
+        if (metadata != null) {
+            if (other.metadata == null) return false
+            if (!metadata.contentEquals(other.metadata)) return false
+        } else if (other.metadata != null) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + data.hashCode()
+        result = 31 * result + (metadata?.contentHashCode() ?: 0)
+        return result
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
@@ -10,7 +10,6 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.storage.EventBatchWriter
-import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.metrics.MetricsDispatcher
 import com.datadog.android.core.internal.metrics.RemovalReason
 import com.datadog.android.core.internal.persistence.file.FileMover
@@ -84,17 +83,10 @@ internal class ConsentAwareStorage(
 
     /** @inheritdoc */
     @WorkerThread
-    override fun readNextBatch(
-        noBatchCallback: () -> Unit,
-        readBatchCallback: (BatchId, BatchReader) -> Unit
-    ) {
+    override fun readNextBatch(): BatchData? {
         val (batchFile, metaFile) = synchronized(lockedBatches) {
             val batchFile = grantedOrchestrator
-                .getReadableFile(lockedBatches.map { it.file }.toSet())
-            if (batchFile == null) {
-                noBatchCallback()
-                return
-            }
+                .getReadableFile(lockedBatches.map { it.file }.toSet()) ?: return null
 
             val metaFile = grantedOrchestrator.getMetadataFile(batchFile)
             lockedBatches.add(Batch(batchFile, metaFile))
@@ -102,21 +94,14 @@ internal class ConsentAwareStorage(
         }
 
         val batchId = BatchId.fromFile(batchFile)
-        val reader = object : BatchReader {
-
-            @WorkerThread
-            override fun currentMetadata(): ByteArray? {
-                if (metaFile == null || !metaFile.existsSafe(internalLogger)) return null
-
-                return batchMetadataReaderWriter.readData(metaFile)
-            }
-
-            @WorkerThread
-            override fun read(): List<RawBatchEvent> {
-                return batchEventsReaderWriter.readData(batchFile)
-            }
+        val batchMetadata = if (metaFile == null || !metaFile.existsSafe(internalLogger)) {
+            null
+        } else {
+            batchMetadataReaderWriter.readData(metaFile)
         }
-        readBatchCallback(batchId, reader)
+        val batchData = batchEventsReaderWriter.readData(batchFile)
+
+        return BatchData(id = batchId, data = batchData, metadata = batchMetadata)
     }
 
     /** @inheritdoc */
@@ -124,23 +109,18 @@ internal class ConsentAwareStorage(
     override fun confirmBatchRead(
         batchId: BatchId,
         removalReason: RemovalReason,
-        callback: (BatchConfirmation) -> Unit
+        deleteBatch: Boolean
     ) {
         val batch = synchronized(lockedBatches) {
             lockedBatches.firstOrNull { batchId.matchesFile(it.file) }
         } ?: return
-        val confirmation = object : BatchConfirmation {
-            @WorkerThread
-            override fun markAsRead(deleteBatch: Boolean) {
-                if (deleteBatch) {
-                    deleteBatch(batch, removalReason)
-                }
-                synchronized(lockedBatches) {
-                    lockedBatches.remove(batch)
-                }
-            }
+
+        if (deleteBatch) {
+            deleteBatch(batch, removalReason)
         }
-        callback(confirmation)
+        synchronized(lockedBatches) {
+            lockedBatches.remove(batch)
+        }
     }
 
     /** @inheritdoc */

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
@@ -39,28 +39,23 @@ internal interface Storage {
     )
 
     /**
-     * Utility to read a batch, asynchronously.
-     * @param noBatchCallback an optional callback which is called when there is no batch available to read.
-     * @param readBatchCallback an operation to perform with a [BatchId] and [BatchReader] that will target
-     * the next readable Batch
+     * Utility to read a batch, synchronously.
      */
     @WorkerThread
-    fun readNextBatch(
-        noBatchCallback: () -> Unit = {},
-        readBatchCallback: (BatchId, BatchReader) -> Unit
-    )
+    fun readNextBatch(): BatchData?
 
     /**
-     * Utility to update the state of a batch, asynchronously.
+     * Utility to update the state of a batch, synchronously.
      * @param batchId the id of the Batch to confirm
      * @param removalReason the reason why the batch is being removed
-     * @param callback an operation to perform with a [BatchConfirmation]
+     * @param deleteBatch if `true` the batch will be deleted, otherwise it will be marked as
+     * not readable.
      */
     @WorkerThread
     fun confirmBatchRead(
         batchId: BatchId,
         removalReason: RemovalReason,
-        callback: (BatchConfirmation) -> Unit
+        deleteBatch: Boolean
     )
 
     /**

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/BatchDataTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/BatchDataTest.kt
@@ -1,0 +1,34 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.persistence
+
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.ObjectTest
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(ExtendWith(ForgeExtension::class))
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class BatchDataTest : ObjectTest<BatchData>() {
+    override fun createInstance(forge: Forge): BatchData {
+        return forge.getForgery()
+    }
+
+    override fun createEqualInstance(source: BatchData, forge: Forge): BatchData {
+        return BatchData(source.id, source.data, source.metadata)
+    }
+
+    override fun createUnequalInstance(source: BatchData, forge: Forge): BatchData? {
+        return forge.getForgery()
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
@@ -32,7 +32,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
-import org.junit.jupiter.api.fail
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
@@ -359,7 +358,7 @@ internal class ConsentAwareStorageTest {
     // region readNextBatch
 
     @Test
-    fun `𝕄 provide reader 𝕎 readNextBatch()`(
+    fun `𝕄 provide batchData 𝕎 readNextBatch()`(
         @Forgery fakeData: List<RawBatchEvent>,
         @StringForgery metadata: String,
         @Forgery batchFile: File
@@ -377,42 +376,37 @@ internal class ConsentAwareStorageTest {
         whenever(mockMetaReaderWriter.readData(mockMetaFile)) doReturn mockMetadata
 
         // Whenever
-        var readData: List<RawBatchEvent>? = null
-        var readMetadata: ByteArray? = null
-        testedStorage.readNextBatch { _, reader ->
-            readMetadata = reader.currentMetadata()
-            readData = reader.read()
-        }
+        val batchData = testedStorage.readNextBatch()
 
         // Then
-        assertThat(readData).isEqualTo(fakeData)
-        assertThat(readMetadata).isEqualTo(mockMetadata)
+        assertThat(batchData).isNotNull
+        assertThat(batchData?.id).isNotNull
+        assertThat(batchData?.data).isEqualTo(fakeData)
+        assertThat(batchData?.metadata).isEqualTo(mockMetadata)
     }
 
     @Test
-    fun `𝕄 provide reader 𝕎 readNextBatch() { no metadata file provided }`(
+    fun `𝕄 provide batchData 𝕎 readNextBatch() { no metadata file provided }`(
         @Forgery fakeData: List<RawBatchEvent>,
         @Forgery batchFile: File
     ) {
         // Given
         whenever(mockGrantedOrchestrator.getReadableFile(any())) doReturn batchFile
         whenever(mockBatchReaderWriter.readData(batchFile)) doReturn fakeData
+        whenever(mockGrantedOrchestrator.getMetadataFile(batchFile)) doReturn null
 
         // Whenever
-        var readData: List<RawBatchEvent>? = null
-        var readMetadata: ByteArray? = null
-        testedStorage.readNextBatch { _, reader ->
-            readMetadata = reader.currentMetadata()
-            readData = reader.read()
-        }
+        val batchData = testedStorage.readNextBatch()
 
         // Then
-        assertThat(readData).isEqualTo(fakeData)
-        assertThat(readMetadata).isNull()
+        assertThat(batchData).isNotNull
+        assertThat(batchData?.id).isNotNull
+        assertThat(batchData?.data).isEqualTo(fakeData)
+        assertThat(batchData?.metadata).isNull()
     }
 
     @Test
-    fun `𝕄 provide reader 𝕎 readNextBatch() { metadata file doesn't exist }`(
+    fun `𝕄 provide batchData 𝕎 readNextBatch() { metadata file doesn't exist }`(
         @Forgery fakeData: List<RawBatchEvent>,
         @Forgery batchFile: File
     ) {
@@ -427,61 +421,53 @@ internal class ConsentAwareStorageTest {
         whenever(mockGrantedOrchestrator.getMetadataFile(batchFile)) doReturn mockMetaFile
 
         // Whenever
-        var readData: List<RawBatchEvent>? = null
-        var readMetadata: ByteArray? = null
-        testedStorage.readNextBatch { _, reader ->
-            readMetadata = reader.currentMetadata()
-            readData = reader.read()
-        }
+        val batchData = testedStorage.readNextBatch()
 
         // Then
-        assertThat(readData).isEqualTo(fakeData)
-        assertThat(readMetadata).isNull()
+        assertThat(batchData).isNotNull
+        assertThat(batchData?.id).isNotNull
+        assertThat(batchData?.data).isEqualTo(fakeData)
+        assertThat(batchData?.metadata).isNull()
     }
 
     @Test
-    fun `𝕄 provide reader only once 𝕎 readNextBatch()`(
-        @Forgery fakeData: List<RawBatchEvent>,
-        @Forgery file: File
-    ) {
-        // Given
-        whenever(mockGrantedOrchestrator.getReadableFile(emptySet())) doReturn file
-        whenever(mockGrantedOrchestrator.getReadableFile(setOf(file))) doReturn null
-        whenever(mockBatchReaderWriter.readData(file)) doReturn fakeData
-
-        // When
-        var readData: List<RawBatchEvent>? = null
-        testedStorage.readNextBatch { _, reader ->
-            readData = reader.read()
-        }
-        testedStorage.readNextBatch { _, _ ->
-            fail { "Callback should not have been called again" }
-        }
-
-        // Then
-        assertThat(readData).isEqualTo(fakeData)
-    }
-
-    @Test
-    fun `𝕄 notify no batch available 𝕎 readNextBatch() {no file}`() {
+    fun `𝕄 return null no batch available 𝕎 readNextBatch() {no file}`() {
         // Given
         whenever(mockGrantedOrchestrator.getReadableFile(any())) doReturn null
-        val mockNoBatchCallback = mock<() -> Unit>()
 
-        // When
-        testedStorage.readNextBatch(
-            noBatchCallback = mockNoBatchCallback
-        ) { _, _ ->
-            fail { "Callback should not have been called here" }
-        }
+        // Whenever
+        val batchData = testedStorage.readNextBatch()
 
         // Then
-        verify(mockNoBatchCallback).invoke()
+        assertThat(batchData).isNull()
     }
 
     // endregion
 
     // region confirmBatchRead
+
+    @Test
+    fun `𝕄 read batch twice if released 𝕎 readNextBatch()+confirmBatchRead() {delete=false}`(
+        @Forgery reason: RemovalReason,
+        @Forgery file: File
+    ) {
+        // Given
+        whenever(mockGrantedOrchestrator.getReadableFile(emptySet())) doReturn file
+        val mockMetaFile: File = mock()
+        whenever(mockMetaFile.exists()) doReturn true
+        whenever(mockGrantedOrchestrator.getMetadataFile(file)) doReturn mockMetaFile
+        whenever(mockGrantedOrchestrator.getReadableFile(setOf(file))) doReturn null
+
+        // When
+        val batchData1 = testedStorage.readNextBatch()
+        testedStorage.confirmBatchRead(batchData1!!.id, reason, false)
+        val batchData2 = testedStorage.readNextBatch()
+
+        // Then
+        verify(mockFileMover, never()).delete(file)
+        verify(mockFileMover, never()).delete(mockMetaFile)
+        assertThat(batchData1).isEqualTo(batchData2)
+    }
 
     @Test
     fun `𝕄 delete batch files 𝕎 readNextBatch()+confirmBatchRead() {delete=true}`(
@@ -511,52 +497,14 @@ internal class ConsentAwareStorageTest {
         doReturn(true).whenever(mockFileMover).delete(mockMetaFile)
 
         // When
-        var batchId: BatchId? = null
-        testedStorage.readNextBatch { id, _ ->
-            batchId = id
-        }
-        testedStorage.confirmBatchRead(batchId!!, reason) { confirm ->
-            confirm.markAsRead(true)
-        }
+        val batchData1 = testedStorage.readNextBatch()
+        testedStorage.confirmBatchRead(batchData1!!.id, reason, true)
+        testedStorage.readNextBatch()
 
         // Then
         verify(mockFileMover).delete(file)
         verify(mockFileMover).delete(mockMetaFile)
         verify(mockMetricsDispatcher).sendBatchDeletedMetric(eq(file), eq(reason))
-    }
-
-    @Test
-    fun `𝕄 read batch twice if released 𝕎 readNextBatch()+confirmBatchRead() {delete=false}`(
-        @Forgery reason: RemovalReason,
-        @Forgery file: File
-    ) {
-        // Given
-        whenever(mockGrantedOrchestrator.getReadableFile(emptySet())) doReturn file
-        val mockMetaFile: File = mock()
-        whenever(mockMetaFile.exists()) doReturn true
-        whenever(mockGrantedOrchestrator.getMetadataFile(file)) doReturn mockMetaFile
-        whenever(mockGrantedOrchestrator.getReadableFile(setOf(file))) doReturn null
-
-        // When
-        var batchId1: BatchId? = null
-        var batchId2: BatchId? = null
-        testedStorage.readNextBatch { id, _ ->
-            batchId1 = id
-        }
-        testedStorage.readNextBatch { _, _ ->
-            fail { "Callback should not have been called here" }
-        }
-        testedStorage.confirmBatchRead(batchId1!!, reason) { confirm ->
-            confirm.markAsRead(false)
-        }
-        testedStorage.readNextBatch { id, _ ->
-            batchId2 = id
-        }
-
-        // Then
-        verify(mockFileMover, never()).delete(file)
-        verify(mockFileMover, never()).delete(mockMetaFile)
-        assertThat(batchId1).isEqualTo(batchId2)
     }
 
     @Test
@@ -572,15 +520,9 @@ internal class ConsentAwareStorageTest {
         whenever(mockGrantedOrchestrator.getMetadataFile(file)) doReturn mockMetaFile
 
         // When
-        testedStorage.readNextBatch { _, _ ->
-            // no-op
-        }
-        testedStorage.confirmBatchRead(BatchId.fromFile(anotherFile), reason) { confirm ->
-            confirm.markAsRead(true)
-        }
-        testedStorage.readNextBatch { _, _ ->
-            fail { "Callback should not have been called here" }
-        }
+        testedStorage.readNextBatch()
+        testedStorage.confirmBatchRead(BatchId.fromFile(anotherFile), reason, false)
+        testedStorage.readNextBatch()
 
         // Then
         verify(mockFileMover, never()).delete(file)
@@ -598,13 +540,9 @@ internal class ConsentAwareStorageTest {
         whenever(mockFileMover.delete(file)) doReturn false
 
         // When
-        var batchId: BatchId? = null
-        testedStorage.readNextBatch { id, _ ->
-            batchId = id
-        }
-        testedStorage.confirmBatchRead(batchId!!, reason) { confirm ->
-            confirm.markAsRead(true)
-        }
+        val batchData1 = testedStorage.readNextBatch()
+        testedStorage.confirmBatchRead(batchData1!!.id, reason, true)
+        testedStorage.readNextBatch()
 
         // Then
         verify(mockFileMover).delete(file)
@@ -633,13 +571,8 @@ internal class ConsentAwareStorageTest {
         doReturn(false).whenever(mockFileMover).delete(mockMetaFile)
 
         // When
-        var batchId: BatchId? = null
-        testedStorage.readNextBatch { id, _ ->
-            batchId = id
-        }
-        testedStorage.confirmBatchRead(batchId!!, reason) { confirm ->
-            confirm.markAsRead(true)
-        }
+        val batchData1 = testedStorage.readNextBatch()
+        testedStorage.confirmBatchRead(batchData1!!.id, reason, true)
 
         // Then
         verify(mockFileMover).delete(file)
@@ -748,9 +681,7 @@ internal class ConsentAwareStorageTest {
         // ConcurrentModificationException is thrown only during the next check after remove,
         // so to make sure it is not thrown we need at least 2 locked batches
         repeat(files.size) {
-            testedStorage.readNextBatch { _, _ ->
-                // no-op
-            }
+            testedStorage.readNextBatch()
         }
 
         // When

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/BatchDataForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/BatchDataForgeryFactory.kt
@@ -1,0 +1,29 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.persistence.BatchData
+import com.datadog.android.core.internal.persistence.BatchId
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class BatchDataForgeryFactory : ForgeryFactory<BatchData> {
+    override fun getForgery(forge: Forge): BatchData {
+        return BatchData(
+            id = BatchId(id = forge.anAlphaNumericalString()),
+            data = forge.aList { getForgery() },
+            metadata = forge.aNullable {
+                forge.aString(
+                    forge.anInt(min = 0, max = DATA_SIZE_LIMIT)
+                ).toByteArray()
+            }
+        )
+    }
+    companion object {
+        const val DATA_SIZE_LIMIT = 32
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -26,6 +26,7 @@ internal class Configurator :
         forge.addFactory(FilePersistenceConfigForgeryFactory())
         forge.addFactory(AndroidInfoProviderForgeryFactory())
         forge.addFactory(FeatureStorageConfigurationForgeryFactory())
+        forge.addFactory(BatchDataForgeryFactory())
 
         // IO
         forge.addFactory(BatchForgeryFactory())

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -800,6 +800,7 @@ datadog:
       - "kotlin.collections.List.forEachIndexed(kotlin.Function2)"
       - "kotlin.collections.List.getOrNull(kotlin.Int)"
       - "kotlin.collections.List.groupBy(kotlin.Function1)"
+      - "kotlin.collections.List.hashCode()"
       - "kotlin.collections.List.isEmpty()"
       - "kotlin.collections.List.isNotEmpty()"
       - "kotlin.collections.List.join(kotlin.ByteArray, kotlin.ByteArray, kotlin.ByteArray, com.datadog.android.api.InternalLogger)"


### PR DESCRIPTION
In this PR we are replacing the async methods `readNextBatch` and `confirmBatchRead` from `Storage` interface with their synchronous equivalents. 

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

