### PR TITLE
RUM-4501 Enable desugaring for sample and single-fit apps

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,6 +7,7 @@ okHttp = "4.11.0"
 kronosNTP = "0.0.1-alpha11"
 
 # Android
+androidDesugaringSdk = "2.0.4"
 androidToolsPlugin = "8.1.1"
 androidXAnnotations = "1.1.0"
 androidXAppCompat = "1.3.0"
@@ -120,6 +121,7 @@ kronosNTP = { module = "com.lyft.kronos:kronos-android", version.ref = "kronosNT
 assertJ = { module = "org.assertj:assertj-core", version.ref = "assertJ" }
 
 # Android libs
+androidDesugaringSdk = { module = "com.android.tools:desugar_jdk_libs", version.ref = "androidDesugaringSdk" }
 androidXMultidex = { module = "androidx.multidex:multidex", version.ref = "androidXMultidex" }
 androidXAnnotation = { module = "androidx.annotation:annotation", version.ref = "androidXAnnotations" }
 androidXAppCompat = { module = "androidx.appcompat:appcompat", version.ref = "androidXAppCompat" }

--- a/reliability/single-fit/trace/build.gradle.kts
+++ b/reliability/single-fit/trace/build.gradle.kts
@@ -32,6 +32,10 @@ android {
         // Required because AGP doesn't support kotlin test fixtures :/
         java.srcDir("${project.rootDir.path}/dd-sdk-android-core/src/testFixtures/kotlin")
     }
+
+    compileOptions {
+        isCoreLibraryDesugaringEnabled = true
+    }
 }
 
 dependencies {
@@ -39,6 +43,9 @@ dependencies {
     implementation(project(":features:dd-sdk-android-trace"))
     implementation(project(":features:dd-sdk-android-trace-otel"))
     implementation(libs.kotlin)
+
+    // Desugaring SDK
+    coreLibraryDesugaring(libs.androidDesugaringSdk)
 
     // Testing
     testImplementation(project(":tools:unit")) {

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -61,6 +61,7 @@ android {
     namespace = "com.datadog.android.sample"
 
     compileOptions {
+        isCoreLibraryDesugaringEnabled = true
         java17()
     }
 
@@ -163,6 +164,9 @@ dependencies {
     implementation(project(":integrations:dd-sdk-android-sqldelight"))
     implementation(project(":integrations:dd-sdk-android-compose"))
     implementation(project(":integrations:dd-sdk-android-okhttp"))
+
+    // Desugaring SDK
+    coreLibraryDesugaring(libs.androidDesugaringSdk)
 
     // Sample Vendor Library
     implementation(project(":sample:vendor-lib"))


### PR DESCRIPTION
### What does this PR do?

We are enabling desugaring for the sample and single-fit apps as they are the ones using the newly introduced `dd-sdk-android-trace-otel` module.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

