### PR TITLE
Safe getting of Intent extras

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityLifecycleTrackingStrategy.kt
@@ -93,7 +93,7 @@ abstract class ActivityLifecycleTrackingStrategy :
     @MainThread
     override fun onActivityCreated(activity: Activity, savedInstanceState: Bundle?) {
         val intent = activity.intent
-        val extras = intent.extras
+        val extras = intent.safeExtras
         val testId = extras?.getString("_dd.synthetics.test_id")
         val resultId = extras?.getString("_dd.synthetics.result_id")
         if (!testId.isNullOrBlank() && !resultId.isNullOrBlank()) {
@@ -130,7 +130,7 @@ abstract class ActivityLifecycleTrackingStrategy :
             attributes[INTENT_URI_TAG] = it
         }
 
-        intent.extras?.let { bundle ->
+        intent.safeExtras?.let { bundle ->
             bundle.keySet().forEach {
                 // TODO RUMM-2717 Bundle#get is deprecated, but there is no replacement for it.
                 // Issue is opened in the Google Issue Tracker.
@@ -186,6 +186,20 @@ abstract class ActivityLifecycleTrackingStrategy :
             null
         }
     }
+
+    private val Intent.safeExtras: Bundle?
+        get() = try {
+            // old Androids can throw different exceptions here making native calls
+            extras
+        } catch (@Suppress("TooGenericExceptionCaught") e: Exception) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.USER,
+                { "Error getting Intent extras, ignoring it." },
+                e
+            )
+            null
+        }
 
     internal companion object {
         internal const val ARGUMENT_TAG = "view.arguments"

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityLifecycleTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityLifecycleTrackingStrategyTest.kt
@@ -21,6 +21,7 @@ import com.datadog.tools.unit.ObjectTest
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
+import com.datadog.tools.unit.forge.anException
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -36,6 +37,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.doThrow
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
@@ -146,6 +148,25 @@ internal abstract class ActivityLifecycleTrackingStrategyTest<T> : ObjectTest<T>
         // verify
         val mockRumMonitor = rumMonitor.mockInstance as AdvancedRumMonitor
         verify(mockRumMonitor).setSyntheticsAttribute(testId, resultId)
+    }
+
+    @Test
+    fun `M do nothing W onActivityCreated() { getting intent extras throws }`(
+        forge: Forge
+    ) {
+        // Given
+        testedStrategy.register(rumMonitor.mockSdkCore, mockAppContext)
+        val mockIntent = mock<Intent>()
+        val mockActivity = mock<Activity>()
+        whenever(mockActivity.intent) doReturn mockIntent
+        whenever(mockIntent.extras) doThrow forge.anException()
+
+        // When
+        testedStrategy.onActivityCreated(mockActivity, null)
+
+        // verify
+        val mockRumMonitor = rumMonitor.mockInstance as AdvancedRumMonitor
+        verifyNoInteractions(mockRumMonitor)
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

It seems that on old Androids (Android 7 and below) calling `Intent#getExtras` sometimes may throw different non-documented exceptions.

This PR creates a safe wrapper around this call.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

