### PR TITLE
RUM-1662: Integration of SessionEndedMetric into sdk core

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScope.kt
@@ -17,6 +17,7 @@ import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import java.util.concurrent.TimeUnit
 
@@ -31,6 +32,7 @@ internal class RumApplicationScope(
     private val cpuVitalMonitor: VitalMonitor,
     private val memoryVitalMonitor: VitalMonitor,
     private val frameRateVitalMonitor: VitalMonitor,
+    private val sessionEndedMetricDispatcher: SessionMetricDispatcher,
     private val sessionListener: RumSessionListener?
 ) : RumScope, RumViewChangedListener {
 
@@ -40,6 +42,7 @@ internal class RumApplicationScope(
         RumSessionScope(
             this,
             sdkCore,
+            sessionEndedMetricDispatcher,
             sampleRate,
             backgroundTrackingEnabled,
             trackFrustrations,
@@ -131,6 +134,7 @@ internal class RumApplicationScope(
         val newSession = RumSessionScope(
             this,
             sdkCore,
+            sessionEndedMetricDispatcher,
             sampleRate,
             backgroundTrackingEnabled,
             trackFrustrations,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScope.kt
@@ -14,6 +14,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.utils.percent
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import java.security.SecureRandom
@@ -25,6 +26,7 @@ import java.util.concurrent.atomic.AtomicLong
 internal class RumSessionScope(
     private val parentScope: RumScope,
     private val sdkCore: InternalSdkCore,
+    private val sessionEndedMetricDispatcher: SessionMetricDispatcher,
     internal val sampleRate: Float,
     internal val backgroundTrackingEnabled: Boolean,
     internal val trackFrustrations: Boolean,
@@ -55,6 +57,7 @@ internal class RumSessionScope(
     internal var childScope: RumScope? = RumViewManagerScope(
         this,
         sdkCore,
+        sessionEndedMetricDispatcher,
         backgroundTrackingEnabled,
         trackFrustrations,
         viewChangedListener,
@@ -149,6 +152,7 @@ internal class RumSessionScope(
 
     private fun stopSession() {
         isActive = false
+        sessionEndedMetricDispatcher.onSessionStopped(sessionId)
     }
 
     private fun isSessionComplete(): Boolean {
@@ -169,6 +173,11 @@ internal class RumSessionScope(
         val isBackgroundEvent = event.javaClass in RumViewManagerScope.validBackgroundEventTypes
         val isSdkInitInForeground = event is RumRawEvent.SdkInit && event.isAppInForeground
         val isSdkInitInBackground = event is RumRawEvent.SdkInit && !event.isAppInForeground
+
+        // When the session is expired, time-out or stopSession API is called, session ended metric should be sent
+        if (isExpired || isTimedOut || isActive.not()) {
+            sessionEndedMetricDispatcher.endMetric(sessionId)
+        }
 
         if (isInteraction || isSdkInitInForeground) {
             if (isNewSession || isExpired || isTimedOut) {
@@ -203,6 +212,7 @@ internal class RumSessionScope(
         sessionId = UUID.randomUUID().toString()
         sessionStartNs.set(nanoTime)
         sessionListener?.onSessionStarted(sessionId, !keepSession)
+        sessionEndedMetricDispatcher.startMetric(sessionId, reason)
     }
 
     private fun updateSessionStateForSessionReplay(state: State, sessionId: String) {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -16,13 +16,16 @@ import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import java.util.Locale
 
+@Suppress("LongParameterList")
 internal class RumViewManagerScope(
     private val parentScope: RumScope,
     private val sdkCore: InternalSdkCore,
+    private val sessionEndedMetricDispatcher: SessionMetricDispatcher,
     private val backgroundTrackingEnabled: Boolean,
     private val trackFrustrations: Boolean,
     private val viewChangedListener: RumViewChangedListener?,
@@ -148,6 +151,7 @@ internal class RumViewManagerScope(
     private fun startForegroundView(event: RumRawEvent.StartView, writer: DataWriter<Any>) {
         val viewScope = RumViewScope.fromEvent(
             this,
+            sessionEndedMetricDispatcher,
             sdkCore,
             event,
             viewChangedListener,
@@ -203,6 +207,7 @@ internal class RumViewManagerScope(
         return RumViewScope(
             this,
             sdkCore,
+            sessionEndedMetricDispatcher,
             RumScopeKey(
                 RUM_BACKGROUND_VIEW_ID,
                 RUM_BACKGROUND_VIEW_URL,
@@ -225,6 +230,7 @@ internal class RumViewManagerScope(
         return RumViewScope(
             this,
             sdkCore,
+            sessionEndedMetricDispatcher,
             RumScopeKey(
                 RUM_APP_LAUNCH_VIEW_ID,
                 RUM_APP_LAUNCH_VIEW_URL,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetric.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetric.kt
@@ -50,8 +50,9 @@ internal class SessionEndedMetric(
         return true
     }
 
-    fun onErrorTracked(sdkErrorKind: String) {
-        errorKindFrequencies[sdkErrorKind] = (errorKindFrequencies[sdkErrorKind] ?: 0) + 1
+    fun onErrorTracked(sdkErrorKind: String?) {
+        val errorKindKey = sdkErrorKind ?: SDK_ERROR_DEFAULT_KIND
+        errorKindFrequencies[errorKindKey] = (errorKindFrequencies[errorKindKey] ?: 0) + 1
     }
 
     fun onSessionStopped() {
@@ -202,6 +203,11 @@ internal class SessionEndedMetric(
          * Key of TOP [TOP_ERROR_LIMIT] error kinds to the number of their occurrences in the session.
          */
         internal const val SDK_ERRORS_COUNT_BY_KIND_KEY = "by_kind"
+
+        /**
+         * Placeholder of error kind if the attribute is absent.
+         */
+        internal const val SDK_ERROR_DEFAULT_KIND = "Empty error kind"
     }
 
     /**

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
@@ -52,9 +52,15 @@ internal class SessionEndedMetricDispatcher(private val internalLogger: Internal
     }
 
     override fun onSdkErrorTracked(sessionId: String, errorKind: String?) {
-        errorKind?.let {
-            metricsBySessionId[sessionId]?.onErrorTracked(it)
-        }
+        metricsBySessionId[sessionId]?.onErrorTracked(errorKind) ?: internalLogger.log(
+            level = InternalLogger.Level.INFO,
+            target = InternalLogger.Target.MAINTAINER,
+            { buildSdkErrorTrackError(sessionId, errorKind) }
+        )
+    }
+
+    private fun buildSdkErrorTrackError(sessionId: String, errorKind: String?): String {
+        return "Failed to track $errorKind error, session $sessionId has ended"
     }
 
     private fun buildViewTrackError(sessionId: String, viewEvent: ViewEvent): String {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -41,6 +41,7 @@ import com.datadog.android.rum.internal.domain.scope.RumScopeKey
 import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.telemetry.internal.TelemetryCoreConfiguration
 import com.datadog.android.telemetry.internal.TelemetryEventHandler
@@ -63,6 +64,7 @@ internal class DatadogRumMonitor(
     private val writer: DataWriter<Any>,
     internal val handler: Handler,
     internal val telemetryEventHandler: TelemetryEventHandler,
+    sessionEndedMetricDispatcher: SessionMetricDispatcher,
     firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
     cpuVitalMonitor: VitalMonitor,
     memoryVitalMonitor: VitalMonitor,
@@ -81,6 +83,7 @@ internal class DatadogRumMonitor(
         cpuVitalMonitor,
         memoryVitalMonitor,
         frameRateVitalMonitor,
+        sessionEndedMetricDispatcher = sessionEndedMetricDispatcher,
         CombinedRumSessionListener(sessionListener, telemetryEventHandler)
     )
 

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -19,6 +19,7 @@ import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
 import com.datadog.android.rum.tracking.MixedViewTrackingStrategy
@@ -33,6 +34,7 @@ internal class TelemetryEventHandler(
     internal val sdkCore: InternalSdkCore,
     internal val eventSampler: Sampler,
     internal val configurationExtraSampler: Sampler = RateBasedSampler(DEFAULT_CONFIGURATION_SAMPLE_RATE),
+    private val sessionEndedMetricDispatcher: SessionMetricDispatcher,
     private val maxEventCountPerSession: Int = MAX_EVENTS_PER_SESSION
 ) : RumSessionListener {
 
@@ -64,6 +66,10 @@ internal class TelemetryEventHandler(
                 }
 
                 TelemetryType.ERROR -> {
+                    sessionEndedMetricDispatcher.onSdkErrorTracked(
+                        sessionId = datadogContext.rumContext().sessionId,
+                        errorKind = event.kind
+                    )
                     createErrorEvent(
                         datadogContext = datadogContext,
                         timestamp = timestamp,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -18,6 +18,7 @@ import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.tools.unit.forge.exhaustiveAttributes
@@ -88,6 +89,9 @@ internal class RumApplicationScopeTest {
     @Mock
     lateinit var mockRumFeatureScope: FeatureScope
 
+    @Mock
+    lateinit var mockDispatcher: SessionMetricDispatcher
+
     @StringForgery(regex = "[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}")
     lateinit var fakeApplicationId: String
 
@@ -122,6 +126,7 @@ internal class RumApplicationScopeTest {
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
             mockFrameRateVitalMonitor,
+            mockDispatcher,
             mockSessionListener
         )
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -14,6 +14,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.rum.RumSessionListener
 import com.datadog.android.rum.internal.domain.RumContext
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
@@ -81,6 +82,9 @@ internal class RumSessionScopeTest {
 
     @Mock
     lateinit var mockSdkCore: InternalSdkCore
+
+    @Mock
+    lateinit var mockSessionEndedMetricDispatcher: SessionMetricDispatcher
 
     @Mock
     lateinit var mockViewChangedListener: RumViewChangedListener
@@ -1252,6 +1256,7 @@ internal class RumSessionScopeTest {
         testedScope = RumSessionScope(
             mockParentScope,
             mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             sampleRate,
             backgroundTrackingEnabled ?: fakeBackgroundTrackingEnabled,
             fakeTrackFrustrations,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -23,6 +23,7 @@ import com.datadog.android.rum.internal.anr.ANRDetectorRunnable
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.model.ActionEvent
@@ -88,6 +89,9 @@ internal class RumViewManagerScopeTest {
     lateinit var mockFrameRateVitalMonitor: VitalMonitor
 
     @Mock
+    lateinit var mockSessionEndedMetricDispatcher: SessionMetricDispatcher
+
+    @Mock
     lateinit var mockSdkCore: InternalSdkCore
 
     @Mock
@@ -124,6 +128,7 @@ internal class RumViewManagerScopeTest {
         testedScope = RumViewManagerScope(
             mockParentScope,
             mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             true,
             fakeTrackFrustrations,
             mockViewChangedListener,
@@ -474,6 +479,7 @@ internal class RumViewManagerScopeTest {
         testedScope = RumViewManagerScope(
             parentScope = mockParentScope,
             sdkCore = mockSdkCore,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
             backgroundTrackingEnabled = false,
             trackFrustrations = fakeTrackFrustrations,
             viewChangedListener = mockViewChangedListener,
@@ -502,6 +508,7 @@ internal class RumViewManagerScopeTest {
         testedScope = RumViewManagerScope(
             parentScope = mockParentScope,
             sdkCore = mockSdkCore,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
             backgroundTrackingEnabled = false,
             trackFrustrations = fakeTrackFrustrations,
             viewChangedListener = mockViewChangedListener,
@@ -533,6 +540,7 @@ internal class RumViewManagerScopeTest {
         testedScope = RumViewManagerScope(
             parentScope = mockParentScope,
             sdkCore = mockSdkCore,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
             backgroundTrackingEnabled = false,
             trackFrustrations = fakeTrackFrustrations,
             viewChangedListener = mockViewChangedListener,
@@ -597,6 +605,7 @@ internal class RumViewManagerScopeTest {
         testedScope = RumViewManagerScope(
             parentScope = mockParentScope,
             sdkCore = mockSdkCore,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
             backgroundTrackingEnabled = false,
             trackFrustrations = fakeTrackFrustrations,
             viewChangedListener = mockViewChangedListener,
@@ -629,6 +638,7 @@ internal class RumViewManagerScopeTest {
         testedScope = RumViewManagerScope(
             parentScope = mockParentScope,
             sdkCore = mockSdkCore,
+            sessionEndedMetricDispatcher = mockSessionEndedMetricDispatcher,
             backgroundTrackingEnabled = false,
             trackFrustrations = fakeTrackFrustrations,
             viewChangedListener = mockViewChangedListener,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -32,6 +32,7 @@ import com.datadog.android.rum.internal.RumErrorSourceType
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.Time
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.StorageEvent
 import com.datadog.android.rum.internal.vitals.VitalInfo
@@ -187,6 +188,9 @@ internal class RumViewScopeTest {
     @Mock
     lateinit var mockViewChangedListener: RumViewChangedListener
 
+    @Mock
+    private lateinit var mockSessionEndedMetricDispatcher: SessionMetricDispatcher
+
     @BoolForgery
     var fakeTrackFrustrations: Boolean = true
 
@@ -268,6 +272,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -368,6 +373,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -566,6 +572,7 @@ internal class RumViewScopeTest {
         val anotherScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -751,6 +758,7 @@ internal class RumViewScopeTest {
         RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             key,
             fakeEventTime,
             fakeAttributes,
@@ -805,6 +813,7 @@ internal class RumViewScopeTest {
         RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             key,
             fakeEventTime,
             fakeAttributes,
@@ -1385,6 +1394,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -1478,6 +1488,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -1568,6 +1579,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -1664,6 +1676,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -8449,6 +8462,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             rawEventData.viewKey,
             fakeEventTime,
             fakeAttributes,
@@ -8513,6 +8527,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -8565,6 +8580,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -8623,6 +8639,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -8687,6 +8704,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -8761,6 +8779,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -8835,6 +8854,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -8890,6 +8910,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,
@@ -8951,6 +8972,7 @@ internal class RumViewScopeTest {
         testedScope = RumViewScope(
             mockParentScope,
             rumMonitor.mockSdkCore,
+            mockSessionEndedMetricDispatcher,
             fakeKey,
             fakeEventTime,
             fakeAttributes,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -39,6 +39,7 @@ import com.datadog.android.rum.internal.domain.scope.RumScopeKey
 import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.rum.utils.verifyLog
@@ -130,6 +131,9 @@ internal class DatadogRumMonitorTest {
     lateinit var mockTelemetryEventHandler: TelemetryEventHandler
 
     @Mock
+    lateinit var sessionEndedMetricDispatcher: SessionMetricDispatcher
+
+    @Mock
     lateinit var mockSdkCore: InternalSdkCore
 
     @Mock
@@ -178,6 +182,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -199,6 +204,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -257,6 +263,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -293,6 +300,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -1452,6 +1460,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -1496,6 +1505,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -1527,6 +1537,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
+            sessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -20,6 +20,7 @@ import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.RumContext
 import com.datadog.android.rum.internal.domain.scope.RumRawEvent
+import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.tracking.ActivityViewTrackingStrategy
 import com.datadog.android.rum.tracking.FragmentViewTrackingStrategy
 import com.datadog.android.rum.tracking.MixedViewTrackingStrategy
@@ -107,6 +108,9 @@ internal class TelemetryEventHandlerTest {
     @Mock
     lateinit var mockDeviceInfo: DeviceInfo
 
+    @Mock
+    lateinit var sessionEndedMetricDispatcher: SessionMetricDispatcher
+
     @Forgery
     lateinit var fakeDatadogContext: DatadogContext
 
@@ -180,6 +184,7 @@ internal class TelemetryEventHandlerTest {
             mockSdkCore,
             mockSampler,
             mockConfigurationSampler,
+            sessionEndedMetricDispatcher,
             MAX_EVENTS_PER_SESSION_TEST
         )
     }

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumSessionEndedIntegrationTelemetryTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumSessionEndedIntegrationTelemetryTest.kt
@@ -1,0 +1,108 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.integration
+
+import com.datadog.android.core.stub.StubSDKCore
+import com.datadog.android.rum.GlobalRumMonitor
+import com.datadog.android.rum.Rum
+import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum.integration.tests.assertj.TelemetryMetricAssert.Companion.assertThat
+import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
+import com.datadog.android.rum.integration.tests.utils.MainLooperTestConfiguration
+import com.datadog.tools.unit.annotations.TestConfigurationsProvider
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import com.datadog.tools.unit.extensions.config.TestConfiguration
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@ForgeConfiguration(RumIntegrationForgeConfigurator::class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class RumSessionEndedIntegrationTelemetryTest {
+
+    @StringForgery
+    private lateinit var fakeApplicationId: String
+
+    private lateinit var fakeRumConfiguration: RumConfiguration
+
+    private lateinit var stubSdkCore: StubSDKCore
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        stubSdkCore = StubSDKCore(forge)
+        fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
+            .trackNonFatalAnrs(false)
+            .setTelemetrySampleRate(100f)
+            .build()
+    }
+
+    @Test
+    fun `M receive an event with 'was_stopped' is true W stopSession()`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String
+    ) {
+        // Given
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        rumMonitor.startView(key = viewKey, name = viewName)
+
+        // When
+        rumMonitor.stopSession()
+
+        // Then
+        assertThat(stubSdkCore.lastMetric())
+            .hasWasStopped(true)
+    }
+
+    @Test
+    fun `M receive an event with correct view counts W track multiple views`(
+        @IntForgery(min = 1, max = 5) repeatCount: Int,
+        forge: Forge
+    ) {
+        // Given
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        repeat(repeatCount) {
+            val viewKey = forge.anAlphaNumericalString()
+            rumMonitor.startView(key = viewKey, name = forge.anAlphaNumericalString())
+            rumMonitor.stopView(key = viewKey)
+        }
+
+        // When
+        rumMonitor.stopSession()
+
+        // Then
+        assertThat(stubSdkCore.lastMetric())
+            .hasViewCount(repeatCount)
+    }
+
+    companion object {
+        private val mainLooper = MainLooperTestConfiguration()
+
+        @TestConfigurationsProvider
+        @JvmStatic
+        fun getTestConfigurations(): List<TestConfiguration> {
+            return listOf(mainLooper)
+        }
+    }
+}

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/assertj/TelemetryMetricAssert.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/assertj/TelemetryMetricAssert.kt
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.integration.tests.assertj
+
+import com.datadog.tools.unit.assertj.JsonObjectAssert
+import com.google.gson.Gson
+import com.google.gson.JsonObject
+
+class TelemetryMetricAssert(actual: JsonObject) : JsonObjectAssert(actual, true) {
+
+    fun hasWasStopped(wasStopped: Boolean): TelemetryMetricAssert {
+        hasField("additionalProperties.rse.was_stopped", wasStopped)
+        return this
+    }
+
+    fun hasViewCount(viewCount: Int): TelemetryMetricAssert {
+        hasField("additionalProperties.rse.views_count.total", viewCount)
+        return this
+    }
+
+    companion object {
+        fun assertThat(actual: Map<*, *>?): TelemetryMetricAssert {
+            return TelemetryMetricAssert(Gson().toJsonTree(actual).asJsonObject)
+        }
+    }
+}

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubInternalLogger.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubInternalLogger.kt
@@ -12,6 +12,8 @@ import com.datadog.android.core.metrics.TelemetryMetricType
 
 @Suppress("UnsafeThirdPartyFunctionCall")
 internal class StubInternalLogger : InternalLogger {
+
+    val telemetryEventsWritten = mutableListOf<Map<String, Any>>()
     override fun log(
         level: InternalLogger.Level,
         target: InternalLogger.Target,
@@ -44,6 +46,14 @@ internal class StubInternalLogger : InternalLogger {
     ) {
         println("M [T]: ${messageBuilder()}")
         additionalProperties.log()
+        val message = messageBuilder()
+        val telemetryEvent =
+            mapOf(
+                "type" to "mobile_metric",
+                "message" to message,
+                "additionalProperties" to additionalProperties
+            )
+        telemetryEventsWritten.add(telemetryEvent)
     }
 
     override fun startPerformanceMeasure(

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -73,6 +73,14 @@ class StubSDKCore(
     }
 
     /**
+     * Returns the last metric is sent by [StubInternalLogger].
+     */
+    fun lastMetric(): Map<String, Any>? {
+        return (internalLogger as StubInternalLogger)
+            .telemetryEventsWritten.lastOrNull { it["type"] == "mobile_metric" }
+    }
+
+    /**
      * Stubs the user info visible via the SDK Core.
      * @param userInfo the user info
      */


### PR DESCRIPTION
### What does this PR do?

* Integration of `SessionEndedMetricDispatcher` into core of SDK
* Add integration tests to test "was_stopped" and view counts can be calculate correctly

### Motivation

https://datadoghq.atlassian.net/browse/RUM-1662


### Additional Notes

* the way of tracking sdk error is modified, the session Id retrieved inside TelmetryEventHandler is always `NULL_UUID`, so now it relies on the last session id in `SessionEndedMetricDispatcher`
* `StubInternalLogger` is updated to send the event when `logMetric` is called, so that in integration test the event can be intercepted.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

