### PR TITLE
RUM-3905: Use custom naming for threads created inside SDK

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -115,8 +115,8 @@ interface com.datadog.android.api.feature.FeatureSdkCore : com.datadog.android.a
   fun setContextUpdateReceiver(String, FeatureContextUpdateReceiver)
   fun removeContextUpdateReceiver(String, FeatureContextUpdateReceiver)
   fun removeEventReceiver(String)
-  fun createSingleThreadExecutorService(): java.util.concurrent.ExecutorService
-  fun createScheduledExecutorService(): java.util.concurrent.ScheduledExecutorService
+  fun createSingleThreadExecutorService(String): java.util.concurrent.ExecutorService
+  fun createScheduledExecutorService(String): java.util.concurrent.ScheduledExecutorService
 interface com.datadog.android.api.feature.StorageBackedFeature : Feature
   val requestFactory: com.datadog.android.api.net.RequestFactory
   val storageConfiguration: com.datadog.android.api.storage.FeatureStorageConfiguration
@@ -292,7 +292,7 @@ interface com.datadog.android.core.sampling.Sampler
 interface com.datadog.android.core.thread.FlushableExecutorService : java.util.concurrent.ExecutorService
   fun drainTo(MutableCollection<Runnable>)
   interface Factory
-    fun create(com.datadog.android.api.InternalLogger, com.datadog.android.core.configuration.BackPressureStrategy): FlushableExecutorService
+    fun create(com.datadog.android.api.InternalLogger, String, com.datadog.android.core.configuration.BackPressureStrategy): FlushableExecutorService
 interface com.datadog.android.event.EventMapper<T: Any>
   fun map(T): T?
 class com.datadog.android.event.MapperSerializer<T: Any> : com.datadog.android.core.persistence.Serializer<T>

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -332,8 +332,8 @@ public final class com/datadog/android/api/feature/FeatureScope$DefaultImpls {
 }
 
 public abstract interface class com/datadog/android/api/feature/FeatureSdkCore : com/datadog/android/api/SdkCore {
-	public abstract fun createScheduledExecutorService ()Ljava/util/concurrent/ScheduledExecutorService;
-	public abstract fun createSingleThreadExecutorService ()Ljava/util/concurrent/ExecutorService;
+	public abstract fun createScheduledExecutorService (Ljava/lang/String;)Ljava/util/concurrent/ScheduledExecutorService;
+	public abstract fun createSingleThreadExecutorService (Ljava/lang/String;)Ljava/util/concurrent/ExecutorService;
 	public abstract fun getFeature (Ljava/lang/String;)Lcom/datadog/android/api/feature/FeatureScope;
 	public abstract fun getFeatureContext (Ljava/lang/String;)Ljava/util/Map;
 	public abstract fun getInternalLogger ()Lcom/datadog/android/api/InternalLogger;
@@ -777,7 +777,7 @@ public abstract interface class com/datadog/android/core/thread/FlushableExecuto
 }
 
 public abstract interface class com/datadog/android/core/thread/FlushableExecutorService$Factory {
-	public abstract fun create (Lcom/datadog/android/api/InternalLogger;Lcom/datadog/android/core/configuration/BackPressureStrategy;)Lcom/datadog/android/core/thread/FlushableExecutorService;
+	public abstract fun create (Lcom/datadog/android/api/InternalLogger;Ljava/lang/String;Lcom/datadog/android/core/configuration/BackPressureStrategy;)Lcom/datadog/android/core/thread/FlushableExecutorService;
 }
 
 public abstract interface class com/datadog/android/event/EventMapper {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureSdkCore.kt
@@ -92,12 +92,16 @@ interface FeatureSdkCore : SdkCore {
 
     /**
      * Returns a new single thread [ExecutorService], set up with backpressure and internal monitoring.
+     *
+     * @param executorContext Context to be used for logging and naming threads running on this executor.
      */
-    fun createSingleThreadExecutorService(): ExecutorService
+    fun createSingleThreadExecutorService(executorContext: String): ExecutorService
 
     /**
      * Returns a new [ScheduledExecutorService], set up with internal monitoring.
      * It will use a default of one thread and can spawn at most as many thread as there are CPU cores.
+     *
+     * @param executorContext Context to be used for logging and naming threads running on this executor.
      */
-    fun createScheduledExecutorService(): ScheduledExecutorService
+    fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
@@ -259,13 +259,13 @@ internal class DatadogCore(
     }
 
     /** @inheritDoc */
-    override fun createSingleThreadExecutorService(): ExecutorService {
-        return coreFeature.createExecutorService()
+    override fun createSingleThreadExecutorService(executorContext: String): ExecutorService {
+        return coreFeature.createExecutorService(executorContext)
     }
 
     /** @inheritDoc */
-    override fun createScheduledExecutorService(): ScheduledExecutorService {
-        return coreFeature.createScheduledExecutorService()
+    override fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService {
+        return coreFeature.createScheduledExecutorService(executorContext)
     }
 
     // endregion

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/NoOpInternalSdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/NoOpInternalSdkCore.kt
@@ -116,11 +116,11 @@ internal object NoOpInternalSdkCore : InternalSdkCore {
         listener: FeatureContextUpdateReceiver
     ) = Unit
 
-    override fun createSingleThreadExecutorService(): ExecutorService {
+    override fun createSingleThreadExecutorService(executorContext: String): ExecutorService {
         return NoOpExecutorService()
     }
 
-    override fun createScheduledExecutorService(): ScheduledExecutorService {
+    override fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService {
         return NoOpScheduledExecutorService()
     }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -272,12 +272,12 @@ internal class CoreFeature(
         )
     }
 
-    fun createExecutorService(): ExecutorService {
-        return executorServiceFactory.create(internalLogger, backpressureStrategy)
+    fun createExecutorService(executorContext: String): ExecutorService {
+        return executorServiceFactory.create(internalLogger, executorContext, backpressureStrategy)
     }
 
-    fun createScheduledExecutorService(): ScheduledExecutorService {
-        return scheduledExecutorServiceFactory.create(internalLogger, backpressureStrategy)
+    fun createScheduledExecutorService(executorContext: String): ScheduledExecutorService {
+        return scheduledExecutorServiceFactory.create(internalLogger, executorContext, backpressureStrategy)
     }
 
     @Throws(UnsupportedOperationException::class, InterruptedException::class)
@@ -601,11 +601,16 @@ internal class CoreFeature(
 
     private fun setupExecutors() {
         uploadExecutorService = LoggingScheduledThreadPoolExecutor(
-            CORE_DEFAULT_POOL_SIZE,
-            internalLogger,
-            backpressureStrategy
+            corePoolSize = CORE_DEFAULT_POOL_SIZE,
+            executorContext = "upload",
+            logger = internalLogger,
+            backPressureStrategy = backpressureStrategy
         )
-        persistenceExecutorService = executorServiceFactory.create(internalLogger, backpressureStrategy)
+        persistenceExecutorService = executorServiceFactory.create(
+            internalLogger = internalLogger,
+            executorContext = "storage",
+            backPressureStrategy = backpressureStrategy
+        )
     }
 
     private fun resolveProcessInfo(appContext: Context) {
@@ -671,13 +676,13 @@ internal class CoreFeature(
     companion object {
 
         internal val DEFAULT_FLUSHABLE_EXECUTOR_SERVICE_FACTORY =
-            FlushableExecutorService.Factory { logger, backPressureStrategy ->
-                BackPressureExecutorService(logger, backPressureStrategy)
+            FlushableExecutorService.Factory { logger, executorContext, backPressureStrategy ->
+                BackPressureExecutorService(logger, executorContext, backPressureStrategy)
             }
 
         internal val DEFAULT_SCHEDULED_EXECUTOR_SERVICE_FACTORY =
-            ScheduledExecutorServiceFactory { logger, backPressureStrategy ->
-                LoggingScheduledThreadPoolExecutor(1, logger, backPressureStrategy)
+            ScheduledExecutorServiceFactory { logger, executorContext, backPressureStrategy ->
+                LoggingScheduledThreadPoolExecutor(1, executorContext, logger, backPressureStrategy)
             }
 
         // region Constants

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/BackPressureExecutorService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/BackPressureExecutorService.kt
@@ -17,13 +17,15 @@ import java.util.concurrent.TimeUnit
  */
 internal class BackPressureExecutorService(
     val logger: InternalLogger,
+    executorContext: String,
     backpressureStrategy: BackPressureStrategy
 ) : ThreadPoolExecutor(
     CORE_POOL_SIZE,
     CORE_POOL_SIZE,
     THREAD_POOL_MAX_KEEP_ALIVE_MS,
     TimeUnit.MILLISECONDS,
-    BackPressuredBlockingQueue(logger, backpressureStrategy)
+    BackPressuredBlockingQueue(logger, executorContext, backpressureStrategy),
+    DatadogThreadFactory(executorContext)
 ),
     FlushableExecutorService {
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/BackPressuredBlockingQueue.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/BackPressuredBlockingQueue.kt
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeUnit
 
 internal class BackPressuredBlockingQueue<E : Any>(
     private val logger: InternalLogger,
+    private val executorContext: String,
     private val backPressureStrategy: BackPressureStrategy
 ) : LinkedBlockingQueue<E>(
     backPressureStrategy.capacity
@@ -72,7 +73,10 @@ internal class BackPressuredBlockingQueue<E : Any>(
             messageBuilder = { "BackPressuredBlockingQueue reached capacity:${backPressureStrategy.capacity}" },
             throwable = null,
             onlyOnce = false,
-            additionalProperties = mapOf("backpressure.capacity" to backPressureStrategy.capacity)
+            additionalProperties = mapOf(
+                "backpressure.capacity" to backPressureStrategy.capacity,
+                "executor.context" to executorContext
+            )
         )
     }
 
@@ -86,7 +90,10 @@ internal class BackPressuredBlockingQueue<E : Any>(
             messageBuilder = { "Dropped item in BackPressuredBlockingQueue queue: $item" },
             throwable = null,
             onlyOnce = false,
-            additionalProperties = mapOf("backpressure.capacity" to backPressureStrategy.capacity)
+            additionalProperties = mapOf(
+                "backpressure.capacity" to backPressureStrategy.capacity,
+                "executor.context" to executorContext
+            )
         )
     }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/DatadogThreadFactory.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/DatadogThreadFactory.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.thread
+
+import java.util.concurrent.ThreadFactory
+import java.util.concurrent.atomic.AtomicInteger
+
+internal class DatadogThreadFactory(
+    private val newThreadContext: String
+) : ThreadFactory {
+
+    private val threadNumber = AtomicInteger(1)
+
+    override fun newThread(r: Runnable?): Thread {
+        val index = threadNumber.getAndIncrement()
+        val threadName = "datadog-$newThreadContext-thread-$index"
+
+        @Suppress("UnsafeThirdPartyFunctionCall") // both arguments are safe
+        val thread = Thread(r, threadName)
+        thread.priority = Thread.NORM_PRIORITY
+        thread.isDaemon = false
+        return thread
+    }
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/ScheduledExecutorServiceFactory.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/thread/ScheduledExecutorServiceFactory.kt
@@ -18,11 +18,13 @@ internal fun interface ScheduledExecutorServiceFactory {
     /**
      * Create an instance of [ScheduledExecutorService].
      * @param internalLogger the internal logger
+     * @param executorContext Context to be used for logging and naming threads running on this executor.
      * @param backPressureStrategy the strategy to handle back-pressure
      * @return the instance
      */
     fun create(
         internalLogger: InternalLogger,
+        executorContext: String,
         backPressureStrategy: BackPressureStrategy
     ): ScheduledExecutorService
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/thread/FlushableExecutorService.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/thread/FlushableExecutorService.kt
@@ -34,11 +34,13 @@ interface FlushableExecutorService : ExecutorService {
         /**
          * Create an instance of [FlushableExecutorService].
          * @param internalLogger the internal logger
+         * @param executorContext Context to be used for logging and naming threads running on this executor.
          * @param backPressureStrategy the strategy to handle back-pressure
          * @return the instance
          */
         fun create(
             internalLogger: InternalLogger,
+            executorContext: String,
             backPressureStrategy: BackPressureStrategy
         ): FlushableExecutorService
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreInitializationTest.kt
@@ -111,7 +111,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(fakeConfiguration.copy(crashReportsEnabled = crashReportsEnabled))
         }
@@ -187,7 +187,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(fakeConfiguration)
         }
@@ -210,7 +210,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -238,7 +238,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -267,7 +267,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -295,7 +295,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -354,7 +354,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(configuration)
         }
@@ -396,7 +396,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(fakeConfiguration.copy(additionalConfig = mapOf(Datadog.DD_SOURCE_TAG to source)))
         }
@@ -414,7 +414,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(additionalConfig = mapOf(Datadog.DD_SOURCE_TAG to source))
@@ -434,7 +434,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(additionalConfig = mapOf(Datadog.DD_SOURCE_TAG to source))
@@ -454,7 +454,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(fakeConfiguration.copy(additionalConfig = customAttributes.nonNullData))
         }
@@ -472,7 +472,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -494,7 +494,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -516,7 +516,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -538,7 +538,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(fakeConfiguration.copy(additionalConfig = customAttributes.nonNullData))
         }
@@ -556,7 +556,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -578,7 +578,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(
@@ -602,7 +602,7 @@ internal class DatadogCoreInitializationTest {
             appContext.mockInstance,
             fakeInstanceId,
             fakeInstanceName,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService }
         ).apply {
             initialize(
                 fakeConfiguration.copy(

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -124,7 +124,7 @@ internal class DatadogCoreTest {
             fakeInstanceId,
             fakeInstanceName,
             internalLoggerProvider = { mockInternalLogger },
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService },
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService },
             buildSdkVersionProvider = mockBuildSdkVersionProvider
         ).apply {
             initialize(fakeConfiguration)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -145,8 +145,8 @@ internal class CoreFeatureTest {
         testedFeature = CoreFeature(
             mockInternalLogger,
             mockAppStartTimeProvider,
-            executorServiceFactory = { _, _ -> mockPersistenceExecutorService },
-            scheduledExecutorServiceFactory = { _, _ -> mockScheduledExecutorService }
+            executorServiceFactory = { _, _, _ -> mockPersistenceExecutorService },
+            scheduledExecutorServiceFactory = { _, _, _ -> mockScheduledExecutorService }
         )
         whenever(appContext.mockInstance.getSystemService(Context.CONNECTIVITY_SERVICE))
             .doReturn(mockConnectivityMgr)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/AbstractExecutorServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/AbstractExecutorServiceTest.kt
@@ -59,14 +59,14 @@ internal abstract class AbstractExecutorServiceTest<T : ExecutorService> {
     lateinit var fakeBackpressureStrategy: BackPressureStrategy
 
     @BeforeEach
-    fun `set up`() {
+    fun `set up`(forge: Forge) {
         fakeBackpressureStrategy = BackPressureStrategy(
             fakeBackPressureCapacity,
             mockOnThresholdReached,
             mockOnItemDropped,
             fakeBackPressureMitigation
         )
-        testedExecutor = createTestedExecutorService(fakeBackpressureStrategy)
+        testedExecutor = createTestedExecutorService(forge, fakeBackpressureStrategy)
     }
 
     @AfterEach
@@ -74,7 +74,7 @@ internal abstract class AbstractExecutorServiceTest<T : ExecutorService> {
         testedExecutor.shutdownNow()
     }
 
-    abstract fun createTestedExecutorService(backPressureStrategy: BackPressureStrategy): T
+    abstract fun createTestedExecutorService(forge: Forge, backPressureStrategy: BackPressureStrategy): T
 
     // region execute
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/BackPressureExecutorServiceTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/BackPressureExecutorServiceTest.kt
@@ -7,14 +7,27 @@
 package com.datadog.android.core.internal.thread
 
 import com.datadog.android.core.configuration.BackPressureStrategy
+import fr.xgouchet.elmyr.Forge
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
 
 internal class BackPressureExecutorServiceTest :
     AbstractExecutorServiceTest<BackPressureExecutorService>() {
 
-    override fun createTestedExecutorService(backPressureStrategy: BackPressureStrategy): BackPressureExecutorService {
+    override fun createTestedExecutorService(
+        forge: Forge,
+        backPressureStrategy: BackPressureStrategy
+    ): BackPressureExecutorService {
         return BackPressureExecutorService(
             mockInternalLogger,
+            forge.anAlphabeticalString(),
             backPressureStrategy
         )
+    }
+
+    @Test
+    fun `M use DatadogThreadFactory W constructor()`() {
+        // Then
+        assertThat(testedExecutor.threadFactory).isInstanceOf(DatadogThreadFactory::class.java)
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/DatadogThreadFactoryTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/DatadogThreadFactoryTest.kt
@@ -1,0 +1,56 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.thread
+
+import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+
+@Extensions(
+    ExtendWith(ForgeExtension::class)
+)
+@ForgeConfiguration(Configurator::class)
+internal class DatadogThreadFactoryTest {
+
+    @Test
+    fun `M create a new thread W newThread()`(
+        @StringForgery fakeNewThreadContext: String
+    ) {
+        // Given
+        val testedFactory = DatadogThreadFactory(fakeNewThreadContext)
+
+        // When
+        val thread = testedFactory.newThread {}
+
+        // Then
+        assertThat(thread.name).isEqualTo("datadog-$fakeNewThreadContext-thread-1")
+        assertThat(thread.isDaemon).isFalse()
+        assertThat(thread.priority).isEqualTo(Thread.NORM_PRIORITY)
+    }
+
+    @Test
+    fun `M create a new thread with incremented index W newThread()`(
+        @StringForgery fakeNewThreadContext: String
+    ) {
+        // Given
+        val testedFactory = DatadogThreadFactory(fakeNewThreadContext)
+
+        // When
+        testedFactory.newThread {}
+        val thread = testedFactory.newThread {}
+
+        // Then
+        assertThat(thread.name).isEqualTo("datadog-$fakeNewThreadContext-thread-2")
+        assertThat(thread.isDaemon).isFalse()
+        assertThat(thread.priority).isEqualTo(Thread.NORM_PRIORITY)
+    }
+}

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/DropOldestBackPressuredBlockingQueueTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/DropOldestBackPressuredBlockingQueueTest.kt
@@ -4,6 +4,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.configuration.BackPressureMitigation
 import com.datadog.android.core.configuration.BackPressureStrategy
 import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -48,9 +49,10 @@ class DropOldestBackPressuredBlockingQueueTest {
     var fakeBackPressureThreshold: Int = 0
 
     @BeforeEach
-    fun `set up`() {
+    fun `set up`(forge: Forge) {
         testedQueue = BackPressuredBlockingQueue(
             mockLogger,
+            forge.anAlphabeticalString(),
             BackPressureStrategy(
                 fakeBackPressureThreshold,
                 mockOnThresholdReached,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/IgnoreNewestBackPressuredBlockingQueueTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/IgnoreNewestBackPressuredBlockingQueueTest.kt
@@ -4,6 +4,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.configuration.BackPressureMitigation
 import com.datadog.android.core.configuration.BackPressureStrategy
 import com.datadog.android.utils.forge.Configurator
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -48,9 +49,10 @@ class IgnoreNewestBackPressuredBlockingQueueTest {
     var fakeBackPressureThreshold: Int = 0
 
     @BeforeEach
-    fun `set up`() {
+    fun `set up`(forge: Forge) {
         testedQueue = BackPressuredBlockingQueue(
             mockLogger,
+            forge.anAlphabeticalString(),
             BackPressureStrategy(
                 fakeBackPressureThreshold,
                 mockOnThresholdReached,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/LoggingScheduledThreadPoolExecutorTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/thread/LoggingScheduledThreadPoolExecutorTest.kt
@@ -21,8 +21,16 @@ import java.util.concurrent.TimeUnit
 internal class LoggingScheduledThreadPoolExecutorTest :
     AbstractExecutorServiceTest<ScheduledThreadPoolExecutor>() {
 
-    override fun createTestedExecutorService(backPressureStrategy: BackPressureStrategy): ScheduledThreadPoolExecutor {
-        return LoggingScheduledThreadPoolExecutor(1, mockInternalLogger, backPressureStrategy)
+    override fun createTestedExecutorService(
+        forge: Forge,
+        backPressureStrategy: BackPressureStrategy
+    ): ScheduledThreadPoolExecutor {
+        return LoggingScheduledThreadPoolExecutor(
+            1,
+            forge.anAlphabeticalString(),
+            mockInternalLogger,
+            backPressureStrategy
+        )
     }
 
     @Test
@@ -95,5 +103,11 @@ internal class LoggingScheduledThreadPoolExecutorTest :
             ERROR_UNCAUGHT_EXECUTION_EXCEPTION,
             CancellationException::class.java
         )
+    }
+
+    @Test
+    fun `M use DatadogThreadFactory W constructor()`() {
+        // Then
+        assertThat(testedExecutor.threadFactory).isInstanceOf(DatadogThreadFactory::class.java)
     }
 }

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -177,7 +177,7 @@ datadog:
       - "java.nio.channels.FileLock.release():java.io.IOException"
       # endregion
       # region Java Concurrency
-      - "java.lang.Thread.constructor(java.lang.Runnable, kotlin.String):java.lang.NullPointerException,java.lang.SecurityException,java.lang.IllegalArgumentException"
+      - "java.lang.Thread.constructor(java.lang.Runnable?, kotlin.String?):java.lang.NullPointerException,java.lang.SecurityException,java.lang.IllegalArgumentException"
       - "java.lang.Thread.constructor(java.lang.Runnable, kotlin.String):java.lang.NullPointerException,java.lang.SecurityException,java.lang.IllegalArgumentException"
       - "java.lang.Thread.getAllStackTraces():java.lang.SecurityException"
       - "java.lang.Thread.interrupt():java.lang.SecurityException"
@@ -661,6 +661,7 @@ datadog:
       - "java.util.concurrent.atomic.AtomicInteger.constructor(kotlin.Int)"
       - "java.util.concurrent.atomic.AtomicInteger.decrementAndGet()"
       - "java.util.concurrent.atomic.AtomicInteger.get()"
+      - "java.util.concurrent.atomic.AtomicInteger.getAndIncrement()"
       - "java.util.concurrent.atomic.AtomicInteger.incrementAndGet()"
       - "java.util.concurrent.atomic.AtomicLong.constructor(kotlin.Long)"
       - "java.util.concurrent.atomic.AtomicLong.get()"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/Rum.kt
@@ -120,7 +120,7 @@ object Rum {
         backgroundTrackingEnabled = rumFeature.backgroundEventTracking,
         trackFrustrations = rumFeature.trackFrustrations,
         sessionListener = rumFeature.sessionListener,
-        executorService = sdkCore.createSingleThreadExecutorService()
+        executorService = sdkCore.createSingleThreadExecutorService("rum-pipeline")
     )
 
     // endregion

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -391,7 +391,7 @@ internal class RumFeature(
 
     private fun initializeVitalReaders(periodInMs: Long) {
         @Suppress("UnsafeThirdPartyFunctionCall") // pool size can't be <= 0
-        vitalExecutorService = sdkCore.createScheduledExecutorService()
+        vitalExecutorService = sdkCore.createScheduledExecutorService("rum-vital")
 
         initializeVitalMonitor(
             CPUVitalReader(internalLogger = sdkCore.internalLogger),
@@ -436,7 +436,7 @@ internal class RumFeature(
 
     private fun initializeANRDetector() {
         val detectorRunnable = ANRDetectorRunnable(sdkCore, Handler(Looper.getMainLooper()))
-        anrDetectorExecutorService = sdkCore.createSingleThreadExecutorService()
+        anrDetectorExecutorService = sdkCore.createSingleThreadExecutorService("rum-anr-detection")
         anrDetectorExecutorService?.executeSafe(
             "ANR detection",
             sdkCore.internalLogger,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/tracking/AndroidXFragmentLifecycleCallbacks.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/tracking/AndroidXFragmentLifecycleCallbacks.kt
@@ -32,7 +32,11 @@ internal open class AndroidXFragmentLifecycleCallbacks(
 ) : FragmentLifecycleCallbacks<FragmentActivity>, FragmentManager.FragmentLifecycleCallbacks() {
 
     protected lateinit var sdkCore: FeatureSdkCore
-    private val executor: ScheduledExecutorService by lazy { sdkCore.createScheduledExecutorService() }
+    private val executor: ScheduledExecutorService by lazy {
+        sdkCore.createScheduledExecutorService(
+            "rum-fragmentx-lifecycle"
+        )
+    }
 
     private val internalLogger: InternalLogger
         get() = if (this::sdkCore.isInitialized) {
@@ -55,7 +59,6 @@ internal open class AndroidXFragmentLifecycleCallbacks(
     // endregion
 
     // TODO RUM-3793 Update Androidx packages and handle deprecated APIs
-    @Suppress("DEPRECATION")
     @MainThread
     override fun onFragmentActivityCreated(
         fm: FragmentManager,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/tracking/OreoFragmentLifecycleCallbacks.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/tracking/OreoFragmentLifecycleCallbacks.kt
@@ -33,7 +33,11 @@ internal class OreoFragmentLifecycleCallbacks(
 ) : FragmentLifecycleCallbacks<Activity>, FragmentManager.FragmentLifecycleCallbacks() {
 
     private lateinit var sdkCore: FeatureSdkCore
-    private val executor: ScheduledExecutorService by lazy { sdkCore.createScheduledExecutorService() }
+    private val executor: ScheduledExecutorService by lazy {
+        sdkCore.createScheduledExecutorService(
+            "rum-fragment-lifecycle"
+        )
+    }
 
     private val internalLogger: InternalLogger
         get() = if (this::sdkCore.isInitialized) {
@@ -61,6 +65,7 @@ internal class OreoFragmentLifecycleCallbacks(
 
     // region FragmentManager.FragmentLifecycleCallbacks
 
+    @Deprecated("Deprecated in Java")
     override fun onFragmentActivityCreated(
         fm: FragmentManager,
         f: Fragment,
@@ -77,6 +82,7 @@ internal class OreoFragmentLifecycleCallbacks(
         }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onFragmentResumed(fm: FragmentManager, f: Fragment) {
         super.onFragmentResumed(fm, f)
         if (isNotAViewFragment(f)) return
@@ -88,6 +94,7 @@ internal class OreoFragmentLifecycleCallbacks(
         }
     }
 
+    @Deprecated("Deprecated in Java")
     override fun onFragmentStopped(fm: FragmentManager, f: Fragment) {
         super.onFragmentStopped(fm, f)
         if (isNotAViewFragment(f)) return

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/tracking/ActivityViewTrackingStrategy.kt
@@ -34,7 +34,11 @@ constructor(
     ActivityLifecycleTrackingStrategy(),
     ViewTrackingStrategy {
 
-    private val executor: ScheduledExecutorService by lazy { sdkCore.createScheduledExecutorService() }
+    private val executor: ScheduledExecutorService by lazy {
+        sdkCore.createScheduledExecutorService(
+            "rum-activity-tracking"
+        )
+    }
 
     // region ActivityLifecycleTrackingStrategy
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityLifecycleTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/ActivityLifecycleTrackingStrategyTest.kt
@@ -81,7 +81,7 @@ internal abstract class ActivityLifecycleTrackingStrategyTest<T> : ObjectTest<T>
         whenever(mockActivity.intent).thenReturn(mockIntent)
         whenever(mockActivity.window).thenReturn(mockWindow)
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mock()
-        whenever(rumMonitor.mockSdkCore.createScheduledExecutorService()) doReturn mockScheduledExecutorService
+        whenever(rumMonitor.mockSdkCore.createScheduledExecutorService(any())) doReturn mockScheduledExecutorService
         whenever(
             mockScheduledExecutorService.schedule(any(), eq(STOP_VIEW_DELAY_MS), eq(TimeUnit.MILLISECONDS))
         ) doAnswer { invocationOnMock ->

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -62,8 +62,8 @@ internal class RumTest {
     fun `set up`() {
         whenever(mockSdkCore.internalLogger) doReturn mock()
         whenever(mockSdkCore.firstPartyHostResolver) doReturn mock()
-        whenever(mockSdkCore.createSingleThreadExecutorService()) doReturn mock()
-        whenever(mockSdkCore.createScheduledExecutorService()) doReturn mock()
+        whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mock()
+        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn mock()
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -131,7 +131,7 @@ internal class RumFeatureTest {
     @BeforeEach
     fun `set up`() {
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
-        whenever(mockSdkCore.createScheduledExecutorService()) doReturn mockScheduledExecutorService
+        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn mockScheduledExecutorService
 
         testedFeature = RumFeature(
             mockSdkCore,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/tracking/AndroidXFragmentLifecycleCallbacksTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/tracking/AndroidXFragmentLifecycleCallbacksTest.kt
@@ -102,7 +102,7 @@ internal class AndroidXFragmentLifecycleCallbacksTest {
         whenever(mockRumFeature.actionTrackingStrategy) doReturn mockUserActionTrackingStrategy
         whenever(mockUserActionTrackingStrategy.getGesturesTracker()) doReturn mockGesturesTracker
         whenever(mockFragmentActivity.supportFragmentManager).thenReturn(mockFragmentManager)
-        whenever(mockSdkCore.createScheduledExecutorService()) doReturn mockScheduledExecutorService
+        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn mockScheduledExecutorService
         whenever(
             mockScheduledExecutorService.schedule(
                 any(),

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/tracking/OreoFragmentLifecycleCallbacksTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/tracking/OreoFragmentLifecycleCallbacksTest.kt
@@ -109,7 +109,7 @@ internal class OreoFragmentLifecycleCallbacksTest {
         whenever(mockBuildSdkVersionProvider.version) doReturn Build.VERSION_CODES.BASE
 
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
-        whenever(mockSdkCore.createScheduledExecutorService()) doReturn mockScheduledExecutorService
+        whenever(mockSdkCore.createScheduledExecutorService(any())) doReturn mockScheduledExecutorService
         whenever(
             mockScheduledExecutorService.schedule(
                 any(),

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tracking/FragmentViewTrackingStrategyTest.kt
@@ -112,7 +112,7 @@ internal class FragmentViewTrackingStrategyTest : ObjectTest<FragmentViewTrackin
         ) doReturn mockRumFeatureScope
         whenever(rumMonitor.mockSdkCore.internalLogger) doReturn mockInternalLogger
         whenever(mockBuildSdkVersionProvider.version) doReturn Build.VERSION_CODES.LOLLIPOP
-        whenever(rumMonitor.mockSdkCore.createScheduledExecutorService()) doReturn mockScheduledExecutorService
+        whenever(rumMonitor.mockSdkCore.createScheduledExecutorService(any())) doReturn mockScheduledExecutorService
         whenever(
             mockScheduledExecutorService.schedule(
                 any(),


### PR DESCRIPTION
### What does this PR do?

This PR introduces custom `ThreadFactory` for the threads created by SDK. Its only purpose is to name them in format `datadog-{context}-threadN`, where context may be feature track, etc.

This will give us a better visibility in telemetry (the necessary attribute was added for the executor-related events) and also allows to better navigate profiling data.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

