### PR TITLE
RUM-4329: Fix `ConcurrentModificationException` during features iteration

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/DatadogCore.kt
@@ -43,6 +43,7 @@ import com.datadog.android.privacy.TrackingConsent
 import com.google.gson.JsonObject
 import java.io.File
 import java.util.Locale
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.ScheduledExecutorService
 import java.util.concurrent.TimeUnit
@@ -71,7 +72,7 @@ internal class DatadogCore(
 
     private lateinit var shutdownHook: Thread
 
-    internal val features: MutableMap<String, SdkFeature> = mutableMapOf()
+    internal val features: MutableMap<String, SdkFeature> = ConcurrentHashMap()
 
     internal val context: Context = context.applicationContext
 


### PR DESCRIPTION
### What does this PR do?

It is possible to have a crash like that:

```
java.util.ConcurrentModificationException
	at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:760)
	at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:792)
	at java.util.LinkedHashMap$LinkedEntryIterator.next(LinkedHashMap.java:790)
	at com.datadog.android.core.DatadogCore.updateFeatureContext(SourceFile:65)
	at com.datadog.android.rum.internal.domain.scope.RumViewScope.<init>(SourceFile:21)
	at com.datadog.android.rum.internal.domain.scope.RumViewScope.<init>(SourceFile:31)
	at com.datadog.android.rum.internal.domain.scope.RumViewManagerScope.handleEvent(SourceFile:620)
	at com.datadog.android.rum.internal.domain.scope.RumSessionScope.handleEvent(SourceFile:246)
	at com.datadog.android.rum.internal.domain.scope.RumApplicationScope.handleEvent(SourceFile:356)
	at androidx.lifecycle.DispatchQueue$$ExternalSyntheticLambda0.run(SourceFile:278)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:487)
	at java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1145)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:644)
	at java.lang.Thread.run(Thread.java:1012)
```

The problem is that `DatadogCore.features` can be accessed from different threads. This PR makes access for the items of this collection thread-safe.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

