### PR TITLE
Add testable core wrapper behind property

### DIFF
--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/BuildConfigPropertiesKeys.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/BuildConfigPropertiesKeys.kt
@@ -8,4 +8,5 @@ package com.datadog.gradle.config
 
 object BuildConfigPropertiesKeys {
     const val LOGCAT_ENABLED = "LOGCAT_ENABLED"
+    const val BUILD_FOR_CORE_TESTING = "BUILD_FOR_CORE_TESTING"
 }

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/GradlePropertiesKeys.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/GradlePropertiesKeys.kt
@@ -9,4 +9,6 @@ object GradlePropertiesKeys {
 
     // you can set this property from your gradle.properties as: forceEnableLogcat = true | false
     const val FORCE_ENABLE_LOGCAT = "forceEnableLogcat"
+    // you can set this property from your gradle.properties as: buildForCoreTesting = true | false
+    const val BUILD_FOR_CORE_TESTING = "buildForCoreTesting"
 }

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -139,6 +139,8 @@ data class com.datadog.android.api.storage.RawBatchEvent
   constructor(ByteArray, ByteArray = EMPTY_BYTE_ARRAY)
   override fun equals(Any?): Boolean
   override fun hashCode(): Int
+class com.datadog.android.core.DatadogCoreProxy : InternalSdkCore
+  constructor(InternalSdkCore)
 interface com.datadog.android.core.InternalSdkCore : com.datadog.android.api.feature.FeatureSdkCore
   val networkInfo: com.datadog.android.api.context.NetworkInfo
   val trackingConsent: com.datadog.android.privacy.TrackingConsent

--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -29,6 +29,7 @@ class com.datadog.android._InternalProxy
     fun error(String, String?, String?)
   val _telemetry: _TelemetryProxy
   fun setCustomAppVersion(String)
