### PR TITLE
RUM-4413 Add telemetry on SR resources track

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -94,6 +94,7 @@ interface com.datadog.android.api.feature.Feature
     const val RUM_FEATURE_NAME: String
     const val TRACING_FEATURE_NAME: String
     const val SESSION_REPLAY_FEATURE_NAME: String
+    const val SESSION_REPLAY_RESOURCES_FEATURE_NAME: String
     const val NDK_CRASH_REPORTS_FEATURE_NAME: String
 interface com.datadog.android.api.feature.FeatureContextUpdateReceiver
   fun onContextUpdate(String, Map<String, Any?>)

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -299,6 +299,7 @@ public abstract interface class com/datadog/android/api/feature/Feature {
 	public static final field NDK_CRASH_REPORTS_FEATURE_NAME Ljava/lang/String;
 	public static final field RUM_FEATURE_NAME Ljava/lang/String;
 	public static final field SESSION_REPLAY_FEATURE_NAME Ljava/lang/String;
+	public static final field SESSION_REPLAY_RESOURCES_FEATURE_NAME Ljava/lang/String;
 	public static final field TRACING_FEATURE_NAME Ljava/lang/String;
 	public abstract fun getName ()Ljava/lang/String;
 	public abstract fun onInitialize (Landroid/content/Context;)V
@@ -310,6 +311,7 @@ public final class com/datadog/android/api/feature/Feature$Companion {
 	public static final field NDK_CRASH_REPORTS_FEATURE_NAME Ljava/lang/String;
 	public static final field RUM_FEATURE_NAME Ljava/lang/String;
 	public static final field SESSION_REPLAY_FEATURE_NAME Ljava/lang/String;
+	public static final field SESSION_REPLAY_RESOURCES_FEATURE_NAME Ljava/lang/String;
 	public static final field TRACING_FEATURE_NAME Ljava/lang/String;
 }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/Feature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/Feature.kt
@@ -55,6 +55,11 @@ interface Feature {
         const val SESSION_REPLAY_FEATURE_NAME: String = "session-replay"
 
         /**
+         * Session Replay Resources sub-feature name.
+         */
+        const val SESSION_REPLAY_RESOURCES_FEATURE_NAME: String = "session-replay-resources"
+
+        /**
          * NDK Crash Reports feature name.
          */
         const val NDK_CRASH_REPORTS_FEATURE_NAME: String = "ndk-crash-reporting"

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
@@ -160,6 +160,8 @@ internal class BatchMetricsDispatcher(
             Feature.LOGS_FEATURE_NAME -> LOGS_TRACK_NAME
             Feature.TRACING_FEATURE_NAME -> TRACE_TRACK_NAME
             Feature.SESSION_REPLAY_FEATURE_NAME -> SR_TRACK_NAME
+            Feature.SESSION_REPLAY_RESOURCES_FEATURE_NAME -> SR_RESOURCES_TRACK_NAME
+
             else -> null
         }
     }
@@ -183,6 +185,7 @@ internal class BatchMetricsDispatcher(
         internal const val LOGS_TRACK_NAME = "logs"
         internal const val TRACE_TRACK_NAME = "trace"
         internal const val SR_TRACK_NAME = "sr"
+        internal const val SR_RESOURCES_TRACK_NAME = "sr-resources"
 
         private const val METRICS_DISPATCHER_DEFAULT_SAMPLING_RATE = 15f
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
@@ -77,7 +77,8 @@ internal class BatchMetricsDispatcherTest {
                 Feature.RUM_FEATURE_NAME,
                 Feature.TRACING_FEATURE_NAME,
                 Feature.LOGS_FEATURE_NAME,
-                Feature.SESSION_REPLAY_FEATURE_NAME
+                Feature.SESSION_REPLAY_FEATURE_NAME,
+                Feature.SESSION_REPLAY_RESOURCES_FEATURE_NAME
             )
         )
         whenever(mockDateTimeProvider.getDeviceTimestamp()).doReturn(currentTimeInMillis)
@@ -655,6 +656,7 @@ internal class BatchMetricsDispatcherTest {
             Feature.LOGS_FEATURE_NAME -> BatchMetricsDispatcher.LOGS_TRACK_NAME
             Feature.TRACING_FEATURE_NAME -> BatchMetricsDispatcher.TRACE_TRACK_NAME
             Feature.SESSION_REPLAY_FEATURE_NAME -> BatchMetricsDispatcher.SR_TRACK_NAME
+            Feature.SESSION_REPLAY_RESOURCES_FEATURE_NAME -> BatchMetricsDispatcher.SR_RESOURCES_TRACK_NAME
             else -> null
         }
     }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -46,6 +46,7 @@ import com.datadog.android.sample.picture.PicassoImageLoader
 import com.datadog.android.sample.user.UserFragment
 import com.datadog.android.sessionreplay.SessionReplay
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.material.MaterialExtensionSupport
 import com.datadog.android.timber.DatadogTree
 import com.datadog.android.trace.AndroidTracer
@@ -149,6 +150,7 @@ class SampleApplication : Application() {
                     useCustomEndpoint(BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL)
                 }
             }
+            .setPrivacy(SessionReplayPrivacy.MASK_USER_INPUT)
             .addExtensionSupport(MaterialExtensionSupport())
             .build()
         SessionReplay.enable(sessionReplayConfig)


### PR DESCRIPTION
### What does this PR do?

In order to better read the performance of the Image Resource upload for Session Replay, we add the telemetry on batch deleted/closed/expired with a dedicated track name.
