### PR TITLE
Add delay before executors are flushed and stopped in nightly tests

### DIFF
--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rules/NightlyTestRule.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/rules/NightlyTestRule.kt
@@ -17,6 +17,19 @@ class NightlyTestRule : ExternalResource() {
     override fun after() {
         super.after()
         InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        // waitForIdleSync above waits only for idle of the main thread. We need this delay to be
+        // able to digest all the events, especially for RUM. Flushing and stopping executors below
+        // is not enough, because write logic may be complicated. Imagine resource error in
+        // background tracking in RUM:
+        // - error is submitted to RUM monitor
+        // - we flush and shutdown executors. During this process we process tasks in RUM (error),
+        // and process tasks in persistence thread (write this error)
+        // - once error is written it will trigger event saying it is written. This event is
+        // submitted to RUM (which was already stopped), so that we can send 1st view event
+        // (impossible to process - RUM is stopped; impossible to write - persistence executor is stopped)
+        Thread.sleep(200)
+
         flushAndShutdownExecutors()
         stopSdk()
         cleanStorageFiles()


### PR DESCRIPTION
### What does this PR do?

The current logic of stopping executors and flushing data after each nightly test is not reliable, because in case of RUM we have a backward loop which cannot be executed if executors are stopped.

This PR adds a delay, so that all the events __possibly__ can get processed.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

