### PR TITLE
RUM-4369: Support additional properties in Telemetry Error events

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/SdkInternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/SdkInternalLogger.kt
@@ -181,22 +181,24 @@ internal class SdkInternalLogger(
             level == InternalLogger.Level.WARN ||
             error != null
         ) {
-            mapOf(
+            mutableMapOf<String, Any?>(
                 TYPE_KEY to "telemetry_error",
                 MESSAGE_KEY to message,
                 THROWABLE_KEY to error
-            )
-        } else if (!additionalProperties.isNullOrEmpty()) {
-            mapOf(
-                TYPE_KEY to "telemetry_debug",
-                MESSAGE_KEY to message,
-                ADDITIONAL_PROPERTIES_KEY to additionalProperties
-            )
+            ).apply {
+                if (!additionalProperties.isNullOrEmpty()) {
+                    put(ADDITIONAL_PROPERTIES_KEY, additionalProperties)
+                }
+            }
         } else {
-            mapOf(
+            mutableMapOf<String, Any?>(
                 TYPE_KEY to "telemetry_debug",
                 MESSAGE_KEY to message
-            )
+            ).apply {
+                if (!additionalProperties.isNullOrEmpty()) {
+                    put(ADDITIONAL_PROPERTIES_KEY, additionalProperties)
+                }
+            }
         }
         rumFeature.sendEvent(telemetryEvent)
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/SdkInternalLoggerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/SdkInternalLoggerTest.kt
@@ -356,6 +356,7 @@ internal class SdkInternalLoggerTest {
         forge: Forge
     ) {
         // Given
+        val fakeAdditionalProperties = forge.exhaustiveAttributes()
         val mockLambda: () -> String = mock()
         whenever(mockLambda.invoke()) doReturn fakeMessage
         val fakeLevel = forge.anElementFrom(InternalLogger.Level.WARN, InternalLogger.Level.ERROR)
@@ -367,7 +368,8 @@ internal class SdkInternalLoggerTest {
             fakeLevel,
             InternalLogger.Target.TELEMETRY,
             mockLambda,
-            null
+            null,
+            additionalProperties = fakeAdditionalProperties
         )
 
         // Then
@@ -376,7 +378,8 @@ internal class SdkInternalLoggerTest {
                 mapOf(
                     "type" to "telemetry_error",
                     "message" to fakeMessage,
-                    "throwable" to null
+                    "throwable" to null,
+                    "additionalProperties" to fakeAdditionalProperties
                 )
             )
     }
@@ -387,6 +390,7 @@ internal class SdkInternalLoggerTest {
         forge: Forge
     ) {
         // Given
+        val fakeAdditionalProperties = forge.exhaustiveAttributes()
         val mockLambda: () -> String = mock()
         whenever(mockLambda.invoke()) doReturn fakeMessage
         val fakeLevel = forge.aValueFrom(InternalLogger.Level::class.java)
@@ -399,7 +403,8 @@ internal class SdkInternalLoggerTest {
             fakeLevel,
             InternalLogger.Target.TELEMETRY,
             mockLambda,
-            fakeThrowable
+            fakeThrowable,
+            additionalProperties = fakeAdditionalProperties
         )
 
         // Then
@@ -408,7 +413,8 @@ internal class SdkInternalLoggerTest {
                 mapOf(
                     "type" to "telemetry_error",
                     "message" to fakeMessage,
-                    "throwable" to fakeThrowable
+                    "throwable" to fakeThrowable,
+                    "additionalProperties" to fakeAdditionalProperties
                 )
             )
     }

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -1796,7 +1796,7 @@ data class com.datadog.android.telemetry.model.TelemetryConfigurationEvent
       fun fromJson(kotlin.String): Os
       fun fromJsonObject(com.google.gson.JsonObject): Os
   data class Configuration