+  fun registerCoreWithProxy(): com.datadog.android.core.DatadogCoreProxy?
   companion object 
     fun allowClearTextHttp(com.datadog.android.core.configuration.Configuration.Builder): com.datadog.android.core.configuration.Configuration.Builder
 interface com.datadog.android.api.InternalLogger

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -429,6 +429,36 @@ public final class com/datadog/android/api/storage/RawBatchEvent {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/datadog/android/core/DatadogCoreProxy : com/datadog/android/core/InternalSdkCore {
+	public fun <init> (Lcom/datadog/android/core/InternalSdkCore;)V
+	public fun addUserProperties (Ljava/util/Map;)V
+	public fun clearAllData ()V
+	public final fun clearData (Ljava/lang/String;)V
+	public final fun eventsWritten (Ljava/lang/String;)Ljava/lang/String;
+	public fun getAllFeatures ()Ljava/util/List;
+	public final fun getCore ()Lcom/datadog/android/core/InternalSdkCore;
+	public fun getDatadogContext ()Lcom/datadog/android/api/context/DatadogContext;
+	public fun getFeature (Ljava/lang/String;)Lcom/datadog/android/api/feature/FeatureScope;
+	public fun getFeatureContext (Ljava/lang/String;)Ljava/util/Map;
+	public fun getFirstPartyHostResolver ()Lcom/datadog/android/core/internal/net/FirstPartyHostHeaderTypeResolver;
+	public fun getInternalLogger ()Lcom/datadog/android/api/InternalLogger;
+	public fun getName ()Ljava/lang/String;
+	public fun getNetworkInfo ()Lcom/datadog/android/api/context/NetworkInfo;
+	public fun getPersistenceExecutorService ()Ljava/util/concurrent/ExecutorService;
+	public fun getRootStorageDir ()Ljava/io/File;
+	public fun getService ()Ljava/lang/String;
+	public fun getTime ()Lcom/datadog/android/api/context/TimeInfo;
+	public fun getTrackingConsent ()Lcom/datadog/android/privacy/TrackingConsent;
+	public fun isDeveloperModeEnabled ()Z
+	public fun registerFeature (Lcom/datadog/android/api/feature/Feature;)V
+	public fun removeEventReceiver (Ljava/lang/String;)V
+	public fun setEventReceiver (Ljava/lang/String;Lcom/datadog/android/api/feature/FeatureEventReceiver;)V
+	public fun setTrackingConsent (Lcom/datadog/android/privacy/TrackingConsent;)V
+	public fun setUserInfo (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public fun updateFeatureContext (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)V
+	public fun writeLastViewEvent ([B)V
+}
+
 public abstract interface class com/datadog/android/core/InternalSdkCore : com/datadog/android/api/feature/FeatureSdkCore {
 	public abstract fun getAllFeatures ()Ljava/util/List;
 	public abstract fun getDatadogContext ()Lcom/datadog/android/api/context/DatadogContext;

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -1,4 +1,5 @@
 public final class com/datadog/android/BuildConfig {
+	public static final field BUILD_FOR_CORE_TESTING Ljava/lang/Boolean;
 	public static final field BUILD_TYPE Ljava/lang/String;
 	public static final field DEBUG Z
 	public static final field LIBRARY_PACKAGE_NAME Ljava/lang/String;
@@ -59,6 +60,7 @@ public final class com/datadog/android/DatadogSite : java/lang/Enum {
 public final class com/datadog/android/_InternalProxy {
 	public static final field Companion Lcom/datadog/android/_InternalProxy$Companion;
 	public final fun get_telemetry ()Lcom/datadog/android/_InternalProxy$_TelemetryProxy;
+	public final fun registerCoreWithProxy ()Lcom/datadog/android/core/DatadogCoreProxy;
 	public final fun setCustomAppVersion (Ljava/lang/String;)V
 }
 

--- a/dd-sdk-android-core/build.gradle.kts
+++ b/dd-sdk-android-core/build.gradle.kts
@@ -48,6 +48,14 @@ fun isLogEnabledInRelease(): String {
     return project.findProperty(GradlePropertiesKeys.FORCE_ENABLE_LOGCAT) as? String ?: "false"
 }
 
+/**
+ * Checks whether the SDK should enable core testing.
+ * @return true if core testing should be enabled
+ */
+fun isBuiltForCoreTesting(): String {
+    return project.findProperty(GradlePropertiesKeys.BUILD_FOR_CORE_TESTING) as? String ?: "false"
+}
+
 android {
     defaultConfig {
         buildFeatures {
@@ -62,6 +70,11 @@ android {
             "String",
             "SDK_VERSION_NAME",
             "\"${AndroidConfig.VERSION.name}\""
+        )
+        buildConfigField(
+            "Boolean",
+            BuildConfigPropertiesKeys.BUILD_FOR_CORE_TESTING,
+            isBuiltForCoreTesting()
         )
     }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -319,7 +319,7 @@ object Datadog {
     @InternalApi
     @Suppress("FunctionNaming", "FunctionName")
     fun _internalProxy(instanceName: String? = null): _InternalProxy {
-        return _InternalProxy(getInstance(instanceName))
+        return _InternalProxy(getInstance(instanceName), registry)
     }
 
     // endregion

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/_InternalProxy.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/_InternalProxy.kt
@@ -11,7 +11,9 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.DatadogCore
+import com.datadog.android.core.DatadogCoreProxy
 import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.internal.SdkCoreRegistry
 import com.datadog.android.lint.InternalApi
 
 /**
@@ -34,7 +36,8 @@ import com.datadog.android.lint.InternalApi
     "VariableNaming"
 )
 class _InternalProxy internal constructor(
-    private val sdkCore: SdkCore
+    private val sdkCore: SdkCore,
+    private val registry: SdkCoreRegistry,
 ) {
     @Suppress("StringLiteralDuplication")
     class _TelemetryProxy internal constructor(private val sdkCore: SdkCore) {
@@ -76,6 +79,10 @@ class _InternalProxy internal constructor(
     fun setCustomAppVersion(version: String) {
         val coreFeature = (sdkCore as? DatadogCore)?.coreFeature
         coreFeature?.packageVersionProvider?.version = version
+    }
+
+    fun registerCoreWithProxy(): DatadogCoreProxy? {
+        return registry.wrapCoreWithProxy(sdkCore.name)
     }
 
     companion object {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCoreProxy.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCoreProxy.kt
@@ -1,0 +1,103 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core
+
+import com.datadog.android.api.context.DatadogContext
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureScope
+import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.RawBatchEvent
+import com.google.gson.Gson
+import com.google.gson.JsonElement
+
+class DatadogCoreProxy(
+    val core: InternalSdkCore,
+) : InternalSdkCore by core {
+    private val featureScopes = mutableMapOf<String, FeatureScopeInterceptor>()
+
+    fun eventsWritten(featureName: String): String {
+        val events = featureScopes[featureName]?.eventsWritten()?.toList() ?: emptyList<Any>()
+        return Gson().toJson(events)
+    }
+
+    fun clearData(featureName: String) {
+        featureScopes[featureName]?.clearData()
+    }
+
+    override fun registerFeature(feature: Feature) {
+        core.registerFeature(feature)
+        val featureScope = core.getFeature(feature.name)
+        featureScopes[feature.name] = FeatureScopeInterceptor(featureScope!!, core, feature)
+    }
+
+    override fun getFeature(featureName: String): FeatureScope? {
+        core.getFeature(featureName)
+        return featureScopes[featureName]
+    }
+}
+
+internal class FeatureScopeInterceptor(
+    private val featureScope: FeatureScope,
+    private val core: InternalSdkCore,
+    private val feature: Feature,
+    ) : FeatureScope by featureScope {
+
+    private val eventsBatchInterceptor = EventBatchInterceptor()
+
+    fun eventsWritten(): List<String> {
+        return eventsBatchInterceptor.events
+    }
+
+    fun clearData() {
+        eventsBatchInterceptor.clearData()
+    }
+
+    // region FeatureScope
+
+    override fun withWriteContext(
+        forceNewBatch: Boolean,
+        callback: (DatadogContext, EventBatchWriter) -> Unit
+    ) {
+        featureScope.withWriteContext(forceNewBatch, callback)
+
+        val context = core.getDatadogContext()!!
+        callback(context, eventsBatchInterceptor)
+    }
+
+    override fun <T : Feature> unwrap(): T {
+        @Suppress("UNCHECKED_CAST")
+        return feature as T
+    }
+
+    // endregion
+}
+
+
+internal class EventBatchInterceptor: EventBatchWriter {
+    internal val events = mutableListOf<String>()
+
+    override fun currentMetadata(): ByteArray? {
+        TODO("Not yet implemented")
+    }
+
+    fun clearData() {
+        events.clear()
+    }
+
+    override fun write(
+        event: RawBatchEvent,
+        batchMetadata: ByteArray?
+    ): Boolean {
+        val eventContent = String(event.data)
+
+        events.add(events.size,
+            eventContent
+        )
+
+        return false
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkCoreRegistry.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkCoreRegistry.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.core.internal
 
+import com.datadog.android.BuildConfig
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.core.DatadogCoreProxy
@@ -73,12 +74,14 @@ internal class SdkCoreRegistry(
      * This must be called before any feature is registered.
      */
     fun wrapCoreWithProxy(name: String?): DatadogCoreProxy? {
-        val key = name ?: DEFAULT_INSTANCE_NAME
-        val sdkCore = instances[key]
-        if (sdkCore != null) {
-            val proxiedCore = DatadogCoreProxy(sdkCore as InternalSdkCore)
-            instances[key] = proxiedCore
-            return proxiedCore
+        if (BuildConfig.BUILD_FOR_CORE_TESTING) {
+            val key = name ?: DEFAULT_INSTANCE_NAME
+            val sdkCore = instances[key]
+            if (sdkCore != null) {
+                val proxiedCore = DatadogCoreProxy(sdkCore as InternalSdkCore)
+                instances[key] = proxiedCore
+                return proxiedCore
+            }
         }
         return null
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkCoreRegistry.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkCoreRegistry.kt
@@ -8,6 +8,8 @@ package com.datadog.android.core.internal
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
+import com.datadog.android.core.DatadogCoreProxy
+import com.datadog.android.core.InternalSdkCore
 
 /**
  * A Registry for all [SdkCore] instances, allowing customers to retrieve the one
@@ -64,6 +66,21 @@ internal class SdkCoreRegistry(
      */
     fun clear() {
         instances.clear()
+    }
+
+    /**
+     * Wraps the core with a proxy to start listening to feature events.
+     * This must be called before any feature is registered.
+     */
+    fun wrapCoreWithProxy(name: String?): DatadogCoreProxy? {
+        val key = name ?: DEFAULT_INSTANCE_NAME
+        val sdkCore = instances[key]
+        if (sdkCore != null) {
+            val proxiedCore = DatadogCoreProxy(sdkCore as InternalSdkCore)
+            instances[key] = proxiedCore
+            return proxiedCore
+        }
+        return null
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

This is a follow-up on the [initial POC](https://github.com/DataDog/dd-sdk-ios/pull/1570).
I've extracted the functionality in a method of the internal core proxy and added a condition on a build config field to make it harder to use it by mistake.

I'd like to get feedback on the implementation before moving on to add some unit tests to the feature.

### Motivation

The goal of the testable core wrapper is to enable UI feature testing. With this we can make assertions as to what fields were called by the SDK.
This is going to enable us to test the React Native Session Replay implementation, as the work to correctly mock UI RN components in unit test is much larger.

### Additional Notes

On iOS we can get rid of the wrapper altogether with compiler flags, but I don't think such a thing exists on Android. As far as I understand we cannot totally hide or remove the feature for other users. The best I could find was to put it behind an internal proxy and require a build config field to be set.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

