### PR TITLE
Make constructors of `DatadogSite` private

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -12,7 +12,6 @@ object com.datadog.android.Datadog
   fun clearAllData(com.datadog.android.api.SdkCore = getInstance())
   fun _internalProxy(String? = null): _InternalProxy
 enum com.datadog.android.DatadogSite
-  constructor(String, String)
   - US1
   - US3
   - US5
@@ -20,7 +19,6 @@ enum com.datadog.android.DatadogSite
   - AP1
   - US1_FED
   - STAGING
-  constructor(String)
   val intakeEndpoint: String
 class com.datadog.android._InternalProxy
   class _TelemetryProxy

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/DatadogSite.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/DatadogSite.kt
@@ -13,7 +13,7 @@ package com.datadog.android
  * instance ID (because this value is used there) in case if enum values are renamed.
  * @param intakeHostName the host name for the given site.
  */
-enum class DatadogSite(internal val siteName: String, private val intakeHostName: String) {
+enum class DatadogSite private constructor(internal val siteName: String, private val intakeHostName: String) {
 
     /**
      *  The US1 site: [app.datadoghq.com](https://app.datadoghq.com).
@@ -55,7 +55,7 @@ enum class DatadogSite(internal val siteName: String, private val intakeHostName
      * @param siteName Explicit site name property introduced in order to have a consistent SDK
      * instance ID (because this value is used there) in case if enum values are renamed.
      */
-    constructor(siteName: String) : this(
+    private constructor(siteName: String) : this(
         siteName,
         "browser-intake-$siteName-datadoghq.com"
     )


### PR DESCRIPTION
### What does this PR do?

Constructors of `DatadogSite` shouldn't be public.

This may be see as a breaking change (removing items from public API), but this was never intended to be public.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

