### PR TITLE
RUM-1633 Drop batch telemetry where duration or age have negative values

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
@@ -84,12 +84,18 @@ internal class BatchMetricsDispatcher(
 
     // region Internal
 
+    @SuppressWarnings("ReturnCount")
     private fun resolveBatchDeletedMetricAttributes(
         file: File,
         deletionReason: RemovalReason
     ): Map<String, Any?>? {
         val fileCreationTimestamp = file.nameAsTimestampSafe(internalLogger) ?: return null
         val fileAgeInMillis = dateTimeProvider.getDeviceTimestamp() - fileCreationTimestamp
+        if (fileAgeInMillis < 0) {
+            // the device time was manually modified or the time zone changed
+            // we are dropping this metric to not skew our charts
+            return null
+        }
         return mapOf(
             TRACK_KEY to trackName,
             TYPE_KEY to BATCH_DELETED_TYPE_VALUE,
@@ -108,12 +114,18 @@ internal class BatchMetricsDispatcher(
         )
     }
 
+    @SuppressWarnings("ReturnCount")
     private fun resolveBatchClosedMetricAttributes(
         file: File,
         batchMetadata: BatchClosedMetadata
     ): Map<String, Any?>? {
         val fileCreationTimestamp = file.nameAsTimestampSafe(internalLogger) ?: return null
         val batchDurationInMs = batchMetadata.lastTimeWasUsedInMs - fileCreationTimestamp
+        if (batchDurationInMs < 0) {
+            // the device time was manually modified or the time zone changed
+            // we are dropping this metric to not skew our charts
+            return null
+        }
         return mapOf(
             TRACK_KEY to trackName,
             TYPE_KEY to BATCH_CLOSED_TYPE_VALUE,


### PR DESCRIPTION
### What does this PR do?

In order to prevent the graphs skewing in the telemetry dashboards we are dropping the metrics for which the batch age and batch duration values are negatives due to the device time manual modification or time zone change. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

