### PR TITLE
RUM-2314 Fix ConcurrentModificationException in BitmapPool

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/BitmapPool.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/base64/BitmapPool.kt
@@ -103,6 +103,21 @@ internal class BitmapPool(
         }?.apply { markBitmapAsUsed(this) }
     }
 
+    override fun onConfigurationChanged(newConfig: Configuration) {}
+
+    @Synchronized
+    override fun onLowMemory() {
+        bitmapPoolHelper.safeCall {
+            @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
+            cache.evictAll()
+        }
+    }
+
+    @Synchronized
+    override fun onTrimMemory(level: Int) {
+        cacheUtils.handleTrimMemory(level, cache)
+    }
+
     internal fun getBitmapByProperties(width: Int, height: Int, config: Config): Bitmap? {
         val key = bitmapPoolHelper.generateKey(width, height, config)
         return get(key)
@@ -144,19 +159,6 @@ internal class BitmapPool(
             @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
             bitmapsBySize[key]?.add(bitmap)
         }
-    }
-
-    override fun onConfigurationChanged(newConfig: Configuration) {}
-
-    override fun onLowMemory() {
-        bitmapPoolHelper.safeCall {
-            @Suppress("UnsafeThirdPartyFunctionCall") // Called within a try/catch block
-            cache.evictAll()
-        }
-    }
-
-    override fun onTrimMemory(level: Int) {
-        cacheUtils.handleTrimMemory(level, cache)
     }
 
     internal companion object {


### PR DESCRIPTION
### What does this PR do?
Fixes a ConcurrentModificationException that can occur due a race condition between low memory evicting items from the cache, and threads attempting to query the cache.

### Motivation

What inspired you to submit this pull request?

### Additional Notes
3000 iterations is the lower bound to reliably reproduce the issue in a reasonable number of unit test runs when it exists. This number of iterations takes around 4 seconds to run locally.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

