### PR TITLE
Enable setting DatadogCore features through reflection

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
@@ -190,7 +190,7 @@ internal class DatadogCore(
         featureName: String,
         updateCallback: (context: MutableMap<String, Any?>) -> Unit
     ) {
-        val feature = features[featureName] ?: return
+        val feature = getFeature(featureName) ?: return
         contextProvider?.let {
             synchronized(feature) {
                 val featureContext = it.getFeatureContext(featureName)


### PR DESCRIPTION
### What does this PR do?

Enable calling `updateFeatureContext` after the `features` attribute has been set through reflection.

### Motivation

When using reflection to set DatadogCore features in UI-level tests we cannot set a value with the internal `SdkFeature` type.
This creates an issue when calling `features[featureName]` as the type is not the expected one and so the thread stops here ([see here for more context](https://github.com/DataDog/dd-sdk-reactnative/pull/587/files#diff-e77ae76bffe30485fd02474f4cb441a7fd332502d11266eb8f29151efbfa29baR57-R65)). This creates an issue because this is called when creating enw RUM Views, which makes the UI-level tests hard to use.

However if we expect a `FeatureScope` (public type) this does not break anymore. 

We don't need the `SdkFeature` type for this function, we just need the object for synchronization, so there's no functional impact. I don't know if it has a performance impact.

### Additional Notes

Alternatives could be:
- using `as? FeatureScope` 
- making `SdkFeature` public so we can use this type outside of the SDK.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

