### PR TITLE
RUM-4103 add telemetry to detect uncovered View/Drawable in Session Replay

### DIFF
--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/SliderWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/SliderWireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.material
 
 import android.content.res.ColorStateList
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper
@@ -28,7 +29,8 @@ internal open class SliderWireframeMapper(
     override fun map(
         view: Slider,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         val activeTrackId = viewIdentifierResolver
             .resolveChildUniqueIdentifier(view, TRACK_ACTIVE_KEY_NAME)

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/TabWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/TabWireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.material
 
 import android.widget.TextView
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper
@@ -46,12 +47,14 @@ internal open class TabWireframeMapper(
     override fun map(
         view: TabView,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         val labelWireframes = findAndResolveLabelWireframes(
             view,
             mappingContext,
-            asyncJobStatusCallback
+            asyncJobStatusCallback,
+            internalLogger
         )
         if (view.isSelected) {
             val selectedTabIndicatorWireframe = resolveTabIndicatorWireframe(
@@ -106,7 +109,8 @@ internal open class TabWireframeMapper(
     private fun findAndResolveLabelWireframes(
         view: TabView,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         for (i in 0 until view.childCount) {
             val viewChild = view.getChildAt(i) ?: continue
@@ -117,7 +121,8 @@ internal open class TabWireframeMapper(
                 return textViewMapper.map(
                     viewChild as TextView,
                     mappingContext,
-                    asyncJobStatusCallback
+                    asyncJobStatusCallback,
+                    internalLogger
                 )
             }
         }

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/BaseSliderWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/BaseSliderWireframeMapperTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.material
 
 import android.content.res.ColorStateList
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.material.internal.densityNormalized
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -149,6 +150,9 @@ internal abstract class BaseSliderWireframeMapperTest {
     @Mock
     lateinit var mockAsyncJobStatusCallback: AsyncJobStatusCallback
 
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
     lateinit var testedSliderWireframeMapper: SliderWireframeMapper
 
     lateinit var mockSlider: Slider
@@ -264,7 +268,8 @@ internal abstract class BaseSliderWireframeMapperTest {
             testedSliderWireframeMapper.map(
                 mockSlider,
                 fakeMappingContext,
-                mockAsyncJobStatusCallback
+                mockAsyncJobStatusCallback,
+                mockInternalLogger
             )
         ).isEmpty()
     }
@@ -284,7 +289,8 @@ internal abstract class BaseSliderWireframeMapperTest {
             testedSliderWireframeMapper.map(
                 mockSlider,
                 fakeMappingContext,
-                mockAsyncJobStatusCallback
+                mockAsyncJobStatusCallback,
+                mockInternalLogger
             )
         ).isEmpty()
     }
@@ -304,7 +310,8 @@ internal abstract class BaseSliderWireframeMapperTest {
             testedSliderWireframeMapper.map(
                 mockSlider,
                 fakeMappingContext,
-                mockAsyncJobStatusCallback
+                mockAsyncJobStatusCallback,
+                mockInternalLogger
             )
         ).isEmpty()
     }

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/BaseTabWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/BaseTabWireframeMapperTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.material
 
 import android.widget.TextView
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper
 import com.datadog.android.sessionreplay.material.internal.densityNormalized
@@ -75,6 +76,9 @@ internal abstract class BaseTabWireframeMapperTest {
     @Mock
     lateinit var mockAsyncJobStatusCallback: AsyncJobStatusCallback
 
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeTextWireframes = forge.aList(size = 1) { getForgery() }
@@ -92,7 +96,14 @@ internal abstract class BaseTabWireframeMapperTest {
             )
         )
             .thenReturn(fakeTabIndicatorUniqueId)
-        whenever(mockTextWireframeMapper.map(eq(mockTabLabelView), eq(fakeMappingContext), any()))
+        whenever(
+            mockTextWireframeMapper.map(
+                eq(mockTabLabelView),
+                eq(fakeMappingContext),
+                any(),
+                eq(mockInternalLogger)
+            )
+        )
             .thenReturn(fakeTextWireframes)
         testedTabWireframeMapper = provideTestInstance()
     }
@@ -128,7 +139,12 @@ internal abstract class BaseTabWireframeMapperTest {
         val expectedMappedWireframes = fakeTextWireframes + expectedTabIndicatorWireframe
 
         // When
-        val mappedWireframes = testedTabWireframeMapper.map(mockTabView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedTabWireframeMapper.map(
+            mockTabView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEqualTo(expectedMappedWireframes)
@@ -141,7 +157,12 @@ internal abstract class BaseTabWireframeMapperTest {
         val expectedMappedWireframes = fakeTextWireframes
 
         // When
-        val mappedWireframes = testedTabWireframeMapper.map(mockTabView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedTabWireframeMapper.map(
+            mockTabView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEqualTo(expectedMappedWireframes)
@@ -179,7 +200,12 @@ internal abstract class BaseTabWireframeMapperTest {
         val expectedMappedWireframes = listOf(expectedTabIndicatorWireframe)
 
         // When
-        val mappedWireframes = testedTabWireframeMapper.map(mockTabView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedTabWireframeMapper.map(
+            mockTabView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEqualTo(expectedMappedWireframes)
@@ -194,7 +220,12 @@ internal abstract class BaseTabWireframeMapperTest {
         whenever(mockTabView.isSelected).thenReturn(false)
 
         // When
-        val mappedWireframes = testedTabWireframeMapper.map(mockTabView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedTabWireframeMapper.map(
+            mockTabView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEmpty()
@@ -230,7 +261,12 @@ internal abstract class BaseTabWireframeMapperTest {
         val expectedMappedWireframes = listOf(expectedTabIndicatorWireframe)
 
         // When
-        val mappedWireframes = testedTabWireframeMapper.map(mockTabView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedTabWireframeMapper.map(
+            mockTabView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEqualTo(expectedMappedWireframes)
@@ -243,7 +279,12 @@ internal abstract class BaseTabWireframeMapperTest {
         whenever(mockTabView.isSelected).thenReturn(false)
 
         // When
-        val mappedWireframes = testedTabWireframeMapper.map(mockTabView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedTabWireframeMapper.map(
+            mockTabView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEmpty()
@@ -258,7 +299,12 @@ internal abstract class BaseTabWireframeMapperTest {
         val expectedMappedWireframes = fakeTextWireframes
 
         // When
-        val mappedWireframes = testedTabWireframeMapper.map(mockTabView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedTabWireframeMapper.map(
+            mockTabView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEqualTo(expectedMappedWireframes)
@@ -273,7 +319,12 @@ internal abstract class BaseTabWireframeMapperTest {
         val expectedMappedWireframes = fakeTextWireframes
 
         // When
-        val mappedWireframes = testedTabWireframeMapper.map(mockTabView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedTabWireframeMapper.map(
+            mockTabView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEqualTo(expectedMappedWireframes)

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/SliderWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/SliderWireframeMapperTest.kt
@@ -71,8 +71,12 @@ internal class SliderWireframeMapperTest : BaseSliderWireframeMapperTest() {
         )
 
         // When
-        val mappedWireframes =
-            testedSliderWireframeMapper.map(mockSlider, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedSliderWireframeMapper.map(
+            mockSlider,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEqualTo(
@@ -101,8 +105,12 @@ internal class SliderWireframeMapperTest : BaseSliderWireframeMapperTest() {
         )
 
         // When
-        val mappedWireframes =
-            testedSliderWireframeMapper.map(mockSlider, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedSliderWireframeMapper.map(
+            mockSlider,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEqualTo(
@@ -129,8 +137,12 @@ internal class SliderWireframeMapperTest : BaseSliderWireframeMapperTest() {
         )
 
         // When
-        val mappedWireframes =
-            testedSliderWireframeMapper.map(mockSlider, fakeMappingContext, mockAsyncJobStatusCallback)
+        val mappedWireframes = testedSliderWireframeMapper.map(
+            mockSlider,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(mappedWireframes).isEqualTo(

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -25,28 +25,28 @@ interface com.datadog.android.sessionreplay.internal.recorder.OptionSelectorDete
 data class com.datadog.android.sessionreplay.internal.recorder.SystemInformation
   constructor(com.datadog.android.sessionreplay.utils.GlobalBounds, Int = Configuration.ORIENTATION_UNDEFINED, Float, String? = null)
 abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseAsyncBackgroundWireframeMapper<T: android.view.View> : BaseWireframeMapper<T>
-  override fun map(T, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
+  override fun map(T, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback, com.datadog.android.api.InternalLogger): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
   companion object 
 open class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseViewGroupMapper<T: android.view.ViewGroup> : BaseAsyncBackgroundWireframeMapper<T>, TraverseAllChildrenMapper<T>
   constructor(com.datadog.android.sessionreplay.utils.ViewIdentifierResolver, com.datadog.android.sessionreplay.utils.ColorStringFormatter, com.datadog.android.sessionreplay.utils.ViewBoundsResolver, com.datadog.android.sessionreplay.utils.DrawableToColorMapper)
 abstract class com.datadog.android.sessionreplay.internal.recorder.mapper.BaseWireframeMapper<T: android.view.View> : WireframeMapper<T>
   constructor(com.datadog.android.sessionreplay.utils.ViewIdentifierResolver, com.datadog.android.sessionreplay.utils.ColorStringFormatter, com.datadog.android.sessionreplay.utils.ViewBoundsResolver, com.datadog.android.sessionreplay.utils.DrawableToColorMapper)
   protected fun resolveViewId(android.view.View): Long
-  protected fun resolveShapeStyle(android.graphics.drawable.Drawable, Float): com.datadog.android.sessionreplay.model.MobileSegment.ShapeStyle?
+  protected fun resolveShapeStyle(android.graphics.drawable.Drawable, Float, com.datadog.android.api.InternalLogger): com.datadog.android.sessionreplay.model.MobileSegment.ShapeStyle?
   companion object 
 open class com.datadog.android.sessionreplay.internal.recorder.mapper.TextViewMapper : BaseAsyncBackgroundWireframeMapper<android.widget.TextView>
   constructor(com.datadog.android.sessionreplay.utils.ViewIdentifierResolver, com.datadog.android.sessionreplay.utils.ColorStringFormatter, com.datadog.android.sessionreplay.utils.ViewBoundsResolver, com.datadog.android.sessionreplay.utils.DrawableToColorMapper)
-  override fun map(android.widget.TextView, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
+  override fun map(android.widget.TextView, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback, com.datadog.android.api.InternalLogger): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
 interface com.datadog.android.sessionreplay.internal.recorder.mapper.TraverseAllChildrenMapper<T: android.view.ViewGroup> : WireframeMapper<T>
 interface com.datadog.android.sessionreplay.internal.recorder.mapper.WireframeMapper<T: android.view.View>
-  fun map(T, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
+  fun map(T, com.datadog.android.sessionreplay.internal.recorder.MappingContext, com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback, com.datadog.android.api.InternalLogger): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
 class com.datadog.android.sessionreplay.internal.recorder.obfuscator.AndroidNStringObfuscator : StringObfuscator
   override fun obfuscate(String): String
 open class com.datadog.android.sessionreplay.utils.AndroidMDrawableToColorMapper : LegacyDrawableToColorMapper
-  override fun resolveRippleDrawable(android.graphics.drawable.RippleDrawable): Int?
-  override fun resolveInsetDrawable(android.graphics.drawable.InsetDrawable): Int?
+  override fun resolveRippleDrawable(android.graphics.drawable.RippleDrawable, com.datadog.android.api.InternalLogger): Int?
+  override fun resolveInsetDrawable(android.graphics.drawable.InsetDrawable, com.datadog.android.api.InternalLogger): Int?
 open class com.datadog.android.sessionreplay.utils.AndroidQDrawableToColorMapper : AndroidMDrawableToColorMapper
-  override fun resolveGradientDrawable(android.graphics.drawable.GradientDrawable): Int?
+  override fun resolveGradientDrawable(android.graphics.drawable.GradientDrawable, com.datadog.android.api.InternalLogger): Int?
   companion object 
 interface com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
   fun jobStarted()
@@ -63,7 +63,7 @@ object com.datadog.android.sessionreplay.utils.DefaultViewIdentifierResolver : V
   override fun resolveViewId(android.view.View): Long
   override fun resolveChildUniqueIdentifier(android.view.View, String): Long?
 interface com.datadog.android.sessionreplay.utils.DrawableToColorMapper
-  fun mapDrawableToColor(android.graphics.drawable.Drawable): Int?
+  fun mapDrawableToColor(android.graphics.drawable.Drawable, com.datadog.android.api.InternalLogger): Int?
   companion object 
     fun getDefault(): DrawableToColorMapper
 data class com.datadog.android.sessionreplay.utils.GlobalBounds
@@ -73,12 +73,12 @@ interface com.datadog.android.sessionreplay.utils.ImageWireframeHelper
   fun createCompoundDrawableWireframes(android.widget.TextView, com.datadog.android.sessionreplay.internal.recorder.MappingContext, Int, AsyncJobStatusCallback): MutableList<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
   companion object 
 open class com.datadog.android.sessionreplay.utils.LegacyDrawableToColorMapper : DrawableToColorMapper
-  override fun mapDrawableToColor(android.graphics.drawable.Drawable): Int?
+  override fun mapDrawableToColor(android.graphics.drawable.Drawable, com.datadog.android.api.InternalLogger): Int?
   protected open fun resolveColorDrawable(android.graphics.drawable.ColorDrawable): Int?
-  protected open fun resolveRippleDrawable(android.graphics.drawable.RippleDrawable): Int?
-  protected open fun resolveLayerDrawable(android.graphics.drawable.LayerDrawable, (Int, android.graphics.drawable.Drawable) -> Boolean = { _, _ -> true }): Int?
-  protected open fun resolveGradientDrawable(android.graphics.drawable.GradientDrawable): Int?
-  protected open fun resolveInsetDrawable(android.graphics.drawable.InsetDrawable): Int?
+  protected open fun resolveRippleDrawable(android.graphics.drawable.RippleDrawable, com.datadog.android.api.InternalLogger): Int?
+  protected open fun resolveLayerDrawable(android.graphics.drawable.LayerDrawable, com.datadog.android.api.InternalLogger, (Int, android.graphics.drawable.Drawable) -> Boolean = { _, _ -> true }): Int?
+  protected open fun resolveGradientDrawable(android.graphics.drawable.GradientDrawable, com.datadog.android.api.InternalLogger): Int?
+  protected open fun resolveInsetDrawable(android.graphics.drawable.InsetDrawable, com.datadog.android.api.InternalLogger): Int?
   protected fun mergeColorAndAlpha(Int, Int): Int
   companion object 
 interface com.datadog.android.sessionreplay.utils.ViewBoundsResolver

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -87,7 +87,7 @@ public final class com/datadog/android/sessionreplay/internal/recorder/SystemInf
 
 public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper$Companion;
-	public fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;)Ljava/util/List;
+	public fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;Lcom/datadog/android/api/InternalLogger;)Ljava/util/List;
 }
 
 public final class com/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper$Companion {
@@ -104,7 +104,7 @@ public abstract class com/datadog/android/sessionreplay/internal/recorder/mapper
 	protected final fun getDrawableToColorMapper ()Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper;
 	protected final fun getViewBoundsResolver ()Lcom/datadog/android/sessionreplay/utils/ViewBoundsResolver;
 	protected final fun getViewIdentifierResolver ()Lcom/datadog/android/sessionreplay/utils/ViewIdentifierResolver;
-	protected final fun resolveShapeStyle (Landroid/graphics/drawable/Drawable;F)Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;
+	protected final fun resolveShapeStyle (Landroid/graphics/drawable/Drawable;FLcom/datadog/android/api/InternalLogger;)Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;
 	protected final fun resolveViewId (Landroid/view/View;)J
 }
 
@@ -113,15 +113,15 @@ public final class com/datadog/android/sessionreplay/internal/recorder/mapper/Ba
 
 public class com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper {
 	public fun <init> (Lcom/datadog/android/sessionreplay/utils/ViewIdentifierResolver;Lcom/datadog/android/sessionreplay/utils/ColorStringFormatter;Lcom/datadog/android/sessionreplay/utils/ViewBoundsResolver;Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper;)V
-	public synthetic fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;)Ljava/util/List;
-	public fun map (Landroid/widget/TextView;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;)Ljava/util/List;
+	public synthetic fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;Lcom/datadog/android/api/InternalLogger;)Ljava/util/List;
+	public fun map (Landroid/widget/TextView;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;Lcom/datadog/android/api/InternalLogger;)Ljava/util/List;
 }
 
 public abstract interface class com/datadog/android/sessionreplay/internal/recorder/mapper/TraverseAllChildrenMapper : com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper {
 }
 
 public abstract interface class com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper {
-	public abstract fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;)Ljava/util/List;
+	public abstract fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/internal/recorder/MappingContext;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;Lcom/datadog/android/api/InternalLogger;)Ljava/util/List;
 }
 
 public final class com/datadog/android/sessionreplay/internal/recorder/obfuscator/AndroidNStringObfuscator : com/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator {
@@ -1391,14 +1391,14 @@ public final class com/datadog/android/sessionreplay/model/ResourceMetadata$Comp
 
 public class com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper : com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper {
 	public fun <init> ()V
-	protected fun resolveInsetDrawable (Landroid/graphics/drawable/InsetDrawable;)Ljava/lang/Integer;
-	protected fun resolveRippleDrawable (Landroid/graphics/drawable/RippleDrawable;)Ljava/lang/Integer;
+	protected fun resolveInsetDrawable (Landroid/graphics/drawable/InsetDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
+	protected fun resolveRippleDrawable (Landroid/graphics/drawable/RippleDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
 }
 
 public class com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper : com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper$Companion;
 	public fun <init> ()V
-	protected fun resolveGradientDrawable (Landroid/graphics/drawable/GradientDrawable;)Ljava/lang/Integer;
+	protected fun resolveGradientDrawable (Landroid/graphics/drawable/GradientDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
 }
 
 public final class com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper$Companion {
@@ -1433,7 +1433,7 @@ public final class com/datadog/android/sessionreplay/utils/DefaultViewIdentifier
 
 public abstract interface class com/datadog/android/sessionreplay/utils/DrawableToColorMapper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper$Companion;
-	public abstract fun mapDrawableToColor (Landroid/graphics/drawable/Drawable;)Ljava/lang/Integer;
+	public abstract fun mapDrawableToColor (Landroid/graphics/drawable/Drawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
 }
 
 public final class com/datadog/android/sessionreplay/utils/DrawableToColorMapper$Companion {
@@ -1473,14 +1473,14 @@ public final class com/datadog/android/sessionreplay/utils/ImageWireframeHelper$
 public class com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper : com/datadog/android/sessionreplay/utils/DrawableToColorMapper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper$Companion;
 	public fun <init> ()V
-	public fun mapDrawableToColor (Landroid/graphics/drawable/Drawable;)Ljava/lang/Integer;
+	public fun mapDrawableToColor (Landroid/graphics/drawable/Drawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
 	protected final fun mergeColorAndAlpha (II)I
 	protected fun resolveColorDrawable (Landroid/graphics/drawable/ColorDrawable;)Ljava/lang/Integer;
-	protected fun resolveGradientDrawable (Landroid/graphics/drawable/GradientDrawable;)Ljava/lang/Integer;
-	protected fun resolveInsetDrawable (Landroid/graphics/drawable/InsetDrawable;)Ljava/lang/Integer;
-	protected fun resolveLayerDrawable (Landroid/graphics/drawable/LayerDrawable;Lkotlin/jvm/functions/Function2;)Ljava/lang/Integer;
-	public static synthetic fun resolveLayerDrawable$default (Lcom/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper;Landroid/graphics/drawable/LayerDrawable;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/lang/Integer;
-	protected fun resolveRippleDrawable (Landroid/graphics/drawable/RippleDrawable;)Ljava/lang/Integer;
+	protected fun resolveGradientDrawable (Landroid/graphics/drawable/GradientDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
+	protected fun resolveInsetDrawable (Landroid/graphics/drawable/InsetDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
+	protected fun resolveLayerDrawable (Landroid/graphics/drawable/LayerDrawable;Lcom/datadog/android/api/InternalLogger;Lkotlin/jvm/functions/Function2;)Ljava/lang/Integer;
+	public static synthetic fun resolveLayerDrawable$default (Lcom/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper;Landroid/graphics/drawable/LayerDrawable;Lcom/datadog/android/api/InternalLogger;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/lang/Integer;
+	protected fun resolveRippleDrawable (Landroid/graphics/drawable/RippleDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
 }
 
 public final class com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper$Companion {

--- a/features/dd-sdk-android-session-replay/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay/consumer-rules.pro
@@ -1,3 +1,4 @@
 # Keep the optional selector class name. We need this in the SR recorder.
--keepnames class androidx.appcompat.widget.DropDownListView
--keepnames class android.graphics.drawable.GradientDrawable
+-keepnames class * extends android.view.View
+-keepnames class * extends android.graphics.drawable.Drawable
+-keepnames class * extends android.graphics.ColorFilter

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorder.kt
@@ -155,7 +155,8 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
                     mappers = mappers,
                     defaultViewMapper = defaultVWM,
                     decorViewMapper = DecorViewMapper(defaultVWM, viewIdentifierResolver),
-                    viewUtilsInternal = ViewUtilsInternal()
+                    viewUtilsInternal = ViewUtilsInternal(),
+                    internalLogger = internalLogger
                 ),
                 ComposedOptionSelectorDetector(
                     customOptionSelectorDetectors + DefaultOptionSelectorDetector()

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapper.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import androidx.appcompat.widget.ActionBarContainer
 import androidx.appcompat.widget.DatadogActionBarContainerAccessor
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -31,7 +32,8 @@ internal class ActionBarContainerMapper(
     override fun map(
         view: ActionBarContainer,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         // The ActionBarContainer uses an internal Drawable implementation that redirects to some fields in the
         // ActionBarContainer class. It uses an ActionBarContainer.mBackground field (not to be confused with the
@@ -39,7 +41,7 @@ internal class ActionBarContainerMapper(
         // Fortunately, the ActionBarContainer.mBackground field we're interested in is package private,
         // which allows us to access it via the DatadogActionBarContainerAccessor.
         val background = DatadogActionBarContainerAccessor(view).getBackgroundDrawable()
-        val shapeStyle = background?.let { resolveShapeStyle(it, view.alpha) }
+        val shapeStyle = background?.let { resolveShapeStyle(it, view.alpha, internalLogger) }
         val id = viewIdentifierResolver.resolveChildUniqueIdentifier(view, PREFIX_BACKGROUND_DRAWABLE)
 
         if ((shapeStyle != null) && (id != null)) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseAsyncBackgroundWireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.view.View
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -46,9 +47,10 @@ abstract class BaseAsyncBackgroundWireframeMapper<T : View> internal constructor
     override fun map(
         view: T,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
-        val backgroundWireframe = resolveViewBackground(view, mappingContext, asyncJobStatusCallback)
+        val backgroundWireframe = resolveViewBackground(view, mappingContext, asyncJobStatusCallback, internalLogger)
 
         return backgroundWireframe?.let { listOf(it) } ?: emptyList()
     }
@@ -56,9 +58,10 @@ abstract class BaseAsyncBackgroundWireframeMapper<T : View> internal constructor
     private fun resolveViewBackground(
         view: View,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): MobileSegment.Wireframe? {
-        val shapeStyle = view.background?.let { resolveShapeStyle(it, view.alpha) }
+        val shapeStyle = view.background?.let { resolveShapeStyle(it, view.alpha, internalLogger) }
 
         val resources = view.resources
         val density = resources.displayMetrics.density

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapper.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.graphics.drawable.Drawable
 import android.view.View
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
@@ -44,8 +45,12 @@ abstract class BaseWireframeMapper<in T : View>(
     /**
      * Resolves the [MobileSegment.ShapeStyle] based on the [View] drawables.
      */
-    protected fun resolveShapeStyle(drawable: Drawable, viewAlpha: Float): MobileSegment.ShapeStyle? {
-        val color = drawableToColorMapper.mapDrawableToColor(drawable)
+    protected fun resolveShapeStyle(
+        drawable: Drawable,
+        viewAlpha: Float,
+        internalLogger: InternalLogger
+    ): MobileSegment.ShapeStyle? {
+        val color = drawableToColorMapper.mapDrawableToColor(drawable, internalLogger)
         return if (color != null) {
             MobileSegment.ShapeStyle(colorStringFormatter.formatColorAsHexString(color), viewAlpha)
         } else {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.widget.Button
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -18,9 +19,10 @@ internal class ButtonMapper(
     override fun map(
         view: Button,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
-        return textWireframeMapper.map(view, mappingContext, asyncJobStatusCallback).map {
+        return textWireframeMapper.map(view, mappingContext, asyncJobStatusCallback, internalLogger).map {
             if (it is MobileSegment.Wireframe.TextWireframe &&
                 it.shapeStyle == null && it.border == null
             ) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.widget.Checkable
 import android.widget.TextView
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -35,9 +36,10 @@ internal abstract class CheckableTextViewMapper<T>(
     override fun resolveMainWireframes(
         view: T,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
-        return textWireframeMapper.map(view, mappingContext, asyncJobStatusCallback)
+        return textWireframeMapper.map(view, mappingContext, asyncJobStatusCallback, internalLogger)
     }
 
     override fun resolveCheckedCheckable(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.view.View
 import android.widget.Checkable
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -32,9 +33,10 @@ internal abstract class CheckableWireframeMapper<T>(
     override fun map(
         view: T,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
-        val mainWireframes = resolveMainWireframes(view, mappingContext, asyncJobStatusCallback)
+        val mainWireframes = resolveMainWireframes(view, mappingContext, asyncJobStatusCallback, internalLogger)
         val checkableWireframes = if (mappingContext.privacy != SessionReplayPrivacy.ALLOW) {
             resolveMaskedCheckable(view, mappingContext)
         } else if (view.isChecked) {
@@ -51,7 +53,8 @@ internal abstract class CheckableWireframeMapper<T>(
     abstract fun resolveMainWireframes(
         view: T,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe>
 
     abstract fun resolveMaskedCheckable(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/DecorViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/DecorViewMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.view.View
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -23,9 +24,10 @@ internal class DecorViewMapper(
     override fun map(
         view: View,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
-        val wireframes = viewWireframeMapper.map(view, mappingContext, NoOpAsyncJobStatusCallback())
+        val wireframes = viewWireframeMapper.map(view, mappingContext, NoOpAsyncJobStatusCallback(), internalLogger)
             .toMutableList()
         if (mappingContext.systemInformation.themeColor != null) {
             // we add the background color from the theme to the decorView

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.widget.ImageView
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.internal.utils.ImageViewUtils
@@ -33,12 +34,13 @@ internal class ImageViewMapper(
     override fun map(
         view: ImageView,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         val wireframes = mutableListOf<MobileSegment.Wireframe>()
 
         // add background wireframes if any
-        wireframes.addAll(super.map(view, mappingContext, asyncJobStatusCallback))
+        wireframes.addAll(super.map(view, mappingContext, asyncJobStatusCallback, internalLogger))
 
         val drawable = view.drawable?.current ?: return wireframes
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/NumberPickerMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/NumberPickerMapper.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 import android.os.Build
 import android.widget.NumberPicker
 import androidx.annotation.RequiresApi
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
@@ -35,7 +36,8 @@ internal open class NumberPickerMapper(
     override fun map(
         view: NumberPicker,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         val prevIndexLabelId = viewIdentifierResolver.resolveChildUniqueIdentifier(
             view,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapper.kt
@@ -11,6 +11,7 @@ import android.content.res.Configuration
 import android.os.Build
 import android.widget.SeekBar
 import androidx.annotation.RequiresApi
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
@@ -38,7 +39,8 @@ internal open class SeekBarWireframeMapper(
     override fun map(
         view: SeekBar,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         val activeTrackId = viewIdentifierResolver
             .resolveChildUniqueIdentifier(view, TRACK_ACTIVE_KEY_NAME)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapper.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.graphics.Rect
 import androidx.appcompat.widget.SwitchCompat
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
@@ -36,9 +37,10 @@ internal open class SwitchCompatMapper(
     override fun resolveMainWireframes(
         view: SwitchCompat,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
-        return textWireframeMapper.map(view, mappingContext, asyncJobStatusCallback)
+        return textWireframeMapper.map(view, mappingContext, asyncJobStatusCallback, internalLogger)
     }
 
     @Suppress("ReturnCount")

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapper.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 import android.graphics.Typeface
 import android.view.Gravity
 import android.widget.TextView
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
@@ -46,11 +47,12 @@ open class TextViewMapper(
     override fun map(
         view: TextView,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         val wireframes = mutableListOf<MobileSegment.Wireframe>()
 
-        wireframes.addAll(super.map(view, mappingContext, asyncJobStatusCallback))
+        wireframes.addAll(super.map(view, mappingContext, asyncJobStatusCallback, internalLogger))
 
         val density = mappingContext.systemInformation.screenDensity
         val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/UnsupportedViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/UnsupportedViewMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.view.View
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.ViewUtilsInternal
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -31,7 +32,8 @@ internal class UnsupportedViewMapper(
     override fun map(
         view: View,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         val pixelsDensity = mappingContext.systemInformation.screenDensity
         val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(view, pixelsDensity)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.view.View
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -30,13 +31,14 @@ internal class ViewWireframeMapper(
     override fun map(
         view: View,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(
             view,
             mappingContext.systemInformation.screenDensity
         )
-        val shapeStyle = view.background?.let { resolveShapeStyle(it, view.alpha) }
+        val shapeStyle = view.background?.let { resolveShapeStyle(it, view.alpha, internalLogger) }
 
         if (shapeStyle != null) {
             return listOf(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WebViewWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WebViewWireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.webkit.WebView
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -31,7 +32,8 @@ internal class WebViewWireframeMapper(
     override fun map(
         view: WebView,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(
             view,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.view.View
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -30,12 +31,14 @@ interface WireframeMapper<in T : View> {
      * are updated by the async jobs. It can be used to
      * offload heavy work from the calling thread (main) to a background thread while mapping
      * some view properties.
+     * @param internalLogger the logger to log internal warnings
      * @see MobileSegment.Wireframe
      * @see SystemInformation
      */
     fun map(
         view: T,
         mappingContext: MappingContext,
-        asyncJobStatusCallback: AsyncJobStatusCallback
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe>
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper.kt
@@ -12,6 +12,7 @@ import android.graphics.drawable.InsetDrawable
 import android.graphics.drawable.RippleDrawable
 import android.os.Build
 import androidx.annotation.RequiresApi
+import com.datadog.android.api.InternalLogger
 
 /**
  * Drawable utility object needed in the Session Replay Wireframe Mappers.
@@ -20,14 +21,14 @@ import androidx.annotation.RequiresApi
 @RequiresApi(Build.VERSION_CODES.M)
 open class AndroidMDrawableToColorMapper : LegacyDrawableToColorMapper() {
 
-    override fun resolveRippleDrawable(drawable: RippleDrawable): Int? {
+    override fun resolveRippleDrawable(drawable: RippleDrawable, internalLogger: InternalLogger): Int? {
         // A ripple drawable can have a layer marked as mask, and which is not drawn
         // We can reuse the LayerDrawable by passing a way to filter the mask layer
         val maskLayerIndex = drawable.findIndexByLayerId(R.id.mask)
-        return resolveLayerDrawable(drawable) { idx, _ -> idx != maskLayerIndex }
+        return resolveLayerDrawable(drawable, internalLogger) { idx, _ -> idx != maskLayerIndex }
     }
 
-    override fun resolveInsetDrawable(drawable: InsetDrawable): Int? {
-        return drawable.drawable?.let { mapDrawableToColor(it) }
+    override fun resolveInsetDrawable(drawable: InsetDrawable, internalLogger: InternalLogger): Int? {
+        return drawable.drawable?.let { mapDrawableToColor(it, internalLogger) }
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper.kt
@@ -14,6 +14,7 @@ import android.graphics.Paint
 import android.graphics.drawable.GradientDrawable
 import android.os.Build
 import androidx.annotation.RequiresApi
+import com.datadog.android.api.InternalLogger
 
 /**
  * Drawable utility object needed in the Session Replay Wireframe Mappers.
@@ -22,7 +23,7 @@ import androidx.annotation.RequiresApi
 @RequiresApi(Build.VERSION_CODES.Q)
 open class AndroidQDrawableToColorMapper : AndroidMDrawableToColorMapper() {
 
-    override fun resolveGradientDrawable(drawable: GradientDrawable): Int? {
+    override fun resolveGradientDrawable(drawable: GradientDrawable, internalLogger: InternalLogger): Int? {
         @Suppress("SwallowedException")
         val fillPaint = try {
             fillPaintField?.get(drawable) as? Paint
@@ -42,7 +43,7 @@ open class AndroidQDrawableToColorMapper : AndroidMDrawableToColorMapper() {
             null
         } else {
             if (colorFilter != null) {
-                fillColor = resolveBlendModeColorFilter(fillColor, colorFilter)
+                fillColor = resolveBlendModeColorFilter(fillColor, colorFilter, internalLogger)
             }
             mergeColorAndAlpha(fillColor, fillAlpha)
         }
@@ -56,15 +57,38 @@ open class AndroidQDrawableToColorMapper : AndroidMDrawableToColorMapper() {
      */
     private fun resolveBlendModeColorFilter(
         fillColor: Int,
-        colorFilter: ColorFilter
+        colorFilter: ColorFilter,
+        internalLogger: InternalLogger
     ): Int {
         return if (colorFilter is BlendModeColorFilter) {
             when (colorFilter.mode) {
                 in blendModesReturningBlendColor -> colorFilter.color
                 in blendModesReturningOriginalColor -> fillColor
-                else -> fillColor
+                else -> {
+                    internalLogger.log(
+                        level = InternalLogger.Level.INFO,
+                        target = InternalLogger.Target.TELEMETRY,
+                        messageBuilder = { "No mapper found for gradient blend mode ${colorFilter.mode}" },
+                        throwable = null,
+                        onlyOnce = true,
+                        additionalProperties = mapOf(
+                            "replay.gradient.blend_mode" to colorFilter.mode
+                        )
+                    )
+                    fillColor
+                }
             }
         } else {
+            internalLogger.log(
+                level = InternalLogger.Level.INFO,
+                target = InternalLogger.Target.TELEMETRY,
+                messageBuilder = { "No mapper found for gradient color filter ${colorFilter.javaClass}" },
+                throwable = null,
+                onlyOnce = true,
+                additionalProperties = mapOf(
+                    "replay.gradient.filter_type" to colorFilter.javaClass
+                )
+            )
             fillColor
         }
     }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/DrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/DrawableToColorMapper.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.utils
 
 import android.graphics.drawable.Drawable
 import android.os.Build
+import com.datadog.android.api.InternalLogger
 
 /**
  * A utility interface to convert a [Drawable] to a meaningful color.
@@ -18,9 +19,10 @@ fun interface DrawableToColorMapper {
     /**
      * Maps the drawable to its meaningful color, or null if the drawable is mostly invisible.
      * @param drawable the drawable to convert
+     * @param internalLogger the internalLogger to report warnings
      * @return the color as an Int (in 0xAARRGGBB order), or null if the drawable is mostly invisible
      */
-    fun mapDrawableToColor(drawable: Drawable): Int?
+    fun mapDrawableToColor(drawable: Drawable, internalLogger: InternalLogger): Int?
 
     companion object {
         /**

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapperTest.kt
@@ -101,11 +101,17 @@ internal class ActionBarContainerMapperTest : BaseWireframeMapperTest() {
     @Test
     fun `M return a shape wireframe with the background W map()`() {
         // Given
-        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockBackgroundDrawable)) doReturn fakeBackgroundColor
+        whenever(
+            mockDrawableToColorMapper.mapDrawableToColor(
+                mockBackgroundDrawable,
+                mockInternalLogger
+            )
+        ) doReturn fakeBackgroundColor
         whenever(mockColorStringFormatter.formatColorAsHexString(fakeBackgroundColor)) doReturn fakeBackgroundHexColor
 
         // When
-        val result = testedMapper.map(mockActionBarContainer, fakeMappingContext, mockAsyncJobStatusCallback)
+        val result =
+            testedMapper.map(mockActionBarContainer, fakeMappingContext, mockAsyncJobStatusCallback, mockInternalLogger)
 
         // Then
         assertThat(result).hasSize(1)
@@ -131,10 +137,15 @@ internal class ActionBarContainerMapperTest : BaseWireframeMapperTest() {
     @Test
     fun `M return nothing W map() {unsupported background drawable}`() {
         // Given
-        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockBackgroundDrawable)) doReturn null
+        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockBackgroundDrawable, mockInternalLogger)) doReturn null
 
         // When
-        val result = testedMapper.map(mockActionBarContainer, fakeMappingContext, mockAsyncJobStatusCallback)
+        val result = testedMapper.map(
+            mockActionBarContainer,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(result).isEmpty()

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckBoxMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckBoxMapperTest.kt
@@ -89,7 +89,7 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
             )
         ).thenReturn(fakeGeneratedIdentifier)
 
-        whenever(mockTextWireframeMapper.map(eq(mockCheckBox), eq(fakeMappingContext), any()))
+        whenever(mockTextWireframeMapper.map(eq(mockCheckBox), eq(fakeMappingContext), any(), eq(mockInternalLogger)))
             .thenReturn(fakeTextWireframes)
 
         whenever(
@@ -149,7 +149,8 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedCheckBoxMapper.map(
             mockCheckBox,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -185,7 +186,8 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedCheckBoxMapper.map(
             mockCheckBox,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -216,7 +218,8 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedCheckBoxMapper.map(
             mockCheckBox,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -247,7 +250,8 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedCheckBoxMapper.map(
             mockCheckBox,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -268,7 +272,8 @@ internal abstract class BaseCheckBoxMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedCheckBoxMapper.map(
             mockCheckBox,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckedTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckedTextViewMapperTest.kt
@@ -116,7 +116,8 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
             mockTextWireframeMapper.map(
                 eq(mockCheckedTextView),
                 eq(fakeMappingContext),
-                any()
+                any(),
+                eq(mockInternalLogger)
             )
         ).thenReturn(fakeTextWireframes)
 
@@ -171,7 +172,8 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         val resolvedWireframes = testedCheckedTextWireframeMapper.map(
             mockCheckedTextView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -201,7 +203,8 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         val resolvedWireframes = testedCheckedTextWireframeMapper.map(
             mockCheckedTextView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -231,7 +234,8 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         val resolvedWireframes = testedCheckedTextWireframeMapper.map(
             mockCheckedTextView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -264,7 +268,8 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         val resolvedWireframes = testedCheckedTextWireframeMapper.map(
             mockCheckedTextView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -293,7 +298,8 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         val resolvedWireframes = testedCheckedTextWireframeMapper.map(
             mockCheckedTextView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -321,7 +327,8 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         val resolvedWireframes = testedCheckedTextWireframeMapper.map(
             mockCheckedTextView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -342,7 +349,8 @@ internal abstract class BaseCheckedTextViewMapperTest : BaseWireframeMapperTest(
         val resolvedWireframes = testedCheckedTextWireframeMapper.map(
             mockCheckedTextView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseNumberPickerMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseNumberPickerMapperTest.kt
@@ -205,7 +205,12 @@ internal abstract class BaseNumberPickerMapperTest : BaseWireframeMapperTest() {
             .thenReturn(null)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEmpty()
@@ -224,7 +229,12 @@ internal abstract class BaseNumberPickerMapperTest : BaseWireframeMapperTest() {
             .thenReturn(null)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEmpty()
@@ -243,7 +253,12 @@ internal abstract class BaseNumberPickerMapperTest : BaseWireframeMapperTest() {
             .thenReturn(null)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEmpty()

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseRadioButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseRadioButtonMapperTest.kt
@@ -88,7 +88,14 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
             )
         ).thenReturn(fakeGeneratedIdentifier)
 
-        whenever(mockTextWireframeMapper.map(eq(mockRadioButton), eq(fakeMappingContext), any()))
+        whenever(
+            mockTextWireframeMapper.map(
+                eq(mockRadioButton),
+                eq(fakeMappingContext),
+                any(),
+                eq(mockInternalLogger)
+            )
+        )
             .thenReturn(fakeTextWireframes)
 
         whenever(
@@ -158,7 +165,8 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedRadioButtonMapper.map(
             mockRadioButton,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -194,7 +202,8 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedRadioButtonMapper.map(
             mockRadioButton,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -225,7 +234,8 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedRadioButtonMapper.map(
             mockRadioButton,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -256,7 +266,8 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedRadioButtonMapper.map(
             mockRadioButton,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -277,7 +288,8 @@ internal abstract class BaseRadioButtonMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedRadioButtonMapper.map(
             mockRadioButton,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseSeekBarWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseSeekBarWireframeMapperTest.kt
@@ -10,6 +10,7 @@ import android.content.res.ColorStateList
 import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.widget.SeekBar
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -147,6 +148,9 @@ internal abstract class BaseSeekBarWireframeMapperTest {
 
     lateinit var mockSeekBar: SeekBar
 
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeViewGlobalBounds = GlobalBounds(
@@ -251,7 +255,12 @@ internal abstract class BaseSeekBarWireframeMapperTest {
         ).thenReturn(null)
 
         // When
-        val map = testedSeekBarWireframeMapper.map(mockSeekBar, fakeMappingContext, mockAsyncJobStatusCallback)
+        val map = testedSeekBarWireframeMapper.map(
+            mockSeekBar,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(map).isEmpty()
@@ -268,7 +277,12 @@ internal abstract class BaseSeekBarWireframeMapperTest {
         ).thenReturn(null)
 
         // When
-        val map = testedSeekBarWireframeMapper.map(mockSeekBar, fakeMappingContext, mockAsyncJobStatusCallback)
+        val map = testedSeekBarWireframeMapper.map(
+            mockSeekBar,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(map).isEmpty()
@@ -285,7 +299,12 @@ internal abstract class BaseSeekBarWireframeMapperTest {
         ).thenReturn(null)
 
         // When
-        val map = testedSeekBarWireframeMapper.map(mockSeekBar, fakeMappingContext, mockAsyncJobStatusCallback)
+        val map = testedSeekBarWireframeMapper.map(
+            mockSeekBar,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(map).isEmpty()

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseSwitchCompatMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseSwitchCompatMapperTest.kt
@@ -127,7 +127,7 @@ internal abstract class BaseSwitchCompatMapperTest : BaseWireframeMapperTest() {
                 SwitchCompatMapper.THUMB_KEY_NAME
             )
         ).thenReturn(fakeThumbIdentifier)
-        whenever(mockTextWireframeMapper.map(eq(mockSwitch), eq(fakeMappingContext), any()))
+        whenever(mockTextWireframeMapper.map(eq(mockSwitch), eq(fakeMappingContext), any(), eq(mockInternalLogger)))
             .thenReturn(fakeTextWireframes)
         whenever(
             mockViewBoundsResolver.resolveViewGlobalBounds(
@@ -155,7 +155,8 @@ internal abstract class BaseSwitchCompatMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -172,7 +173,8 @@ internal abstract class BaseSwitchCompatMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -218,7 +220,8 @@ internal abstract class BaseSwitchCompatMapperTest : BaseWireframeMapperTest() {
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseWireframeMapperTest.kt
@@ -11,6 +11,7 @@ import android.view.Gravity
 import android.view.View
 import android.view.ViewGroup
 import android.widget.TextView
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -46,6 +47,9 @@ internal abstract class BaseWireframeMapperTest {
 
     @Mock
     lateinit var mockAsyncJobStatusCallback: AsyncJobStatusCallback
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
 
     protected fun mockNonDecorView(): View {
         return mock {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapperTest.kt
@@ -51,7 +51,8 @@ internal class ButtonMapperTest : BaseWireframeMapperTest() {
             mockTextWireframeMapper.map(
                 eq(mockButton),
                 eq(fakeMappingContext),
-                any()
+                any(),
+                eq(mockInternalLogger)
             )
         ).thenReturn(fakeTextWireframes)
         testedButtonMapper = ButtonMapper(mockTextWireframeMapper)
@@ -67,12 +68,18 @@ internal class ButtonMapperTest : BaseWireframeMapperTest() {
             mockTextWireframeMapper.map(
                 eq(mockButton),
                 eq(fakeMappingContext),
-                any()
+                any(),
+                eq(mockInternalLogger)
             )
         ).thenReturn(fakeTextWireframes)
 
         // When
-        val buttonWireframes = testedButtonMapper.map(mockButton, fakeMappingContext, mockAsyncJobStatusCallback)
+        val buttonWireframes = testedButtonMapper.map(
+            mockButton,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(buttonWireframes).isEqualTo(fakeTextWireframes)
@@ -88,12 +95,18 @@ internal class ButtonMapperTest : BaseWireframeMapperTest() {
             mockTextWireframeMapper.map(
                 eq(mockButton),
                 eq(fakeMappingContext),
-                any()
+                any(),
+                eq(mockInternalLogger)
             )
         ).thenReturn(fakeTextWireframes)
 
         // When
-        val buttonWireframes = testedButtonMapper.map(mockButton, fakeMappingContext, mockAsyncJobStatusCallback)
+        val buttonWireframes = testedButtonMapper.map(
+            mockButton,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(buttonWireframes).isEqualTo(fakeTextWireframes)
@@ -107,7 +120,8 @@ internal class ButtonMapperTest : BaseWireframeMapperTest() {
             mockTextWireframeMapper.map(
                 eq(mockButton),
                 eq(fakeMappingContext),
-                any()
+                any(),
+                eq(mockInternalLogger)
             )
         ).thenReturn(fakeTextWireframes)
 
@@ -116,7 +130,12 @@ internal class ButtonMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val buttonWireframes = testedButtonMapper.map(mockButton, fakeMappingContext, mockAsyncJobStatusCallback)
+        val buttonWireframes = testedButtonMapper.map(
+            mockButton,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(buttonWireframes).isEqualTo(expectedWireframes)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/DecorViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/DecorViewMapperTest.kt
@@ -61,7 +61,7 @@ internal class DecorViewMapperTest : BaseWireframeMapperTest() {
         mockViewWireframes = forge.aList(forge.anInt(min = 1, max = 10)) {
             getForgery()
         }
-        whenever(mockViewWireframeMapper.map(eq(mockDecorView), eq(fakeMappingContext), any()))
+        whenever(mockViewWireframeMapper.map(eq(mockDecorView), eq(fakeMappingContext), any(), eq(mockInternalLogger)))
             .thenReturn(mockViewWireframes)
         testedDecorViewMapper = DecorViewMapper(
             mockViewWireframeMapper,
@@ -88,7 +88,7 @@ internal class DecorViewMapperTest : BaseWireframeMapperTest() {
         mockViewWireframes = mockViewWireframes.map {
             it.copy(shapeStyle = null)
         }
-        whenever(mockViewWireframeMapper.map(eq(mockDecorView), eq(fakeMappingContext), any()))
+        whenever(mockViewWireframeMapper.map(eq(mockDecorView), eq(fakeMappingContext), any(), eq(mockInternalLogger)))
             .thenReturn(mockViewWireframes)
         val viewWireframesIds = mockViewWireframes.map { it.id }.toSet()
         val expectedDecorViewWireframes = mockViewWireframes.map {
@@ -97,7 +97,7 @@ internal class DecorViewMapperTest : BaseWireframeMapperTest() {
 
         // When
         val mappedDecorViewWireframes = testedDecorViewMapper
-            .map(mockDecorView, fakeMappingContext, mockAsyncJobStatusCallback)
+            .map(mockDecorView, fakeMappingContext, mockAsyncJobStatusCallback, mockInternalLogger)
             .filter { (it as MobileSegment.Wireframe.ShapeWireframe).id in viewWireframesIds }
 
         // Then
@@ -122,14 +122,14 @@ internal class DecorViewMapperTest : BaseWireframeMapperTest() {
                 wireframe.copy(shapeStyle = null)
             }
         }
-        whenever(mockViewWireframeMapper.map(eq(mockDecorView), eq(fakeMappingContext), any()))
+        whenever(mockViewWireframeMapper.map(eq(mockDecorView), eq(fakeMappingContext), any(), eq(mockInternalLogger)))
             .thenReturn(mockViewWireframes)
         val viewWireframesIds = mockViewWireframes.map { it.id }.toSet()
         val expectedDecorViewWireframes = mockViewWireframes
 
         // When
         val mappedDecorViewWireframes = testedDecorViewMapper
-            .map(mockDecorView, fakeMappingContext, mockAsyncJobStatusCallback)
+            .map(mockDecorView, fakeMappingContext, mockAsyncJobStatusCallback, mockInternalLogger)
             .filter { (it as MobileSegment.Wireframe.ShapeWireframe).id in viewWireframesIds }
 
         // Then
@@ -146,14 +146,14 @@ internal class DecorViewMapperTest : BaseWireframeMapperTest() {
         mockViewWireframes = mockViewWireframes.map {
             it.copy(shapeStyle = null)
         }
-        whenever(mockViewWireframeMapper.map(eq(mockDecorView), eq(fakeMappingContext), any()))
+        whenever(mockViewWireframeMapper.map(eq(mockDecorView), eq(fakeMappingContext), any(), eq(mockInternalLogger)))
             .thenReturn(mockViewWireframes)
         val viewWireframesIds = mockViewWireframes.map { it.id }.toSet()
         val expectedDecorViewWireframes = mockViewWireframes
 
         // When
         val mappedDecorViewWireframes = testedDecorViewMapper
-            .map(mockDecorView, fakeMappingContext, mockAsyncJobStatusCallback)
+            .map(mockDecorView, fakeMappingContext, mockAsyncJobStatusCallback, mockInternalLogger)
             .filter { (it as MobileSegment.Wireframe.ShapeWireframe).id in viewWireframesIds }
 
         // Then
@@ -180,7 +180,12 @@ internal class DecorViewMapperTest : BaseWireframeMapperTest() {
         )
 
         // When
-        val wireframes = testedDecorViewMapper.map(mockDecorView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedDecorViewMapper.map(
+            mockDecorView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes.size).isEqualTo(mockViewWireframes.size + 1)
@@ -209,7 +214,12 @@ internal class DecorViewMapperTest : BaseWireframeMapperTest() {
         )
 
         // When
-        val wireframes = testedDecorViewMapper.map(mockDecorView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedDecorViewMapper.map(
+            mockDecorView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes.size).isEqualTo(mockViewWireframes.size)
@@ -226,7 +236,14 @@ internal class DecorViewMapperTest : BaseWireframeMapperTest() {
                 DecorViewMapper.WINDOW_KEY_NAME
             )
         ).thenReturn(fakeUniqueIdentifier)
-        whenever(mockViewWireframeMapper.map(eq(mockPopUpDecorView), eq(fakeMappingContext), any()))
+        whenever(
+            mockViewWireframeMapper.map(
+                eq(mockPopUpDecorView),
+                eq(fakeMappingContext),
+                any(),
+                eq(mockInternalLogger)
+            )
+        )
             .thenReturn(mockViewWireframes)
         val expectedWindowWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeUniqueIdentifier,
@@ -241,7 +258,12 @@ internal class DecorViewMapperTest : BaseWireframeMapperTest() {
         )
 
         // When
-        val wireframes = testedDecorViewMapper.map(mockPopUpDecorView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedDecorViewMapper.map(
+            mockPopUpDecorView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes.size).isEqualTo(mockViewWireframes.size)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapperTest.kt
@@ -15,6 +15,7 @@ import android.graphics.drawable.Drawable.ConstantState
 import android.util.DisplayMetrics
 import android.view.View
 import android.widget.ImageView
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.MappingContext
 import com.datadog.android.sessionreplay.internal.recorder.SystemInformation
@@ -125,6 +126,9 @@ internal class ImageViewMapperTest {
     @Mock
     lateinit var mockContext: Context
 
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
     @LongForgery
     var fakeId: Long = 0L
 
@@ -159,7 +163,7 @@ internal class ImageViewMapperTest {
         whenever(mockContext.applicationContext).thenReturn(mockContext)
         whenever(mockImageView.context).thenReturn(mockContext)
         whenever(mockBackgroundDrawable.current).thenReturn(mockBackgroundDrawable)
-        whenever(mockDrawableToColorMapper.mapDrawableToColor(any())) doReturn null
+        whenever(mockDrawableToColorMapper.mapDrawableToColor(any(), eq(mockInternalLogger))) doReturn null
 
         whenever(stubImageViewUtils.resolveParentRectAbsPosition(any())).thenReturn(stubParentRect)
         whenever(stubImageViewUtils.resolveContentRectWithScaling(any(), any())).thenReturn(stubContentRect)
@@ -209,7 +213,12 @@ internal class ImageViewMapperTest {
         )
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedMapper.map(
+            mockImageView,
+            mockMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes.size).isEqualTo(1)
@@ -232,7 +241,7 @@ internal class ImageViewMapperTest {
             mimeType = fakeMimeType,
             isEmpty = true
         )
-        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockBackgroundDrawable)) doReturn null
+        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockBackgroundDrawable, mockInternalLogger)) doReturn null
         whenever(mockImageView.background).thenReturn(mockBackgroundDrawable)
         mockImageWireframeHelper(
             expectedView = mockImageView,
@@ -252,7 +261,12 @@ internal class ImageViewMapperTest {
         )
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedMapper.map(
+            mockImageView,
+            mockMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes.size).isEqualTo(2)
@@ -282,7 +296,12 @@ internal class ImageViewMapperTest {
         ).thenReturn(expectedImageWireframe)
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedMapper.map(
+            mockImageView,
+            mockMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes.size).isEqualTo(1)
@@ -342,7 +361,12 @@ internal class ImageViewMapperTest {
         )
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedMapper.map(
+            mockImageView,
+            mockMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes[0]::class.java).isEqualTo(MobileSegment.Wireframe.ImageWireframe::class.java)
@@ -355,10 +379,15 @@ internal class ImageViewMapperTest {
     ) {
         // Given
         whenever(mockImageView.background).thenReturn(mockColorDrawable)
-        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockColorDrawable)) doReturn mockColor
+        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockColorDrawable, mockInternalLogger)) doReturn mockColor
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedMapper.map(
+            mockImageView,
+            mockMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes[0]::class.java).isEqualTo(MobileSegment.Wireframe.ShapeWireframe::class.java)
@@ -382,7 +411,12 @@ internal class ImageViewMapperTest {
         )
 
         // When
-        val wireframes = testedMapper.map(mockImageView, mockMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedMapper.map(
+            mockImageView,
+            mockMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes.size).isEqualTo(1)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/NumberPickerMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/NumberPickerMapperTest.kt
@@ -56,7 +56,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedNextLabelValue)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -89,7 +94,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedNextLabelValue)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -122,7 +132,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedNextLabelValue)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -159,7 +174,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedNextLabelValue)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -197,7 +217,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedNextLabelValue)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -236,7 +261,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedNextLabelValue)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -264,7 +294,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .thenReturn(null)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEmpty()
@@ -284,7 +319,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .thenReturn(null)
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEmpty()
@@ -304,7 +344,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedSelectedLabelValue)
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -328,7 +373,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedSelectedLabelValue)
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -353,7 +403,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -380,7 +435,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedSelectedLabelValue)
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -409,7 +469,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedSelectedLabelValue)
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -439,7 +504,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -465,7 +535,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedSelectedLabelValue)
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -489,7 +564,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedSelectedLabelValue)
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -514,7 +594,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -541,7 +626,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedSelectedLabelValue)
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -570,7 +660,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
             .copy(text = expectedSelectedLabelValue)
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(
@@ -600,7 +695,12 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         val expectedBottomDividerWireframe = fakeBottomDividerWireframe()
 
         // When
-        val wireframes = testedNumberPickerMapper.map(mockNumberPicker, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedNumberPickerMapper.map(
+            mockNumberPicker,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEqualTo(

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapperTest.kt
@@ -87,7 +87,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -171,7 +172,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -255,7 +257,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -331,7 +334,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -407,7 +411,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -444,7 +449,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -496,7 +502,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -544,7 +551,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -575,7 +583,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -627,7 +636,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -677,7 +687,8 @@ internal class SeekBarWireframeMapperTest : BaseSeekBarWireframeMapperTest() {
         val mappedWireframes = testedSeekBarWireframeMapper.map(
             mockSeekBar,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
@@ -78,7 +78,8 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -130,7 +131,8 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -175,7 +177,8 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/TextViewMapperTest.kt
@@ -161,7 +161,12 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val textWireframes = testedTextWireframeMapper.map(
+            mockTextView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         val expectedWireframes = mockTextView.toTextWireframes().map {
@@ -194,7 +199,12 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val textWireframes = testedTextWireframeMapper.map(
+            mockTextView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         val expectedWireframes = mockTextView.toTextWireframes().map {
@@ -227,7 +237,12 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val textWireframes = testedTextWireframeMapper.map(
+            mockTextView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         val expectedWireframes = mockTextView.toTextWireframes().map {
@@ -269,7 +284,12 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
         )
 
         // When
-        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val textWireframes = testedTextWireframeMapper.map(
+            mockTextView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         val expectedWireframes = mockTextView.toTextWireframes().map {
@@ -305,7 +325,9 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
             whenever(this.resources).thenReturn(mockResources)
             whenever(this.currentTextColor).thenReturn(fakeCurrentTextColor)
         }
-        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockDrawable)).thenReturn(fakeBackgroundColor)
+        whenever(
+            mockDrawableToColorMapper.mapDrawableToColor(mockDrawable, mockInternalLogger)
+        ).thenReturn(fakeBackgroundColor)
         whenever(mockColorStringFormatter.formatColorAsHexString(fakeBackgroundColor))
             .thenReturn(fakeBackgroundColorString)
 
@@ -313,7 +335,8 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
         val actualWireframes = testedTextWireframeMapper.map(
             mockTextView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -367,7 +390,7 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
             }
             whenever(mockDrawable.constantState) doReturn mockConstantState
         }
-        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockDrawable)) doReturn null
+        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockDrawable, mockInternalLogger)) doReturn null
         val mockTextView = forge.aMockTextView().apply {
             whenever(this.background).thenReturn(mockDrawable)
             whenever(this.text).thenReturn(fakeText)
@@ -399,7 +422,8 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
         val actualWireframes = testedTextWireframeMapper.map(
             mockTextView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then
@@ -459,7 +483,12 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
             .doReturn(fakeHintColorString)
 
         // When
-        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val textWireframes = testedTextWireframeMapper.map(
+            mockTextView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         val expectedWireframes = mockTextView
@@ -494,7 +523,12 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
         }
 
         // When
-        val textWireframes = testedTextWireframeMapper.map(mockTextView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val textWireframes = testedTextWireframeMapper.map(
+            mockTextView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         val expectedWireframes = mockTextView
@@ -548,7 +582,8 @@ internal class TextViewMapperTest : BaseWireframeMapperTest() {
         val wireframes = testedTextWireframeMapper.map(
             mockTextView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
         val imageWireframes = wireframes.filterIsInstance<MobileSegment.Wireframe.ImageWireframe>()
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/UnsupportedViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/UnsupportedViewMapperTest.kt
@@ -208,7 +208,8 @@ internal class UnsupportedViewMapperTest : BaseWireframeMapperTest() {
         return testedUnsupportedViewMapper.map(
             view,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )[0]
     }
     // endregion

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapperTest.kt
@@ -73,7 +73,12 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
         whenever(mockViewIdentifierResolver.resolveViewId(mockView)) doReturn fakeWireframeId
 
         // When
-        val wireframes = testedWireframeMapper.map(mockView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val wireframes = testedWireframeMapper.map(
+            mockView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         assertThat(wireframes).isEmpty()
@@ -98,13 +103,19 @@ internal class ViewWireframeMapperTest : BaseWireframeMapperTest() {
                 fakeMappingContext.systemInformation.screenDensity
             )
         ) doReturn fakeBounds
-        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockDrawable)) doReturn fakeBackgroundColor
+        whenever(mockDrawableToColorMapper.mapDrawableToColor(mockDrawable, mockInternalLogger))
+            .doReturn(fakeBackgroundColor)
         whenever(mockColorStringFormatter.formatColorAsHexString(fakeBackgroundColor))
             .doReturn(fakeBackgroundColorString)
         whenever(mockViewIdentifierResolver.resolveViewId(mockView)) doReturn fakeWireframeId
 
         // When
-        val shapeWireframes = testedWireframeMapper.map(mockView, fakeMappingContext, mockAsyncJobStatusCallback)
+        val shapeWireframes = testedWireframeMapper.map(
+            mockView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
 
         // Then
         val expectedWireframe = MobileSegment.Wireframe.ShapeWireframe(

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WebViewWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WebViewWireframeMapperTest.kt
@@ -82,7 +82,8 @@ internal class WebViewWireframeMapperTest : BaseWireframeMapperTest() {
         val mappedWireframes = testedWebViewWireframeMapper.map(
             mockWebView,
             fakeMappingContext,
-            mockAsyncJobStatusCallback
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
         )
 
         // Then

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapperTest.kt
@@ -67,7 +67,7 @@ open class AndroidMDrawableToColorMapperTest : LegacyDrawableToColorMapperTest()
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(rippleDrawable)
+        val result = testedMapper.mapDrawableToColor(rippleDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isEqualTo(drawableColor)
@@ -90,7 +90,7 @@ open class AndroidMDrawableToColorMapperTest : LegacyDrawableToColorMapperTest()
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(insetDrawable)
+        val result = testedMapper.mapDrawableToColor(insetDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isEqualTo(drawableColor)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapperTest.kt
@@ -71,7 +71,7 @@ class AndroidQDrawableToColorMapperTest : AndroidMDrawableToColorMapperTest() {
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(gradientDrawable)
+        val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isEqualTo(expectedBlendColor)
@@ -103,7 +103,7 @@ class AndroidQDrawableToColorMapperTest : AndroidMDrawableToColorMapperTest() {
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(gradientDrawable)
+        val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isNull()
@@ -136,7 +136,7 @@ class AndroidQDrawableToColorMapperTest : AndroidMDrawableToColorMapperTest() {
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(gradientDrawable)
+        val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isEqualTo(fillPaintColor)
@@ -168,7 +168,7 @@ class AndroidQDrawableToColorMapperTest : AndroidMDrawableToColorMapperTest() {
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(gradientDrawable)
+        val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isNull()

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapperTest.kt
@@ -13,6 +13,7 @@ import android.graphics.drawable.Drawable
 import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.LayerDrawable
 import android.graphics.drawable.RippleDrawable
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -23,6 +24,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.doReturn
@@ -40,6 +42,9 @@ open class LegacyDrawableToColorMapperTest {
 
     lateinit var testedMapper: DrawableToColorMapper
 
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
     @BeforeEach
     fun `set up`() {
         testedMapper = createTestedMapper()
@@ -55,7 +60,7 @@ open class LegacyDrawableToColorMapperTest {
         val colorDrawable = mock<Drawable>()
 
         // When
-        val result = testedMapper.mapDrawableToColor(colorDrawable)
+        val result = testedMapper.mapDrawableToColor(colorDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isNull()
@@ -74,7 +79,7 @@ open class LegacyDrawableToColorMapperTest {
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(colorDrawable)
+        val result = testedMapper.mapDrawableToColor(colorDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isEqualTo(drawableColor)
@@ -105,7 +110,7 @@ open class LegacyDrawableToColorMapperTest {
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(rippleDrawable)
+        val result = testedMapper.mapDrawableToColor(rippleDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isEqualTo(drawableColor)
@@ -136,7 +141,7 @@ open class LegacyDrawableToColorMapperTest {
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(layerDrawable)
+        val result = testedMapper.mapDrawableToColor(layerDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isEqualTo(drawableColor)
@@ -159,7 +164,7 @@ open class LegacyDrawableToColorMapperTest {
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(gradientDrawable)
+        val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isEqualTo(drawableColor)
@@ -181,7 +186,7 @@ open class LegacyDrawableToColorMapperTest {
         }
 
         // When
-        val result = testedMapper.mapDrawableToColor(gradientDrawable)
+        val result = testedMapper.mapDrawableToColor(gradientDrawable, mockInternalLogger)
 
         // Then
         assertThat(result).isNull()


### PR DESCRIPTION

### What does this PR do?

Adds some telemetry when a View or Drawable cannot be converted into Session Replay data.

### Motivation

We need to better understand the UI features used by our customer that we don't have support of yet. 