### PR TITLE
RUM-4879: Granular telemetry sampling for mappers

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -268,6 +268,11 @@ fun java.math.BigInteger.toHexString(): String
 fun Thread.State.asString(): String
 fun Array<StackTraceElement>.loggableStackTrace(): String
 fun Throwable.loggableStackTrace(): String
+enum com.datadog.android.core.metrics.MethodCallSamplingRate
+  constructor(Float)
+  - DEFAULT
+  - REDUCED
+  - RARE
 interface com.datadog.android.core.metrics.PerformanceMetric
   fun stopAndSend(Boolean)
   companion object 

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -731,6 +731,15 @@ public final class com/datadog/android/core/internal/utils/ThrowableExtKt {
 	public static final fun loggableStackTrace (Ljava/lang/Throwable;)Ljava/lang/String;
 }
 
+public final class com/datadog/android/core/metrics/MethodCallSamplingRate : java/lang/Enum {
+	public static final field DEFAULT Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
+	public static final field RARE Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
+	public static final field REDUCED Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
+	public final fun getRate ()F
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
+	public static fun values ()[Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
+}
+
 public abstract interface class com/datadog/android/core/metrics/PerformanceMetric {
 	public static final field Companion Lcom/datadog/android/core/metrics/PerformanceMetric$Companion;
 	public static final field METRIC_TYPE Ljava/lang/String;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/metrics/MethodCallSamplingRate.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/metrics/MethodCallSamplingRate.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.metrics
+
+/**
+ * Sampling rates for Method Call telemetry.
+ * @param rate the rate to sample at.
+ */
+enum class MethodCallSamplingRate(val rate: Float) {
+    DEFAULT(rate = 0.1f),
+    REDUCED(rate = 0.01f),
+    RARE(rate = 0.001f)
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/DefaultOnDrawListenerProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/DefaultOnDrawListenerProducer.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.view.View
 import android.view.ViewTreeObserver
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener
@@ -26,7 +27,7 @@ internal class DefaultOnDrawListenerProducer(
             snapshotProducer = snapshotProducer,
             privacy = privacy,
             internalLogger = sdkCore.internalLogger,
-            methodCallSamplingRate = WindowsOnDrawListener.METHOD_CALL_SAMPLING_RATE
+            methodCallSamplingRate = MethodCallSamplingRate.DEFAULT.rate
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversal.kt
@@ -13,9 +13,14 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.measureMethodCallPerf
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.DecorViewMapper
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ImageViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.QueueStatusCallback
+import com.datadog.android.sessionreplay.internal.recorder.mapper.ViewWireframeMapper
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
+import com.datadog.android.sessionreplay.recorder.mapper.TextViewMapper
 import com.datadog.android.sessionreplay.recorder.mapper.TraverseAllChildrenMapper
 import com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -86,7 +91,7 @@ internal class TreeViewTraversal(
         val resolvedWireframes = internalLogger.measureMethodCallPerf(
             javaClass,
             "$METHOD_CALL_MAP_PREFIX ${mapper.javaClass.simpleName}",
-            METHOD_CALL_SAMPLING_RATE
+            getSamplingRateForMapper(mapper.javaClass.simpleName)
         ) {
             mapper.map(view, mappingContext, jobStatusCallback, internalLogger)
         }
@@ -104,13 +109,29 @@ internal class TreeViewTraversal(
         return mappers.firstOrNull { it.supportsView(view) }?.getUnsafeMapper()
     }
 
+    private fun getSamplingRateForMapper(mapperName: String): Float {
+        return when (mapperName) {
+            ViewWireframeMapper::class.simpleName -> MethodCallSamplingRate.RARE.rate
+            TextViewMapper::class.simpleName -> MethodCallSamplingRate.RARE.rate
+            ImageViewMapper::class.simpleName -> MethodCallSamplingRate.RARE.rate
+            DecorViewMapper::class.simpleName -> MethodCallSamplingRate.REDUCED.rate
+            ButtonMapper::class.simpleName -> MethodCallSamplingRate.REDUCED.rate
+            else -> MethodCallSamplingRate.DEFAULT.rate
+        }
+    }
+
     data class TraversedTreeView(
         val mappedWireframes: List<MobileSegment.Wireframe>,
         val nextActionStrategy: TraversalStrategy
     )
 
-    companion object {
-        const val METHOD_CALL_SAMPLING_RATE = 0.1f
-        private const val METHOD_CALL_MAP_PREFIX: String = "Map with"
+    internal enum class MethodCallSamplingRate(val rate: Float) {
+        DEFAULT(rate = 0.1f),
+        REDUCED(rate = 0.01f),
+        RARE(rate = 0.001f)
+    }
+
+    internal companion object {
+        internal const val METHOD_CALL_MAP_PREFIX = "Map with"
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
@@ -75,7 +75,6 @@ internal class WindowsOnDrawListener(
     }
 
     companion object {
-        const val METHOD_CALL_SAMPLING_RATE = 0.1f
         private const val METHOD_CALL_CAPTURE_RECORD: String = "Capture Record"
 
         private val METHOD_CALL_CALLER_CLASS = WindowsOnDrawListener::class.java

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversalTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversalTest.kt
@@ -18,6 +18,7 @@ import android.widget.TextView
 import androidx.drawerlayout.widget.DrawerLayout
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.measureMethodCallPerf
+import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
@@ -378,7 +379,7 @@ internal class TreeViewTraversalTest {
     @Test
     fun `M return correct sample rate W traverse { ViewWireframeMapper }()`(forge: Forge) {
         // Given
-        val expectedSampleRate = TreeViewTraversal.MethodCallSamplingRate.RARE.rate
+        val expectedSampleRate = MethodCallSamplingRate.RARE.rate
         val mockViewGroup = forge.aMockView<ViewGroup>()
 
         val mockView = mock<View> {
@@ -404,7 +405,7 @@ internal class TreeViewTraversalTest {
     @Test
     fun `M return correct sample rate W traverse { DecorViewMapper }()`() {
         // Given
-        val expectedSampleRate = TreeViewTraversal.MethodCallSamplingRate.REDUCED.rate
+        val expectedSampleRate = MethodCallSamplingRate.RARE.rate
         val mockView = mock<View> {
             whenever(it.parent) doReturn null
         }
@@ -426,9 +427,9 @@ internal class TreeViewTraversalTest {
     }
 
     @Test
-    fun `M return default sample rate W traverse() { specific mapper }`(forge: Forge) {
+    fun `M return correct sample rate W traverse() { specific mapper }`(forge: Forge) {
         // Given
-        val expectedSampleRate = TreeViewTraversal.MethodCallSamplingRate.DEFAULT.rate
+        val expectedSampleRate = MethodCallSamplingRate.RARE.rate
         val mockViewGroup = forge.aMockView<ViewGroup>()
         val mockDefaultView = mock<View> {
             whenever(it.parent) doReturn mockViewGroup

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversalTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/TreeViewTraversalTest.kt
@@ -17,9 +17,11 @@ import android.widget.RadioButton
 import android.widget.TextView
 import androidx.drawerlayout.widget.DrawerLayout
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.measureMethodCallPerf
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
+import com.datadog.android.sessionreplay.internal.recorder.TreeViewTraversal.Companion.METHOD_CALL_MAP_PREFIX
 import com.datadog.android.sessionreplay.internal.recorder.mapper.DecorViewMapper
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ViewWireframeMapper
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -42,6 +44,7 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
@@ -366,6 +369,97 @@ internal class TreeViewTraversalTest {
         assertThat(traversedTreeView.mappedWireframes).isEmpty()
         assertThat(traversedTreeView.nextActionStrategy)
             .isEqualTo(TraversalStrategy.STOP_AND_DROP_NODE)
+    }
+
+    // endregion
+
+    // region MapWith Telemetry
+
+    @Test
+    fun `M return correct sample rate W traverse { ViewWireframeMapper }()`(forge: Forge) {
+        // Given
+        val expectedSampleRate = TreeViewTraversal.MethodCallSamplingRate.RARE.rate
+        val mockViewGroup = forge.aMockView<ViewGroup>()
+
+        val mockView = mock<View> {
+            whenever(it.parent) doReturn mockViewGroup
+        }
+
+        // When
+        testedTreeViewTraversal.traverse(
+            mockView,
+            fakeMappingContext,
+            mockRecordedDataQueueRefs
+        )
+
+        // Then
+        val expectedOperationName = "$METHOD_CALL_MAP_PREFIX ${ViewWireframeMapper::class.simpleName}"
+        verify(mockInternalLogger).measureMethodCallPerf(
+            callerClass = TreeViewTraversal::class.java,
+            operationName = expectedOperationName,
+            samplingRate = expectedSampleRate
+        ) {}
+    }
+
+    @Test
+    fun `M return correct sample rate W traverse { DecorViewMapper }()`() {
+        // Given
+        val expectedSampleRate = TreeViewTraversal.MethodCallSamplingRate.REDUCED.rate
+        val mockView = mock<View> {
+            whenever(it.parent) doReturn null
+        }
+
+        // When
+        testedTreeViewTraversal.traverse(
+            mockView,
+            fakeMappingContext,
+            mockRecordedDataQueueRefs
+        )
+
+        // Then
+        val expectedOperationName = "$METHOD_CALL_MAP_PREFIX ${DecorViewMapper::class.simpleName}"
+        verify(mockInternalLogger).measureMethodCallPerf(
+            callerClass = TreeViewTraversal::class.java,
+            operationName = expectedOperationName,
+            samplingRate = expectedSampleRate
+        ) {}
+    }
+
+    @Test
+    fun `M return default sample rate W traverse() { specific mapper }`(forge: Forge) {
+        // Given
+        val expectedSampleRate = TreeViewTraversal.MethodCallSamplingRate.DEFAULT.rate
+        val mockViewGroup = forge.aMockView<ViewGroup>()
+        val mockDefaultView = mock<View> {
+            whenever(it.parent) doReturn mockViewGroup
+        }
+        val mockMapper = mock<MapperTypeWrapper<*>>()
+        val mockWireFrameMapper = mock<WireframeMapper<View>>()
+        whenever(mockMapper.supportsView(mockDefaultView)).thenReturn(true)
+        whenever(mockMapper.getUnsafeMapper()).thenReturn(mockWireFrameMapper)
+
+        testedTreeViewTraversal = TreeViewTraversal(
+            listOf(mockMapper),
+            mockDefaultViewMapper,
+            mockDecorViewMapper,
+            mockViewUtilsInternal,
+            mockInternalLogger
+        )
+
+        // When
+        testedTreeViewTraversal.traverse(
+            mockDefaultView,
+            fakeMappingContext,
+            mockRecordedDataQueueRefs
+        )
+
+        // Then
+        val expectedOperationName = "$METHOD_CALL_MAP_PREFIX ${mockWireFrameMapper::class.simpleName}"
+        verify(mockInternalLogger).measureMethodCallPerf(
+            callerClass = TreeViewTraversal::class.java,
+            operationName = expectedOperationName,
+            samplingRate = expectedSampleRate
+        ) {}
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?
Have more granular telemetry sampling for mappers, using three levels - default, reduced and rare, with each level reducing the number of events by a factor of 10.

### Motivation
At the moment the default sampling rate is producing far too many events for some mappers.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

