### PR TITLE
Update Detekt API version used to 1.23.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ include:
 # SETUP
 
 variables:
-  CURRENT_CI_IMAGE: "8"
+  CURRENT_CI_IMAGE: "9"
   CI_IMAGE_DOCKER: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/dd-sdk-android:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -5,6 +5,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Set timezone to UTC by default
 RUN ln -sf /usr/share/zoneinfo/Etc/UTC /etc/localtime
 
+# keep in sync with JAVA_HOME path below
 RUN apt-get update \
     && apt-get -y install openjdk-17-jdk \
     && rm -rf /var/lib/apt/lists/*
@@ -31,6 +32,9 @@ ENV ANDROID_SDK_TOOLS 10406996
 ENV NDK_VERSION 25.1.8937393
 ENV CMAKE_VERSION 3.22.1
 ENV DD_TRACER_VERSION 1.26.1
+# requires build with BuildKit to be available https://docs.docker.com/build/building/variables/#multi-platform-build-arguments
+ARG TARGETARCH
+ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH}
 
 RUN apt update && apt install -y python3
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -52,7 +52,7 @@ kover = "0.7.6"
 kspTesting = "1.5.0"
 
 # Tools
-detekt = "1.22.0"
+detekt = "1.23.0"
 dokka = "1.8.20"
 unmock = "0.7.9"
 robolectric = "4.4_r1-robolectric-r2"

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/sdk/UnsafeThirdPartyFunctionCall.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/sdk/UnsafeThirdPartyFunctionCall.kt
@@ -43,7 +43,7 @@ class UnsafeThirdPartyFunctionCall(
             val splitColon = it.split(':')
             val key = splitColon.first()
             if (splitColon.size == 1) {
-                println("✘ ERROR WHITH KNOWN THROWING CALL: $it")
+                println("✘ ERROR WITH KNOWN THROWING CALL: $it")
             }
             val exceptions = splitColon[1].split(',').toList()
             key to exceptions

--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/pyramid/ApiSurfaceTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/pyramid/ApiSurfaceTest.kt
@@ -40,9 +40,7 @@ internal class ApiSurfaceTest {
     @Test
     fun `generateApiSurface`() {
         // Given
-        val config = TestConfig(
-            mapOf("outputFileName" to fileName)
-        )
+        val config = TestConfig("outputFileName" to fileName)
         val code =
             """
                 package com.example.foo
@@ -68,9 +66,7 @@ internal class ApiSurfaceTest {
     @Test
     fun `generateApiSurface {ignore internal fun}`() {
         // Given
-        val config = TestConfig(
-            mapOf("outputFileName" to fileName)
-        )
+        val config = TestConfig("outputFileName" to fileName)
         val code =
             """
                 package com.example.foo
@@ -100,9 +96,7 @@ internal class ApiSurfaceTest {
     @Test
     fun `generateApiSurface {ignore private fun}`() {
         // Given
-        val config = TestConfig(
-            mapOf("outputFileName" to fileName)
-        )
+        val config = TestConfig("outputFileName" to fileName)
         val code =
             """
                 package com.example.foo

--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/TodoWithoutTaskTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/TodoWithoutTaskTest.kt
@@ -279,7 +279,7 @@ class TodoWithoutTaskTest {
         @StringForgery(regex = "[A-Z]+") deprecatedProject: String,
         @IntForgery(min = 1) taskNumber: Int
     ) {
-        config = TestConfig(mapOf("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT")))
+        config = TestConfig("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT"))
         val code =
             """
             class Foo {
@@ -299,7 +299,7 @@ class TodoWithoutTaskTest {
         @StringForgery(regex = "[A-Z]+") deprecatedProject: String,
         @IntForgery(min = 1) taskNumber: Int
     ) {
-        config = TestConfig(mapOf("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT")))
+        config = TestConfig("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT"))
         val code =
             """
             class Foo {
@@ -321,7 +321,7 @@ class TodoWithoutTaskTest {
         @StringForgery(regex = "[A-Z]+") deprecatedProject: String,
         @IntForgery(min = 1) taskNumber: Int
     ) {
-        config = TestConfig(mapOf("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT")))
+        config = TestConfig("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT"))
         val code =
             """
             class Foo {
@@ -344,7 +344,7 @@ class TodoWithoutTaskTest {
         @StringForgery(regex = "[A-Z]+") deprecatedProject: String,
         @IntForgery(min = 1) taskNumber: Int
     ) {
-        config = TestConfig(mapOf("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT")))
+        config = TestConfig("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT"))
         val code = """
             class Foo {
             
@@ -367,7 +367,7 @@ class TodoWithoutTaskTest {
         @StringForgery(regex = "[A-Z]+") deprecatedProject: String,
         @IntForgery(min = 1) taskNumber: Int
     ) {
-        config = TestConfig(mapOf("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT")))
+        config = TestConfig("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT"))
         val code = """
             /**
              * TODO $deprecatedProject-$taskNumber $commentText
@@ -388,7 +388,7 @@ class TodoWithoutTaskTest {
         @StringForgery(regex = "[A-Z]+") deprecatedProject: String,
         @IntForgery(min = 1) taskNumber: Int
     ) {
-        config = TestConfig(mapOf("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT")))
+        config = TestConfig("deprecatedPrefixes" to listOf("FOOPROJECT", deprecatedProject, "BARPROJECT"))
         val code =
             """
             /**

--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/UnsafeThirdPartyFunctionCallTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/UnsafeThirdPartyFunctionCallTest.kt
@@ -36,9 +36,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
     @Test
     fun `ignore call on internal type`() {
         // Given
-        val config = TestConfig(
-            mapOf("internalPackagePrefix" to "java.io")
-        )
+        val config = TestConfig("internalPackagePrefix" to "java.io")
         val code =
             """
                 import java.io.File
@@ -62,9 +60,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
         val knownThrowingCalls = listOf(
             "java.io.File.inputStream():java.io.FileNotFoundException"
         )
-        val config = TestConfig(
-            mapOf("knownThrowingCalls" to knownThrowingCalls)
-        )
+        val config = TestConfig("knownThrowingCalls" to knownThrowingCalls)
         val code =
             """
                 import java.io.File
@@ -150,10 +146,8 @@ internal class UnsafeThirdPartyFunctionCallTest {
             "java.io.File.listFiles(java.io.FileFilter?):java.io.FileNotFoundException"
         )
         val config = TestConfig(
-            mapOf(
-                "knownThrowingCalls" to knownThrowingCalls,
-                "treatUnknownFunctionAsThrowing" to false
-            )
+            "knownThrowingCalls" to knownThrowingCalls,
+            "treatUnknownFunctionAsThrowing" to false
         )
         val code =
             """
@@ -181,9 +175,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
         val knownThrowingCalls = listOf(
             "java.io.File.inputStream():java.io.FileNotFoundException"
         )
-        val config = TestConfig(
-            mapOf("knownThrowingCalls" to knownThrowingCalls)
-        )
+        val config = TestConfig("knownThrowingCalls" to knownThrowingCalls)
         val code =
             """
                 import java.io.File
@@ -212,9 +204,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
         val knownThrowingCalls = listOf(
             "java.io.File.inputStream():java.io.FileNotFoundException"
         )
-        val config = TestConfig(
-            mapOf("knownThrowingCalls" to knownThrowingCalls)
-        )
+        val config = TestConfig("knownThrowingCalls" to knownThrowingCalls)
         val code =
             """
                 import java.io.File
@@ -246,9 +236,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
         val knownThrowingCalls = listOf(
             "java.io.File.inputStream():java.io.FileNotFoundException"
         )
-        val config = TestConfig(
-            mapOf("knownThrowingCalls" to knownThrowingCalls)
-        )
+        val config = TestConfig("knownThrowingCalls" to knownThrowingCalls)
         val code =
             """
                 import java.io.File
@@ -278,9 +266,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
         val knownThrowingCalls = listOf(
             "java.io.File.inputStream():java.io.FileNotFoundException"
         )
-        val config = TestConfig(
-            mapOf("knownThrowingCalls" to knownThrowingCalls)
-        )
+        val config = TestConfig("knownThrowingCalls" to knownThrowingCalls)
         val code =
             """
                 import java.io.File
@@ -310,9 +296,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
         val knownThrowingCalls = listOf(
             "java.io.File.inputStream():java.io.FileNotFoundException"
         )
-        val config = TestConfig(
-            mapOf("knownThrowingCalls" to knownThrowingCalls)
-        )
+        val config = TestConfig("knownThrowingCalls" to knownThrowingCalls)
         val code =
             """
                 import java.io.File
@@ -344,9 +328,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
         val knownThrowingCalls = listOf(
             "java.io.File.inputStream():java.io.FileNotFoundException"
         )
-        val config = TestConfig(
-            mapOf("knownThrowingCalls" to knownThrowingCalls)
-        )
+        val config = TestConfig("knownThrowingCalls" to knownThrowingCalls)
         val code =
             """
                 import java.io.File
@@ -385,9 +367,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
         val knownSafeCalls = listOf(
             "java.io.File.inputStream()"
         )
-        val config = TestConfig(
-            mapOf("knownSafeCalls" to knownSafeCalls)
-        )
+        val config = TestConfig("knownSafeCalls" to knownSafeCalls)
         val code =
             """
                 import java.io.File
@@ -408,9 +388,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
     @Test
     fun `detekt unsafe call on unknown function {treatUnknownFunctionAsThrowing=true}`() {
         // Given
-        val config = TestConfig(
-            mapOf("treatUnknownFunctionAsThrowing" to true)
-        )
+        val config = TestConfig("treatUnknownFunctionAsThrowing" to true)
         val code =
             """
                 import java.io.File
@@ -431,9 +409,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
     @Test
     fun `ignore calls on unknown function {treatUnknownFunctionAsThrowing=false}`() {
         // Given
-        val config = TestConfig(
-            mapOf("treatUnknownFunctionAsThrowing" to false)
-        )
+        val config = TestConfig("treatUnknownFunctionAsThrowing" to false)
         val code =
             """
                 import java.io.File
@@ -454,9 +430,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
     @Test
     fun `detekt unsafe call on unknown constructor {treatUnknownFunctionAsThrowing=true}`() {
         // Given
-        val config = TestConfig(
-            mapOf("treatUnknownFunctionAsThrowing" to true)
-        )
+        val config = TestConfig("treatUnknownFunctionAsThrowing" to true)
         val code =
             """
                 import java.io.File
@@ -477,9 +451,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
     @Test
     fun `ignore calls on unknown constructor {treatUnknownFunctionAsThrowing=false}`() {
         // Given
-        val config = TestConfig(
-            mapOf("treatUnknownFunctionAsThrowing" to false)
-        )
+        val config = TestConfig("treatUnknownFunctionAsThrowing" to false)
         val code =
             """
                 import java.io.File


### PR DESCRIPTION
### What does this PR do?

I noticed some Kotlin 1.7 artifacts downloaded for the test classpath and they were coming from Detekt 1.22.0.

This PR updates Detekt to 1.23.0 to be better aligned with the version we use for the checks (1.23.4) and to stop Kotlin 1.7 artifacts being downloaded.

Detekt 1.23.4 is not used because it will bring Kotlin 1.9, this is not what we want.

Detekt changelog is [here](https://github.com/detekt/detekt/releases).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

