### PR TITLE
RUM-4359: Add status code in user-facing message in case of `UnknownError` during batch upload

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadStatus.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadStatus.kt
@@ -86,7 +86,7 @@ internal sealed class UploadStatus(val shouldRetry: Boolean = false, val code: I
             is UnknownError -> logger.log(
                 InternalLogger.Level.ERROR,
                 InternalLogger.Target.USER,
-                { "$batchInfo failed because of an unknown error; the batch was dropped." }
+                { "$batchInfo failed because of an unknown error (status code = $code); the batch was dropped." }
             )
 
             is RequestCreationError -> logger.log(

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadStatusTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadStatusTest.kt
@@ -209,7 +209,7 @@ internal class UploadStatusTest {
             InternalLogger.Level.ERROR,
             InternalLogger.Target.USER,
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of an unknown error; the batch was dropped."
+                "because of an unknown error (status code = ${status.code}); the batch was dropped."
         )
     }
 


### PR DESCRIPTION
### What does this PR do?

This change aims to help in investigation of #2013: it will be handy to have HTTP status code logged in the user-facing message in case of `UnknownError` during batch upload.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

