### PR TITLE
RUM-3068 Add support for global attributes on logs

### DIFF
--- a/features/dd-sdk-android-logs/api/apiSurface
+++ b/features/dd-sdk-android-logs/api/apiSurface
@@ -27,6 +27,8 @@ class com.datadog.android.log.Logger
 object com.datadog.android.log.Logs
   fun enable(LogsConfiguration, com.datadog.android.api.SdkCore = Datadog.getInstance())
   fun isEnabled(com.datadog.android.api.SdkCore = Datadog.getInstance()): Boolean
+  fun addAttribute(String, Any?, com.datadog.android.api.SdkCore = Datadog.getInstance())
+  fun removeAttribute(String, com.datadog.android.api.SdkCore = Datadog.getInstance())
 data class com.datadog.android.log.LogsConfiguration
   class Builder
     fun useCustomEndpoint(String): Builder

--- a/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
+++ b/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
@@ -55,12 +55,18 @@ public final class com/datadog/android/log/Logger$Builder {
 
 public final class com/datadog/android/log/Logs {
 	public static final field INSTANCE Lcom/datadog/android/log/Logs;
+	public static final fun addAttribute (Ljava/lang/String;Ljava/lang/Object;)V
+	public static final fun addAttribute (Ljava/lang/String;Ljava/lang/Object;Lcom/datadog/android/api/SdkCore;)V
+	public static synthetic fun addAttribute$default (Ljava/lang/String;Ljava/lang/Object;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
 	public static final fun enable (Lcom/datadog/android/log/LogsConfiguration;)V
 	public static final fun enable (Lcom/datadog/android/log/LogsConfiguration;Lcom/datadog/android/api/SdkCore;)V
 	public static synthetic fun enable$default (Lcom/datadog/android/log/LogsConfiguration;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
 	public static final fun isEnabled ()Z
 	public static final fun isEnabled (Lcom/datadog/android/api/SdkCore;)Z
 	public static synthetic fun isEnabled$default (Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)Z
+	public static final fun removeAttribute (Ljava/lang/String;)V
+	public static final fun removeAttribute (Ljava/lang/String;Lcom/datadog/android/api/SdkCore;)V
+	public static synthetic fun removeAttribute$default (Ljava/lang/String;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/log/LogsConfiguration {

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/Logs.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/Logs.kt
@@ -54,7 +54,7 @@ object Logs {
     }
 
     /**
-     * Add a custom attribute to all future logs sent by loggers created from the given Core
+     * Add a custom attribute to all future logs sent by loggers created from the given SDK core.
      *
      * Values can be nested up to 10 levels deep. Keys
      * using more than 10 levels will be sanitized by SDK.
@@ -82,13 +82,13 @@ object Logs {
     }
 
     /**
-     * Remove a custom attribute from all future logs sent by loggers created from the given Core
+     * Remove a custom attribute from all future logs sent by loggers created from the given SDK core.
      *
      * Previous logs won't lose the attribute value associated with this key if they were created
      * prior to this call.
      *
      * @param key the key of the attribute to remove
-     * @param sdkCore the [SdkCore] instance to add the attribute to. If not provided, the default
+     * @param sdkCore the [SdkCore] instance to remove the attribute from. If not provided, the default
      * instance is used.
      */
     @JvmOverloads

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/Logs.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/Logs.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.log
 
 import com.datadog.android.Datadog
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
@@ -51,4 +52,63 @@ object Logs {
     fun isEnabled(sdkCore: SdkCore = Datadog.getInstance()): Boolean {
         return (sdkCore as FeatureSdkCore).getFeature(Feature.LOGS_FEATURE_NAME) != null
     }
+
+    /**
+     * Add a custom attribute to all future logs sent by loggers created from the given Core
+     *
+     * Values can be nested up to 10 levels deep. Keys
+     * using more than 10 levels will be sanitized by SDK.
+     *
+     * @param key the key for this attribute
+     * @param value the attribute value
+     * @param sdkCore the [SdkCore] instance to add the attribute to. If not provided, the default
+     * instance is used.
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun addAttribute(key: String, value: Any?, sdkCore: SdkCore = Datadog.getInstance()) {
+        val featureCore = sdkCore as FeatureSdkCore
+        val logsFeature = featureCore.getFeature(Feature.LOGS_FEATURE_NAME)?.unwrap<LogsFeature>()
+        if (logsFeature == null) {
+            sdkCore.internalLogger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.USER,
+                { LOGS_NOT_ENABLED_MESSAGE }
+            )
+            return
+        } else {
+            logsFeature.addAttribute(key, value)
+        }
+    }
+
+    /**
+     * Remove a custom attribute from all future logs sent by loggers created from the given Core
+     *
+     * Previous logs won't lose the attribute value associated with this key if they were created
+     * prior to this call.
+     *
+     * @param key the key of the attribute to remove
+     * @param sdkCore the [SdkCore] instance to add the attribute to. If not provided, the default
+     * instance is used.
+     */
+    @JvmOverloads
+    @JvmStatic
+    fun removeAttribute(key: String, sdkCore: SdkCore = Datadog.getInstance()) {
+        val featureCore = sdkCore as FeatureSdkCore
+        val logsFeature = featureCore.getFeature(Feature.LOGS_FEATURE_NAME)?.unwrap<LogsFeature>()
+        if (logsFeature == null) {
+            sdkCore.internalLogger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.USER,
+                { LOGS_NOT_ENABLED_MESSAGE }
+            )
+            return
+        } else {
+            logsFeature.removeAttribute(key)
+        }
+    }
+
+    internal const val LOGS_NOT_ENABLED_MESSAGE =
+        "You're trying to add attributes to logs, but the feature is not enabled. " +
+                "Please enable it first."
 }

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -115,6 +115,8 @@ internal class LogsFeature(
         dataWriter = NoOpDataWriter()
         packageName = ""
         initialized.set(false)
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        attributes.clear()
     }
 
     // endregion

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -84,7 +84,7 @@ internal class LogsFeature(
         @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
         return attributes.toMap()
     }
-    
+
     // endregion
 
     // region Feature

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -61,7 +61,7 @@ internal class LogsFeature(
      * @param key the key for this attribute
      * @param value the attribute value
      */
-    fun addAttribute(key: String, value: Any?) {
+    internal fun addAttribute(key: String, value: Any?) {
         if (value == null) {
             attributes[key] = NULL_MAP_VALUE
         } else {
@@ -69,15 +69,13 @@ internal class LogsFeature(
         }
     }
 
-    public
-
     /**
      * Remove a custom attribute from all future logs sent by any logger created from this feature.
      * Previous logs won't lose the attribute value associated with this key if they were created
      * prior to this call.
      * @param key the key of the attribute to remove
      */
-    fun removeAttribute(key: String) {
+    internal fun removeAttribute(key: String) {
         @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
         attributes.remove(key)
     }
@@ -86,6 +84,8 @@ internal class LogsFeature(
         @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
         return attributes.toMap()
     }
+    
+    // endregion
 
     // region Feature
 

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -83,6 +83,7 @@ internal class LogsFeature(
     }
 
     internal fun getAttributes(): Map<String, Any?> {
+        @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
         return attributes.toMap()
     }
 

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -45,7 +45,7 @@ internal class DatadogLogHandler(
         }
 
         val resolvedTimeStamp = timestamp ?: System.currentTimeMillis()
-        var combinedAttributes = attributes
+        val combinedAttributes = attributes.toMutableMap()
         val logsFeature = sdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
         if (logsFeature != null) {
             combinedAttributes = logsFeature.unwrap<LogsFeature>().getAttributes().toMutableMap()

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -45,12 +45,12 @@ internal class DatadogLogHandler(
         }
 
         val resolvedTimeStamp = timestamp ?: System.currentTimeMillis()
-        val combinedAttributes = attributes.toMutableMap()
+        val combinedAttributes = mutableMapOf<String, Any?>()
         val logsFeature = sdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
         if (logsFeature != null) {
-            combinedAttributes = logsFeature.unwrap<LogsFeature>().getAttributes().toMutableMap()
-            combinedAttributes.putAll(attributes)
+            combinedAttributes.putAll(logsFeature.unwrap<LogsFeature>().getAttributes().toMutableMap())
         }
+        combinedAttributes.putAll(attributes)
         if (sampler.sample()) {
             if (logsFeature != null) {
                 val threadName = Thread.currentThread().name
@@ -116,12 +116,13 @@ internal class DatadogLogHandler(
         }
 
         val resolvedTimeStamp = timestamp ?: System.currentTimeMillis()
-        var combinedAttributes = attributes
+        val combinedAttributes = mutableMapOf<String, Any?>()
         val logsFeature = sdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
         if (logsFeature != null) {
-            combinedAttributes = logsFeature.unwrap<LogsFeature>().getAttributes().toMutableMap()
-            combinedAttributes.putAll(attributes)
+            combinedAttributes.putAll(logsFeature.unwrap<LogsFeature>().getAttributes().toMutableMap())
         }
+        combinedAttributes.putAll(attributes)
+
         if (sampler.sample()) {
             if (logsFeature != null) {
                 val threadName = Thread.currentThread().name

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsTest.kt
@@ -96,7 +96,7 @@ internal class LogsTest {
     }
 
     @Test
-    fun `M warn W addAttribute { logs not enabled }`(
+    fun `M log user error W addAttribute { logs not enabled }`(
         @StringForgery key: String,
         @StringForgery value: String
     ) {
@@ -121,7 +121,7 @@ internal class LogsTest {
     }
 
     @Test
-    fun `M warn W removeAttribute { logs not enabled }`(
+    fun `M log user error W removeAttribute { logs not enabled }`(
         @StringForgery key: String
     ) {
         // Given

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/LogsTest.kt
@@ -6,7 +6,9 @@
 
 package com.datadog.android.log
 
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.log.internal.net.LogsRequestFactory
@@ -25,6 +27,8 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isNull
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -89,5 +93,89 @@ internal class LogsTest {
 
         // Then
         assertThat(result).isFalse
+    }
+
+    @Test
+    fun `M warn W addAttribute { logs not enabled }`(
+        @StringForgery key: String,
+        @StringForgery value: String
+    ) {
+        // Given
+        whenever(mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)) doReturn null
+
+        // When
+        Logs.addAttribute(key, value, mockSdkCore)
+
+        // Then
+        argumentCaptor<() -> String> {
+            verify(mockSdkCore.internalLogger).log(
+                eq(InternalLogger.Level.ERROR),
+                eq(InternalLogger.Target.USER),
+                capture(),
+                isNull(),
+                eq(false),
+                eq(null)
+            )
+            assertThat(lastValue()).isEqualTo(Logs.LOGS_NOT_ENABLED_MESSAGE)
+        }
+    }
+
+    @Test
+    fun `M warn W removeAttribute { logs not enabled }`(
+        @StringForgery key: String
+    ) {
+        // Given
+        whenever(mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)) doReturn null
+
+        // When
+        Logs.removeAttribute(key, mockSdkCore)
+
+        // Then
+        argumentCaptor<() -> String> {
+            verify(mockSdkCore.internalLogger).log(
+                eq(InternalLogger.Level.ERROR),
+                eq(InternalLogger.Target.USER),
+                capture(),
+                isNull(),
+                eq(false),
+                eq(null)
+            )
+            assertThat(lastValue()).isEqualTo(Logs.LOGS_NOT_ENABLED_MESSAGE)
+        }
+    }
+
+    @Test
+    fun `M forward attributes to Feature W addAttribute`(
+        @StringForgery key: String,
+        @StringForgery value: String
+    ) {
+        // Given
+        val mockFeatureScope: FeatureScope = mock()
+        val mockLogsFeature: LogsFeature = mock()
+        whenever(mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)) doReturn mockFeatureScope
+        whenever(mockFeatureScope.unwrap<LogsFeature>()) doReturn mockLogsFeature
+
+        // When
+        Logs.addAttribute(key, value, mockSdkCore)
+
+        // Then
+        verify(mockLogsFeature).addAttribute(key, value)
+    }
+
+    @Test
+    fun `M forward remove attributes to Feature W removeAttribute`(
+        @StringForgery key: String
+    ) {
+        // Given
+        val mockFeatureScope: FeatureScope = mock()
+        val mockLogsFeature: LogsFeature = mock()
+        whenever(mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)) doReturn mockFeatureScope
+        whenever(mockFeatureScope.unwrap<LogsFeature>()) doReturn mockLogsFeature
+
+        // When
+        Logs.removeAttribute(key, mockSdkCore)
+
+        // Then
+        verify(mockLogsFeature).removeAttribute(key)
     }
 }

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -333,7 +333,7 @@ internal class DatadogLogHandlerTest {
         }
     }
 
-    // region Fowarding to RUM
+    // region Forwarding to RUM
 
     @Test
     fun `doesn't forward low level log to RumMonitor`(forge: Forge) {

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.assertj.LogEventAssert.Companion.assertThat
+import com.datadog.android.log.internal.LogsFeature
 import com.datadog.android.log.internal.domain.DatadogLogGenerator
 import com.datadog.android.log.model.LogEvent
 import com.datadog.android.utils.extension.asLogStatus
@@ -92,6 +93,9 @@ internal class DatadogLogHandlerTest {
     lateinit var mockLogsFeatureScope: FeatureScope
 
     @Mock
+    lateinit var mockLogsFeature: LogsFeature
+
+    @Mock
     lateinit var mockRumFeature: FeatureScope
 
     @Mock
@@ -131,6 +135,7 @@ internal class DatadogLogHandlerTest {
         whenever(
             mockSdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
         ) doReturn mockLogsFeatureScope
+        whenever(mockLogsFeatureScope.unwrap<LogsFeature>()) doReturn mockLogsFeature
         whenever(mockLogsFeatureScope.withWriteContext(any(), any())) doAnswer {
             val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
@@ -328,6 +333,8 @@ internal class DatadogLogHandlerTest {
         }
     }
 
+    // region Fowarding to RUM
+
     @Test
     fun `doesn't forward low level log to RumMonitor`(forge: Forge) {
         fakeLevel = forge.anInt(AndroidLog.VERBOSE, AndroidLog.ERROR)
@@ -434,6 +441,74 @@ internal class DatadogLogHandlerTest {
             )
         )
     }
+
+    @ParameterizedTest
+    @ValueSource(ints = [AndroidLog.ERROR, AndroidLog.ASSERT])
+    fun `forward error log with feature attributes to RumMonitor`(
+        logLevel: Int,
+        @StringForgery key: String,
+        @StringForgery value: String
+    ) {
+        // Given
+        whenever(mockLogsFeature.getAttributes()) doReturn mapOf(
+            key to value
+        )
+
+        // When
+        testedHandler.handleLog(
+            logLevel,
+            fakeMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags
+        )
+
+        argumentCaptor<Map<String, Any?>> {
+            verify(mockRumFeature).sendEvent(
+                capture()
+            )
+            assertThat(lastValue["attributes"] as Map<String, *>)
+                .containsEntry(key, value)
+                .containsAllEntriesOf(fakeAttributes)
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [AndroidLog.ERROR, AndroidLog.ASSERT])
+    fun `forward error log with feature attributes and error strings to RumMonitor`(
+        logLevel: Int,
+        @StringForgery errorKind: String,
+        @StringForgery errorMessage: String,
+        @StringForgery errorStack: String,
+        @StringForgery key: String,
+        @StringForgery value: String
+    ) {
+        // Given
+        whenever(mockLogsFeature.getAttributes()) doReturn mapOf(
+            key to value
+        )
+
+        testedHandler.handleLog(
+            logLevel,
+            fakeMessage,
+            errorKind,
+            errorMessage,
+            errorStack,
+            fakeAttributes,
+            fakeTags
+        )
+
+        argumentCaptor<Map<String, Any?>> {
+            verify(mockRumFeature).sendEvent(
+                capture()
+            )
+            assertThat(lastValue["attributes"] as Map<String, *>)
+                .containsEntry(key, value)
+                .containsAllEntriesOf(fakeAttributes)
+        }
+    }
+
+    // endregion
 
     @Test
     fun `forward log with custom timestamp to LogWriter`(forge: Forge) {
@@ -638,6 +713,98 @@ internal class DatadogLogHandlerTest {
                 .doesNotHaveError()
         }
     }
+
+    // region Attributes
+
+    @Test
+    fun `M add feature attributes W handleLog`(
+        @StringForgery key: String,
+        @StringForgery value: String
+    ) {
+        // Given
+        whenever(mockLogsFeature.getAttributes()) doReturn mapOf(
+            key to value
+        )
+
+        // When
+        testedHandler.handleLog(
+            fakeLevel,
+            fakeMessage,
+            fakeThrowable,
+            emptyMap(),
+            fakeTags
+        )
+
+        // Then
+        argumentCaptor<LogEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+
+            assertThat(lastValue.additionalProperties)
+                .containsEntry(key, value)
+        }
+    }
+
+    @Test
+    fun `M combine feature attributes with logged attributes W handleLog`(
+        @StringForgery key: String,
+        @StringForgery value: String,
+        @StringForgery loggerKey: String,
+        @StringForgery loggerValue: String
+    ) {
+        // Given
+        whenever(mockLogsFeature.getAttributes()) doReturn mapOf(
+            key to value
+        )
+
+        // When
+        testedHandler.handleLog(
+            fakeLevel,
+            fakeMessage,
+            fakeThrowable,
+            mapOf(loggerKey to loggerValue),
+            fakeTags
+        )
+
+        // Then
+        argumentCaptor<LogEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+
+            assertThat(lastValue.additionalProperties)
+                .containsEntry(key, value)
+                .containsEntry(loggerKey, loggerValue)
+        }
+    }
+
+    @Test
+    fun `M overwrite attributes with logged attributes W handleLog`(
+        @StringForgery key: String,
+        @StringForgery value: String,
+        @StringForgery loggerValue: String
+    ) {
+        // Given
+        whenever(mockLogsFeature.getAttributes()) doReturn mapOf(
+            key to value
+        )
+
+        // When
+        testedHandler.handleLog(
+            fakeLevel,
+            fakeMessage,
+            fakeThrowable,
+            mapOf(key to loggerValue),
+            fakeTags
+        )
+
+        // Then
+        argumentCaptor<LogEvent> {
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+
+            assertThat(lastValue.additionalProperties)
+                .containsEntry(key, loggerValue)
+        }
+    }
+
+    // endregion
 
     @Test
     fun `it will add the span id and trace id if we active an active tracer`(

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -467,6 +467,7 @@ internal class DatadogLogHandlerTest {
             verify(mockRumFeature).sendEvent(
                 capture()
             )
+            @Suppress("UNCHECKED_CAST")
             assertThat(lastValue["attributes"] as Map<String, *>)
                 .containsEntry(key, value)
                 .containsAllEntriesOf(fakeAttributes)
@@ -502,6 +503,7 @@ internal class DatadogLogHandlerTest {
             verify(mockRumFeature).sendEvent(
                 capture()
             )
+            @Suppress("UNCHECKED_CAST")
             assertThat(lastValue["attributes"] as Map<String, *>)
                 .containsEntry(key, value)
                 .containsAllEntriesOf(fakeAttributes)

--- a/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
+++ b/instrumented/nightly-tests/src/androidTest/kotlin/com/datadog/android/nightly/main/NotTestableApis.kt
@@ -15,6 +15,7 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.Datadog#fun clearAllData(com.datadog.android.api.SdkCore = getInstance())
  * apiMethodSignature: com.datadog.android.Datadog#fun isInitialized(String? = null): Boolean
  * apiMethodSignature: com.datadog.android.Datadog#fun setVerbosity(Int)
+ * apiMethodSignature: com.datadog.android.Datadog#fun getVerbosity(): Int
  * apiMethodSignature: com.datadog.android.Datadog#fun stopInstance(String? = null)
  * apiMethodSignature: com.datadog.android.Datadog#fun stopSession()
  * apiMethodSignature: com.datadog.android.Datadog#fun _internalProxy(String? = null): _InternalProxy
@@ -23,6 +24,8 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setUploadFrequency(UploadFrequency): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setUseDeveloperModeWhenDebuggable(Boolean): Builder
  * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun useSite(com.datadog.android.DatadogSite): Builder
+ * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setBatchProcessingLevel(BatchProcessingLevel): Builder
+ * apiMethodSignature: com.datadog.android.core.configuration.Configuration$Builder#fun setPersistenceStrategyFactory(com.datadog.android.core.persistence.PersistenceStrategy.Factory?): Builder
  * apiMethodSignature: com.datadog.android.core.internal.thread.LoggingScheduledThreadPoolExecutor#constructor(Int, com.datadog.android.api.InternalLogger)
  * apiMethodSignature: com.datadog.android.core.internal.utils.JsonSerializer#fun Map<String, Any?>.safeMapValuesToJson(com.datadog.android.api.InternalLogger): Map<String, com.google.gson.JsonElement>
  * apiMethodSignature: com.datadog.android.core.internal.utils.JsonSerializer#fun toJsonElement(Any?): com.google.gson.JsonElement
@@ -95,5 +98,7 @@ package com.datadog.android.nightly.main
  * apiMethodSignature: com.datadog.android.log.LogsConfiguration$Builder#fun build(): LogsConfiguration
  * apiMethodSignature: com.datadog.android.log.LogsConfiguration$Builder#fun setEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.log.model.LogEvent>): Builder
  * apiMethodSignature: com.datadog.android.log.LogsConfiguration$Builder#fun useCustomEndpoint(String): Builder
+ * apiMethodSignature: com.datadog.android.log.Logs#fun addAttribute(String, Any?, com.datadog.android.api.SdkCore = Datadog.getInstance())
+ * apiMethodSignature: com.datadog.android.log.Logs#fun removeAttribute(String, com.datadog.android.api.SdkCore = Datadog.getInstance())
  *
  */

--- a/reliability/single-fit/logs/src/test/kotlin/com/datadog/android/logs/integration/LoggerTest.kt
+++ b/reliability/single-fit/logs/src/test/kotlin/com/datadog/android/logs/integration/LoggerTest.kt
@@ -760,6 +760,119 @@ class LoggerTest {
     }
 
     @RepeatedTest(16)
+    fun `M send log with custom attribute W Logs#addAttribute() + Logger#log()`(
+        @StringForgery fakeAttributeKey: String,
+        @StringForgery fakeAttributeValue: String,
+        @StringForgery fakeMessage: String,
+        @IntForgery(Log.VERBOSE, 10) fakeLevel: Int
+    ) {
+        // Given
+        val testedLogger = Logger.Builder(stubSdkCore).build()
+
+        // When
+        Logs.addAttribute(fakeAttributeKey, fakeAttributeValue, sdkCore = stubSdkCore)
+        testedLogger.log(fakeLevel, fakeMessage)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(1)
+        val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
+        assertThat(event0.getString("ddtags")).contains("env:" + stubSdkCore.getDatadogContext().env)
+        assertThat(event0.getString("ddtags")).contains("version:" + stubSdkCore.getDatadogContext().version)
+        assertThat(event0.getString("ddtags")).contains("variant:" + stubSdkCore.getDatadogContext().variant)
+        assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
+        assertThat(event0.getString("message")).isEqualTo(fakeMessage)
+        assertThat(event0.getString("status")).isEqualTo(LEVEL_NAMES[fakeLevel])
+        assertThat(event0.getString(fakeAttributeKey)).isEqualTo(fakeAttributeValue)
+    }
+
+    @RepeatedTest(16)
+    fun `M send log with updated custom attribute W Logs#addAttribute() + Logs#addAttribute() + Logger#log()`(
+        @StringForgery fakeAttributeKey: String,
+        @StringForgery fakeAttributeValue: String,
+        @StringForgery fakeAttributeValue2: String,
+        @StringForgery fakeMessage: String,
+        @IntForgery(Log.VERBOSE, 10) fakeLevel: Int
+    ) {
+        // Given
+        val testedLogger = Logger.Builder(stubSdkCore).build()
+
+        // When
+        Logs.addAttribute(fakeAttributeKey, fakeAttributeValue, stubSdkCore)
+        Logs.addAttribute(fakeAttributeKey, fakeAttributeValue2, stubSdkCore)
+        testedLogger.log(fakeLevel, fakeMessage)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(1)
+        val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
+        assertThat(event0.getString("ddtags")).contains("env:" + stubSdkCore.getDatadogContext().env)
+        assertThat(event0.getString("ddtags")).contains("version:" + stubSdkCore.getDatadogContext().version)
+        assertThat(event0.getString("ddtags")).contains("variant:" + stubSdkCore.getDatadogContext().variant)
+        assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
+        assertThat(event0.getString("message")).isEqualTo(fakeMessage)
+        assertThat(event0.getString("status")).isEqualTo(LEVEL_NAMES[fakeLevel])
+        assertThat(event0.getString(fakeAttributeKey)).isEqualTo(fakeAttributeValue2)
+    }
+
+    @RepeatedTest(16)
+    fun `M send log with overridden custom attribute W Logs#addAttribute() + Logger#addAttribute() + Logger#log()`(
+        @StringForgery fakeAttributeKey: String,
+        @StringForgery fakeAttributeValue: String,
+        @StringForgery fakeAttributeValue2: String,
+        @StringForgery fakeMessage: String,
+        @IntForgery(Log.VERBOSE, 10) fakeLevel: Int
+    ) {
+        // Given
+        val testedLogger = Logger.Builder(stubSdkCore).build()
+
+        // When
+        Logs.addAttribute(fakeAttributeKey, fakeAttributeValue, stubSdkCore)
+        testedLogger.addAttribute(fakeAttributeKey, fakeAttributeValue2)
+        testedLogger.log(fakeLevel, fakeMessage)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(1)
+        val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
+        assertThat(event0.getString("ddtags")).contains("env:" + stubSdkCore.getDatadogContext().env)
+        assertThat(event0.getString("ddtags")).contains("version:" + stubSdkCore.getDatadogContext().version)
+        assertThat(event0.getString("ddtags")).contains("variant:" + stubSdkCore.getDatadogContext().variant)
+        assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
+        assertThat(event0.getString("message")).isEqualTo(fakeMessage)
+        assertThat(event0.getString("status")).isEqualTo(LEVEL_NAMES[fakeLevel])
+        assertThat(event0.getString(fakeAttributeKey)).isEqualTo(fakeAttributeValue2)
+    }
+
+    @RepeatedTest(16)
+    fun `M send log with overridden custom attribute W Logs#addAttribute() + Logger#log()`(
+        @StringForgery fakeAttributeKey: String,
+        @StringForgery fakeAttributeValue: String,
+        @StringForgery fakeAttributeValue2: String,
+        @StringForgery fakeMessage: String,
+        @IntForgery(Log.VERBOSE, 10) fakeLevel: Int
+    ) {
+        // Given
+        val testedLogger = Logger.Builder(stubSdkCore).build()
+
+        // When
+        Logs.addAttribute(fakeAttributeKey, fakeAttributeValue, stubSdkCore)
+        testedLogger.log(fakeLevel, fakeMessage, attributes = mapOf(fakeAttributeKey to fakeAttributeValue2))
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(1)
+        val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
+        assertThat(event0.getString("ddtags")).contains("env:" + stubSdkCore.getDatadogContext().env)
+        assertThat(event0.getString("ddtags")).contains("version:" + stubSdkCore.getDatadogContext().version)
+        assertThat(event0.getString("ddtags")).contains("variant:" + stubSdkCore.getDatadogContext().variant)
+        assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
+        assertThat(event0.getString("message")).isEqualTo(fakeMessage)
+        assertThat(event0.getString("status")).isEqualTo(LEVEL_NAMES[fakeLevel])
+        assertThat(event0.getString(fakeAttributeKey)).isEqualTo(fakeAttributeValue2)
+    }
+
+    @RepeatedTest(16)
     fun `M send log with updated custom attribute W Logger#addAttribute() + Logger#removeAttribute() + Logger#log()`(
         @StringForgery fakeAttributeKey: String,
         @StringForgery fakeAttributeValue: String,


### PR DESCRIPTION
### What does this PR do?

Add a `Logs.addAttribute` and `Logs.removeAttribute` function to add attributes to all logs generated by Loggers created from a specific Core.  Individual loggers and log events override global attributes.

These log attributes are also sent on unhandled exceptions and added to errors forwarded to RUM.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

