### PR TITLE
Prevent `ConcurrentModificationException` when reading feature flags

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -385,6 +385,8 @@ internal open class RumViewScope(
         } else {
             event.message
         }
+        // make a copy - by the time we iterate over it on another thread, it may already be changed
+        val eventFeatureFlags = featureFlags.toMutableMap()
 
         sdkCore.newRumEventWriteOperation(writer) { datadogContext ->
 
@@ -411,7 +413,7 @@ internal open class RumViewScope(
             }
             ErrorEvent(
                 date = event.eventTime.timestamp + serverTimeOffsetInMs,
-                featureFlags = ErrorEvent.Context(featureFlags),
+                featureFlags = ErrorEvent.Context(eventFeatureFlags),
                 error = ErrorEvent.Error(
                     message = message,
                     source = event.source.toSchemaSource(),


### PR DESCRIPTION
### What does this PR do?

Small change to prevent `ConcurrentModificationException` which may happen when feature flags are read during `ErrorEvent` serialization on the worker thread.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

