### PR TITLE
RUM-4358: Log warning about tag modification only once

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/constraints/DatadogDataConstraints.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/constraints/DatadogDataConstraints.kt
@@ -35,7 +35,8 @@ class DatadogDataConstraints(private val internalLogger: InternalLogger) : DataC
                 internalLogger.log(
                     InternalLogger.Level.WARN,
                     InternalLogger.Target.USER,
-                    { "tag \"$it\" was modified to \"$tag\" to match our constraints." }
+                    { "tag \"$it\" was modified to \"$tag\" to match our constraints." },
+                    onlyOnce = true
                 )
             }
             tag

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/constraints/DatadogDataConstraintsTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/constraints/DatadogDataConstraintsTest.kt
@@ -94,7 +94,8 @@ internal class DatadogDataConstraintsTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            "tag \"$tag\" was modified to \"$expectedCorrectedTag\" to match our constraints."
+            "tag \"$tag\" was modified to \"$expectedCorrectedTag\" to match our constraints.",
+            onlyOnce = true
         )
     }
 
@@ -112,7 +113,8 @@ internal class DatadogDataConstraintsTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            "tag \"$tag\" was modified to \"$expectedCorrectedTag\" to match our constraints."
+            "tag \"$tag\" was modified to \"$expectedCorrectedTag\" to match our constraints.",
+            onlyOnce = true
         )
     }
 
@@ -128,7 +130,8 @@ internal class DatadogDataConstraintsTest {
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
-            "tag \"$tag\" was modified to \"$expectedCorrectedTag\" to match our constraints."
+            "tag \"$tag\" was modified to \"$expectedCorrectedTag\" to match our constraints.",
+            onlyOnce = true
         )
     }
 
@@ -144,7 +147,8 @@ internal class DatadogDataConstraintsTest {
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,
             "tag \"$expectedCorrectedTag:\" was modified to " +
-                "\"$expectedCorrectedTag\" to match our constraints."
+                "\"$expectedCorrectedTag\" to match our constraints.",
+            onlyOnce = true
         )
     }
 


### PR DESCRIPTION
### What does this PR do?

This PR addresses issue #1018: with SDK v2 functionality we can now log a particular message only once. This is useful to avoid logcat spamming.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

