### PR TITLE
RUM-3150 Set source_type on native crashes to `ndk`

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -296,6 +296,7 @@ object com.datadog.android.log.LogAttributes
   const val ERROR_KIND: String
   const val ERROR_MESSAGE: String
   const val ERROR_STACK: String
+  const val ERROR_SOURCE_TYPE: String
   const val HOST: String
   const val HTTP_METHOD: String
   const val HTTP_REFERRER: String

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -756,6 +756,7 @@ public final class com/datadog/android/log/LogAttributes {
 	public static final field ENV Ljava/lang/String;
 	public static final field ERROR_KIND Ljava/lang/String;
 	public static final field ERROR_MESSAGE Ljava/lang/String;
+	public static final field ERROR_SOURCE_TYPE Ljava/lang/String;
 	public static final field ERROR_STACK Ljava/lang/String;
 	public static final field HOST Ljava/lang/String;
 	public static final field HTTP_METHOD Ljava/lang/String;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -340,6 +340,7 @@ object Datadog {
     internal const val DD_SOURCE_TAG = "_dd.source"
     internal const val DD_SDK_VERSION_TAG = "_dd.sdk_version"
     internal const val DD_APP_VERSION_TAG = "_dd.version"
+    internal const val DD_NATIVE_SOURCE_TYPE = "_dd.native_source_type"
 
     // endregion
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
@@ -105,6 +105,12 @@ object LogAttributes {
     const val ERROR_STACK: String = "error.stack"
 
     /**
+     * The source type of the error. This value is used to indicate the language or platform
+     * that the error originates from, such as Flutter, React Native, or the NDK. (String)
+     */
+    const val ERROR_SOURCE_TYPE: String = "error.source_type"
+
+    /**
      * The name of the originating host as defined in metrics. (String)
      * This value is automatically filled by the Datadog framework.
      */

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
@@ -36,7 +36,8 @@ internal class DatadogNdkCrashHandler(
     private val userInfoDeserializer: Deserializer<String, UserInfo>,
     private val internalLogger: InternalLogger,
     private val rumFileReader: BatchFileReader,
-    private val envFileReader: FileReader<ByteArray>
+    private val envFileReader: FileReader<ByteArray>,
+    internal val nativeCrashSourceType: String = "ndk"
 ) : NdkCrashHandler {
 
     internal val ndkCrashDataDirectory: File = getNdkGrantedDir(storageDir)
@@ -255,16 +256,19 @@ internal class DatadogNdkCrashHandler(
                     LogAttributes.RUM_SESSION_ID to sessionId,
                     LogAttributes.RUM_APPLICATION_ID to applicationId,
                     LogAttributes.RUM_VIEW_ID to viewId,
-                    LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace
+                    LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace,
+                    LogAttributes.ERROR_SOURCE_TYPE to nativeCrashSourceType
                 )
             } else {
                 mapOf(
-                    LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace
+                    LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace,
+                    LogAttributes.ERROR_SOURCE_TYPE to nativeCrashSourceType
                 )
             }
         } else {
             mapOf(
-                LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace
+                LogAttributes.ERROR_STACK to ndkCrashLog.stacktrace,
+                LogAttributes.ERROR_SOURCE_TYPE to nativeCrashSourceType
             )
         }
         return logAttributes
@@ -283,6 +287,7 @@ internal class DatadogNdkCrashHandler(
             rumFeature.sendEvent(
                 mapOf(
                     "type" to "ndk_crash",
+                    "sourceType" to nativeCrashSourceType,
                     "timestamp" to ndkCrashLog.timestamp,
                     "signalName" to ndkCrashLog.signalName,
                     "stacktrace" to ndkCrashLog.stacktrace,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumErrorSourceType.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumErrorSourceType.kt
@@ -14,5 +14,7 @@ internal enum class RumErrorSourceType {
     ANDROID,
     BROWSER,
     REACT_NATIVE,
-    FLUTTER
+    FLUTTER,
+    NDK,
+    NDK_IL2CPP
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumEventExt.kt
@@ -103,6 +103,8 @@ internal fun RumErrorSourceType.toSchemaSourceType(): ErrorEvent.SourceType {
         RumErrorSourceType.BROWSER -> ErrorEvent.SourceType.BROWSER
         RumErrorSourceType.REACT_NATIVE -> ErrorEvent.SourceType.REACT_NATIVE
         RumErrorSourceType.FLUTTER -> ErrorEvent.SourceType.FLUTTER
+        RumErrorSourceType.NDK -> ErrorEvent.SourceType.NDK
+        RumErrorSourceType.NDK_IL2CPP -> ErrorEvent.SourceType.NDK_IL2CPP
     }
 }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -704,6 +704,8 @@ internal class DatadogRumMonitor(
             "react-native" -> RumErrorSourceType.REACT_NATIVE
             "browser" -> RumErrorSourceType.BROWSER
             "flutter" -> RumErrorSourceType.FLUTTER
+            "ndk" -> RumErrorSourceType.NDK
+            "ndk+il2cpp" -> RumErrorSourceType.NDK_IL2CPP
             else -> RumErrorSourceType.ANDROID
         }
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/ndk/DatadogNdkCrashEventHandler.kt
@@ -38,6 +38,7 @@ internal class DatadogNdkCrashEventHandler(
             return
         }
 
+        val sourceType = event["sourceType"] as? String
         val timestamp = event["timestamp"] as? Long
         val signalName = event["signalName"] as? String
         val stacktrace = event["stacktrace"] as? String
@@ -63,6 +64,7 @@ internal class DatadogNdkCrashEventHandler(
         rumFeature.withWriteContext { datadogContext, eventBatchWriter ->
             val toSendErrorEvent = resolveErrorEventFromViewEvent(
                 datadogContext,
+                sourceType,
                 errorLogMessage,
                 timestamp,
                 stacktrace,
@@ -84,6 +86,7 @@ internal class DatadogNdkCrashEventHandler(
     @Suppress("LongMethod", "LongParameterList")
     private fun resolveErrorEventFromViewEvent(
         datadogContext: DatadogContext,
+        sourceTypeStr: String?,
         errorLogMessage: String,
         timestamp: Long,
         stacktrace: String,
@@ -107,6 +110,21 @@ internal class DatadogNdkCrashEventHandler(
         val hasUserInfo = user?.id != null || user?.name != null ||
             user?.email != null || additionalUserProperties.isNotEmpty()
         val deviceInfo = datadogContext.deviceInfo
+
+        val sourceType = sourceTypeStr?.let {
+            @Suppress("TooGenericExceptionCaught")
+            try {
+                ErrorEvent.SourceType.fromJson(sourceTypeStr)
+            } catch (e: Exception) {
+                internalLogger.log(
+                    InternalLogger.Level.ERROR,
+                    InternalLogger.Target.TELEMETRY,
+                    { "Error parsing source type from NDK crash event: $sourceTypeStr" },
+                    e
+                )
+                ErrorEvent.SourceType.NDK
+            }
+        } ?: ErrorEvent.SourceType.NDK
 
         return ErrorEvent(
             date = timestamp + datadogContext.time.serverTimeOffsetMs,
@@ -162,7 +180,7 @@ internal class DatadogNdkCrashEventHandler(
                 stack = stacktrace,
                 isCrash = true,
                 type = signalName,
-                sourceType = ErrorEvent.SourceType.ANDROID
+                sourceType = sourceType
             ),
             version = viewEvent.version
         )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1102,6 +1102,8 @@ internal class DatadogRumMonitorTest {
             "browser" to RumErrorSourceType.BROWSER,
             "react-native" to RumErrorSourceType.REACT_NATIVE,
             "flutter" to RumErrorSourceType.FLUTTER,
+            "ndk" to RumErrorSourceType.NDK,
+            "ndk+il2cpp" to RumErrorSourceType.NDK_IL2CPP,
             nonSupportedValue to RumErrorSourceType.ANDROID,
             null to RumErrorSourceType.ANDROID
         )


### PR DESCRIPTION
### What does this PR do?

To properly symbolicate NDK crashes, we need to know that the provided stack trace is an NDK trace, instead of a standard Java stack trace. This changes it so that crashes caught by the NDK crash reporter report an `error.source_type` as "ndk" to both Logs and RUM.

Additionally, because certain platforms will want to override symbolication behavior, we provide a way to change the default native source type by using the `_dd.native_source_type` additional configuration option.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

