### PR TITLE
Move reading `BUILDENV_HOST_IP` variable to the job script definition

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,7 +8,6 @@ variables:
   CI_IMAGE_DOCKER: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/dd-sdk-android:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 
-  DD_AGENT_HOST: "$BUILDENV_HOST_IP"
   DD_SERVICE: "dd-sdk-android"
   DD_ENV_TESTS: "ci"
   DD_INTEGRATION_JUNIT_5_ENABLED: "true"
@@ -104,6 +103,7 @@ test:debug:
     policy: pull
   script:
     - rm -rf ~/.gradle/daemon/
+    - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :unitTestDebug --stacktrace --no-daemon --build-cache --gradle-user-home cache/
   artifacts:
     when: always
@@ -124,6 +124,7 @@ test:release:
     policy: pull
   script:
     - rm -rf ~/.gradle/daemon/
+    - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :unitTestRelease --stacktrace --no-daemon --build-cache --gradle-user-home cache/
   artifacts:
     when: always
@@ -144,6 +145,7 @@ test:tools:
     policy: pull
   script:
     - rm -rf ~/.gradle/daemon/
+    - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :unitTestTools --stacktrace --no-daemon --build-cache --gradle-user-home cache/
 
 test:kover:
@@ -159,6 +161,7 @@ test:kover:
   script:
     - pip3 install datadog
     - rm -rf ~/.gradle/daemon/
+    - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.api_key --with-decryption --query "Parameter.Value" --out text)
     - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.app_key --with-decryption --query "Parameter.Value" --out text)
     - CODECOV_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.codecov-token  --with-decryption --query "Parameter.Value" --out text)
@@ -183,6 +186,7 @@ test-pyramid:single-fit-logs:
     policy: pull
   script:
     - rm -rf ~/.gradle/daemon/
+    - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :reliability:single-fit:logs:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/
   artifacts:
     when: always
@@ -203,6 +207,7 @@ test-pyramid:single-fit-rum:
     policy: pull
   script:
     - rm -rf ~/.gradle/daemon/
+    - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :reliability:single-fit:rum:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/
   artifacts:
     when: always
@@ -223,6 +228,7 @@ test-pyramid:single-fit-trace:
     policy: pull
   script:
     - rm -rf ~/.gradle/daemon/
+    - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :reliability:single-fit:trace:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/
   artifacts:
     when: always


### PR DESCRIPTION
### What does this PR do?

We've changed the runner type here https://github.com/DataDog/dd-sdk-android/pull/1789 and since it is now k8s-based, the variables that depends on information related to k8s resources (host IP) needs to be referenced directly from the job otherwise is not going to work.

This PR fixes `dd-trace-java` bootstrap which was failing, because `BUILDENV_HOST_IP` wasn't available at the `variables` set stage.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

