### PR TITLE
RUM-1702: Start session when RUM is initialized

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -6,21 +6,15 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import android.app.ActivityManager
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
-import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.RumSessionListener
-import com.datadog.android.rum.internal.AppStartTimeProvider
-import com.datadog.android.rum.internal.DefaultAppStartTimeProvider
 import com.datadog.android.rum.internal.domain.RumContext
-import com.datadog.android.rum.internal.domain.Time
 import com.datadog.android.rum.internal.vitals.VitalMonitor
-import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")
 internal class RumApplicationScope(
@@ -33,8 +27,7 @@ internal class RumApplicationScope(
     private val cpuVitalMonitor: VitalMonitor,
     private val memoryVitalMonitor: VitalMonitor,
     private val frameRateVitalMonitor: VitalMonitor,
-    private val sessionListener: RumSessionListener?,
-    private val appStartTimeProvider: AppStartTimeProvider = DefaultAppStartTimeProvider()
+    private val sessionListener: RumSessionListener?
 ) : RumScope, RumViewChangedListener {
 
     private var rumContext = RumContext(applicationId = applicationId)
@@ -62,7 +55,6 @@ internal class RumApplicationScope(
         }
 
     private var lastActiveViewInfo: RumViewInfo? = null
-    private var isSentAppStartedEvent = false
 
     // region RumScope
 
@@ -85,10 +77,6 @@ internal class RumApplicationScope(
             sdkCore.updateFeatureContext(Feature.RUM_FEATURE_NAME) {
                 it.putAll(getRumContext().toMap())
             }
-        }
-
-        if (!isSentAppStartedEvent) {
-            sendApplicationStartEvent(event.eventTime, writer)
         }
 
         delegateToChildren(event, writer)
@@ -166,37 +154,9 @@ internal class RumApplicationScope(
         }
     }
 
-    @WorkerThread
-    private fun sendApplicationStartEvent(eventTime: Time, writer: DataWriter<Any>) {
-        val processImportance = DdRumContentProvider.processImportance
-        val isForegroundProcess = processImportance ==
-                ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-        if (isForegroundProcess) {
-            val processStartTimeNs = appStartTimeProvider.appStartTimeNs
-            // processStartTime is the time in nanoseconds since VM start. To get a timestamp, we want
-            // to convert it to milliseconds since epoch provided by System.currentTimeMillis.
-            // To do so, we take the offset of those times in the event time, which should be consistent,
-            // then add that to our processStartTime to get the correct value.
-            val timestampNs = (
-                    TimeUnit.MILLISECONDS.toNanos(eventTime.timestamp) - eventTime.nanoTime
-                    ) + processStartTimeNs
-            val applicationLaunchViewTime = Time(
-                timestamp = TimeUnit.NANOSECONDS.toMillis(timestampNs),
-                nanoTime = processStartTimeNs
-            )
-            val startupTime = eventTime.nanoTime - processStartTimeNs
-            val appStartedEvent =
-                RumRawEvent.ApplicationStarted(applicationLaunchViewTime, startupTime)
-            delegateToChildren(appStartedEvent, writer)
-            isSentAppStartedEvent = true
-        }
-    }
-
     // endregion
 
     companion object {
-        internal const val LAST_ACTIVE_VIEW_GONE_WARNING_MESSAGE = "Attempting to start a new " +
-                "session on the last known view (%s) failed because that view has been disposed. "
         internal const val MULTIPLE_ACTIVE_SESSIONS_ERROR = "Application has multiple active " +
                 "sessions when starting a new session"
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -215,4 +215,10 @@ internal sealed class RumRawEvent {
         override val eventTime: Time = Time(),
         val isMetric: Boolean = false
     ) : RumRawEvent()
+
+    internal data class SdkInit(
+        val isAppInForeground: Boolean,
+        val appStartTimeNs: Long,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -280,7 +280,7 @@ internal class RumViewManagerScope(
         internal const val MESSAGE_MISSING_VIEW =
             "A RUM event was detected, but no view is active. " +
                     "To track views automatically, try calling the " +
-                    "Configuration.Builder.useViewTrackingStrategy() method.\n" +
+                    "RumConfiguration.Builder.useViewTrackingStrategy() method.\n" +
                     "You can also track views manually using the RumMonitor.startView() and " +
                     "RumMonitor.stopView() methods."
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -22,6 +22,8 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
 
     fun resetSession()
 
+    fun start()
+
     fun sendWebViewEvent()
 
     fun addLongTask(durationNs: Long, target: String)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.monitor
 
+import android.app.ActivityManager
 import android.os.Handler
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
@@ -14,6 +15,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.internal.utils.submitSafe
+import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -23,7 +25,9 @@ import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum._RumInternalProxy
+import com.datadog.android.rum.internal.AppStartTimeProvider
 import com.datadog.android.rum.internal.CombinedRumSessionListener
+import com.datadog.android.rum.internal.DefaultAppStartTimeProvider
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.debug.RumDebugListener
@@ -66,6 +70,7 @@ internal class DatadogRumMonitor(
     memoryVitalMonitor: VitalMonitor,
     frameRateVitalMonitor: VitalMonitor,
     sessionListener: RumSessionListener,
+    private val appStartTimeProvider: AppStartTimeProvider = DefaultAppStartTimeProvider(),
     private val executorService: ExecutorService = Executors.newSingleThreadExecutor()
 ) : RumMonitor, AdvancedRumMonitor {
 
@@ -394,6 +399,16 @@ internal class DatadogRumMonitor(
     override fun resetSession() {
         handleEvent(
             RumRawEvent.ResetSession()
+        )
+    }
+
+    override fun start() {
+        val processImportance = DdRumContentProvider.processImportance
+        val isAppInForeground = processImportance ==
+                ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+        val processStartTimeNs = appStartTimeProvider.appStartTimeNs
+        handleEvent(
+            RumRawEvent.SdkInit(isAppInForeground, processStartTimeNs)
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.rum
 
 import android.os.Looper
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.sampling.RateBasedSampler
@@ -195,6 +196,27 @@ internal class RumTest {
         )
         verify(mockSdkCore, never()).registerFeature(any())
         check(GlobalRumMonitor.get(mockSdkCore) is NoOpRumMonitor)
+    }
+
+    @Test
+    fun `𝕄 register nothing 𝕎 build() { RUM feature already registered }`(
+        @Forgery fakeRumConfiguration: RumConfiguration
+    ) {
+        // Given
+        val mockInternalLogger = mock<InternalLogger>()
+        whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mock()
+
+        // When
+        Rum.enable(fakeRumConfiguration, mockSdkCore)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            Rum.RUM_FEATURE_ALREADY_ENABLED
+        )
+        verify(mockSdkCore, never()).registerFeature(any())
     }
 
     companion object {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
-import android.app.ActivityManager
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.context.TimeInfo
 import com.datadog.android.api.feature.Feature
@@ -14,10 +13,8 @@ import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
-import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumSessionListener
-import com.datadog.android.rum.internal.AppStartTimeProvider
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.utils.forge.Configurator
@@ -47,7 +44,6 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
-import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -70,9 +66,6 @@ internal class RumApplicationScopeTest {
 
     @Mock
     lateinit var mockResolver: FirstPartyHostHeaderTypeResolver
-
-    @Mock
-    lateinit var mockAppStartTimeProvider: AppStartTimeProvider
 
     @Mock
     lateinit var mockCpuVitalMonitor: VitalMonitor
@@ -126,8 +119,7 @@ internal class RumApplicationScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockSessionListener,
-            mockAppStartTimeProvider
+            mockSessionListener
         )
     }
 
@@ -368,89 +360,6 @@ internal class RumApplicationScopeTest {
             assertThat(rumContext["application_id"]).isEqualTo(fakeApplicationId)
             assertThat(rumContext["session_id"]).isEqualTo(newSessionId)
             assertThat(rumContext["view_id"]).isNotNull
-        }
-    }
-
-    @Test
-    fun `M send ApplicationStarted event once W handleEvent { app is in foreground }`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeEvents = forge.aList {
-            forge.anyRumEvent(excluding = listOf(RumRawEvent.ApplicationStarted::class.java))
-        }
-        val firstEvent = fakeEvents.first()
-        val appStartTimeNs = forge.aLong(min = 0, max = fakeEvents.first().eventTime.nanoTime)
-        whenever(mockAppStartTimeProvider.appStartTimeNs) doReturn appStartTimeNs
-        DdRumContentProvider.processImportance =
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
-        val mockSessionScope = mock<RumScope>()
-        testedScope.childScopes.clear()
-        testedScope.childScopes += mockSessionScope
-
-        val expectedEventTimestamp =
-            TimeUnit.NANOSECONDS.toMillis(
-                TimeUnit.MILLISECONDS.toNanos(firstEvent.eventTime.timestamp) -
-                    firstEvent.eventTime.nanoTime + appStartTimeNs
-            )
-
-        // When
-        fakeEvents.forEach {
-            testedScope.handleEvent(it, mockWriter)
-        }
-
-        // Then
-        argumentCaptor<RumRawEvent> {
-            verify(mockSessionScope).handleEvent(capture(), eq(mockWriter))
-            assertThat(firstValue).isInstanceOf(RumRawEvent.ApplicationStarted::class.java)
-            val appStartEventTime = (firstValue as RumRawEvent.ApplicationStarted).eventTime
-            assertThat(appStartEventTime.timestamp).isEqualTo(expectedEventTimestamp)
-            assertThat(appStartEventTime.nanoTime).isEqualTo(appStartTimeNs)
-
-            val processStartTimeNs =
-                (firstValue as RumRawEvent.ApplicationStarted).applicationStartupNanos
-            assertThat(processStartTimeNs).isEqualTo(firstEvent.eventTime.nanoTime - appStartTimeNs)
-
-            assertThat(allValues.filterIsInstance<RumRawEvent.ApplicationStarted>()).hasSize(1)
-        }
-    }
-
-    @Test
-    fun `M not send ApplicationStarted event W handleEvent { app is not in foreground }`(
-        forge: Forge
-    ) {
-        // Given
-        val fakeEvents = forge.aList {
-            forge.anyRumEvent(excluding = listOf(RumRawEvent.ApplicationStarted::class.java))
-        }
-        val appStartTimeNs = forge.aLong(min = 0, max = fakeEvents.first().eventTime.nanoTime)
-        whenever(mockAppStartTimeProvider.appStartTimeNs) doReturn appStartTimeNs
-        DdRumContentProvider.processImportance = forge.anElementFrom(
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE,
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING,
-            @Suppress("DEPRECATION")
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING_PRE_28,
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE,
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE,
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE_PRE_26,
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE,
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE,
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED,
-            ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE
-        )
-        val mockSessionScope = mock<RumScope>()
-        testedScope.childScopes.clear()
-        testedScope.childScopes += mockSessionScope
-
-        // When
-        fakeEvents.forEach {
-            testedScope.handleEvent(it, mockWriter)
-        }
-
-        // Then
-        argumentCaptor<RumRawEvent> {
-            verify(mockSessionScope).handleEvent(capture(), eq(mockWriter))
-            assertThat(allValues).doesNotHaveSameClassAs(RumRawEvent.ApplicationStarted::class.java)
         }
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -124,6 +124,15 @@ internal fun Forge.applicationStartedEvent(): RumRawEvent.ApplicationStarted {
     )
 }
 
+internal fun Forge.sdkInitEvent(): RumRawEvent.SdkInit {
+    val time = Time()
+    return RumRawEvent.SdkInit(
+        isAppInForeground = aBool(),
+        appStartTimeNs = aLong(min = 0L, max = time.nanoTime),
+        eventTime = time
+    )
+}
+
 internal fun Forge.validBackgroundEvent(): RumRawEvent {
     return this.anElementFrom(
         listOf(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.monitor
 
+import android.app.ActivityManager
 import android.os.Handler
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
@@ -14,6 +15,7 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -21,6 +23,7 @@ import com.datadog.android.rum.RumPerformanceMetric
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.RumSessionListener
+import com.datadog.android.rum.internal.AppStartTimeProvider
 import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.debug.RumDebugListener
@@ -131,6 +134,9 @@ internal class DatadogRumMonitorTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @Mock
+    lateinit var mockAppStartTimeProvider: AppStartTimeProvider
+
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
 
@@ -142,6 +148,9 @@ internal class DatadogRumMonitorTest {
     @LongForgery(TIMESTAMP_MIN, TIMESTAMP_MAX)
     var fakeTimestamp: Long = 0L
 
+    @LongForgery(min = 0L)
+    var fakeAppStartTimeNs: Long = 0L
+
     @BoolForgery
     var fakeBackgroundTrackingEnabled: Boolean = false
 
@@ -151,6 +160,7 @@ internal class DatadogRumMonitorTest {
     @BeforeEach
     fun `set up`(forge: Forge) {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
+        whenever(mockAppStartTimeProvider.appStartTimeNs) doReturn fakeAppStartTimeNs
 
         fakeAttributes = forge.exhaustiveAttributes()
         testedMonitor = DatadogRumMonitor(
@@ -166,7 +176,8 @@ internal class DatadogRumMonitorTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
-            mockSessionListener
+            mockSessionListener,
+            mockAppStartTimeProvider
         )
         testedMonitor.rootScope = mockScope
     }
@@ -746,6 +757,65 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
+    fun `M delegate event to rootScope W start() { application is in foreground }`() {
+        // Given
+        DdRumContentProvider.processImportance =
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND
+
+        // When
+        testedMonitor.start()
+        Thread.sleep(PROCESSING_DELAY)
+
+        // Then
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            assertThat(firstValue).isInstanceOf(RumRawEvent.SdkInit::class.java)
+            with(firstValue as RumRawEvent.SdkInit) {
+                assertThat(isAppInForeground).isTrue()
+                assertThat(appStartTimeNs).isEqualTo(fakeAppStartTimeNs)
+            }
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W start() { application is not in foreground }`(
+        forge: Forge
+    ) {
+        // Given
+        DdRumContentProvider.processImportance = forge.anElementFrom(
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND_SERVICE,
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING,
+            @Suppress("DEPRECATION")
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_TOP_SLEEPING_PRE_28,
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE,
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE,
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_PERCEPTIBLE_PRE_26,
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_CANT_SAVE_STATE,
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_SERVICE,
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_CACHED,
+            ActivityManager.RunningAppProcessInfo.IMPORTANCE_GONE
+        )
+
+        // When
+        testedMonitor.start()
+        Thread.sleep(PROCESSING_DELAY)
+
+        // Then
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            assertThat(firstValue).isInstanceOf(RumRawEvent.SdkInit::class.java)
+            with(firstValue as RumRawEvent.SdkInit) {
+                assertThat(isAppInForeground).isFalse()
+                assertThat(appStartTimeNs).isEqualTo(fakeAppStartTimeNs)
+            }
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
     fun `M delegate event to rootScope with timestamp W startView()`(
         @StringForgery(type = StringForgeryType.ASCII) key: String,
         @StringForgery name: String
@@ -1317,6 +1387,7 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
+            mockAppStartTimeProvider,
             mockExecutor
         )
 
@@ -1361,6 +1432,7 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
+            mockAppStartTimeProvider,
             mockExecutorService
         )
 
@@ -1392,6 +1464,7 @@ internal class DatadogRumMonitorTest {
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
             mockSessionListener,
+            mockAppStartTimeProvider,
             mockExecutorService
         )
         whenever(mockExecutorService.isShutdown).thenReturn(true)

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/ActivityTrackingPlaygroundActivity.kt
@@ -33,19 +33,19 @@ internal class ActivityTrackingPlaygroundActivity : AppCompatActivity() {
         val sdkCore = Datadog.initialize(this, config, trackingConsent)
         checkNotNull(sdkCore)
 
-        val rumConfig = RuntimeConfig.rumConfigBuilder()
-            .trackUserInteractions()
-            .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
-            .useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
-            .build()
-        Rum.enable(rumConfig, sdkCore)
-
         DdRumContentProvider::class.java.declaredMethods.firstOrNull() {
             it.name == "overrideProcessImportance"
         }?.apply {
             isAccessible = true
             invoke(null, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
         }
+
+        val rumConfig = RuntimeConfig.rumConfigBuilder()
+            .trackUserInteractions()
+            .trackLongTasks(RuntimeConfig.LONG_TASK_LARGE_THRESHOLD)
+            .useViewTrackingStrategy(ActivityViewTrackingStrategy(true))
+            .build()
+        Rum.enable(rumConfig, sdkCore)
         setContentView(R.layout.fragment_tracking_layout)
     }
 }


### PR DESCRIPTION
### What does this PR do?

This change starts RUM session during the `Rum.enable` call. The general rule is like that:

* If application process has `foreground` type, then session will be started (with interaction time set at the moment of initialization), and `ApplicationLaunch` view with `application_started` event will be created.
* Otherwise, if application process has something different from `foreground` as type, session will be initialized only if background tracking is enabled, no `ApplicationLaunch` view will be created.

This PR is using the notion of `SdkInit` class, even though it is possible to use only `ApplicationStarted` event in order to be on-par with the similar logic in iOS SDK. Also it is still using event system for the session initialization in order to minimize the footprint of the change (it will be easier to rollback it if needed).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

