### PR TITLE
Enable recording session if first RUM message happened before init

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -222,7 +222,8 @@ internal class SessionReplayFeature(
      * Resumes the replay recorder.
      */
     internal fun startRecording() {
-        if (!isRecording.getAndSet(true)) {
+        // Check initialization again so we don't forget to do it when this method is made public
+        if (checkIfInitialized() && !isRecording.getAndSet(true)) {
             @Suppress("ThreadSafety") // TODO REPLAY-1861 can be called from any thread
             sessionReplayRecorder.resumeRecorders()
         }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -188,24 +188,11 @@ internal class SessionReplayFeature(
             return
         }
 
-        val recordNewSession = keepSession && rateBasedSampler.sample()
-
-        if (!initialized.get()) {
-            sdkCore.internalLogger.log(
-                InternalLogger.Level.WARN,
-                InternalLogger.Target.USER,
-                {
-                    if (recordNewSession) {
-                        CANNOT_START_RECORDING_NOT_INITIALIZED
-                    } else {
-                        CANNOT_STOP_RECORDING_NOT_INITIALIZED
-                    }
-                }
-            )
+        if (!checkIfInitialized()) {
             return
         }
 
-        if (recordNewSession) {
+        if (keepSession && rateBasedSampler.sample()) {
             startRecording()
         } else {
             sdkCore.internalLogger.log(
@@ -217,6 +204,18 @@ internal class SessionReplayFeature(
         }
 
         currentRumSessionId.set(sessionId)
+    }
+
+    private fun checkIfInitialized(): Boolean {
+        if (!initialized.get()) {
+            sdkCore.internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.USER,
+                { CANNOT_START_RECORDING_NOT_INITIALIZED }
+            )
+            return false
+        }
+        return true
     }
 
     /**
@@ -276,8 +275,6 @@ internal class SessionReplayFeature(
             " are either missing or have wrong type."
         internal const val CANNOT_START_RECORDING_NOT_INITIALIZED =
             "Cannot start session recording, because Session Replay feature is not initialized."
-        internal const val CANNOT_STOP_RECORDING_NOT_INITIALIZED =
-            "Cannot stop session recording, because Session Replay feature is not initialized."
         const val SESSION_REPLAY_FEATURE_NAME = "session-replay"
         const val SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY = "type"
         const val RUM_SESSION_RENEWED_BUS_MESSAGE = "rum_session_renewed"

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -324,6 +324,20 @@ internal class SessionReplayFeatureTest {
     }
 
     @Test
+    fun `M log warning and do nothing W startRecording() { feature is not initialized }`() {
+        // When
+        testedFeature.startRecording()
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            SessionReplayFeature.CANNOT_START_RECORDING_NOT_INITIALIZED
+        )
+        verifyNoInteractions(mockRecorder)
+    }
+
+    @Test
     fun `M log warning and do nothing W onInitialize() { context is not Application }`() {
         // When
         testedFeature.onInitialize(mock())

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -635,7 +635,7 @@ internal class SessionReplayFeatureTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            SessionReplayFeature.CANNOT_STOP_RECORDING_NOT_INITIALIZED
+            SessionReplayFeature.CANNOT_START_RECORDING_NOT_INITIALIZED
         )
         verifyNoInteractions(mockRecorder)
     }
@@ -659,7 +659,7 @@ internal class SessionReplayFeatureTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            SessionReplayFeature.CANNOT_STOP_RECORDING_NOT_INITIALIZED
+            SessionReplayFeature.CANNOT_START_RECORDING_NOT_INITIALIZED
         )
         verifyNoInteractions(mockRecorder)
     }
@@ -683,7 +683,7 @@ internal class SessionReplayFeatureTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            SessionReplayFeature.CANNOT_STOP_RECORDING_NOT_INITIALIZED
+            SessionReplayFeature.CANNOT_START_RECORDING_NOT_INITIALIZED
         )
         verifyNoInteractions(mockRecorder)
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -324,20 +324,6 @@ internal class SessionReplayFeatureTest {
     }
 
     @Test
-    fun `M log warning and do nothing W startRecording() { feature is not initialized }`() {
-        // When
-        testedFeature.startRecording()
-
-        // Then
-        mockInternalLogger.verifyLog(
-            InternalLogger.Level.WARN,
-            InternalLogger.Target.USER,
-            SessionReplayFeature.CANNOT_START_RECORDING_NOT_INITIALIZED
-        )
-        verifyNoInteractions(mockRecorder)
-    }
-
-    @Test
     fun `M log warning and do nothing W onInitialize() { context is not Application }`() {
         // When
         testedFeature.onInitialize(mock())
@@ -604,6 +590,134 @@ internal class SessionReplayFeatureTest {
             InternalLogger.Target.USER,
             SessionReplayFeature.SESSION_SAMPLED_OUT_MESSAGE
         )
+    }
+
+    @Test
+    fun `M log warning W rum session updated before initialization { keep true, sample in }`() {
+        // Given
+        whenever(mockSampler.sample()).thenReturn(true)
+        val rumSessionUpdateBusMessage = mapOf(
+            SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
+            SessionReplayFeature.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to
+                true,
+            SessionReplayFeature.RUM_SESSION_ID_BUS_MESSAGE_KEY to fakeSessionId
+        )
+
+        // When
+        testedFeature.onReceive(rumSessionUpdateBusMessage)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            SessionReplayFeature.CANNOT_START_RECORDING_NOT_INITIALIZED
+        )
+        verifyNoInteractions(mockRecorder)
+    }
+
+    @Test
+    fun `M log warning W rum session updated before initialization { keep true, sample out }`() {
+        // Given
+        whenever(mockSampler.sample()).thenReturn(false)
+        val rumSessionUpdateBusMessage = mapOf(
+            SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
+            SessionReplayFeature.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to
+                true,
+            SessionReplayFeature.RUM_SESSION_ID_BUS_MESSAGE_KEY to fakeSessionId
+        )
+
+        // When
+        testedFeature.onReceive(rumSessionUpdateBusMessage)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            SessionReplayFeature.CANNOT_STOP_RECORDING_NOT_INITIALIZED
+        )
+        verifyNoInteractions(mockRecorder)
+    }
+
+    @Test
+    fun `M log warning W rum session updated before initialization { keep false, sample in }`() {
+        // Given
+        whenever(mockSampler.sample()).thenReturn(true)
+        val rumSessionUpdateBusMessage = mapOf(
+            SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
+            SessionReplayFeature.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to
+                false,
+            SessionReplayFeature.RUM_SESSION_ID_BUS_MESSAGE_KEY to fakeSessionId
+        )
+
+        // When
+        testedFeature.onReceive(rumSessionUpdateBusMessage)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            SessionReplayFeature.CANNOT_STOP_RECORDING_NOT_INITIALIZED
+        )
+        verifyNoInteractions(mockRecorder)
+    }
+
+    @Test
+    fun `M log warning W rum session updated before initialization { keep false, sample out }`() {
+        // Given
+        whenever(mockSampler.sample()).thenReturn(false)
+        val rumSessionUpdateBusMessage = mapOf(
+            SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
+            SessionReplayFeature.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to
+                false,
+            SessionReplayFeature.RUM_SESSION_ID_BUS_MESSAGE_KEY to fakeSessionId
+        )
+
+        // When
+        testedFeature.onReceive(rumSessionUpdateBusMessage)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            SessionReplayFeature.CANNOT_STOP_RECORDING_NOT_INITIALIZED
+        )
+        verifyNoInteractions(mockRecorder)
+    }
+
+    @Test
+    fun `M start recording W rum session is initialized after first message`() {
+        // Given
+        whenever(mockSampler.sample()).thenReturn(true)
+        val rumSessionUpdateBusMessage1 = mapOf(
+            SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
+            SessionReplayFeature.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to
+                true,
+            SessionReplayFeature.RUM_SESSION_ID_BUS_MESSAGE_KEY to fakeSessionId
+        )
+        val rumSessionUpdateBusMessage2 = mapOf(
+            SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
+                SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
+            SessionReplayFeature.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to
+                true,
+            SessionReplayFeature.RUM_SESSION_ID_BUS_MESSAGE_KEY to fakeSessionId
+        )
+
+        // When
+        testedFeature.onReceive(rumSessionUpdateBusMessage1)
+        testedFeature.onInitialize(appContext.mockInstance)
+        testedFeature.onReceive(rumSessionUpdateBusMessage2)
+
+        // Then
+        inOrder(mockRecorder) {
+            verify(mockRecorder).registerCallbacks()
+            verify(mockRecorder).resumeRecorders()
+        }
+        verifyNoMoreInteractions(mockRecorder)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This fixes a race condition that was quite present in RN - see description below.

The solution I choose was to move the responsibility of checking for initialization from `startRecording` into `checkStatusAndApplySample`. 
The `startRecording` method is easier to work with if it just performs an atomic action (like `stopRecording`).

It seems fit to put the check in `checkStatusAndApplySample` since it's the method that registers the `currentRumSessionId` that was creating the lock before.

### Motivation

#### Description of the race condition
This can happen in any Android app, it’s just that conditions for creating the race condition are more present in RN since we collect JS framerate through RUM events on every frame.

The race condition happens in SessionReplayFeature.kt, in the onInitialize function:

```kotlin
        // first line making the race condition possible
        sdkCore.setEventReceiver(SESSION_REPLAY_FEATURE_NAME, this)
        dataWriter = createDataWriter()
        sessionReplayRecorder = sessionReplayRecorderProvider(dataWriter, appContext)
        @Suppress("ThreadSafety") // TODO REPLAY-1861 can be called from any thread
        sessionReplayRecorder.registerCallbacks()
        initialized.set(true) 
        // end of race condition
```

This is called when we call SessionReplay.enable.

By setting the event receiver, we listen on all RUM events. Now if a RUM event happens before we call initialized.set(true), here is what is going to happen in SessionReplayFeature:

- [onReceive](https://github.com/DataDog/dd-sdk-android/blob/develop/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt#L136) is called
- onReceive [calls handleRumSession](https://github.com/DataDog/dd-sdk-android/blob/develop/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt#L146)
- handleRumSession [calls checkStatusAndApplySample](https://github.com/DataDog/dd-sdk-android/blob/develop/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt#L157)
- checkStatusAndApplySample:
  - [calls startRecording](https://github.com/DataDog/dd-sdk-android/blob/develop/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt#L191) since we haven’t started recording
    - startRecording will [immediately return](https://github.com/DataDog/dd-sdk-android/blob/develop/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt#L208) since we haven’t called initialized.set(true)
  - calls currentRumSessionId.set(sessionId) [at the end of the ](https://github.com/DataDog/dd-sdk-android/blob/develop/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt#L201)function to mark the session as started

So far the Session Replay is not recording, and on the next RUM event, even if initialized.set(true) has been called:

- onReceive is called
- onReceive calls handleRumSession
- handleRumSession calls checkStatusAndApplySample
- [checkStatusAndApplySample returns before starting the replay](https://github.com/DataDog/dd-sdk-android/blob/develop/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt#L185C13-L185C51) since currentRumSessionId.get() == sessionId

So we fail to ever initialize the SDK.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

