### PR TITLE
RUM-3281 Implement webview bridge getCapabilities

### DIFF
--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/DatadogEventBridge.kt
@@ -61,9 +61,22 @@ internal class DatadogEventBridge(
         return privacyLevel
     }
 
+    /**
+     *  Called from the browser-sdk to know the capabilities supported by this version of the bridge.
+     *  @return the capabilities as an array of Strings.
+     */
+    @JavascriptInterface
+    fun getCapabilities(): String {
+        return capabilities.toString()
+    }
+
     // endregion
 
     companion object {
         internal const val WEB_VIEW_TRACKING_FEATURE_NAME = "WebView"
+
+        internal val capabilities = JsonArray().apply {
+            add("records")
+        }
     }
 }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/DatadogEventBridgeTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/DatadogEventBridgeTest.kt
@@ -19,7 +19,6 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.quality.Strictness
 import java.net.URL
@@ -62,7 +61,7 @@ internal class DatadogEventBridgeTest {
     fun `M return sanitized webViewTrackingHosts W getAllowedWebViewHosts() { allow IP addresses }`(
         @StringForgery(
             regex = "(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}" +
-                "([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])"
+                    "([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])"
         ) hosts: List<String>
     ) {
         // Given
@@ -80,7 +79,7 @@ internal class DatadogEventBridgeTest {
     fun `M return sanitized webViewTrackingHosts W getAllowedWebViewHosts() { allow host names }`(
         @StringForgery(
             regex = "(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])\\.)+" +
-                "([A-Za-z]|[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9])"
+                    "([A-Za-z]|[A-Za-z][A-Za-z0-9-]*[A-Za-z0-9])"
         ) hosts: List<String>
     ) {
         // Given
@@ -127,5 +126,17 @@ internal class DatadogEventBridgeTest {
 
         // Then
         assertThat(privacyLevel).isEqualTo(fakePrivacyLevel)
+    }
+
+    @Test
+    fun `M return the supported capabilities W getCapabilities()`() {
+        // Given
+        val expectedCapabilities = "[\"records\"]"
+
+        // When
+        val capabilities = testedDatadogEventBridge.getCapabilities()
+
+        // Then
+        assertThat(capabilities).isEqualTo(expectedCapabilities)
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/WebViewModel.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/webview/WebViewModel.kt
@@ -6,7 +6,6 @@
 package com.datadog.android.sample.webview
 
 import androidx.lifecycle.ViewModel
-import com.datadog.android.sample.BuildConfig
 import com.datadog.android.vendor.sample.LocalServer
 
 internal class WebViewModel(
@@ -17,10 +16,7 @@ internal class WebViewModel(
 
     fun onResume() {
         localServer.start(
-            "https://datadoghq.dev/browser-sdk-test-playground/" +
-                "?client_token=${BuildConfig.DD_CLIENT_TOKEN}" +
-                "&application_id=${BuildConfig.DD_RUM_APPLICATION_ID}" +
-                "&site=datadoghq.com"
+            "https://datadoghq.dev/browser-sdk-test-playground/webview-support/"
         )
     }
 


### PR DESCRIPTION
### What does this PR do?

Following the updated bridge RFC, we implement `getCapabilities` to let the Browser SDK know which events are supported by the SDK.

