### PR TITLE
RUM-3458: Fix time drift in RecordedDataQueueHandler

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueItem.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueItem.kt
@@ -9,7 +9,8 @@ package com.datadog.android.sessionreplay.internal.async
 import com.datadog.android.sessionreplay.internal.processor.RecordedQueuedItemContext
 
 internal abstract class RecordedDataQueueItem(
-    internal val recordedQueuedItemContext: RecordedQueuedItemContext
+    internal val recordedQueuedItemContext: RecordedQueuedItemContext,
+    internal val creationTimeStampInNs: Long = System.nanoTime()
 ) {
     internal abstract fun isValid(): Boolean
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
@@ -8,12 +8,12 @@ package com.datadog.android.sessionreplay.internal.async
 
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler.Companion.MAX_DELAY_MS
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler.Companion.ITEM_DROPPED_EXPIRED_MESSAGE
+import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler.Companion.ITEM_DROPPED_INVALID_MESSAGE
 import com.datadog.android.sessionreplay.internal.processor.RecordedDataProcessor
 import com.datadog.android.sessionreplay.internal.processor.RecordedQueuedItemContext
 import com.datadog.android.sessionreplay.internal.processor.RumContextDataHandler
 import com.datadog.android.sessionreplay.internal.recorder.Node
-import com.datadog.android.sessionreplay.internal.time.SessionReplayTimeProvider
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.SystemInformation
 import com.datadog.android.utils.verifyLog
@@ -47,6 +47,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.Locale
 import java.util.Queue
 import java.util.UUID
 import java.util.concurrent.ConcurrentLinkedQueue
@@ -75,9 +76,6 @@ internal class RecordedDataQueueHandlerTest {
 
     @Mock
     lateinit var mockSystemInformation: SystemInformation
-
-    @Mock
-    lateinit var mockTimeProvider: SessionReplayTimeProvider
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
@@ -129,10 +127,9 @@ internal class RecordedDataQueueHandlerTest {
         testedHandler = RecordedDataQueueHandler(
             processor = mockProcessor,
             rumContextDataHandler = mockRumContextDataHandler,
-            timeProvider = mockTimeProvider,
             executorService = spyExecutorService,
             internalLogger = mockInternalLogger,
-            recordedQueue = fakeRecordedDataQueue
+            recordedDataQueue = fakeRecordedDataQueue
         )
     }
 
@@ -152,10 +149,9 @@ internal class RecordedDataQueueHandlerTest {
         testedHandler = RecordedDataQueueHandler(
             processor = mockProcessor,
             rumContextDataHandler = mockRumContextDataHandler,
-            timeProvider = mockTimeProvider,
             executorService = spyExecutorService,
             internalLogger = mockInternalLogger,
-            recordedQueue = mockQueue
+            recordedDataQueue = mockQueue
         )
         testedHandler.recordedDataQueue.add(fakeSnapshotQueueItem)
 
@@ -279,14 +275,19 @@ internal class RecordedDataQueueHandlerTest {
     }
 
     @Test
-    fun `M remove item from queue W tryToConsumeItems() { expired item }`() {
+    fun `M remove item from queue W tryToConsumeItems() { expired item }`(
+        @Mock mockSnapshotItem: SnapshotRecordedDataQueueItem
+    ) {
         // Given
-        val item = testedHandler.addSnapshotItem(mockSystemInformation)
-            ?: fail("item is null")
-        item.nodes = fakeNodeData
+        mockSnapshotItem.apply {
+            val expiredTime = System.nanoTime() - RecordedDataQueueHandler.MAX_DELAY_NS
+            whenever(creationTimeStampInNs).thenReturn(expiredTime)
+            whenever(isValid()).thenReturn(true)
+            whenever(isReady()).thenReturn(true)
+            whenever(nodes).thenReturn(fakeNodeData)
+        }
 
-        whenever(mockTimeProvider.getDeviceTimestamp())
-            .thenReturn(item.recordedQueuedItemContext.timestamp + MAX_DELAY_MS + 1)
+        testedHandler.recordedDataQueue.offer(mockSnapshotItem)
 
         // When
         testedHandler.tryToConsumeItems()
@@ -295,13 +296,14 @@ internal class RecordedDataQueueHandlerTest {
 
         // Then
         assertThat(testedHandler.recordedDataQueue.isEmpty()).isTrue
+        val expectedMessage = ITEM_DROPPED_EXPIRED_MESSAGE.split("=")[0]
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             listOf(
                 InternalLogger.Target.MAINTAINER,
                 InternalLogger.Target.TELEMETRY
             ),
-            { it.startsWith("SR RecordedDataQueueHandler: dropped item from the queue. age=") }
+            { it.startsWith(expectedMessage) }
         )
         verifyNoMoreInteractions(mockProcessor)
     }
@@ -317,10 +319,6 @@ internal class RecordedDataQueueHandlerTest {
 
         testedHandler.recordedDataQueue.offer(mockSnapshotItem)
 
-        val timestamp = mockSnapshotItem.recordedQueuedItemContext.timestamp
-        whenever(mockTimeProvider.getDeviceTimestamp())
-            .thenReturn(timestamp)
-
         // When
         testedHandler.tryToConsumeItems()
         spyExecutorService.shutdown()
@@ -328,14 +326,15 @@ internal class RecordedDataQueueHandlerTest {
 
         // Then
         assertThat(testedHandler.recordedDataQueue).isEmpty()
+        val expectedMessage =
+            ITEM_DROPPED_INVALID_MESSAGE.format(Locale.US, "SnapshotRecordedDataQueueItem")
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             listOf(
                 InternalLogger.Target.MAINTAINER,
                 InternalLogger.Target.TELEMETRY
             ),
-            "SR RecordedDataQueueHandler: dropped item from the queue. isValid=false, " +
-                "type=SnapshotRecordedDataQueueItem"
+            expectedMessage
         )
         verifyNoMoreInteractions(mockProcessor)
     }
@@ -350,10 +349,6 @@ internal class RecordedDataQueueHandlerTest {
 
         testedHandler.recordedDataQueue.offer(mockTouchEventItem)
 
-        val spyTimestamp = mockTouchEventItem.recordedQueuedItemContext.timestamp
-        whenever(mockTimeProvider.getDeviceTimestamp())
-            .thenReturn(spyTimestamp)
-
         // When
         testedHandler.tryToConsumeItems()
         spyExecutorService.shutdown()
@@ -361,14 +356,15 @@ internal class RecordedDataQueueHandlerTest {
 
         // Then
         assertThat(testedHandler.recordedDataQueue).isEmpty()
+        val expectedMessage =
+            ITEM_DROPPED_INVALID_MESSAGE.format(Locale.US, "TouchEventRecordedDataQueueItem")
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             listOf(
                 InternalLogger.Target.MAINTAINER,
                 InternalLogger.Target.TELEMETRY
             ),
-            "SR RecordedDataQueueHandler: dropped item from the queue. isValid=false, " +
-                "type=TouchEventRecordedDataQueueItem"
+            expectedMessage
         )
         verifyNoMoreInteractions(mockProcessor)
     }
@@ -382,10 +378,6 @@ internal class RecordedDataQueueHandlerTest {
         whenever(mockResourceItem.recordedQueuedItemContext).thenReturn(fakeRecordedQueuedItemContext)
         testedHandler.recordedDataQueue.offer(mockResourceItem)
 
-        val timestamp = mockResourceItem.recordedQueuedItemContext.timestamp
-        whenever(mockTimeProvider.getDeviceTimestamp())
-            .thenReturn(timestamp)
-
         // When
         testedHandler.tryToConsumeItems()
         spyExecutorService.shutdown()
@@ -393,14 +385,15 @@ internal class RecordedDataQueueHandlerTest {
 
         // Then
         assertThat(testedHandler.recordedDataQueue).isEmpty()
+        val expectedMessage =
+            ITEM_DROPPED_INVALID_MESSAGE.format(Locale.US, "ResourceRecordedDataQueueItem")
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             listOf(
                 InternalLogger.Target.MAINTAINER,
                 InternalLogger.Target.TELEMETRY
             ),
-            "SR RecordedDataQueueHandler: dropped item from the queue. isValid=false, " +
-                "type=ResourceRecordedDataQueueItem"
+            expectedMessage
         )
         verifyNoMoreInteractions(mockProcessor)
     }
@@ -414,9 +407,6 @@ internal class RecordedDataQueueHandlerTest {
         doReturn(false).whenever(mockSnapshotItem).isReady()
 
         testedHandler.recordedDataQueue.add(mockSnapshotItem)
-
-        whenever(mockTimeProvider.getDeviceTimestamp())
-            .thenReturn(fakeRecordedQueuedItemContext.timestamp)
 
         // When
         testedHandler.tryToConsumeItems()
@@ -433,9 +423,6 @@ internal class RecordedDataQueueHandlerTest {
         val item = testedHandler.addSnapshotItem(mockSystemInformation) ?: fail("item is null")
         item.nodes = fakeNodeData
         item.isFinishedTraversal = true
-
-        whenever(mockTimeProvider.getDeviceTimestamp())
-            .thenReturn(item.recordedQueuedItemContext.timestamp)
 
         // When
         testedHandler.tryToConsumeItems()
@@ -454,9 +441,6 @@ internal class RecordedDataQueueHandlerTest {
     fun `M call processor W tryToConsumeItems() { valid Touch Event item }`() {
         // Given
         val item = testedHandler.addTouchEventItem(fakeTouchData) ?: fail("item is null")
-
-        whenever(mockTimeProvider.getDeviceTimestamp())
-            .thenReturn(item.recordedQueuedItemContext.timestamp)
 
         // When
         testedHandler.tryToConsumeItems()
@@ -482,9 +466,6 @@ internal class RecordedDataQueueHandlerTest {
             fakeApplicationId,
             fakePayload.toByteArray()
         ) ?: fail("item is null")
-
-        whenever(mockTimeProvider.getDeviceTimestamp())
-            .thenReturn(item.recordedQueuedItemContext.timestamp)
 
         // When
         testedHandler.tryToConsumeItems()
@@ -513,13 +494,9 @@ internal class RecordedDataQueueHandlerTest {
         item3.isFinishedTraversal = true
 
         assertThat(testedHandler.recordedDataQueue.size).isEqualTo(3)
-        val itemTimestamp = item1.recordedQueuedItemContext.timestamp
 
         // When
         repeat(50) {
-            whenever(mockTimeProvider.getDeviceTimestamp())
-                .thenReturn(itemTimestamp + it)
-
             testedHandler.tryToConsumeItems()
             spyExecutorService.shutdown()
             spyExecutorService.awaitTermination(1, TimeUnit.SECONDS)
@@ -542,41 +519,37 @@ internal class RecordedDataQueueHandlerTest {
     ) {
         // Given
         // item1
-        val item1RumContextData = fakeRecordedQueuedItemContext.copy(timestamp = 1)
-
-        whenever(mockSnapshotItem1.recordedQueuedItemContext).thenReturn(item1RumContextData)
-        whenever(mockSnapshotItem1.systemInformation).thenReturn(mockSystemInformation)
-        whenever(mockSnapshotItem1.nodes).thenReturn(fakeNodeData)
-        doReturn(true).whenever(mockSnapshotItem1).isValid()
-        doReturn(true).whenever(mockSnapshotItem1).isReady()
+        mockSnapshotItem1.apply {
+            whenever(systemInformation).thenReturn(mockSystemInformation)
+            whenever(nodes).thenReturn(fakeNodeData)
+            whenever(creationTimeStampInNs).thenReturn(System.nanoTime())
+            whenever(isValid()).thenReturn(true)
+            whenever(isReady()).thenReturn(true)
+        }
 
         // item2
-        val item2RumContextData = fakeRecordedQueuedItemContext.copy(timestamp = 2)
-
-        whenever(mockSnapshotItem2.recordedQueuedItemContext).thenReturn(item2RumContextData)
-        whenever(mockSnapshotItem2.systemInformation).thenReturn(mockSystemInformation)
-        whenever(mockSnapshotItem2.nodes).thenReturn(emptyList())
-        doReturn(true).whenever(mockSnapshotItem2).isValid()
-        doReturn(false).whenever(mockSnapshotItem2).isReady()
+        mockSnapshotItem2.apply {
+            whenever(systemInformation).thenReturn(mockSystemInformation)
+            whenever(nodes).thenReturn(fakeNodeData)
+            whenever(creationTimeStampInNs).thenReturn(System.nanoTime())
+            whenever(isValid()).thenReturn(true)
+            whenever(isReady()).thenReturn(false)
+        }
 
         // item3
-        val item3RumContextData = fakeRecordedQueuedItemContext.copy(timestamp = 3)
-
-        whenever(mockSnapshotItem3.recordedQueuedItemContext).thenReturn(item3RumContextData)
-        whenever(mockSnapshotItem3.systemInformation).thenReturn(mockSystemInformation)
-        whenever(mockSnapshotItem3.nodes).thenReturn(fakeNodeData)
-        doReturn(true).whenever(mockSnapshotItem3).isValid()
-        doReturn(true).whenever(mockSnapshotItem3).isReady()
+        mockSnapshotItem3.apply {
+            whenever(systemInformation).thenReturn(mockSystemInformation)
+            whenever(nodes).thenReturn(fakeNodeData)
+            whenever(creationTimeStampInNs).thenReturn(System.nanoTime())
+            whenever(isValid()).thenReturn(true)
+            whenever(isReady()).thenReturn(true)
+        }
 
         testedHandler.recordedDataQueue.offer(mockSnapshotItem1)
         testedHandler.recordedDataQueue.offer(mockSnapshotItem2)
         testedHandler.recordedDataQueue.offer(mockSnapshotItem3)
 
         assertThat(testedHandler.recordedDataQueue.size).isEqualTo(3)
-        val item1Time = mockSnapshotItem1.recordedQueuedItemContext.timestamp
-
-        whenever(mockTimeProvider.getDeviceTimestamp())
-            .thenReturn(item1Time + 1)
 
         // When
         repeat(3) {
@@ -699,7 +672,7 @@ internal class RecordedDataQueueHandlerTest {
 
     private fun createFakeSnapshotItemWithDelayMs(delay: Int): SnapshotRecordedDataQueueItem {
         val newRumContext = RecordedQueuedItemContext(
-            timestamp = System.currentTimeMillis() + delay,
+            timestamp = System.nanoTime() + delay,
             newRumContext = fakeRecordedQueuedItemContext.newRumContext
         )
 


### PR DESCRIPTION
### What does this PR do?
Fixes an issue in the RecordedDataQueueHandler where the "current" time was being passed in to the loop, but never updated inside it. This could lead to the time drifting when the queue was very long, leading to items being considered out of date.

### Motivation
We have telemetry indicating numerous DataQueueItems are being dropped for being out of date. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

