### PR TITLE
RUM-3992 Prevent crash in JankStats listener

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListenerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/vitals/JankStatsActivityLifecycleListenerTest.kt
@@ -178,9 +178,28 @@ internal class JankStatsActivityLifecycleListenerTest {
     }
 
     @Test
-    fun `M log error W onActivityStopped() { jankStats stop tracking throws error }`() {
+    fun `M log error W onActivityStopped() { jankStats stop tracking throws IAE error }`() {
         // Given
         val exception = IllegalArgumentException()
+        whenever(mockJankStats::isTrackingEnabled.set(false)) doThrow exception
+
+        // When
+        testedJankListener.onActivityStarted(mockActivity)
+        testedJankListener.onActivityStopped(mockActivity)
+
+        // Then
+        mockInternalLogger.verifyLog(
+            level = InternalLogger.Level.ERROR,
+            target = InternalLogger.Target.TELEMETRY,
+            message = JankStatsActivityLifecycleListener.JANK_STATS_TRACKING_DISABLE_ERROR,
+            throwable = exception
+        )
+    }
+
+    @Test
+    fun `M log error W onActivityStopped() { jankStats stop tracking throws NPE error }`() {
+        // Given
+        val exception = NullPointerException()
         whenever(mockJankStats::isTrackingEnabled.set(false)) doThrow exception
 
         // When


### PR DESCRIPTION
### What does this PR do?

Fixes #1976

In Android N (until Android P included), the internal [View. findFrameMetricsObserver()](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/nougat-release/core/java/android/view/View.java#5584) method did not check the nullability of the `mFrameMetricsObservers` field, leading to possible NPE when trying to remove a listener that wasn't yet added.

### Motivation

Some customer have seen a crash with an NPE thrown from the Android [View](https://android.googlesource.com/platform/frameworks/base/+/refs/heads/nougat-release/core/java/android/view/View.java) when removing the `FrameMetricsListener` via the `JankStats` library. 
Even though all versions of the official Android View are written in a way that NPE should never happen, those crash still occurred. 
