### PR TITLE
Add a test for the safe events serialization produced by `RumViewScope` in multi-threaded environment

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -60,7 +60,7 @@ internal open class RumViewScope(
     internal val url = key.url.replace('.', '/')
 
     internal val eventAttributes: MutableMap<String, Any?> = initialAttributes.toMutableMap()
-    private var globalAttributes: MutableMap<String, Any?> = resolveGlobalAttributes(sdkCore)
+    private var globalAttributes: Map<String, Any?> = resolveGlobalAttributes(sdkCore)
 
     private var sessionId: String = parentScope.getRumContext().sessionId
     internal var viewId: String = UUID.randomUUID().toString()
@@ -862,8 +862,8 @@ internal open class RumViewScope(
         }
     }
 
-    private fun resolveGlobalAttributes(sdkCore: InternalSdkCore): MutableMap<String, Any?> {
-        return GlobalRumMonitor.get(sdkCore).getAttributes().toMutableMap()
+    private fun resolveGlobalAttributes(sdkCore: InternalSdkCore): Map<String, Any?> {
+        return GlobalRumMonitor.get(sdkCore).getAttributes().toMap()
     }
 
     private fun resolveViewDuration(event: RumRawEvent): Long {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -135,6 +135,32 @@ internal fun Forge.sdkInitEvent(): RumRawEvent.SdkInit {
     )
 }
 
+internal fun Forge.updatePerformanceMetricEvent(): RumRawEvent.UpdatePerformanceMetric {
+    val time = Time()
+    return RumRawEvent.UpdatePerformanceMetric(
+        metric = getForgery(),
+        value = aDouble(),
+        eventTime = time
+    )
+}
+
+internal fun Forge.addFeatureFlagEvaluationEvent(): RumRawEvent.AddFeatureFlagEvaluation {
+    val time = Time()
+    return RumRawEvent.AddFeatureFlagEvaluation(
+        name = anAlphabeticalString(),
+        value = anElementFrom(aString(), anInt(), Any()),
+        eventTime = time
+    )
+}
+
+internal fun Forge.addCustomTimingEvent(): RumRawEvent.AddCustomTiming {
+    val time = Time()
+    return RumRawEvent.AddCustomTiming(
+        name = anAlphabeticalString(),
+        eventTime = time
+    )
+}
+
 internal fun Forge.validBackgroundEvent(): RumRawEvent {
     return this.anElementFrom(
         listOf(
@@ -168,7 +194,10 @@ internal fun Forge.anyRumEvent(excluding: List<Type> = listOf()): RumRawEvent {
         stopResourceWithErrorEvent(),
         stopResourceWithStacktraceEvent(),
         addErrorEvent(),
-        addLongTaskEvent()
+        addLongTaskEvent(),
+        addFeatureFlagEvaluationEvent(),
+        addCustomTimingEvent(),
+        updatePerformanceMetricEvent()
     )
     return this.anElementFrom(
         allEvents.filter {


### PR DESCRIPTION
### What does this PR do?

This test emulates updates for the `RumViewScope` in one thread and serialization of events produced in another thread. It shouldn't be any issues doing that.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

