### PR TITLE
RUM-3589: : Add AddAttributes and RemoveAttributes

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -108,6 +108,8 @@ interface com.datadog.android.rum.RumMonitor
   fun addFeatureFlagEvaluations(Map<String, Any>)
   fun addAttribute(String, Any?)
   fun removeAttribute(String)
+  fun addAttributes(Map<String, Any?>)
+  fun removeAttributes(Set<String>)
   fun getAttributes(): Map<String, Any?>
   fun clearAttributes()
   fun stopSession()

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -136,6 +136,7 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract synthetic fun _getInternal ()Lcom/datadog/android/rum/_RumInternalProxy;
 	public abstract fun addAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun addAttribute (Ljava/lang/String;Ljava/lang/Object;)V
+	public abstract fun addAttributes (Ljava/util/Map;)V
 	public abstract fun addError (Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public abstract fun addErrorWithStacktrace (Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun addFeatureFlagEvaluation (Ljava/lang/String;Ljava/lang/Object;)V
@@ -146,6 +147,7 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun getCurrentSessionId (Lkotlin/jvm/functions/Function1;)V
 	public abstract fun getDebug ()Z
 	public abstract fun removeAttribute (Ljava/lang/String;)V
+	public abstract fun removeAttributes (Ljava/util/Set;)V
 	public abstract fun setDebug (Z)V
 	public abstract fun startAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun startResource (Ljava/lang/String;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;)V

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -306,6 +306,18 @@ interface RumMonitor {
     fun removeAttribute(key: String)
 
     /**
+     * Adds multiple global attributes to all future RUM events.
+     * @param attributes a map of attribute keys (non null) to values (nullable)
+     */
+    fun addAttributes(attributes: Map<String, Any?>)
+
+    /**
+     * Remove multiple global attributes from all future RUM events.
+     * @param keys the attribute keys to remove (non null)
+     */
+    fun removeAttributes(keys: Set<String>)
+
+    /**
      * @return the global attributes added to this monitor
      */
     fun getAttributes(): Map<String, Any?>

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -53,7 +53,7 @@ import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LargeClass")
 internal class DatadogRumMonitor(
     applicationId: String,
     private val sdkCore: InternalSdkCore,
@@ -388,8 +388,30 @@ internal class DatadogRumMonitor(
         handleEvent(RumRawEvent.UpdateView())
     }
 
+    override fun addAttributes(attributes: Map<String, Any?>) {
+        attributes.forEach {
+            if (it.value == null) {
+                globalAttributes.remove(it.key)
+            } else {
+                globalAttributes[it.key] = it.value
+            }
+        }
+
+        // update the attributes in the view
+        handleEvent(RumRawEvent.UpdateView())
+    }
+
     override fun removeAttribute(key: String) {
         globalAttributes.remove(key)
+
+        // update the attributes in the view
+        handleEvent(RumRawEvent.UpdateView())
+    }
+
+    override fun removeAttributes(keys: Set<String>) {
+        keys.forEach { key ->
+            globalAttributes.remove(key)
+        }
 
         // update the attributes in the view
         handleEvent(RumRawEvent.UpdateView())


### PR DESCRIPTION
### What does this PR do?
• Adds the new apis addAttributes/removeAttributes, in order to allow adding/removing multiple attributes while reducing the number of UpdateView events.

### Motivation
Fixes an issue where performing addAttribute/removeAttribute is not reflected in the RUM dashboard until after the next event. This change consists of 3 parts split into 3 separate prs.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

