### PR TITLE
RUM-2207 Call RUM error mapper even for crashes

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
@@ -311,6 +311,11 @@ internal class RumEventMapperTest {
         assertThat(mappedRumEvent)
             .isSameAs(fakeCrashEvent)
             .isEqualTo(fakeCrashEvent)
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            RumEventMapper.NO_DROPPING_FATAL_ERRORS_WARNING_MESSAGE
+        )
     }
 
     @Test
@@ -329,7 +334,6 @@ internal class RumEventMapperTest {
             InternalLogger.Level.INFO,
             InternalLogger.Target.USER,
             RumEventMapper.EVENT_NULL_WARNING_MESSAGE.format(Locale.US, fakeRumEvent)
-
         )
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/event/RumEventMapperTest.kt
@@ -127,6 +127,23 @@ internal class RumEventMapperTest {
     }
 
     @Test
+    fun `M map the bundled event W map { fatal ErrorEvent }`(forge: Forge) {
+        // GIVEN
+        val fakeErrorEvent = forge.getForgery<ErrorEvent>()
+        val fakeCrashEvent = fakeErrorEvent.copy(
+            error = fakeErrorEvent.error.copy(isCrash = true)
+        )
+        whenever(mockErrorEventMapper.map(fakeCrashEvent)).thenReturn(fakeCrashEvent)
+
+        // WHEN
+        val mappedRumEvent = testedRumEventMapper.map(fakeCrashEvent)
+
+        // THEN
+        assertThat(mappedRumEvent).isNotNull
+        assertThat(mappedRumEvent).isEqualTo(fakeCrashEvent)
+    }
+
+    @Test
     fun `M map the bundled event W map { ActionEvent }`(forge: Forge) {
         // GIVEN
         val fakeRumEvent = forge.getForgery<ActionEvent>()


### PR DESCRIPTION
### What does this PR do?

This changes the RUM error event mapper to call the user supplied mapper even for crashes, which it previously excluded.

The error event mapper still does not support discarding fatal errors, and a warning is sent if the user returns null for a fatal error in the mapper.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

