### PR TITLE
RUM-4148 Add support to the Toolbar in Session Replay

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -496,8 +496,8 @@ datadog:
       - "androidx.work.WorkManager.cancelAllWorkByTag(kotlin.String)"
       - "androidx.work.WorkManager.getInstance(android.content.Context)"
       - "androidx.work.WorkManager.isInitialized()"
-      - "androidx.appcompat.widget.ActionBarContainerDrawableAccessor.constructor(androidx.appcompat.widget.ActionBarContainer)"
-      - "androidx.appcompat.widget.ActionBarContainerDrawableAccessor.getBackgroundDrawable()"
+      - "androidx.appcompat.widget.DatadogActionBarContainerAccessor.constructor(androidx.appcompat.widget.ActionBarContainer)"
+      - "androidx.appcompat.widget.DatadogActionBarContainerAccessor.getBackgroundDrawable()"
       # endregion
       # region Google Material
       - "com.google.android.material.tabs.TabLayout.TabView.getChildAt(kotlin.Int)"

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -496,6 +496,8 @@ datadog:
       - "androidx.work.WorkManager.cancelAllWorkByTag(kotlin.String)"
       - "androidx.work.WorkManager.getInstance(android.content.Context)"
       - "androidx.work.WorkManager.isInitialized()"
+      - "androidx.appcompat.widget.ActionBarContainerDrawableAccessor.constructor(androidx.appcompat.widget.ActionBarContainer)"
+      - "androidx.appcompat.widget.ActionBarContainerDrawableAccessor.getBackgroundDrawable()"
       # endregion
       # region Google Material
       - "com.google.android.material.tabs.TabLayout.TabView.getChildAt(kotlin.Int)"

--- a/features/dd-sdk-android-session-replay-material/build.gradle.kts
+++ b/features/dd-sdk-android-session-replay-material/build.gradle.kts
@@ -36,6 +36,10 @@ plugins {
 }
 
 android {
+    defaultConfig {
+        consumerProguardFiles("consumer-rules.pro")
+    }
+
     namespace = "com.datadog.android.sessionreplay.material"
 }
 

