### PR TITLE
RUM-2746: Add additional status codes as retryable

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploader.kt
@@ -159,8 +159,11 @@ internal class DataOkHttpUploader(
             HTTP_CLIENT_TIMEOUT -> UploadStatus.HttpClientRateLimiting(code)
             HTTP_ENTITY_TOO_LARGE -> UploadStatus.HttpClientError(code)
             HTTP_TOO_MANY_REQUESTS -> UploadStatus.HttpClientRateLimiting(code)
-            HTTP_INTERNAL_ERROR -> UploadStatus.HttpServerError(code)
-            HTTP_UNAVAILABLE -> UploadStatus.HttpServerError(code)
+            HTTP_INTERNAL_ERROR,
+            HTTP_BAD_GATEWAY,
+            HTTP_UNAVAILABLE,
+            HTTP_GATEWAY_TIMEOUT,
+            HTTP_INSUFFICIENT_STORAGE -> UploadStatus.HttpServerError(code)
             else -> {
                 internalLogger.log(
                     InternalLogger.Level.WARN,
@@ -184,7 +187,10 @@ internal class DataOkHttpUploader(
         const val HTTP_TOO_MANY_REQUESTS = 429
 
         const val HTTP_INTERNAL_ERROR = 500
+        const val HTTP_BAD_GATEWAY = 502
         const val HTTP_UNAVAILABLE = 503
+        const val HTTP_GATEWAY_TIMEOUT = 504
+        const val HTTP_INSUFFICIENT_STORAGE = 507
 
         const val SYSTEM_UA = "http.agent"
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploaderTest.kt
@@ -410,6 +410,26 @@ internal class DataOkHttpUploaderTest {
     }
 
     @Test
+    fun `𝕄 return server error 𝕎 upload() {502 bad gateway status}`(
+        @Forgery batch: List<RawBatchEvent>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(502, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batch, batchMetadata)
+
+        // Then
+        assertThat(result).isInstanceOf(UploadStatus.HttpServerError::class.java)
+        assertThat(result.code).isEqualTo(502)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
     fun `𝕄 return server error 𝕎 upload() {503 unavailable status}`(
         @Forgery batch: List<RawBatchEvent>,
         @StringForgery batchMeta: String,
@@ -425,6 +445,46 @@ internal class DataOkHttpUploaderTest {
         // Then
         assertThat(result).isInstanceOf(UploadStatus.HttpServerError::class.java)
         assertThat(result.code).isEqualTo(503)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return server error 𝕎 upload() {504 gateway timeout status}`(
+        @Forgery batch: List<RawBatchEvent>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(504, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batch, batchMetadata)
+
+        // Then
+        assertThat(result).isInstanceOf(UploadStatus.HttpServerError::class.java)
+        assertThat(result.code).isEqualTo(504)
+        verifyRequest(fakeDatadogRequest)
+        verifyResponseIsClosed()
+    }
+
+    @Test
+    fun `𝕄 return server error 𝕎 upload() {507 insufficient storage status}`(
+        @Forgery batch: List<RawBatchEvent>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doReturn mockResponse(507, message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batch, batchMetadata)
+
+        // Then
+        assertThat(result).isInstanceOf(UploadStatus.HttpServerError::class.java)
+        assertThat(result.code).isEqualTo(507)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
     }
@@ -446,7 +506,7 @@ internal class DataOkHttpUploaderTest {
         var statusCode: Int
         do {
             statusCode = forge.anInt(200, 600)
-        } while (statusCode in arrayOf(202, 400, 401, 403, 408, 413, 429, 500, 503))
+        } while (statusCode in arrayOf(202, 400, 401, 403, 408, 413, 429, 500, 502, 503, 504, 507))
         whenever(mockCall.execute()) doReturn mockResponse(statusCode, message)
 
         // When


### PR DESCRIPTION
### What does this PR do?

This PR adds additional status codes which we can get from intake as retryable in order to prevent data loss:

* 502 - bad gateway
* 504 - gateway timeout
* 507 - insufficient storage

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

