### PR TITLE
RUM-1662: Create SessionEndedMetric and SessionEndedMetricDispatcher with unit test

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -201,7 +201,7 @@ datadog:
       - "java.util.concurrent.Callable.call():java.lang.Exception"
       - "java.util.concurrent.ConcurrentHashMap.contains(kotlin.Any?):java.lang.NullPointerException"
       - "java.util.concurrent.ConcurrentHashMap.remove(com.datadog.android.api.feature.FeatureContextUpdateReceiver):java.lang.NullPointerException"
-      - "java.util.concurrent.ConcurrentHashMap.remove(kotlin.String):java.lang.NullPointerException"
+      - "java.util.concurrent.ConcurrentHashMap.remove(kotlin.String?):java.lang.NullPointerException"
       - "java.util.concurrent.ConcurrentLinkedQueue.offer(com.datadog.android.sessionreplay.internal.async.RecordedDataQueueItem):java.lang.NullPointerException"
       - "java.util.concurrent.CopyOnWriteArraySet.removeAll(kotlin.collections.Collection):java.lang.NullPointerException,java.lang.ClassCastException"
       - "java.util.concurrent.CountDownLatch.await(kotlin.Long, java.util.concurrent.TimeUnit?):java.lang.InterruptedException"
@@ -262,7 +262,6 @@ datadog:
       - "kotlin.ByteArray.copyOf(kotlin.Int):java.lang.NegativeArraySizeException"
       - "kotlin.ByteArray.copyOfRange(kotlin.Int, kotlin.Int):java.lang.IndexOutOfBoundsException,java.lang.IllegalArgumentException"
       - "kotlin.ByteArray.get(kotlin.Int):java.lang.IndexOutOfBoundsException"
-      - "kotlin.collections.MutableSet.first():java.util.NoSuchElementException"
       - "kotlin.Double.roundToLong():java.lang.IllegalArgumentException"
       # endregion
       # region Kotlin Collections
@@ -274,6 +273,8 @@ datadog:
       - "kotlin.collections.List.get(kotlin.Int):java.util.NoSuchElementException"
       - "kotlin.collections.MutableIterator.next():java.util.NoSuchElementException"
       - "kotlin.collections.MutableIterator.remove():java.lang.UnsupportedOperationException,java.lang.IllegalStateException"
+      - "kotlin.collections.MutableSet.first():java.util.NoSuchElementException"
+      - "kotlin.collections.MutableSet.last():java.util.NoSuchElementException"
       # endregion
       # region Kotlin Coroutines
       - "kotlinx.coroutines.Deferred.await():java.util.concurrent.CancellationException"
@@ -950,6 +951,8 @@ datadog:
       - "kotlin.collections.MutableSet.remove(com.datadog.android.core.internal.persistence.ConsentAwareStorage.Batch)"
       - "kotlin.collections.MutableSet.remove(java.io.File)"
       - "kotlin.collections.MutableSet.toList()"
+      - "kotlin.collections.MutableSet.lastOrNull()"
+      - "kotlin.collections.MutableSet.sortedByDescending(kotlin.Function1)"
       - "kotlin.collections.Set.any(kotlin.Function1)"
       - "kotlin.collections.Set.associate(kotlin.Function1)"
       - "kotlin.collections.Set.contains(com.datadog.android.trace.TracingHeaderType)"
@@ -991,6 +994,11 @@ datadog:
       - "kotlin.collections.setOf(kotlin.Array)"
       - "kotlin.collections.setOf(kotlin.Int)"
       - "kotlin.collections.setOf(kotlin.String)"
+      - "kotlin.collections.linkedMapOf()"
+      - "kotlin.collections.MutableCollection.count(kotlin.Function1)"
+      - "kotlin.collections.MutableCollection.sumOf(kotlin.Function1)"
+      - "kotlin.collections.MutableCollection.sum()"
+      - "kotlin.collections.List.sortedByDescending(kotlin.Function1)"
       - "kotlin.emptyArray()"
       - "kotlin.sequences.Sequence.groupBy(kotlin.Function1)"
       - "kotlin.sequences.Sequence.filter(kotlin.Function1)"
@@ -1006,6 +1014,7 @@ datadog:
       - "kotlin.Any.hashCode()"
       - "kotlin.Any.toString()"
       - "kotlin.Boolean.hashCode()"
+      - "kotlin.Boolean.not()"
       - "kotlin.Byte.toInt()"
       - "kotlin.ByteArray.constructor(kotlin.Int)"
       - "kotlin.Char.isLowerCase()"
@@ -1028,6 +1037,7 @@ datadog:
       - "kotlin.Int.toDouble()"
       - "kotlin.Int.toFloat()"
       - "kotlin.Int.toLong()"
