### PR TITLE
RUM-4098: Add api to clear all datastore data

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -156,6 +156,7 @@ interface com.datadog.android.api.storage.datastore.DataStoreHandler
   fun <T: Any> setValue(String, T, Int = 0, DataStoreWriteCallback? = null, com.datadog.android.core.persistence.Serializer<T>)
   fun <T: Any> value(String, Int? = null, DataStoreReadCallback<T>, com.datadog.android.core.internal.persistence.Deserializer<String, T>)
   fun removeValue(String, DataStoreWriteCallback? = null)
+  fun clearAllData()
   companion object 
     const val CURRENT_DATASTORE_VERSION: Int
 interface com.datadog.android.api.storage.datastore.DataStoreReadCallback<T: Any>

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -466,6 +466,7 @@ public final class com/datadog/android/api/storage/RawBatchEvent {
 public abstract interface class com/datadog/android/api/storage/datastore/DataStoreHandler {
 	public static final field CURRENT_DATASTORE_VERSION I
 	public static final field Companion Lcom/datadog/android/api/storage/datastore/DataStoreHandler$Companion;
+	public abstract fun clearAllData ()V
 	public abstract fun removeValue (Ljava/lang/String;Lcom/datadog/android/api/storage/datastore/DataStoreWriteCallback;)V
 	public abstract fun setValue (Ljava/lang/String;Ljava/lang/Object;ILcom/datadog/android/api/storage/datastore/DataStoreWriteCallback;Lcom/datadog/android/core/persistence/Serializer;)V
 	public abstract fun value (Ljava/lang/String;Ljava/lang/Integer;Lcom/datadog/android/api/storage/datastore/DataStoreReadCallback;Lcom/datadog/android/core/internal/persistence/Deserializer;)V

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/datastore/DataStoreHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/storage/datastore/DataStoreHandler.kt
@@ -64,6 +64,11 @@ interface DataStoreHandler {
         callback: DataStoreWriteCallback? = null
     )
 
+    /**
+     * Removes all saved datastore entries.
+     */
+    fun clearAllData()
+
     companion object {
         /**
          * The current version of the datastore.

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -131,6 +131,7 @@ internal class SdkFeature(
     @AnyThread
     fun clearAllData() {
         storage.dropAll()
+        dataStore.clearAllData()
     }
 
     fun stop() {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHandler.kt
@@ -40,6 +40,12 @@ internal class DataStoreFileHandler(
         }
     }
 
+    override fun clearAllData() {
+        executorService.executeSafe("dataStoreClearAllData", internalLogger) {
+            datastoreFileWriter.clearAllData()
+        }
+    }
+
     override fun <T : Any> value(
         key: String,
         version: Int?,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHelper.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHelper.kt
@@ -30,19 +30,29 @@ internal class DataStoreFileHelper(
         return File(dataStoreDirectory, key)
     }
 
-    internal fun createDataStoreDirectoryIfNecessary(
-        featureName: String,
+    internal fun getDataStoreDirectory(
         storageDir: File,
-        internalLogger: InternalLogger
+        featureName: String
     ): File {
         val folderName = DATASTORE_FOLDER_NAME.format(
             Locale.US,
             DataStoreHandler.CURRENT_DATASTORE_VERSION
         )
 
-        val dataStoreDirectory = File(
+        return File(
             storageDir,
             "$folderName/$featureName"
+        )
+    }
+
+    internal fun createDataStoreDirectoryIfNecessary(
+        featureName: String,
+        storageDir: File,
+        internalLogger: InternalLogger
+    ): File {
+        val dataStoreDirectory = getDataStoreDirectory(
+            storageDir = storageDir,
+            featureName = featureName
         )
 
         if (!dataStoreDirectory.existsSafe(internalLogger)) {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHelper.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DataStoreFileHelper.kt
@@ -30,7 +30,7 @@ internal class DataStoreFileHelper(
         return File(dataStoreDirectory, key)
     }
 
-    private fun createDataStoreDirectoryIfNecessary(
+    internal fun createDataStoreDirectoryIfNecessary(
         featureName: String,
         storageDir: File,
         internalLogger: InternalLogger

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DatastoreFileWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DatastoreFileWriter.kt
@@ -88,13 +88,14 @@ internal class DatastoreFileWriter(
 
     @WorkerThread
     internal fun clearAllData() {
-        val dataStoreDirectory = dataStoreFileHelper.createDataStoreDirectoryIfNecessary(
+        val dataStoreDirectory = dataStoreFileHelper.getDataStoreDirectory(
             featureName = featureName,
-            storageDir = storageDir,
-            internalLogger = internalLogger
+            storageDir = storageDir
         )
 
-        dataStoreDirectory.deleteDirectoryContentsSafe(internalLogger)
+        if (dataStoreDirectory.existsSafe(internalLogger)) {
+            dataStoreDirectory.deleteDirectoryContentsSafe(internalLogger)
+        }
     }
 
     private fun <T : Any> getDataBlock(

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DatastoreFileWriter.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/DatastoreFileWriter.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.datastore.DataStoreWriteCallback
 import com.datadog.android.core.internal.persistence.datastore.ext.toByteArray
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
+import com.datadog.android.core.internal.persistence.file.deleteDirectoryContentsSafe
 import com.datadog.android.core.internal.persistence.file.deleteSafe
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.tlvformat.TLVBlock
@@ -83,6 +84,17 @@ internal class DatastoreFileWriter(
                 callback?.onFailure()
             }
         }
+    }
+
+    @WorkerThread
+    internal fun clearAllData() {
+        val dataStoreDirectory = dataStoreFileHelper.createDataStoreDirectoryIfNecessary(
+            featureName = featureName,
+            storageDir = storageDir,
+            internalLogger = internalLogger
+        )
+
+        dataStoreDirectory.deleteDirectoryContentsSafe(internalLogger)
     }
 
     private fun <T : Any> getDataBlock(

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/NoOpDataStoreHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/datastore/NoOpDataStoreHandler.kt
@@ -38,4 +38,8 @@ internal class NoOpDataStoreHandler : DataStoreHandler {
     ) {
         // NoOp Implementation
     }
+
+    override fun clearAllData() {
+        // NoOp Implementation
+    }
 }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileExt.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/FileExt.kt
@@ -139,6 +139,12 @@ internal fun File.renameToSafe(dest: File, internalLogger: InternalLogger): Bool
     }
 }
 
+internal fun File.deleteDirectoryContentsSafe(internalLogger: InternalLogger) {
+    this.listFilesSafe(internalLogger)?.forEach {
+        it.deleteSafe(internalLogger)
+    }
+}
+
 /**
  * Non-throwing version of [File.readText]. If exception happens, null is returned.
  */

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/SdkFeatureTest.kt
@@ -16,6 +16,7 @@ import com.datadog.android.api.feature.FeatureEventReceiver
 import com.datadog.android.api.feature.StorageBackedFeature
 import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.FeatureStorageConfiguration
+import com.datadog.android.api.storage.datastore.DataStoreHandler
 import com.datadog.android.core.configuration.BatchProcessingLevel
 import com.datadog.android.core.configuration.BatchSize
 import com.datadog.android.core.configuration.UploadFrequency
@@ -89,6 +90,9 @@ internal class SdkFeatureTest {
 
     @Mock
     lateinit var mockStorage: Storage
+
+    @Mock
+    lateinit var mockDataStore: DataStoreHandler
 
     @Mock
     lateinit var mockWrappedFeature: StorageBackedFeature
@@ -422,6 +426,18 @@ internal class SdkFeatureTest {
 
         // Then
         verify(mockStorage).dropAll()
+    }
+
+    @Test
+    fun `M clear data store W clearAllData()`() {
+        // Given
+        testedFeature.dataStore = mockDataStore
+
+        // When
+        testedFeature.clearAllData()
+
+        // Then
+        verify(mockDataStore).clearAllData()
     }
 
     // region FeatureScope

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/datastore/DataStoreFileWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/datastore/DataStoreFileWriterTest.kt
@@ -193,10 +193,9 @@ internal class DataStoreFileWriterTest {
     fun `M call deleteSafe W clearAllData() { for files }`() {
         // Given
         whenever(
-            mockDataStoreFileHelper.createDataStoreDirectoryIfNecessary(
-                fakeFeatureName,
-                mockStorageDir,
-                mockInternalLogger
+            mockDataStoreFileHelper.getDataStoreDirectory(
+                storageDir = mockStorageDir,
+                featureName = fakeFeatureName
             )
         ).thenReturn(mockDataStoreDirectory)
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/datastore/DataStoreFileWriterTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/file/datastore/DataStoreFileWriterTest.kt
@@ -188,4 +188,25 @@ internal class DataStoreFileWriterTest {
         // Then
         verify(mockDataStoreFile, never()).deleteSafe(mockInternalLogger)
     }
+
+    @Test
+    fun `M call deleteSafe W clearAllData() { for files }`() {
+        // Given
+        whenever(
+            mockDataStoreFileHelper.createDataStoreDirectoryIfNecessary(
+                fakeFeatureName,
+                mockStorageDir,
+                mockInternalLogger
+            )
+        ).thenReturn(mockDataStoreDirectory)
+
+        whenever(mockDataStoreDirectory.listFiles())
+            .thenReturn(arrayOf(mockDataStoreFile))
+
+        // When
+        testedDatastoreFileWriter.clearAllData()
+
+        // Then
+        verify(mockDataStoreFile).deleteSafe(mockInternalLogger)
+    }
 }


### PR DESCRIPTION
### What does this PR do?
Adds an api to delete all saved datastore entries. 

### Motivation
The core's clearAllData api should return the sdk to a fresh state and therefore requires removal of datastore information.

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

