### PR TITLE
Add text overflow examples in sample app

### DIFF
--- a/sample/kotlin/src/main/res/layout/fragment_text_view_components.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_text_view_components.xml
@@ -19,8 +19,19 @@
         android:textColor="@color/datadog_violet"
         android:text="@string/text_view" />
 
-    <com.google.android.material.textview.MaterialTextView
+    <TextView
         app:layout_constraintTop_toBottomOf="@+id/text_view"
+        app:layout_constraintStart_toStartOf="parent"
+        android:ellipsize="start"
+        android:id="@+id/ellipsize_text_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:singleLine="true"
+        android:textColor="@color/datadog_violet"
+        android:text="@string/ellipsize_text_view" />
+
+    <com.google.android.material.textview.MaterialTextView
+        app:layout_constraintTop_toBottomOf="@+id/ellipsize_text_view"
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginTop="@dimen/default_padding"
         android:id="@+id/material_text_view"
@@ -50,8 +61,20 @@
         android:hint="@string/edit_text_view"
         android:textColorHint="@color/datadog_violet"/>
 
-    <AutoCompleteTextView
+    <EditText
         app:layout_constraintTop_toBottomOf="@+id/edit_text_view"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="@dimen/default_padding"
+        android:id="@+id/edit_text_view_multiline"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:backgroundTint="@color/datadog_violet"
+        android:hint="@string/edit_text_view_multiline"
+        android:textColorHint="@color/datadog_violet"
+        android:maxLines="2"/>
+
+    <AutoCompleteTextView
+        app:layout_constraintTop_toBottomOf="@+id/edit_text_view_multiline"
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginTop="@dimen/default_padding"
         android:id="@+id/auto_complete_text_view"

--- a/sample/kotlin/src/main/res/values/strings.xml
+++ b/sample/kotlin/src/main/res/values/strings.xml
@@ -112,10 +112,12 @@
     <string name="granted">GRANTED</string>
     <string name="not_granted">NOT GRANTED</string>
     <string name="text_view">Default Text View</string>
+    <string name="ellipsize_text_view">Default Text View with some super long text for ellipsis. Default Text View with some super long text. Default Text View with some super long text. Default Text View with some super long text. Default Text View with some super long text. Default Text View with some super long text. Default Text View with some super long text.</string>
     <string name="material_text_view">Material Text View</string>
     <string name="app_compat_text_view">App Compat Text View</string>
     <string name="auto_complete_text_view">Default Auto Complete Text View</string>
     <string name="edit_text_view">Edit Text View</string>
+    <string name="edit_text_view_multiline">Edit Text View on 2 lines</string>
     <string name="app_compat_edit_text_view">App Compat Edit Text View</string>
     <string name="app_compat_auto_complete_text_view">App Compat Auto Complete Text View</string>
     <string name="material_auto_complete_text_view">Material Auto Complete Text View</string>


### PR DESCRIPTION
### What does this PR do?

Add text overflow examples in sample app. These example overflow in the replays. Now that they're added they will be easier to check on when we apply the fix.

| Emulator | Replay |
|--------|--------|
| ![image](https://github.com/DataDog/dd-sdk-android/assets/8973379/a7c4e14b-c0b3-4910-83f5-3dfd760e0717) | ![image](https://github.com/DataDog/dd-sdk-android/assets/8973379/2d2710b3-2261-472a-b196-31c717601307) | 


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

