### PR TITLE
RUM-1462 Fix thread safety warnings

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -7,6 +7,8 @@
 package com.datadog.android
 
 import android.content.Context
+import androidx.annotation.AnyThread
+import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.context.UserInfo
@@ -282,6 +284,7 @@ object Datadog {
      */
     @JvmStatic
     @JvmOverloads
+    @AnyThread
     fun clearAllData(sdkCore: SdkCore = getInstance()) {
         sdkCore.clearAllData()
     }
@@ -293,6 +296,7 @@ object Datadog {
     // stop the SDKs persistence - upload streams and will leave it in an inconsistent state. This
     // method is mainly for test purposes.
     @Suppress("unused")
+    @WorkerThread
     private fun flushAndShutdownExecutors() {
         // Note for the future: if we decide to make this a public feature,
         // we need to drain, execute and flush from a background thread or ensure we're

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/SdkCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/SdkCore.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.api
 
+import androidx.annotation.AnyThread
 import com.datadog.android.api.context.TimeInfo
 import com.datadog.android.api.context.UserInfo
 import com.datadog.android.privacy.TrackingConsent
@@ -37,6 +38,7 @@ interface SdkCore {
      * @param consent which can take one of the values
      * ([TrackingConsent.PENDING], [TrackingConsent.GRANTED], [TrackingConsent.NOT_GRANTED])
      */
+    @AnyThread
     fun setTrackingConsent(consent: TrackingConsent)
 
     /**
@@ -48,6 +50,7 @@ interface SdkCore {
      * @param extraInfo additional information. An extra information can be
      * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
      */
+    @AnyThread
     fun setUserInfo(
         id: String? = null,
         name: String? = null,
@@ -64,10 +67,12 @@ interface SdkCore {
      * @param extraInfo additional information. An extra information can be
      * nested up to 8 levels deep. Keys using more than 8 levels will be sanitized by SDK.
      */
+    @AnyThread
     fun addUserProperties(extraInfo: Map<String, Any?>)
 
     /**
      * Clears all unsent data in all registered features.
      */
+    @AnyThread
     fun clearAllData()
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/feature/FeatureScope.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.api.feature
 
+import androidx.annotation.AnyThread
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.storage.EventBatchWriter
 
@@ -13,6 +14,7 @@ import com.datadog.android.api.storage.EventBatchWriter
  * Represents a Datadog feature.
  */
 interface FeatureScope {
+
     /**
      * Utility to write an event, asynchronously.
      * @param forceNewBatch if `true` forces the [EventBatchWriter] to write in a new file and
@@ -22,6 +24,7 @@ interface FeatureScope {
      * [DatadogContext] will have a state created at the moment this method is called, before the
      * thread switch for the callback invocation.
      */
+    @AnyThread
     fun withWriteContext(
         forceNewBatch: Boolean = false,
         callback: (DatadogContext, EventBatchWriter) -> Unit

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -201,7 +201,6 @@ internal class CoreFeature(
         setupExecutors()
         persistenceExecutorService.submitSafe("NTP Sync initialization", unboundInternalLogger) {
             // Kronos performs I/O operation on startup, it needs to run in background
-            @Suppress("ThreadSafety") // we are in the worker thread context
             initializeClockSync(appContext)
         }
         setupOkHttpClient(configuration.coreConfig)

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -8,6 +8,8 @@ package com.datadog.android.core.internal
 
 import android.app.Application
 import android.content.Context
+import androidx.annotation.AnyThread
+import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
@@ -112,8 +114,8 @@ internal class SdkFeature(
         return initialized.get()
     }
 
+    @AnyThread
     fun clearAllData() {
-        @Suppress("ThreadSafety") // TODO RUM-3756 delegate to another thread
         storage.dropAll()
     }
 
@@ -344,6 +346,7 @@ internal class SdkFeature(
     // endregion
 
     // Used for nightly tests only
+    @WorkerThread
     internal fun flushStoredData() {
         val flusher = DataFlusher(
             coreFeature.contextProvider,
@@ -353,7 +356,6 @@ internal class SdkFeature(
             FileMover(internalLogger),
             internalLogger
         )
-        @Suppress("ThreadSafety") // TODO RUM-1462 address Thread safety
         flusher.flush(uploader)
     }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/net/info/BroadcastReceiverNetworkInfoProvider.kt
@@ -54,8 +54,6 @@ internal class BroadcastReceiverNetworkInfoProvider(
     override fun register(context: Context) {
         val filter = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
         registerReceiver(context, filter).also {
-            // TODO RUM-1462 address Thread safety
-            @Suppress("ThreadSafety") // Treatment should be fast enough
             onReceive(context, it)
         }
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/AbstractStorage.kt
@@ -110,8 +110,8 @@ internal class AbstractStorage(
         }
     }
 
+    @AnyThread
     override fun dropAll() {
-        @Suppress("ThreadSafety") // TODO RUM-1462 address Thread safety
         executorService.submitSafe("Data drop", internalLogger) {
             grantedPersistenceStrategy.dropAll()
             pendingPersistenceStrategy.dropAll()
@@ -126,7 +126,6 @@ internal class AbstractStorage(
         previousConsent: TrackingConsent,
         newConsent: TrackingConsent
     ) {
-        @Suppress("ThreadSafety") // TODO RUM-1462 address Thread safety
         executorService.submitSafe("Data migration", internalLogger) {
             if (previousConsent == TrackingConsent.PENDING) {
                 when (newConsent) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/Storage.kt
@@ -57,5 +57,6 @@ internal interface Storage {
     /**
      * Removes all the files backed by this storage, synchronously.
      */
+    @AnyThread
     fun dropAll()
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
@@ -90,7 +90,6 @@ internal open class ConsentAwareFileOrchestrator(
         val previousOrchestrator = resolveDelegateOrchestrator(previousConsent)
         val newOrchestrator = resolveDelegateOrchestrator(newConsent)
         executorService.submitSafe("Data migration", internalLogger) {
-            @Suppress("ThreadSafety") // we are in the worker thread context
             dataMigrator.migrateData(
                 previousConsent,
                 previousOrchestrator,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/ndk/internal/DatadogNdkCrashHandler.kt
@@ -51,7 +51,6 @@ internal class DatadogNdkCrashHandler(
 
     override fun prepareData() {
         dataPersistenceExecutorService.submitSafe("NDK crash check", internalLogger) {
-            @Suppress("ThreadSafety") // TODO RUM-1462 address Thread safety
             readCrashData()
         }
     }
@@ -61,7 +60,6 @@ internal class DatadogNdkCrashHandler(
         reportTarget: NdkCrashHandler.ReportTarget
     ) {
         dataPersistenceExecutorService.submitSafe("NDK crash report ", internalLogger) {
-            @Suppress("ThreadSafety") // TODO RUM-1462 address Thread safety
             checkAndHandleNdkCrashReport(sdkCore, reportTarget)
         }
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -78,6 +78,7 @@ import org.mockito.quality.Strictness
 import java.util.Collections
 import java.util.Locale
 import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Future
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -728,6 +729,13 @@ internal class DatadogCoreTest {
         )
         val mockCoreFeature = mock<CoreFeature>()
         testedCore.coreFeature = mockCoreFeature
+        val mockExecutorService: FlushableExecutorService = mock()
+        whenever(mockCoreFeature.persistenceExecutorService) doReturn mockExecutorService
+        whenever(mockExecutorService.submit(any())) doAnswer {
+            val runnable = it.arguments.first() as Runnable
+            runnable.run()
+            mock<Future<*>>()
+        }
 
         // When
         testedCore.clearAllData()

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -90,6 +90,15 @@ datadog:
     - '**/reliability/**'
     - '**/sample/**'
     - '**/tools/**'
+  ThreadSafety:
+    active: true
+    workerThreadSwitchingCalls:
+      - "com.datadog.android.core.internal.utils.submitSafe"
+      - "com.datadog.android.core.internal.utils.executeSafe"
+      - "com.datadog.android.core.internal.utils.scheduleSafe"
+      - "com.datadog.android.api.feature.FeatureScope.withWriteContext"
+    mainThreadSwitchingCalls:
+      - "android.widget.LinearLayout.post"
   TodoWithoutTask:
     active: true
     deprecatedPrefixes:

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/LogsFeature.kt
@@ -192,7 +192,6 @@ internal class LogsFeature(
                     tags = emptySet()
                 )
 
-                @Suppress("ThreadSafety") // called in a worker thread context
                 dataWriter.write(eventBatchWriter, log, EventType.CRASH)
                 lock.countDown()
             }
@@ -249,7 +248,6 @@ internal class LogsFeature(
                     tags = emptySet()
                 )
 
-                @Suppress("ThreadSafety") // called in a worker thread context
                 dataWriter.write(eventBatchWriter, log, EventType.CRASH)
             }
     }
@@ -290,7 +288,6 @@ internal class LogsFeature(
                     tags = emptySet()
                 )
 
-                @Suppress("ThreadSafety") // called in a worker thread context
                 dataWriter.write(eventBatchWriter, log, EventType.DEFAULT)
             }
     }

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -67,7 +67,6 @@ internal class DatadogLogHandler(
                         resolvedTimeStamp
                     )
                     if (log != null) {
-                        @Suppress("ThreadSafety") // called in a worker thread context
                         writer.write(eventBatchWriter, log, EventType.DEFAULT)
                     }
                 }
@@ -141,7 +140,6 @@ internal class DatadogLogHandler(
                         resolvedTimeStamp
                     )
                     if (log != null) {
-                        @Suppress("ThreadSafety") // called in a worker thread context
                         writer.write(eventBatchWriter, log, EventType.DEFAULT)
                     }
                 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/DatadogLateCrashReporter.kt
@@ -89,11 +89,9 @@ internal class DatadogLateCrashReporter(
                 null,
                 lastViewEvent
             )
-            @Suppress("ThreadSafety") // called in a worker thread context
             rumWriter.write(eventBatchWriter, toSendErrorEvent, EventType.CRASH)
             if (lastViewEvent.isWithinSessionAvailability) {
                 val updatedViewEvent = updateViewEvent(lastViewEvent)
-                @Suppress("ThreadSafety") // called in a worker thread context
                 rumWriter.write(eventBatchWriter, updatedViewEvent, EventType.CRASH)
             }
         }
@@ -144,14 +142,11 @@ internal class DatadogLateCrashReporter(
                     threadDumps,
                     lastViewEvent
                 )
-                @Suppress("ThreadSafety") // called in a worker thread context
                 rumWriter.write(eventBatchWriter, toSendErrorEvent, EventType.CRASH)
                 if (lastViewEvent.isWithinSessionAvailability) {
                     val updatedViewEvent = updateViewEvent(lastViewEvent)
-                    @Suppress("ThreadSafety") // called in a worker thread context
                     rumWriter.write(eventBatchWriter, updatedViewEvent, EventType.CRASH)
                 }
-                @Suppress("ThreadSafety") // called in a worker thread context
                 sdkCore.writeLastFatalAnrSent(anrExitInfo.timestamp)
             }
         }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -637,11 +637,7 @@ internal class DatadogRumMonitor(
                 rootScope.handleEvent(event, writer)
             }
         } else if (event is RumRawEvent.SendTelemetry) {
-            // If an issue arise, use the unbound logger to prevent a cycle that would lead
-            // to a stack overflow
-            executorService.submitSafe("Telemetry event handling", InternalLogger.UNBOUND) {
-                telemetryEventHandler.handleEvent(event, writer)
-            }
+            telemetryEventHandler.handleEvent(event, writer)
         } else {
             handler.removeCallbacks(keepAliveRunnable)
             // avoid trowing a RejectedExecutionException

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/SdkCoreExt.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/utils/SdkCoreExt.kt
@@ -58,7 +58,6 @@ internal class WriteOperation(
                     try {
                         val event = eventSource(datadogContext)
 
-                        @Suppress("ThreadSafety") // called in a worker thread context
                         val isSuccess = rumDataWriter.write(eventBatchWriter, event, eventType)
                         if (isSuccess) {
                             advancedRumMonitor?.let {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.telemetry.internal
 
-import androidx.annotation.WorkerThread
+import androidx.annotation.AnyThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.context.DatadogContext
 import com.datadog.android.api.feature.Feature
@@ -40,7 +40,7 @@ internal class TelemetryEventHandler(
 
     private val seenInCurrentSession = mutableSetOf<TelemetryEventId>()
 
-    @WorkerThread
+    @AnyThread
     fun handleEvent(
         event: RumRawEvent.SendTelemetry,
         writer: DataWriter<Any>

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/internal/SliderWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/internal/SliderWireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.material.internal
 
 import android.content.res.ColorStateList
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -27,6 +28,7 @@ internal open class SliderWireframeMapper(
 ) : WireframeMapper<Slider> {
 
     @Suppress("LongMethod")
+    @UiThread
     override fun map(
         view: Slider,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/internal/TabWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/internal/TabWireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.material.internal
 
 import android.widget.TextView
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -42,6 +43,7 @@ internal open class TabWireframeMapper(
         )
     )
 
+    @UiThread
     override fun map(
         view: TabView,
         mappingContext: MappingContext,
@@ -104,6 +106,7 @@ internal open class TabWireframeMapper(
         )
     }
 
+    @UiThread
     private fun findAndResolveLabelWireframes(
         view: TabView,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -93,7 +93,6 @@ internal class SessionReplayFeature(
         dataWriter = createDataWriter()
         sessionReplayRecorder =
             recorderProvider.provideSessionReplayRecorder(resourcesFeature.dataWriter, dataWriter, appContext)
-        @Suppress("ThreadSafety") // TODO RUM-1462 can be called from any thread
         sessionReplayRecorder.registerCallbacks()
         initialized.set(true)
         sdkCore.updateFeatureContext(SESSION_REPLAY_FEATURE_NAME) {
@@ -222,7 +221,6 @@ internal class SessionReplayFeature(
             sdkCore.updateFeatureContext(SESSION_REPLAY_FEATURE_NAME) {
                 it[SESSION_REPLAY_ENABLED_KEY] = true
             }
-            @Suppress("ThreadSafety") // TODO RUM-1462 can be called from any thread
             sessionReplayRecorder.resumeRecorders()
         }
     }
@@ -240,7 +238,6 @@ internal class SessionReplayFeature(
             sdkCore.updateFeatureContext(SESSION_REPLAY_FEATURE_NAME) {
                 it[SESSION_REPLAY_ENABLED_KEY] = false
             }
-            @Suppress("ThreadSafety") // TODO RUM-1462 can be called from any thread
             sessionReplayRecorder.stopRecorders()
         }
     }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.UiThread
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -23,6 +24,7 @@ internal class SnapshotProducer(
     private val optionSelectorDetector: OptionSelectorDetector
 ) {
 
+    @UiThread
     fun produce(
         rootView: View,
         systemInformation: SystemInformation,
@@ -38,6 +40,7 @@ internal class SnapshotProducer(
     }
 
     @Suppress("ComplexMethod", "ReturnCount")
+    @UiThread
     private fun convertViewToNode(
         view: View,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 
 import android.view.View
 import android.view.ViewGroup
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.measureMethodCallPerf
 import com.datadog.android.sessionreplay.MapperTypeWrapper
@@ -29,6 +30,7 @@ internal class TreeViewTraversal(
 ) {
 
     @Suppress("ReturnCount")
+    @UiThread
     fun traverse(
         view: View,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ActionBarContainerMapper.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
+import androidx.annotation.UiThread
 import androidx.appcompat.widget.ActionBarContainer
 import androidx.appcompat.widget.DatadogActionBarContainerAccessor
 import com.datadog.android.api.InternalLogger
@@ -30,6 +31,7 @@ internal class ActionBarContainerMapper(
     drawableToColorMapper
 ) {
 
+    @UiThread
     override fun map(
         view: ActionBarContainer,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.widget.Button
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -18,6 +19,7 @@ internal class ButtonMapper(
     private val textWireframeMapper: TextViewMapper<Button>
 ) : WireframeMapper<Button> {
 
+    @UiThread
     override fun map(
         view: Button,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableCompoundButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableCompoundButtonMapper.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.os.Build
 import android.widget.CompoundButton
+import androidx.annotation.UiThread
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.recorder.mapper.TextViewMapper
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
@@ -32,6 +33,7 @@ internal abstract class CheckableCompoundButtonMapper<T : CompoundButton>(
 
     // region CheckableTextViewMapper
 
+    @UiThread
     override fun resolveCheckableBounds(view: T, pixelsDensity: Float): GlobalBounds {
         val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(view, pixelsDensity)
         var checkBoxHeight = DEFAULT_CHECKABLE_HEIGHT_IN_PX

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.widget.Checkable
 import android.widget.TextView
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -35,6 +36,7 @@ internal abstract class CheckableTextViewMapper<T>(
 
     // region CheckableWireframeMapper
 
+    @UiThread
     override fun resolveMainWireframes(
         view: T,
         mappingContext: MappingContext,
@@ -44,6 +46,7 @@ internal abstract class CheckableTextViewMapper<T>(
         return textWireframeMapper.map(view, mappingContext, asyncJobStatusCallback, internalLogger)
     }
 
+    @UiThread
     override fun resolveCheckedCheckable(
         view: T,
         mappingContext: MappingContext
@@ -72,6 +75,7 @@ internal abstract class CheckableTextViewMapper<T>(
         )
     }
 
+    @UiThread
     override fun resolveNotCheckedCheckable(
         view: T,
         mappingContext: MappingContext
@@ -100,6 +104,7 @@ internal abstract class CheckableTextViewMapper<T>(
         )
     }
 
+    @UiThread
     override fun resolveMaskedCheckable(view: T, mappingContext: MappingContext): List<MobileSegment.Wireframe>? {
         return resolveNotCheckedCheckable(view, mappingContext)
     }
@@ -108,6 +113,7 @@ internal abstract class CheckableTextViewMapper<T>(
 
     // region CheckableTextViewMapper
 
+    @UiThread
     abstract fun resolveCheckableBounds(view: T, pixelsDensity: Float): GlobalBounds
 
     protected open fun resolveCheckableColor(view: T): String {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.view.View
 import android.widget.Checkable
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -31,6 +32,7 @@ internal abstract class CheckableWireframeMapper<T>(
     drawableToColorMapper
 ) where T : View, T : Checkable {
 
+    @UiThread
     override fun map(
         view: T,
         mappingContext: MappingContext,
@@ -51,6 +53,7 @@ internal abstract class CheckableWireframeMapper<T>(
         return mainWireframes
     }
 
+    @UiThread
     abstract fun resolveMainWireframes(
         view: T,
         mappingContext: MappingContext,
@@ -58,16 +61,19 @@ internal abstract class CheckableWireframeMapper<T>(
         internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe>
 
+    @UiThread
     abstract fun resolveMaskedCheckable(
         view: T,
         mappingContext: MappingContext
     ): List<MobileSegment.Wireframe>?
 
+    @UiThread
     abstract fun resolveNotCheckedCheckable(
         view: T,
         mappingContext: MappingContext
     ): List<MobileSegment.Wireframe>?
 
+    @UiThread
     abstract fun resolveCheckedCheckable(
         view: T,
         mappingContext: MappingContext

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckedTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckedTextViewMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.widget.CheckedTextView
+import androidx.annotation.UiThread
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.recorder.mapper.TextViewMapper
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
@@ -32,11 +33,13 @@ internal open class CheckedTextViewMapper(
 
     // region CheckableTextViewMapper
 
+    @UiThread
     override fun resolveCheckableColor(view: CheckedTextView): String {
         val color = view.checkMarkTintList?.defaultColor ?: view.currentTextColor
         return colorStringFormatter.formatColorAndAlphaAsHexString(color, OPAQUE_ALPHA_VALUE)
     }
 
+    @UiThread
     override fun resolveCheckableBounds(view: CheckedTextView, pixelsDensity: Float): GlobalBounds {
         val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(view, pixelsDensity)
         val textViewPaddingRight =

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/DecorViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/DecorViewMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.view.View
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -22,6 +23,7 @@ internal class DecorViewMapper(
     private val viewIdentifierResolver: ViewIdentifierResolver = DefaultViewIdentifierResolver
 ) : WireframeMapper<View> {
 
+    @UiThread
     override fun map(
         view: View,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.widget.ImageView
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.internal.utils.ImageViewUtils
@@ -32,6 +33,7 @@ internal class ImageViewMapper(
     viewBoundsResolver,
     drawableToColorMapper
 ) {
+    @UiThread
     override fun map(
         view: ImageView,
         mappingContext: MappingContext,
@@ -59,7 +61,6 @@ internal class ImageViewMapper(
 
         if (contentDrawable != null) {
             // resolve foreground
-            @Suppress("ThreadSafety") // TODO RUM-1462 caller thread of .map is unknown?
             mappingContext.imageWireframeHelper.createImageWireframe(
                 view = view,
                 currentWireframeIndex = wireframes.size,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/NumberPickerMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/NumberPickerMapper.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 import android.os.Build
 import android.widget.NumberPicker
 import androidx.annotation.RequiresApi
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -34,6 +35,7 @@ internal open class NumberPickerMapper(
     drawableToColorMapper
 ) {
 
+    @UiThread
     override fun map(
         view: NumberPicker,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/RadioButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/RadioButtonMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.widget.RadioButton
+import androidx.annotation.UiThread
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.mapper.TextViewMapper
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
@@ -30,6 +31,7 @@ internal open class RadioButtonMapper(
 
     // region CheckableTextViewMapper
 
+    @UiThread
     override fun resolveCheckedShapeStyle(view: RadioButton, checkBoxColor: String): MobileSegment.ShapeStyle? {
         return MobileSegment.ShapeStyle(
             backgroundColor = checkBoxColor,
@@ -38,6 +40,7 @@ internal open class RadioButtonMapper(
         )
     }
 
+    @UiThread
     override fun resolveNotCheckedShapeStyle(view: RadioButton, checkBoxColor: String): MobileSegment.ShapeStyle? {
         return MobileSegment.ShapeStyle(
             backgroundColor = null,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapper.kt
@@ -12,6 +12,7 @@ import android.os.Build
 import android.os.Build.VERSION
 import android.widget.SeekBar
 import androidx.annotation.RequiresApi
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
@@ -39,7 +40,7 @@ internal open class SeekBarWireframeMapper(
     viewBoundsResolver,
     drawableToColorMapper
 ) {
-
+    @UiThread
     override fun map(
         view: SeekBar,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.graphics.Rect
+import androidx.annotation.UiThread
 import androidx.appcompat.widget.SwitchCompat
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
@@ -36,6 +37,7 @@ internal open class SwitchCompatMapper(
 
     // region CheckableWireframeMapper
 
+    @UiThread
     override fun resolveMainWireframes(
         view: SwitchCompat,
         mappingContext: MappingContext,
@@ -46,6 +48,7 @@ internal open class SwitchCompatMapper(
     }
 
     @Suppress("ReturnCount")
+    @UiThread
     override fun resolveCheckedCheckable(
         view: SwitchCompat,
         mappingContext: MappingContext
@@ -96,6 +99,7 @@ internal open class SwitchCompatMapper(
         return wireframes
     }
 
+    @UiThread
     override fun resolveNotCheckedCheckable(
         view: SwitchCompat,
         mappingContext: MappingContext
@@ -146,6 +150,7 @@ internal open class SwitchCompatMapper(
         return wireframes
     }
 
+    @UiThread
     override fun resolveMaskedCheckable(
         view: SwitchCompat,
         mappingContext: MappingContext

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/UnsupportedViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/UnsupportedViewMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.view.View
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.ViewUtilsInternal
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -30,6 +31,7 @@ internal class UnsupportedViewMapper(
     drawableToColorMapper
 ) {
 
+    @UiThread
     override fun map(
         view: View,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ViewWireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.view.View
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -28,7 +29,7 @@ internal class ViewWireframeMapper(
     viewBoundsResolver,
     drawableToColorMapper
 ) {
-
+    @UiThread
     override fun map(
         view: View,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WebViewWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/WebViewWireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.webkit.WebView
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -29,6 +30,7 @@ internal class WebViewWireframeMapper(
     drawableToColorMapper
 ) {
 
+    @UiThread
     override fun map(
         view: WebView,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
@@ -12,7 +12,7 @@ import android.graphics.drawable.InsetDrawable
 import android.graphics.drawable.LayerDrawable
 import android.view.View
 import android.widget.TextView
-import androidx.annotation.MainThread
+import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.ViewUtilsInternal
@@ -36,7 +36,7 @@ internal class DefaultImageWireframeHelper(
 ) : ImageWireframeHelper {
 
     @Suppress("ReturnCount")
-    @MainThread
+    @UiThread
     override fun createImageWireframe(
         view: View,
         currentWireframeIndex: Int,
@@ -130,6 +130,7 @@ internal class DefaultImageWireframeHelper(
     }
 
     @Suppress("NestedBlockDepth")
+    @UiThread
     override fun createCompoundDrawableWireframes(
         textView: TextView,
         mappingContext: MappingContext,
@@ -160,7 +161,6 @@ internal class DefaultImageWireframeHelper(
                     pixelsDensity = density,
                     position = compoundDrawablePosition
                 )
-                @Suppress("ThreadSafety") // TODO RUM-1462 caller thread of .map is unknown?
                 createImageWireframe(
                     view = textView,
                     currentWireframeIndex = ++wireframeIndex,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolver.kt
@@ -70,7 +70,6 @@ internal class ResourceResolver(
 
         // do in the background
         threadPoolExecutor.executeSafe("resolveResourceId", logger) {
-            @Suppress("ThreadSafety") // this runs inside an executor
             createBitmap(
                 resources = resources,
                 drawable = drawable,
@@ -192,6 +191,7 @@ internal class ResourceResolver(
             drawableHeight = drawableHeight,
             displayMetrics = displayMetrics,
             bitmapCreationCallback = object : BitmapCreationCallback {
+                @WorkerThread
                 override fun onReady(bitmap: Bitmap) {
                     val compressedBitmapBytes = webPImageCompression.compressBitmap(bitmap)
 
@@ -201,7 +201,6 @@ internal class ResourceResolver(
                         return
                     }
 
-                    @Suppress("ThreadSafety") // this runs inside an executor
                     resolveResourceHash(
                         drawable = drawable,
                         bitmap = bitmap,
@@ -211,6 +210,7 @@ internal class ResourceResolver(
                     )
                 }
 
+                @WorkerThread
                 override fun onFailure() {
                     resolveResourceCallback.onFailed()
                 }
@@ -272,7 +272,11 @@ internal class ResourceResolver(
     // endregion
 
     internal interface BitmapCreationCallback {
+
+        @WorkerThread
         fun onReady(bitmap: Bitmap)
+
+        @WorkerThread
         fun onFailure()
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriter.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayRecordWriter.kt
@@ -23,7 +23,6 @@ internal class SessionReplayRecordWriter(
                 val serializedRecord = record.toJson().toByteArray(Charsets.UTF_8)
                 val rawBatchEvent = RawBatchEvent(data = serializedRecord)
                 synchronized(this) {
-                    @Suppress("ThreadSafety") // called from the worker thread
                     if (eventBatchWriter.write(
                             event = rawBatchEvent,
                             batchMetadata = null,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriter.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/storage/SessionReplayResourcesWriter.kt
@@ -20,7 +20,6 @@ internal class SessionReplayResourcesWriter(
         sdkCore.getFeature(SESSION_REPLAY_RESOURCES_FEATURE_NAME)?.withWriteContext() { _, eventBatchWriter ->
             synchronized(this) {
                 val serializedMetadata = enrichedResource.asBinaryMetadata()
-                @Suppress("ThreadSafety") // called from the worker thread
                 eventBatchWriter.write(
                     event = RawBatchEvent(
                         data = enrichedResource.resource,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/DrawableUtils.kt
@@ -13,7 +13,6 @@ import android.graphics.Color
 import android.graphics.PorterDuff
 import android.graphics.drawable.Drawable
 import android.util.DisplayMetrics
-import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import androidx.annotation.WorkerThread
 import com.datadog.android.api.InternalLogger
@@ -55,11 +54,10 @@ internal class DrawableUtils(
             requestedSizeInBytes,
             displayMetrics,
             config,
-            resizeBitmapCallback = object :
-                ResizeBitmapCallback {
+            resizeBitmapCallback = object : ResizeBitmapCallback {
+                @WorkerThread
                 override fun onSuccess(bitmap: Bitmap) {
                     executorService.submitSafe("drawOnCanvas", internalLogger) {
-                        @Suppress("ThreadSafety") // this runs on a background thread
                         drawOnCanvas(
                             resources,
                             bitmap,
@@ -69,6 +67,7 @@ internal class DrawableUtils(
                     }
                 }
 
+                @WorkerThread
                 override fun onFailure() {
                     internalLogger.log(
                         InternalLogger.Level.ERROR,
@@ -95,11 +94,14 @@ internal class DrawableUtils(
     }
 
     internal interface ResizeBitmapCallback {
+        @WorkerThread
         fun onSuccess(bitmap: Bitmap)
+
+        @WorkerThread
         fun onFailure()
     }
 
-    @MainThread
+    @WorkerThread
     private fun drawOnCanvas(
         resources: Resources,
         bitmap: Bitmap,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseAsyncBackgroundWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseAsyncBackgroundWireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.recorder.mapper
 
 import android.view.View
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -44,6 +45,7 @@ abstract class BaseAsyncBackgroundWireframeMapper<in T : View> internal construc
 
     private var uniqueIdentifierGenerator = DefaultViewIdentifierResolver
 
+    @UiThread
     override fun map(
         view: T,
         mappingContext: MappingContext,
@@ -55,6 +57,7 @@ abstract class BaseAsyncBackgroundWireframeMapper<in T : View> internal construc
         return backgroundWireframe?.let { listOf(it) } ?: emptyList()
     }
 
+    @UiThread
     private fun resolveViewBackground(
         view: View,
         mappingContext: MappingContext,
@@ -112,6 +115,7 @@ abstract class BaseAsyncBackgroundWireframeMapper<in T : View> internal construc
         )
     }
 
+    @UiThread
     private fun resolveBackgroundAsImageWireframe(
         view: View,
         bounds: GlobalBounds,
@@ -124,7 +128,6 @@ abstract class BaseAsyncBackgroundWireframeMapper<in T : View> internal construc
 
         val drawableCopy = view.background?.constantState?.newDrawable(resources)
         return if (drawableCopy != null) {
-            @Suppress("ThreadSafety") // TODO RUM-1462 caller thread of .map is unknown?
             mappingContext.imageWireframeHelper.createImageWireframe(
                 view = view,
                 currentWireframeIndex = 0,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapper.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.recorder.mapper
 import android.graphics.Typeface
 import android.view.Gravity
 import android.widget.TextView
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
@@ -38,6 +39,7 @@ open class TextViewMapper<in T : TextView>(
     drawableToColorMapper
 ) {
 
+    @UiThread
     override fun map(
         view: T,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/WireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/WireframeMapper.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.recorder.mapper
 
 import android.view.View
+import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -35,6 +36,7 @@ interface WireframeMapper<in T : View> {
      * @see MobileSegment.Wireframe
      * @see SystemInformation
      */
+    @UiThread
     fun map(
         view: T,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/ImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/ImageWireframeHelper.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.utils
 import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.TextView
+import androidx.annotation.UiThread
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 
@@ -54,6 +55,7 @@ interface ImageWireframeHelper {
      * Creates the wireframes for the compound drawables in a [TextView].
      * @param
      */
+    @UiThread
     fun createCompoundDrawableWireframes(
         textView: TextView,
         mappingContext: MappingContext,

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
@@ -53,7 +53,6 @@ import java.util.concurrent.ConcurrentLinkedQueue
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.ExecutorService
 import java.util.concurrent.LinkedBlockingDeque
-import java.util.concurrent.RejectedExecutionException
 import java.util.concurrent.ThreadPoolExecutor
 import java.util.concurrent.TimeUnit
 
@@ -134,39 +133,6 @@ internal class RecordedDataQueueHandlerTest {
             executorService = spyExecutorService,
             internalLogger = mockInternalLogger,
             recordedQueue = fakeRecordedDataQueue
-        )
-    }
-
-    @ParameterizedTest
-    @ValueSource(
-        classes = [
-            NullPointerException::class,
-            RejectedExecutionException::class
-        ]
-    )
-    fun `M log exception W executor service throws`(exceptionType: Class<Throwable>) {
-        // Given
-        val fakeThrowable = exceptionType.getDeclaredConstructor().newInstance()
-        val mockExecutorService = mock<ExecutorService>()
-        testedHandler = RecordedDataQueueHandler(
-            processor = mockProcessor,
-            rumContextDataHandler = mockRumContextDataHandler,
-            timeProvider = mockTimeProvider,
-            executorService = mockExecutorService,
-            internalLogger = mockInternalLogger
-        )
-        testedHandler.recordedDataQueue.add(fakeSnapshotQueueItem)
-        whenever(mockExecutorService.execute(any())).thenThrow(fakeThrowable)
-
-        // When
-        testedHandler.tryToConsumeItems()
-
-        // Then
-        mockInternalLogger.verifyLog(
-            InternalLogger.Level.ERROR,
-            InternalLogger.Target.MAINTAINER,
-            RecordedDataQueueHandler.FAILED_TO_CONSUME_RECORDS_QUEUE_ERROR_MESSAGE,
-            fakeThrowable
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListenerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListenerTest.kt
@@ -41,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -253,7 +254,9 @@ internal class WindowsOnDrawListenerTest {
                 "Capture Record"
             )
         ).thenReturn(mockPerformanceMetric)
-        whenever(mockDebouncer.debounce(any())).then { (it.arguments[0] as Runnable).run() }
+        whenever(mockDebouncer.debounce(any())) doAnswer {
+            (it.arguments[0] as Runnable).run()
+        }
         whenever(mockRecordedDataQueueHandler.addSnapshotItem(any<SystemInformation>()))
             .thenReturn(fakeSnapshotQueueItem)
 

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/TraceWriter.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/data/TraceWriter.kt
@@ -40,7 +40,6 @@ internal class TraceWriter(
         sdkCore.getFeature(Feature.TRACING_FEATURE_NAME)
             ?.withWriteContext { datadogContext, eventBatchWriter ->
                 trace.forEach { span ->
-                    @Suppress("ThreadSafety") // called in the worker context
                     writeSpan(datadogContext, eventBatchWriter, span)
                 }
             }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
@@ -34,7 +34,6 @@ internal class WebViewLogEventConsumer(
                     ?.withWriteContext { datadogContext, eventBatchWriter ->
                         val rumContext = rumContextProvider.getRumContext(datadogContext)
                         val mappedEvent = map(event.first, datadogContext, rumContext)
-                        @Suppress("ThreadSafety") // inside worker thread context
                         userLogsWriter.write(eventBatchWriter, mappedEvent, EventType.DEFAULT)
                     }
             }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/replay/WebViewReplayEventConsumer.kt
@@ -42,7 +42,6 @@ internal class WebViewReplayEventConsumer(
                     sessionReplayEnabled
                 ) {
                     map(event, datadogContext, rumContext)?.let { mappedEvent ->
-                        @Suppress("ThreadSafety") // inside worker thread context
                         dataWriter.write(eventBatchWriter, mappedEvent, EventType.DEFAULT)
                     }
                 }

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/rum/WebViewRumEventConsumer.kt
@@ -47,7 +47,6 @@ internal class WebViewRumEventConsumer(
                         WebViewReplayEventConsumer.SESSION_REPLAY_ENABLED_KEY
                     ) as? Boolean ?: false
                     val mappedEvent = map(event, datadogContext, rumContext, sessionReplayEnabled)
-                    @Suppress("ThreadSafety") // inside worker thread context
                     dataWriter.write(eventBatchWriter, mappedEvent, EventType.DEFAULT)
                 }
             }

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/DatadogProvider.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/DatadogProvider.kt
@@ -34,7 +34,7 @@ class DatadogProvider : RuleSetProvider {
                 InvalidStringFormat(),
                 PackageNameVisibility(config),
                 RequireInternal(),
-                ThreadSafety(),
+                ThreadSafety(config),
                 ThrowingInternalException(),
                 TodoWithoutTask(config),
                 UnsafeCallOnNullableType(),

--- a/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/ThreadSafetyTest.kt
+++ b/tools/detekt/src/test/kotlin/com/datadog/tools/detekt/rules/sdk/ThreadSafetyTest.kt
@@ -10,6 +10,8 @@ import android.webkit.JavascriptInterface
 import androidx.annotation.MainThread
 import io.github.detekt.test.utils.KotlinCoreEnvironmentWrapper
 import io.github.detekt.test.utils.createEnvironment
+import io.gitlab.arturbosch.detekt.api.Config
+import io.gitlab.arturbosch.detekt.test.TestConfig
 import io.gitlab.arturbosch.detekt.test.assertThat
 import io.gitlab.arturbosch.detekt.test.compileAndLintWithContext
 import org.junit.jupiter.api.AfterEach
@@ -21,8 +23,11 @@ class ThreadSafetyTest {
 
     lateinit var kotlinEnv: KotlinCoreEnvironmentWrapper
 
+    lateinit var fakeConfig: Config
+
     @BeforeEach
     fun setup() {
+        fakeConfig = TestConfig()
         kotlinEnv = createEnvironment(
             // by some reason all Android-related classes are not discovered by DetektKt compiler,
             // so need to add them explicitly
@@ -61,7 +66,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -84,7 +89,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -107,7 +112,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -130,7 +135,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -153,7 +158,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -174,7 +179,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -197,7 +202,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -219,7 +224,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -242,7 +247,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -265,7 +270,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -288,7 +293,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -309,7 +314,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -332,7 +337,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -355,7 +360,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -378,7 +383,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -400,7 +405,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -423,7 +428,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -444,7 +449,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -467,7 +472,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -490,7 +495,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -512,7 +517,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -535,7 +540,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -558,7 +563,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -579,7 +584,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(1)
     }
 
@@ -602,7 +607,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -625,7 +630,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -648,7 +653,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -671,7 +676,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -693,7 +698,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -714,7 +719,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -735,7 +740,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -756,7 +761,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -777,7 +782,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -798,7 +803,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -819,7 +824,7 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 
@@ -837,7 +842,61 @@ class ThreadSafetyTest {
             }
             """.trimIndent()
 
-        val findings = ThreadSafety().compileAndLintWithContext(kotlinEnv.env, code)
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `ignore call from main thread to worker thread through threadSwitchingCall`() {
+        fakeConfig = TestConfig("workerThreadSwitchingCalls" to listOf("java.util.concurrent.ExecutorService.submit"))
+        val code =
+            """
+            import androidx.annotation.MainThread
+            import androidx.annotation.WorkerThread
+            import java.util.concurrent.ExecutorService
+
+            class Foo(val executorService: ExecutorService) {
+                @WorkerThread
+                fun callee() {}
+
+                @MainThread
+                fun caller() {
+                    executorService.submit {
+                        callee()
+                    }
+                }
+
+            }
+            """.trimIndent()
+
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
+        assertThat(findings).hasSize(0)
+    }
+
+    @Test
+    fun `ignore call from worker thread to main thread through threadSwitchingCall`() {
+        fakeConfig = TestConfig("mainThreadSwitchingCalls" to listOf("android.widget.LinearLayout.post"))
+        val code =
+            """
+            import androidx.annotation.MainThread
+            import androidx.annotation.WorkerThread
+            import android.widget.LinearLayout
+
+            class Foo(val linearLayout: LinearLayout) {
+                @MainThread
+                fun callee() {}
+
+                @WorkerThread
+                fun caller() {
+                    linearLayout.post {
+                        callee()
+                    }
+                }
+
+            }
+            """.trimIndent()
+
+        val findings = ThreadSafety(fakeConfig).compileAndLintWithContext(kotlinEnv.env, code)
         assertThat(findings).hasSize(0)
     }
 }


### PR DESCRIPTION
### What does this PR do?

A rule we used for a while now is using the Thread annotation (e.g.: `@UIThread`, `@WorkerThread`, …) to ensure operations that should happen in a specific context didn't cross thread expectations. 

Unfortunately we had a large number of `@Suppress` annotations and thread  boundaries crossings in our code  base. 

This PR provides two things :
- enhance the rule to detekt some known thread switching (e.g. using executors) to avoid the need of legitimate `@Suppress` annotations
- fix places where needed