### PR TITLE
feat: Add accessor for current session id

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -88,6 +88,7 @@ enum com.datadog.android.rum.RumErrorSource
   - AGENT
   - WEBVIEW
 interface com.datadog.android.rum.RumMonitor
+  val currentSessionId: String?
   fun startView(Any, String, Map<String, Any?> = emptyMap())
   fun stopView(Any, Map<String, Any?> = emptyMap())
   fun addAction(RumActionType, String, Map<String, Any?>)

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -88,7 +88,7 @@ enum com.datadog.android.rum.RumErrorSource
   - AGENT
   - WEBVIEW
 interface com.datadog.android.rum.RumMonitor
-  val currentSessionId: String?
+  fun getCurrentSessionId((String?) -> Unit)
   fun startView(Any, String, Map<String, Any?> = emptyMap())
   fun stopView(Any, Map<String, Any?> = emptyMap())
   fun addAction(RumActionType, String, Map<String, Any?>)

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -140,6 +140,7 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun addTiming (Ljava/lang/String;)V
 	public abstract fun clearAttributes ()V
 	public abstract fun getAttributes ()Ljava/util/Map;
+	public abstract fun getCurrentSessionId ()Ljava/lang/String;
 	public abstract fun getDebug ()Z
 	public abstract fun removeAttribute (Ljava/lang/String;)V
 	public abstract fun setDebug (Z)V

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -140,7 +140,7 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun addTiming (Ljava/lang/String;)V
 	public abstract fun clearAttributes ()V
 	public abstract fun getAttributes ()Ljava/util/Map;
-	public abstract fun getCurrentSessionId ()Ljava/lang/String;
+	public abstract fun getCurrentSessionId (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun getDebug ()Z
 	public abstract fun removeAttribute (Ljava/lang/String;)V
 	public abstract fun setDebug (Z)V

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -20,6 +20,11 @@ import com.datadog.tools.annotation.NoOpImplementation
 @Suppress("ComplexInterface", "TooManyFunctions")
 @NoOpImplementation
 interface RumMonitor {
+    /**
+     * The current active session id. May return null if a session has not been started yet.
+     * Will return a "null session id" (all zeros) if the current session is not tracked.
+     */
+    val currentSessionId: String?
 
     /**
      * Notifies that a View is being shown to the user, linked with the [key] instance.

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -21,10 +21,15 @@ import com.datadog.tools.annotation.NoOpImplementation
 @NoOpImplementation
 interface RumMonitor {
     /**
-     * The current active session id. May return null if a session has not been started yet.
-     * Will return a "null session id" (all zeros) if the current session is not tracked.
+     * Get the current active session ID. The session ID will be null if no session is active or
+     * if the session has been sampled out.
+     *
+     * This method uses an asynchronous callback to ensure all pending RUM events have been processed
+     * up to the moment of the call.
+     *
+     * @param callback the callback to be invoked with the current session id.
      */
-    val currentSessionId: String?
+    fun getCurrentSessionId(callback: (String?) -> Unit)
 
     /**
      * Notifies that a View is being shown to the user, linked with the [key] instance.

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -99,16 +99,21 @@ internal class DatadogRumMonitor(
 
     // region RumMonitor
 
-    override val currentSessionId: String?
-        get() {
-            val applicationScope = rootScope as? RumApplicationScope
-            val sessionScope = applicationScope?.activeSession as? RumSessionScope
-            if (sessionScope != null && sessionScope.sessionState == RumSessionScope.State.NOT_TRACKED) {
-                // Aligns with iOS which assigns a NULL session id when the session is not tracked
-                return RumContext.NULL_UUID
+    override fun getCurrentSessionId(callback: (String?) -> Unit) {
+        executorService.submitSafe(
+            "Get current session ID",
+            sdkCore.internalLogger
+        ) {
+            val activeSession = rootScope
+                .getRumContext()
+                .sessionId
+            if (activeSession == RumContext.NULL_UUID) {
+                callback(null)
+            } else {
+                callback(activeSession)
             }
-            return sessionScope?.sessionId
         }
+    }
 
     override var debug: Boolean
         get() = isDebugEnabled.get()

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -27,6 +27,7 @@ import com.datadog.android.rum.internal.CombinedRumSessionListener
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.debug.RumDebugListener
+import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.domain.asTime
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
@@ -97,6 +98,17 @@ internal class DatadogRumMonitor(
     private val isDebugEnabled = AtomicBoolean(false)
 
     // region RumMonitor
+
+    override val currentSessionId: String?
+        get() {
+            val applicationScope = rootScope as? RumApplicationScope
+            val sessionScope = applicationScope?.activeSession as? RumSessionScope
+            if (sessionScope != null && sessionScope.sessionState == RumSessionScope.State.NOT_TRACKED) {
+                // Aligns with iOS which assigns a NULL session id when the session is not tracked
+                return RumContext.NULL_UUID
+            }
+            return sessionScope?.sessionId
+        }
 
     override var debug: Boolean
         get() = isDebugEnabled.get()


### PR DESCRIPTION
### What does this PR do?

There are use cases (usually support use cases) where clients what to know the current session id without depending on the `sessionStarted` event. This provides that accessor.

refs: RUM-1962

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

