### PR TITLE
RUM-3338 Allow disabling ANR tracking

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -79,6 +79,7 @@ data class com.datadog.android.rum.RumConfiguration
     fun setVitalsUpdateFrequency(com.datadog.android.rum.configuration.VitalsUpdateFrequency): Builder
     fun useCustomEndpoint(String): Builder
     fun setSessionListener(RumSessionListener): Builder
+    fun trackApplicationNotResponding(Boolean): Builder
     fun build(): RumConfiguration
 enum com.datadog.android.rum.RumErrorSource
   - NETWORK

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -106,6 +106,7 @@ public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public final fun setTelemetrySampleRate (F)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setViewEventMapper (Lcom/datadog/android/rum/event/ViewEventMapper;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun setVitalsUpdateFrequency (Lcom/datadog/android/rum/configuration/VitalsUpdateFrequency;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun trackApplicationNotResponding (Z)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun trackBackgroundEvents (Z)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun trackFrustrations (Z)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun trackLongTasks ()Lcom/datadog/android/rum/RumConfiguration$Builder;

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -243,6 +243,17 @@ data class RumConfiguration internal constructor(
         }
 
         /**
+         * Enable or disable ANR tracking.
+         * This tracking uses a custom heuristic to estimate ANRs, but might give different result than the
+         * Google Play Store.
+         * @param enabled whether ANR tracking should be enabled (default: true)
+         */
+        fun trackApplicationNotResponding(enabled: Boolean): Builder {
+            rumConfig = rumConfig.copy(anrTrackingEnabled = enabled)
+            return this
+        }
+
+        /**
          * Builds a [RumConfiguration] based on the current state of this Builder.
          */
         fun build(): RumConfiguration {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -94,6 +94,7 @@ internal class RumConfigurationBuilderTest {
                 trackFrustrations = true,
                 vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE,
                 sessionListener = NoOpRumSessionListener(),
+                anrTrackingEnabled = true,
                 additionalConfig = emptyMap()
             )
         )
@@ -501,5 +502,39 @@ internal class RumConfigurationBuilderTest {
         // Then
         assertThat(rumConfiguration.featureConfiguration.sessionListener)
             .isSameAs(mockSessionListener)
+    }
+
+    @Test
+    fun `𝕄 build config with ANR enabled 𝕎 setANRTrackingEnabled(true) and build()`() {
+        // Given
+
+        // When
+        val rumConfiguration = testedBuilder
+            .trackApplicationNotResponding(true)
+            .build()
+
+        // Then
+        assertThat(rumConfiguration.featureConfiguration).isEqualTo(
+            RumFeature.DEFAULT_RUM_CONFIG.copy(
+                anrTrackingEnabled = true
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with ANR disabled 𝕎 setANRTrackingEnabled(false) and build()`() {
+        // Given
+
+        // When
+        val rumConfiguration = testedBuilder
+            .trackApplicationNotResponding(false)
+            .build()
+
+        // Then
+        assertThat(rumConfiguration.featureConfiguration).isEqualTo(
+            RumFeature.DEFAULT_RUM_CONFIG.copy(
+                anrTrackingEnabled = false
+            )
+        )
     }
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -729,6 +729,48 @@ internal class RumFeatureTest {
             .unregisterActivityLifecycleCallbacks(listener)
     }
 
+    @Test
+    fun `𝕄 start ANR tracking 𝕎 onInitialise() {ANR enabled}`() {
+        // Given
+        fakeConfiguration = fakeConfiguration.copy(
+            anrTrackingEnabled = true
+        )
+        testedFeature = RumFeature(
+            mockSdkCore,
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
+        )
+
+        // When
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        // Then
+        assertThat(testedFeature.anrDetectorExecutorService).isNotNull()
+        assertThat(testedFeature.anrDetectorRunnable).isNotNull()
+    }
+
+    @Test
+    fun `𝕄 not start ANR tracking 𝕎 onInitialise() {ANR disabled}`() {
+        // Given
+        fakeConfiguration = fakeConfiguration.copy(
+            anrTrackingEnabled = false
+        )
+        testedFeature = RumFeature(
+            mockSdkCore,
+            fakeApplicationId.toString(),
+            fakeConfiguration,
+            ndkCrashEventHandlerFactory = { mockNdkCrashEventHandler }
+        )
+
+        // When
+        testedFeature.onInitialize(appContext.mockInstance)
+
+        // Then
+        assertThat(testedFeature.anrDetectorExecutorService).isNull()
+        assertThat(testedFeature.anrDetectorRunnable).isNull()
+    }
+
     // region FeatureEventReceiver#onReceive
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -46,6 +46,7 @@ internal class ConfigurationRumForgeryFactory :
             trackFrustrations = forge.aBool(),
             vitalsMonitorUpdateFrequency = forge.aValueFrom(VitalsUpdateFrequency::class.java),
             sessionListener = mock(),
+            anrTrackingEnabled = forge.aBool(),
             additionalConfig = forge.aMap { aString() to aString() }
         )
     }


### PR DESCRIPTION
### What does this PR do?

Add a configuration option to disable ANR tracking in the RUM feature configuration.

### Motivation

Our in-house ANR tracking provides information that are an estimation and not exactly the same as what the Google Play Store console reports. This makes it an optional feature to let customer disable it.