-    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<SelectedTracingPropagator>? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.Boolean? = null, ViewTrackingStrategy? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
+    constructor(kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, TraceContextInjection? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, TrackingConsent? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<SelectedTracingPropagator>? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.collections.List<kotlin.String>? = null, kotlin.Boolean? = null, ViewTrackingStrategy? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.Boolean? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.Long? = null, kotlin.Boolean? = null, kotlin.String? = null, kotlin.String? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Configuration
@@ -1812,6 +1812,21 @@ data class com.datadog.android.telemetry.model.TelemetryConfigurationEvent
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Source
+  enum TraceContextInjection
+    constructor(kotlin.String)
+    - ALL
+    - SAMPLED
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TraceContextInjection
+  enum TrackingConsent
+    constructor(kotlin.String)
+    - GRANTED
+    - NOT_GRANTED
+    - PENDING
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): TrackingConsent
   enum SelectedTracingPropagator
     constructor(kotlin.String)
     - DATADOG

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -5357,10 +5357,10 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 public final class com/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration {
 	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration$Companion;
 	public fun <init> ()V
-	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
-	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;IIILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/Long;
-	public final fun component10 ()Ljava/lang/Boolean;
+	public final fun component10 ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
 	public final fun component11 ()Ljava/lang/Boolean;
 	public final fun component12 ()Ljava/lang/Boolean;
 	public final fun component13 ()Ljava/lang/Boolean;
@@ -5371,63 +5371,76 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public final fun component18 ()Ljava/lang/Boolean;
 	public final fun component19 ()Ljava/lang/Boolean;
 	public final fun component2 ()Ljava/lang/Long;
-	public final fun component20 ()Ljava/lang/String;
+	public final fun component20 ()Ljava/lang/Boolean;
 	public final fun component21 ()Ljava/lang/Boolean;
 	public final fun component22 ()Ljava/lang/Boolean;
-	public final fun component23 ()Ljava/util/List;
+	public final fun component23 ()Ljava/lang/Boolean;
 	public final fun component24 ()Ljava/lang/String;
 	public final fun component25 ()Ljava/lang/Boolean;
 	public final fun component26 ()Ljava/lang/Boolean;
-	public final fun component27 ()Ljava/lang/Boolean;
-	public final fun component28 ()Ljava/lang/Boolean;
+	public final fun component27 ()Ljava/util/List;
+	public final fun component28 ()Ljava/lang/String;
 	public final fun component29 ()Ljava/lang/Boolean;
 	public final fun component3 ()Ljava/lang/Long;
 	public final fun component30 ()Ljava/lang/Boolean;
 	public final fun component31 ()Ljava/lang/Boolean;
-	public final fun component32 ()Ljava/util/List;
-	public final fun component33 ()Ljava/util/List;
+	public final fun component32 ()Ljava/lang/Boolean;
+	public final fun component33 ()Ljava/lang/Boolean;
 	public final fun component34 ()Ljava/lang/Boolean;
-	public final fun component35 ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;
+	public final fun component35 ()Ljava/lang/Boolean;
 	public final fun component36 ()Ljava/lang/Boolean;
-	public final fun component37 ()Ljava/lang/Long;
-	public final fun component38 ()Ljava/lang/Boolean;
-	public final fun component39 ()Ljava/lang/Boolean;
+	public final fun component37 ()Ljava/lang/Boolean;
+	public final fun component38 ()Ljava/util/List;
+	public final fun component39 ()Ljava/util/List;
 	public final fun component4 ()Ljava/lang/Long;
 	public final fun component40 ()Ljava/lang/Boolean;
-	public final fun component41 ()Ljava/lang/Boolean;
+	public final fun component41 ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;
 	public final fun component42 ()Ljava/lang/Boolean;
-	public final fun component43 ()Ljava/lang/Boolean;
+	public final fun component43 ()Ljava/lang/Long;
 	public final fun component44 ()Ljava/lang/Boolean;
 	public final fun component45 ()Ljava/lang/Boolean;
-	public final fun component46 ()Ljava/lang/String;
+	public final fun component46 ()Ljava/lang/Boolean;
 	public final fun component47 ()Ljava/lang/Boolean;
-	public final fun component48 ()Ljava/lang/Long;
-	public final fun component49 ()Ljava/lang/Long;
+	public final fun component48 ()Ljava/lang/Boolean;
+	public final fun component49 ()Ljava/lang/Boolean;
 	public final fun component5 ()Ljava/lang/Long;
-	public final fun component50 ()Ljava/lang/Long;
+	public final fun component50 ()Ljava/lang/Boolean;
 	public final fun component51 ()Ljava/lang/Boolean;
 	public final fun component52 ()Ljava/lang/String;
-	public final fun component53 ()Ljava/lang/String;
-	public final fun component54 ()Ljava/lang/String;
-	public final fun component55 ()Ljava/lang/String;
-	public final fun component6 ()Ljava/lang/Long;
+	public final fun component53 ()Ljava/lang/Boolean;
+	public final fun component54 ()Ljava/lang/Long;
+	public final fun component55 ()Ljava/lang/Long;
+	public final fun component56 ()Ljava/lang/Long;
+	public final fun component57 ()Ljava/lang/Boolean;
+	public final fun component58 ()Ljava/lang/String;
+	public final fun component59 ()Ljava/lang/String;
+	public final fun component6 ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
+	public final fun component60 ()Ljava/lang/String;
+	public final fun component61 ()Ljava/lang/String;
+	public final fun component62 ()Ljava/lang/Long;
+	public final fun component63 ()Ljava/lang/Boolean;
+	public final fun component64 ()Ljava/lang/String;
+	public final fun component65 ()Ljava/lang/String;
 	public final fun component7 ()Ljava/lang/Long;
-	public final fun component8 ()Ljava/lang/Boolean;
-	public final fun component9 ()Ljava/lang/Boolean;
-	public final fun copy (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
-	public static synthetic fun copy$default (Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;IILjava/lang/Object;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Ljava/lang/Long;
+	public final fun copy (Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
+	public static synthetic fun copy$default (Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/util/List;Ljava/util/List;Ljava/lang/Boolean;Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$ViewTrackingStrategy;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/Boolean;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Boolean;Ljava/lang/String;Ljava/lang/String;IIILjava/lang/Object;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Configuration;
 	public final fun getActionNameAttribute ()Ljava/lang/String;
 	public final fun getAllowFallbackToLocalStorage ()Ljava/lang/Boolean;
 	public final fun getAllowUntrustedEvents ()Ljava/lang/Boolean;
+	public final fun getAppHangThreshold ()Ljava/lang/Long;
 	public final fun getBackgroundTasksEnabled ()Ljava/lang/Boolean;
 	public final fun getBatchProcessingLevel ()Ljava/lang/Long;
 	public final fun getBatchSize ()Ljava/lang/Long;
 	public final fun getBatchUploadFrequency ()Ljava/lang/Long;
+	public final fun getCompressIntakeRequests ()Ljava/lang/Boolean;
 	public final fun getDartVersion ()Ljava/lang/String;
 	public final fun getDefaultPrivacyLevel ()Ljava/lang/String;
+	public final fun getEnablePrivacyForActionName ()Ljava/lang/Boolean;
 	public final fun getForwardConsoleLogs ()Ljava/util/List;
 	public final fun getForwardErrorsToLogs ()Ljava/lang/Boolean;
 	public final fun getForwardReports ()Ljava/util/List;
@@ -5445,7 +5458,11 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public final fun getStoreContextsAcrossPages ()Ljava/lang/Boolean;
 	public final fun getTelemetryConfigurationSampleRate ()Ljava/lang/Long;
 	public final fun getTelemetrySampleRate ()Ljava/lang/Long;
+	public final fun getTelemetryUsageSampleRate ()Ljava/lang/Long;
+	public final fun getTraceContextInjection ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
 	public final fun getTraceSampleRate ()Ljava/lang/Long;
+	public final fun getTracerApi ()Ljava/lang/String;
+	public final fun getTracerApiVersion ()Ljava/lang/String;
 	public final fun getTrackBackgroundEvents ()Ljava/lang/Boolean;
 	public final fun getTrackCrossPlatformLongTasks ()Ljava/lang/Boolean;
 	public final fun getTrackErrors ()Ljava/lang/Boolean;
@@ -5461,6 +5478,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public final fun getTrackSessionAcrossSubdomains ()Ljava/lang/Boolean;
 	public final fun getTrackUserInteractions ()Ljava/lang/Boolean;
 	public final fun getTrackViewsManually ()Ljava/lang/Boolean;
+	public final fun getTrackingConsent ()Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
 	public final fun getUnityVersion ()Ljava/lang/String;
 	public final fun getUseAllowedTracingOrigins ()Ljava/lang/Boolean;
 	public final fun getUseAllowedTracingUrls ()Ljava/lang/Boolean;
@@ -5469,6 +5487,8 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public final fun getUseExcludedActivityUrls ()Ljava/lang/Boolean;
 	public final fun getUseFirstPartyHosts ()Ljava/lang/Boolean;
 	public final fun getUseLocalEncryption ()Ljava/lang/Boolean;
+	public final fun getUsePartitionedCrossSiteSessionCookie ()Ljava/lang/Boolean;
+	public final fun getUsePciIntake ()Ljava/lang/Boolean;
 	public final fun getUseProxy ()Ljava/lang/Boolean;
 	public final fun getUseSecureSessionCookie ()Ljava/lang/Boolean;
 	public final fun getUseTracing ()Ljava/lang/Boolean;
@@ -5477,12 +5497,16 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public fun hashCode ()I
 	public final fun setDartVersion (Ljava/lang/String;)V
 	public final fun setDefaultPrivacyLevel (Ljava/lang/String;)V
+	public final fun setEnablePrivacyForActionName (Ljava/lang/Boolean;)V
 	public final fun setInitializationType (Ljava/lang/String;)V
 	public final fun setMobileVitalsUpdatePeriod (Ljava/lang/Long;)V
 	public final fun setReactNativeVersion (Ljava/lang/String;)V
 	public final fun setReactVersion (Ljava/lang/String;)V
 	public final fun setSessionReplaySampleRate (Ljava/lang/Long;)V
 	public final fun setStartSessionReplayRecordingManually (Ljava/lang/Boolean;)V
+	public final fun setTraceContextInjection (Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;)V
+	public final fun setTracerApi (Ljava/lang/String;)V
+	public final fun setTracerApiVersion (Ljava/lang/String;)V
 	public final fun setTrackBackgroundEvents (Ljava/lang/Boolean;)V
 	public final fun setTrackCrossPlatformLongTasks (Ljava/lang/Boolean;)V
 	public final fun setTrackErrors (Ljava/lang/Boolean;)V
@@ -5499,6 +5523,7 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 	public final fun setTrackViewsManually (Ljava/lang/Boolean;)V
 	public final fun setUnityVersion (Ljava/lang/String;)V
 	public final fun setUseFirstPartyHosts (Ljava/lang/Boolean;)V
+	public final fun setUsePciIntake (Ljava/lang/Boolean;)V
 	public final fun setUseProxy (Ljava/lang/Boolean;)V
 	public final fun toJson ()Lcom/google/gson/JsonElement;
 	public fun toString ()Ljava/lang/String;
@@ -5647,6 +5672,35 @@ public final class com/datadog/android/telemetry/model/TelemetryConfigurationEve
 public final class com/datadog/android/telemetry/model/TelemetryConfigurationEvent$Telemetry$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Telemetry;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$Telemetry;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection : java/lang/Enum {
+	public static final field ALL Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
+	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection$Companion;
+	public static final field SAMPLED Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
+	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TraceContextInjection;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent : java/lang/Enum {
+	public static final field Companion Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent$Companion;
+	public static final field GRANTED Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
+	public static final field NOT_GRANTED Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
+	public static final field PENDING Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
+	public static fun values ()[Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
+}
+
+public final class com/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/telemetry/model/TelemetryConfigurationEvent$TrackingConsent;
 }
 
 public final class com/datadog/android/telemetry/model/TelemetryConfigurationEvent$View {

--- a/features/dd-sdk-android-rum/src/main/json/telemetry/_common-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/telemetry/_common-schema.json
@@ -4,21 +4,12 @@
   "title": "CommonTelemetryProperties",
   "type": "object",
   "description": "Schema of common properties of Telemetry events",
-  "required": [
-    "_dd",
-    "type",
-    "date",
-    "service",
-    "source",
-    "version"
-  ],
+  "required": ["_dd", "type", "date", "service", "source", "version"],
   "properties": {
     "_dd": {
       "type": "object",
       "description": "Internal properties",
-      "required": [
-        "format_version"
-      ],
+      "required": ["format_version"],
       "properties": {
         "format_version": {
           "type": "integer",
@@ -46,14 +37,7 @@
     "source": {
       "type": "string",
       "description": "The source of this event",
-      "enum": [
-        "android",
-        "ios",
-        "browser",
-        "flutter",
-        "react-native",
-        "unity"
-      ],
+      "enum": ["android", "ios", "browser", "flutter", "react-native", "unity"],
       "readOnly": true
     },
     "version": {
@@ -63,9 +47,7 @@
     "application": {
       "type": "object",
       "description": "Application properties",
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "properties": {
         "id": {
           "type": "string",
@@ -78,9 +60,7 @@
     "session": {
       "type": "object",
       "description": "Session properties",
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "properties": {
         "id": {
           "type": "string",
@@ -92,9 +72,7 @@
     "view": {
       "type": "object",
       "description": "View properties",
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "properties": {
         "id": {
           "type": "string",
@@ -106,9 +84,7 @@
     "action": {
       "type": "object",
       "description": "Action properties",
-      "required": [
-        "id"
-      ],
+      "required": ["id"],
       "properties": {
         "id": {
           "type": "string",

--- a/features/dd-sdk-android-rum/src/main/json/telemetry/configuration-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/telemetry/configuration-schema.json
@@ -43,11 +43,23 @@
                   "minimum": 0,
                   "maximum": 100
                 },
+                "telemetry_usage_sample_rate": {
+                  "type": "integer",
+                  "description": "The percentage of telemetry usage events sent after being sampled by telemetry_sample_rate",
+                  "minimum": 0,
+                  "maximum": 100
+                },
                 "trace_sample_rate": {
                   "type": "integer",
                   "description": "The percentage of requests traced",
                   "minimum": 0,
                   "maximum": 100
+                },
+                "trace_context_injection": {
+                  "type": "string",
+                  "description": "The opt-in configuration to add trace context",
+                  "enum": ["all", "sampled"],
+                  "readOnly": false
                 },
                 "premium_sample_rate": {
                   "type": "integer",
@@ -67,6 +79,11 @@
                   "minimum": 0,
                   "maximum": 100,
                   "readOnly": false
+                },
+                "tracking_consent": {
+                  "type": "string",
+                  "description": "The initial tracking consent value",
+                  "enum": ["granted", "not-granted", "pending"]
                 },
                 "start_session_replay_recording_manually": {
                   "type": "boolean",
@@ -102,7 +119,11 @@
                 },
                 "use_cross_site_session_cookie": {
                   "type": "boolean",
-                  "description": "Whether a secure cross-site session cookie is used"
+                  "description": "Whether a secure cross-site session cookie is used (deprecated)"
+                },
+                "use_partitioned_cross_site_session_cookie": {
+                  "type": "boolean",
+                  "description": "Whether a partitioned secure cross-site session cookie is used"
                 },
                 "use_secure_session_cookie": {
                   "type": "boolean",
@@ -145,6 +166,11 @@
                   "description": "Session replay default privacy level",
                   "readOnly": false
                 },
+                "enable_privacy_for_action_name": {
+                  "type": "boolean",
+                  "description": "Privacy control for action name",
+                  "readOnly": false
+                },
                 "use_excluded_activity_urls": {
                   "type": "boolean",
                   "description": "Whether the request origins list to ignore when computing the page activity is used"
@@ -152,6 +178,10 @@
                 "use_worker_url": {
                   "type": "boolean",
                   "description": "Whether the Worker is loaded from an external URL"
+                },
+                "compress_intake_requests": {
+                  "type": "boolean",
+                  "description": "Whether intake requests are compressed"
                 },
                 "track_frustrations": {
                   "type": "boolean",
@@ -290,7 +320,7 @@
                 },
                 "batch_processing_level": {
                   "type": "integer",
-                  "description": "Maximum number of batches processed sequencially without a delay"
+                  "description": "Maximum number of batches processed sequentially without a delay"
                 },
                 "background_tasks_enabled": {
                   "type": "boolean",
@@ -314,6 +344,25 @@
                 "unity_version": {
                   "type": "string",
                   "description": "The version of Unity used in a Unity application",
+                  "readOnly": false
+                },
+                "app_hang_threshold": {
+                  "type": "integer",
+                  "description": "The threshold used for iOS App Hangs monitoring (in milliseconds)"
+                },
+                "use_pci_intake": {
+                  "type": "boolean",
+                  "description": "Whether logs are sent to the PCI-compliant intake",
+                  "readOnly": false
+                },
+                "tracer_api": {
+                  "type": "string",
+                  "description": "The tracer API used by the SDK. Possible values: 'Datadog', 'OpenTelemetry', 'OpenTracing'",
+                  "readOnly": false
+                },
+                "tracer_api_version": {
+                  "type": "string",
+                  "description": "The version of the tracer API used by the SDK. Eg. '0.1.0'",
                   "readOnly": false
                 }
               }

--- a/features/dd-sdk-android-rum/src/main/json/telemetry/error-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/telemetry/error-schema.json
@@ -15,6 +15,7 @@
           "type": "object",
           "description": "The telemetry log information",
           "required": ["status", "message"],
+          "additionalProperties": true,
           "properties": {
             "type": {
               "type": "string",

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -515,10 +515,13 @@ internal class RumFeature(
         val throwable = telemetryEvent[EVENT_THROWABLE_PROPERTY] as? Throwable
         val stack = telemetryEvent[EVENT_STACKTRACE_PROPERTY] as? String
         val kind = telemetryEvent["kind"] as? String
+
+        @Suppress("UNCHECKED_CAST")
+        val additionalProperties = telemetryEvent[EVENT_ADDITIONAL_PROPERTIES] as? Map<String, Any?>
         if (throwable != null) {
-            telemetry.error(message, throwable)
+            telemetry.error(message, throwable, additionalProperties)
         } else {
-            telemetry.error(message, stack, kind)
+            telemetry.error(message, stack, kind, additionalProperties)
         }
     }
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -44,18 +44,20 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
 
     fun sendDebugTelemetryEvent(
         message: String,
-        additionalProperties: Map<String, Any?>?
+        additionalProperties: Map<String, Any?>? = null
     )
 
     fun sendErrorTelemetryEvent(
         message: String,
-        throwable: Throwable?
+        throwable: Throwable?,
+        additionalProperties: Map<String, Any?>? = null
     )
 
     fun sendErrorTelemetryEvent(
         message: String,
         stack: String?,
-        kind: String?
+        kind: String?,
+        additionalProperties: Map<String, Any?>? = null
     )
 
     fun sendMetricEvent(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -535,7 +535,8 @@ internal class DatadogRumMonitor(
 
     override fun sendErrorTelemetryEvent(
         message: String,
-        throwable: Throwable?
+        throwable: Throwable?,
+        additionalProperties: Map<String, Any?>?
     ) {
         val stack: String? = throwable?.loggableStackTrace()
         val kind: String? = throwable?.javaClass?.canonicalName ?: throwable?.javaClass?.simpleName
@@ -546,7 +547,7 @@ internal class DatadogRumMonitor(
                 stack = stack,
                 kind = kind,
                 coreConfiguration = null,
-                additionalProperties = null
+                additionalProperties = additionalProperties
             )
         )
     }
@@ -554,7 +555,8 @@ internal class DatadogRumMonitor(
     override fun sendErrorTelemetryEvent(
         message: String,
         stack: String?,
-        kind: String?
+        kind: String?,
+        additionalProperties: Map<String, Any?>?
     ) {
         handleEvent(
             RumRawEvent.SendTelemetry(
@@ -563,7 +565,7 @@ internal class DatadogRumMonitor(
                 stack = stack,
                 kind = kind,
                 coreConfiguration = null,
-                additionalProperties = null
+                additionalProperties = additionalProperties
             )
         )
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/Telemetry.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/Telemetry.kt
@@ -14,31 +14,36 @@ import com.datadog.android.rum.internal.monitor.NoOpAdvancedRumMonitor
 internal class Telemetry(
     private val sdkCore: SdkCore
 ) {
+
     internal val rumMonitor: AdvancedRumMonitor
         get() {
             return GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor ?: NoOpAdvancedRumMonitor()
         }
+
     fun error(
         message: String,
-        throwable: Throwable? = null
+        throwable: Throwable? = null,
+        additionalProperties: Map<String, Any?>? = null
     ) {
         (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor)
-            ?.sendErrorTelemetryEvent(message, throwable)
+            ?.sendErrorTelemetryEvent(message, throwable, additionalProperties)
     }
 
     fun error(
         message: String,
         stack: String? = null,
-        kind: String? = null
+        kind: String? = null,
+        additionalProperties: Map<String, Any?>? = null
     ) {
         (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor)
-            ?.sendErrorTelemetryEvent(message, stack, kind)
+            ?.sendErrorTelemetryEvent(message, stack, kind, additionalProperties)
     }
 
     fun debug(message: String, additionalProperties: Map<String, Any?>? = null) {
         (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor)
             ?.sendDebugTelemetryEvent(message, additionalProperties)
     }
+
     fun metric(message: String, additionalProperties: Map<String, Any?>? = null) {
         (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor)
             ?.sendMetricEvent(message, additionalProperties)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -63,8 +63,8 @@ internal class TelemetryEventHandler(
                             datadogContext,
                             timestamp,
                             event.message,
-                            event.additionalProperties,
-                            deviceInfo
+                            deviceInfo,
+                            event.additionalProperties
                         )
                     }
 
@@ -75,7 +75,8 @@ internal class TelemetryEventHandler(
                             event.message,
                             event.stack,
                             event.kind,
-                            deviceInfo
+                            deviceInfo,
+                            event.additionalProperties
                         )
                     }
 
@@ -86,9 +87,10 @@ internal class TelemetryEventHandler(
                                 datadogContext,
                                 timestamp,
                                 "Trying to send configuration event with null config",
-                                null,
-                                null,
-                                deviceInfo
+                                stack = null,
+                                kind = null,
+                                deviceInfo,
+                                additionalProperties = null
                             )
                         } else {
                             createConfigurationEvent(
@@ -152,8 +154,8 @@ internal class TelemetryEventHandler(
         datadogContext: DatadogContext,
         timestamp: Long,
         message: String,
-        additionalProperties: Map<String, Any?>?,
-        deviceInfo: DeviceInfo?
+        deviceInfo: DeviceInfo?,
+        additionalProperties: Map<String, Any?>?
     ): TelemetryDebugEvent {
         val rumContext = datadogContext.rumContext()
         val resolvedAdditionalProperties = additionalProperties?.toMutableMap() ?: mutableMapOf()
@@ -199,9 +201,12 @@ internal class TelemetryEventHandler(
         message: String,
         stack: String?,
         kind: String?,
-        deviceInfo: DeviceInfo?
+        deviceInfo: DeviceInfo?,
+        additionalProperties: Map<String, Any?>?
     ): TelemetryErrorEvent {
         val rumContext = datadogContext.rumContext()
+        val resolvedAdditionalProperties = additionalProperties?.toMutableMap() ?: mutableMapOf()
+
         return TelemetryErrorEvent(
             dd = TelemetryErrorEvent.Dd(),
             date = timestamp,
@@ -217,6 +222,7 @@ internal class TelemetryEventHandler(
             action = rumContext.actionId?.let { TelemetryErrorEvent.Action(it) },
             telemetry = TelemetryErrorEvent.Telemetry(
                 message = message,
+                additionalProperties = resolvedAdditionalProperties,
                 error = if (stack != null || kind != null) {
                     TelemetryErrorEvent.Error(
                         stack = stack,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -1279,7 +1279,7 @@ internal class RumFeatureTest {
     }
 
     @Test
-    fun `M handle telemetry error event W onReceive() { with throwable }`(
+    fun `M handle telemetry error event W onReceive() { with throwable, no additional properties }`(
         @StringForgery fakeMessage: String,
         forge: Forge
     ) {
@@ -1303,7 +1303,33 @@ internal class RumFeatureTest {
     }
 
     @Test
-    fun `M handle telemetry error event W onReceive() { with stack and kind }`(
+    fun `M handle telemetry error event W onReceive() { with throwable, with additional properties }`(
+        @StringForgery fakeMessage: String,
+        forge: Forge
+    ) {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+        val fakeThrowable = forge.aThrowable()
+        val fakeAdditionalProperties = forge.exhaustiveAttributes()
+        val event = mapOf(
+            "type" to "telemetry_error",
+            "message" to fakeMessage,
+            "throwable" to fakeThrowable,
+            "additionalProperties" to fakeAdditionalProperties
+        )
+
+        // When
+        testedFeature.onReceive(event)
+
+        // Then
+        verify(mockRumMonitor)
+            .sendErrorTelemetryEvent(fakeMessage, fakeThrowable, fakeAdditionalProperties)
+        verifyNoMoreInteractions(mockRumMonitor)
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `M handle telemetry error event W onReceive() { with stack and kind, no additional properties }`(
         @StringForgery fakeMessage: String,
         forge: Forge
     ) {
@@ -1324,6 +1350,36 @@ internal class RumFeatureTest {
         // Then
         verify(mockRumMonitor)
             .sendErrorTelemetryEvent(fakeMessage, fakeStack, fakeKind)
+
+        verifyNoMoreInteractions(mockRumMonitor)
+
+        verifyNoInteractions(mockInternalLogger)
+    }
+
+    @Test
+    fun `M handle telemetry error event W onReceive() { with stack and kind, with additional properties }`(
+        @StringForgery fakeMessage: String,
+        forge: Forge
+    ) {
+        // Given
+        testedFeature.onInitialize(appContext.mockInstance)
+        val fakeStack = forge.aNullable { aString() }
+        val fakeKind = forge.aNullable { aString() }
+        val fakeAdditionalProperties = forge.exhaustiveAttributes()
+        val event = mapOf(
+            "type" to "telemetry_error",
+            "message" to fakeMessage,
+            "stacktrace" to fakeStack,
+            "kind" to fakeKind,
+            "additionalProperties" to fakeAdditionalProperties
+        )
+
+        // When
+        testedFeature.onReceive(event)
+
+        // Then
+        verify(mockRumMonitor)
+            .sendErrorTelemetryEvent(fakeMessage, fakeStack, fakeKind, fakeAdditionalProperties)
 
         verifyNoMoreInteractions(mockRumMonitor)
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -1707,10 +1707,14 @@ internal class DatadogRumMonitorTest {
     fun `M handle error telemetry event W sendErrorTelemetryEvent() {stack+kind}`(
         @StringForgery message: String,
         @StringForgery stackTrace: String,
-        @StringForgery kind: String
+        @StringForgery kind: String,
+        forge: Forge
     ) {
+        // Given
+        val fakeAdditionalProperties = forge.aNullable { exhaustiveAttributes() }
+
         // When
-        testedMonitor.sendErrorTelemetryEvent(message, stackTrace, kind)
+        testedMonitor.sendErrorTelemetryEvent(message, stackTrace, kind, fakeAdditionalProperties)
 
         // Then
         argumentCaptor<RumRawEvent.SendTelemetry> {
@@ -1724,6 +1728,7 @@ internal class DatadogRumMonitorTest {
             assertThat(lastValue.kind).isEqualTo(kind)
             assertThat(lastValue.isMetric).isFalse
             assertThat(lastValue.coreConfiguration).isNull()
+            assertThat(lastValue.additionalProperties).isEqualTo(fakeAdditionalProperties)
         }
     }
 
@@ -1732,9 +1737,12 @@ internal class DatadogRumMonitorTest {
         @StringForgery message: String,
         forge: Forge
     ) {
-        // When
+        // Given
         val throwable = forge.aNullable { forge.aThrowable() }
-        testedMonitor.sendErrorTelemetryEvent(message, throwable)
+        val fakeAdditionalProperties = forge.aNullable { exhaustiveAttributes() }
+
+        // When
+        testedMonitor.sendErrorTelemetryEvent(message, throwable, fakeAdditionalProperties)
 
         // Then
         argumentCaptor<RumRawEvent.SendTelemetry> {
@@ -1748,6 +1756,7 @@ internal class DatadogRumMonitorTest {
             assertThat(lastValue.kind).isEqualTo(throwable?.javaClass?.canonicalName)
             assertThat(lastValue.isMetric).isFalse
             assertThat(lastValue.coreConfiguration).isNull()
+            assertThat(lastValue.additionalProperties).isEqualTo(fakeAdditionalProperties)
         }
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryErrorEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryErrorEventAssert.kt
@@ -179,6 +179,16 @@ internal class TelemetryErrorEventAssert(actual: TelemetryErrorEvent) :
         return this
     }
 
+    fun hasAdditionalProperties(additionalProperties: Map<String, Any?>): TelemetryErrorEventAssert {
+        assertThat(actual.telemetry.additionalProperties)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.additionalProperties $additionalProperties" +
+                    " but was ${actual.telemetry.additionalProperties}"
+            )
+            .isEqualTo(additionalProperties)
+        return this
+    }
+
     companion object {
         fun assertThat(actual: TelemetryErrorEvent) = TelemetryErrorEventAssert(actual)
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -908,6 +908,7 @@ internal class TelemetryEventHandlerTest {
             .hasOsBuild(fakeOsBuildId)
             .hasOsName(fakeOsName)
             .hasOsVersion(fakeOsVersion)
+            .hasAdditionalProperties(rawEvent.additionalProperties ?: emptyMap())
     }
 
     private fun assertConfigEventMatchesRawEvent(
@@ -969,7 +970,7 @@ internal class TelemetryEventHandlerTest {
             throwable?.loggableStackTrace(),
             throwable?.javaClass?.canonicalName,
             coreConfiguration = null,
-            additionalProperties = null,
+            additionalProperties = aNullable { exhaustiveAttributes() },
             isMetric = aBool()
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryTest.kt
@@ -50,13 +50,14 @@ internal class TelemetryTest {
     ) {
         // Given
         val throwable = forge.aNullable { forge.aThrowable() }
+        val fakeAdditionalProperties = forge.aNullable { exhaustiveAttributes() }
 
         // When
-        testedTelemetry.error(message, throwable)
+        testedTelemetry.error(message, throwable, fakeAdditionalProperties)
 
         // Then
         verify(rumMonitor.mockInstance as AdvancedRumMonitor)
-            .sendErrorTelemetryEvent(message, throwable)
+            .sendErrorTelemetryEvent(message, throwable, fakeAdditionalProperties)
     }
 
     @Test
@@ -66,6 +67,7 @@ internal class TelemetryTest {
     ) {
         // Given
         val fakeAdditionalProperties = forge.aNullable { exhaustiveAttributes() }
+
         // When
         testedTelemetry.debug(message, fakeAdditionalProperties)
 
@@ -81,6 +83,7 @@ internal class TelemetryTest {
     ) {
         // Given
         val fakeAdditionalProperties = forge.aNullable { exhaustiveAttributes() }
+
         // When
         testedTelemetry.metric(message, fakeAdditionalProperties)
 


### PR DESCRIPTION
### What does this PR do?

This PR adds support for the `additionalProperties` for the `TelemetryErrorEvent`. They are already supported in `TelemetryDebugEvent`, but were missing for the errors.

Code is updated to propagate these additional properties to the telemetry.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

