### PR TITLE
Fix flaky `TodoWithoutTask` tests

### DIFF
--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/TodoWithoutTaskTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/TodoWithoutTaskTest.kt
@@ -411,12 +411,13 @@ class TodoWithoutTaskTest {
     @Test
     fun `detekt todo with valid task number`(
         @StringForgery(regex = "[\\w ]+") commentText: String,
-        @StringForgery(regex = "[A-Z]+-\\d{1,8}") task: String
+        @StringForgery(regex = "[A-Z]+") taskProject: String,
+        @IntForgery(min = 1) taskNumber: Int
     ) {
         val code = """
             class Foo {
                 fun bar() {
-                    // TODO $task $commentText
+                    // TODO $taskProject-$taskNumber $commentText
                 }
             }
         """.trimIndent()
@@ -428,14 +429,15 @@ class TodoWithoutTaskTest {
     @Test
     fun `detekt todo with valid task number in multiline comment`(
         @StringForgery(regex = "[\\w ]+") commentText: String,
-        @StringForgery(regex = "[A-Z]+-\\d{1,8}") task: String
+        @StringForgery(regex = "[A-Z]+") taskProject: String,
+        @IntForgery(min = 1) taskNumber: Int
     ) {
         val code =
             """
             class Foo {
                 fun bar() {
                     /*
-                     * TODO $task $commentText
+                     * TODO $taskProject-$taskNumber $commentText
                      */
                 }
             }
@@ -448,7 +450,8 @@ class TodoWithoutTaskTest {
     @Test
     fun `detekt todo with valid task number in property doc comment`(
         @StringForgery(regex = "[\\w ]+") commentText: String,
-        @StringForgery(regex = "[A-Z]+-\\d{1,8}") task: String
+        @StringForgery(regex = "[A-Z]+") taskProject: String,
+        @IntForgery(min = 1) taskNumber: Int
     ) {
         val code =
             """
@@ -456,7 +459,7 @@ class TodoWithoutTaskTest {
             
                 /**
                  * Do Something.
-                 * TODO $task $commentText
+                 * TODO $taskProject-$taskNumber $commentText
                  */
                 lateinit var property : String 
             }
@@ -469,7 +472,8 @@ class TodoWithoutTaskTest {
     @Test
     fun `detekt todo with valid task number in method doc comment`(
         @StringForgery(regex = "[\\w ]+") commentText: String,
-        @StringForgery(regex = "[A-Z]+-\\d{1,8}") task: String
+        @StringForgery(regex = "[A-Z]+") taskProject: String,
+        @IntForgery(min = 1) taskNumber: Int
     ) {
         val code =
             """
@@ -477,7 +481,7 @@ class TodoWithoutTaskTest {
             
                 /**
                  * Do Something.
-                 * TODO $task $commentText
+                 * TODO $taskProject-$taskNumber $commentText
                  */
                 fun bar() {
                 }
@@ -491,12 +495,13 @@ class TodoWithoutTaskTest {
     @Test
     fun `detekt todo with valid task number in class doc comment`(
         @StringForgery(regex = "[\\w ]+") commentText: String,
-        @StringForgery(regex = "[A-Z]+-\\d{1,8}") task: String
+        @StringForgery(regex = "[A-Z]+") taskProject: String,
+        @IntForgery(min = 1) taskNumber: Int
     ) {
         val code =
             """
             /**
-             * TODO $task $commentText
+             * TODO $taskProject-$taskNumber $commentText
              */
             class Foo {
                 fun bar() {
@@ -511,12 +516,13 @@ class TodoWithoutTaskTest {
     @Test
     fun `detekt todo with valid task number in object doc comment`(
         @StringForgery(regex = "[\\w ]+") commentText: String,
-        @StringForgery(regex = "[A-Z]+-\\d{1,8}") task: String
+        @StringForgery(regex = "[A-Z]+") taskProject: String,
+        @IntForgery(min = 1) taskNumber: Int
     ) {
         val code =
             """
             /**
-             * TODO $task $commentText
+             * TODO $taskProject-$taskNumber $commentText
              */
             object Foo {
                 fun bar() {


### PR DESCRIPTION
### What does this PR do?

Regex `[A-Z]+-\\d{1,8}` may generate something like `ABC-0` because of the `d{1,8}`, and this will fail some tests, because 0 as a task number is not allowed.

This PR fixes that.

Note: In theory it is possible to have  something like `ABC-012`, but generating `012` and avoiding to have all zeros at the same time requires using matching groups/negative lookaheads, which is not supported by `Forge`.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

