### PR TITLE
RUM-4561 Delegate Drawable copy to background thread

### DIFF
--- a/features/dd-sdk-android-session-replay/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay/consumer-rules.pro
@@ -5,3 +5,4 @@
 
 # Kept for our internal telemetry
 -keepnames class com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener
+-keepnames class * extends com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
@@ -130,7 +130,11 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
             applicationId = applicationId,
             recordedDataQueueHandler = recordedDataQueueHandler,
             bitmapCachesManager = bitmapCachesManager,
-            drawableUtils = DrawableUtils(internalLogger, bitmapCachesManager),
+            drawableUtils = DrawableUtils(
+                internalLogger,
+                bitmapCachesManager,
+                sdkCore.createSingleThreadExecutorService("drawables")
+            ),
             logger = internalLogger,
             md5HashGenerator = MD5HashGenerator(internalLogger),
             webPImageCompression = WebPImageCompression(internalLogger)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -36,6 +36,7 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
@@ -50,6 +51,7 @@ import org.mockito.quality.Strictness
 import java.util.Locale
 import java.util.UUID
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.ExecutorService
 import java.util.concurrent.TimeUnit
 
 @Extensions(
@@ -76,6 +78,9 @@ internal class SessionReplayFeatureTest {
     lateinit var mockInternalLogger: InternalLogger
 
     @Mock
+    lateinit var mockExecutorService: ExecutorService
+
+    @Mock
     lateinit var mockSampler: Sampler
 
     lateinit var fakeSessionId: String
@@ -88,6 +93,8 @@ internal class SessionReplayFeatureTest {
         whenever(mockSampler.getSampleRate()).thenReturn(fakeSampleRate)
         fakeSessionId = UUID.randomUUID().toString()
         whenever(mockSdkCore.internalLogger) doReturn mockInternalLogger
+        whenever(mockSdkCore.createSingleThreadExecutorService(any())) doReturn mockExecutorService
+
         testedFeature = SessionReplayFeature(
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,


### PR DESCRIPTION
### What does this PR do?

Our previous mechanism of copying a drawable's content was performed on the main thread. 
When starting an app, this would create a lot of main thread task to run. And any new image would also take some of the main thread time, creating a lot of jank frames in any non hello world app. 

This will fix the performance issue some of our customers started to notice when enabling SR.