### PR TITLE
RUM-2075 remove data store/upload config from feature configuration

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -132,7 +132,7 @@ interface com.datadog.android.api.storage.EventBatchWriter
   fun currentMetadata(): ByteArray?
   fun write(RawBatchEvent, ByteArray?): Boolean
 data class com.datadog.android.api.storage.FeatureStorageConfiguration
-  constructor(Long, Int, Long, Long, com.datadog.android.core.configuration.UploadFrequency?, com.datadog.android.core.configuration.BatchSize?, com.datadog.android.core.configuration.BatchProcessingLevel?)
+  constructor(Long, Int, Long, Long)
   companion object 
     val DEFAULT: FeatureStorageConfiguration
 data class com.datadog.android.api.storage.RawBatchEvent

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -395,24 +395,18 @@ public abstract interface class com/datadog/android/api/storage/EventBatchWriter
 
 public final class com/datadog/android/api/storage/FeatureStorageConfiguration {
 	public static final field Companion Lcom/datadog/android/api/storage/FeatureStorageConfiguration$Companion;
-	public fun <init> (JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;Lcom/datadog/android/core/configuration/BatchProcessingLevel;)V
+	public fun <init> (JIJJ)V
 	public final fun component1 ()J
 	public final fun component2 ()I
 	public final fun component3 ()J
 	public final fun component4 ()J
-	public final fun component5 ()Lcom/datadog/android/core/configuration/UploadFrequency;
-	public final fun component6 ()Lcom/datadog/android/core/configuration/BatchSize;
-	public final fun component7 ()Lcom/datadog/android/core/configuration/BatchProcessingLevel;
-	public final fun copy (JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;Lcom/datadog/android/core/configuration/BatchProcessingLevel;)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/api/storage/FeatureStorageConfiguration;JIJJLcom/datadog/android/core/configuration/UploadFrequency;Lcom/datadog/android/core/configuration/BatchSize;Lcom/datadog/android/core/configuration/BatchProcessingLevel;ILjava/lang/Object;)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
+	public final fun copy (JIJJ)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/api/storage/FeatureStorageConfiguration;JIJJILjava/lang/Object;)Lcom/datadog/android/api/storage/FeatureStorageConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
-	public final fun getBatchProcessingLevel ()Lcom/datadog/android/core/configuration/BatchProcessingLevel;
-	public final fun getBatchSize ()Lcom/datadog/android/core/configuration/BatchSize;
 	public final fun getMaxBatchSize ()J
 	public final fun getMaxItemSize ()J
 	public final fun getMaxItemsPerBatch ()I
 	public final fun getOldBatchThreshold ()J
-	public final fun getUploadFrequency ()Lcom/datadog/android/core/configuration/UploadFrequency;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/FeatureStorageConfiguration.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/FeatureStorageConfiguration.kt
@@ -6,10 +6,6 @@
 
 package com.datadog.android.api.storage
 
-import com.datadog.android.core.configuration.BatchProcessingLevel
-import com.datadog.android.core.configuration.BatchSize
-import com.datadog.android.core.configuration.UploadFrequency
-
 /**
  * Contains the storage configuration for an [FeatureScope] instance.
  * @property maxItemSize the maximum size (in bytes) for a single item in a batch
@@ -17,21 +13,12 @@ import com.datadog.android.core.configuration.UploadFrequency
  * @property maxBatchSize the maximum size (in bytes) of a complete batch
  * @property oldBatchThreshold the duration (in milliseconds) after which a batch is considered too
  * old to be uploaded (usually because it'll be discarded at ingestion by the backend)
- * @property uploadFrequency the desired upload frequency policy. If not explicitly provided this
- * value will be taken from core configuration.
- * @property batchSize the desired batch size policy. If not explicitly provided this
- * value will be taken from core configuration.
- * @property batchProcessingLevel the desired batch processing level policy.
- * If not explicitly provided this value will be taken from core configuration.
  */
 data class FeatureStorageConfiguration(
     val maxItemSize: Long,
     val maxItemsPerBatch: Int,
     val maxBatchSize: Long,
-    val oldBatchThreshold: Long,
-    val uploadFrequency: UploadFrequency?,
-    val batchSize: BatchSize?,
-    val batchProcessingLevel: BatchProcessingLevel?
+    val oldBatchThreshold: Long
 ) {
     companion object {
 
@@ -49,10 +36,7 @@ data class FeatureStorageConfiguration(
             // 4 MB
             maxBatchSize = 4L * 1024 * 1024,
             // 18 hours
-            oldBatchThreshold = 18L * 60L * 60L * 1000L,
-            uploadFrequency = null,
-            batchSize = null,
-            batchProcessingLevel = null
+            oldBatchThreshold = 18L * 60L * 60L * 1000L
         )
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/FeatureStorageConfigurationForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/FeatureStorageConfigurationForgeryFactory.kt
@@ -7,9 +7,6 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.android.api.storage.FeatureStorageConfiguration
-import com.datadog.android.core.configuration.BatchProcessingLevel
-import com.datadog.android.core.configuration.BatchSize
-import com.datadog.android.core.configuration.UploadFrequency
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
@@ -20,10 +17,7 @@ internal class FeatureStorageConfigurationForgeryFactory :
             maxBatchSize = forge.aPositiveLong(),
             maxItemsPerBatch = forge.aBigInt(),
             maxItemSize = forge.aPositiveLong(),
-            oldBatchThreshold = forge.aPositiveLong(),
-            uploadFrequency = forge.aNullable { forge.aValueFrom(UploadFrequency::class.java) },
-            batchSize = forge.aNullable { forge.aValueFrom(BatchSize::class.java) },
-            batchProcessingLevel = forge.aNullable { forge.aValueFrom(BatchProcessingLevel::class.java) }
+            oldBatchThreshold = forge.aPositiveLong()
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -15,8 +15,6 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.FeatureStorageConfiguration
-import com.datadog.android.core.configuration.BatchSize
-import com.datadog.android.core.configuration.UploadFrequency
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.sessionreplay.NoOpRecorder
@@ -248,9 +246,7 @@ internal class SessionReplayFeature(
         internal val STORAGE_CONFIGURATION: FeatureStorageConfiguration =
             FeatureStorageConfiguration.DEFAULT.copy(
                 maxItemSize = 10 * 1024 * 1024,
-                maxBatchSize = 10 * 1024 * 1024,
-                uploadFrequency = UploadFrequency.FREQUENT,
-                batchSize = BatchSize.SMALL
+                maxBatchSize = 10 * 1024 * 1024
             )
 
         internal const val REQUIRES_APPLICATION_CONTEXT_WARN_MESSAGE = "Session Replay could not " +


### PR DESCRIPTION
### What does this PR do?

Because we needed to add a workaround for SR data storage and upload configuration we added the `batchProcessingLevel`, `batchSize` and `uploadFrequency` at the `FeatureStorageConfiguration` level. Based on the latest improvements we added at the `Uploader` and the latest telemetry we concluded that this workaround is not needed anymore and we can remove this noise from our code base.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

