### PR TITLE
RUM-3669 avoid feature flag spamming events

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -105,6 +105,7 @@ interface com.datadog.android.rum.RumMonitor
   fun addErrorWithStacktrace(String, RumErrorSource, String?, Map<String, Any?>)
   fun addTiming(String)
   fun addFeatureFlagEvaluation(String, Any)
+  fun addFeatureFlagBatchEvaluation(Map<String, Any>)
   fun addAttribute(String, Any?)
   fun removeAttribute(String)
   fun getAttributes(): Map<String, Any?>

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -138,6 +138,7 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun addAttribute (Ljava/lang/String;Ljava/lang/Object;)V
 	public abstract fun addError (Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public abstract fun addErrorWithStacktrace (Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun addFeatureFlagBatchEvaluation (Ljava/util/Map;)V
 	public abstract fun addFeatureFlagEvaluation (Ljava/lang/String;Ljava/lang/Object;)V
 	public abstract fun addTiming (Ljava/lang/String;)V
 	public abstract fun clearAttributes ()V

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -284,6 +284,13 @@ interface RumMonitor {
     )
 
     /**
+     * Adds result of evaluating a set of feature flag to the view.
+     * Feature flag evaluations are local to the active view and are cleared when the view is stopped.
+     * @param featureFlags the map of feature flags
+     */
+    fun addFeatureFlagBatchEvaluation(featureFlags: Map<String, Any>)
+
+    /**
      * Adds a global attribute to all future RUM events.
      * @param key the attribute key (non null)
      * @param value the attribute value (or null)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -188,6 +188,11 @@ internal sealed class RumRawEvent {
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
+    internal data class AddFeatureFlagBatchEvaluation(
+        val featureFlags: Map<String, Any>,
+        override val eventTime: Time = Time()
+    ) : RumRawEvent()
+
     internal data class StopSession(
         override val eventTime: Time = Time()
     ) : RumRawEvent()

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -180,7 +180,9 @@ internal open class RumViewScope(
             is RumRawEvent.StartResource -> onStartResource(event, writer)
             is RumRawEvent.AddError -> onAddError(event, writer)
             is RumRawEvent.AddLongTask -> onAddLongTask(event, writer)
+
             is RumRawEvent.AddFeatureFlagEvaluation -> onAddFeatureFlagEvaluation(event, writer)
+            is RumRawEvent.AddFeatureFlagBatchEvaluation -> onAddFeatureFlagBatchEvaluation(event, writer)
 
             is RumRawEvent.ApplicationStarted -> onApplicationStarted(event, writer)
             is RumRawEvent.AddCustomTiming -> onAddCustomTiming(event, writer)
@@ -1113,9 +1115,31 @@ internal open class RumViewScope(
     ) {
         if (stopped) return
 
-        featureFlags[event.name] = event.value
-        sendViewUpdate(event, writer)
-        sendViewChanged()
+        if (event.value != featureFlags[event.name]) {
+            featureFlags[event.name] = event.value
+            sendViewUpdate(event, writer)
+            sendViewChanged()
+        }
+    }
+
+    private fun onAddFeatureFlagBatchEvaluation(
+        event: RumRawEvent.AddFeatureFlagBatchEvaluation,
+        writer: DataWriter<Any>
+    ) {
+        if (stopped) return
+
+        var modified = false
+        event.featureFlags.forEach { (k, v) ->
+            if (v != featureFlags[k]) {
+                featureFlags[k] = v
+                modified = true
+            }
+        }
+
+        if (modified) {
+            sendViewUpdate(event, writer)
+            sendViewChanged()
+        }
     }
 
     private fun sendViewChanged() {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -365,6 +365,12 @@ internal class DatadogRumMonitor(
         )
     }
 
+    override fun addFeatureFlagBatchEvaluation(featureFlags: Map<String, Any>) {
+        handleEvent(
+            RumRawEvent.AddFeatureFlagBatchEvaluation(featureFlags)
+        )
+    }
+
     override fun stopSession() {
         handleEvent(
             RumRawEvent.StopSession()

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1349,6 +1349,42 @@ internal class DatadogRumMonitorTest {
     }
 
     @Test
+    fun `M delegate event to rootScope W addFeatureFlagEvaluation`(
+        @StringForgery name: String,
+        @StringForgery value: String
+    ) {
+        testedMonitor.addFeatureFlagEvaluation(name, value)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.AddFeatureFlagEvaluation
+            assertThat(event.name).isEqualTo(name)
+            assertThat(event.value).isEqualTo(value)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W addFeatureFlagBatchEvaluation`(
+        @StringForgery name: String,
+        @StringForgery value: String
+    ) {
+        val batch = mapOf(name to value)
+        testedMonitor.addFeatureFlagBatchEvaluation(batch)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.AddFeatureFlagBatchEvaluation
+            assertThat(event.featureFlags).isSameAs(batch)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
     fun `sends keep alive event to rootScope regularly`() {
         argumentCaptor<Runnable> {
             inOrder(mockScope, mockWriter, mockHandler) {


### PR DESCRIPTION
### What does this PR do?

This PR attempts to improve the performance linked to setting FeatureFlag evaluations on a RUM View. Namely: 

- create an `addFeatureFlagBatchEvaluation()` method allowing to send a batch of feature flags instead of sending them once at a time. This limits the number of event the Rum View Scope has to process, and the number of view updates written on disk. 
- add a check in the `RumViewScope` handling the feature flags updates: instead of writing an event update for every call to the `addFeatureFlagEvaluation()` and `addFeatureFlagBatchEvaluation()` methods, it only writes an event if at least one feature flag value was changed. 

### Motivation

For some customer updating many feature flags at once, that would result in a lot of RawRumEvents being processed, and a lot of RUM View updates being written on disk. In some extreme cases it could lead to a lot of backpressure on the executor queues. 
