### PR TITLE
RUM-2879: Disable non-fatal ANR reporting by default

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -69,6 +69,7 @@ data class com.datadog.android.rum.RumConfiguration
     fun disableUserInteractionTracking(): Builder
     fun useViewTrackingStrategy(com.datadog.android.rum.tracking.ViewTrackingStrategy?): Builder
     fun trackLongTasks(Long = RumFeature.DEFAULT_LONG_TASK_THRESHOLD_MS): Builder
+    fun trackNonFatalAnrs(Boolean): Builder
     fun setViewEventMapper(com.datadog.android.rum.event.ViewEventMapper): Builder
     fun setResourceEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ResourceEvent>): Builder
     fun setActionEventMapper(com.datadog.android.event.EventMapper<com.datadog.android.rum.model.ActionEvent>): Builder

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -111,6 +111,7 @@ public final class com/datadog/android/rum/RumConfiguration$Builder {
 	public final fun trackLongTasks ()Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun trackLongTasks (J)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public static synthetic fun trackLongTasks$default (Lcom/datadog/android/rum/RumConfiguration$Builder;JILjava/lang/Object;)Lcom/datadog/android/rum/RumConfiguration$Builder;
+	public final fun trackNonFatalAnrs (Z)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun trackUserInteractions ()Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun trackUserInteractions ([Lcom/datadog/android/rum/tracking/ViewAttributesProvider;)Lcom/datadog/android/rum/RumConfiguration$Builder;
 	public final fun trackUserInteractions ([Lcom/datadog/android/rum/tracking/ViewAttributesProvider;Lcom/datadog/android/rum/tracking/InteractionPredicate;)Lcom/datadog/android/rum/RumConfiguration$Builder;

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumConfiguration.kt
@@ -134,6 +134,21 @@ data class RumConfiguration internal constructor(
         }
 
         /**
+         * Enable tracking of non-fatal ANRs. This is enabled by default on Android API 29 and
+         * below, and disabled by default on Android API 30 and above. Android API 30+ has a
+         * capability to report fatal ANRs (always enabled). Please note, that tracking non-fatal
+         * ANRs is using Watchdog thread approach, which can be noisy, and also leads to ANR
+         * duplication on Android 30+ if fatal ANR happened, because Watchdog thread approach cannot
+         * categorize ANR as fatal or non-fatal.
+         *
+         * @param enabled whether tracking of non-fatal ANRs is enabled or not.
+         */
+        fun trackNonFatalAnrs(enabled: Boolean): Builder {
+            rumConfig = rumConfig.copy(trackNonFatalAnrs = enabled)
+            return this
+        }
+
+        /**
          * Sets the [ViewEventMapper] for the RUM [ViewEvent]. You can use this interface implementation
          * to modify the [ViewEvent] attributes before serialisation.
          *

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumConfigurationBuilderTest.kt
@@ -92,6 +92,11 @@ internal class RumConfigurationBuilderTest {
                 longTaskTrackingStrategy = MainLooperLongTaskStrategy(100L),
                 backgroundEventTracking = false,
                 trackFrustrations = true,
+                // on Android R+ this should be false, but since default value is static property
+                // RumFeature.DEFAULT_RUM_CONFIG, it is evaluated at the static() block during class
+                // loading, so we are not able to set Build API version at this point. We will test
+                // it through a helper method in RumFeature.Companion
+                trackNonFatalAnrs = true,
                 vitalsMonitorUpdateFrequency = VitalsUpdateFrequency.AVERAGE,
                 sessionListener = NoOpRumSessionListener(),
                 additionalConfig = emptyMap()
@@ -315,6 +320,23 @@ internal class RumConfigurationBuilderTest {
         assertThat(rumConfiguration.featureConfiguration).isEqualTo(
             RumFeature.DEFAULT_RUM_CONFIG.copy(
                 backgroundEventTracking = backgroundEventEnabled
+            )
+        )
+    }
+
+    @Test
+    fun `𝕄 build config with track non-fatal ANRs 𝕎 trackNonFatalAnrs() and build()`(
+        @BoolForgery trackNonFatalAnrsEnabled: Boolean
+    ) {
+        // When
+        val rumConfiguration = testedBuilder
+            .trackNonFatalAnrs(trackNonFatalAnrsEnabled)
+            .build()
+
+        // Then
+        assertThat(rumConfiguration.featureConfiguration).isEqualTo(
+            RumFeature.DEFAULT_RUM_CONFIG.copy(
+                trackNonFatalAnrs = trackNonFatalAnrsEnabled
             )
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ConfigurationRumForgeryFactory.kt
@@ -44,6 +44,7 @@ internal class ConfigurationRumForgeryFactory :
             longTaskTrackingStrategy = mock(),
             backgroundEventTracking = forge.aBool(),
             trackFrustrations = forge.aBool(),
+            trackNonFatalAnrs = forge.aBool(),
             vitalsMonitorUpdateFrequency = forge.aValueFrom(VitalsUpdateFrequency::class.java),
             sessionListener = mock(),
             additionalConfig = forge.aMap { aString() to aString() }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -202,6 +202,7 @@ class SampleApplication : Application() {
             .setTelemetrySampleRate(100f)
             .trackUserInteractions()
             .trackLongTasks(250L)
+            .trackNonFatalAnrs(true)
             .setViewEventMapper(object : ViewEventMapper {
                 override fun map(event: ViewEvent): ViewEvent {
                     event.context?.additionalProperties?.put(ATTR_IS_MAPPED, true)


### PR DESCRIPTION
### What does this PR do?

This PR disables non-fatal ANR reporting (the one which is using watchdog approach) by default for API 30+, but keeps it enabled on Android API 29 and below (because there is no fatal ANR reporting there).

Customer now has an opportunity to explicitly enable/disable it.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

