### PR TITLE
RUM-3836 Provide the DatadogContextStorage for Opentelemetry

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -1256,9 +1256,17 @@ datadog:
       - "io.opentracing.util.GlobalTracer.isRegistered()"
       # endregion
       # region Opentelemetry
+      - "io.opentelemetry.api.trace.Span.getInvalid()"
       - "io.opentelemetry.api.trace.TracerBuilder.build()"
       - "io.opentelemetry.api.trace.SpanBuilder.setAttribute(kotlin.String?, kotlin.String?)"
       - "io.opentelemetry.api.trace.TracerBuilder.setInstrumentationVersion(kotlin.String?)"
+      - "io.opentelemetry.context.Context.get(io.opentelemetry.context.ContextKey?)"
+      - "io.opentelemetry.context.Context.makeCurrent()"
+      - "io.opentelemetry.context.Context.root()"
+      - "io.opentelemetry.context.ContextStorage.addWrapper(java.util.function.Function?)"
+      - "io.opentelemetry.context.ContextStorage.attach(io.opentelemetry.context.Context?)"
+      - "io.opentelemetry.context.ContextStorage.current()"
+      - "io.opentelemetry.context.Scope.close()"
       # endregion
       # region RxJava
       - "io.reactivex.rxjava3.core.Completable.doOnError(io.reactivex.rxjava3.functions.Consumer?)"

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -877,7 +877,7 @@ public class com/datadog/opentelemetry/trace/OtelExtractedContext : com/datadog/
 }
 
 public class com/datadog/opentelemetry/trace/OtelSpan : io/opentelemetry/api/trace/Span {
-	public fun <init> (Lcom/datadog/trace/bootstrap/instrumentation/api/AgentSpan;)V
+	public fun <init> (Lcom/datadog/trace/bootstrap/instrumentation/api/AgentSpan;Lcom/datadog/trace/bootstrap/instrumentation/api/AgentTracer$TracerAPI;)V
 	public fun activate ()Lcom/datadog/trace/bootstrap/instrumentation/api/AgentScope;
 	public fun addEvent (Ljava/lang/String;Lio/opentelemetry/api/common/Attributes;)Lio/opentelemetry/api/trace/Span;
 	public fun addEvent (Ljava/lang/String;Lio/opentelemetry/api/common/Attributes;JLjava/util/concurrent/TimeUnit;)Lio/opentelemetry/api/trace/Span;
@@ -885,6 +885,7 @@ public class com/datadog/opentelemetry/trace/OtelSpan : io/opentelemetry/api/tra
 	public fun end (JLjava/util/concurrent/TimeUnit;)V
 	public fun getAgentSpanContext ()Lcom/datadog/trace/bootstrap/instrumentation/api/AgentSpan$Context;
 	public fun getSpanContext ()Lio/opentelemetry/api/trace/SpanContext;
+	public fun getStatusCode ()Lio/opentelemetry/api/trace/StatusCode;
 	public static fun invalid ()Lio/opentelemetry/api/trace/Span;
 	public fun isRecording ()Z
 	public fun recordException (Ljava/lang/Throwable;Lio/opentelemetry/api/common/Attributes;)Lio/opentelemetry/api/trace/Span;
@@ -894,7 +895,7 @@ public class com/datadog/opentelemetry/trace/OtelSpan : io/opentelemetry/api/tra
 }
 
 public class com/datadog/opentelemetry/trace/OtelSpanBuilder : io/opentelemetry/api/trace/SpanBuilder {
-	public fun <init> (Lcom/datadog/trace/bootstrap/instrumentation/api/AgentTracer$SpanBuilder;Lcom/datadog/android/api/InternalLogger;)V
+	public fun <init> (Lcom/datadog/trace/bootstrap/instrumentation/api/AgentTracer$SpanBuilder;Lcom/datadog/trace/bootstrap/instrumentation/api/AgentTracer$TracerAPI;Lcom/datadog/android/api/InternalLogger;)V
 	public fun addLink (Lio/opentelemetry/api/trace/SpanContext;)Lio/opentelemetry/api/trace/SpanBuilder;
 	public fun addLink (Lio/opentelemetry/api/trace/SpanContext;Lio/opentelemetry/api/common/Attributes;)Lio/opentelemetry/api/trace/SpanBuilder;
 	public fun setAttribute (Lio/opentelemetry/api/common/AttributeKey;Ljava/lang/Object;)Lio/opentelemetry/api/trace/SpanBuilder;

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/opentelemetry/trace/OtelSpanBuilder.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/opentelemetry/trace/OtelSpanBuilder.java
@@ -21,6 +21,7 @@ import androidx.annotation.NonNull;
 import com.datadog.android.api.InternalLogger;
 import com.datadog.trace.bootstrap.instrumentation.api.AgentSpan;
 import com.datadog.trace.bootstrap.instrumentation.api.AgentTracer;
+
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
 import io.opentelemetry.api.trace.Span;
@@ -28,161 +29,168 @@ import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanContext;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.context.Context;
+
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 public class OtelSpanBuilder implements SpanBuilder {
-  private final AgentTracer.SpanBuilder delegate;
-  private boolean spanKindSet;
-  /**
-   * Operation name overridden value by {@link OtelConventions#OPERATION_NAME_SPECIFIC_ATTRIBUTE}
-   * reserved attribute ({@code null} if not set).
-   */
-  private String overriddenOperationName;
-  /**
-   * Analytics sample rate metric value from {@link
-   * OtelConventions#ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES} reserved attribute ({@code -1} if not
-   * set).
-   */
-  private int overriddenAnalyticsSampleRate;
+    private final AgentTracer.SpanBuilder delegate;
+    private final AgentTracer.TracerAPI agentTracer;
 
-  @NonNull
-  private final InternalLogger logger;
+    private boolean spanKindSet;
+    /**
+     * Operation name overridden value by {@link OtelConventions#OPERATION_NAME_SPECIFIC_ATTRIBUTE}
+     * reserved attribute ({@code null} if not set).
+     */
+    private String overriddenOperationName;
+    /**
+     * Analytics sample rate metric value from {@link
+     * OtelConventions#ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES} reserved attribute ({@code -1} if not
+     * set).
+     */
+    private int overriddenAnalyticsSampleRate;
 
-  public OtelSpanBuilder(AgentTracer.SpanBuilder delegate, @NonNull InternalLogger logger) {
-    this.delegate = delegate;
-    this.spanKindSet = false;
-    this.overriddenOperationName = null;
-    this.overriddenAnalyticsSampleRate = -1;
-    this.logger = logger;
-  }
+    @NonNull
+    private final InternalLogger logger;
 
-  @Override
-  public SpanBuilder setParent(Context context) {
-    AgentSpan.Context extractedContext = extract(context, logger);
-    if (extractedContext != null) {
-      this.delegate.asChildOf(extractedContext);
+    public OtelSpanBuilder(
+            AgentTracer.SpanBuilder delegate,
+            AgentTracer.TracerAPI agentTracer,
+            @NonNull InternalLogger logger) {
+        this.delegate = delegate;
+        this.spanKindSet = false;
+        this.overriddenOperationName = null;
+        this.overriddenAnalyticsSampleRate = -1;
+        this.logger = logger;
+        this.agentTracer = agentTracer;
     }
-    return this;
-  }
 
-  @Override
-  public SpanBuilder setNoParent() {
-    this.delegate.asChildOf(null);
-    this.delegate.ignoreActiveSpan();
-    return this;
-  }
-
-  @Override
-  public SpanBuilder addLink(SpanContext spanContext) {
-    if (spanContext.isValid()) {
-      this.delegate.withLink(new OtelSpanLink(spanContext));
-    }
-    return this;
-  }
-
-  @Override
-  public SpanBuilder addLink(SpanContext spanContext, Attributes attributes) {
-    if (spanContext.isValid()) {
-      this.delegate.withLink(new OtelSpanLink(spanContext, attributes));
-    }
-    return this;
-  }
-
-  @Override
-  public SpanBuilder setAttribute(String key, String value) {
-    // Check reserved attributes
-    if (OPERATION_NAME_SPECIFIC_ATTRIBUTE.equals(key) && value != null) {
-      this.overriddenOperationName = value.toLowerCase(ROOT);
-      return this;
-    } else if (ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES.equals(key) && value != null) {
-      this.overriddenAnalyticsSampleRate = parseBoolean(value) ? 1 : 0;
-      return this;
-    }
-    // Store as object to prevent delegate to remove tag when value is empty
-    this.delegate.withTag(key, (Object) value);
-    return this;
-  }
-
-  @Override
-  public SpanBuilder setAttribute(String key, long value) {
-    this.delegate.withTag(key, value);
-    return this;
-  }
-
-  @Override
-  public SpanBuilder setAttribute(String key, double value) {
-    this.delegate.withTag(key, value);
-    return this;
-  }
-
-  @Override
-  public SpanBuilder setAttribute(String key, boolean value) {
-    // Check reserved attributes
-    if (ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES.equals(key)) {
-      this.overriddenAnalyticsSampleRate = value ? 1 : 0;
-      return this;
-    }
-    this.delegate.withTag(key, value);
-    return this;
-  }
-
-  @Override
-  public <T> SpanBuilder setAttribute(AttributeKey<T> key, T value) {
-    switch (key.getType()) {
-      case STRING_ARRAY:
-      case BOOLEAN_ARRAY:
-      case LONG_ARRAY:
-      case DOUBLE_ARRAY:
-        if (value instanceof List) {
-          List<?> valueList = (List<?>) value;
-          if (valueList.isEmpty()) {
-            // Store as object to prevent delegate to remove tag when value is empty
-            this.delegate.withTag(key.getKey(), (Object) "");
-          } else {
-            for (int index = 0; index < valueList.size(); index++) {
-              this.delegate.withTag(key.getKey() + "." + index, valueList.get(index));
-            }
-          }
+    @Override
+    public SpanBuilder setParent(Context context) {
+        AgentSpan.Context extractedContext = extract(context, logger);
+        if (extractedContext != null) {
+            this.delegate.asChildOf(extractedContext);
         }
-        break;
-      default:
-        this.delegate.withTag(key.getKey(), value);
-        break;
+        return this;
     }
-    return this;
-  }
 
-  @Override
-  public SpanBuilder setSpanKind(SpanKind spanKind) {
-    if (spanKind != null) {
-      this.delegate.withTag(SPAN_KIND, toSpanKindTagValue(spanKind));
-      this.spanKindSet = true;
+    @Override
+    public SpanBuilder setNoParent() {
+        this.delegate.asChildOf(null);
+        this.delegate.ignoreActiveSpan();
+        return this;
     }
-    return this;
-  }
 
-  @Override
-  public SpanBuilder setStartTimestamp(long startTimestamp, TimeUnit unit) {
-    this.delegate.withStartTimestamp(unit.toMicros(startTimestamp));
-    return this;
-  }
+    @Override
+    public SpanBuilder addLink(SpanContext spanContext) {
+        if (spanContext.isValid()) {
+            this.delegate.withLink(new OtelSpanLink(spanContext));
+        }
+        return this;
+    }
 
-  @Override
-  public Span startSpan() {
-    // Ensure the span kind is set
-    if (!this.spanKindSet) {
-      setSpanKind(INTERNAL);
+    @Override
+    public SpanBuilder addLink(SpanContext spanContext, Attributes attributes) {
+        if (spanContext.isValid()) {
+            this.delegate.withLink(new OtelSpanLink(spanContext, attributes));
+        }
+        return this;
     }
-    AgentSpan delegate = this.delegate.start();
-    // Apply overrides
-    if (this.overriddenOperationName != null) {
-      delegate.setOperationName(this.overriddenOperationName);
+
+    @Override
+    public SpanBuilder setAttribute(String key, String value) {
+        // Check reserved attributes
+        if (OPERATION_NAME_SPECIFIC_ATTRIBUTE.equals(key) && value != null) {
+            this.overriddenOperationName = value.toLowerCase(ROOT);
+            return this;
+        } else if (ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES.equals(key) && value != null) {
+            this.overriddenAnalyticsSampleRate = parseBoolean(value) ? 1 : 0;
+            return this;
+        }
+        // Store as object to prevent delegate to remove tag when value is empty
+        this.delegate.withTag(key, (Object) value);
+        return this;
     }
-    if (this.overriddenAnalyticsSampleRate != -1) {
-      delegate.setMetric(ANALYTICS_SAMPLE_RATE, this.overriddenAnalyticsSampleRate);
+
+    @Override
+    public SpanBuilder setAttribute(String key, long value) {
+        this.delegate.withTag(key, value);
+        return this;
     }
-    return new OtelSpan(delegate);
-  }
+
+    @Override
+    public SpanBuilder setAttribute(String key, double value) {
+        this.delegate.withTag(key, value);
+        return this;
+    }
+
+    @Override
+    public SpanBuilder setAttribute(String key, boolean value) {
+        // Check reserved attributes
+        if (ANALYTICS_EVENT_SPECIFIC_ATTRIBUTES.equals(key)) {
+            this.overriddenAnalyticsSampleRate = value ? 1 : 0;
+            return this;
+        }
+        this.delegate.withTag(key, value);
+        return this;
+    }
+
+    @Override
+    public <T> SpanBuilder setAttribute(AttributeKey<T> key, T value) {
+        switch (key.getType()) {
+            case STRING_ARRAY:
+            case BOOLEAN_ARRAY:
+            case LONG_ARRAY:
+            case DOUBLE_ARRAY:
+                if (value instanceof List) {
+                    List<?> valueList = (List<?>) value;
+                    if (valueList.isEmpty()) {
+                        // Store as object to prevent delegate to remove tag when value is empty
+                        this.delegate.withTag(key.getKey(), (Object) "");
+                    } else {
+                        for (int index = 0; index < valueList.size(); index++) {
+                            this.delegate.withTag(key.getKey() + "." + index, valueList.get(index));
+                        }
+                    }
+                }
+                break;
+            default:
+                this.delegate.withTag(key.getKey(), value);
+                break;
+        }
+        return this;
+    }
+
+    @Override
+    public SpanBuilder setSpanKind(SpanKind spanKind) {
+        if (spanKind != null) {
+            this.delegate.withTag(SPAN_KIND, toSpanKindTagValue(spanKind));
+            this.spanKindSet = true;
+        }
+        return this;
+    }
+
+    @Override
+    public SpanBuilder setStartTimestamp(long startTimestamp, TimeUnit unit) {
+        this.delegate.withStartTimestamp(unit.toMicros(startTimestamp));
+        return this;
+    }
+
+    @Override
+    public Span startSpan() {
+        // Ensure the span kind is set
+        if (!this.spanKindSet) {
+            setSpanKind(INTERNAL);
+        }
+        AgentSpan delegate = this.delegate.start();
+        // Apply overrides
+        if (this.overriddenOperationName != null) {
+            delegate.setOperationName(this.overriddenOperationName);
+        }
+        if (this.overriddenAnalyticsSampleRate != -1) {
+            delegate.setMetric(ANALYTICS_SAMPLE_RATE, this.overriddenAnalyticsSampleRate);
+        }
+        return new OtelSpan(delegate, agentTracer);
+    }
 }

--- a/features/dd-sdk-android-trace/src/main/java/com/datadog/opentelemetry/trace/OtelTracer.java
+++ b/features/dd-sdk-android-trace/src/main/java/com/datadog/opentelemetry/trace/OtelTracer.java
@@ -54,6 +54,6 @@ public class OtelTracer implements Tracer {
                 this.tracer
                         .buildSpan(instrumentationScopeName, OtelConventions.SPAN_KIND_INTERNAL)
                         .withResourceName(spanName);
-        return spanBuilderDecorator.apply(new OtelSpanBuilder(delegate, logger));
+        return spanBuilderDecorator.apply(new OtelSpanBuilder(delegate, tracer, logger));
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/OtelTracerProvider.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/OtelTracerProvider.kt
@@ -253,13 +253,13 @@ class OtelTracerProvider(
 
     private fun resolveSpanBuilderDecorator(): (SpanBuilder) -> SpanBuilder {
         return if (bundleWithRumEnabled) {
-            resolveSpanBuilderDecoratorFromContext()
+            resolveDecoratorFromRumContext()
         } else {
             NO_OP_SPAN_BUILDER_DECORATOR
         }
     }
 
-    private fun resolveSpanBuilderDecoratorFromContext(): (SpanBuilder) -> SpanBuilder = { spanBuilder ->
+    private fun resolveDecoratorFromRumContext(): (SpanBuilder) -> SpanBuilder = { spanBuilder ->
         val rumContext = sdkCore.getFeatureContext(Feature.RUM_FEATURE_NAME)
         val applicationId = rumContext[RUM_APPLICATION_ID_KEY] as? String
         val sessionId = rumContext[RUM_SESSION_ID_KEY] as? String

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/TracingFeature.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/TracingFeature.kt
@@ -22,7 +22,9 @@ import com.datadog.android.trace.internal.domain.event.OtelDdSpanToSpanEventMapp
 import com.datadog.android.trace.internal.domain.event.SpanEventMapperWrapper
 import com.datadog.android.trace.internal.domain.event.SpanEventSerializer
 import com.datadog.android.trace.internal.net.TracesRequestFactory
+import com.datadog.android.trace.opentelemetry.DatadogContextStorage
 import com.datadog.legacy.trace.common.writer.Writer
+import io.opentelemetry.context.ContextStorage
 import java.util.concurrent.atomic.AtomicBoolean
 
 /**
@@ -46,6 +48,7 @@ internal class TracingFeature constructor(
     override fun onInitialize(appContext: Context) {
         dataWriter = createDataWriter(sdkCore)
         otelDataWriter = createOtelDataWriter(sdkCore)
+        ContextStorage.addWrapper { DatadogContextStorage(it) }
         initialized.set(true)
     }
 

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/DatadogContextStorage.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/DatadogContextStorage.kt
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+package com.datadog.android.trace.opentelemetry
+
+import com.datadog.opentelemetry.context.OtelContext
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextStorage
+import io.opentelemetry.context.Scope
+
+internal class DatadogContextStorage(private val wrapped: ContextStorage) : ContextStorage {
+    override fun current(): Context {
+        val current = wrapped.current() ?: Context.root()
+        return if (current is OtelContext) {
+            current
+        } else {
+            OtelContext(current)
+        }
+    }
+
+    override fun attach(toAttach: Context): Scope {
+        return wrapped.attach(toAttach)
+    }
+}

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/DatadogContextStorage.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/DatadogContextStorage.kt
@@ -5,7 +5,6 @@
  */
 package com.datadog.android.trace.opentelemetry
 
-import com.datadog.opentelemetry.context.OtelContext
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextStorage
 import io.opentelemetry.context.Scope

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelContext.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelContext.kt
@@ -1,0 +1,46 @@
+package com.datadog.opentelemetry.context
+
+import com.datadog.android.trace.opentelemetry.OtelScope
+import com.datadog.opentelemetry.trace.OtelSpan
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
+import io.opentelemetry.context.Scope
+
+internal class OtelContext(
+    internal val wrapped: Context,
+    private val currentSpan: Span = Span.getInvalid(),
+    private val rootSpan: Span = Span.getInvalid()
+) : Context {
+    override fun <V> get(key: ContextKey<V>): V? {
+        if (OTEL_CONTEXT_SPAN_KEY == key.toString()) {
+            return currentSpan as V
+        } else if (OTEL_CONTEXT_ROOT_SPAN_KEY == key.toString()) {
+            return rootSpan as V
+        }
+        return wrapped.get(key)
+    }
+
+    override fun <V> with(k1: ContextKey<V>, v1: V): Context {
+        if (OTEL_CONTEXT_SPAN_KEY == k1.toString()) {
+            return OtelContext(wrapped, v1 as Span, rootSpan)
+        } else if (OTEL_CONTEXT_ROOT_SPAN_KEY == k1.toString()) {
+            return OtelContext(wrapped, currentSpan, v1 as Span)
+        }
+        return OtelContext(wrapped.with(k1, v1), currentSpan, rootSpan)
+    }
+
+    override fun makeCurrent(): Scope {
+        var scope = super.makeCurrent()
+        if (currentSpan is OtelSpan) {
+            val agentScope = currentSpan.activate()
+            scope = OtelScope(scope, agentScope)
+        }
+        return scope
+    }
+
+    companion object {
+        internal const val OTEL_CONTEXT_SPAN_KEY = "opentelemetry-trace-span-key"
+        internal const val OTEL_CONTEXT_ROOT_SPAN_KEY = "opentelemetry-traces-local-root-span"
+    }
+}

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelContext.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelContext.kt
@@ -1,6 +1,11 @@
-package com.datadog.opentelemetry.context
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
 
-import com.datadog.android.trace.opentelemetry.OtelScope
+package com.datadog.android.trace.opentelemetry
+
 import com.datadog.opentelemetry.trace.OtelSpan
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.context.Context
@@ -9,18 +14,21 @@ import io.opentelemetry.context.Scope
 
 internal class OtelContext(
     internal val wrapped: Context,
-    private val currentSpan: Span = Span.getInvalid(),
-    private val rootSpan: Span = Span.getInvalid()
+    internal val currentSpan: Span = Span.getInvalid(),
+    internal val rootSpan: Span = Span.getInvalid()
 ) : Context {
+
+    @Suppress("ReturnCount", "UNCHECKED_CAST")
     override fun <V> get(key: ContextKey<V>): V? {
         if (OTEL_CONTEXT_SPAN_KEY == key.toString()) {
-            return currentSpan as V
+            return currentSpan as? V
         } else if (OTEL_CONTEXT_ROOT_SPAN_KEY == key.toString()) {
-            return rootSpan as V
+            return rootSpan as? V
         }
         return wrapped.get(key)
     }
 
+    @Suppress("ReturnCount")
     override fun <V> with(k1: ContextKey<V>, v1: V): Context {
         if (OTEL_CONTEXT_SPAN_KEY == k1.toString()) {
             return OtelContext(wrapped, v1 as Span, rootSpan)

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelScope.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelScope.kt
@@ -1,0 +1,11 @@
+package com.datadog.android.trace.opentelemetry
+
+import com.datadog.trace.bootstrap.instrumentation.api.AgentScope
+import io.opentelemetry.context.Scope
+
+internal class OtelScope(internal val scope: Scope, internal val delegate: AgentScope) : Scope {
+    override fun close() {
+        delegate.close()
+        scope.close()
+    }
+}

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelScope.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/opentelemetry/OtelScope.kt
@@ -1,3 +1,9 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
 package com.datadog.android.trace.opentelemetry
 
 import com.datadog.trace.bootstrap.instrumentation.api.AgentScope

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TracingFeatureTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/TracingFeatureTest.kt
@@ -17,11 +17,13 @@ import com.datadog.android.trace.internal.domain.event.DdSpanToSpanEventMapper
 import com.datadog.android.trace.internal.domain.event.OtelDdSpanToSpanEventMapper
 import com.datadog.android.trace.internal.domain.event.SpanEventMapperWrapper
 import com.datadog.android.trace.internal.net.TracesRequestFactory
+import com.datadog.android.trace.opentelemetry.DatadogContextStorage
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.opentelemetry.context.ContextStorage
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -85,6 +87,7 @@ internal class TracingFeatureTest {
         assertThat(ddSpanToSpanEventMapper).isInstanceOf(DdSpanToSpanEventMapper::class.java)
         assertThat((ddSpanToSpanEventMapper as DdSpanToSpanEventMapper).networkInfoEnabled)
             .isEqualTo(fakeNetworkInfoEnabled)
+        assertThat(ContextStorage.get()).isInstanceOf(DatadogContextStorage::class.java)
     }
 
     @Test

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/opentelemetry/DatadogContextStorageTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/opentelemetry/DatadogContextStorageTest.kt
@@ -6,7 +6,6 @@
 
 package com.datadog.android.trace.opentelemetry
 
-import com.datadog.opentelemetry.context.OtelContext
 import io.opentelemetry.context.Context
 import io.opentelemetry.context.ContextStorage
 import io.opentelemetry.context.Scope
@@ -72,7 +71,7 @@ internal class DatadogContextStorageTest {
     // region attach
 
     @Test
-    fun `M delgate to the wrapper W attach { }`() {
+    fun `M delegate to the wrapper W attach { }`() {
         // Given
         val mockScope: Scope = mock()
         val mockContext: Context = mock()

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/opentelemetry/DatadogContextStorageTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/opentelemetry/DatadogContextStorageTest.kt
@@ -1,0 +1,89 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.opentelemetry
+
+import com.datadog.opentelemetry.context.OtelContext
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextStorage
+import io.opentelemetry.context.Scope
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class DatadogContextStorageTest {
+
+    lateinit var testedStorage: DatadogContextStorage
+
+    @Mock
+    lateinit var mockWrappedStorage: ContextStorage
+
+    @Mock
+    lateinit var mockCurrentContext: Context
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(mockWrappedStorage.current()).thenReturn(mockCurrentContext)
+        testedStorage = DatadogContextStorage(mockWrappedStorage)
+    }
+
+    // region current
+
+    @Test
+    fun `M return OtelContext W current { current context is not null }`() {
+        // When
+        val current = testedStorage.current()
+
+        // Then
+        assertThat(current).isInstanceOf(OtelContext::class.java)
+        assertThat((current as OtelContext).wrapped).isSameAs(mockCurrentContext)
+    }
+
+    @Test
+    fun `M return OtelContext W current { current context is null }`() {
+        // Given
+        whenever(mockWrappedStorage.current()).thenReturn(null)
+
+        // When
+        val current = testedStorage.current()
+
+        // Then
+        assertThat(current).isInstanceOf(OtelContext::class.java)
+        assertThat((current as OtelContext).wrapped).isSameAs(Context.root())
+    }
+
+    // endregion current
+
+    // region attach
+
+    @Test
+    fun `M delgate to the wrapper W attach { }`() {
+        // Given
+        val mockScope: Scope = mock()
+        val mockContext: Context = mock()
+        whenever(mockWrappedStorage.attach(mockContext)).thenReturn(mockScope)
+
+        // When
+        val scope = testedStorage.attach(mockContext)
+
+        // Then
+        assertThat(scope).isSameAs(mockScope)
+    }
+
+    // endregion
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/opentelemetry/OtelContextTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/opentelemetry/OtelContextTest.kt
@@ -1,0 +1,205 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.opentelemetry
+
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.opentelemetry.context.OtelContext
+import com.datadog.opentelemetry.trace.OtelSpan
+import com.datadog.trace.bootstrap.instrumentation.api.AgentScope
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.opentelemetry.api.trace.Span
+import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
+import io.opentelemetry.context.Scope
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class OtelContextTest {
+
+    @Mock
+    private lateinit var mockContext: Context
+
+    @Mock
+    private lateinit var mockCurrentSpan: Span
+
+    @Mock
+    private lateinit var mockRootSpan: Span
+
+    private lateinit var testedContext: OtelContext
+
+    @BeforeEach
+    fun setUp() {
+        mockContext = mock()
+        testedContext = OtelContext(mockContext, mockCurrentSpan, mockRootSpan)
+    }
+
+    // region get by key
+
+    @Test
+    fun `M return current span W get { key is OTEL_CONTEXT_SPAN_KEY }`() {
+        // Given
+        val key = ContextKey.named<Span>(OtelContext.OTEL_CONTEXT_SPAN_KEY)
+
+        // When
+        val result = testedContext.get(key)
+
+        // Then
+        assertThat(result).isEqualTo(mockCurrentSpan)
+    }
+
+    @Test
+    fun `M return root span W get { key is OTEL_CONTEXT_ROOT_SPAN_KEY }`() {
+        // Given
+        val key = ContextKey.named<Span>(OtelContext.OTEL_CONTEXT_ROOT_SPAN_KEY)
+
+        // When
+        val result = testedContext.get(key)
+
+        // Then
+        assertThat(result).isEqualTo(mockRootSpan)
+    }
+
+    @Test
+    fun `M delegate to wrapped Context W get { key is not recognized }`(forge: Forge) {
+        // Given
+        val fakeKeyName = forge.anAlphabeticalString()
+        val key = ContextKey.named<String>(fakeKeyName)
+        val fakeKeyValue = forge.anAlphabeticalString()
+        whenever(mockContext.get(key)).thenReturn(fakeKeyValue)
+
+        // When
+        val result = testedContext.get(key)
+
+        // Then
+        assertThat(result).isEqualTo(fakeKeyValue)
+    }
+
+    // endregion
+
+    // region with key and value
+
+    @Test
+    fun `M return OtelContext W with { key is OTEL_CONTEXT_SPAN_KEY }`() {
+        // Given
+        val key = ContextKey.named<Span>(OtelContext.OTEL_CONTEXT_SPAN_KEY)
+        val value = mock<Span>()
+
+        // When
+        val result = testedContext.with(key, value)
+
+        // Then
+        assertThat(result).isInstanceOf(OtelContext::class.java)
+    }
+
+    @Test
+    fun `M return OtelContext W with { key is OTEL_CONTEXT_ROOT_SPAN_KEY }`() {
+        // Given
+        val key = ContextKey.named<Span>(OtelContext.OTEL_CONTEXT_ROOT_SPAN_KEY)
+        val value = mock<Span>()
+
+        // When
+        val result = testedContext.with(key, value)
+
+        // Then
+        assertThat(result).isInstanceOf(OtelContext::class.java)
+    }
+
+    @Test
+    fun `M return OtelContext W with { key is not recognized }`(forge: Forge) {
+        // Given
+        val fakeKeyName = forge.anAlphabeticalString()
+        val key = ContextKey.named<String>(fakeKeyName)
+        val fakeKeyValue = forge.anAlphabeticalString()
+        val value = fakeKeyValue
+        val wrappedContext: Context = mock()
+        whenever(mockContext.with(key, value)).thenReturn(wrappedContext)
+
+        // When
+        val result = testedContext.with(key, value)
+
+        // Then
+        assertThat(result).isInstanceOf(OtelContext::class.java)
+    }
+
+    @Test
+    fun `M return OtelContext W with consecutively { key is OTEL_CONTEXT_SPAN_KEY }`(forge: Forge) {
+        // Given
+        val keysToValues = forge.aList {
+            ContextKey.named<String>(forge.anAlphabeticalString()) to forge.anAlphabeticalString()
+        }
+
+        // When
+        val context = keysToValues.fold(OtelContext(Context.root())) { acc, (key, value) ->
+            acc.with(key, value) as OtelContext
+        }
+
+        // Then
+        assertThat(context).isInstanceOf(OtelContext::class.java)
+        val wrapped = (context as OtelContext).wrapped
+        assertThat(wrapped).isInstanceOf(Context::class.java)
+        assertThat(wrapped).isNotExactlyInstanceOf(OtelContext::class.java)
+        keysToValues.forEach {
+            val (key, value) = it
+            assertThat(wrapped.get(key)).isEqualTo(value)
+        }
+    }
+
+    // endregion
+
+    // region makeCurrent
+
+    @Test
+    fun `M return OtelScope W makeCurrent { currentSpan is OtelSpan }`() {
+        // Given
+        val mockAgentScope: AgentScope = mock()
+        val mockOtelSpan: OtelSpan = mock {
+            on { activate() }.thenReturn(mockAgentScope)
+        }
+        testedContext = OtelContext(mockContext, mockOtelSpan, mockRootSpan)
+
+        // When
+        val result = testedContext.makeCurrent()
+
+        // Then
+        assertThat(result).isInstanceOf(OtelScope::class.java)
+        val otelScope = result as OtelScope
+        assertThat(otelScope.delegate).isSameAs(mockAgentScope)
+        assertThat(otelScope.scope).isInstanceOf(Scope::class.java)
+    }
+
+    @Test
+    fun `M return OtelScope W makeCurrent { currentSpan is not OtelSpan }`() {
+        // Given
+        testedContext = OtelContext(mockContext)
+
+        // When
+        val result = testedContext.makeCurrent()
+
+        // Then
+        assertThat(result).isInstanceOf(Scope::class.java)
+        assertThat(result).isNotExactlyInstanceOf(OtelScope::class.java)
+    }
+
+    // endregion
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/opentelemetry/OtelScopeTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/opentelemetry/OtelScopeTest.kt
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.opentelemetry
+
+import com.datadog.trace.bootstrap.instrumentation.api.AgentScope
+import io.opentelemetry.context.Scope
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.verify
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class OtelScopeTest {
+
+    @Mock
+    lateinit var mockWrappedScope: Scope
+
+    @Mock
+    lateinit var mockAgentScope: AgentScope
+
+    lateinit var testedScope: OtelScope
+
+    @BeforeEach
+    fun `set up`() {
+        testedScope = OtelScope(mockWrappedScope, mockAgentScope)
+    }
+
+    @Test
+    fun `M call close on wrapped scope W close`() {
+        // When
+        testedScope.close()
+
+        // Then
+        verify(mockWrappedScope).close()
+    }
+
+    @Test
+    fun `M call close on agent scope W close`() {
+        // When
+        testedScope.close()
+
+        // Then
+        verify(mockAgentScope).close()
+    }
+}

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentelemetry/trace/OtelSpanTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentelemetry/trace/OtelSpanTest.kt
@@ -8,7 +8,6 @@ package com.datadog.opentelemetry.trace
 
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.trace.api.ConfigDefaults
-import com.datadog.trace.api.DDTags
 import com.datadog.trace.bootstrap.instrumentation.api.AgentSpan
 import com.datadog.trace.bootstrap.instrumentation.api.AgentTracer
 import com.datadog.trace.bootstrap.instrumentation.api.ErrorPriorities
@@ -82,46 +81,46 @@ internal class OtelSpanTest {
 
     // region setAttribute
 
-    fun `M add attribute W setAttribute`(tagBuilder: Boolean, tagSpan: Boolean) {
+    @Test
+    fun `M add attribute W setAttribute`() {
         // Given
-        val expectedTags = mapOf(
-            "string" to "a",
+        val expectedTags = listOf(
+            "string" to "b",
             "empty_string" to "",
-            "number" to 1,
-            "boolean" to true,
+            "number" to 2L,
+            "boolean" to false,
             "empty-string-attribute" to "",
-            "string-array.0" to "a",
-            "string-array.1" to "b",
-            "string-array.2" to "c",
-            "boolean-array.0" to true,
-            "boolean-array.1" to false,
-            "long-array.0" to 1L,
-            "long-array.1" to 2L,
-            "long-array.2" to 3L,
-            "long-array.3" to 4L,
-            "double-array.0" to 1.23,
-            "double-array.1" to 4.56,
+            "string-array.0" to "d",
+            "string-array.1" to "e",
+            "string-array.2" to "f",
+            "boolean-array.0" to false,
+            "boolean-array.1" to true,
+            "long-array.0" to 5L,
+            "long-array.1" to 6L,
+            "long-array.2" to 7L,
+            "long-array.3" to 8L,
+            "double-array.0" to 34.0,
+            "double-array.1" to 5.67,
             "empty-array" to ""
         )
 
         // When
-        testedSpan.setAttribute(DDTags.RESOURCE_NAME, "other-resource")
-            .setAttribute("string", "b")
-            .setAttribute("empty_string", "")
-            .setAttribute("number", 2)
-            .setAttribute("boolean", false)
-            .setAttribute(AttributeKey.stringKey("null-string-attribute"), null)
-            .setAttribute(AttributeKey.stringKey("empty-string-attribute"), "")
-            .setAttribute(AttributeKey.stringArrayKey("string-array"), listOf("d", "e", "f"))
-            .setAttribute(AttributeKey.booleanArrayKey("boolean-array"), listOf(false, true))
-            .setAttribute(AttributeKey.longArrayKey("long-array"), listOf(5L, 6L, 7L, 8L))
-            .setAttribute(AttributeKey.doubleArrayKey("double-array"), listOf(2.34, 5.67))
-            .setAttribute(AttributeKey.stringArrayKey("empty-array"), emptyList<String>())
-            .setAttribute(AttributeKey.stringArrayKey("null-array"), null)
+        testedSpan.setAttribute("string", "b")
+        testedSpan.setAttribute("empty_string", "")
+        testedSpan.setAttribute("number", 2L)
+        testedSpan.setAttribute("boolean", false)
+        testedSpan.setAttribute(AttributeKey.stringKey("null-string-attribute"), null)
+        testedSpan.setAttribute(AttributeKey.stringKey("empty-string-attribute"), "")
+        testedSpan.setAttribute(AttributeKey.stringArrayKey("string-array"), listOf("d", "e", "f"))
+        testedSpan.setAttribute(AttributeKey.booleanArrayKey("boolean-array"), listOf(false, true))
+        testedSpan.setAttribute(AttributeKey.longArrayKey("long-array"), listOf(5L, 6L, 7L, 8L))
+        testedSpan.setAttribute(AttributeKey.doubleArrayKey("double-array"), listOf(34.0, 5.67))
+        testedSpan.setAttribute(AttributeKey.stringArrayKey("empty-array"), emptyList())
+        testedSpan.setAttribute(AttributeKey.stringArrayKey("null-array"), null)
 
         // Then
-        expectedTags.entries.forEach {
-            verify(mockAgentSpan).setTag(it.key, it.value)
+        expectedTags.forEach {
+            verify(mockAgentSpan).setTag(it.first, it.second)
         }
     }
 
@@ -156,8 +155,6 @@ internal class OtelSpanTest {
     ) {
         // Given
         testedSpan.end()
-        val expectedIsError = fakeStatusCode == StatusCode.ERROR
-        val expectedErrorMessage = if (expectedIsError) fakeDescription else null
 
         // When
         testedSpan.setStatus(fakeStatusCode, fakeDescription)

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentelemetry/trace/OtelSpanTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/opentelemetry/trace/OtelSpanTest.kt
@@ -1,0 +1,273 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.opentelemetry.trace
+
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.trace.api.ConfigDefaults
+import com.datadog.trace.api.DDTags
+import com.datadog.trace.bootstrap.instrumentation.api.AgentSpan
+import com.datadog.trace.bootstrap.instrumentation.api.AgentTracer
+import com.datadog.trace.bootstrap.instrumentation.api.ErrorPriorities
+import com.datadog.trace.bootstrap.instrumentation.api.ScopeSource
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.opentelemetry.api.common.AttributeKey
+import io.opentelemetry.api.common.Attributes
+import io.opentelemetry.api.trace.StatusCode
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.EnumSource
+import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class OtelSpanTest {
+
+    @Mock
+    lateinit var mockAgentTracer: AgentTracer.TracerAPI
+
+    @Mock
+    lateinit var mockAgentSpan: AgentSpan
+    lateinit var testedSpan: OtelSpan
+
+    @BeforeEach
+    fun `set up`() {
+        testedSpan = OtelSpan(mockAgentSpan, mockAgentTracer)
+    }
+
+    // region Init
+    @Test
+    fun `M set default attributes W init`() {
+        // Then
+        assertThat(testedSpan.isRecording).isTrue()
+        assertThat(testedSpan.statusCode).isEqualTo(StatusCode.UNSET)
+    }
+
+    @Test
+    fun `M return NOOP W invalid()`() {
+        // When
+        val result = OtelSpan.invalid()
+
+        // Then
+        assertThat(result).isSameAs(OtelSpan.NoopSpan.INSTANCE)
+    }
+
+    // endregion
+
+    // region setAttribute
+
+    fun `M add attribute W setAttribute`(tagBuilder: Boolean, tagSpan: Boolean) {
+        // Given
+        val expectedTags = mapOf(
+            "string" to "a",
+            "empty_string" to "",
+            "number" to 1,
+            "boolean" to true,
+            "empty-string-attribute" to "",
+            "string-array.0" to "a",
+            "string-array.1" to "b",
+            "string-array.2" to "c",
+            "boolean-array.0" to true,
+            "boolean-array.1" to false,
+            "long-array.0" to 1L,
+            "long-array.1" to 2L,
+            "long-array.2" to 3L,
+            "long-array.3" to 4L,
+            "double-array.0" to 1.23,
+            "double-array.1" to 4.56,
+            "empty-array" to ""
+        )
+
+        // When
+        testedSpan.setAttribute(DDTags.RESOURCE_NAME, "other-resource")
+            .setAttribute("string", "b")
+            .setAttribute("empty_string", "")
+            .setAttribute("number", 2)
+            .setAttribute("boolean", false)
+            .setAttribute(AttributeKey.stringKey("null-string-attribute"), null)
+            .setAttribute(AttributeKey.stringKey("empty-string-attribute"), "")
+            .setAttribute(AttributeKey.stringArrayKey("string-array"), listOf("d", "e", "f"))
+            .setAttribute(AttributeKey.booleanArrayKey("boolean-array"), listOf(false, true))
+            .setAttribute(AttributeKey.longArrayKey("long-array"), listOf(5L, 6L, 7L, 8L))
+            .setAttribute(AttributeKey.doubleArrayKey("double-array"), listOf(2.34, 5.67))
+            .setAttribute(AttributeKey.stringArrayKey("empty-array"), emptyList<String>())
+            .setAttribute(AttributeKey.stringArrayKey("null-array"), null)
+
+        // Then
+        expectedTags.entries.forEach {
+            verify(mockAgentSpan).setTag(it.key, it.value)
+        }
+    }
+
+    // endregion
+
+    // region setStatus
+
+    @ParameterizedTest
+    @EnumSource(StatusCode::class)
+    fun `M delegate to AgentSpan W setStatus { statusCode not set }`(
+        fakeStatusCode: StatusCode,
+        @StringForgery fakeDescription: String
+    ) {
+        // Given
+        val expectedIsError = fakeStatusCode == StatusCode.ERROR
+        val expectedErrorMessage = if (expectedIsError) fakeDescription else null
+
+        // When
+        testedSpan.setStatus(fakeStatusCode, fakeDescription)
+
+        // Then
+        verify(mockAgentSpan).setError(expectedIsError)
+        verify(mockAgentSpan).setErrorMessage(expectedErrorMessage)
+        assertThat(testedSpan.statusCode).isEqualTo(fakeStatusCode)
+    }
+
+    @ParameterizedTest
+    @EnumSource(StatusCode::class)
+    fun `M do nothing W setStatus { isRecording is false }`(
+        fakeStatusCode: StatusCode,
+        @StringForgery fakeDescription: String
+    ) {
+        // Given
+        testedSpan.end()
+        val expectedIsError = fakeStatusCode == StatusCode.ERROR
+        val expectedErrorMessage = if (expectedIsError) fakeDescription else null
+
+        // When
+        testedSpan.setStatus(fakeStatusCode, fakeDescription)
+
+        // Then
+        verify(mockAgentSpan, never()).setError(any())
+        verify(mockAgentSpan, never()).setErrorMessage(anyOrNull())
+        assertThat(testedSpan.statusCode).isEqualTo(StatusCode.UNSET)
+    }
+
+    @Test
+    fun `M delegate to AgentSpan W setStatus { statusCode Error to Ok }`(
+        @StringForgery fakeDescription1: String,
+        @StringForgery fakeDescription2: String
+    ) {
+        // Given
+        testedSpan.setStatus(StatusCode.ERROR, fakeDescription1)
+
+        // When
+        testedSpan.setStatus(StatusCode.OK, fakeDescription2)
+
+        // Then
+        verify(mockAgentSpan).setError(false)
+        verify(mockAgentSpan).setErrorMessage(null)
+        assertThat(testedSpan.statusCode).isEqualTo(StatusCode.ERROR)
+    }
+
+    @ParameterizedTest
+    @MethodSource("errorStatuses")
+    fun `M do nothing W setStatus { status code Any to Error or UNSET }`(
+        fakeStatusCode1: StatusCode,
+        fakeStatusCode2: StatusCode,
+        @StringForgery fakeDescription1: String,
+        @StringForgery fakeDescription2: String
+    ) {
+        // Given
+        val expectedIsError = fakeStatusCode1 == StatusCode.ERROR
+        val expectedErrorMessage = if (expectedIsError) fakeDescription1 else null
+        testedSpan.setStatus(fakeStatusCode1, fakeDescription1)
+
+        // When
+        testedSpan.setStatus(fakeStatusCode2, fakeDescription2)
+
+        // Then
+        verify(mockAgentSpan).setError(expectedIsError)
+        verify(mockAgentSpan).setErrorMessage(expectedErrorMessage)
+        assertThat(testedSpan.statusCode).isEqualTo(fakeStatusCode1)
+        verifyNoMoreInteractions(mockAgentSpan)
+    }
+
+    // endregion
+
+    // region recordException
+
+    @Test
+    fun `M delegate to AgentSpan W recordException`(@Forgery fakeThrowable: Throwable) {
+        // Given
+        val mockAttributes: Attributes = mock()
+
+        // When
+        testedSpan.recordException(fakeThrowable, mockAttributes)
+
+        // Then
+        verify(mockAgentSpan).addThrowable(fakeThrowable, ErrorPriorities.UNSET)
+        verifyNoInteractions(mockAttributes)
+    }
+
+    @Test
+    fun `M do nothing W recordException { isRecording is false }`(@Forgery fakeThrowable: Throwable) {
+        // Given
+        testedSpan.end()
+        val mockAttributes: Attributes = mock()
+
+        // When
+        testedSpan.recordException(fakeThrowable, mockAttributes)
+
+        // Then
+        verify(mockAgentSpan, never()).addThrowable(fakeThrowable, ErrorPriorities.UNSET)
+        verifyNoInteractions(mockAttributes)
+    }
+
+    // endregion
+
+    // region activate
+
+    @Test
+    fun `M delegate to AgentSpan W activate`() {
+        // When
+        testedSpan.activate()
+
+        // Then
+        verify(mockAgentTracer).activateSpan(
+            mockAgentSpan,
+            ScopeSource.INSTRUMENTATION,
+            ConfigDefaults.DEFAULT_ASYNC_PROPAGATING
+        )
+    }
+
+    // endregion
+
+    companion object {
+        @JvmStatic
+        fun errorStatuses(): List<Arguments> {
+            return listOf(
+                Arguments.of(StatusCode.ERROR, StatusCode.ERROR),
+                Arguments.of(StatusCode.ERROR, StatusCode.UNSET),
+                Arguments.of(StatusCode.OK, StatusCode.ERROR),
+                Arguments.of(StatusCode.OK, StatusCode.UNSET),
+                Arguments.of(StatusCode.OK, StatusCode.OK)
+            )
+        }
+    }
+}

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -186,10 +186,12 @@ class SampleApplication : Application() {
                 .build()
         )
         GlobalOpenTelemetry.set(object : OpenTelemetry {
+            private val tracerProvider = OtelTracerProvider.Builder()
+                .setService(BuildConfig.APPLICATION_ID)
+                .build()
+
             override fun getTracerProvider(): OtelTracerProvider {
-                return OtelTracerProvider.Builder()
-                    .setService(BuildConfig.APPLICATION_ID)
-                    .build()
+                return tracerProvider
             }
 
             override fun getPropagators(): ContextPropagators {

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/OtelTracesFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/OtelTracesFragment.kt
@@ -31,6 +31,7 @@ internal class OtelTracesFragment : Fragment(), View.OnClickListener {
     ): View? {
         val rootView = inflater.inflate(R.layout.fragment_otel_traces, container, false)
         rootView.findViewById<Button>(R.id.start_async_operation).setOnClickListener(this)
+        rootView.findViewById<Button>(R.id.start_chained_contexts_test).setOnClickListener(this)
         progressBarAsync = rootView.findViewById(R.id.spinner_async)
         return rootView
     }
@@ -60,6 +61,14 @@ internal class OtelTracesFragment : Fragment(), View.OnClickListener {
                     onProgress = {
                         progressBarAsync.progress = it
                     },
+                    onDone = {
+                        progressBarAsync.visibility = View.INVISIBLE
+                    }
+                )
+            }
+            R.id.start_chained_contexts_test -> {
+                progressBarAsync.visibility = View.VISIBLE
+                viewModel.startChainedContexts(
                     onDone = {
                         progressBarAsync.visibility = View.INVISIBLE
                     }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/OtelTracesViewModel.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/OtelTracesViewModel.kt
@@ -47,6 +47,13 @@ internal class OtelTracesViewModel : ViewModel() {
             .startSpan()
         val scope: Scope = parentSpan.makeCurrent()
 
+        init {
+            tracer
+                .spanBuilder("Child of AsyncOperation")
+                .startSpan()
+                .end()
+        }
+
         @Suppress("CheckInternal")
         private val logger: Logger by lazy {
             Logger.Builder()

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/OtelTracesViewModel.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/OtelTracesViewModel.kt
@@ -14,12 +14,14 @@ import io.opentelemetry.api.GlobalOpenTelemetry
 import io.opentelemetry.api.trace.Span
 import io.opentelemetry.api.trace.Tracer
 import io.opentelemetry.context.Context
+import io.opentelemetry.context.ContextKey
 import io.opentelemetry.context.Scope
 
 @Suppress("DEPRECATION")
 internal class OtelTracesViewModel : ViewModel() {
 
     private var asyncOperationTask: AsyncTask<Unit, Unit, Unit>? = null
+    private var chainedContextsTask: AsyncTask<Unit, Unit, Unit>? = null
 
     fun startAsyncOperation(
         onProgress: (Int) -> Unit = {},
@@ -31,6 +33,12 @@ internal class OtelTracesViewModel : ViewModel() {
 
     fun stopAsyncOperations() {
         asyncOperationTask?.cancel(true)
+        chainedContextsTask?.cancel(true)
+    }
+
+    fun startChainedContexts(onDone: () -> Unit = {}) {
+        chainedContextsTask = ChainedContextsTask(onDone)
+        chainedContextsTask?.execute()
     }
 
     // region AsyncOperationTask
@@ -47,14 +55,6 @@ internal class OtelTracesViewModel : ViewModel() {
             .startSpan()
         val scope: Scope = parentSpan.makeCurrent()
 
-        init {
-            tracer
-                .spanBuilder("Child of AsyncOperation")
-                .startSpan()
-                .end()
-        }
-
-        @Suppress("CheckInternal")
         private val logger: Logger by lazy {
             Logger.Builder()
                 .setName("async_task")
@@ -70,7 +70,6 @@ internal class OtelTracesViewModel : ViewModel() {
         override fun onPreExecute() {
             val span = tracer
                 .spanBuilder("OnPreExecute")
-                .setParent(Context.current())
                 .startSpan()
             super.onPreExecute()
             span.end()
@@ -97,10 +96,8 @@ internal class OtelTracesViewModel : ViewModel() {
 
         @Deprecated("Deprecated in Java")
         override fun onPostExecute(result: Unit?) {
-            val parentContext = Context.current()
             val span = tracer
                 .spanBuilder("OnPostExecute")
-                .setParent(parentContext)
                 .startSpan()
             if (!isCancelled) {
                 onDone()
@@ -110,6 +107,64 @@ internal class OtelTracesViewModel : ViewModel() {
             scope.close()
             // finish the parent span
             parentSpan.end()
+        }
+    }
+
+    private class ChainedContextsTask(
+        val onDone: () -> Unit
+    ) : AsyncTask<Unit, Unit, Unit>() {
+        private val tracer: Tracer = GlobalOpenTelemetry.get()
+            .getTracer("chainedContexts")
+        private val email = "john.doe@example.com"
+        private val username = "John Doe"
+        private val emailKey: ContextKey<String> = ContextKey.named("email")
+        private val usernameKey: ContextKey<String> = ContextKey.named("username")
+        private val context: Context =
+            Context.current().with(emailKey, email).with(usernameKey, username)
+        val startSpan: Span = tracer
+            .spanBuilder("submitForm")
+            .setParent(context)
+            .startSpan()
+        val scope: Scope = startSpan.makeCurrent()
+
+        private val logger: Logger by lazy {
+            Logger.Builder()
+                .setName("chained-contexts-task")
+                .setLogcatLogsEnabled(true)
+                .build()
+                .apply {
+                    addTag(ATTR_FLAVOR, BuildConfig.FLAVOR)
+                    addTag("build_type", BuildConfig.BUILD_TYPE)
+                }
+        }
+
+        @Suppress("MagicNumber")
+        @Deprecated("Deprecated in Java")
+        override fun doInBackground(vararg params: Unit?) {
+            val processingFormSpan = tracer
+                .spanBuilder("processingForm")
+                .setParent(Context.current().with(startSpan))
+                .startSpan()
+            val email = context.get(emailKey)
+            val username = context.get(usernameKey)
+            val formScope = processingFormSpan.makeCurrent()
+            val processingSanitization = tracer
+                .spanBuilder("formSanitization")
+                .startSpan()
+            logger.v("Sanitizing email: $email")
+            logger.v("Sanitizing username: $username")
+            Thread.sleep(2000)
+            processingSanitization.end()
+            Thread.sleep(5000)
+            formScope.close()
+            processingFormSpan.end()
+        }
+
+        @Deprecated("Deprecated in Java")
+        override fun onPostExecute(result: Unit?) {
+            scope.close()
+            startSpan.end()
+            onDone()
         }
     }
 

--- a/sample/kotlin/src/main/res/layout/fragment_otel_traces.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_otel_traces.xml
@@ -30,10 +30,34 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_margin="16dp"
-        android:text="@string/button_start"
+        android:text="@string/start_async_operation"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/async_operation"/>
+
+
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/chained_contexts_test"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center_horizontal"
+        android:padding="16dp"
+        android:layout_margin="8dp"
+        android:text="@string/chained_contexts_test"
+        android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/start_async_operation"/>
+
+    <androidx.appcompat.widget.AppCompatButton
+        android:id="@+id/start_chained_contexts_test"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="@string/start_chained_contexts_test"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/chained_contexts_test"/>
 
     <ProgressBar
         android:id="@+id/spinner_async"
@@ -45,7 +69,7 @@
         style="?android:attr/progressBarStyleHorizontal"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/start_async_operation"
+        app:layout_constraintTop_toBottomOf="@id/start_chained_contexts_test"
         android:visibility="invisible"/>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/kotlin/src/main/res/values/strings.xml
+++ b/sample/kotlin/src/main/res/values/strings.xml
@@ -157,4 +157,7 @@
     <string name="visible_password_label">Visible Password</string>
     <string name="default_password_label">Default password</string>
     <string name="title_otel_traces">OpenTelemetry Traces</string>
+    <string name="start_chained_contexts_test">Start Chained Contexts Test</string>
+    <string name="start_async_operation">Start Async Operation</string>
+    <string name="chained_contexts_test">Chained Otel Contexts Test</string>
 </resources>


### PR DESCRIPTION
### What does this PR do?

In this PR we are providing our own implementation of https://github.com/open-telemetry/opentelemetryjava/blob/main/context/src/main/java/io/opentelemetry/context/ContextStorage.java
interface which wraps inside the default one in order to be able to provide our own implementation of `Context` -> `OtelContext`. 
The main reason for this update was to be able to tight the Opentelemetry Scopes to the `CoreTracer` ones.

See more here how you can create a `Scope` in Opentelemetry: 
https://github.com/open-telemetry/opentelemetry-java/blob/main/context/src/main/java/io/opentelemetry/context/ContextStorage.java

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

