### PR TITLE
RUM-1308: Add more HTTP methods to RUM

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -139,6 +139,9 @@ enum com.datadog.android.rum.RumResourceMethod
   - PUT
   - DELETE
   - PATCH
+  - TRACE
+  - OPTIONS
+  - CONNECT
 interface com.datadog.android.rum.RumSessionListener
   fun onSessionStarted(String, Boolean)
 class com.datadog.android.rum._RumInternalProxy
@@ -775,6 +778,9 @@ data class com.datadog.android.rum.model.ErrorEvent
     - PUT
     - DELETE
     - PATCH
+    - TRACE
+    - OPTIONS
+    - CONNECT
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Method
@@ -1261,6 +1267,9 @@ data class com.datadog.android.rum.model.ResourceEvent
     - PUT
     - DELETE
     - PATCH
+    - TRACE
+    - OPTIONS
+    - CONNECT
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Method

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -201,12 +201,15 @@ public final class com/datadog/android/rum/RumResourceKind$Companion {
 }
 
 public final class com/datadog/android/rum/RumResourceMethod : java/lang/Enum {
+	public static final field CONNECT Lcom/datadog/android/rum/RumResourceMethod;
 	public static final field DELETE Lcom/datadog/android/rum/RumResourceMethod;
 	public static final field GET Lcom/datadog/android/rum/RumResourceMethod;
 	public static final field HEAD Lcom/datadog/android/rum/RumResourceMethod;
+	public static final field OPTIONS Lcom/datadog/android/rum/RumResourceMethod;
 	public static final field PATCH Lcom/datadog/android/rum/RumResourceMethod;
 	public static final field POST Lcom/datadog/android/rum/RumResourceMethod;
 	public static final field PUT Lcom/datadog/android/rum/RumResourceMethod;
+	public static final field TRACE Lcom/datadog/android/rum/RumResourceMethod;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/RumResourceMethod;
 	public static fun values ()[Lcom/datadog/android/rum/RumResourceMethod;
 }
@@ -1715,13 +1718,16 @@ public final class com/datadog/android/rum/model/ErrorEvent$Interface$Companion 
 }
 
 public final class com/datadog/android/rum/model/ErrorEvent$Method : java/lang/Enum {
+	public static final field CONNECT Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public static final field Companion Lcom/datadog/android/rum/model/ErrorEvent$Method$Companion;
 	public static final field DELETE Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public static final field GET Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public static final field HEAD Lcom/datadog/android/rum/model/ErrorEvent$Method;
+	public static final field OPTIONS Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public static final field PATCH Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public static final field POST Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public static final field PUT Lcom/datadog/android/rum/model/ErrorEvent$Method;
+	public static final field TRACE Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Method;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ErrorEvent$Method;
@@ -3221,13 +3227,16 @@ public final class com/datadog/android/rum/model/ResourceEvent$Interface$Compani
 }
 
 public final class com/datadog/android/rum/model/ResourceEvent$Method : java/lang/Enum {
+	public static final field CONNECT Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public static final field Companion Lcom/datadog/android/rum/model/ResourceEvent$Method$Companion;
 	public static final field DELETE Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public static final field GET Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public static final field HEAD Lcom/datadog/android/rum/model/ResourceEvent$Method;
+	public static final field OPTIONS Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public static final field PATCH Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public static final field POST Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public static final field PUT Lcom/datadog/android/rum/model/ResourceEvent$Method;
+	public static final field TRACE Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Method;

--- a/features/dd-sdk-android-rum/src/main/json/rum/error-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/error-schema.json
@@ -123,7 +123,7 @@
                 "method": {
                   "type": "string",
                   "description": "HTTP method of the resource",
-                  "enum": ["POST", "GET", "HEAD", "PUT", "DELETE", "PATCH"],
+                  "enum": ["POST", "GET", "HEAD", "PUT", "DELETE", "PATCH", "TRACE", "OPTIONS", "CONNECT"],
                   "readOnly": true
                 },
                 "status_code": {

--- a/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
@@ -43,7 +43,7 @@
             "method": {
               "type": "string",
               "description": "HTTP method of the resource",
-              "enum": ["POST", "GET", "HEAD", "PUT", "DELETE", "PATCH"],
+              "enum": ["POST", "GET", "HEAD", "PUT", "DELETE", "PATCH", "TRACE", "OPTIONS", "CONNECT"],
               "readOnly": true
             },
             "url": {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumResourceMethod.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumResourceMethod.kt
@@ -39,5 +39,20 @@ enum class RumResourceMethod {
     /**
      * PATCH Method.
      */
-    PATCH
+    PATCH,
+
+    /**
+     * TRACE Method.
+     */
+    TRACE,
+
+    /**
+     * OPTIONS Method.
+     */
+    OPTIONS,
+
+    /**
+     * CONNECT Method.
+     */
+    CONNECT
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
@@ -33,6 +33,9 @@ internal fun RumResourceMethod.toResourceMethod(): ResourceEvent.Method {
         RumResourceMethod.PUT -> ResourceEvent.Method.PUT
         RumResourceMethod.DELETE -> ResourceEvent.Method.DELETE
         RumResourceMethod.PATCH -> ResourceEvent.Method.PATCH
+        RumResourceMethod.TRACE -> ResourceEvent.Method.TRACE
+        RumResourceMethod.OPTIONS -> ResourceEvent.Method.OPTIONS
+        RumResourceMethod.CONNECT -> ResourceEvent.Method.CONNECT
     }
 }
 
@@ -44,6 +47,9 @@ internal fun RumResourceMethod.toErrorMethod(): ErrorEvent.Method {
         RumResourceMethod.PUT -> ErrorEvent.Method.PUT
         RumResourceMethod.DELETE -> ErrorEvent.Method.DELETE
         RumResourceMethod.PATCH -> ErrorEvent.Method.PATCH
+        RumResourceMethod.TRACE -> ErrorEvent.Method.TRACE
+        RumResourceMethod.OPTIONS -> ErrorEvent.Method.OPTIONS
+        RumResourceMethod.CONNECT -> ErrorEvent.Method.CONNECT
     }
 }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -204,6 +204,9 @@ internal class DatadogRumMonitor(
             "PUT" -> RumResourceMethod.PUT
             "DELETE" -> RumResourceMethod.DELETE
             "PATCH" -> RumResourceMethod.PATCH
+            "CONNECT" -> RumResourceMethod.CONNECT
+            "TRACE" -> RumResourceMethod.TRACE
+            "OPTIONS" -> RumResourceMethod.OPTIONS
             else -> {
                 sdkCore.internalLogger.log(
                     InternalLogger.Level.WARN,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -403,7 +403,10 @@ internal class DatadogRumMonitorTest {
             "pUt",
             "HeAd",
             "DeLeTe",
-            "pAtCh"
+            "pAtCh",
+            "cOnnEct",
+            "TrAcE",
+            "oPtIoNs"
         )
         @Suppress("DEPRECATION")
         testedMonitor.startResource(key, method, url, fakeAttributes)

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -374,6 +374,9 @@ internal constructor(
             "HEAD" -> RumResourceMethod.HEAD
             "DELETE" -> RumResourceMethod.DELETE
             "POST" -> RumResourceMethod.POST
+            "TRACE" -> RumResourceMethod.TRACE
+            "OPTIONS" -> RumResourceMethod.OPTIONS
+            "CONNECT" -> RumResourceMethod.CONNECT
             else -> {
                 internalLogger.log(
                     InternalLogger.Level.WARN,

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -389,7 +389,10 @@ internal class DatadogInterceptorWithoutTracesTest {
             fakeMethod = forge.anElementFrom(
                 RumResourceMethod.GET,
                 RumResourceMethod.HEAD,
-                RumResourceMethod.DELETE
+                RumResourceMethod.DELETE,
+                RumResourceMethod.CONNECT,
+                RumResourceMethod.TRACE,
+                RumResourceMethod.OPTIONS
             )
             fakeBody = null
             builder.method(fakeMethod.name, null)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -1274,11 +1274,21 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     ): Request {
         val builder = Request.Builder().url(fakeUrl)
         if (forge.aBool()) {
-            fakeMethod = "POST"
+            fakeMethod = forge.anElementFrom("POST", "PUT", "PATCH")
             fakeBody = forge.anAlphabeticalString()
-            builder.post(fakeBody!!.toByteArray().toRequestBody(null))
+            with(builder) {
+                val body = fakeBody!!.toByteArray().toRequestBody(null)
+                when (fakeMethod) {
+                    "POST" -> post(body)
+                    "PUT" -> put(body)
+                    "PATCH" -> patch(body)
+                    else -> {
+                        throw IllegalArgumentException("Unknown method value: $fakeMethod")
+                    }
+                }
+            }
         } else {
-            fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE")
+            fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE", "CONNECT", "TRACE", "OPTIONS")
             fakeBody = null
             builder.method(fakeMethod, null)
         }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -1391,11 +1391,21 @@ internal open class TracingInterceptorNonDdTracerTest {
     ): Request {
         val builder = Request.Builder().url(url)
         if (forge.aBool()) {
-            fakeMethod = "POST"
+            fakeMethod = forge.anElementFrom("POST", "PUT", "PATCH")
             fakeBody = forge.anAlphabeticalString()
-            builder.post(fakeBody!!.toByteArray().toRequestBody(null))
+            with(builder) {
+                val body = fakeBody!!.toByteArray().toRequestBody(null)
+                when (fakeMethod) {
+                    "POST" -> post(body)
+                    "PUT" -> put(body)
+                    "PATCH" -> patch(body)
+                    else -> {
+                        throw IllegalArgumentException("Unknown method value: $fakeMethod")
+                    }
+                }
+            }
         } else {
-            fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE")
+            fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE", "CONNECT", "TRACE", "OPTIONS")
             fakeBody = null
             builder.method(fakeMethod, null)
         }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -1359,7 +1359,10 @@ internal open class TracingInterceptorNotSendingSpanTest {
             fakeMethod = forge.anElementFrom(
                 RumResourceMethod.GET,
                 RumResourceMethod.HEAD,
-                RumResourceMethod.DELETE
+                RumResourceMethod.DELETE,
+                RumResourceMethod.CONNECT,
+                RumResourceMethod.TRACE,
+                RumResourceMethod.OPTIONS
             )
             fakeBody = null
             builder.method(fakeMethod.name, null)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -1523,11 +1523,21 @@ internal open class TracingInterceptorTest {
     ): Request {
         val builder = Request.Builder().url(url)
         if (forge.aBool()) {
-            fakeMethod = "POST"
+            fakeMethod = forge.anElementFrom("POST", "PUT", "PATCH")
             fakeBody = forge.anAlphabeticalString()
-            builder.post(fakeBody!!.toByteArray().toRequestBody(null))
+            with(builder) {
+                val body = fakeBody!!.toByteArray().toRequestBody(null)
+                when (fakeMethod) {
+                    "POST" -> post(body)
+                    "PUT" -> put(body)
+                    "PATCH" -> patch(body)
+                    else -> {
+                        throw IllegalArgumentException("Unknown method value: $fakeMethod")
+                    }
+                }
+            }
         } else {
-            fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE")
+            fakeMethod = forge.anElementFrom("GET", "HEAD", "DELETE", "CONNECT", "TRACE", "OPTIONS")
             fakeBody = null
             builder.method(fakeMethod, null)
         }


### PR DESCRIPTION
### What does this PR do?

Fixes #1816.

This PR adds support of `CONNECT`, `TRACE`, `OPTIONS` to the `RumMonitor#startResource` call.

Both RUM resources view and traces/spans created by RUM2APM are working fine for these methods.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

