### PR TITLE
RUM-3280 Remove `spotbugs` and `slf4j` dependencies in the `dd-trace-core` module

### DIFF
--- a/features/dd-sdk-android-trace/build.gradle.kts
+++ b/features/dd-sdk-android-trace/build.gradle.kts
@@ -51,11 +51,11 @@ android {
 
 dependencies {
     api(project(":dd-sdk-android-core"))
+    api(libs.openTelemetryApi)
     implementation(project(":features:dd-trace-core"))
     implementation(libs.kotlin)
     implementation(libs.gson)
     implementation(libs.androidXAnnotation)
-    implementation(libs.openTelemetry)
 
     // Generate NoOp implementations
     ksp(project(":tools:noopfactory"))

--- a/features/dd-sdk-android-trace/transitiveDependencies
+++ b/features/dd-sdk-android-trace/transitiveDependencies
@@ -2,6 +2,8 @@ Dependencies List
 
 androidx.annotation:annotation:1.3.0                            :   30 Kb
 com.google.code.gson:gson:2.10.1                                :  276 Kb
+io.opentelemetry:opentelemetry-api:1.4.0                        :   78 Kb
+io.opentelemetry:opentelemetry-context:1.4.0                    :   42 Kb
 io.opentracing:opentracing-api:0.32.0                           :   18 Kb
 io.opentracing:opentracing-noop:0.32.0                          :   10 Kb
 io.opentracing:opentracing-util:0.32.0                          :   10 Kb

--- a/features/dd-trace-core/build.gradle.kts
+++ b/features/dd-trace-core/build.gradle.kts
@@ -43,7 +43,6 @@ dependencies {
     implementation(libs.androidXAnnotation)
     implementation(libs.datadogSketchesJava)
     implementation(libs.re2j)
-    compileOnly(libs.spotbugs)
 
     // TODO: RUM-3268 Port and enable the groovy unit tests
 

--- a/features/dd-trace-core/build.gradle.kts
+++ b/features/dd-trace-core/build.gradle.kts
@@ -24,9 +24,6 @@ plugins {
 }
 
 android {
-    defaultConfig {
-        consumerProguardFiles("consumer-rules.pro")
-    }
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
     }
@@ -35,7 +32,6 @@ android {
 
 dependencies {
     coreLibraryDesugaring(libs.desugarJdk)
-    implementation(libs.slf4j)
     implementation(libs.moshi)
     implementation(libs.jctools)
     implementation(libs.kotlin)

--- a/features/dd-trace-core/consumer-rules.pro
+++ b/features/dd-trace-core/consumer-rules.pro
@@ -1,4 +1,0 @@
-# Do not warn about missing classes required only at compile time by dependencies
--dontwarn org.slf4j.**
--dontwarn com.google.protobuf.**
--dontwarn edu.umd.cs.findbugs.**

--- a/features/dd-trace-core/lint.xml
+++ b/features/dd-trace-core/lint.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<lint>
-    <issue id="DuplicatePlatformClasses">
-        <ignore path="*"/>
-    </issue>
-</lint>

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/Config.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/Config.java
@@ -322,8 +322,8 @@ import android.os.Build;
 
 import androidx.annotation.NonNull;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.io.BufferedReader;
 import java.io.File;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/DynamicConfig.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/DynamicConfig.java
@@ -11,8 +11,8 @@ import static com.datadog.trace.api.config.TracerConfig.SERVICE_MAPPING;
 import static com.datadog.trace.api.config.TracerConfig.TRACE_SAMPLE_RATE;
 import static com.datadog.trace.util.CollectionUtils.tryMakeImmutableMap;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/EndpointCheckpointerHolder.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/EndpointCheckpointerHolder.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.api;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/MethodFilterConfigParser.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/MethodFilterConfigParser.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.api;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.Collections;
 import java.util.HashMap;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/WithGlobalTracer.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/WithGlobalTracer.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.api;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import com.datadog.trace.bootstrap.instrumentation.api.AgentTracer.TracerAPI;
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/gateway/InstrumentationGateway.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/gateway/InstrumentationGateway.java
@@ -17,8 +17,8 @@ import static com.datadog.trace.api.gateway.Events.RESPONSE_HEADER_DONE_ID;
 import static com.datadog.trace.api.gateway.Events.RESPONSE_HEADER_ID;
 import static com.datadog.trace.api.gateway.Events.RESPONSE_STARTED_ID;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReferenceArray;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/http/StoredByteBody.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/http/StoredByteBody.java
@@ -2,8 +2,8 @@ package com.datadog.trace.api.http;
 
 import androidx.annotation.Nullable;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.lang.reflect.UndeclaredThrowableException;
 import java.nio.ByteBuffer;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/http/StoredCharBody.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/http/StoredCharBody.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.api.http;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.nio.CharBuffer;
 import java.util.Arrays;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/iast/IastEnabledChecks.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/iast/IastEnabledChecks.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.api.iast;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import com.datadog.trace.api.Platform;
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/iast/IastModule.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/iast/IastModule.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.api.iast;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public interface IastModule {
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/iast/Taintable.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/iast/Taintable.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.api.iast;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/iast/telemetry/IastMetricCollector.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/iast/telemetry/IastMetricCollector.java
@@ -5,8 +5,8 @@ import static com.datadog.trace.api.iast.telemetry.IastMetric.Scope.REQUEST;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.Collection;
 import java.util.Collections;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/normalize/AntPatternHttpPathNormalizer.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/normalize/AntPatternHttpPathNormalizer.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.api.normalize;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/normalize/SQLNormalizer.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/normalize/SQLNormalizer.java
@@ -2,8 +2,8 @@ package com.datadog.trace.api.normalize;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.Arrays;
 import java.util.BitSet;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/api/telemetry/LogCollector.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/api/telemetry/LogCollector.java
@@ -1,8 +1,5 @@
 package com.datadog.trace.api.telemetry;
 
-import org.slf4j.Marker;
-import org.slf4j.MarkerFactory;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -14,7 +11,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class LogCollector {
-  public static final Marker SEND_TELEMETRY = MarkerFactory.getMarker("SEND_TELEMETRY");
   private static final int DEFAULT_MAX_CAPACITY = 1024;
   private static final LogCollector INSTANCE = new LogCollector();
   private final Map<RawLogMessage, AtomicInteger> rawLogMessages;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/bootstrap/config/provider/AgentArgsParser.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/bootstrap/config/provider/AgentArgsParser.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.bootstrap.config.provider;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/bootstrap/config/provider/ConfigConverter.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/bootstrap/config/provider/ConfigConverter.java
@@ -2,12 +2,9 @@ package com.datadog.trace.bootstrap.config.provider;
 
 import androidx.annotation.NonNull;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
-import java.lang.invoke.MethodHandle;
-import java.lang.invoke.MethodHandles;
-import java.lang.invoke.MethodType;
 import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Collections;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/bootstrap/config/provider/ConfigProvider.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/bootstrap/config/provider/ConfigProvider.java
@@ -2,8 +2,8 @@ package com.datadog.trace.bootstrap.config.provider;
 
 import static com.datadog.trace.api.config.GeneralConfig.CONFIGURATION_FILE;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.io.File;
 import java.io.FileNotFoundException;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/bootstrap/instrumentation/api/URIUtils.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/bootstrap/instrumentation/api/URIUtils.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.bootstrap.instrumentation.api;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.net.MalformedURLException;
 import java.net.URI;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/RateByServiceTraceSampler.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/RateByServiceTraceSampler.java
@@ -9,8 +9,8 @@ import com.datadog.trace.core.CoreSpan;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /**
  * A rate sampler which maintains different sample rates per service+env name.

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/RuleBasedTraceSampler.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/RuleBasedTraceSampler.java
@@ -13,8 +13,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public class RuleBasedTraceSampler<T extends CoreSpan<T>> implements Sampler, PrioritySampler {
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/Sampler.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/Sampler.java
@@ -11,8 +11,8 @@ import com.datadog.trace.api.sampling.SamplingMechanism;
 import com.datadog.trace.core.CoreSpan;
 import java.util.Map;
 import java.util.Properties;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /** Main interface to sample a collection of traces. */
 public interface Sampler {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/SingleSpanSampler.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/SingleSpanSampler.java
@@ -8,8 +8,8 @@ import com.datadog.trace.core.CoreSpan;
 import com.datadog.trace.core.util.SimpleRateLimiter;
 import java.util.ArrayList;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public interface SingleSpanSampler {
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/SpanSamplingRules.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/SpanSamplingRules.java
@@ -15,8 +15,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import okio.Okio;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /** Represents list of Span Sampling Rules read from JSON. See SPAN_SAMPLING_RULES */
 public class SpanSamplingRules {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/TraceSamplingRules.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/sampling/TraceSamplingRules.java
@@ -10,8 +10,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /** Represents list of Trace Sampling Rules read from JSON. See TRACE_SAMPLING_RULES */
 public class TraceSamplingRules {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/ListWriter.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/ListWriter.java
@@ -10,8 +10,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /** List writer used by tests mostly */
 public class ListWriter extends CopyOnWriteArrayList<List<DDSpan>> implements Writer {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/LoggingWriter.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/LoggingWriter.java
@@ -5,8 +5,8 @@ import com.squareup.moshi.Moshi;
 import com.squareup.moshi.Types;
 import com.datadog.trace.core.DDSpan;
 import java.util.List;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public class LoggingWriter implements Writer {
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/RemoteApi.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/RemoteApi.java
@@ -2,7 +2,7 @@ package com.datadog.trace.common.writer;
 
 import com.datadog.trace.relocate.api.IOLogger;
 import java.io.IOException;
-import org.slf4j.Logger;
+import com.datadog.trace.logger.Logger;
 
 public abstract class RemoteApi {
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/RemoteApi.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/RemoteApi.java
@@ -1,7 +1,6 @@
 package com.datadog.trace.common.writer;
 
 import com.datadog.trace.relocate.api.IOLogger;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
 import org.slf4j.Logger;
 
@@ -65,7 +64,6 @@ public abstract class RemoteApi {
         + ".";
   }
 
-  @SuppressFBWarnings("DCN_NULLPOINTER_EXCEPTION")
   protected static String getResponseBody(okhttp3.Response response) {
     if (response != null) {
       try {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/SpanSamplingWorker.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/SpanSamplingWorker.java
@@ -14,8 +14,8 @@ import java.util.List;
 import java.util.Queue;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscBlockingConsumerArrayQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public interface SpanSamplingWorker extends AutoCloseable {
   static SpanSamplingWorker build(

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/TraceProcessingWorker.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/TraceProcessingWorker.java
@@ -19,8 +19,8 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscBlockingConsumerArrayQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /**
  * Worker which applies rules to traces and serializes the results. Upon completion, the serialized

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/TraceStructureWriter.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/common/writer/TraceStructureWriter.java
@@ -13,8 +13,8 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public class TraceStructureWriter implements Writer {
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/CoreTracer.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/CoreTracer.java
@@ -91,8 +91,8 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.zip.ZipOutputStream;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /**
  * Main entrypoint into the tracer implementation. In addition to implementing

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/DDSpan.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/DDSpan.java
@@ -37,8 +37,8 @@ import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /**
  * Represents a period of time. Associated information is stored in the SpanContext.

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/DDSpan.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/DDSpan.java
@@ -35,8 +35,8 @@ import java.util.Map;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,7 +55,7 @@ public class DDSpan
   static DDSpan create(
       final String instrumentationName,
       final long timestampMicro,
-      @Nonnull DDSpanContext context,
+      @NonNull DDSpanContext context,
       final List<AgentSpanLink> links) {
     final DDSpan span = new DDSpan(instrumentationName, timestampMicro, context, links);
     log.debug("Started span: {}", span);
@@ -121,9 +121,9 @@ public class DDSpan
    * @param context the context used for the span
    */
   private DDSpan(
-      @Nonnull String instrumentationName,
+      @NonNull String instrumentationName,
       final long timestampMicro,
-      @Nonnull DDSpanContext context,
+      @NonNull DDSpanContext context,
       final List<AgentSpanLink> links) {
     this.context = context;
     this.metrics = SpanMetricRegistry.getInstance().get(instrumentationName);
@@ -484,7 +484,7 @@ public class DDSpan
   }
 
   @Override
-  @Nonnull
+  @NonNull
   public final DDSpanContext context() {
     return context;
   }
@@ -760,7 +760,7 @@ public class DDSpan
    *
    * @param endpointTracker the end-point tracker instance
    */
-  public void setEndpointTracker(@Nonnull EndpointTracker endpointTracker) {
+  public void setEndpointTracker(@NonNull EndpointTracker endpointTracker) {
     DDSpan localRootSpan = getLocalRootSpan();
     if (localRootSpan == null) {
       log.warn("Span {} has no associated local root span", this);

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/DDSpanContext.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/DDSpanContext.java
@@ -38,8 +38,8 @@ import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /**
  * SpanContext represents Span state that must propagate to descendant Spans and across process

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/DDSpanLink.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/DDSpanLink.java
@@ -15,8 +15,8 @@ import com.datadog.trace.core.propagation.ExtractedContext;
 import com.datadog.trace.core.propagation.PropagationTags;
 import java.util.List;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /** This class holds helper methods to encode span links into span context. */
 public class DDSpanLink extends SpanLink {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/PendingTrace.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/PendingTrace.java
@@ -17,7 +17,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import javax.annotation.Nonnull;
+import androidx.annotation.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -68,11 +68,11 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
     }
 
     /** Used by tests and benchmarks. */
-    PendingTrace create(@Nonnull DDTraceId traceId) {
+    PendingTrace create(@NonNull DDTraceId traceId) {
       return create(traceId, null);
     }
 
-    PendingTrace create(@Nonnull DDTraceId traceId, ConfigSnapshot traceConfig) {
+    PendingTrace create(@NonNull DDTraceId traceId, ConfigSnapshot traceConfig) {
       return new PendingTrace(
           tracer,
           traceId,
@@ -145,10 +145,10 @@ public class PendingTrace implements AgentTrace, PendingTraceBuffer.Element {
       AtomicLongFieldUpdater.newUpdater(PendingTrace.class, "endToEndStartTime");
 
   private PendingTrace(
-      @Nonnull CoreTracer tracer,
-      @Nonnull DDTraceId traceId,
-      @Nonnull PendingTraceBuffer pendingTraceBuffer,
-      @Nonnull TimeSource timeSource,
+      @NonNull CoreTracer tracer,
+      @NonNull DDTraceId traceId,
+      @NonNull PendingTraceBuffer pendingTraceBuffer,
+      @NonNull TimeSource timeSource,
       ConfigSnapshot traceConfig,
       boolean strictTraceWrites,
       HealthMetrics healthMetrics) {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/PendingTrace.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/PendingTrace.java
@@ -18,8 +18,8 @@ import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import androidx.annotation.NonNull;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /**
  * This class implements the following data flow rules when a Span is finished:

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/PendingTraceBuffer.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/PendingTraceBuffer.java
@@ -11,8 +11,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.jctools.queues.MessagePassingQueue;
 import org.jctools.queues.MpscBlockingConsumerArrayQueue;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public abstract class PendingTraceBuffer implements AutoCloseable {
   private static final int BUFFER_SIZE = 1 << 12; // 4096

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/StatusLogger.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/StatusLogger.java
@@ -19,8 +19,8 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.Map;
 import java.util.Set;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public final class StatusLogger extends JsonAdapter<Config>
     implements AgentTaskScheduler.Task<Config>, JsonAdapter.Factory {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/datastreams/DataStreamContextInjector.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/datastreams/DataStreamContextInjector.java
@@ -8,8 +8,8 @@ import com.datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import com.datadog.trace.bootstrap.instrumentation.api.PathwayContext;
 import java.io.IOException;
 import java.util.LinkedHashMap;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public class DataStreamContextInjector {
   private static final Logger LOGGER = LoggerFactory.getLogger(DataStreamContextInjector.class);

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/datastreams/DefaultPathwayContext.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/datastreams/DefaultPathwayContext.java
@@ -27,8 +27,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Consumer;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public class DefaultPathwayContext implements PathwayContext {
   private static final Logger log = LoggerFactory.getLogger(DefaultPathwayContext.class);

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/B3HttpCodec.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/B3HttpCodec.java
@@ -18,8 +18,8 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.TreeMap;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /** A codec designed for HTTP transport via headers using B3 headers */
 class B3HttpCodec {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/DatadogHttpCodec.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/DatadogHttpCodec.java
@@ -21,8 +21,8 @@ import com.datadog.trace.core.propagation.PropagationTags.HeaderType;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /** A codec designed for HTTP transport via headers using Datadog headers */
 class DatadogHttpCodec {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/HaystackHttpCodec.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/HaystackHttpCodec.java
@@ -15,8 +15,8 @@ import com.datadog.trace.core.DDSpanContext;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /**
  * A codec designed for HTTP transport via headers using Haystack headers.

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/HttpCodec.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/HttpCodec.java
@@ -22,8 +22,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public class HttpCodec {
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/W3CHttpCodec.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/W3CHttpCodec.java
@@ -24,8 +24,8 @@ import com.datadog.trace.core.DDSpanContext;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /** A codec designed for HTTP transport via headers using W3C traceparent and tracestate headers */
 class W3CHttpCodec {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/XRayHttpCodec.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/XRayHttpCodec.java
@@ -20,8 +20,8 @@ import com.datadog.trace.core.DDSpanContext;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.function.Supplier;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /**
  * A codec designed for AWS requests using the {@code X-Amzn-Trace-Id} tracing header.

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/ptags/DatadogPTagsCodec.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/ptags/DatadogPTagsCodec.java
@@ -8,7 +8,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntPredicate;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.LoggerFactory;
 
 /** Captures configuration required for PropagationTags logic */
 final class DatadogPTagsCodec extends PTagsCodec {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/ptags/PTagsFactory.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/ptags/PTagsFactory.java
@@ -10,13 +10,12 @@ import com.datadog.trace.api.sampling.PrioritySampling;
 import com.datadog.trace.api.sampling.SamplingMechanism;
 import com.datadog.trace.core.propagation.PropagationTags;
 import com.datadog.trace.core.propagation.PropagationTags.HeaderType;
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Collections;
 import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nonnull;
+import androidx.annotation.NonNull;
 
 public class PTagsFactory implements PropagationTags.Factory {
   static final String PROPAGATION_ERROR_TAG_KEY = "_dd.propagation_error";
@@ -39,7 +38,7 @@ public class PTagsFactory implements PropagationTags.Factory {
     return xDatadogTagsLimit;
   }
 
-  PTagsCodec getDecoderEncoder(@Nonnull HeaderType headerType) {
+  PTagsCodec getDecoderEncoder(@NonNull HeaderType headerType) {
     return DEC_ENC_MAP.get(headerType);
   }
 
@@ -49,7 +48,7 @@ public class PTagsFactory implements PropagationTags.Factory {
   }
 
   @Override
-  public final PropagationTags fromHeaderValue(@Nonnull HeaderType headerType, String value) {
+  public final PropagationTags fromHeaderValue(@NonNull HeaderType headerType, String value) {
     return DEC_ENC_MAP.get(headerType).fromHeaderValue(this, value);
   }
 
@@ -215,7 +214,6 @@ public class PTagsFactory implements PropagationTags.Factory {
 
     @Override
     @SuppressWarnings("StringEquality")
-    @SuppressFBWarnings("ES_COMPARING_STRINGS_WITH_EQ")
     public String headerValue(HeaderType headerType) {
       String header = getCachedHeader(headerType);
       if (header == null) {

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/ptags/TagKey.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/ptags/TagKey.java
@@ -2,8 +2,8 @@ package com.datadog.trace.core.propagation.ptags;
 
 import com.datadog.trace.api.cache.DDCaches;
 import com.datadog.trace.api.cache.DDPartialKeyCache;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 final class TagKey extends TagElement {
   private static final Logger log = LoggerFactory.getLogger(TagKey.class);

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/ptags/TagValue.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/ptags/TagValue.java
@@ -2,8 +2,8 @@ package com.datadog.trace.core.propagation.ptags;
 
 import com.datadog.trace.api.cache.DDCaches;
 import com.datadog.trace.api.cache.DDPartialKeyCache;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 final class TagValue extends TagElement {
   private static final Logger log = LoggerFactory.getLogger(TagValue.class);

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/propagation/ptags/W3CPTagsCodec.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.IntPredicate;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.LoggerFactory;
 
 public class W3CPTagsCodec extends PTagsCodec {
   private static final RatelimitedLogger log =

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/scopemanager/ContinuableScope.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/scopemanager/ContinuableScope.java
@@ -8,7 +8,7 @@ import com.datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import com.datadog.trace.bootstrap.instrumentation.api.AttachableWrapper;
 import com.datadog.trace.bootstrap.instrumentation.api.ScopeSource;
 import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
-import javax.annotation.Nonnull;
+import androidx.annotation.NonNull;
 
 class ContinuableScope implements AgentScope, AttachableWrapper {
   private final ContinuableScopeManager scopeManager;
@@ -196,7 +196,7 @@ class ContinuableScope implements AgentScope, AttachableWrapper {
   }
 
   @Override
-  public void attachWrapper(@Nonnull Object wrapper) {
+  public void attachWrapper(@NonNull Object wrapper) {
     WRAPPER_FIELD_UPDATER.set(this, wrapper);
   }
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/scopemanager/ContinuableScopeManager.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/scopemanager/ContinuableScopeManager.java
@@ -28,8 +28,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /**
  * The primary ScopeManager. This class has ownership of the core ThreadLocal containing the

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/taginterceptor/TagInterceptor.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/taginterceptor/TagInterceptor.java
@@ -33,8 +33,8 @@ import com.datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import com.datadog.trace.core.DDSpanContext;
 import java.net.URI;
 import java.util.Set;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 public class TagInterceptor {
 
@@ -136,7 +136,7 @@ public class TagInterceptor {
   }
 
   private static void setResourceFromUrl(
-      @Nonnull final DDSpanContext span, @Nullable final String method, @Nonnull final Object url) {
+      @NonNull final DDSpanContext span, @Nullable final String method, @NonNull final Object url) {
     final String path;
     if (url instanceof URIUtils.LazyUrl) {
       path = ((URIUtils.LazyUrl) url).path();

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/tagprocessor/BaseServiceAdder.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/tagprocessor/BaseServiceAdder.java
@@ -4,7 +4,7 @@ import com.datadog.trace.api.DDTags;
 import com.datadog.trace.bootstrap.instrumentation.api.UTF8BytesString;
 import com.datadog.trace.core.DDSpanContext;
 import java.util.Map;
-import javax.annotation.Nullable;
+import androidx.annotation.Nullable;
 
 public class BaseServiceAdder implements TagsPostProcessor {
   private final UTF8BytesString ddService;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/tagprocessor/PeerServiceCalculator.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/tagprocessor/PeerServiceCalculator.java
@@ -6,7 +6,7 @@ import com.datadog.trace.api.naming.NamingSchema;
 import com.datadog.trace.api.naming.SpanNaming;
 import com.datadog.trace.bootstrap.instrumentation.api.Tags;
 import java.util.Map;
-import javax.annotation.Nonnull;
+import androidx.annotation.NonNull;
 
 public class PeerServiceCalculator implements TagsPostProcessor {
   private final NamingSchema.ForPeerService peerServiceNaming;
@@ -21,8 +21,8 @@ public class PeerServiceCalculator implements TagsPostProcessor {
 
   // Visible for testing
   PeerServiceCalculator(
-      @Nonnull final NamingSchema.ForPeerService peerServiceNaming,
-      @Nonnull final Map<String, String> peerServiceMapping) {
+      @NonNull final NamingSchema.ForPeerService peerServiceNaming,
+      @NonNull final Map<String, String> peerServiceMapping) {
     this.peerServiceNaming = peerServiceNaming;
     this.peerServiceMapping = peerServiceMapping;
     this.canRemap = !peerServiceMapping.isEmpty();

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/tagprocessor/PostProcessorChain.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/tagprocessor/PostProcessorChain.java
@@ -3,12 +3,12 @@ package com.datadog.trace.core.tagprocessor;
 import com.datadog.trace.core.DDSpanContext;
 import java.util.Map;
 import java.util.Objects;
-import javax.annotation.Nonnull;
+import androidx.annotation.NonNull;
 
 public class PostProcessorChain implements TagsPostProcessor {
   private final TagsPostProcessor[] chain;
 
-  public PostProcessorChain(@Nonnull final TagsPostProcessor... processors) {
+  public PostProcessorChain(@NonNull final TagsPostProcessor... processors) {
     chain = Objects.requireNonNull(processors);
   }
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/tagprocessor/QueryObfuscator.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/tagprocessor/QueryObfuscator.java
@@ -7,8 +7,8 @@ import com.datadog.trace.api.DDTags;
 import com.datadog.trace.bootstrap.instrumentation.api.Tags;
 import com.datadog.trace.util.Strings;
 import java.util.Map;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public class QueryObfuscator implements TagsPostProcessor {
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/core/util/SystemAccess.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/core/util/SystemAccess.java
@@ -1,8 +1,8 @@
 package com.datadog.trace.core.util;
 
 import com.datadog.trace.api.Config;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public final class SystemAccess {
   private static final Logger log = LoggerFactory.getLogger(SystemAccess.class);

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/logger/ILoggerFactory.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/logger/ILoggerFactory.java
@@ -1,0 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.trace.logger;
+
+public interface ILoggerFactory {
+
+    Logger getLogger(String name);
+}

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/logger/Logger.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/logger/Logger.java
@@ -1,0 +1,42 @@
+
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.trace.logger;
+public interface Logger {
+    public static String ROOT_LOGGER_NAME = "ROOT";
+    public String getName();
+    public void trace(String msg);
+    public void trace(String format, Object arg);
+    public void trace(String format, Object arg1, Object arg2);
+    public void trace(String format, Object... argArray);
+    public void trace(String msg, Throwable t);
+    public boolean isTraceEnabled();
+    public boolean isInfoEnabled();
+    public boolean isWarnEnabled();
+    public boolean isErrorEnabled();
+    public boolean isDebugEnabled();
+    public void debug(String msg);
+    public void debug(String format, Object arg);
+    public void debug(String format, Object arg1, Object arg2);
+    public void debug(String format, Object... arguments);
+    public void debug(String msg, Throwable t);
+    public void info(String msg);
+    public void info(String format, Object arg);
+    public void info(String format, Object arg1, Object arg2);
+    public void info(String format, Object... arguments);
+    public void info(String msg, Throwable t);
+    public void warn(String msg);
+    public void warn(String format, Object arg);
+    public void warn(String format, Object arg1, Object arg2);
+    public void warn(String format, Object... arguments);
+    public void warn(String msg, Throwable t);
+    public void error(String msg);
+    public void error(String format, Object arg);
+    public void error(String format, Object arg1, Object arg2);
+    public void error(String format, Object... arguments);
+    public void error(String msg, Throwable t);
+}

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/logger/LoggerFactory.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/logger/LoggerFactory.java
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.trace.logger;
+
+public final class LoggerFactory {
+
+    public static Logger getLogger(String name) {
+        return new NoOpLogger();
+    }
+
+    public static Logger getLogger(Class<?> clazz) {
+        return new NoOpLogger();
+    }
+
+    public static ILoggerFactory getILoggerFactory() {
+        return new ILoggerFactory() {
+            @Override
+            public Logger getLogger(String name) {
+                return new NoOpLogger();
+            }
+        };
+    }
+}

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/logger/NoOpLogger.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/logger/NoOpLogger.java
@@ -1,0 +1,167 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.trace.logger;
+
+
+// TODO: 04/03/2024 https://datadoghq.atlassian.net/browse/RUM-3405 Add a proper implementation here
+public class NoOpLogger implements Logger {
+
+    @Override
+    public boolean isDebugEnabled() {
+        return false;
+    }
+
+    @Override
+    public String getName() {
+        return "";
+    }
+
+    @Override
+    public boolean isTraceEnabled() {
+        return false;
+    }
+
+    @Override
+    public void trace(String msg) {
+
+    }
+
+    @Override
+    public void trace(String format, Object arg) {
+
+    }
+
+    @Override
+    public void trace(String format, Object arg1, Object arg2) {
+
+    }
+
+    @Override
+    public void trace(String format, Object... argArray) {
+
+    }
+
+    @Override
+    public void trace(String msg, Throwable t) {
+
+    }
+
+    @Override
+    public void debug(String msg) {
+
+    }
+
+    @Override
+    public void debug(String format, Object arg) {
+
+    }
+
+    @Override
+    public void debug(String format, Object arg1, Object arg2) {
+
+    }
+
+    @Override
+    public void debug(String format, Object... arguments) {
+
+    }
+
+    @Override
+    public void debug(String msg, Throwable t) {
+
+    }
+
+    @Override
+    public boolean isInfoEnabled() {
+        return false;
+    }
+
+    @Override
+    public void info(String msg) {
+
+    }
+
+    @Override
+    public void info(String format, Object arg) {
+
+    }
+
+    @Override
+    public void info(String format, Object arg1, Object arg2) {
+
+    }
+
+    @Override
+    public void info(String format, Object... arguments) {
+
+    }
+
+    @Override
+    public void info(String msg, Throwable t) {
+
+    }
+
+    @Override
+    public boolean isWarnEnabled() {
+        return false;
+    }
+
+    @Override
+    public void warn(String msg) {
+
+    }
+
+    @Override
+    public void warn(String format, Object arg) {
+
+    }
+
+    @Override
+    public void warn(String format, Object arg1, Object arg2) {
+
+    }
+
+    @Override
+    public void warn(String format, Object... arguments) {
+
+    }
+
+    @Override
+    public void warn(String msg, Throwable t) {
+
+    }
+
+    @Override
+    public boolean isErrorEnabled() {
+        return false;
+    }
+
+    @Override
+    public void error(String msg) {
+
+    }
+
+    @Override
+    public void error(String format, Object arg) {
+
+    }
+
+    @Override
+    public void error(String format, Object arg1, Object arg2) {
+
+    }
+
+    @Override
+    public void error(String format, Object... arguments) {
+
+    }
+
+    @Override
+    public void error(String msg, Throwable t) {
+
+    }
+}

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/logging/GlobalLogLevelSwitcher.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/logging/GlobalLogLevelSwitcher.java
@@ -1,8 +1,8 @@
 package com.datadog.trace.logging;
 
-import org.slf4j.ILoggerFactory;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.ILoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 public class GlobalLogLevelSwitcher implements LogLevelSwitcher {
   private static volatile LogLevelSwitcher INSTANCE = null;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/relocate/api/IOLogger.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/relocate/api/IOLogger.java
@@ -1,6 +1,6 @@
 package com.datadog.trace.relocate.api;
 
-import org.slf4j.Logger;
+import com.datadog.trace.logger.Logger;
 
 import java.util.concurrent.TimeUnit;
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/relocate/api/RatelimitedLogger.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/relocate/api/RatelimitedLogger.java
@@ -1,6 +1,6 @@
 package com.datadog.trace.relocate.api;
 
-import org.slf4j.Logger;
+import com.datadog.trace.logger.Logger;
 
 import java.util.Locale;
 import java.util.concurrent.TimeUnit;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/util/AgentTaskScheduler.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/util/AgentTaskScheduler.java
@@ -7,8 +7,8 @@ import static com.datadog.trace.util.AgentThreadFactory.AGENT_THREAD_GROUP;
 import static com.datadog.trace.util.AgentThreadFactory.AgentThread.TASK_SCHEDULER;
 import static com.datadog.trace.util.AgentThreadFactory.newAgentThread;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.lang.ref.WeakReference;
 import java.util.concurrent.DelayQueue;

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/util/AgentThreadFactory.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/util/AgentThreadFactory.java
@@ -1,6 +1,6 @@
 package com.datadog.trace.util;
 
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.concurrent.ThreadFactory;
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/util/PidHelper.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/util/PidHelper.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.util;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.function.Supplier;
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/util/ProcessUtils.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/util/ProcessUtils.java
@@ -2,8 +2,8 @@ package com.datadog.trace.util;
 
 import androidx.annotation.Nullable;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.function.Supplier;
 

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/util/TraceUtils.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/util/TraceUtils.java
@@ -2,8 +2,8 @@ package com.datadog.trace.util;
 
 import static com.datadog.trace.util.Strings.truncate;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 /**
  * Utility methods to normalize trace data. This normalization is recommended if the trace is sent

--- a/features/dd-trace-core/src/main/java/com/datadog/trace/util/stacktrace/StackWalkerFactory.java
+++ b/features/dd-trace-core/src/main/java/com/datadog/trace/util/stacktrace/StackWalkerFactory.java
@@ -1,7 +1,7 @@
 package com.datadog.trace.util.stacktrace;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import com.datadog.trace.logger.Logger;
+import com.datadog.trace.logger.LoggerFactory;
 
 import java.util.Objects;
 import java.util.function.Supplier;

--- a/features/dd-trace-core/transitiveDependencies
+++ b/features/dd-trace-core/transitiveDependencies
@@ -12,7 +12,6 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10                  :  963 b
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10                  :  969 b 
 org.jetbrains.kotlin:kotlin-stdlib:1.8.10                       : 1598 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
-org.slf4j:slf4j-api:1.7.30                                      :   40 Kb
 
 Total transitive dependencies size                              :    3 Mb
 

--- a/features/dd-trace-core/transitiveDependencies
+++ b/features/dd-trace-core/transitiveDependencies
@@ -2,31 +2,17 @@ Dependencies List
 
 androidx.annotation:annotation:1.1.0                            :   27 Kb
 com.datadoghq:sketches-java:0.8.2                               :  125 Kb
-com.github.spotbugs:spotbugs-annotations:4.2.0                  :   14 Kb
-com.github.spotbugs:spotbugs:4.2.0                              :    3 Mb
-com.google.code.findbugs:jsr305:3.0.2                           :   19 Kb
 com.google.re2j:re2j:1.7                                        :  111 Kb
 com.squareup.moshi:moshi:1.11.0                                 :  148 Kb
 com.squareup.okhttp3:okhttp:4.11.0                              :  768 Kb
 com.squareup.okio:okio-jvm:3.2.0                                :  337 Kb
-net.jcip:jcip-annotations:1.0                                   :    2 Kb
-org.apache.bcel:bcel:6.5.0                                      :  678 Kb
-org.apache.commons:commons-lang3:3.11                           :  564 Kb
-org.apache.commons:commons-text:1.9                             :  211 Kb
-org.dom4j:dom4j:2.1.3                                           :  316 Kb
 org.jctools:jctools-core:3.3.0                                  :  328 Kb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.8.10                :  212 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.10                  :  963 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.10                  :  969 b 
 org.jetbrains.kotlin:kotlin-stdlib:1.8.10                       : 1598 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
-org.json:json:20200518                                          :   64 Kb
-org.ow2.asm:asm-analysis:9.0                                    :   32 Kb
-org.ow2.asm:asm-commons:9.0                                     :   69 Kb
-org.ow2.asm:asm-tree:9.0                                        :   51 Kb
-org.ow2.asm:asm-util:9.0                                        :   82 Kb
-org.ow2.asm:asm:9.0                                             :  118 Kb
 org.slf4j:slf4j-api:1.7.30                                      :   40 Kb
 
-Total transitive dependencies size                              :    9 Mb
+Total transitive dependencies size                              :    3 Mb
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -91,7 +91,6 @@ openTelemetry = "1.4.0"
 desugarJdk = "2.0.4"
 datatadogSketchesJava = "0.8.2"
 re2j = "1.7"
-spotbugs = "4.2.0"
 
 
 [libraries]
@@ -236,7 +235,6 @@ openTelemetry = { module = "io.opentelemetry:opentelemetry-api", version.ref = "
 desugarJdk = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdk" }
 datadogSketchesJava = { module = "com.datadoghq:sketches-java", version.ref = "datatadogSketchesJava" }
 re2j = { module = "com.google.re2j:re2j", version.ref = "re2j" }
-spotbugs = { module = "com.github.spotbugs:spotbugs", version.ref = "spotbugs" }
 
 [bundles]
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -84,7 +84,6 @@ coroutines = "1.4.2"
 ktor = "1.6.0"
 
 # Otel
-slf4j = "1.7.30"
 moshi = "1.11.0"
 jctools = "3.3.0"
 openTelemetry = "1.4.0"
@@ -228,10 +227,9 @@ ktorNetty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktorGson = { module = "io.ktor:ktor-gson", version.ref = "ktor" }
 
 # Otel
-slf4j = { module = "org.slf4j:slf4j-api", version.ref = "slf4j" }
 moshi = { module = "com.squareup.moshi:moshi", version.ref = "moshi" }
 jctools = { module = "org.jctools:jctools-core", version.ref = "jctools" }
-openTelemetry = { module = "io.opentelemetry:opentelemetry-api", version.ref = "openTelemetry" }
+openTelemetryApi = { module = "io.opentelemetry:opentelemetry-api", version.ref = "openTelemetry" }
 desugarJdk = { module = "com.android.tools:desugar_jdk_libs", version.ref = "desugarJdk" }
 datadogSketchesJava = { module = "com.datadoghq:sketches-java", version.ref = "datatadogSketchesJava" }
 re2j = { module = "com.google.re2j:re2j", version.ref = "re2j" }

--- a/instrumented/integration/proguard-rules.pro
+++ b/instrumented/integration/proguard-rules.pro
@@ -33,3 +33,6 @@
 
 -dontwarn kotlin.Experimental$Level
 -dontwarn kotlin.Experimental
+# Required because we are compiling the `dd-sdk-android-trace` module which depends on "io.opentelemetry.api" which
+# uses google autovalue annotations
+-dontwarn com.google.**


### PR DESCRIPTION
### What does this PR do?

In this PR we are doing more cleanup work in the `dd-core-tracer` java module:

- removing the `slf4j` dependency and switching to a `NoOpLogger` internally for now. A task was added to JIRA to add a proper logger implementation later
- removing the `spotbug` dependency which solved the last lint rule in the project
- making sure the compiler does not complain in the `integration` test project due to the `opentelemetry` API using the  Google autovalue annotations

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

