### PR TITLE
RUM-3757: Make sure `error.threads` always have content from `error.stack`

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -32,7 +32,7 @@ internal class DatadogExceptionHandler(
     // region Thread.UncaughtExceptionHandler
 
     override fun uncaughtException(t: Thread, e: Throwable) {
-        val threads = getAllThreadsDump(t, e)
+        val threads = getThreadDumps(t, e)
         // write the log immediately
         val logsFeature = sdkCore.getFeature(Feature.LOGS_FEATURE_NAME)
         if (logsFeature != null) {
@@ -121,30 +121,31 @@ internal class DatadogExceptionHandler(
         }
     }
 
-    private fun getAllThreadsDump(
-        crashedThread: Thread,
-        crashException: Throwable
-    ): List<ThreadDump> {
+    private fun getThreadDumps(crashedThread: Thread, e: Throwable): List<ThreadDump> {
+        return mutableListOf(
+            ThreadDump(
+                crashed = true,
+                name = crashedThread.name,
+                state = crashedThread.state.asString(),
+                stack = e.loggableStackTrace()
+            )
+        ) + safeGetAllStacktraces()
+            .filterKeys { it != crashedThread }
+            .filterValues { it.isNotEmpty() }
+            .map {
+                val thread = it.key
+                ThreadDump(
+                    name = thread.name,
+                    state = thread.state.asString(),
+                    stack = it.value.loggableStackTrace(),
+                    crashed = false
+                )
+            }
+    }
+
+    private fun safeGetAllStacktraces(): Map<Thread, Array<StackTraceElement>> {
         return try {
             Thread.getAllStackTraces()
-                // from getAllStackTraces: A zero-length array will be returned in the map value if
-                // the virtual machine has no stack trace information about a thread.
-                .filterValues { it.isNotEmpty() }
-                .map {
-                    val thread = it.key
-                    val isCrashedThread = thread == crashedThread
-                    val stack = if (isCrashedThread) {
-                        crashException.loggableStackTrace()
-                    } else {
-                        thread.stackTrace.loggableStackTrace()
-                    }
-                    ThreadDump(
-                        name = thread.name,
-                        state = thread.state.asString(),
-                        stack = stack,
-                        crashed = isCrashedThread
-                    )
-                }
         } catch (e: SecurityException) {
             sdkCore.internalLogger.log(
                 InternalLogger.Level.ERROR,
@@ -152,7 +153,7 @@ internal class DatadogExceptionHandler(
                 { "Failed to get all threads dump" },
                 e
             )
-            emptyList()
+            emptyMap()
         }
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -172,6 +172,8 @@ internal class DatadogExceptionHandlerTest {
                 val crashedThread = first { it.crashed }
                 assertThat(crashedThread.name).isEqualTo(currentThread.name)
                 assertThat(crashedThread.stack).isEqualTo(fakeThrowable.loggableStackTrace())
+                val nonCrashedThreadNames = filterNot { it.crashed }.map { it.name }
+                assertThat(nonCrashedThreadNames).doesNotContain(crashedThread.name)
             }
         }
         verifyNoInteractions(mockPreviousHandler)
@@ -205,6 +207,9 @@ internal class DatadogExceptionHandlerTest {
                 val crashedThread = first { it.crashed }
                 assertThat(crashedThread.name).isEqualTo(currentThread.name)
                 assertThat(crashedThread.stack).isEqualTo(fakeThrowable.loggableStackTrace())
+                val nonCrashedThreadNames = filterNot { it.crashed }.map { it.name }
+                assertThat(nonCrashedThreadNames).isNotEmpty
+                assertThat(nonCrashedThreadNames).doesNotContain(crashedThread.name)
             }
         }
         verify(mockPreviousHandler).uncaughtException(currentThread, fakeThrowable)
@@ -240,6 +245,9 @@ internal class DatadogExceptionHandlerTest {
                 val crashedThread = first { it.crashed }
                 assertThat(crashedThread.name).isEqualTo(currentThread.name)
                 assertThat(crashedThread.stack).isEqualTo(throwable.loggableStackTrace())
+                val nonCrashedThreadNames = filterNot { it.crashed }.map { it.name }
+                assertThat(nonCrashedThreadNames).isNotEmpty
+                assertThat(nonCrashedThreadNames).doesNotContain(crashedThread.name)
             }
         }
         verify(mockPreviousHandler).uncaughtException(currentThread, throwable)
@@ -275,6 +283,9 @@ internal class DatadogExceptionHandlerTest {
                 val crashedThread = first { it.crashed }
                 assertThat(crashedThread.name).isEqualTo(currentThread.name)
                 assertThat(crashedThread.stack).isEqualTo(throwable.loggableStackTrace())
+                val nonCrashedThreadNames = filterNot { it.crashed }.map { it.name }
+                assertThat(nonCrashedThreadNames).isNotEmpty
+                assertThat(nonCrashedThreadNames).doesNotContain(crashedThread.name)
             }
         }
         verify(mockPreviousHandler).uncaughtException(currentThread, throwable)
@@ -318,6 +329,9 @@ internal class DatadogExceptionHandlerTest {
                 val crashedThread = first { it.crashed }
                 assertThat(crashedThread.name).isEqualTo(thread.name)
                 assertThat(crashedThread.stack).isEqualTo(fakeThrowable.loggableStackTrace())
+                val nonCrashedThreadNames = filterNot { it.crashed }.map { it.name }
+                assertThat(nonCrashedThreadNames).isNotEmpty
+                assertThat(nonCrashedThreadNames).doesNotContain(crashedThread.name)
             }
         }
         verify(mockPreviousHandler).uncaughtException(thread, fakeThrowable)
