### PR TITLE
RUM-1520 prevent false positive warning

### DIFF
--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandler.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandler.kt
@@ -79,7 +79,7 @@ internal class AndroidSpanLogsHandler(
                     "timestamp" to timestamp
                 )
             )
-        } else {
+        } else if (logsFeature == null) {
             sdkCore.internalLogger.log(
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,


### PR DESCRIPTION
### What does this PR do?

Prevent a false positive warning in the logcat when the logs feature is available but no fields is provided to the span.log() method
