### PR TITLE
fix: getCurrentSessionId returns correct value

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -104,14 +104,20 @@ internal class DatadogRumMonitor(
             "Get current session ID",
             sdkCore.internalLogger
         ) {
-            val activeSession = rootScope
-                .getRumContext()
-                .sessionId
-            if (activeSession == RumContext.NULL_UUID) {
-                callback(null)
-            } else {
-                callback(activeSession)
-            }
+            val activeSessionId = (rootScope as? RumApplicationScope)
+                ?.activeSession
+                ?.getRumContext()
+                ?.let {
+                    val sessionId = it.sessionId
+                    if (it.sessionState == RumSessionScope.State.NOT_TRACKED ||
+                        sessionId == RumContext.NULL_UUID
+                    ) {
+                        null
+                    } else {
+                        sessionId
+                    }
+                }
+            callback(activeSessionId)
         }
     }
 
@@ -181,7 +187,7 @@ internal class DatadogRumMonitor(
 
     @Deprecated(
         "This method is deprecated and will be removed in the future versions." +
-            " Use `startResource` method which takes `RumHttpMethod` as `method` parameter instead."
+                " Use `startResource` method which takes `RumHttpMethod` as `method` parameter instead."
     )
     override fun startResource(
         key: String,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -220,7 +220,7 @@ internal class DatadogRumMonitorTest {
         // Then
         completableFuture.thenAccept {
             assertThat(it).isEqualTo(null)
-        }.orTimeout(PROCESSING_DELAY, TimeUnit.MILLISECONDS)
+        }.orTimeout(PROCESSING_DELAY, TimeUnit.MILLISECONDS).join()
     }
 
     @Test
@@ -276,8 +276,9 @@ internal class DatadogRumMonitorTest {
                 verify(mockSessionListener).onSessionStarted(capture(), any())
 
                 assertThat(it).isEqualTo(firstValue)
+                assertThat(it).isNotNull()
             }
-        }.orTimeout(PROCESSING_DELAY, TimeUnit.MILLISECONDS)
+        }.orTimeout(PROCESSING_DELAY, TimeUnit.MILLISECONDS).join()
     }
 
     @Test
@@ -311,7 +312,7 @@ internal class DatadogRumMonitorTest {
         // Then
         completableFuture.thenAccept {
             assertThat(it).isEqualTo(null)
-        }.orTimeout(PROCESSING_DELAY, TimeUnit.MILLISECONDS)
+        }.orTimeout(PROCESSING_DELAY, TimeUnit.MILLISECONDS).join()
     }
 
     @Test
@@ -1428,7 +1429,7 @@ internal class DatadogRumMonitorTest {
         val viewScopes = forge.aList {
             mock<RumViewScope>().apply {
                 whenever(getRumContext()) doReturn
-                    RumContext(viewName = forge.aNullable { forge.anAlphaNumericalString() })
+                        RumContext(viewName = forge.aNullable { forge.anAlphaNumericalString() })
 
                 whenever(isActive()) doReturn true
             }
@@ -1464,7 +1465,7 @@ internal class DatadogRumMonitorTest {
         val viewScopes = forge.aList {
             mock<RumViewScope>().apply {
                 whenever(getRumContext()) doReturn
-                    RumContext(viewName = forge.aNullable { forge.anAlphaNumericalString() })
+                        RumContext(viewName = forge.aNullable { forge.anAlphaNumericalString() })
 
                 whenever(isActive()) doReturn false
             }
@@ -1788,7 +1789,7 @@ internal class DatadogRumMonitorTest {
                 if (isMethodOccupied) {
                     throw IllegalStateException(
                         "Only one thread should" +
-                            " be allowed to enter rootScope at the time."
+                                " be allowed to enter rootScope at the time."
                     )
                 }
                 isMethodOccupied = true


### PR DESCRIPTION
### What does this PR do?

Fix getCurrentSessionId to actually return the correct session id for the currently active session.

refs: RUM-1962

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

