### PR TITLE
Make a copy of attributes before passing them to RUM event

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -925,6 +925,7 @@ datadog:
       - "kotlin.collections.MutableMap.remove(kotlin.Long)"
       - "kotlin.collections.MutableMap.remove(kotlin.String)"
       - "kotlin.collections.MutableMap.safeMapValuesToJson(com.datadog.android.api.InternalLogger)"
+      - "kotlin.collections.MutableMap.toMutableMap()"
       - "kotlin.collections.MutableMap?.forEach(kotlin.Function1)"
       - "kotlin.collections.MutableSet.add(com.datadog.android.core.internal.persistence.ConsentAwareStorage.Batch)"
       - "kotlin.collections.MutableSet.add(com.datadog.android.telemetry.internal.TelemetryEventId)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -194,6 +194,7 @@ internal class RumActionScope(
 
         val actualType = type
         attributes.putAll(GlobalRumMonitor.get(sdkCore).getAttributes())
+        val eventAttributes = attributes.toMutableMap()
         val rumContext = getRumContext()
 
         // make a copy so that closure captures at the state as of now
@@ -288,7 +289,7 @@ internal class RumActionScope(
                     brand = datadogContext.deviceInfo.deviceBrand,
                     architecture = datadogContext.deviceInfo.architecture
                 ),
-                context = ActionEvent.Context(additionalProperties = attributes),
+                context = ActionEvent.Context(additionalProperties = eventAttributes),
                 dd = ActionEvent.Dd(
                     session = ActionEvent.DdSession(
                         plan = ActionEvent.Plan.PLAN_1,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -204,6 +204,7 @@ internal class RumResourceScope(
             attributes.remove(RumAttributes.GRAPHQL_PAYLOAD) as? String?,
             attributes.remove(RumAttributes.GRAPHQL_VARIABLES) as? String?
         )
+        val eventAttributes = attributes.toMutableMap()
         sdkCore.newRumEventWriteOperation(writer) { datadogContext ->
             val user = datadogContext.userInfo
             val hasReplay = featuresContextResolver.resolveViewHasReplay(
@@ -269,7 +270,7 @@ internal class RumResourceScope(
                     brand = datadogContext.deviceInfo.deviceBrand,
                     architecture = datadogContext.deviceInfo.architecture
                 ),
-                context = ResourceEvent.Context(additionalProperties = attributes),
+                context = ResourceEvent.Context(additionalProperties = eventAttributes),
                 dd = ResourceEvent.Dd(
                     traceId = traceId,
                     spanId = spanId,
@@ -333,6 +334,7 @@ internal class RumResourceScope(
 
         val rumContext = getRumContext()
 
+        val eventAttributes = attributes.toMutableMap()
         val syntheticsAttribute = if (
             rumContext.syntheticsTestId.isNullOrBlank() ||
             rumContext.syntheticsResultId.isNullOrBlank()
@@ -411,7 +413,7 @@ internal class RumResourceScope(
                     brand = datadogContext.deviceInfo.deviceBrand,
                     architecture = datadogContext.deviceInfo.architecture
                 ),
-                context = ErrorEvent.Context(additionalProperties = attributes),
+                context = ErrorEvent.Context(additionalProperties = eventAttributes),
                 dd = ErrorEvent.Dd(
                     session = ErrorEvent.DdSession(
                         plan = ErrorEvent.Plan.PLAN_1,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -725,6 +725,9 @@ internal open class RumViewScope(
         val memoryInfo = lastMemoryInfo
         val refreshRateInfo = lastFrameRateInfo
         val isSlowRendered = resolveRefreshRateInfo(refreshRateInfo) ?: false
+        // make a copy - by the time we iterate over it on another thread, it may already be changed
+        val eventFeatureFlags = featureFlags.toMutableMap()
+        val eventAdditionalAttributes = attributes.toMutableMap()
 
         sdkCore.newRumEventWriteOperation(writer) { datadogContext ->
             val currentViewId = rumContext.viewId.orEmpty()
@@ -757,7 +760,7 @@ internal open class RumViewScope(
 
             ViewEvent(
                 date = eventTimestamp,
-                featureFlags = ViewEvent.Context(additionalProperties = featureFlags),
+                featureFlags = ViewEvent.Context(additionalProperties = eventFeatureFlags),
                 view = ViewEvent.ViewEventView(
                     id = currentViewId,
                     name = rumContext.viewName,
@@ -821,7 +824,7 @@ internal open class RumViewScope(
                     brand = datadogContext.deviceInfo.deviceBrand,
                     architecture = datadogContext.deviceInfo.architecture
                 ),
-                context = ViewEvent.Context(additionalProperties = attributes),
+                context = ViewEvent.Context(additionalProperties = eventAdditionalAttributes),
                 dd = ViewEvent.Dd(
                     documentVersion = eventVersion,
                     session = ViewEvent.DdSession(


### PR DESCRIPTION
### What does this PR do?

This PR makes a copy of the attributes used by the different RUM events, because usually these attributes are stored in as the shared property of the RUM scope, they could be modified by the RUM thread while being read during the serialization on the I/O thread.

This will eventually prevent `ConcurrentModificationException`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

