### PR TITLE
Use automatic Gradle daemon instrumentation with CI Visibility instead of manual test tasks instrumentation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,15 +4,15 @@ include:
 # SETUP
 
 variables:
-  CURRENT_CI_IMAGE: "5"
+  CURRENT_CI_IMAGE: "6"
   CI_IMAGE_DOCKER: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/dd-sdk-android:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 
   DD_SERVICE: "dd-sdk-android"
   DD_ENV_TESTS: "ci"
-  DD_INTEGRATION_JUNIT_5_ENABLED: "true"
   DD_CIVISIBILITY_ENABLED: "true"
   DD_INSIDE_CI: "true"
+  DD_COMMON_AGENT_CONFIG: "dd.env=ci,dd.trace.enabled=false,dd.jmx.fetch.enabled=false"
 
   KUBERNETES_MEMORY_REQUEST: "8Gi"
   KUBERNETES_MEMORY_LIMIT: "16Gi"
@@ -104,7 +104,7 @@ test:debug:
   script:
     - rm -rf ~/.gradle/daemon/
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
-    - GRADLE_OPTS="-Xmx3072m" ./gradlew :unitTestDebug --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+    - GRADLE_OPTS="-Xmx3072m" DD_TAGS="test.configuration.variant:debug" ./gradlew :unitTestDebug --stacktrace --no-daemon --build-cache --gradle-user-home cache/ -Dorg.gradle.jvmargs=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG
   artifacts:
     when: always
     expire_in: 1 week
@@ -125,7 +125,7 @@ test:release:
   script:
     - rm -rf ~/.gradle/daemon/
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
-    - GRADLE_OPTS="-Xmx3072m" ./gradlew :unitTestRelease --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+    - GRADLE_OPTS="-Xmx3072m" DD_TAGS="test.configuration.variant:release" ./gradlew :unitTestRelease --stacktrace --no-daemon --build-cache --gradle-user-home cache/ -Dorg.gradle.jvmargs=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG
   artifacts:
     when: always
     expire_in: 1 week
@@ -146,7 +146,7 @@ test:tools:
   script:
     - rm -rf ~/.gradle/daemon/
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
-    - GRADLE_OPTS="-Xmx3072m" ./gradlew :unitTestTools --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+    - GRADLE_OPTS="-Xmx3072m" DD_TAGS="test.configuration.variant:jvmRelease" ./gradlew :unitTestTools --stacktrace --no-daemon --build-cache --gradle-user-home cache/ -Dorg.gradle.jvmargs=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG
 
 test:kover:
   tags: [ "arch:amd64" ]
@@ -165,7 +165,7 @@ test:kover:
     - export DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.api_key --with-decryption --query "Parameter.Value" --out text)
     - export DD_APP_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.app_key --with-decryption --query "Parameter.Value" --out text)
     - CODECOV_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.codecov-token  --with-decryption --query "Parameter.Value" --out text)
-    - GRADLE_OPTS="-Xmx3072m" ./gradlew :koverReportAll --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+    - GRADLE_OPTS="-Xmx3072m" DD_TAGS="test.configuration.variant:release" ./gradlew :koverReportAll --stacktrace --no-daemon --build-cache --gradle-user-home cache/ -Dorg.gradle.jvmargs=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG
     - python3 ddcoverage.py --prefix dd-sdk-android
     - bash <(cat ./codecov.sh) -t $CODECOV_TOKEN
 
@@ -187,7 +187,7 @@ test-pyramid:single-fit-logs:
   script:
     - rm -rf ~/.gradle/daemon/
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
-    - GRADLE_OPTS="-Xmx3072m" ./gradlew :reliability:single-fit:logs:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+    - GRADLE_OPTS="-Xmx3072m" DD_TAGS="test.configuration.variant:release" ./gradlew :reliability:single-fit:logs:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/ -Dorg.gradle.jvmargs=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG
   artifacts:
     when: always
     expire_in: 1 week
@@ -208,7 +208,7 @@ test-pyramid:single-fit-rum:
   script:
     - rm -rf ~/.gradle/daemon/
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
-    - GRADLE_OPTS="-Xmx3072m" ./gradlew :reliability:single-fit:rum:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+    - GRADLE_OPTS="-Xmx3072m" DD_TAGS="test.configuration.variant:release" ./gradlew :reliability:single-fit:rum:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/ -Dorg.gradle.jvmargs=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG
   artifacts:
     when: always
     expire_in: 1 week
