### PR TITLE
RUM-2604: Fix view url in case of `NavigationViewTrackingStrategy` usage

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategy.kt
@@ -43,11 +43,6 @@ class NavigationViewTrackingStrategy(
     ViewTrackingStrategy,
     NavController.OnDestinationChangedListener {
 
-    internal data class NavigationKey(
-        val controller: NavController,
-        val destination: NavDestination
-    )
-
     private var startedActivity: Activity? = null
 
     private var lifecycleCallbackRefs =
@@ -102,7 +97,7 @@ class NavigationViewTrackingStrategy(
         componentPredicate.runIfValid(destination, internalLogger) {
             val attributes = if (trackArguments) convertToRumAttributes(arguments) else emptyMap()
             val viewName = componentPredicate.resolveViewName(destination)
-            rumMonitor?.startView(NavigationKey(controller, destination), viewName, attributes)
+            rumMonitor?.startView(destination, viewName, attributes)
         }
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/NavigationViewTrackingStrategyTest.kt
@@ -96,8 +96,6 @@ internal class NavigationViewTrackingStrategyTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
-    private lateinit var mockNavigationKey: NavigationViewTrackingStrategy.NavigationKey
-
     @IntForgery
     var fakeNavViewId: Int = 0
 
@@ -124,9 +122,6 @@ internal class NavigationViewTrackingStrategyTest {
             rumMonitor.mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)
         ) doReturn mockRumFeatureScope
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
-
-        mockNavigationKey =
-            NavigationViewTrackingStrategy.NavigationKey(mockNavController, mockNavDestination)
 
         testedStrategy = NavigationViewTrackingStrategy(fakeNavViewId, true, mockPredicate)
         testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
@@ -316,7 +311,7 @@ internal class NavigationViewTrackingStrategyTest {
         testedStrategy.onDestinationChanged(mockNavController, mockNavDestination, null)
 
         verify(rumMonitor.mockInstance).startView(
-            mockNavigationKey,
+            mockNavDestination,
             fakeDestinationName,
             emptyMap()
         )
@@ -342,7 +337,7 @@ internal class NavigationViewTrackingStrategyTest {
 
         testedStrategy.onDestinationChanged(mockNavController, mockNavDestination, null)
 
-        verify(rumMonitor.mockInstance).startView(mockNavigationKey, customName, emptyMap())
+        verify(rumMonitor.mockInstance).startView(mockNavDestination, customName, emptyMap())
     }
 
     @Test
@@ -363,7 +358,7 @@ internal class NavigationViewTrackingStrategyTest {
         testedStrategy.onDestinationChanged(mockNavController, mockNavDestination, arguments)
 
         verify(rumMonitor.mockInstance).startView(
-            mockNavigationKey,
+            mockNavDestination,
             fakeDestinationName,
             expectedAttrs
         )
@@ -387,7 +382,7 @@ internal class NavigationViewTrackingStrategyTest {
         testedStrategy.onDestinationChanged(mockNavController, mockNavDestination, arguments)
 
         verify(rumMonitor.mockInstance).startView(
-            mockNavigationKey,
+            mockNavDestination,
             fakeDestinationName,
             emptyMap()
         )
@@ -409,12 +404,12 @@ internal class NavigationViewTrackingStrategyTest {
 
         inOrder(rumMonitor.mockInstance) {
             verify(rumMonitor.mockInstance).startView(
-                mockNavigationKey,
+                mockNavDestination,
                 fakeDestinationName,
                 emptyMap()
             )
             verify(rumMonitor.mockInstance).startView(
-                NavigationViewTrackingStrategy.NavigationKey(mockNavController, newDestination),
+                newDestination,
                 newDestinationName,
                 emptyMap()
             )


### PR DESCRIPTION
### What does this PR do?

This fixes a bug originally introduced in `1.17.2` with the following [commit](https://github.com/DataDog/dd-sdk-android/commit/62139739d7a85c2550ce5e29d3389e96ba68a51b): since we didn't have a special `NavigationKey` handling in the `Any.resolveViewUrl` method, view URL was always displayed as `com/datadog/android/rum/tracking/NavigationViewTrackingStrategy/NavigationKey`.

Also the key used between `stopView` and `startView` calls in `NavigationViewTrackingStrategy` was different because of this bug (`NavDestination` vs `NavigationKey` respectively)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

