### PR TITLE
Disable flaky Session Replay test

### DIFF
--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/ConsentGrantedSrTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/ConsentGrantedSrTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import org.junit.Ignore
 import org.junit.Rule
+import org.junit.Test
 
 internal class ConsentGrantedSrTest : BaseSessionReplayTest<SessionReplayPlaygroundActivity>() {
 
@@ -21,6 +22,7 @@ internal class ConsentGrantedSrTest : BaseSessionReplayTest<SessionReplayPlaygro
     )
 
     @Ignore("Flakiness in CI, unsolved yet")
+    @Test
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsAllowTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImageButto
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,6 +27,7 @@ internal class SrImageButtonsAllowTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
+    @Ignore("Flakiness in CI, unsolved yet")
     @Test
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import org.junit.Ignore
 import org.junit.Rule
+import org.junit.Test
 
 internal class SrImageButtonsMaskTest :
     BaseSessionReplayTest<SessionReplayImageButtonsActivity>() {
@@ -27,6 +28,7 @@ internal class SrImageButtonsMaskTest :
     )
 
     @Ignore("Flakiness in CI, unsolved yet")
+    @Test
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskUserInputTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import org.junit.Ignore
 import org.junit.Rule
+import org.junit.Test
 
 internal class SrImageButtonsMaskUserInputTest :
     BaseSessionReplayTest<SessionReplayImageButtonsActivity>() {
@@ -27,6 +28,7 @@ internal class SrImageButtonsMaskUserInputTest :
     )
 
     @Ignore("Flakiness in CI, unsolved yet")
+    @Test
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)


### PR DESCRIPTION
### What does this PR do?

This changes disables flaky Session Replay test and also puts `@Test` annotations back (they don't need to be removed when adding `@Ignore` annotation).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

