### PR TITLE
RUM-2566: Convert pending resource to pending error when Resource scope completes with an error

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -591,6 +591,14 @@ internal open class RumViewScope(
             val entry = iterator.next()
             val scope = entry.value.handleEvent(event, writer)
             if (scope == null) {
+                // if we finalized this scope and it was by error, we won't have resource
+                // event written, but error event instead
+                if (event is RumRawEvent.StopResourceWithError ||
+                    event is RumRawEvent.StopResourceWithStackTrace
+                ) {
+                    pendingResourceCount--
+                    pendingErrorCount++
+                }
                 iterator.remove()
             }
         }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -4246,8 +4246,10 @@ internal class RumViewScopeTest {
         testedScope.pendingResourceCount = 0
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
 
+        // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
+        // Then
         assertThat(testedScope.pendingResourceCount).isEqualTo(1)
         assertThat(result).isSameAs(testedScope)
     }
@@ -4260,8 +4262,10 @@ internal class RumViewScopeTest {
         testedScope.pendingResourceCount = pending
         fakeEvent = RumRawEvent.ResourceDropped(testedScope.viewId)
 
+        // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
+        // Then
         assertThat(testedScope.pendingResourceCount).isEqualTo(pending - 1)
         assertThat(result).isSameAs(testedScope)
     }
@@ -4276,8 +4280,10 @@ internal class RumViewScopeTest {
         fakeEvent = RumRawEvent.ResourceDropped(testedScope.viewId)
         testedScope.viewId = fakeNewViewId.toString()
 
+        // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
+        // Then
         assertThat(testedScope.pendingResourceCount).isEqualTo(pending - 1)
         assertThat(result).isSameAs(testedScope)
     }
@@ -4289,8 +4295,10 @@ internal class RumViewScopeTest {
         fakeEvent = RumRawEvent.ResourceDropped(testedScope.viewId)
         testedScope.stopped = true
 
+        // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
+        // Then
         assertThat(testedScope.pendingResourceCount).isEqualTo(0)
         assertThat(result).isNull()
     }
@@ -4305,8 +4313,10 @@ internal class RumViewScopeTest {
         testedScope.stopped = true
         testedScope.viewId = fakeNewViewId.toString()
 
+        // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
+        // Then
         assertThat(testedScope.pendingResourceCount).isEqualTo(0)
         assertThat(result).isNull()
     }
@@ -4322,8 +4332,10 @@ internal class RumViewScopeTest {
         testedScope.pendingResourceCount = pending
         fakeEvent = RumRawEvent.ResourceDropped(viewId)
 
+        // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
+        // Then
         assertThat(testedScope.pendingResourceCount).isEqualTo(pending)
         assertThat(result).isSameAs(testedScope)
     }
@@ -4340,10 +4352,52 @@ internal class RumViewScopeTest {
         fakeEvent = RumRawEvent.ResourceDropped(viewId)
         testedScope.stopped = true
 
+        // When
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
+        // Then
         assertThat(testedScope.pendingResourceCount).isEqualTo(pending)
         assertThat(result).isSameAs(testedScope)
+    }
+
+    @Test
+    fun `𝕄 convert pending resource to error 𝕎 handleEvent() {resource stopped by error}`(
+        @LongForgery(1) pendingResources: Long,
+        @LongForgery(min = 0, max = Long.MAX_VALUE - 1) pendingErrors: Long,
+        forge: Forge
+    ) {
+        // Given
+        testedScope.pendingErrorCount = pendingErrors
+        testedScope.pendingResourceCount = pendingResources
+        val fakeEvent = forge.stopResourceWithErrorEvent()
+        testedScope.activeResourceScopes[fakeEvent.key] = mock()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.pendingResourceCount).isEqualTo(pendingResources - 1)
+        assertThat(testedScope.pendingErrorCount).isEqualTo(pendingErrors + 1)
+    }
+
+    @Test
+    fun `𝕄 convert pending resource to error 𝕎 handleEvent() {resource stopped by error with stacktrace}`(
+        @LongForgery(1) pendingResources: Long,
+        @LongForgery(min = 0, max = Long.MAX_VALUE - 1) pendingErrors: Long,
+        forge: Forge
+    ) {
+        // Given
+        testedScope.pendingErrorCount = pendingErrors
+        testedScope.pendingResourceCount = pendingResources
+        val fakeEvent = forge.stopResourceWithStacktraceEvent()
+        testedScope.activeResourceScopes[fakeEvent.key] = mock()
+
+        // When
+        testedScope.handleEvent(fakeEvent, mockWriter)
+
+        // Then
+        assertThat(testedScope.pendingResourceCount).isEqualTo(pendingResources - 1)
+        assertThat(testedScope.pendingErrorCount).isEqualTo(pendingErrors + 1)
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

There is a following bug: we increate `RumViewScope#pendingResourceCount` when we create resource scope, but resource scope can be finalized with 2 outcomes: either resource event or error event. In latter case we should instead decrease `pendingResourceCount` and increase `pendingErrorCount`, because `ResourceSent` / `ResourceDropped` will never be sent and we get instead `ErrorSent` / `ErrorDropped`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

