### PR TITLE
Optimize response body length reporting in OkHttp instrumentation

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -1173,6 +1173,7 @@ datadog:
       - "okhttp3.Response.code()"
       - "okhttp3.Response.header(kotlin.String, kotlin.String?)"
       - "okhttp3.ResponseBody.contentLength()"
+      - "okhttp3.ResponseBody.contentLengthOrNull()"
       - "okio.Buffer.constructor()"
       # endregion
       # region org.json


### PR DESCRIPTION
### What does this PR do?

This PR optimizes the way we are reporting response body length in OkHttp instrumentation.

We first try to get content length from response body as-is, and if it didn't work, we try to call `peekBody`. The explanation to that is related to the way OkHttp works: the [following doc](https://github.com/square/okhttp/blob/7bcc720d85128c2d663cb0719d0d52850af260f6/docs/features/calls.md?plain=1#L23C4-L23C15) states, that OkHttp will remove `Content-Length` header (and make `contentLength()` return -1) if transparent compression is used. This means that if `body.contentLength` returns positive value, then we are good already, and if it is not, we may try to call `peekBody` which **will apply decompression** and load a decompressed body in memory.

Another benefit is that now we can report body length more than 1MB, because `peekBody` was limited by 1MB and if there is no need to call it, we may report full body length.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

