### PR TITLE
RUM-2600: Add traversal flag to snapshot items

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
@@ -254,7 +254,7 @@ internal class RecordedDataQueueHandler {
 
     internal companion object {
         @VisibleForTesting
-        internal const val MAX_DELAY_MS = 200L
+        internal const val MAX_DELAY_MS = 1000L
 
         private val THREAD_POOL_MAX_KEEP_ALIVE_MS = TimeUnit.SECONDS.toMillis(5)
         private const val CORE_DEFAULT_POOL_SIZE = 1 // Only one thread will be kept alive

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
@@ -65,9 +65,12 @@ internal class WindowsOnDrawListener(
 
         if (nodes.isNotEmpty()) {
             item.nodes = nodes
-            if (item.isReady()) {
-                recordedDataQueueHandler.tryToConsumeItems()
-            }
+        }
+
+        item.isFinishedTraversal = true
+
+        if (item.isReady()) {
+            recordedDataQueueHandler.tryToConsumeItems()
         }
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
@@ -420,6 +420,7 @@ internal class RecordedDataQueueHandlerTest {
         // Given
         val item = testedHandler.addSnapshotItem(mockSystemInformation) ?: fail("item is null")
         item.nodes = fakeNodeData
+        item.isFinishedTraversal = true
 
         whenever(mockTimeProvider.getDeviceTimestamp())
             .thenReturn(item.recordedQueuedItemContext.timestamp)
@@ -463,6 +464,10 @@ internal class RecordedDataQueueHandlerTest {
         val item1 = createFakeSnapshotItemWithDelayMs(1)
         val item2 = createFakeSnapshotItemWithDelayMs(2)
         val item3 = createFakeSnapshotItemWithDelayMs(3)
+
+        item1.isFinishedTraversal = true
+        item2.isFinishedTraversal = true
+        item3.isFinishedTraversal = true
 
         assertThat(testedHandler.recordedDataQueue.size).isEqualTo(3)
         val itemTimestamp = item1.recordedQueuedItemContext.timestamp


### PR DESCRIPTION
### What does this PR do?
Adds a flag to snapshot items that indicates that they have finished traversing the view tree. Also, increases the interval that snapshots are considered stale from 200ms to 1 second

### Motivation
The RecordedDataQueueHandler in some situations could attempt to process an item that was still performing a traversal. Because items are inserted into the queue at the beginning of their traversals without nodes, the handler could regard the item as invalid and drop it from the queue. With this change, items that haven't finished traversals will only be dropped if stale. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

