### PR TITLE
Remove the usage of deprecated `TestConfig` constructor

### DIFF
--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/UnsafeThirdPartyFunctionCallTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/UnsafeThirdPartyFunctionCallTest.kt
@@ -81,9 +81,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
     @Test
     fun `ignore call on internal package extension function`() {
         // Given
-        val config = TestConfig(
-            mapOf("internalPackagePrefix" to "com.datadog")
-        )
+        val config = TestConfig("internalPackagePrefix" to "com.datadog")
 
         @Suppress("UnusedReceiverParameter")
         val code =
@@ -131,9 +129,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
     @Test
     fun `detekt unsafe call on unknown third party extension function`() {
         // Given
-        val config = TestConfig(
-            mapOf("internalPackagePrefix" to "com.datadog")
-        )
+        val config = TestConfig("internalPackagePrefix" to "com.datadog")
         val code =
             """
                 package com.datadog
@@ -576,9 +572,7 @@ internal class UnsafeThirdPartyFunctionCallTest {
     @Test
     fun `ignore kotlin helper calls { with + run + also + println }`() {
         // Given
-        val config = TestConfig(
-            mapOf("knownSafeCalls" to "java.io.File.readBytes()")
-        )
+        val config = TestConfig("knownSafeCalls" to "java.io.File.readBytes()")
         val code =
             """
                 import java.io.File


### PR DESCRIPTION
### What does this PR do?

These usages were added in https://github.com/DataDog/dd-sdk-android/pull/1996. This PR fixes that.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

