### PR TITLE
RUM-3868: Don't traverse non-visible ViewGroups for searching user interaction targets

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListener.kt
@@ -281,6 +281,8 @@ internal class GesturesListener(
         stack: LinkedList<View>,
         coordinatesContainer: IntArray
     ) {
+        if (!view.isVisible) return
+
         for (i in 0 until view.childCount) {
             val child = view.getChildAt(i)
             if (hitTest(child, x, y, coordinatesContainer)) {
@@ -290,11 +292,11 @@ internal class GesturesListener(
     }
 
     private fun isValidTapTarget(view: View): Boolean {
-        return view.isClickable && view.visibility == View.VISIBLE
+        return view.isClickable && view.isVisible
     }
 
     private fun isValidScrollableTarget(view: View): Boolean {
-        return view.visibility == View.VISIBLE && isScrollableView(view)
+        return view.isVisible && isScrollableView(view)
     }
 
     @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
@@ -344,6 +346,9 @@ internal class GesturesListener(
         // methods are final.
         return view::class.java.name.startsWith("androidx.compose.ui.platform.ComposeView")
     }
+
+    private val View.isVisible: Boolean
+        get() = visibility == View.VISIBLE
 
     // endregion
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/instrumentation/gestures/GesturesListenerTapTest.kt
@@ -247,6 +247,43 @@ internal class GesturesListenerTapTest : AbstractGesturesListenerTest() {
     }
 
     @Test
+    fun `onTap does nothing if not visible ViewGroup contains visible views`(forge: Forge) {
+        // Given
+        val mockEvent: MotionEvent = forge.getForgery()
+        val validTarget: View = mockView(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            forge = forge,
+            clickable = true
+        )
+        mockDecorView = mockDecorView<ViewGroup>(
+            id = forge.anInt(),
+            forEvent = mockEvent,
+            hitTest = true,
+            forge = forge
+        ) {
+            whenever(it.visibility).thenReturn(forge.anElementFrom(View.INVISIBLE, View.GONE))
+            whenever(it.childCount).thenReturn(1)
+            whenever(it.getChildAt(0)).thenReturn(validTarget)
+        }
+        val expectedResourceName = forge.anAlphabeticalString()
+        mockResourcesForTarget(validTarget, expectedResourceName)
+        testedListener = GesturesListener(
+            rumMonitor.mockSdkCore,
+            WeakReference(mockWindow),
+            contextRef = WeakReference(mockAppContext),
+            internalLogger = mockInternalLogger
+        )
+
+        // When
+        testedListener.onSingleTapUp(mockEvent)
+
+        // Then
+        verifyNoInteractions(rumMonitor.mockInstance)
+    }
+
+    @Test
     fun `onTap does nothing if no children present and decor view not clickable`(
         forge: Forge
     ) {


### PR DESCRIPTION
### What does this PR do?

This a fix for the following bug: let's imagine we have a container view and a child view in this container, both are visible. If we set `View.GONE` or `View.INVISIBLE` for the container view, both views won't be visible, but if we click on the place where child view would be rendered, the tap will be reported.

This happens because when we hide container view, child view still have a visibility `View.VISIBLE` despite not participating in rendering (if parent group has `View.INVISIBLE`) or even in the layout process (if parent group has `View.GONE`).

This means we need to take into account the visibility of the view groups as well when we are searching for the user interaction target.

Note: child cannot be shown without parent shown, meaning even if we have `View.INVISIBLE` for parent container switching visibility for child view has no effect (at least for built-in view groups as I tested).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

