### PR TITLE
Add artifacts in Gitlab test jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -103,6 +103,11 @@ test:debug:
   script:
     - rm -rf ~/.gradle/daemon/
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :unitTestDebug --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+  artifacts:
+    when: always
+    expire_in: 1 week
+    reports:
+      junit: "**/build/test-results/testDebugUnitTest/*.xml"
 
 test:release:
   tags: [ "runner:main" ]
@@ -118,6 +123,11 @@ test:release:
   script:
     - rm -rf ~/.gradle/daemon/
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :unitTestRelease --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+  artifacts:
+    when: always
+    expire_in: 1 week
+    reports:
+      junit: "**/build/test-results/testReleaseUnitTest/*.xml"
 
 test:tools:
   tags: [ "runner:main" ]
@@ -172,6 +182,11 @@ test-pyramid:single-fit-logs:
   script:
     - rm -rf ~/.gradle/daemon/
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :reliability:single-fit:logs:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+  artifacts:
+    when: always
+    expire_in: 1 week
+    reports:
+      junit: "**/build/test-results/testReleaseUnitTest/*.xml"
 
 test-pyramid:single-fit-rum:
   tags: [ "runner:main" ]
@@ -187,6 +202,11 @@ test-pyramid:single-fit-rum:
   script:
     - rm -rf ~/.gradle/daemon/
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :reliability:single-fit:rum:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+  artifacts:
+    when: always
+    expire_in: 1 week
+    reports:
+      junit: "**/build/test-results/testReleaseUnitTest/*.xml"
 
 test-pyramid:single-fit-trace:
   tags: [ "runner:main" ]
@@ -202,7 +222,11 @@ test-pyramid:single-fit-trace:
   script:
     - rm -rf ~/.gradle/daemon/
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :reliability:single-fit:trace:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/
-
+  artifacts:
+    when: always
+    expire_in: 1 week
+    reports:
+      junit: "**/build/test-results/testReleaseUnitTest/*.xml"
 
 test-pyramid:publish-e2e-synthetics:
   tags: [ "runner:main" ]
@@ -225,6 +249,11 @@ test-pyramid:publish-e2e-synthetics:
     - npm update -g @datadog/datadog-ci
     - echo "Using datadog-ci $(npx @datadog/datadog-ci version)"
     - npx @datadog/datadog-ci synthetics upload-application --appKey "$E2E_DD_APP_KEY" --apiKey "$E2E_DD_API_KEY" --mobileApp "sample/kotlin/build/outputs/apk/us1/release/kotlin-us1-release.apk" --mobileApplicationId "$E2E_MOBILE_APP_ID" --versionName "$CI_COMMIT_SHORT_SHA" --latest
+  artifacts:
+    when: always
+    expire_in: 1 week
+    paths:
+      - sample/kotlin/build/outputs/apk/us1/release/kotlin-us1-release.apk
 
 # PUBLISH ARTIFACTS ON MAVEN
 


### PR DESCRIPTION
### What does this PR do?

Ensure Gitlab has junit reports when necessary

### Motivation

There were several job runs where a test step failed and it wasn't captured by CI app. Having the Junit Reports will help diagnose and improve our coverage