### PR TITLE
RUM-2441 make synthetics logs more verbose

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.rum.internal.domain.scope
 
 import android.app.ActivityManager
-import android.util.Log
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
@@ -78,7 +77,6 @@ internal class RumApplicationScope(
                 syntheticsTestId = event.testId,
                 syntheticsResultId = event.resultId
             )
-            Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.application.id=${rumContext.applicationId}")
         }
 
         val isInteraction = (event is RumRawEvent.StartView) || (event is RumRawEvent.StartAction)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import android.util.Log
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
@@ -201,9 +200,6 @@ internal class RumSessionScope(
         sessionId = UUID.randomUUID().toString()
         sessionStartNs.set(nanoTime)
         sessionListener?.onSessionStarted(sessionId, !keepSession)
-        if (getRumContext().syntheticsTestId != null) {
-            Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.session.id=$sessionId")
-        }
     }
 
     private fun updateSessionStateForSessionReplay(state: State, sessionId: String) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -70,10 +70,14 @@ internal open class RumViewScope(
         set(value) {
             oldViewIds += field
             field = value
-            if (getRumContext().syntheticsTestId != null) {
+            val rumContext = getRumContext()
+            if (rumContext.syntheticsTestId != null) {
+                Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.application.id=${rumContext.applicationId}")
+                Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.session.id=${rumContext.sessionId}")
                 Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.view.id=$viewId")
             }
         }
+
     private val oldViewIds = mutableSetOf<String>()
     private val startedNanos: Long = eventTime.nanoTime
 
@@ -147,7 +151,10 @@ internal open class RumViewScope(
         cpuVitalMonitor.register(cpuVitalListener)
         memoryVitalMonitor.register(memoryVitalListener)
         frameRateVitalMonitor.register(frameRateVitalListener)
-        if (parentScope.getRumContext().syntheticsTestId != null) {
+        val rumContext = parentScope.getRumContext()
+        if (rumContext.syntheticsTestId != null) {
+            Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.application.id=${rumContext.applicationId}")
+            Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.session.id=${rumContext.sessionId}")
             Log.i(RumScope.SYNTHETICS_LOGCAT_TAG, "_dd.view.id=$viewId")
         }
     }


### PR DESCRIPTION
### What does this PR do?

Prints the application and session id whenever a view changes. 

### Motivation

The Synthetics team have a delay when fetching logs from the device running the app under test. Because of this the initial Application and Session ID (printed early in the app's lifecycle) are lost and can't be retrieved. Repeating them whenever a view is started provides a workaround if the first logs of the app can't be read.