### PR TITLE
Add telemetry point for null file content

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
@@ -128,7 +128,19 @@ internal class DatadogNdkCrashHandler(
         return if (content.isEmpty()) {
             null
         } else {
-            String(content)
+            String(content).also {
+                // temporary, to have more telemetry data
+                if (it.contains("\\u0000") || it.contains("\u0000")) {
+                    internalLogger.log(
+                        InternalLogger.Level.ERROR,
+                        InternalLogger.Target.TELEMETRY,
+                        {
+                        "Decoded file (${file.name}) content contains NULL character, file content={$it}," +
+                                " raw_bytes=${content.joinToString(",")}"
+                        }
+                    )
+                }
+            }
         }
     }
 


### PR DESCRIPTION
### What does this PR do?

This is an additional telemetry point for the issue, when sometimes file content is only "\\u0000" (happens when we decode information for NDK crash submission).

I didn't manage to understand why it happens. In theory if decoding from bytes to string fails, broken chars should be mapped to `\ufffd`, but to validate the assumption that the issue is on during decoding I'm adding this.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

