### PR TITLE
RUM-2907 Allow setting custom error fingerprint

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -331,6 +331,7 @@ object com.datadog.android.log.LogAttributes
   const val USR_NAME: String
   const val VARIANT: String
   const val SOURCE_TYPE: String
+  const val ERROR_FINGERPRINT: String
 enum com.datadog.android.privacy.TrackingConsent
   - GRANTED
   - NOT_GRANTED

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -754,6 +754,7 @@ public final class com/datadog/android/log/LogAttributes {
 	public static final field DD_TRACE_ID Ljava/lang/String;
 	public static final field DURATION Ljava/lang/String;
 	public static final field ENV Ljava/lang/String;
+	public static final field ERROR_FINGERPRINT Ljava/lang/String;
 	public static final field ERROR_KIND Ljava/lang/String;
 	public static final field ERROR_MESSAGE Ljava/lang/String;
 	public static final field ERROR_SOURCE_TYPE Ljava/lang/String;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/log/LogAttributes.kt
@@ -329,4 +329,9 @@ object LogAttributes {
      * or platform that the error originates from, such as Flutter or React Native (String).
      */
     const val SOURCE_TYPE: String = "_dd.error.source_type"
+
+    /**
+     * Specifies a custom error fingerprint for the supplied log. (String)
+     */
+    const val ERROR_FINGERPRINT: String = "_dd.error.fingerprint"
 }

--- a/features/dd-sdk-android-logs/api/apiSurface
+++ b/features/dd-sdk-android-logs/api/apiSurface
@@ -65,7 +65,7 @@ data class com.datadog.android.log.model.LogEvent
       fun fromJson(kotlin.String): Network
       fun fromJsonObject(com.google.gson.JsonObject): Network
   data class Error
-    constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.List<Thread>? = null)
+    constructor(kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.collections.List<Thread>? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Error

--- a/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
+++ b/features/dd-sdk-android-logs/api/dd-sdk-android-logs.api
@@ -200,24 +200,27 @@ public final class com/datadog/android/log/model/LogEvent$Device$Companion {
 public final class com/datadog/android/log/model/LogEvent$Error {
 	public static final field Companion Lcom/datadog/android/log/model/LogEvent$Error$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
-	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Ljava/lang/String;
 	public final fun component3 ()Ljava/lang/String;
 	public final fun component4 ()Ljava/lang/String;
-	public final fun component5 ()Ljava/util/List;
-	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/datadog/android/log/model/LogEvent$Error;
-	public static synthetic fun copy$default (Lcom/datadog/android/log/model/LogEvent$Error;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/log/model/LogEvent$Error;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun component6 ()Ljava/util/List;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;)Lcom/datadog/android/log/model/LogEvent$Error;
+	public static synthetic fun copy$default (Lcom/datadog/android/log/model/LogEvent$Error;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/log/model/LogEvent$Error;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/log/model/LogEvent$Error;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/log/model/LogEvent$Error;
+	public final fun getFingerprint ()Ljava/lang/String;
 	public final fun getKind ()Ljava/lang/String;
 	public final fun getMessage ()Ljava/lang/String;
 	public final fun getSourceType ()Ljava/lang/String;
 	public final fun getStack ()Ljava/lang/String;
 	public final fun getThreads ()Ljava/util/List;
 	public fun hashCode ()I
+	public final fun setFingerprint (Ljava/lang/String;)V
 	public final fun setKind (Ljava/lang/String;)V
 	public final fun setMessage (Ljava/lang/String;)V
 	public final fun setSourceType (Ljava/lang/String;)V

--- a/features/dd-sdk-android-logs/src/main/json/log/log-schema.json
+++ b/features/dd-sdk-android-logs/src/main/json/log/log-schema.json
@@ -182,6 +182,11 @@
           "description": "The source_type of the error (e.g. 'android', 'flutter', 'react-native')",
           "readOnly": false
         },
+        "fingerprint": {
+          "type": "string",
+          "description": "A custom fingerprint for this error",
+          "readOnly": false
+        },
         "threads": {
           "type": "array",
           "description": "Description of each thread in the process when error happened.",

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/domain/DatadogLogGeneratorTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/domain/DatadogLogGeneratorTest.kt
@@ -316,7 +316,7 @@ internal class DatadogLogGeneratorTest {
     }
 
     @Test
-    fun `M note add sourceType W creating the Log { source_type attribute not set }`() {
+    fun `M not add sourceType W creating the Log { source_type attribute not set }`() {
         // WHEN
         val log = testedLogGenerator.generateLog(
             fakeLevel,
@@ -375,6 +375,103 @@ internal class DatadogLogGeneratorTest {
             )
         )
         assertThat(log.additionalProperties).doesNotContainKey(LogAttributes.SOURCE_TYPE)
+    }
+
+    @Test
+    fun `M not add fingerprint W creating the Log { fingerprint attribute not set }`() {
+        // WHEN
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            fakeAttributes,
+            fakeTags,
+            fakeTimestamp,
+            fakeThreadName,
+            fakeDatadogContext,
+            attachNetworkInfo = true,
+            fakeLoggerName
+        )
+
+        // THEN
+        assertThat(log).hasError(
+            LogEvent.Error(
+                kind = fakeThrowable.javaClass.canonicalName,
+                stack = fakeThrowable.stackTraceToString(),
+                message = fakeThrowable.message,
+                sourceType = null,
+                fingerprint = null,
+                threads = null
+            )
+        )
+    }
+
+    @Test
+    fun `M add fingerprint W creating the Log { fingerprint attribute set }`() {
+        // WHEN
+        val modifiedAttributes = fakeAttributes.toMutableMap().apply {
+            put(LogAttributes.ERROR_FINGERPRINT, "fake_fingerprint")
+        }
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable,
+            modifiedAttributes,
+            fakeTags,
+            fakeTimestamp,
+            fakeThreadName,
+            fakeDatadogContext,
+            attachNetworkInfo = true,
+            fakeLoggerName
+        )
+
+        // THEN
+        assertThat(log).hasError(
+            LogEvent.Error(
+                kind = fakeThrowable.javaClass.canonicalName,
+                stack = fakeThrowable.stackTraceToString(),
+                message = fakeThrowable.message,
+                sourceType = null,
+                fingerprint = "fake_fingerprint",
+                threads = null
+            )
+        )
+        assertThat(log.additionalProperties).doesNotContainKey(LogAttributes.ERROR_FINGERPRINT)
+    }
+
+    @Test
+    fun `M add fingerprint W creating the Log { expanded error, fingerprint attribute set }`() {
+        // WHEN
+        val modifiedAttributes = fakeAttributes.toMutableMap().apply {
+            put(LogAttributes.ERROR_FINGERPRINT, "fake_fingerprint")
+        }
+        val log = testedLogGenerator.generateLog(
+            fakeLevel,
+            fakeLogMessage,
+            fakeThrowable.javaClass.canonicalName,
+            fakeThrowable.message,
+            fakeThrowable.stackTraceToString(),
+            modifiedAttributes,
+            fakeTags,
+            fakeTimestamp,
+            fakeThreadName,
+            fakeDatadogContext,
+            attachNetworkInfo = true,
+            fakeLoggerName
+        )
+
+        // THEN
+        assertThat(log).hasError(
+            LogEvent.Error(
+                kind = fakeThrowable.javaClass.canonicalName,
+                stack = fakeThrowable.stackTraceToString(),
+                message = fakeThrowable.message,
+                sourceType = null,
+                fingerprint = "fake_fingerprint",
+                threads = null
+            )
+        )
+        assertThat(log.additionalProperties).doesNotContainKey(LogAttributes.ERROR_FINGERPRINT)
     }
 
     @Test

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/domain/DatadogLogGeneratorTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/domain/DatadogLogGeneratorTest.kt
@@ -407,10 +407,12 @@ internal class DatadogLogGeneratorTest {
     }
 
     @Test
-    fun `M add fingerprint W creating the Log { fingerprint attribute set }`() {
+    fun `M add fingerprint W creating the Log { fingerprint attribute set }`(
+        @StringForgery fakeFingerprint: String
+    ) {
         // WHEN
         val modifiedAttributes = fakeAttributes.toMutableMap().apply {
-            put(LogAttributes.ERROR_FINGERPRINT, "fake_fingerprint")
+            put(LogAttributes.ERROR_FINGERPRINT, fakeFingerprint)
         }
         val log = testedLogGenerator.generateLog(
             fakeLevel,
@@ -432,7 +434,7 @@ internal class DatadogLogGeneratorTest {
                 stack = fakeThrowable.stackTraceToString(),
                 message = fakeThrowable.message,
                 sourceType = null,
-                fingerprint = "fake_fingerprint",
+                fingerprint = fakeFingerprint,
                 threads = null
             )
         )

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -43,6 +43,7 @@ object com.datadog.android.rum.RumAttributes
   const val ERROR_RESOURCE_URL: String
   const val ERROR_DATABASE_VERSION: String
   const val ERROR_DATABASE_PATH: String
+  const val ERROR_FINGERPRINT: String
   const val ACTION_TARGET_CLASS_NAME: String
   const val ACTION_TARGET_TITLE: String
   const val ACTION_TARGET_PARENT_INDEX: String

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -55,6 +55,7 @@ public final class com/datadog/android/rum/RumAttributes {
 	public static final field ENV Ljava/lang/String;
 	public static final field ERROR_DATABASE_PATH Ljava/lang/String;
 	public static final field ERROR_DATABASE_VERSION Ljava/lang/String;
+	public static final field ERROR_FINGERPRINT Ljava/lang/String;
 	public static final field ERROR_RESOURCE_METHOD Ljava/lang/String;
 	public static final field ERROR_RESOURCE_STATUS_CODE Ljava/lang/String;
 	public static final field ERROR_RESOURCE_URL Ljava/lang/String;

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -159,6 +159,11 @@ object RumAttributes {
      */
     const val ERROR_DATABASE_PATH: String = "error.database.path"
 
+    /**
+     * Specifies a custom error fingerprint for the supplied.
+     */
+    const val ERROR_FINGERPRINT: String = "_dd.error.fingerprint"
+
     // endregion
 
     // region Action

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumAttributes.kt
@@ -160,7 +160,7 @@ object RumAttributes {
     const val ERROR_DATABASE_PATH: String = "error.database.path"
 
     /**
-     * Specifies a custom error fingerprint for the supplied.
+     * Specifies a custom error fingerprint for the supplied error.
      */
     const val ERROR_FINGERPRINT: String = "_dd.error.fingerprint"
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -179,7 +179,9 @@ interface RumMonitor {
      * @param source the source of the error
      * @param throwable the throwable
      * @param attributes additional custom attributes to attach to the error. Attributes can be
-     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
+     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK. Users
+     * that want to supply a custom fingerprint for this error can add a value under the key
+     * [RumAttributes.ERROR_CUSTOM_FINGERPRINT]
      * @see [startResource]
      * @see [stopResource]
      */
@@ -205,7 +207,9 @@ interface RumMonitor {
      * @param errorType the type of the error. Usually it should be the canonical name of the
      * of the Exception class.
      * @param attributes additional custom attributes to attach to the error. Attributes can be
-     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
+     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK. Users
+     * that want to supply a custom fingerprint for this error can add a value under the key
+     * [RumAttributes.ERROR_CUSTOM_FINGERPRINT]
      * @see [startResource]
      * @see [stopResource]
      */

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -226,7 +226,9 @@ interface RumMonitor {
      * @param source the source of the error
      * @param throwable the throwable
      * @param attributes additional custom attributes to attach to the error. Attributes can be
-     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
+     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK. Users
+     * that want to supply a custom fingerprint for this error can add a value under the key
+     * [RumAttributes.ERROR_CUSTOM_FINGERPRINT]
      */
     fun addError(
         message: String,
@@ -245,7 +247,9 @@ interface RumMonitor {
      * @param message a message explaining the error
      * @param source the source of the error
      * @param stacktrace the error stacktrace information
-     * @param attributes additional custom attributes to attach to the error
+     * @param attributes additional custom attributes to attach to the error. Users
+     * that want to supply a custom fingerprint for this error can add a value under the key
+     * [RumAttributes.ERROR_CUSTOM_FINGERPRINT]
      */
     fun addErrorWithStacktrace(
         message: String,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -331,6 +331,7 @@ internal class RumResourceScope(
         writer: DataWriter<Any>
     ) {
         attributes.putAll(GlobalRumMonitor.get(sdkCore).getAttributes())
+        val errorFingerprint = attributes.remove(RumAttributes.ERROR_FINGERPRINT) as? String
 
         val rumContext = getRumContext()
 
@@ -364,6 +365,7 @@ internal class RumResourceScope(
                     source = source.toSchemaSource(),
                     stack = stackTrace,
                     isCrash = false,
+                    fingerprint = errorFingerprint,
                     resource = ErrorEvent.Resource(
                         url = url,
                         method = method.toErrorMethod(),

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -373,6 +373,7 @@ internal open class RumViewScope(
         val updatedAttributes = addExtraAttributes(event.attributes)
         val isFatal = updatedAttributes
             .remove(RumAttributes.INTERNAL_ERROR_IS_CRASH) as? Boolean == true || event.isFatal
+        val errorFingerprint = updatedAttributes.remove(RumAttributes.ERROR_FINGERPRINT) as? String
         // if a cross-platform crash was already reported, do not send its native version
         if (crashCount > 0 && isFatal) return
 
@@ -415,6 +416,7 @@ internal open class RumViewScope(
                     source = event.source.toSchemaSource(),
                     stack = event.stacktrace ?: event.throwable?.loggableStackTrace(),
                     isCrash = isFatal,
+                    fingerprint = errorFingerprint,
                     type = errorType,
                     sourceType = event.sourceType.toSchemaSourceType(),
                     threads = event.threads.map {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/assertj/ErrorEventAssert.kt
@@ -69,6 +69,16 @@ internal class ErrorEventAssert(actual: ErrorEvent) :
         return this
     }
 
+    fun hasErrorFingerprint(expected: String?): ErrorEventAssert {
+        assertThat(actual.error.fingerprint)
+            .overridingErrorMessage(
+                "Expected event data to have error.fingerprint $expected " +
+                    "but was ${actual.error.fingerprint}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
     fun isCrash(expected: Boolean): ErrorEventAssert {
         assertThat(actual.error.isCrash)
             .overridingErrorMessage(

--- a/reliability/single-fit/logs/src/test/kotlin/com/datadog/android/logs/integration/LoggerTest.kt
+++ b/reliability/single-fit/logs/src/test/kotlin/com/datadog/android/logs/integration/LoggerTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.stub.StubSDKCore
 import com.datadog.android.event.EventMapper
+import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.Logger
 import com.datadog.android.log.Logs
 import com.datadog.android.log.LogsConfiguration
@@ -701,6 +702,38 @@ class LoggerTest {
         assertThat(event0.getString("error.kind")).isEqualTo(fakeErrorKind)
         assertThat(event0.getString("error.message")).isEqualTo(fakeErrorMessage)
         assertThat(event0.getString("error.stack")).isEqualTo(fakeErrorStack)
+    }
+
+    @RepeatedTest(16)
+    fun `M send log with custom error fingerprint W Logger#log()`(
+        @StringForgery fakeErrorKind: String,
+        @StringForgery fakeErrorMessage: String,
+        @StringForgery fakeErrorStack: String,
+        @StringForgery fakeMessage: String,
+        @StringForgery fakeFingerprint: String,
+        @IntForgery(Log.VERBOSE, 10) fakeLevel: Int
+    ) {
+        // Given
+        val testedLogger = Logger.Builder(stubSdkCore).build()
+
+        // When
+        val attributes = mapOf(LogAttributes.ERROR_FINGERPRINT to fakeFingerprint)
+        testedLogger.log(fakeLevel, fakeMessage, fakeErrorKind, fakeErrorMessage, fakeErrorStack, attributes)
+
+        // Then
+        val eventsWritten = stubSdkCore.eventsWritten(Feature.LOGS_FEATURE_NAME)
+        assertThat(eventsWritten).hasSize(1)
+        val event0 = JsonParser.parseString(eventsWritten[0].eventData) as JsonObject
+        assertThat(event0.getString("ddtags")).contains("env:" + stubSdkCore.getDatadogContext().env)
+        assertThat(event0.getString("ddtags")).contains("version:" + stubSdkCore.getDatadogContext().version)
+        assertThat(event0.getString("ddtags")).contains("variant:" + stubSdkCore.getDatadogContext().variant)
+        assertThat(event0.getString("service")).isEqualTo(stubSdkCore.getDatadogContext().service)
+        assertThat(event0.getString("message")).isEqualTo(fakeMessage)
+        assertThat(event0.getString("status")).isEqualTo(LEVEL_NAMES[fakeLevel])
+        assertThat(event0.getString("error.kind")).isEqualTo(fakeErrorKind)
+        assertThat(event0.getString("error.message")).isEqualTo(fakeErrorMessage)
+        assertThat(event0.getString("error.stack")).isEqualTo(fakeErrorStack)
+        assertThat(event0.getString("error.fingerprint")).isEqualTo(fakeFingerprint)
     }
 
     @RepeatedTest(16)


### PR DESCRIPTION
### What does this PR do?

This sets up attributes that are automatically transferred to the `Error` objects for Logs and RUM.

For logs, the attribute is  `LogAttributes.ERROR_FINGERPRINT` and sets the fingerprint in the `LogEvent.Error`.

For RUM, the attribute is `RumAttributes.ERROR_FINGERPRINT` and sets the fingerprint member in `ErrorEvent.Error`

Also fixes RUM-2209 by adding the `LogEvent.Error.fingerprint` member

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