+      - "kotlin.Int.coerceAtMost(kotlin.Int)"
       - "kotlin.IntArray.constructor(kotlin.Int)"
       - "kotlin.IntArray.joinToString(kotlin.CharSequence, kotlin.CharSequence, kotlin.CharSequence, kotlin.Int, kotlin.CharSequence, kotlin.Function1?)"
       - "kotlin.Long.coerceIn(kotlin.Long, kotlin.Long)"
@@ -1048,6 +1058,7 @@ datadog:
       - "kotlin.String.trim(kotlin.Function1)"
       # endregion
       # region Kotlin Tuples
+      - "kotlin.Pair.constructor(kotlin.String, kotlin.Int)"
       - "kotlin.Pair.constructor(com.datadog.android.sessionreplay.internal.utils.SessionReplayRumContext, com.google.gson.JsonArray)"
       - "kotlin.Pair.constructor(com.datadog.android.sessionreplay.model.MobileSegment, com.google.gson.JsonObject)"
       - "kotlin.Pair.constructor(com.google.gson.JsonObject, kotlin.Long)"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetric.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetric.kt
@@ -1,0 +1,215 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric
+
+import com.datadog.android.core.metrics.PerformanceMetric
+import com.datadog.android.rum.internal.domain.scope.RumSessionScope
+import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
+import com.datadog.android.rum.model.ViewEvent
+import java.util.concurrent.TimeUnit
+
+/**
+ * Metric for rum session ended event.
+ */
+@Suppress("TooManyFunctions")
+internal class SessionEndedMetric(
+    private val sessionId: String,
+    private val startReason: RumSessionScope.StartReason
+) {
+
+    private val trackedViewsById = mutableMapOf<String, TrackedView>()
+
+    private val errorKindFrequencies = mutableMapOf<String, Int>()
+
+    private var firstTrackedView: TrackedView? = null
+    private var lastTrackedView: TrackedView? = null
+    private var wasStopped: Boolean = false
+
+    /**
+     * Called on view tracked event, return true if the view is recorded by the metric, false otherwise.
+     */
+    fun onViewTracked(rumViewEvent: ViewEvent): Boolean {
+        if (rumViewEvent.session.id != sessionId) {
+            return false
+        }
+        val trackedView = TrackedView(
+            viewUrl = trackedViewsById[rumViewEvent.view.id]?.viewUrl ?: rumViewEvent.view.url,
+            startMs = trackedViewsById[rumViewEvent.view.id]?.startMs ?: rumViewEvent.date,
+            durationNs = rumViewEvent.view.timeSpent
+        )
+
+        trackedViewsById[rumViewEvent.view.id] = trackedView
+        if (firstTrackedView == null) {
+            firstTrackedView = trackedView
+        }
+        lastTrackedView = trackedView
+        return true
+    }
+
+    fun onErrorTracked(sdkErrorKind: String) {
+        errorKindFrequencies[sdkErrorKind] = (errorKindFrequencies[sdkErrorKind] ?: 0) + 1
+    }
+
+    fun onSessionStopped() {
+        wasStopped = true
+    }
+
+    fun toMetricAttributes(): Map<String, Any?> {
+        return mapOf(
+            METRIC_TYPE_KEY to METRIC_TYPE_VALUE,
+            RSE_KEY to resolveRseAttributes()
+        )
+    }
+
+    private fun calculateDuration(): Long {
+        return lastTrackedView?.let { last ->
+            firstTrackedView?.let { first ->
+                TimeUnit.MILLISECONDS.toNanos(last.startMs - first.startMs) + last.durationNs
+            }
+        } ?: 0L
+    }
+
+    private fun resolveRseAttributes(): Map<String, Any?> {
+        return mapOf(
+            PROCESS_TYPE_KEY to PROCESS_TYPE_VALUE,
+            PRECONDITION_KEY to startReason.asString,
+            DURATION_KEY to calculateDuration(),
+            WAS_STOPPED_KEY to wasStopped,
+            VIEW_COUNTS_KEY to resolveViewCountsAttributes(),
+            SDK_ERRORS_COUNT_KEY to resolveSDKErrorsCountAttributes()
+        )
+    }
+
+    private fun resolveViewCountsAttributes(): Map<String, Any?> {
+        return mapOf(
+            VIEW_COUNTS_TOTAL_KEY
+                to trackedViewsById.size,
+            VIEW_COUNTS_BG_KEY
+                to trackedViewsById.values.count { it.viewUrl == RumViewManagerScope.RUM_BACKGROUND_VIEW_URL },
+            VIEW_COUNTS_APP_LAUNCH_KEY
+                to trackedViewsById.values.count { it.viewUrl == RumViewManagerScope.RUM_APP_LAUNCH_VIEW_URL }
+        )
+    }
+
+    private fun resolveSDKErrorsCountAttributes(): Map<String, Any?> {
+        return mapOf(
+            SDK_ERRORS_COUNT_TOTAL_KEY to errorKindFrequencies.values.sum(),
+            SDK_ERRORS_COUNT_BY_KIND_KEY to resolveTop5ErrorsByKind()
+        )
+    }
+
+    private fun resolveTop5ErrorsByKind(): Map<String, Int> {
+        val limit = TOP_ERROR_LIMIT.coerceAtMost(errorKindFrequencies.size)
+        return errorKindFrequencies.entries.sortedByDescending {
+            it.value
+        }.subList(0, limit).associate { entry ->
+            escapeNonAlphanumericCharacters(entry.key) to entry.value
+        }
+    }
+
+    private fun escapeNonAlphanumericCharacters(key: String): String {
+        val regex = Regex("[^\\w']+")
+        return key.replace(regex, "_")
+    }
+
+    companion object {
+
+        /**
+         * The metric holds the map of TOP 5 error kinds to the number of their occurrences in the session.
+         */
+        private const val TOP_ERROR_LIMIT = 5
+
+        /**
+         * Title of the metric to be sent.
+         */
+        internal const val RUM_SESSION_ENDED_METRIC_NAME: String = "[Mobile Metric] RUM Session Ended"
+
+        /**
+         * Basic Metric type key.
+         */
+        internal const val METRIC_TYPE_KEY: String = PerformanceMetric.METRIC_TYPE
+
+        /**
+         * Metric type value.
+         */
+        internal const val METRIC_TYPE_VALUE: String = "rum session ended"
+
+        /**
+         * Name space of bundling.
+         */
+        internal const val RSE_KEY = "rse"
+
+        /**
+         * Key of process type.
+         */
+        internal const val PROCESS_TYPE_KEY = "process_type"
+
+        /**
+         * The type of OS component where the session was tracked. Android platform has only "app" type.
+         */
+        internal const val PROCESS_TYPE_VALUE = "app"
+
+        /**
+         * Key of the reason that led to the creation of this session.
+         */
+        internal const val PRECONDITION_KEY = "precondition"
+
+        /**
+         * Key of the session's duration in nanoseconds.
+         */
+        internal const val DURATION_KEY = "duration"
+
+        /**
+         * Key of boolean value indicating if the session was stopped through stopSession() API.
+         */
+        internal const val WAS_STOPPED_KEY = "was_stopped"
+
+        /**
+         * Key of the attributes of view counts.
+         */
+        internal const val VIEW_COUNTS_KEY = "views_count"
+
+        /**
+         * Key of the total view counts.
+         */
+        internal const val VIEW_COUNTS_TOTAL_KEY = "total"
+
+        /**
+         * Key of the number of standard "Background" views tracked during this session.
+         */
+        internal const val VIEW_COUNTS_BG_KEY = "background"
+
+        /**
+         * Key of the number of standard "ApplicationLaunch" views tracked during this session.
+         */
+        internal const val VIEW_COUNTS_APP_LAUNCH_KEY = "app_launch"
+
+        /**
+         * Key of the sdk errors attribute.
+         */
+        internal const val SDK_ERRORS_COUNT_KEY = "sdk_errors_count"
+
+        /**
+         * Key of the counts the total number of SDK errors that occurred during the session.
+         */
+        internal const val SDK_ERRORS_COUNT_TOTAL_KEY = "total"
+
+        /**
+         * Key of TOP [TOP_ERROR_LIMIT] error kinds to the number of their occurrences in the session.
+         */
+        internal const val SDK_ERRORS_COUNT_BY_KIND_KEY = "by_kind"
+    }
+
+    /**
+     * Class to hold the view information tracked by the metric.
+     */
+    internal data class TrackedView(
+        val viewUrl: String,
+        val startMs: Long,
+        val durationNs: Long
+    )
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
@@ -1,0 +1,68 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.rum.internal.domain.scope.RumSessionScope
+import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
+import com.datadog.android.rum.model.ViewEvent
+import java.util.concurrent.ConcurrentHashMap
+
+internal class SessionEndedMetricDispatcher(private val internalLogger: InternalLogger) :
+    SessionMetricDispatcher {
+
+    private val metricsBySessionId = ConcurrentHashMap<String, SessionEndedMetric>()
+
+    override fun startMetric(
+        sessionId: String,
+        startReason: RumSessionScope.StartReason
+    ) {
+        metricsBySessionId[sessionId] = SessionEndedMetric(sessionId, startReason)
+    }
+
+    override fun endMetric(sessionId: String) {
+        // the argument is always non - null, so we can suppress the warning
+        @Suppress("UnsafeThirdPartyFunctionCall")
+        val metric = metricsBySessionId.remove(sessionId)
+        metric?.let {
+            internalLogger.logMetric(
+                messageBuilder = { SessionEndedMetric.RUM_SESSION_ENDED_METRIC_NAME },
+                additionalProperties = it.toMetricAttributes()
+            )
+        }
+    }
+
+    override fun onSessionStopped(sessionId: String) {
+        metricsBySessionId[sessionId]?.onSessionStopped()
+    }
+
+    override fun onViewTracked(sessionId: String, viewEvent: ViewEvent) {
+        val result = metricsBySessionId[sessionId]?.onViewTracked(viewEvent) ?: false
+        if (result.not()) {
+            internalLogger.log(
+                InternalLogger.Level.INFO,
+                InternalLogger.Target.MAINTAINER,
+                { buildViewTrackError(sessionId, viewEvent) }
+            )
+        }
+    }
+
+    override fun onSdkErrorTracked(sessionId: String, errorKind: String?) {
+        errorKind?.let {
+            metricsBySessionId[sessionId]?.onErrorTracked(it)
+        }
+    }
+
+    private fun buildViewTrackError(sessionId: String, viewEvent: ViewEvent): String {
+        val viewType = when (viewEvent.view.url) {
+            RumViewManagerScope.RUM_APP_LAUNCH_VIEW_URL -> "AppLaunch"
+            RumViewManagerScope.RUM_BACKGROUND_VIEW_URL -> "Background"
+            else -> "Custom"
+        }
+        return "Failed to track $viewType view in session with different UUID $sessionId"
+    }
+}

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionMetricDispatcher.kt
@@ -1,0 +1,43 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric
+
+import com.datadog.android.rum.internal.domain.scope.RumSessionScope
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.tools.annotation.NoOpImplementation
+
+/**
+ * Interface to dispatch the session metric.
+ */
+@NoOpImplementation
+internal interface SessionMetricDispatcher {
+
+    /**
+     * Starts a session metric with given session id and start reason of this session.
+     */
+    fun startMetric(sessionId: String, startReason: RumSessionScope.StartReason)
+
+    /**
+     * Ends the session metric with given session id.
+     */
+    fun endMetric(sessionId: String)
+
+    /**
+     * Called when the session is stopped.
+     */
+    fun onSessionStopped(sessionId: String)
+
+    /**
+     * Called when a view is tracked by this session metric.
+     */
+    fun onViewTracked(sessionId: String, viewEvent: ViewEvent)
+
+    /**
+     * Called when a sdk error is tracked by this session metric.
+     */
+    fun onSdkErrorTracked(sessionId: String, errorKind: String?)
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/FakeInternalLogger.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/FakeInternalLogger.kt
@@ -1,0 +1,57 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.metrics.PerformanceMetric
+import com.datadog.android.core.metrics.TelemetryMetricType
+
+class FakeInternalLogger : InternalLogger {
+
+    var lastMetric: Pair<String, Map<String, Any?>>? = null
+
+    var errorLog: String? = null
+
+    override fun log(
+        level: InternalLogger.Level,
+        target: InternalLogger.Target,
+        messageBuilder: () -> String,
+        throwable: Throwable?,
+        onlyOnce: Boolean,
+        additionalProperties: Map<String, Any?>?
+    ) {
+        errorLog = messageBuilder()
+    }
+
+    override fun log(
+        level: InternalLogger.Level,
+        targets: List<InternalLogger.Target>,
+        messageBuilder: () -> String,
+        throwable: Throwable?,
+        onlyOnce: Boolean,
+        additionalProperties: Map<String, Any?>?
+    ) {
+        // do nothing
+    }
+
+    override fun logMetric(
+        messageBuilder: () -> String,
+        additionalProperties: Map<String, Any?>
+    ) {
+        lastMetric = Pair(messageBuilder(), additionalProperties)
+    }
+
+    override fun startPerformanceMeasure(
+        callerClass: String,
+        metric: TelemetryMetricType,
+        samplingRate: Float,
+        operationName: String
+    ): PerformanceMetric? {
+        // do nothing
+        return null
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/RumSessionEndedMetricTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/RumSessionEndedMetricTest.kt
@@ -1,0 +1,431 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.rum.internal.domain.scope.RumSessionScope
+import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.AssertionsForClassTypes.assertThat
+import org.json.JSONObject
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.util.concurrent.TimeUnit
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+class RumSessionEndedMetricTest {
+
+    @StringForgery
+    private lateinit var fakeSessionId: String
+
+    @Forgery
+    private lateinit var fakeStartReason: RumSessionScope.StartReason
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @Test
+    fun `M create attributes with session ended metric type W toMetricAttributes`() {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        val attributes = sessionEndedMetric.toMetricAttributes()
+
+        // Then
+        assertThat(attributes[SessionEndedMetric.METRIC_TYPE_KEY]).isEqualTo(SessionEndedMetric.METRIC_TYPE_VALUE)
+    }
+
+    @Test
+    fun `M create attributes with session ended process type W toMetricAttributes`() {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        val attributes = sessionEndedMetric.toMetricAttributes()
+
+        // Then
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val processType = rse[SessionEndedMetric.PROCESS_TYPE_KEY] as String
+        assertThat(processType).isEqualTo(SessionEndedMetric.PROCESS_TYPE_VALUE)
+    }
+
+    @Test
+    fun `M create attributes with session ended precondition W toMetricAttributes`() {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        val attributes = sessionEndedMetric.toMetricAttributes()
+
+        // Then
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val precondition = rse[SessionEndedMetric.PRECONDITION_KEY] as String
+        assertThat(precondition).isEqualTo(fakeStartReason.asString)
+    }
+
+    @Test
+    fun `M init attributes W toMetricAttributes { empty metric }`() {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        val attributes = sessionEndedMetric.toMetricAttributes()
+
+        // Then
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+
+        assertThat(rse[SessionEndedMetric.DURATION_KEY] as Long).isEqualTo(0L)
+        assertThat(rse[SessionEndedMetric.WAS_STOPPED_KEY] as Boolean).isFalse()
+
+        val viewCounts = rse[SessionEndedMetric.VIEW_COUNTS_KEY] as Map<*, *>
+        assertThat(viewCounts[SessionEndedMetric.VIEW_COUNTS_TOTAL_KEY] as Int).isEqualTo(0)
+        assertThat(viewCounts[SessionEndedMetric.VIEW_COUNTS_BG_KEY] as Int).isEqualTo(0)
+        assertThat(viewCounts[SessionEndedMetric.VIEW_COUNTS_APP_LAUNCH_KEY] as Int).isEqualTo(0)
+
+        val errorCounts = rse[SessionEndedMetric.SDK_ERRORS_COUNT_KEY] as Map<*, *>
+        assertThat(errorCounts[SessionEndedMetric.SDK_ERRORS_COUNT_TOTAL_KEY] as Int).isEqualTo(0)
+        assertTrue((errorCounts[SessionEndedMetric.SDK_ERRORS_COUNT_BY_KIND_KEY] as Map<*, *>).isEmpty())
+    }
+
+    @Test
+    fun `M calculate wasStopped attribute W onSessionStopped`() {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        sessionEndedMetric.onSessionStopped()
+        val attributes = sessionEndedMetric.toMetricAttributes()
+
+        // Then
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val wasStopped = rse[SessionEndedMetric.WAS_STOPPED_KEY] as Boolean
+        assertThat(wasStopped).isTrue()
+    }
+
+    @Test
+    fun `M calculate duration W onViewTracked { track single view }`(@Forgery event: ViewEvent) {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(event.session.id, fakeStartReason)
+
+        // When
+        sessionEndedMetric.onViewTracked(event)
+
+        val attributes = sessionEndedMetric.toMetricAttributes()
+
+        // Then
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val duration = rse[SessionEndedMetric.DURATION_KEY] as Long
+        assertThat(duration).isEqualTo(event.view.timeSpent)
+    }
+
+    @Test
+    fun `M calculate duration W onViewTracked {  multiple views tracked }`(
+        @Forgery event1: ViewEvent,
+        @Forgery event2: ViewEvent,
+        @Forgery event3: ViewEvent
+    ) {
+        // Given
+        val duration1 = TimeUnit.SECONDS.toNanos(15)
+        val duration2 = TimeUnit.SECONDS.toNanos(10)
+        val duration3 = TimeUnit.SECONDS.toNanos(5)
+        val date1 = TimeUnit.SECONDS.toMillis(20)
+        val date2 = TimeUnit.SECONDS.toMillis(30)
+        val date3 = TimeUnit.SECONDS.toMillis(40)
+        val sessionEvent1 = event1.copy(
+            session = event1.session.copy(id = fakeSessionId),
+            date = date1,
+            view = event1.view.copy(timeSpent = duration1)
+        )
+        val sessionEvent2 = event2.copy(
+            session = event2.session.copy(id = fakeSessionId),
+            date = date2,
+            view = event2.view.copy(timeSpent = duration2)
+        )
+        val sessionEvent3 = event3.copy(
+            session = event3.session.copy(id = fakeSessionId),
+            date = date3,
+            view = event3.view.copy(timeSpent = duration3)
+        )
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        sessionEndedMetric.onViewTracked(sessionEvent1)
+        sessionEndedMetric.onViewTracked(sessionEvent2)
+        sessionEndedMetric.onViewTracked(sessionEvent3)
+
+        // Then
+        val attributes = sessionEndedMetric.toMetricAttributes()
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val duration = rse[SessionEndedMetric.DURATION_KEY] as Long
+        val expected = TimeUnit.MILLISECONDS.toNanos(date3 - date1) + duration3
+        assertThat(duration).isEqualTo(expected)
+    }
+
+    @Test
+    fun `M ignore unexpected view W onViewTracked { track different session id view event }`(
+        @Forgery event1: ViewEvent,
+        @Forgery event2: ViewEvent
+    ) {
+        // Given
+        val duration1 = TimeUnit.SECONDS.toNanos(15)
+        val duration2 = TimeUnit.SECONDS.toNanos(10)
+        val date1 = TimeUnit.SECONDS.toMillis(20)
+        val date2 = TimeUnit.SECONDS.toMillis(30)
+
+        val currentSessionViewEvent = event1.copy(
+            session = event1.session.copy(id = fakeSessionId),
+            date = date1,
+            view = event1.view.copy(timeSpent = duration1)
+        )
+        val differentSessionViewEvent = event2.copy(
+            date = date2,
+            view = event2.view.copy(timeSpent = duration2)
+        )
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        sessionEndedMetric.onViewTracked(currentSessionViewEvent)
+        sessionEndedMetric.onViewTracked(differentSessionViewEvent)
+
+        // Then
+        val attributes = sessionEndedMetric.toMetricAttributes()
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val viewCounts = rse[SessionEndedMetric.VIEW_COUNTS_KEY] as Map<*, *>
+        assertThat(viewCounts[SessionEndedMetric.VIEW_COUNTS_TOTAL_KEY]).isEqualTo(1)
+    }
+
+    @Test
+    fun `M calculate total view counts W onViewTracked`(@Forgery events: List<ViewEvent>) {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        events.map {
+            it.copy(session = it.session.copy(id = fakeSessionId))
+        }.forEach {
+            sessionEndedMetric.onViewTracked(it)
+        }
+
+        // Then
+        val attributes = sessionEndedMetric.toMetricAttributes()
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val viewCounts = rse[SessionEndedMetric.VIEW_COUNTS_KEY] as Map<*, *>
+        assertThat(viewCounts[SessionEndedMetric.VIEW_COUNTS_TOTAL_KEY]).isEqualTo(events.count())
+    }
+
+    @Test
+    fun `M count correct number of background views W track views`(
+        @Forgery events: List<ViewEvent>,
+        forge: Forge
+    ) {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+        val backgroundViewCount = forge.anInt(min = 1, max = events.size)
+
+        // When
+        events.mapIndexed { index, viewEvent ->
+            val url = if (index in 0 until backgroundViewCount) {
+                RumViewManagerScope.RUM_BACKGROUND_VIEW_URL
+            } else {
+                viewEvent.view.url
+            }
+            viewEvent.copy(
+                session = viewEvent.session.copy(id = fakeSessionId),
+                view = viewEvent.view.copy(url = url)
+            )
+        }.forEach {
+            sessionEndedMetric.onViewTracked(it)
+        }
+
+        // Then
+        val attributes = sessionEndedMetric.toMetricAttributes()
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val viewCounts = rse[SessionEndedMetric.VIEW_COUNTS_KEY] as Map<*, *>
+        assertThat(viewCounts[SessionEndedMetric.VIEW_COUNTS_BG_KEY]).isEqualTo(backgroundViewCount)
+    }
+
+    @Test
+    fun `M view counts app launch correct W track views`(
+        @Forgery events: List<ViewEvent>,
+        forge: Forge
+    ) {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+        val appLaunchViewCount = forge.anInt(min = 1, max = events.size)
+
+        // When
+        events.mapIndexed { index, viewEvent ->
+            val url = if (index in 0 until appLaunchViewCount) {
+                RumViewManagerScope.RUM_APP_LAUNCH_VIEW_URL
+            } else {
+                viewEvent.view.url
+            }
+            viewEvent.copy(
+                session = viewEvent.session.copy(id = fakeSessionId),
+                view = viewEvent.view.copy(url = url)
+            )
+        }.forEach {
+            sessionEndedMetric.onViewTracked(it)
+        }
+
+        // Then
+        val attributes = sessionEndedMetric.toMetricAttributes()
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val viewCounts = rse[SessionEndedMetric.VIEW_COUNTS_KEY] as Map<*, *>
+        assertThat(viewCounts[SessionEndedMetric.VIEW_COUNTS_APP_LAUNCH_KEY]).isEqualTo(appLaunchViewCount)
+    }
+
+    @Test
+    fun `M error counts correct W track errors`(@StringForgery errorKinds: List<String>) {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        errorKinds.forEach {
+            sessionEndedMetric.onErrorTracked(it)
+        }
+
+        // Then
+        val attributes = sessionEndedMetric.toMetricAttributes()
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val sdkErrorCount = rse[SessionEndedMetric.SDK_ERRORS_COUNT_KEY] as Map<*, *>
+        assertThat(sdkErrorCount[SessionEndedMetric.SDK_ERRORS_COUNT_TOTAL_KEY]).isEqualTo(errorKinds.size)
+    }
+
+    @Test
+    fun `M error attribute correct W track errors`() {
+        // Given
+        val errorKindsMap = mapOf(
+            "top1" to 10,
+            "top2" to 9,
+            "top3" to 8,
+            "top4" to 7,
+            "top5" to 6,
+            "top6" to 5,
+            "top7" to 4,
+            "top8" to 3
+        )
+
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        errorKindsMap.forEach { errorKind ->
+            repeat(errorKind.value) {
+                sessionEndedMetric.onErrorTracked(errorKind.key)
+            }
+        }
+
+        // Then
+        val attributes = sessionEndedMetric.toMetricAttributes()
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val sdkErrorCount = rse[SessionEndedMetric.SDK_ERRORS_COUNT_KEY] as Map<*, *>
+
+        val expectedErrorKind = mapOf(
+            "top1" to 10,
+            "top2" to 9,
+            "top3" to 8,
+            "top4" to 7,
+            "top5" to 6
+        )
+        assertThat(sdkErrorCount[SessionEndedMetric.SDK_ERRORS_COUNT_BY_KIND_KEY]).isEqualTo(expectedErrorKind)
+    }
+
+    @Test
+    fun `M error kind escape non alpha numeric W track errors`() {
+        // Given
+        val errorKindsMap = mapOf(
+            "top 1 error" to 10,
+            "top:2:error" to 9,
+            "top_3_error" to 8,
+            "top/4/error" to 7
+        )
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        errorKindsMap.forEach { errorKind ->
+            repeat(errorKind.value) {
+                sessionEndedMetric.onErrorTracked(errorKind.key)
+            }
+        }
+
+        // Then
+        val attributes = sessionEndedMetric.toMetricAttributes()
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val sdkErrorCount = rse[SessionEndedMetric.SDK_ERRORS_COUNT_KEY] as Map<*, *>
+
+        val expectedErrorKind = mapOf(
+            "top_1_error" to 10,
+            "top_2_error" to 9,
+            "top_3_error" to 8,
+            "top_4_error" to 7
+        )
+        assertThat(sdkErrorCount[SessionEndedMetric.SDK_ERRORS_COUNT_BY_KIND_KEY]).isEqualTo(expectedErrorKind)
+    }
+
+    @Test
+    fun `M encode type W creating metric`(@Forgery viewEvent: ViewEvent) {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        viewEvent.copy(session = viewEvent.session.copy(id = fakeSessionId)).apply {
+            sessionEndedMetric.onViewTracked(this)
+        }
+
+        // Then
+
+        val attributes = sessionEndedMetric.toMetricAttributes()
+        val json = JSONObject(attributes)
+
+        val rseObject = json.get(SessionEndedMetric.RSE_KEY) as JSONObject
+
+        assertThat(rseObject.get(SessionEndedMetric.PROCESS_TYPE_KEY)).isInstanceOf(String::class.java)
+        assertThat(rseObject.get(SessionEndedMetric.PRECONDITION_KEY)).isInstanceOf(String::class.java)
+        assertThat(rseObject.get(SessionEndedMetric.DURATION_KEY)).isInstanceOf(java.lang.Long::class.java)
+        assertThat(rseObject.get(SessionEndedMetric.WAS_STOPPED_KEY)).isInstanceOf(java.lang.Boolean::class.java)
+
+        val viewCountsObject = rseObject.get(SessionEndedMetric.VIEW_COUNTS_KEY) as JSONObject
+        assertThat(
+            viewCountsObject.get(SessionEndedMetric.VIEW_COUNTS_TOTAL_KEY)
+        ).isInstanceOf(java.lang.Integer::class.java)
+        assertThat(
+            viewCountsObject.get(SessionEndedMetric.VIEW_COUNTS_BG_KEY)
+        ).isInstanceOf(java.lang.Integer::class.java)
+        assertThat(
+            viewCountsObject.get(SessionEndedMetric.VIEW_COUNTS_APP_LAUNCH_KEY)
+        ).isInstanceOf(java.lang.Integer::class.java)
+
+        val sdkErrorsCount = rseObject.get(SessionEndedMetric.SDK_ERRORS_COUNT_KEY) as JSONObject
+
+        assertThat(
+            sdkErrorsCount.get(SessionEndedMetric.SDK_ERRORS_COUNT_TOTAL_KEY)
+        ).isInstanceOf(java.lang.Integer::class.java)
+        assertThat(
+            sdkErrorsCount.get(SessionEndedMetric.SDK_ERRORS_COUNT_BY_KIND_KEY)
+        ).isInstanceOf(JSONObject::class.java)
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcherTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcherTest.kt
@@ -1,0 +1,170 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.internal.metric
+
+import com.datadog.android.rum.internal.domain.scope.RumSessionScope
+import com.datadog.android.rum.model.ViewEvent
+import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+class SessionEndedMetricDispatcherTest {
+
+    private val fakeInternalLogger = FakeInternalLogger()
+
+    @Forgery
+    private lateinit var fakeStartReason: RumSessionScope.StartReason
+
+    @Test
+    fun `M register session stop W call onSessionStopped()`(@StringForgery fakeSessionId: String) {
+        // Given
+        val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
+        dispatcher.startMetric(fakeSessionId, fakeStartReason)
+
+        // When
+        dispatcher.onSessionStopped(fakeSessionId)
+        dispatcher.endMetric(fakeSessionId)
+
+        // Then
+        assertThat(fakeInternalLogger.isSessionStopped()).isTrue()
+    }
+
+    @Test
+    fun `M log error W track view in different sessions`(
+        @StringForgery fakeSessionId1: String,
+        @StringForgery fakeSessionId2: String,
+        @Forgery viewEvent: ViewEvent
+    ) {
+        // Given
+        val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
+
+        // When
+        dispatcher.startMetric(fakeSessionId1, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId2, fakeStartReason)
+        viewEvent.copy(session = viewEvent.session.copy(id = fakeSessionId2)).apply {
+            dispatcher.onViewTracked(fakeSessionId1, this)
+        }
+
+        dispatcher.endMetric(fakeSessionId1)
+        dispatcher.endMetric(fakeSessionId2)
+
+        // Then
+        assertThat(fakeInternalLogger.errorLog).isNotNull()
+    }
+
+    @Test
+    fun `M count views for given session W track view with session id`(
+        @StringForgery fakeSessionId1: String,
+        @StringForgery fakeSessionId2: String,
+        @StringForgery fakeSessionId3: String,
+        @StringForgery fakeSessionId4: String,
+        @Forgery viewEvents: List<ViewEvent>
+    ) {
+        // Given
+        val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
+
+        // When
+        dispatcher.startMetric(fakeSessionId1, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId2, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId3, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId4, fakeStartReason)
+
+        viewEvents.map {
+            it.copy(session = it.session.copy(id = fakeSessionId2))
+        }.forEach {
+            dispatcher.onViewTracked(fakeSessionId2, it)
+        }
+
+        // Then
+        dispatcher.endMetric(fakeSessionId1)
+        assertThat(fakeInternalLogger.getViewCounts()).isEqualTo(0)
+
+        dispatcher.endMetric(fakeSessionId2)
+        assertThat(fakeInternalLogger.getViewCounts()).isEqualTo(fakeInternalLogger.getViewCounts())
+
+        dispatcher.endMetric(fakeSessionId3)
+        assertThat(fakeInternalLogger.getViewCounts()).isEqualTo(0)
+
+        dispatcher.endMetric(fakeSessionId1)
+        assertThat(fakeInternalLogger.getViewCounts()).isEqualTo(0)
+    }
+
+    @Test
+    fun `M calculate error tracked count W onSdkErrorTracked`(
+        @StringForgery fakeSessionId1: String,
+        @StringForgery fakeSessionId2: String,
+        @StringForgery fakeSessionId3: String,
+        @StringForgery fakeSessionId4: String,
+        @StringForgery errorKinds: List<String>
+    ) {
+        // Given
+        val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
+
+        // When
+        dispatcher.startMetric(fakeSessionId1, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId2, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId3, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId4, fakeStartReason)
+
+        // Ends the last started session
+        dispatcher.endMetric(fakeSessionId4)
+        // Ends a middle session
+        dispatcher.endMetric(fakeSessionId2)
+
+        errorKinds.forEach {
+            dispatcher.onSdkErrorTracked(fakeSessionId3, it)
+        }
+
+        // Then
+        dispatcher.endMetric(fakeSessionId1)
+        assertThat(fakeInternalLogger.getErrorCounts()).isEqualTo(0)
+
+        // Errors can is reported by the last session when they are tracked
+        dispatcher.endMetric(fakeSessionId3)
+        assertThat(fakeInternalLogger.getErrorCounts()).isEqualTo(errorKinds.size)
+    }
+
+    private fun FakeInternalLogger.isSessionStopped(): Boolean? {
+        return lastMetric?.second?.let { attributes ->
+            val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+            rse[SessionEndedMetric.WAS_STOPPED_KEY] as? Boolean
+        }
+    }
+
+    private fun FakeInternalLogger.getErrorCounts(): Int {
+        return lastMetric?.second?.let { attributes ->
+            val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+            val viewCount = rse[SessionEndedMetric.SDK_ERRORS_COUNT_KEY] as Map<*, *>
+            viewCount[SessionEndedMetric.SDK_ERRORS_COUNT_TOTAL_KEY] as Int
+        } ?: -1
+    }
+
+    private fun FakeInternalLogger.getViewCounts(): Int {
+        return lastMetric?.second?.let { attributes ->
+            val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+            val viewCount = rse[SessionEndedMetric.VIEW_COUNTS_KEY] as Map<*, *>
+            viewCount[SessionEndedMetric.VIEW_COUNTS_TOTAL_KEY] as Int
+        } ?: -1
+    }
+}


### PR DESCRIPTION
### What does this PR do?

* [ADD] Add `SessionEndedMetric` class to record the 
* [ADD] SessionEndedMetricDispatcher to coordinates multiple `SessionEndedMetric` and send telemetry when session is ended
  
### Motivation

Ticket: https://datadoghq.atlassian.net/browse/RUM-1662

### Additional Notes

This is the first step of this task, only implementation of two classes with unit test assuring that the data structure and json format matches the specification. In next PR, these two classes will be used inside `RumSessionScope` or `RumApplicatioScope` to track the session.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