--- a/features/dd-sdk-android-session-replay-material/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay-material/consumer-rules.pro
@@ -1,0 +1,4 @@
+# Keep the optional selector class name. We need this in the SR recorder.
+-keepnames class com.google.android.material.timepicker.TimePickerView
+-keepnames class com.google.android.material.datepicker.MaterialCalendarGridView
+

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -27,6 +27,8 @@ data class com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseAsyncBackgroundWireframeMapper<T: android.view.View> : BaseWireframeMapper<T>
   override fun map(T, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
   companion object 
+open class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseViewGroupMapper<T: android.view.ViewGroup> : BaseAsyncBackgroundWireframeMapper<T>, TraverseAllChildrenMapper<T>
+  constructor(com.datadog.android.sessionreplay.utils.ViewIdentifierResolver, com.datadog.android.sessionreplay.utils.ColorStringFormatter, com.datadog.android.sessionreplay.utils.ViewBoundsResolver, com.datadog.android.sessionreplay.utils.DrawableToColorMapper)
 abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseWireframeMapper<T: android.view.View> : WireframeMapper<T>
   constructor(com.datadog.android.sessionreplay.utils.ViewIdentifierResolver, com.datadog.android.sessionreplay.utils.ColorStringFormatter, com.datadog.android.sessionreplay.utils.ViewBoundsResolver, com.datadog.android.sessionreplay.utils.DrawableToColorMapper)
   protected fun resolveViewId(android.view.View): Long

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -93,6 +93,10 @@ public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper
 public final class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper$Companion {
 }
 
+public class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseViewGroupMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper, com/datadog/android/sessionreplay/internal/recorder/mapper/TraverseAllChildrenMapper {
+	public fun <init> (Lcom/datadog/android/sessionreplay/utils/ViewIdentifierResolver;Lcom/datadog/android/sessionreplay/utils/ColorStringFormatter;Lcom/datadog/android/sessionreplay/utils/ViewBoundsResolver;Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper;)V
+}
+
 public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper$Companion;
 	public fun <init> (Lcom/datadog/android/sessionreplay/utils/ViewIdentifierResolver;Lcom/datadog/android/sessionreplay/utils/ColorStringFormatter;Lcom/datadog/android/sessionreplay/utils/ViewBoundsResolver;Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper;)V

--- a/features/dd-sdk-android-session-replay/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay/consumer-rules.pro
@@ -1,4 +1,3 @@
 # Keep the optional selector class name. We need this in the SR recorder.
 -keepnames class androidx.appcompat.widget.DropDownListView
--keepnames class com.google.android.material.timepicker.TimePickerView
--keepnames class com.google.android.material.datepicker.MaterialCalendarGridView
+-keepnames class android.graphics.drawable.GradientDrawable

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/androidx/appcompat/widget/ActionBarContainerDrawableAccessor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/androidx/appcompat/widget/ActionBarContainerDrawableAccessor.kt
@@ -1,0 +1,26 @@
+@file:Suppress("PackageNaming")
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package androidx.appcompat.widget
+
+import android.annotation.SuppressLint
+import android.graphics.drawable.Drawable
+
+internal class ActionBarContainerDrawableAccessor(
+    val container: ActionBarContainer
+) {
+
+    @SuppressLint("RestrictedApi")
+    fun getBackgroundDrawable(): Drawable? {
+        return container.mBackground
+    }
+
+    @SuppressLint("RestrictedApi")
+    fun setBackgroundDrawabal(drawable: Drawable) {
+        container.mBackground = drawable
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/androidx/appcompat/widget/DatadogActionBarContainerAccessor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/androidx/appcompat/widget/DatadogActionBarContainerAccessor.kt
@@ -10,7 +10,7 @@ package androidx.appcompat.widget
 import android.annotation.SuppressLint
 import android.graphics.drawable.Drawable
 
-internal class ActionBarContainerDrawableAccessor(
+internal class DatadogActionBarContainerAccessor(
     val container: ActionBarContainer
 ) {
 
@@ -20,7 +20,7 @@ internal class ActionBarContainerDrawableAccessor(
     }
 
     @SuppressLint("RestrictedApi")
-    fun setBackgroundDrawabal(drawable: Drawable) {
+    fun setBackgroundDrawable(drawable: Drawable) {
         container.mBackground = drawable
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
@@ -17,14 +17,15 @@ import android.widget.NumberPicker
 import android.widget.RadioButton
 import android.widget.SeekBar
 import android.widget.TextView
+import androidx.appcompat.widget.ActionBarContainer
 import androidx.appcompat.widget.SwitchCompat
-import androidx.appcompat.widget.Toolbar
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.Recorder
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.SessionReplayRecorder
 import com.datadog.android.sessionreplay.internal.recorder.OptionSelectorDetector
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ActionBarContainerMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckBoxMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckedTextViewMapper
@@ -34,7 +35,6 @@ import com.datadog.android.sessionreplay.internal.recorder.mapper.RadioButtonMap
 import com.datadog.android.sessionreplay.internal.recorder.mapper.SeekBarWireframeMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.SwitchCompatMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper
-import com.datadog.android.sessionreplay.internal.recorder.mapper.UnsupportedViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.WebViewWireframeMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
 import com.datadog.android.sessionreplay.internal.storage.RecordWriter
@@ -80,13 +80,6 @@ internal class DefaultRecorderProvider(
         val colorStringFormatter: ColorStringFormatter = DefaultColorStringFormatter
         val viewBoundsResolver: ViewBoundsResolver = DefaultViewBoundsResolver
         val drawableToColorMapper: DrawableToColorMapper = DrawableToColorMapper.getDefault()
-
-        val unsupportedViewMapper = UnsupportedViewMapper(
-            viewIdentifierResolver,
-            colorStringFormatter,
-            viewBoundsResolver,
-            drawableToColorMapper
-        )
         val imageViewMapper = ImageViewMapper(
             ImageViewUtils,
             viewIdentifierResolver,
@@ -155,8 +148,13 @@ internal class DefaultRecorderProvider(
                 imageViewMapper
             ),
             MapperTypeWrapper(
-                Toolbar::class.java,
-                unsupportedViewMapper
+                ActionBarContainer::class.java,
+                ActionBarContainerMapper(
+                    viewIdentifierResolver,
+                    colorStringFormatter,
+                    viewBoundsResolver,
+                    drawableToColorMapper
+                )
             ),
             MapperTypeWrapper(
                 WebView::class.java,
@@ -166,14 +164,6 @@ internal class DefaultRecorderProvider(
                     viewBoundsResolver,
                     drawableToColorMapper
                 )
-            )
-        )
-
-        mappersList.add(
-            0,
-            MapperTypeWrapper(
-                android.widget.Toolbar::class.java,
-                unsupportedViewMapper
             )
         )
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TraversalStrategy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TraversalStrategy.kt
@@ -1,0 +1,13 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder
+
+internal enum class TraversalStrategy {
+    TRAVERSE_ALL_CHILDREN,
+    STOP_AND_RETURN_NODE,
+    STOP_AND_DROP_NODE
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt
@@ -74,9 +74,3 @@ internal class TreeViewTraversal(
         val nextActionStrategy: TraversalStrategy
     )
 }
-
-internal enum class TraversalStrategy {
-    TRAVERSE_ALL_CHILDREN,
-    STOP_AND_RETURN_NODE,
-    STOP_AND_DROP_NODE
-}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapper.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import androidx.appcompat.widget.ActionBarContainer
-import androidx.appcompat.widget.ActionBarContainerDrawableAccessor
+import androidx.appcompat.widget.DatadogActionBarContainerAccessor
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -34,11 +34,11 @@ internal class ActionBarContainerMapper(
         asyncJobStatusCallback: AsyncJobStatusCallback
     ): List<MobileSegment.Wireframe> {
         // The ActionBarContainer uses an internal Drawable implementation that redirects to some fields in the
-        // ActionBarContainer class.
-        // Fortunately, the mBackground field we're interested in is package private,
-        // which allows us to access it.
-//        val background = backgroundField?.get(view) as? Drawable
-        val background = ActionBarContainerDrawableAccessor(view).getBackgroundDrawable()
+        // ActionBarContainer class. It uses an ActionBarContainer.mBackground field (not to be confused with the
+        // View.mBackground field which has a getBackground() accessor.
+        // Fortunately, the ActionBarContainer.mBackground field we're interested in is package private,
+        // which allows us to access it via the DatadogActionBarContainerAccessor.
+        val background = DatadogActionBarContainerAccessor(view).getBackgroundDrawable()
         val shapeStyle = background?.let { resolveShapeStyle(it, view.alpha) }
         val id = viewIdentifierResolver.resolveChildUniqueIdentifier(view, PREFIX_BACKGROUND_DRAWABLE)
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapper.kt
@@ -1,0 +1,64 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.mapper
+
+import androidx.appcompat.widget.ActionBarContainer
+import androidx.appcompat.widget.ActionBarContainerDrawableAccessor
+import com.datadog.android.sessionreplay.internal.recorder.MappingContext
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
+import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
+
+internal class ActionBarContainerMapper(
+    viewIdentifierResolver: ViewIdentifierResolver,
+    colorStringFormatter: ColorStringFormatter,
+    viewBoundsResolver: ViewBoundsResolver,
+    drawableToColorMapper: DrawableToColorMapper
+) : BaseViewGroupMapper<ActionBarContainer>(
+    viewIdentifierResolver,
+    colorStringFormatter,
+    viewBoundsResolver,
+    drawableToColorMapper
+) {
+
+    override fun map(
+        view: ActionBarContainer,
+        mappingContext: MappingContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback
+    ): List<MobileSegment.Wireframe> {
+        // The ActionBarContainer uses an internal Drawable implementation that redirects to some fields in the
+        // ActionBarContainer class.
+        // Fortunately, the mBackground field we're interested in is package private,
+        // which allows us to access it.
+//        val background = backgroundField?.get(view) as? Drawable
+        val background = ActionBarContainerDrawableAccessor(view).getBackgroundDrawable()
+        val shapeStyle = background?.let { resolveShapeStyle(it, view.alpha) }
+        val id = viewIdentifierResolver.resolveChildUniqueIdentifier(view, PREFIX_BACKGROUND_DRAWABLE)
+
+        if ((shapeStyle != null) && (id != null)) {
+            val density = mappingContext.systemInformation.screenDensity
+            val bounds = viewBoundsResolver.resolveViewGlobalBounds(view, density)
+
+            return listOf(
+                MobileSegment.Wireframe.ShapeWireframe(
+                    id,
+                    x = bounds.x,
+                    y = bounds.y,
+                    width = bounds.width,
+                    height = bounds.height,
+                    shapeStyle = shapeStyle,
+                    border = null
+                )
+            )
+        } else {
+            return emptyList()
+        }
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseViewGroupMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseViewGroupMapper.kt
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.mapper
+
+import android.view.ViewGroup
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
+import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
+
+/**
+ * A basic abstract [WireframeMapper] to extend when mapping [ViewGroup] implementations.
+ *
+ * This class extends both [BaseAsyncBackgroundWireframeMapper] and [TraverseAllChildrenMapper],
+ * ensuring that all children of the [ViewGroup] will be mapped by the relevant mappers.
+ *
+ *  @param T the type of the [ViewGroup] to map
+ *  @param viewIdentifierResolver the [ViewIdentifierResolver] (to resolve a view or children stable id)
+ *  @param colorStringFormatter the [ColorStringFormatter] to transform Color into HTML hex strings
+ *  @param viewBoundsResolver the [ViewBoundsResolver] to get a view boundaries in density independent units
+ *  @param drawableToColorMapper the [DrawableToColorMapper] to convert a background drawable into a solid color
+ */
+open class BaseViewGroupMapper<T : ViewGroup>(
+    viewIdentifierResolver: ViewIdentifierResolver,
+    colorStringFormatter: ColorStringFormatter,
+    viewBoundsResolver: ViewBoundsResolver,
+    drawableToColorMapper: DrawableToColorMapper
+) : BaseAsyncBackgroundWireframeMapper<T>(
+    viewIdentifierResolver,
+    colorStringFormatter,
+    viewBoundsResolver,
+    drawableToColorMapper
+),
+    TraverseAllChildrenMapper<T>

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapper.kt
@@ -38,16 +38,20 @@ internal class ViewWireframeMapper(
         )
         val shapeStyle = view.background?.let { resolveShapeStyle(it, view.alpha) }
 
-        return listOf(
-            MobileSegment.Wireframe.ShapeWireframe(
-                resolveViewId(view),
-                viewGlobalBounds.x,
-                viewGlobalBounds.y,
-                viewGlobalBounds.width,
-                viewGlobalBounds.height,
-                shapeStyle = shapeStyle,
-                border = null
+        if (shapeStyle != null) {
+            return listOf(
+                MobileSegment.Wireframe.ShapeWireframe(
+                    resolveViewId(view),
+                    viewGlobalBounds.x,
+                    viewGlobalBounds.y,
+                    viewGlobalBounds.width,
+                    viewGlobalBounds.height,
+                    shapeStyle = shapeStyle,
+                    border = null
+                )
             )
-        )
+        } else {
+            return emptyList()
+        }
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapperTest.kt
@@ -1,0 +1,142 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder.mapper
+
+import android.graphics.drawable.Drawable
+import androidx.appcompat.widget.ActionBarContainer
+import androidx.appcompat.widget.ActionBarContainerDrawableAccessor
+import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.GlobalBounds
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(ForgeConfigurator::class)
+internal class ActionBarContainerMapperTest : BaseWireframeMapperTest() {
+
+    lateinit var testedMapper: WireframeMapper<ActionBarContainer>
+
+    @Mock
+    lateinit var mockActionBarContainer: ActionBarContainer
+
+    @Mock
+    lateinit var mockBackgroundDrawable: Drawable
+
+    @StringForgery(regex = "#[0-9A-F]{8}")
+    lateinit var fakeBackgroundHexColor: String
+
+    @LongForgery
+    var fakeViewId: Long = 0L
+
+    @LongForgery
+    var fakeViewX: Long = 0L
+
+    @LongForgery
+    var fakeViewY: Long = 0L
+
+    @LongForgery
+    var fakeViewWidth: Long = 0L
+
+    @LongForgery
+    var fakeViewHeight: Long = 0L
+
+    @IntForgery
+    var fakeBackgroundColor: Int = 0
+
+    @FloatForgery
+    var fakeViewAlpha: Float = 0f
+
+    @BeforeEach
+    fun `set up`() {
+        whenever(
+            mockViewIdentifierResolver.resolveChildUniqueIdentifier(
+                mockActionBarContainer,
+                BaseAsyncBackgroundWireframeMapper.PREFIX_BACKGROUND_DRAWABLE
+            )
+        ) doReturn fakeViewId
+        whenever(
+            mockViewBoundsResolver.resolveViewGlobalBounds(
+                mockActionBarContainer,
+                fakeMappingContext.systemInformation.screenDensity
+            )
+        ) doReturn GlobalBounds(fakeViewX, fakeViewY, fakeViewWidth, fakeViewHeight)
+
+        ActionBarContainerDrawableAccessor(mockActionBarContainer).setBackgroundDrawabal(mockBackgroundDrawable)
+        whenever(mockActionBarContainer.alpha) doReturn fakeViewAlpha
+
+        testedMapper = ActionBarContainerMapper(
+            mockViewIdentifierResolver,
+            mockColorStringFormatter,
+            mockViewBoundsResolver,
+            mockDrawableToColorMapper
+        )
+    }
+
+    @Test
+    fun `M return a shape wireframe with the background W map()`() {
+        // Given
+        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockBackgroundDrawable)) doReturn fakeBackgroundColor
+        whenever(mockColorStringFormatter.formatColorAsHexString(fakeBackgroundColor)) doReturn fakeBackgroundHexColor
+
+        // When
+        val result = testedMapper.map(mockActionBarContainer, fakeMappingContext, mockAsyncJobStatusCallback)
+
+        // Then
+        assertThat(result).hasSize(1)
+        val wireframe = result[0]
+        assertThat(wireframe).isEqualTo(
+            MobileSegment.Wireframe.ShapeWireframe(
+                id = fakeViewId,
+                x = fakeViewX,
+                y = fakeViewY,
+                width = fakeViewWidth,
+                height = fakeViewHeight,
+                clip = null,
+                shapeStyle = MobileSegment.ShapeStyle(
+                    backgroundColor = fakeBackgroundHexColor,
+                    opacity = fakeViewAlpha,
+                    cornerRadius = null
+                ),
+                border = null
+            )
+        )
+    }
+
+    @Test
+    fun `M return nothing W map() {unsupported background drawable}`() {
+        // Given
+        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockBackgroundDrawable)) doReturn null
+
+        // When
+        val result = testedMapper.map(mockActionBarContainer, fakeMappingContext, mockAsyncJobStatusCallback)
+
+        // Then
+        assertThat(result).isEmpty()
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapperTest.kt
@@ -8,7 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.graphics.drawable.Drawable
 import androidx.appcompat.widget.ActionBarContainer
-import androidx.appcompat.widget.ActionBarContainerDrawableAccessor
+import androidx.appcompat.widget.DatadogActionBarContainerAccessor
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.GlobalBounds
@@ -87,7 +87,7 @@ internal class ActionBarContainerMapperTest : BaseWireframeMapperTest() {
             )
         ) doReturn GlobalBounds(fakeViewX, fakeViewY, fakeViewWidth, fakeViewHeight)
 
-        ActionBarContainerDrawableAccessor(mockActionBarContainer).setBackgroundDrawabal(mockBackgroundDrawable)
+        DatadogActionBarContainerAccessor(mockActionBarContainer).setBackgroundDrawable(mockBackgroundDrawable)
         whenever(mockActionBarContainer.alpha) doReturn fakeViewAlpha
 
         testedMapper = ActionBarContainerMapper(

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapperTest.kt
@@ -59,8 +59,9 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         )
     }
 
+    // TODO flaky ?!
     @Test
-    fun `M resolve a ShapeWireframe W map()`(forge: Forge) {
+    fun `M resolve nothing W map() { no drawable }`(forge: Forge) {
         // Given
         val mockView: View = forge.aMockView()
         whenever(
@@ -75,18 +76,7 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         val wireframes = testedWireframeMapper.map(mockView, fakeMappingContext, mockAsyncJobStatusCallback)
 
         // Then
-        assertThat(wireframes.size).isEqualTo(1)
-        val wireframe = wireframes.first()
-        check(wireframe is MobileSegment.Wireframe.ShapeWireframe)
-
-        assertThat(wireframe.id).isEqualTo(fakeWireframeId)
-        assertThat(wireframe.x).isEqualTo(fakeBounds.x)
-        assertThat(wireframe.y).isEqualTo(fakeBounds.y)
-        assertThat(wireframe.width).isEqualTo(fakeBounds.width)
-        assertThat(wireframe.height).isEqualTo(fakeBounds.height)
-        assertThat(wireframe.clip).isNull()
-        assertThat(wireframe.shapeStyle).isNull()
-        assertThat(wireframe.border).isNull()
+        assertThat(wireframes).isEmpty()
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

This PR allows sessin replay to capture the content of a Toolbar. 

- it let's the default mapping handle all the toolbar's children
- it capture's the `ActionBarContainer`'s background