@@ -358,6 +372,9 @@ internal class DatadogExceptionHandlerTest {
                 assertThat(filter { it.crashed }).hasSize(1)
                 assertThat(first { it.crashed }.name).isEqualTo(crashedThread.name)
                 assertThat(first { it.crashed }.stack).isEqualTo(fakeThrowable.loggableStackTrace())
+                val nonCrashedThreadNames = filterNot { it.crashed }.map { it.name }
+                assertThat(nonCrashedThreadNames).isNotEmpty
+                assertThat(nonCrashedThreadNames).doesNotContain(crashedThread.name)
             }
         }
         verify(mockPreviousHandler).uncaughtException(crashedThread, fakeThrowable)
@@ -488,6 +505,9 @@ internal class DatadogExceptionHandlerTest {
                 val crashedThread = first { it.crashed }
                 assertThat(crashedThread.name).isEqualTo(currentThread.name)
                 assertThat(crashedThread.stack).isEqualTo(fakeThrowable.loggableStackTrace())
+                val nonCrashedThreadNames = filterNot { it.crashed }.map { it.name }
+                assertThat(nonCrashedThreadNames).isNotEmpty
+                assertThat(nonCrashedThreadNames).doesNotContain(crashedThread.name)
             }
         }
         verify(mockPreviousHandler).uncaughtException(currentThread, fakeThrowable)
@@ -521,6 +541,9 @@ internal class DatadogExceptionHandlerTest {
                 val crashedThread = first { it.crashed }
                 assertThat(crashedThread.name).isEqualTo(currentThread.name)
                 assertThat(crashedThread.stack).isEqualTo(throwable.loggableStackTrace())
+                val nonCrashedThreadNames = filterNot { it.crashed }.map { it.name }
+                assertThat(nonCrashedThreadNames).isNotEmpty
+                assertThat(nonCrashedThreadNames).doesNotContain(crashedThread.name)
             }
         }
         verify(mockPreviousHandler).uncaughtException(currentThread, throwable)
@@ -552,6 +575,9 @@ internal class DatadogExceptionHandlerTest {
                 val crashedThread = first { it.crashed }
                 assertThat(crashedThread.name).isEqualTo(currentThread.name)
                 assertThat(crashedThread.stack).isEqualTo(throwable.loggableStackTrace())
+                val nonCrashedThreadNames = filterNot { it.crashed }.map { it.name }
+                assertThat(nonCrashedThreadNames).isNotEmpty
+                assertThat(nonCrashedThreadNames).doesNotContain(crashedThread.name)
             }
         }
         verify(mockPreviousHandler).uncaughtException(currentThread, throwable)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt
@@ -50,20 +50,22 @@ internal class ANRDetectorRunnable(
                     if (!callback.wasCalled()) {
                         val anrThread = handler.looper.thread
                         val anrException = ANRException(anrThread)
-                        val allThreads = safeGetAllStacktraces()
+                        val allThreads = mutableListOf(
+                            ThreadDump(
+                                name = anrThread.name,
+                                state = anrThread.state.asString(),
+                                stack = anrException.loggableStackTrace(),
+                                crashed = false
+                            )
+                        ) + safeGetAllStacktraces()
+                            .filterKeys { it != anrThread }
                             .filterValues { it.isNotEmpty() }
                             .map {
                                 val thread = it.key
-                                val isAnrThread = thread == anrThread
-                                val stack = if (isAnrThread) {
-                                    anrException.loggableStackTrace()
-                                } else {
-                                    thread.stackTrace.loggableStackTrace()
-                                }
                                 ThreadDump(
                                     name = thread.name,
                                     state = thread.state.asString(),
-                                    stack = stack,
+                                    stack = thread.stackTrace.loggableStackTrace(),
                                     crashed = false
                                 )
                             }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
@@ -102,6 +102,8 @@ internal class ANRDetectorRunnableTest {
             val anrThread = allThreads.firstOrNull { it.name == Thread.currentThread().name }
             check(anrThread != null)
             assertThat(anrThread.stack).isEqualTo(anrExceptionCaptor.lastValue.loggableStackTrace())
+            assertThat(allThreads.filter { it.name == anrThread.name }).hasSize(1)
+            assertThat(allThreads.filterNot { it.name == anrThread.name }).isNotEmpty
         }
 
         argumentCaptor<Runnable> {


### PR DESCRIPTION
### What does this PR do?

It seems sometimes it is possible to have result of `Thread.getAllStackTraces()` without the thread impacted by ANR/crashing thread info (or without attached stacktrace, not sure here). It is not clear why it happens, but we clearly can see such issues in the dashboard, when `error.stack` is not found among `error.threads` reported (meaning `error.threads` doesn't have thread for which we reporting `error.stack`).

This change fixes that by making sure ANR thread/crashing thread is always in the `error.threads` - we will always add it to the list, not relying on the match among `Thread.getAllStackTraces()` results.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

