### PR TITLE
RUM-4516 flag critical events in custom persistence

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -135,10 +135,14 @@ interface com.datadog.android.api.net.RequestFactory
     const val QUERY_PARAM_SOURCE: String
     const val QUERY_PARAM_TAGS: String
 interface com.datadog.android.api.storage.DataWriter<T>
-  fun write(EventBatchWriter, T): Boolean
+  fun write(EventBatchWriter, T, EventType): Boolean
 interface com.datadog.android.api.storage.EventBatchWriter
   fun currentMetadata(): ByteArray?
-  fun write(RawBatchEvent, ByteArray?): Boolean
+  fun write(RawBatchEvent, ByteArray?, EventType): Boolean
+enum com.datadog.android.api.storage.EventType
+  - DEFAULT
+  - CRASH
+  - TELEMETRY
 data class com.datadog.android.api.storage.FeatureStorageConfiguration
   constructor(Long, Int, Long, Long)
   companion object 
@@ -276,7 +280,7 @@ interface com.datadog.android.core.persistence.PersistenceStrategy
   data class Batch
     constructor(String, ByteArray? = null, List<com.datadog.android.api.storage.RawBatchEvent> = mutableListOf())
   fun currentMetadata(): ByteArray?
-  fun write(com.datadog.android.api.storage.RawBatchEvent, ByteArray?): Boolean
+  fun write(com.datadog.android.api.storage.RawBatchEvent, ByteArray?, com.datadog.android.api.storage.EventType): Boolean
   fun lockAndReadNext(): Batch?
   fun unlockAndKeep(String)
   fun unlockAndDelete(String)

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -405,12 +405,20 @@ public final class com/datadog/android/api/net/RequestFactory$Companion {
 }
 
 public abstract interface class com/datadog/android/api/storage/DataWriter {
-	public abstract fun write (Lcom/datadog/android/api/storage/EventBatchWriter;Ljava/lang/Object;)Z
+	public abstract fun write (Lcom/datadog/android/api/storage/EventBatchWriter;Ljava/lang/Object;Lcom/datadog/android/api/storage/EventType;)Z
 }
 
 public abstract interface class com/datadog/android/api/storage/EventBatchWriter {
 	public abstract fun currentMetadata ()[B
-	public abstract fun write (Lcom/datadog/android/api/storage/RawBatchEvent;[B)Z
+	public abstract fun write (Lcom/datadog/android/api/storage/RawBatchEvent;[BLcom/datadog/android/api/storage/EventType;)Z
+}
+
+public final class com/datadog/android/api/storage/EventType : java/lang/Enum {
+	public static final field CRASH Lcom/datadog/android/api/storage/EventType;
+	public static final field DEFAULT Lcom/datadog/android/api/storage/EventType;
+	public static final field TELEMETRY Lcom/datadog/android/api/storage/EventType;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/api/storage/EventType;
+	public static fun values ()[Lcom/datadog/android/api/storage/EventType;
 }
 
 public final class com/datadog/android/api/storage/FeatureStorageConfiguration {
@@ -437,7 +445,7 @@ public final class com/datadog/android/api/storage/FeatureStorageConfiguration$C
 
 public final class com/datadog/android/api/storage/NoOpDataWriter : com/datadog/android/api/storage/DataWriter {
 	public fun <init> ()V
-	public fun write (Lcom/datadog/android/api/storage/EventBatchWriter;Ljava/lang/Object;)Z
+	public fun write (Lcom/datadog/android/api/storage/EventBatchWriter;Ljava/lang/Object;Lcom/datadog/android/api/storage/EventType;)Z
 }
 
 public final class com/datadog/android/api/storage/RawBatchEvent {
@@ -746,7 +754,7 @@ public abstract interface class com/datadog/android/core/persistence/Persistence
 	public abstract fun migrateData (Lcom/datadog/android/core/persistence/PersistenceStrategy;)V
 	public abstract fun unlockAndDelete (Ljava/lang/String;)V
 	public abstract fun unlockAndKeep (Ljava/lang/String;)V
-	public abstract fun write (Lcom/datadog/android/api/storage/RawBatchEvent;[B)Z
+	public abstract fun write (Lcom/datadog/android/api/storage/RawBatchEvent;[BLcom/datadog/android/api/storage/EventType;)Z
 }
 
 public final class com/datadog/android/core/persistence/PersistenceStrategy$Batch {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/DataWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/DataWriter.kt
@@ -18,8 +18,12 @@ interface DataWriter<T> {
     /**
      * Writes the element with a given [EventBatchWriter].
      *
+     * @param writer the writer to use
+     * @param element the event to write
+     * @param eventType additional info about the event
+     *
      * @return true if element was written, false otherwise.
      */
     @WorkerThread
-    fun write(writer: EventBatchWriter, element: T): Boolean
+    fun write(writer: EventBatchWriter, element: T, eventType: EventType): Boolean
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/EventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/EventBatchWriter.kt
@@ -23,12 +23,14 @@ interface EventBatchWriter {
      * Writes the content of the event to the current available batch.
      * @param event the event to write (content + metadata)
      * @param batchMetadata the optional updated batch metadata
+     * @param eventType additional information about the event data
      *
      * @return true if event was written, false otherwise.
      */
     @WorkerThread
     fun write(
         event: RawBatchEvent,
-        batchMetadata: ByteArray?
+        batchMetadata: ByteArray?,
+        eventType: EventType
     ): Boolean
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/EventType.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/EventType.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.api.storage
+
+/**
+ * The type of event being sent to storage.
+ */
+enum class EventType {
+    /** A generic customer event (e.g.: log, span, …). */
+    DEFAULT,
+
+    /** A customer event related to a crash. */
+    CRASH,
+
+    /** An internal telemetry event to monitor the SDK's behavior and performances. */
+    TELEMETRY
+}

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
@@ -11,6 +11,7 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.metrics.RemovalReason
@@ -77,8 +78,8 @@ internal class AbstractStorage(
                 }
 
                 @WorkerThread
-                override fun write(event: RawBatchEvent, batchMetadata: ByteArray?): Boolean {
-                    return strategy.write(event, batchMetadata)
+                override fun write(event: RawBatchEvent, batchMetadata: ByteArray?, eventType: EventType): Boolean {
+                    return strategy.write(event, batchMetadata, eventType)
                 }
             }
             callback.invoke(writer)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriter.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.persistence
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
@@ -36,7 +37,8 @@ internal class FileEventBatchWriter(
     @WorkerThread
     override fun write(
         event: RawBatchEvent,
-        batchMetadata: ByteArray?
+        batchMetadata: ByteArray?,
+        eventType: EventType
     ): Boolean {
         // prevent useless operation for empty event
         return if (event.data.isEmpty()) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/NoOpEventBatchWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/NoOpEventBatchWriter.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal.persistence
 
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 
 internal class NoOpEventBatchWriter : EventBatchWriter {
@@ -17,6 +18,7 @@ internal class NoOpEventBatchWriter : EventBatchWriter {
 
     override fun write(
         event: RawBatchEvent,
-        batchMetadata: ByteArray?
+        batchMetadata: ByteArray?,
+        eventType: EventType
     ): Boolean = true
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/persistence/PersistenceStrategy.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/persistence/PersistenceStrategy.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.persistence
 
 import androidx.annotation.WorkerThread
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.tools.annotation.NoOpImplementation
 
@@ -61,13 +62,18 @@ interface PersistenceStrategy {
      * Writes the content of the event to the current available batch.
      * @param event the event to write (content + metadata)
      * @param batchMetadata the optional updated batch metadata
+     * @param eventType additional information about the event that can impact the way it is stored. Note: events
+     * with the CRASH type are being sent as part of the Crash Reporting feature, and implies that the process will
+     * exit soon, meaning that those event must be kept synchronously and in a way to be retrieved after the app
+     * restarts in a new process (e.g.: on the file system, or in a local database).
      *
      * @return true if event was written, false otherwise.
      */
     @WorkerThread
     fun write(
         event: RawBatchEvent,
-        batchMetadata: ByteArray?
+        batchMetadata: ByteArray?,
+        eventType: EventType
     ): Boolean
 
     /**

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.persistence
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.metrics.RemovalReason
@@ -78,6 +79,9 @@ internal class AbstractStorageTest {
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
+    @Forgery
+    lateinit var fakeEventType: EventType
+
     @BeforeEach
     fun `set up`() {
         whenever(mockPersistenceStrategyFactory.create(argThat { contains("/GRANTED") }, any(), any()))
@@ -107,10 +111,10 @@ internal class AbstractStorageTest {
         // Given
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
-        whenever(mockGrantedPersistenceStrategy.write(any(), anyOrNull())) doReturn fakeResult
+        whenever(mockGrantedPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
         var result: Boolean? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, null)
+            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, null, fakeEventType)
         }
 
         // When
@@ -118,7 +122,7 @@ internal class AbstractStorageTest {
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
-        verify(mockGrantedPersistenceStrategy).write(fakeBatchEvent, null)
+        verify(mockGrantedPersistenceStrategy).write(fakeBatchEvent, null, fakeEventType)
         verifyNoMoreInteractions(
             mockGrantedPersistenceStrategy,
             mockPendingPersistenceStrategy,
@@ -137,10 +141,10 @@ internal class AbstractStorageTest {
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
-        whenever(mockGrantedPersistenceStrategy.write(any(), anyOrNull())) doReturn fakeResult
+        whenever(mockGrantedPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
         var result: Boolean? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata)
+            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata, fakeEventType)
         }
 
         // When
@@ -148,7 +152,7 @@ internal class AbstractStorageTest {
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
-        verify(mockGrantedPersistenceStrategy).write(fakeBatchEvent, batchMetadata)
+        verify(mockGrantedPersistenceStrategy).write(fakeBatchEvent, batchMetadata, fakeEventType)
         verifyNoMoreInteractions(
             mockGrantedPersistenceStrategy,
             mockPendingPersistenceStrategy,
@@ -219,10 +223,10 @@ internal class AbstractStorageTest {
         // Given
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
-        whenever(mockPendingPersistenceStrategy.write(any(), anyOrNull())) doReturn fakeResult
+        whenever(mockPendingPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
         var result: Boolean? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, null)
+            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, null, fakeEventType)
         }
 
         // When
@@ -230,7 +234,7 @@ internal class AbstractStorageTest {
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
-        verify(mockPendingPersistenceStrategy).write(fakeBatchEvent, null)
+        verify(mockPendingPersistenceStrategy).write(fakeBatchEvent, null, fakeEventType)
         verifyNoMoreInteractions(
             mockGrantedPersistenceStrategy,
             mockPendingPersistenceStrategy,
@@ -249,10 +253,10 @@ internal class AbstractStorageTest {
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
-        whenever(mockPendingPersistenceStrategy.write(any(), anyOrNull())) doReturn fakeResult
+        whenever(mockPendingPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
         var result: Boolean? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata)
+            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata, fakeEventType)
         }
 
         // When
@@ -260,7 +264,7 @@ internal class AbstractStorageTest {
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
-        verify(mockPendingPersistenceStrategy).write(fakeBatchEvent, batchMetadata)
+        verify(mockPendingPersistenceStrategy).write(fakeBatchEvent, batchMetadata, fakeEventType)
         verifyNoMoreInteractions(
             mockGrantedPersistenceStrategy,
             mockPendingPersistenceStrategy,
@@ -334,7 +338,7 @@ internal class AbstractStorageTest {
         val batchMetadata = fakeBatchMetadata.toByteArray()
         var result: Boolean? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
-            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata)
+            result = (it.getArgument(0) as? EventBatchWriter)?.write(fakeBatchEvent, batchMetadata, fakeEventType)
         }
 
         // When

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorageTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.core.internal.persistence
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.metrics.MetricsDispatcher
 import com.datadog.android.core.internal.metrics.RemovalReason
@@ -67,9 +68,6 @@ internal class ConsentAwareStorageTest {
 
     private lateinit var testedStorage: Storage
 
-    @Forgery
-    lateinit var fakeDatadogContext: DatadogContext
-
     @Mock
     lateinit var mockPendingOrchestrator: FileOrchestrator
 
@@ -93,6 +91,12 @@ internal class ConsentAwareStorageTest {
 
     @Mock
     lateinit var mockMetricsDispatcher: MetricsDispatcher
+
+    @Forgery
+    lateinit var fakeDatadogContext: DatadogContext
+
+    @Forgery
+    lateinit var fakeEventType: EventType
 
     @BeforeEach
     fun `set up`() {
@@ -322,7 +326,8 @@ internal class ConsentAwareStorageTest {
             val value = it.currentMetadata()?.first() ?: 0
             it.write(
                 event = RawBatchEvent(data = event),
-                batchMetadata = byteArrayOf((value + 1).toByte())
+                batchMetadata = byteArrayOf((value + 1).toByte()),
+                eventType = fakeEventType
             )
         }
         val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/FileEventBatchWriterTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.core.internal.persistence
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.internal.persistence.FileEventBatchWriter.Companion.ERROR_LARGE_DATA
 import com.datadog.android.core.internal.persistence.FileEventBatchWriter.Companion.WARNING_METADATA_WRITE_FAILED
@@ -68,6 +69,9 @@ internal class FileEventBatchWriterTest {
     @Forgery
     lateinit var fakeBatchMetadataFile: File
 
+    @Forgery
+    lateinit var fakeEventType: EventType
+
     @BeforeEach
     fun `set up`() {
         testedWriter = FileEventBatchWriter(
@@ -96,7 +100,7 @@ internal class FileEventBatchWriterTest {
         ) doReturn true
 
         // When
-        val result = testedWriter.write(batchEvent, serializedMetadata)
+        val result = testedWriter.write(batchEvent, serializedMetadata, fakeEventType)
 
         // Then
         assertThat(result).isTrue()
@@ -127,7 +131,7 @@ internal class FileEventBatchWriterTest {
         val serializedBatchMetadata = batchMetadata.toByteArray(Charsets.UTF_8)
 
         // When
-        val result = testedWriter.write(rawBatchEvent, serializedBatchMetadata)
+        val result = testedWriter.write(rawBatchEvent, serializedBatchMetadata, fakeEventType)
 
         // Then
         assertThat(result).isTrue
@@ -149,7 +153,7 @@ internal class FileEventBatchWriterTest {
         whenever(mockFilePersistenceConfig.maxItemSize) doReturn maxItemSize.toLong()
 
         // When
-        val result = testedWriter.write(batchEvent, serializedBatchMetadata)
+        val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
 
         // Then
         assertThat(result).isFalse
@@ -176,7 +180,7 @@ internal class FileEventBatchWriterTest {
         whenever(mockBatchWriter.writeData(batchFile, batchEvent, true)) doReturn false
 
         // When
-        val result = testedWriter.write(batchEvent, serializedBatchMetadata)
+        val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
 
         // Then
         assertThat(result).isFalse
@@ -202,7 +206,7 @@ internal class FileEventBatchWriterTest {
         whenever(mockBatchWriter.writeData(fakeBatchFile, batchEvent, true)) doReturn true
 
         // When
-        val result = testedWriter.write(batchEvent, serializedBatchMetadata)
+        val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
 
         // Then
         assertThat(result).isTrue
@@ -219,7 +223,7 @@ internal class FileEventBatchWriterTest {
         whenever(mockBatchWriter.writeData(fakeBatchFile, batchEvent, true)) doReturn true
 
         // When
-        val result = testedWriter.write(batchEvent, forge.aNullable { ByteArray(0) })
+        val result = testedWriter.write(batchEvent, forge.aNullable { ByteArray(0) }, fakeEventType)
 
         // Then
         assertThat(result).isTrue
@@ -244,7 +248,7 @@ internal class FileEventBatchWriterTest {
         whenever(mockFilePersistenceConfig.maxItemSize) doReturn maxItemSize.toLong()
 
         // When
-        val result = testedWriter.write(batchEvent, serializedBatchMetadata)
+        val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
 
         // Then
         assertThat(result).isFalse
@@ -264,7 +268,7 @@ internal class FileEventBatchWriterTest {
         ) doReturn false
 
         // When
-        val result = testedWriter.write(batchEvent, serializedBatchMetadata)
+        val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
 
         // Then
         assertThat(result).isFalse
@@ -287,7 +291,7 @@ internal class FileEventBatchWriterTest {
         ) doReturn false
 
         // When
-        val result = testedWriter.write(batchEvent, serializedBatchMetadata)
+        val result = testedWriter.write(batchEvent, serializedBatchMetadata, fakeEventType)
 
         // Then
         assertThat(result).isTrue()

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/NoOpEventBatchWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/NoOpEventBatchWriterTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal.persistence
 
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
@@ -31,6 +32,9 @@ internal class NoOpEventBatchWriterTest {
 
     private lateinit var testedWriter: EventBatchWriter
 
+    @Forgery
+    lateinit var fakeEventType: EventType
+
     @BeforeEach
     fun `set up`() {
         testedWriter = NoOpEventBatchWriter()
@@ -50,7 +54,8 @@ internal class NoOpEventBatchWriterTest {
         // When
         val result = testedWriter.write(
             fakeData,
-            forge.aNullable { fakeMetadata.toByteArray() }
+            forge.aNullable { fakeMetadata.toByteArray() },
+            fakeEventType
         )
 
         // Then

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -18,6 +18,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.DataWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.api.storage.NoOpDataWriter
 import com.datadog.android.core.feature.event.JvmCrash
@@ -192,7 +193,7 @@ internal class LogsFeature(
                 )
 
                 @Suppress("ThreadSafety") // called in a worker thread context
-                dataWriter.write(eventBatchWriter, log)
+                dataWriter.write(eventBatchWriter, log, EventType.CRASH)
                 lock.countDown()
             }
 
@@ -249,7 +250,7 @@ internal class LogsFeature(
                 )
 
                 @Suppress("ThreadSafety") // called in a worker thread context
-                dataWriter.write(eventBatchWriter, log)
+                dataWriter.write(eventBatchWriter, log, EventType.CRASH)
             }
     }
 
@@ -290,7 +291,7 @@ internal class LogsFeature(
                 )
 
                 @Suppress("ThreadSafety") // called in a worker thread context
-                dataWriter.write(eventBatchWriter, log)
+                dataWriter.write(eventBatchWriter, log, EventType.DEFAULT)
             }
     }
 

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.log.internal.LogsFeature
@@ -67,7 +68,7 @@ internal class DatadogLogHandler(
                     )
                     if (log != null) {
                         @Suppress("ThreadSafety") // called in a worker thread context
-                        writer.write(eventBatchWriter, log)
+                        writer.write(eventBatchWriter, log, EventType.DEFAULT)
                     }
                 }
             } else {
@@ -141,7 +142,7 @@ internal class DatadogLogHandler(
                     )
                     if (log != null) {
                         @Suppress("ThreadSafety") // called in a worker thread context
-                        writer.write(eventBatchWriter, log)
+                        writer.write(eventBatchWriter, log, EventType.DEFAULT)
                     }
                 }
             } else {

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/storage/LogsDataWriter.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/storage/LogsDataWriter.kt
@@ -10,6 +10,7 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.core.persistence.serializeToByteArray
@@ -21,8 +22,10 @@ internal class LogsDataWriter(
 ) : DataWriter<LogEvent> {
 
     @WorkerThread
-    override fun write(writer: EventBatchWriter, element: LogEvent): Boolean {
+    override fun write(writer: EventBatchWriter, element: LogEvent, eventType: EventType): Boolean {
         val serialized = serializer.serializeToByteArray(element, internalLogger) ?: return false
-        return synchronized(this) { writer.write(RawBatchEvent(data = serialized), batchMetadata = null) }
+        return synchronized(this) {
+            writer.write(RawBatchEvent(data = serialized), batchMetadata = null, eventType = eventType)
+        }
     }
 }

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/LogsFeatureTest.kt
@@ -16,6 +16,7 @@ import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.core.feature.event.JvmCrash
 import com.datadog.android.core.feature.event.ThreadDump
@@ -377,7 +378,7 @@ internal class LogsFeatureTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             val log = lastValue
 
@@ -450,7 +451,7 @@ internal class LogsFeatureTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             val log = lastValue
 
@@ -502,7 +503,7 @@ internal class LogsFeatureTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             val log = lastValue
 
@@ -670,7 +671,7 @@ internal class LogsFeatureTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             val log = lastValue
 
@@ -720,7 +721,7 @@ internal class LogsFeatureTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             val log = lastValue
 
@@ -770,7 +771,7 @@ internal class LogsFeatureTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             val log = lastValue
 
@@ -877,7 +878,7 @@ internal class LogsFeatureTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockDataWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             val log = lastValue
 

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.log.assertj.LogEventAssert.Companion.assertThat
@@ -169,7 +170,7 @@ internal class DatadogLogHandlerTest {
         )
 
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue)
                 .hasServiceName(fakeServiceName)
@@ -242,7 +243,7 @@ internal class DatadogLogHandlerTest {
         )
 
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue)
                 .hasServiceName(fakeServiceName)
@@ -299,7 +300,7 @@ internal class DatadogLogHandlerTest {
         )
 
         argumentCaptor<LogEvent>().apply {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue)
                 .hasServiceName(fakeServiceName)
@@ -535,7 +536,7 @@ internal class DatadogLogHandlerTest {
         )
 
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue)
                 .hasServiceName(fakeServiceName)
@@ -588,7 +589,7 @@ internal class DatadogLogHandlerTest {
         countDownLatch.await(1, TimeUnit.SECONDS)
 
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue)
                 .hasServiceName(fakeServiceName)
@@ -639,7 +640,7 @@ internal class DatadogLogHandlerTest {
         )
 
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue)
                 .hasServiceName(fakeServiceName)
@@ -699,7 +700,7 @@ internal class DatadogLogHandlerTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue)
                 .hasServiceName(fakeServiceName)
@@ -746,7 +747,7 @@ internal class DatadogLogHandlerTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue.additionalProperties)
                 .containsEntry(key, value)
@@ -776,7 +777,7 @@ internal class DatadogLogHandlerTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue.additionalProperties)
                 .containsEntry(key, value)
@@ -806,7 +807,7 @@ internal class DatadogLogHandlerTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue.additionalProperties)
                 .containsEntry(key, loggerValue)
@@ -846,7 +847,7 @@ internal class DatadogLogHandlerTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue.additionalProperties)
                 .containsEntry(LogAttributes.DD_TRACE_ID, fakeTraceId)
@@ -867,7 +868,7 @@ internal class DatadogLogHandlerTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue.additionalProperties)
                 .doesNotContainKey(LogAttributes.DD_TRACE_ID)
@@ -888,7 +889,7 @@ internal class DatadogLogHandlerTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue.additionalProperties)
                 .containsEntry(
@@ -925,7 +926,7 @@ internal class DatadogLogHandlerTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue.additionalProperties)
                 .doesNotContainKey(LogAttributes.DD_TRACE_ID)
@@ -990,7 +991,7 @@ internal class DatadogLogHandlerTest {
 
         // Then
         argumentCaptor<LogEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(lastValue)
                 .hasServiceName(fakeServiceName)

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/storage/LogsDataWriterTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/storage/LogsDataWriterTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.log.internal.storage
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.log.model.LogEvent
@@ -53,6 +54,9 @@ internal class LogsDataWriterTest {
     @Mock
     lateinit var mockEventBatchWriter: EventBatchWriter
 
+    @Forgery
+    lateinit var fakeEventType: EventType
+
     @BeforeEach
     fun `set up`() {
         testedWriter = LogsDataWriter(mockSerializer, mockInternalLogger)
@@ -68,16 +72,21 @@ internal class LogsDataWriterTest {
         whenever(
             mockEventBatchWriter.write(
                 RawBatchEvent(data = fakeSerializedLogEvent.toByteArray()),
-                null
+                null,
+                fakeEventType
             )
         ) doReturn true
 
         // When
-        val result = testedWriter.write(mockEventBatchWriter, fakeLogEvent)
+        val result = testedWriter.write(mockEventBatchWriter, fakeLogEvent, fakeEventType)
 
         // Then
         assertThat(result).isTrue
-        verify(mockEventBatchWriter).write(RawBatchEvent(data = fakeSerializedLogEvent.toByteArray()), null)
+        verify(mockEventBatchWriter).write(
+            RawBatchEvent(data = fakeSerializedLogEvent.toByteArray()),
+            null,
+            fakeEventType
+        )
         verifyNoInteractions(mockInternalLogger)
     }
 
@@ -91,16 +100,21 @@ internal class LogsDataWriterTest {
         whenever(
             mockEventBatchWriter.write(
                 RawBatchEvent(data = fakeSerializedLogEvent.toByteArray()),
-                null
+                null,
+                fakeEventType
             )
         ) doReturn false
 
         // When
-        val result = testedWriter.write(mockEventBatchWriter, fakeLogEvent)
+        val result = testedWriter.write(mockEventBatchWriter, fakeLogEvent, fakeEventType)
 
         // Then
         assertThat(result).isFalse
-        verify(mockEventBatchWriter).write(RawBatchEvent(data = fakeLogEvent.toString().toByteArray()), null)
+        verify(mockEventBatchWriter).write(
+            RawBatchEvent(data = fakeLogEvent.toString().toByteArray()),
+            null,
+            fakeEventType
+        )
         verifyNoInteractions(mockInternalLogger)
     }
 
@@ -112,7 +126,7 @@ internal class LogsDataWriterTest {
         whenever(mockSerializer.serialize(fakeLogEvent)) doReturn null
 
         // When
-        val result = testedWriter.write(mockEventBatchWriter, fakeLogEvent)
+        val result = testedWriter.write(mockEventBatchWriter, fakeLogEvent, fakeEventType)
 
         // Then
         assertThat(result).isFalse
@@ -130,7 +144,7 @@ internal class LogsDataWriterTest {
         whenever(mockSerializer.serialize(fakeLogEvent)) doThrow fakeThrowable
 
         // When
-        val result = testedWriter.write(mockEventBatchWriter, fakeLogEvent)
+        val result = testedWriter.write(mockEventBatchWriter, fakeLogEvent, fakeEventType)
 
         // Then
         assertThat(result).isFalse

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.persistence.Deserializer
@@ -89,11 +90,11 @@ internal class DatadogLateCrashReporter(
                 lastViewEvent
             )
             @Suppress("ThreadSafety") // called in a worker thread context
-            rumWriter.write(eventBatchWriter, toSendErrorEvent)
+            rumWriter.write(eventBatchWriter, toSendErrorEvent, EventType.CRASH)
             if (lastViewEvent.isWithinSessionAvailability) {
                 val updatedViewEvent = updateViewEvent(lastViewEvent)
                 @Suppress("ThreadSafety") // called in a worker thread context
-                rumWriter.write(eventBatchWriter, updatedViewEvent)
+                rumWriter.write(eventBatchWriter, updatedViewEvent, EventType.CRASH)
             }
         }
     }
@@ -144,11 +145,11 @@ internal class DatadogLateCrashReporter(
                     lastViewEvent
                 )
                 @Suppress("ThreadSafety") // called in a worker thread context
-                rumWriter.write(eventBatchWriter, toSendErrorEvent)
+                rumWriter.write(eventBatchWriter, toSendErrorEvent, EventType.CRASH)
                 if (lastViewEvent.isWithinSessionAvailability) {
                     val updatedViewEvent = updateViewEvent(lastViewEvent)
                     @Suppress("ThreadSafety") // called in a worker thread context
-                    rumWriter.write(eventBatchWriter, updatedViewEvent)
+                    rumWriter.write(eventBatchWriter, updatedViewEvent, EventType.CRASH)
                 }
                 @Suppress("ThreadSafety") // called in a worker thread context
                 sdkCore.writeLastFatalAnrSent(anrExitInfo.timestamp)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/RumDataWriter.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum.internal.domain
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.persistence.Serializer
@@ -25,7 +26,7 @@ internal class RumDataWriter(
     // region DataWriter
 
     @WorkerThread
-    override fun write(writer: EventBatchWriter, element: Any): Boolean {
+    override fun write(writer: EventBatchWriter, element: Any, eventType: EventType): Boolean {
         val byteArray = eventSerializer.serializeToByteArray(
             element,
             sdkCore.internalLogger
@@ -48,7 +49,7 @@ internal class RumDataWriter(
         }
 
         synchronized(this) {
-            val result = writer.write(batchEvent, null)
+            val result = writer.write(batchEvent, null, eventType)
             if (result) {
                 onDataWritten(element, byteArray)
             }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.storage.DataWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
@@ -98,7 +99,7 @@ internal class TelemetryEventHandler(
             }
 
             if (telemetryEvent != null) {
-                writer.write(eventBatchWriter, telemetryEvent)
+                writer.write(eventBatchWriter, telemetryEvent, EventType.TELEMETRY)
             }
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporterTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.persistence.Deserializer
@@ -161,7 +162,7 @@ internal class DatadogLateCrashReporterTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasApplicationId(fakeViewEvent.application.id)
@@ -261,7 +262,7 @@ internal class DatadogLateCrashReporterTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasApplicationId(fakeViewEvent.application.id)
@@ -361,7 +362,7 @@ internal class DatadogLateCrashReporterTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasErrorSourceType(ErrorEvent.SourceType.NDK)
@@ -412,7 +413,7 @@ internal class DatadogLateCrashReporterTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasApplicationId(fakeViewEvent.application.id)
@@ -507,7 +508,7 @@ internal class DatadogLateCrashReporterTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(1)).write(eq(mockEventBatchWriter), capture())
+            verify(mockRumWriter, times(1)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasApplicationId(fakeViewEvent.application.id)
@@ -703,7 +704,7 @@ internal class DatadogLateCrashReporterTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasApplicationId(fakeViewEvent.application.id)
@@ -792,7 +793,7 @@ internal class DatadogLateCrashReporterTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockRumWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasApplicationId(fakeViewEvent.application.id)
@@ -879,7 +880,7 @@ internal class DatadogLateCrashReporterTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockRumWriter, times(1)).write(eq(mockEventBatchWriter), capture())
+            verify(mockRumWriter, times(1)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
 
             ErrorEventAssert.assertThat(firstValue as ErrorEvent)
                 .hasApplicationId(fakeViewEvent.application.id)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
@@ -166,7 +167,7 @@ internal class RumActionScopeTest {
                 fakeParentContext.viewId.orEmpty()
             )
         ).thenReturn(fakeHasReplay)
-        whenever(mockWriter.write(eq(mockEventBatchWriter), any())) doReturn true
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true
 
         testedScope = RumActionScope(
             mockParentScope,
@@ -229,7 +230,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -332,7 +333,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -417,7 +418,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -560,7 +561,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -629,7 +630,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -692,7 +693,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -758,7 +759,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -837,7 +838,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -900,7 +901,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -958,7 +959,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1016,7 +1017,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1082,7 +1083,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1145,7 +1146,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1203,7 +1204,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1261,7 +1262,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1326,7 +1327,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1389,7 +1390,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1447,7 +1448,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1505,7 +1506,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1570,7 +1571,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1662,7 +1663,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1743,7 +1744,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1808,7 +1809,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1864,7 +1865,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1923,7 +1924,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1982,7 +1983,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2047,7 +2048,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2105,7 +2106,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2165,7 +2166,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2223,7 +2224,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2281,7 +2282,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2339,7 +2340,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2399,7 +2400,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2489,7 +2490,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2544,7 +2545,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2599,7 +2600,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2654,7 +2655,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2746,7 +2747,7 @@ internal class RumActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2810,7 +2811,7 @@ internal class RumActionScopeTest {
         // When
         testedScope.type = RumActionType.CUSTOM
         val event = RumRawEvent.SendCustomActionNow()
-        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ActionEvent>())) doReturn false
+        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ActionEvent>(), eq(EventType.DEFAULT))) doReturn false
         testedScope.handleEvent(event, mockWriter)
 
         // Then
@@ -2825,7 +2826,8 @@ internal class RumActionScopeTest {
         // When
         testedScope.type = RumActionType.CUSTOM
         val event = RumRawEvent.SendCustomActionNow()
-        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ActionEvent>())) doThrow forge.anException()
+        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ActionEvent>(), eq(EventType.DEFAULT)))
+            .doThrow(forge.anException())
         testedScope.handleEvent(event, mockWriter)
 
         // Then

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind
@@ -146,7 +147,7 @@ internal class RumContinuousActionScopeTest {
             val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
-        whenever(mockWriter.write(eq(mockEventBatchWriter), any())) doReturn true
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true
 
         testedScope = RumActionScope(
             mockParentScope,
@@ -224,7 +225,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -291,7 +292,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -356,7 +357,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -424,7 +425,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -502,7 +503,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -589,7 +590,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -662,7 +663,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -733,7 +734,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -804,7 +805,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -882,7 +883,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -939,7 +940,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -996,7 +997,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1053,7 +1054,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1110,7 +1111,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1174,7 +1175,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1231,7 +1232,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1288,7 +1289,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1345,7 +1346,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1402,7 +1403,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1466,7 +1467,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1525,7 +1526,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1614,7 +1615,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1696,7 +1697,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1763,7 +1764,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1824,7 +1825,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1885,7 +1886,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -1952,7 +1953,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2014,7 +2015,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2078,7 +2079,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2137,7 +2138,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2198,7 +2199,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2257,7 +2258,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2382,7 +2383,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2445,7 +2446,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)
@@ -2501,7 +2502,7 @@ internal class RumContinuousActionScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasId(testedScope.actionId)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumAttributes
@@ -192,7 +193,7 @@ internal class RumResourceScopeTest {
             val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
-        whenever(mockWriter.write(eq(mockEventBatchWriter), any())) doReturn true
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true
 
         testedScope = RumResourceScope(
             mockParentScope,
@@ -253,7 +254,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -322,7 +323,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -406,7 +407,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -482,7 +483,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -552,7 +553,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -640,7 +641,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -701,7 +702,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -762,7 +763,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasKind(kind)
@@ -814,7 +815,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).isNotInstanceOf(ErrorEvent::class.java)
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
@@ -834,7 +835,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).isNotInstanceOf(ErrorEvent::class.java)
         }
         verify(mockParentScope, never()).handleEvent(any(), any())
@@ -879,7 +880,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -950,7 +951,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -1021,7 +1022,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -1094,7 +1095,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -1172,7 +1173,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -1252,7 +1253,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -1327,7 +1328,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -1420,7 +1421,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -1516,7 +1517,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -1605,7 +1606,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -1699,7 +1700,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -1777,7 +1778,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -1857,7 +1858,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -1935,7 +1936,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -2015,7 +2016,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -2098,7 +2099,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -2183,7 +2184,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasMessage(message)
@@ -2345,7 +2346,7 @@ internal class RumResourceScopeTest {
         val resultStop = testedScope.handleEvent(mockEvent, mockWriter)
 
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp())
@@ -2412,7 +2413,7 @@ internal class RumResourceScopeTest {
         val resultStop = testedScope.handleEvent(mockEvent, mockWriter)
 
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp())
@@ -2480,7 +2481,7 @@ internal class RumResourceScopeTest {
         val resultTiming = testedScope.handleEvent(mockEvent, mockWriter)
 
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp())
@@ -2551,7 +2552,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).hasTiming(timing)
         }
     }
@@ -2575,7 +2576,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).hasTiming(timing)
         }
     }
@@ -2600,7 +2601,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -2667,7 +2668,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasId(testedScope.resourceId)
@@ -2741,7 +2742,7 @@ internal class RumResourceScopeTest {
 
         // Then
         argumentCaptor<ResourceEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).hasGraphql(operationType, operationName, payload, variables)
         }
     }
@@ -2777,7 +2778,7 @@ internal class RumResourceScopeTest {
     ) {
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
-        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ResourceEvent>())) doReturn false
+        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ResourceEvent>(), eq(EventType.DEFAULT))) doReturn false
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
@@ -2799,7 +2800,7 @@ internal class RumResourceScopeTest {
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         whenever(
-            mockWriter.write(eq(mockEventBatchWriter), isA<ResourceEvent>())
+            mockWriter.write(eq(mockEventBatchWriter), isA<ResourceEvent>(), eq(EventType.DEFAULT))
         ) doThrow forge.anException()
 
         // When
@@ -2849,7 +2850,7 @@ internal class RumResourceScopeTest {
     ) {
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
-        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>())) doReturn false
+        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>(), eq(EventType.DEFAULT))) doReturn false
 
         mockEvent = RumRawEvent.StopResourceWithError(
             fakeKey,
@@ -2879,7 +2880,7 @@ internal class RumResourceScopeTest {
         // Given
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         whenever(
-            mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>())
+            mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>(), eq(EventType.DEFAULT))
         ) doThrow forge.anException()
 
         mockEvent = RumRawEvent.StopResourceWithError(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.DdRumContentProvider
@@ -673,7 +674,7 @@ internal class RumViewManagerScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter, atLeastOnce()).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, atLeastOnce()).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue.action.type)
                 .isEqualTo(ActionEvent.ActionEventActionType.APPLICATION_START)
             // Application start event occurs at the start time

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
@@ -262,7 +263,7 @@ internal class RumViewScopeTest {
             val callback = it.getArgument<(DatadogContext, EventBatchWriter) -> Unit>(1)
             callback.invoke(fakeDatadogContext, mockEventBatchWriter)
         }
-        whenever(mockWriter.write(eq(mockEventBatchWriter), any())) doReturn true
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doReturn true
         fakeReplayStats = ViewEvent.ReplayStats(recordsCount = fakeReplayRecordsCount)
         testedScope = RumViewScope(
             mockParentScope,
@@ -870,7 +871,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).apply {
                 hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
                 hasName(fakeKey.name)
@@ -941,7 +942,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1015,7 +1016,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1095,7 +1096,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1172,7 +1173,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1249,7 +1250,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1314,7 +1315,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1407,7 +1408,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1499,7 +1500,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1593,7 +1594,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1690,7 +1691,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1767,7 +1768,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1843,7 +1844,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -1955,7 +1956,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2026,7 +2027,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2115,7 +2116,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2186,7 +2187,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2276,7 +2277,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2348,7 +2349,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2440,7 +2441,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2514,7 +2515,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2586,7 +2587,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2660,7 +2661,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2753,7 +2754,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasNonNullId()
@@ -2820,7 +2821,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasNonNullId()
@@ -2876,7 +2877,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -2965,7 +2966,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -3056,7 +3057,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -3146,7 +3147,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -3240,7 +3241,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue as ActionEvent)
                 .apply {
                     hasNonNullId()
@@ -3298,7 +3299,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasNonNullId()
@@ -3367,7 +3368,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -3568,7 +3569,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -3773,7 +3774,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter, times(1)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasNonNullId()
@@ -3842,7 +3843,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ActionEvent> {
-            verify(mockWriter, times(1)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasNonNullId()
@@ -4427,7 +4428,7 @@ internal class RumViewScopeTest {
         // Then
         val expectedMessage = "$message: ${throwable.message}"
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -4507,7 +4508,7 @@ internal class RumViewScopeTest {
         // Then
         val expectedMessage = "$message: ${throwable.message}"
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -4579,7 +4580,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -4651,7 +4652,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -4725,7 +4726,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -4801,7 +4802,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -4870,7 +4871,7 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -4929,7 +4930,7 @@ internal class RumViewScopeTest {
         // Then
         val expectedMessage = "$message: ${throwable.message}"
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -5006,7 +5007,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -5086,7 +5087,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
             assertThat(firstValue as ErrorEvent)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
@@ -5218,7 +5219,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -5292,7 +5293,7 @@ internal class RumViewScopeTest {
         // Then
         val expectedMessage = "$message: ${throwable.message}"
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -5374,7 +5375,7 @@ internal class RumViewScopeTest {
         // Then
         val expectedMessage = "$message: ${throwable.message}"
         argumentCaptor<Any> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
             assertThat(firstValue as ErrorEvent)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
@@ -5519,7 +5520,7 @@ internal class RumViewScopeTest {
         // Then
         val expectedMessage = "$message: ${throwable.message}"
         argumentCaptor<Any> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
             assertThat(firstValue as ErrorEvent)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
@@ -5647,7 +5648,7 @@ internal class RumViewScopeTest {
         // Then
         val expectedMessage = "$message: ${throwable.message}"
         argumentCaptor<Any> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue as ErrorEvent)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
@@ -5726,7 +5727,7 @@ internal class RumViewScopeTest {
         // Then
         val expectedMessage = "$message: ${throwable.message}"
         argumentCaptor<ErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -5809,7 +5810,7 @@ internal class RumViewScopeTest {
         // Then
         val expectedMessage = "$message: ${throwable.message}"
         argumentCaptor<Any> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.CRASH))
             assertThat(firstValue as ErrorEvent)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEvent.eventTime.timestamp))
@@ -6127,7 +6128,7 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
         argumentCaptor<LongTaskEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -6181,7 +6182,7 @@ internal class RumViewScopeTest {
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
 
         argumentCaptor<LongTaskEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -6244,7 +6245,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<LongTaskEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -6307,7 +6308,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<LongTaskEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -6371,7 +6372,7 @@ internal class RumViewScopeTest {
         val expectedTimestamp =
             resolveExpectedTimestamp(fakeLongTaskEvent.eventTime.timestamp) - durationMs
         argumentCaptor<LongTaskEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -6433,7 +6434,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<LongTaskEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
 
             assertThat(firstValue)
                 .apply {
@@ -6740,7 +6741,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -6816,7 +6817,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -6977,7 +6978,7 @@ internal class RumViewScopeTest {
             null
         }
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -7053,7 +7054,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -7128,7 +7129,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -7213,7 +7214,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -7298,7 +7299,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
@@ -7586,7 +7587,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasFlutterBuildTime(ViewEvent.FlutterBuildTime(value, value, value, null))
@@ -7620,7 +7621,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasFlutterBuildTime(null)
@@ -7655,7 +7656,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasFlutterBuildTime(null)
@@ -7717,7 +7718,7 @@ internal class RumViewScopeTest {
         val flutterRasterTimeStats = Arrays.stream(flutterRasterTimes).summaryStatistics()
         val jsFrameTimeStats = Arrays.stream(jsFrameTimes).summaryStatistics()
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasFlutterBuildTime(
@@ -7767,7 +7768,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).hasFeatureFlag(flagName, flagValue)
         }
     }
@@ -7795,7 +7796,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).hasFeatureFlag(flagName, flagValue)
         }
     }
@@ -7848,7 +7849,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<ViewEvent> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).hasFeatureFlag(flagName, flagValue)
         }
     }
@@ -7884,7 +7885,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<Any> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue as ErrorEvent).hasFeatureFlag(flagName, flagValue)
         }
     }
@@ -7912,7 +7913,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).hasFeatureFlag(flagName1, flagValue1)
             assertThat(lastValue).hasFeatureFlag(flagName2, flagValue2)
             assertThat(lastValue).hasFeatureFlag(flagName3, flagValue3)
@@ -7944,7 +7945,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).hasFeatureFlag(flagName1, flagValue1)
             assertThat(lastValue).hasFeatureFlag(flagName2, flagValue2)
             assertThat(lastValue).hasFeatureFlag(flagName3, flagValue3)
@@ -8000,7 +8001,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<ViewEvent> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).hasFeatureFlag(flagName1, flagValue1)
             assertThat(lastValue).hasFeatureFlag(flagName2, flagValue2)
             assertThat(lastValue).hasFeatureFlag(flagName3, flagValue3)
@@ -8041,7 +8042,7 @@ internal class RumViewScopeTest {
 
         // THEN
         argumentCaptor<Any> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue as ErrorEvent).hasFeatureFlag(flagName1, flagValue1)
             assertThat(lastValue as ErrorEvent).hasFeatureFlag(flagName2, flagValue2)
             assertThat(lastValue as ErrorEvent).hasFeatureFlag(flagName3, flagValue3)
@@ -8068,7 +8069,7 @@ internal class RumViewScopeTest {
         assertThat(testedScope.isActive()).isFalse()
 
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue)
                 .apply {
                     hasSessionActive(false)
@@ -8129,7 +8130,7 @@ internal class RumViewScopeTest {
             threads = emptyList(),
             attributes = attributes
         )
-        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>())) doReturn false
+        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>(), eq(EventType.DEFAULT))) doReturn false
 
         // When
         testedScope.handleEvent(fakeEvent, mockWriter)
@@ -8160,7 +8161,7 @@ internal class RumViewScopeTest {
             attributes = attributes
         )
         whenever(
-            mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>())
+            mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>(), eq(EventType.DEFAULT))
         ) doThrow forge.anException()
 
         // When
@@ -8220,7 +8221,7 @@ internal class RumViewScopeTest {
             threads = emptyList(),
             attributes = attributes
         )
-        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>())) doReturn false
+        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>(), eq(EventType.CRASH))) doReturn false
 
         // When
         testedScope.handleEvent(fakeEvent, mockWriter)
@@ -8251,7 +8252,7 @@ internal class RumViewScopeTest {
             attributes = attributes
         )
         whenever(
-            mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>())
+            mockWriter.write(eq(mockEventBatchWriter), isA<ErrorEvent>(), eq(EventType.CRASH))
         ) doThrow forge.anException()
 
         // When
@@ -8291,7 +8292,7 @@ internal class RumViewScopeTest {
             eventTime = Time(),
             applicationStartupNanos = forge.aPositiveLong()
         )
-        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ActionEvent>())) doReturn false
+        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<ActionEvent>(), eq(EventType.DEFAULT))) doReturn false
 
         // When
         testedScope.handleEvent(fakeEvent, mockWriter)
@@ -8312,7 +8313,7 @@ internal class RumViewScopeTest {
             applicationStartupNanos = forge.aPositiveLong()
         )
         whenever(
-            mockWriter.write(eq(mockEventBatchWriter), isA<ActionEvent>())
+            mockWriter.write(eq(mockEventBatchWriter), isA<ActionEvent>(), eq(EventType.DEFAULT))
         ) doThrow forge.anException()
 
         // When
@@ -8348,7 +8349,7 @@ internal class RumViewScopeTest {
         // Given
         testedScope.activeActionScope = mockActionScope
         fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
-        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>())) doReturn false
+        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>(), eq(EventType.DEFAULT))) doReturn false
 
         // When
         testedScope.handleEvent(fakeEvent, mockWriter)
@@ -8368,7 +8369,7 @@ internal class RumViewScopeTest {
         testedScope.activeActionScope = mockActionScope
         fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
         whenever(
-            mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>())
+            mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>(), eq(EventType.DEFAULT))
         ) doThrow forge.anException()
 
         // When
@@ -8404,7 +8405,7 @@ internal class RumViewScopeTest {
         // Given
         testedScope.activeActionScope = mockActionScope
         fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
-        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>())) doReturn false
+        whenever(mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>(), eq(EventType.DEFAULT))) doReturn false
 
         // When
         testedScope.handleEvent(fakeEvent, mockWriter)
@@ -8424,7 +8425,7 @@ internal class RumViewScopeTest {
         testedScope.activeActionScope = mockActionScope
         fakeEvent = RumRawEvent.AddLongTask(durationNs, target)
         whenever(
-            mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>())
+            mockWriter.write(eq(mockEventBatchWriter), isA<LongTaskEvent>(), eq(EventType.DEFAULT))
         ) doThrow forge.anException()
 
         // When
@@ -8466,7 +8467,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue)
                 .apply {
                     hasDuration(1)
@@ -8533,7 +8534,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).containsExactlyContextAttributes(expectedAttributes)
         }
         verifyNoMoreInteractions(mockWriter)
@@ -8584,7 +8585,7 @@ internal class RumViewScopeTest {
         )
 
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).containsExactlyContextAttributes(expectedAttributes)
         }
         verifyNoMoreInteractions(mockWriter)
@@ -8650,7 +8651,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).containsExactlyContextAttributes(expectedAttributes)
         }
         verifyNoMoreInteractions(mockWriter)
@@ -8714,7 +8715,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).containsExactlyContextAttributes(expectedAttributes)
         }
     }
@@ -8789,7 +8790,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).containsExactlyContextAttributes(expectedAttributes)
         }
         verifyNoMoreInteractions(mockWriter)
@@ -8863,7 +8864,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).containsExactlyContextAttributes(expectedAttributes)
         }
     }
@@ -8912,7 +8913,7 @@ internal class RumViewScopeTest {
 
         // Then
         argumentCaptor<ViewEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(lastValue).containsExactlyContextAttributes(expectedAttributes)
         }
         verifyNoMoreInteractions(mockWriter)
@@ -8934,7 +8935,7 @@ internal class RumViewScopeTest {
                 callback.invoke(fakeDatadogContext, mockEventBatchWriter)
             }
         }
-        whenever(mockWriter.write(eq(mockEventBatchWriter), any())) doAnswer {
+        whenever(mockWriter.write(eq(mockEventBatchWriter), any(), eq(EventType.DEFAULT))) doAnswer {
             when (val event = it.getArgument<Any>(1)) {
                 is ViewEvent -> assertDoesNotThrow { event.toJson() }
                 is ErrorEvent -> assertDoesNotThrow { event.toJson() }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.Sampler
@@ -198,7 +199,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryDebugEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertDebugEventMatchesRawEvent(lastValue, debugRawEvent, fakeRumContext)
         }
     }
@@ -224,7 +225,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryDebugEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertDebugEventMatchesRawEvent(lastValue, debugRawEvent, noRumContext)
         }
     }
@@ -243,7 +244,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertErrorEventMatchesRawEvent(lastValue, errorRawEvent, fakeRumContext)
         }
     }
@@ -269,7 +270,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryErrorEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertErrorEventMatchesRawEvent(lastValue, errorRawEvent, noRumContext)
         }
     }
@@ -288,7 +289,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryConfigurationEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent, fakeRumContext)
         }
     }
@@ -314,7 +315,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryConfigurationEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent, noRumContext)
         }
     }
@@ -344,7 +345,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryConfigurationEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent, fakeRumContext)
             assertThat(firstValue)
                 .hasSessionSampleRate(fakeRumConfiguration.sampleRate.toLong())
@@ -372,7 +373,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryConfigurationEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent, fakeRumContext)
             assertThat(firstValue)
                 .hasUseProxy(fakeCoreConfiguration.useProxy)
@@ -404,7 +405,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryConfigurationEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent, fakeRumContext)
             assertThat(firstValue)
                 .hasUseTracing(useTracing)
@@ -438,7 +439,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryConfigurationEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent, fakeRumContext)
             assertThat(firstValue)
                 .hasTrackNetworkRequests(trackNetworkRequests)
@@ -457,7 +458,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryConfigurationEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent)
             assertThat(firstValue).hasSessionReplaySampleRate(null)
             assertThat(firstValue).hasSessionReplayStartManually(null)
@@ -488,7 +489,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryConfigurationEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent)
             assertThat(firstValue).hasSessionReplaySampleRate(fakeSampleRate)
             assertThat(firstValue).hasSessionReplayStartManually(fakeSessionReplayIsStartManually)
@@ -519,7 +520,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<TelemetryConfigurationEvent> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent)
             assertThat(firstValue).hasSessionReplaySampleRate(null)
             assertThat(firstValue).hasSessionReplayStartManually(null)
@@ -561,7 +562,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             if (rawEvent.type == TelemetryType.DEBUG) {
                 assertThat(lastValue).isInstanceOf(TelemetryDebugEvent::class.java)
             } else {
@@ -613,7 +614,7 @@ internal class TelemetryEventHandlerTest {
         )
 
         argumentCaptor<Any> {
-            verify(mockWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             when (val capturedValue = lastValue) {
                 is TelemetryDebugEvent -> {
                     assertDebugEventMatchesRawEvent(capturedValue, rawEvent, fakeRumContext)
@@ -649,7 +650,7 @@ internal class TelemetryEventHandlerTest {
 
         // Then
         argumentCaptor<Any> {
-            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(2)).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             allValues.withIndex().forEach {
                 when (val capturedValue = it.value) {
                     is TelemetryDebugEvent -> {
@@ -708,7 +709,7 @@ internal class TelemetryEventHandlerTest {
 
         argumentCaptor<Any> {
             verify(mockWriter, times(expectedInvocations))
-                .write(eq(mockEventBatchWriter), capture())
+                .write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             allValues.withIndex().forEach {
                 when (val capturedValue = it.value) {
                     is TelemetryDebugEvent -> {
@@ -782,7 +783,8 @@ internal class TelemetryEventHandlerTest {
             mode = times(extraNumber)
         )
         argumentCaptor<Any> {
-            verify(mockWriter, times(expectedInvocations)).write(eq(mockEventBatchWriter), capture())
+            verify(mockWriter, times(expectedInvocations))
+                .write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             allValues.withIndex().forEach {
                 when (val capturedValue = it.value) {
                     is TelemetryDebugEvent -> {
@@ -847,7 +849,7 @@ internal class TelemetryEventHandlerTest {
         // Then
         // if limit would be counted before the sampler, it will be twice less writes
         verify(mockWriter, times(MAX_EVENTS_PER_SESSION_TEST))
-            .write(eq(mockEventBatchWriter), any())
+            .write(eq(mockEventBatchWriter), any(), eq(EventType.TELEMETRY))
         verifyNoInteractions(mockInternalLogger)
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriter.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriter.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.storage
 
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.sessionreplay.internal.RecordCallback
 import com.datadog.android.sessionreplay.internal.SessionReplayFeature
@@ -23,7 +24,12 @@ internal class SessionReplayRecordWriter(
                 val rawBatchEvent = RawBatchEvent(data = serializedRecord)
                 synchronized(this) {
                     @Suppress("ThreadSafety") // called from the worker thread
-                    if (eventBatchWriter.write(rawBatchEvent, batchMetadata = null)) {
+                    if (eventBatchWriter.write(
+                            event = rawBatchEvent,
+                            batchMetadata = null,
+                            eventType = EventType.DEFAULT
+                        )
+                    ) {
                         updateViewSent(record)
                     }
                 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriter.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriter.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.storage
 
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.sessionreplay.internal.ResourcesFeature.Companion.SESSION_REPLAY_RESOURCES_FEATURE_NAME
 import com.datadog.android.sessionreplay.internal.processor.EnrichedResource
@@ -25,7 +26,8 @@ internal class SessionReplayResourcesWriter(
                         data = enrichedResource.resource,
                         metadata = serializedMetadata
                     ),
-                    batchMetadata = null
+                    batchMetadata = null,
+                    eventType = EventType.DEFAULT
                 )
             }
         }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriterTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriterTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.RecordCallback
@@ -62,7 +63,7 @@ internal class SessionReplayRecordWriterTest {
 
     @BeforeEach
     fun `set up`() {
-        whenever(mockEventBatchWriter.write(anyOrNull(), anyOrNull()))
+        whenever(mockEventBatchWriter.write(anyOrNull(), anyOrNull(), any()))
             .thenReturn(true)
 
         whenever(mockSdkCore.getFeature(SessionReplayFeature.SESSION_REPLAY_FEATURE_NAME))
@@ -84,7 +85,11 @@ internal class SessionReplayRecordWriterTest {
         testedWriter.write(fakeRecord)
 
         // Then
-        verify(mockEventBatchWriter).write(RawBatchEvent(data = fakeRecord.toJson().toByteArray()), null)
+        verify(mockEventBatchWriter).write(
+            event = RawBatchEvent(data = fakeRecord.toJson().toByteArray()),
+            batchMetadata = null,
+            eventType = EventType.DEFAULT
+        )
         verifyNoMoreInteractions(mockEventBatchWriter)
 
         verify(mockRecordCallback).onRecordForViewSent(fakeRecord)
@@ -109,7 +114,7 @@ internal class SessionReplayRecordWriterTest {
     @Test
     fun `M not call record callback W write { eventBatchWriter write failed }`(forge: Forge) {
         // Given
-        whenever(mockEventBatchWriter.write(anyOrNull(), anyOrNull()))
+        whenever(mockEventBatchWriter.write(anyOrNull(), anyOrNull(), any()))
             .thenReturn(false)
 
         val fakeRecord = forge.forgeEnrichedRecord()
@@ -122,7 +127,11 @@ internal class SessionReplayRecordWriterTest {
         testedWriter.write(fakeRecord)
 
         // Then
-        verify(mockEventBatchWriter).write(RawBatchEvent(data = fakeRecord.toJson().toByteArray()), null)
+        verify(mockEventBatchWriter).write(
+            event = RawBatchEvent(data = fakeRecord.toJson().toByteArray()),
+            batchMetadata = null,
+            eventType = EventType.DEFAULT
+        )
         verifyNoMoreInteractions(mockEventBatchWriter)
 
         verifyNoMoreInteractions(mockRecordCallback)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriterTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriterTest.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.ResourcesFeature
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.verify
@@ -57,7 +59,7 @@ internal class SessionReplayResourcesWriterTest {
 
     @BeforeEach
     fun setup() {
-        whenever(mockEventBatchWriter.write(anyOrNull(), anyOrNull()))
+        whenever(mockEventBatchWriter.write(anyOrNull(), anyOrNull(), any()))
             .thenReturn(true)
 
         whenever(mockFeatureSdkCore.getFeature(ResourcesFeature.SESSION_REPLAY_RESOURCES_FEATURE_NAME))
@@ -82,8 +84,9 @@ internal class SessionReplayResourcesWriterTest {
         // Then
         val metadataBytearray = fakeEnrichedResource.asBinaryMetadata()
         verify(mockEventBatchWriter).write(
-            RawBatchEvent(data = fakeEnrichedResource.resource, metadata = metadataBytearray),
-            batchMetadata = null
+            event = RawBatchEvent(data = fakeEnrichedResource.resource, metadata = metadataBytearray),
+            batchMetadata = null,
+            eventType = EventType.DEFAULT
         )
     }
 }

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/TraceWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/TraceWriter.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.event.EventMapper
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
@@ -68,7 +69,11 @@ internal class TraceWriter(
                 .serialize(datadogContext, mapped)
                 ?.toByteArray(Charsets.UTF_8) ?: return
             synchronized(this) {
-                writer.write(RawBatchEvent(data = serialized), batchMetadata = null)
+                writer.write(
+                    event = RawBatchEvent(data = serialized),
+                    batchMetadata = null,
+                    eventType = EventType.DEFAULT
+                )
             }
         } catch (@Suppress("TooGenericExceptionCaught") e: Throwable) {
             internalLogger.log(

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/TraceWriterTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/data/TraceWriterTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.event.EventMapper
 import com.datadog.android.trace.internal.domain.event.ContextAwareMapper
@@ -124,7 +125,11 @@ internal class TraceWriterTest {
 
         // THEN
         serializedSpans.forEach {
-            verify(mockEventBatchWriter).write(RawBatchEvent(data = it.toByteArray()), null)
+            verify(mockEventBatchWriter).write(
+                event = RawBatchEvent(data = it.toByteArray()),
+                batchMetadata = null,
+                eventType = EventType.DEFAULT
+            )
         }
         verifyNoMoreInteractions(mockEventBatchWriter)
 
@@ -161,7 +166,11 @@ internal class TraceWriterTest {
 
         // THEN
         serializedSpans.forEach {
-            verify(mockEventBatchWriter).write(RawBatchEvent(data = it.toByteArray()), null)
+            verify(mockEventBatchWriter).write(
+                event = RawBatchEvent(data = it.toByteArray()),
+                batchMetadata = null,
+                eventType = EventType.DEFAULT
+            )
         }
         verifyNoMoreInteractions(mockEventBatchWriter)
 
@@ -193,7 +202,11 @@ internal class TraceWriterTest {
 
         // THEN
         serializedSpans.filterNotNull().forEach {
-            verify(mockEventBatchWriter).write(RawBatchEvent(data = it.toByteArray()), null)
+            verify(mockEventBatchWriter).write(
+                event = RawBatchEvent(data = it.toByteArray()),
+                batchMetadata = null,
+                eventType = EventType.DEFAULT
+            )
         }
         verifyNoMoreInteractions(mockEventBatchWriter)
 
@@ -252,7 +265,11 @@ internal class TraceWriterTest {
         // THEN
         serializedSpans.forEachIndexed { index, serializedSpan ->
             if (index != faultySpanIndex) {
-                verify(mockEventBatchWriter).write(RawBatchEvent(data = serializedSpan.toByteArray()), null)
+                verify(mockEventBatchWriter).write(
+                    event = RawBatchEvent(data = serializedSpan.toByteArray()),
+                    batchMetadata = null,
+                    eventType = EventType.DEFAULT
+                )
             }
         }
         verifyNoMoreInteractions(mockEventBatchWriter)

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.webview.internal.WebViewEventConsumer
@@ -34,7 +35,7 @@ internal class WebViewLogEventConsumer(
                         val rumContext = rumContextProvider.getRumContext(datadogContext)
                         val mappedEvent = map(event.first, datadogContext, rumContext)
                         @Suppress("ThreadSafety") // inside worker thread context
-                        userLogsWriter.write(eventBatchWriter, mappedEvent)
+                        userLogsWriter.write(eventBatchWriter, mappedEvent, EventType.DEFAULT)
                     }
             }
         }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumer.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.webview.internal.WebViewEventConsumer
 import com.datadog.android.webview.internal.rum.WebViewRumEventContextProvider
 import com.datadog.android.webview.internal.rum.domain.RumContext
@@ -42,7 +43,7 @@ internal class WebViewReplayEventConsumer(
                 ) {
                     map(event, datadogContext, rumContext)?.let { mappedEvent ->
                         @Suppress("ThreadSafety") // inside worker thread context
-                        dataWriter.write(eventBatchWriter, mappedEvent)
+                        dataWriter.write(eventBatchWriter, mappedEvent, EventType.DEFAULT)
                     }
                 }
             }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
@@ -12,13 +12,11 @@ import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.webview.internal.WebViewEventConsumer
 import com.datadog.android.webview.internal.replay.WebViewReplayEventConsumer
 import com.datadog.android.webview.internal.rum.domain.RumContext
 import com.google.gson.JsonObject
-import java.lang.IllegalStateException
-import java.lang.NumberFormatException
-import java.lang.UnsupportedOperationException
 
 internal class WebViewRumEventConsumer(
     private val sdkCore: FeatureSdkCore,
@@ -50,7 +48,7 @@ internal class WebViewRumEventConsumer(
                     ) as? Boolean ?: false
                     val mappedEvent = map(event, datadogContext, rumContext, sessionReplayEnabled)
                     @Suppress("ThreadSafety") // inside worker thread context
-                    dataWriter.write(eventBatchWriter, mappedEvent)
+                    dataWriter.write(eventBatchWriter, mappedEvent, EventType.DEFAULT)
                 }
             }
     }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/storage/WebViewDataWriter.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/storage/WebViewDataWriter.kt
@@ -10,6 +10,7 @@ import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.core.persistence.Serializer
 import com.datadog.android.core.persistence.serializeToByteArray
@@ -21,10 +22,16 @@ internal class WebViewDataWriter(
 ) : DataWriter<JsonObject> {
 
     @WorkerThread
-    override fun write(writer: EventBatchWriter, element: JsonObject): Boolean {
+    override fun write(writer: EventBatchWriter, element: JsonObject, eventType: EventType): Boolean {
         // TODO RUM-374 If event is RUM ViewEvent (as Json), we need to store it as last view
         //  event for more precise NDK crash reporting
         val serialized = serializer.serializeToByteArray(element, internalLogger) ?: return false
-        return synchronized(this) { writer.write(RawBatchEvent(data = serialized), batchMetadata = null) }
+        return synchronized(this) {
+            writer.write(
+                event = RawBatchEvent(data = serialized),
+                batchMetadata = null,
+                eventType = eventType
+            )
+        }
     }
 }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/WebViewTrackingTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/WebViewTrackingTest.kt
@@ -16,6 +16,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.api.storage.NoOpDataWriter
 import com.datadog.android.api.storage.RawBatchEvent
 import com.datadog.android.utils.forge.Configurator
@@ -560,7 +561,7 @@ internal class WebViewTrackingTest {
 
         // Then
         argumentCaptor<RawBatchEvent> {
-            verify(mockEventBatchWriter).write(capture(), isNull())
+            verify(mockEventBatchWriter).write(capture(), isNull(), eq(EventType.DEFAULT))
             val capturedJson = String(firstValue.data, Charsets.UTF_8)
             assertThat(capturedJson).isEqualTo(expectedEvent.toString())
         }

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumerTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
@@ -129,7 +130,7 @@ internal class WebViewLogEventConsumerTest {
 
         // Then
         argumentCaptor<JsonObject> {
-            verify(mockUserLogsWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockUserLogsWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).hasField(WebViewLogEventConsumer.DATE_KEY_NAME, expectedDate)
             assertThat(firstValue).hasField(
                 WebViewLogEventConsumer.DDTAGS_KEY_NAME,
@@ -192,7 +193,7 @@ internal class WebViewLogEventConsumerTest {
 
         // Then
         argumentCaptor<JsonObject> {
-            verify(mockUserLogsWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockUserLogsWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).hasField(WebViewLogEventConsumer.DATE_KEY_NAME, expectedDate)
             assertThat(firstValue).hasField(
                 WebViewLogEventConsumer.DDTAGS_KEY_NAME,
@@ -225,7 +226,7 @@ internal class WebViewLogEventConsumerTest {
 
         // Then
         argumentCaptor<JsonObject> {
-            verify(mockUserLogsWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockUserLogsWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).doesNotHaveField(WebViewLogEventConsumer.DATE_KEY_NAME)
             assertThat(firstValue).hasField(
                 WebViewLogEventConsumer.DDTAGS_KEY_NAME,
@@ -245,7 +246,7 @@ internal class WebViewLogEventConsumerTest {
         )
 
         // Then
-        verify(mockUserLogsWriter).write(mockEventBatchWriter, fakeBrokenJsonObject)
+        verify(mockUserLogsWriter).write(mockEventBatchWriter, fakeBrokenJsonObject, EventType.DEFAULT)
     }
 
     @ParameterizedTest
@@ -284,7 +285,7 @@ internal class WebViewLogEventConsumerTest {
 
         // Then
         argumentCaptor<JsonObject> {
-            verify(mockUserLogsWriter).write(eq(mockEventBatchWriter), capture())
+            verify(mockUserLogsWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
             assertThat(firstValue).hasField(WebViewLogEventConsumer.DATE_KEY_NAME, expectedDate)
             assertThat(firstValue).hasField(
                 WebViewLogEventConsumer.DDTAGS_KEY_NAME,

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumerTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog
@@ -141,7 +142,7 @@ internal class WebViewReplayEventConsumerTest {
         testedConsumer.consume(fakeValidBrowserEvent)
 
         // Then
-        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedEvent)
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedEvent, EventType.DEFAULT)
     }
 
     @Test

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumerTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventBatchWriter
+import com.datadog.android.api.storage.EventType
 import com.datadog.android.rum.model.ActionEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.LongTaskEvent
@@ -217,7 +218,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeViewEventAsJson)
 
         // Then
-        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedViewEvent)
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedViewEvent, EventType.DEFAULT)
     }
 
     @Test
@@ -239,7 +240,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeViewEventAsJson)
 
         // Then
-        verify(mockDataWriter, never()).write(any(), any())
+        verify(mockDataWriter, never()).write(any(), any(), any())
     }
 
     // endregion
@@ -293,7 +294,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeActionEventAsJson)
 
         // Then
-        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedActionEvent)
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedActionEvent, EventType.DEFAULT)
     }
 
     @Test
@@ -315,7 +316,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeActionEventAsJson)
 
         // Then
-        verify(mockDataWriter, never()).write(any(), any())
+        verify(mockDataWriter, never()).write(any(), any(), any())
     }
 
     // endregion
@@ -369,7 +370,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeResourceEventAsJson)
 
         // Then
-        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedResourceEvent)
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedResourceEvent, EventType.DEFAULT)
     }
 
     @Test
@@ -391,7 +392,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeResourceEventAsJson)
 
         // Then
-        verify(mockDataWriter, never()).write(any(), any())
+        verify(mockDataWriter, never()).write(any(), any(), any())
     }
 
     // endregion
@@ -445,7 +446,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeErrorEventAsJson)
 
         // Then
-        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedErrorEvent)
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedErrorEvent, EventType.DEFAULT)
     }
 
     @Test
@@ -467,7 +468,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeErrorEventAsJson)
 
         // Then
-        verify(mockDataWriter, never()).write(any(), any())
+        verify(mockDataWriter, never()).write(any(), any(), any())
     }
 
     // endregion
@@ -522,7 +523,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeLongTaskEventAsJson)
 
         // Then
-        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedLongTaskEvent)
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedLongTaskEvent, EventType.DEFAULT)
     }
 
     @Test
@@ -544,7 +545,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeLongTaskEventAsJson)
 
         // Then
-        verify(mockDataWriter, never()).write(any(), any())
+        verify(mockDataWriter, never()).write(any(), any(), any())
     }
 
     // endregion
@@ -572,7 +573,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeRumEvent)
 
         // Then
-        verify(mockDataWriter).write(mockEventBatchWriter, fakeRumEvent)
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeRumEvent, EventType.DEFAULT)
     }
 
     @ParameterizedTest
@@ -620,7 +621,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeRumEvent)
 
         // Then
-        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedRumEvent)
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeMappedRumEvent, EventType.DEFAULT)
     }
 
     @Test
@@ -643,7 +644,7 @@ internal class WebViewRumEventConsumerTest {
         testedConsumer.consume(fakeRumEvent)
 
         // Then
-        verify(mockDataWriter).write(mockEventBatchWriter, fakeRumEvent)
+        verify(mockDataWriter).write(mockEventBatchWriter, fakeRumEvent, EventType.DEFAULT)
     }
 
     @Test

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubFeatureScope.kt
@@ -26,7 +26,7 @@ internal class StubFeatureScope(
 ) : FeatureScope by mockFeatureScope {
 
     private val eventBatchWriter: EventBatchWriter = mock<EventBatchWriter>().also {
-        whenever(it.write(any(), anyOrNull())) doReturn true
+        whenever(it.write(any(), anyOrNull(), any())) doReturn true
     }
 
     private val eventsReceived = mutableListOf<Any>()


### PR DESCRIPTION
### What does this PR do?

Adds an additional flag when writing event to let storage handle those differently. 

### Motivation

Because some users with custom PersistenceStrategy use mainly a memory based storage, they need to know when the app is about to crash in order to persist the data in a way that can be retrieved after an app reboot. 

### Additional Notes

An additional type was created for telemetry, just to be able to distinguish it. 