@@ -229,7 +229,7 @@ test-pyramid:single-fit-trace:
   script:
     - rm -rf ~/.gradle/daemon/
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
-    - GRADLE_OPTS="-Xmx3072m" ./gradlew :reliability:single-fit:trace:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/
+    - GRADLE_OPTS="-Xmx3072m" DD_TAGS="test.configuration.variant:release" ./gradlew :reliability:single-fit:trace:testReleaseUnitTest --stacktrace --no-daemon --build-cache --gradle-user-home cache/ -Dorg.gradle.jvmargs=-javaagent:$DD_TRACER_FOLDER/dd-java-agent.jar=$DD_COMMON_AGENT_CONFIG
   artifacts:
     when: always
     expire_in: 1 week

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -30,6 +30,7 @@ ENV ANDROID_BUILD_TOOLS 34.0.0
 ENV ANDROID_SDK_TOOLS 10406996
 ENV NDK_VERSION 25.1.8937393
 ENV CMAKE_VERSION 3.22.1
+ENV DD_TRACER_VERSION 1.26.1
 
 RUN apt update && apt install -y python3
 
@@ -96,3 +97,8 @@ RUN set -x \
 # Install Datadog CI
 RUN npm install -g npm@9.6.5
 RUN npm install -g @datadog/datadog-ci
+
+# Install Datadog Java tracer
+ENV DD_TRACER_FOLDER $PWD/dd-java-agent
+RUN mkdir -p $DD_TRACER_FOLDER
+RUN wget -O $DD_TRACER_FOLDER/dd-java-agent.jar https://repo1.maven.org/maven2/com/datadoghq/dd-java-agent/$DD_TRACER_VERSION/dd-java-agent-$DD_TRACER_VERSION.jar

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/KotlinConfig.kt
@@ -6,12 +6,10 @@
 
 package com.datadog.gradle.config
 
-import com.android.build.gradle.tasks.factory.AndroidUnitTest
 import org.gradle.api.Project
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinVersion
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
-import java.io.File
 
 fun Project.kotlinConfig(
     evaluateWarningsAsErrors: Boolean = true,
@@ -24,26 +22,6 @@ fun Project.kotlinConfig(
             allWarningsAsErrors.set(evaluateWarningsAsErrors && isCI)
             apiVersion.set(KotlinVersion.KOTLIN_1_7)
             languageVersion.set(KotlinVersion.KOTLIN_1_7)
-        }
-    }
-
-    val moduleName = this@kotlinConfig.name
-    val javaAgentJar = File(File(rootDir, "libs"), "dd-java-agent-1.26.1.jar")
-    taskConfig<AndroidUnitTest> {
-        if (environment["DD_INTEGRATION_JUNIT_5_ENABLED"] == "true") {
-            val variant = variantName.substringBeforeLast("UnitTest")
-
-            // set the `env` tag for the test spans
-            environment("DD_ENV", "ci")
-            // add custom tags based on the module and variant (debug/release, flavors, …)
-            environment("DD_TAGS", "test.module:$moduleName,test.variant:$variant")
-
-            // disable other Datadog integrations that could interact with the Java Agent
-            environment("DD_INTEGRATIONS_ENABLED", "false")
-            // disable JMX integration
-            environment("DD_JMX_FETCH_ENABLED", "false")
-
-            jvmArgs("-javaagent:${javaAgentJar.absolutePath}")
         }
     }
 }


### PR DESCRIPTION
### What does this PR do?

Updates CI Visibility instrumentation: rather than configuring each test task to fork a JVM with the DD Java tracer injected, now the tracer is injected into the Gradle daemon that runs the build.

### Motivation

Instrumenting the Gradle daemon has the following advantages:
- No need to manually change the build files, every test task is instrumented automatically.
- All tests executed within a single build are reported as part of a single test session, and it is possible to see the duration and status for the entire build or individual modules.
- Some background operations (such as reporting Git data or building an index of the repository) are done once for the entire build and not for every test task.

### Additional Notes

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

