### PR TITLE
Remove Runtime shutdown hook when SDK instance is stopped

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -211,6 +211,7 @@ datadog:
       - "java.lang.Class.getMethod(kotlin.String?, kotlin.Array?):java.lang.NoSuchMethodException,java.lang.SecurityException,java.lang.NullPointerException"
       - "java.lang.Class.isAssignableFrom(java.lang.Class?):java.lang.NullPointerException"
       - "java.lang.Runtime.addShutdownHook(java.lang.Thread):java.lang.IllegalArgumentException,java.lang.IllegalStateException,java.lang.SecurityException"
+      - "java.lang.Runtime.removeShutdownHook(java.lang.Thread?):java.lang.IllegalStateException,java.lang.SecurityException"
       - "java.lang.StringBuilder.constructor(kotlin.Int):java.lang.NegativeArraySizeException"
       - "java.lang.System.arraycopy(kotlin.Any, kotlin.Int, kotlin.Any, kotlin.Int, kotlin.Int):java.lang.IndexOutOfBoundsException,java.lang.ArrayStoreException,java.lang.NullPointerException"
       - "java.lang.System.loadLibrary(kotlin.String?):java.lang.SecurityException,java.lang.UnsatisfiedLinkError,java.lang.NullPointerException"


### PR DESCRIPTION
### What does this PR do?

Otherwise it is possible to have a memory leak when SDK instance is stopped, because reference to the SDK instance still exists through the hook runnable.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

