### PR TITLE
RUM-4822 Report upload_size for RUM Resources

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -98,7 +98,7 @@ interface com.datadog.android.rum.RumMonitor
   fun stopAction(RumActionType, String, Map<String, Any?> = emptyMap())
   DEPRECATED fun startResource(String, String, String, Map<String, Any?> = emptyMap())
   fun startResource(String, RumResourceMethod, String, Map<String, Any?> = emptyMap())
-  fun stopResource(String, Int?, Long?, RumResourceKind, Map<String, Any?>)
+  fun stopResource(String, Int?, Long?, Long?, RumResourceKind, Map<String, Any?>)
   fun stopResourceWithError(String, Int?, String, RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
   fun stopResourceWithError(String, Int?, String, RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
   fun addError(String, RumErrorSource, Throwable?, Map<String, Any?>)
@@ -1171,7 +1171,7 @@ data class com.datadog.android.rum.model.ResourceEvent
       fun fromJson(kotlin.String): Container
       fun fromJsonObject(com.google.gson.JsonObject): Container
   data class Resource
-    constructor(kotlin.String? = null, ResourceType, Method? = null, kotlin.String, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, Redirect? = null, Dns? = null, Connect? = null, Ssl? = null, FirstByte? = null, Download? = null, Provider? = null, Graphql? = null)
+    constructor(kotlin.String? = null, ResourceType, Method? = null, kotlin.String, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, kotlin.Long? = null, Redirect? = null, Dns? = null, Connect? = null, Ssl? = null, FirstByte? = null, Download? = null, Provider? = null, Graphql? = null)
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Resource

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -152,7 +152,7 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun startResource (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun startView (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun stopAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun stopResource (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Lcom/datadog/android/rum/RumResourceKind;Ljava/util/Map;)V
+	public abstract fun stopResource (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/RumResourceKind;Ljava/util/Map;)V
 	public abstract fun stopResourceWithError (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun stopResourceWithError (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public abstract fun stopSession ()V
@@ -3627,25 +3627,26 @@ public final class com/datadog/android/rum/model/ResourceEvent$Redirect$Companio
 
 public final class com/datadog/android/rum/model/ResourceEvent$Resource {
 	public static final field Companion Lcom/datadog/android/rum/model/ResourceEvent$Resource$Companion;
-	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
-	public final fun component10 ()Lcom/datadog/android/rum/model/ResourceEvent$Connect;
-	public final fun component11 ()Lcom/datadog/android/rum/model/ResourceEvent$Ssl;
-	public final fun component12 ()Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;
-	public final fun component13 ()Lcom/datadog/android/rum/model/ResourceEvent$Download;
-	public final fun component14 ()Lcom/datadog/android/rum/model/ResourceEvent$Provider;
-	public final fun component15 ()Lcom/datadog/android/rum/model/ResourceEvent$Graphql;
+	public final fun component10 ()Lcom/datadog/android/rum/model/ResourceEvent$Dns;
+	public final fun component11 ()Lcom/datadog/android/rum/model/ResourceEvent$Connect;
+	public final fun component12 ()Lcom/datadog/android/rum/model/ResourceEvent$Ssl;
+	public final fun component13 ()Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;
+	public final fun component14 ()Lcom/datadog/android/rum/model/ResourceEvent$Download;
+	public final fun component15 ()Lcom/datadog/android/rum/model/ResourceEvent$Provider;
+	public final fun component16 ()Lcom/datadog/android/rum/model/ResourceEvent$Graphql;
 	public final fun component2 ()Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;
 	public final fun component3 ()Lcom/datadog/android/rum/model/ResourceEvent$Method;
 	public final fun component4 ()Ljava/lang/String;
 	public final fun component5 ()Ljava/lang/Long;
 	public final fun component6 ()Ljava/lang/Long;
 	public final fun component7 ()Ljava/lang/Long;
-	public final fun component8 ()Lcom/datadog/android/rum/model/ResourceEvent$Redirect;
-	public final fun component9 ()Lcom/datadog/android/rum/model/ResourceEvent$Dns;
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
-	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ResourceEvent$Resource;Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
+	public final fun component8 ()Ljava/lang/Long;
+	public final fun component9 ()Lcom/datadog/android/rum/model/ResourceEvent$Redirect;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
+	public static synthetic fun copy$default (Lcom/datadog/android/rum/model/ResourceEvent$Resource;Ljava/lang/String;Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;Lcom/datadog/android/rum/model/ResourceEvent$Method;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;Lcom/datadog/android/rum/model/ResourceEvent$Redirect;Lcom/datadog/android/rum/model/ResourceEvent$Dns;Lcom/datadog/android/rum/model/ResourceEvent$Connect;Lcom/datadog/android/rum/model/ResourceEvent$Ssl;Lcom/datadog/android/rum/model/ResourceEvent$FirstByte;Lcom/datadog/android/rum/model/ResourceEvent$Download;Lcom/datadog/android/rum/model/ResourceEvent$Provider;Lcom/datadog/android/rum/model/ResourceEvent$Graphql;ILjava/lang/Object;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/rum/model/ResourceEvent$Resource;
@@ -3663,6 +3664,7 @@ public final class com/datadog/android/rum/model/ResourceEvent$Resource {
 	public final fun getSsl ()Lcom/datadog/android/rum/model/ResourceEvent$Ssl;
 	public final fun getStatusCode ()Ljava/lang/Long;
 	public final fun getType ()Lcom/datadog/android/rum/model/ResourceEvent$ResourceType;
+	public final fun getUploadSize ()Ljava/lang/Long;
 	public final fun getUrl ()Ljava/lang/String;
 	public fun hashCode ()I
 	public final fun setUrl (Ljava/lang/String;)V

--- a/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
+++ b/features/dd-sdk-android-rum/src/main/json/rum/resource-schema.json
@@ -63,6 +63,12 @@
               "minimum": 0,
               "readOnly": true
             },
+            "upload_size": {
+              "type": "integer",
+              "description": "Size in octet of the resource request body",
+              "minimum": 0,
+              "readOnly": true
+            },
             "size": {
               "type": "integer",
               "description": "Size in octet of the resource response body",

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -155,7 +155,8 @@ interface RumMonitor {
      * @param key the instance that represents the active view (usually your
      * request or network call instance).
      * @param statusCode the status code of the resource (if any)
-     * @param size the size of the resource, in bytes
+     * @param uploadSize the size of the resource, in bytes
+     * @param downloadSize the size of the resource, in bytes
      * @param kind the type of resource loaded
      * @param attributes additional custom attributes to attach to the resource. Attributes can be
      * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
@@ -165,7 +166,8 @@ interface RumMonitor {
     fun stopResource(
         key: String,
         statusCode: Int?,
-        size: Long?,
+        uploadSize: Long?,
+        downloadSize: Long?,
         kind: RumResourceKind,
         attributes: Map<String, Any?>
     )

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -71,7 +71,8 @@ internal sealed class RumRawEvent {
     internal data class StopResource(
         val key: String,
         val statusCode: Long?,
-        val size: Long?,
+        val uploadSize: Long?,
+        val downloadSize: Long?,
         val kind: RumResourceKind,
         val attributes: Map<String, Any?>,
         override val eventTime: Time = Time()

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -62,7 +62,8 @@ internal class RumResourceScope(
     internal var stopped = false
     private var kind: RumResourceKind = RumResourceKind.UNKNOWN
     private var statusCode: Long? = null
-    private var size: Long? = null
+    private var uploadSize: Long? = null
+    private var downloadSize: Long? = null
 
     // region RumScope
 
@@ -105,10 +106,11 @@ internal class RumResourceScope(
         attributes.putAll(event.attributes)
         kind = event.kind
         statusCode = event.statusCode
-        size = event.size
+        uploadSize = event.uploadSize
+        downloadSize = event.downloadSize
 
         if (!(waitForTiming && timing == null)) {
-            sendResource(kind, event.statusCode, event.size, event.eventTime, writer)
+            sendResource(event.eventTime, writer)
         }
     }
 
@@ -121,7 +123,7 @@ internal class RumResourceScope(
 
         timing = event.timing
         if (stopped && !sent) {
-            sendResource(kind, statusCode, size, event.eventTime, writer)
+            sendResource(event.eventTime, writer)
         }
     }
 
@@ -170,9 +172,6 @@ internal class RumResourceScope(
 
     @Suppress("LongMethod")
     private fun sendResource(
-        kind: RumResourceKind,
-        statusCode: Long?,
-        size: Long?,
         eventTime: Time,
         writer: DataWriter<Any>
     ) {
@@ -226,7 +225,8 @@ internal class RumResourceScope(
                     duration = duration,
                     method = method.toResourceMethod(),
                     statusCode = statusCode,
-                    size = size,
+                    size = downloadSize,
+                    uploadSize = uploadSize,
                     dns = finalTiming?.dns(),
                     connect = finalTiming?.connect(),
                     ssl = finalTiming?.ssl(),

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -241,7 +241,8 @@ internal class DatadogRumMonitor(
     override fun stopResource(
         key: String,
         statusCode: Int?,
-        size: Long?,
+        uploadSize: Long?,
+        downloadSize: Long?,
         kind: RumResourceKind,
         attributes: Map<String, Any?>
     ) {
@@ -250,7 +251,8 @@ internal class DatadogRumMonitor(
             RumRawEvent.StopResource(
                 key,
                 statusCode?.toLong(),
-                size,
+                uploadSize,
+                downloadSize,
                 kind,
                 attributes.toMap(),
                 eventTime

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/resource/RumResourceInputStream.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/resource/RumResourceInputStream.kt
@@ -142,11 +142,12 @@ constructor(
                 )
             )
             monitor.stopResource(
-                key,
-                null,
-                size,
-                RumResourceKind.OTHER,
-                emptyMap()
+                key = key,
+                statusCode = null,
+                uploadSize = null,
+                downloadSize = size,
+                kind = RumResourceKind.OTHER,
+                attributes = emptyMap()
             )
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScopeTest.kt
@@ -216,14 +216,15 @@ internal class RumActionScopeTest {
         @Forgery method: RumResourceMethod,
         @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery kind: RumResourceKind
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        fakeEvent = RumRawEvent.StopResource(key, statusCode, size, kind, emptyMap())
+        fakeEvent = RumRawEvent.StopResource(key, statusCode, uploadSize, downloadSize, kind, emptyMap())
         val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
         val result3 = testedScope.handleEvent(mockEvent(), mockWriter)
@@ -285,14 +286,15 @@ internal class RumActionScopeTest {
         @Forgery method: RumResourceMethod,
         @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery kind: RumResourceKind
     ) {
         // When
         fakeEvent = RumRawEvent.StartResource(key, url, method, emptyMap())
         val result = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        fakeEvent = RumRawEvent.StopResource(key2, statusCode, size, kind, emptyMap())
+        fakeEvent = RumRawEvent.StopResource(key2, statusCode, uploadSize, downloadSize, kind, emptyMap())
         val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
         val result3 = testedScope.handleEvent(mockEvent(), mockWriter)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumContinuousActionScopeTest.kt
@@ -409,7 +409,8 @@ internal class RumContinuousActionScopeTest {
         @Forgery method: RumResourceMethod,
         @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery kind: RumResourceKind
     ) {
         // When
@@ -418,7 +419,7 @@ internal class RumContinuousActionScopeTest {
         fakeEvent = RumRawEvent.StopAction(fakeType, fakeName, emptyMap())
         val result2 = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
-        fakeEvent = RumRawEvent.StopResource(key, statusCode, size, kind, emptyMap())
+        fakeEvent = RumRawEvent.StopResource(key, statusCode, uploadSize, downloadSize, kind, emptyMap())
         val result3 = testedScope.handleEvent(fakeEvent, mockWriter)
         Thread.sleep(TEST_INACTIVITY_MS * 2)
         val result4 = testedScope.handleEvent(mockEvent(), mockWriter)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -69,7 +69,8 @@ internal fun Forge.stopResourceEvent(): RumRawEvent.StopResource {
     return RumRawEvent.StopResource(
         key = anAlphabeticalString(),
         statusCode = aNullable { aLong(100, 600) },
-        size = aNullable { aPositiveLong() },
+        uploadSize = aNullable { aPositiveLong() },
+        downloadSize = aNullable { aPositiveLong() },
         kind = aValueFrom(RumResourceKind::class.java),
         attributes = exhaustiveAttributes()
     )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -238,7 +238,8 @@ internal class RumResourceScopeTest {
     fun `M send Resource event W handleEvent(StopResource)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -249,7 +250,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -306,7 +307,8 @@ internal class RumResourceScopeTest {
     fun `M add first party type provider to Resource W handleEvent(StopResource)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -318,7 +320,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -376,7 +378,8 @@ internal class RumResourceScopeTest {
     fun `M use the url for provider domain W handleEvent(StopResource) { url is broken }`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -402,7 +405,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -460,7 +463,8 @@ internal class RumResourceScopeTest {
     fun `M send Resource with trace info W handleEvent(StopResource)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @StringForgery(type = StringForgeryType.HEXADECIMAL) fakeSpanId: String,
         @StringForgery(type = StringForgeryType.HEXADECIMAL) fakeTraceId: String,
         @FloatForgery(0f, 1f) fakeRulePsr: Float,
@@ -478,7 +482,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -536,7 +540,8 @@ internal class RumResourceScopeTest {
         @Forgery context: RumContext,
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -548,7 +553,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -607,7 +612,8 @@ internal class RumResourceScopeTest {
         @StringForgery fakeResultId: String,
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -636,7 +642,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -693,11 +699,12 @@ internal class RumResourceScopeTest {
     fun `M send event with user extra attributes W handleEvent(StopResource)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long
     ) {
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, emptyMap())
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, emptyMap())
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -754,11 +761,12 @@ internal class RumResourceScopeTest {
     fun `M do not send error event W handleEvent(StopResource with error statusCode)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(400, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long
     ) {
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, emptyMap())
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, emptyMap())
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -806,11 +814,12 @@ internal class RumResourceScopeTest {
     fun `M not send related error event W handleEvent(StopResource with success statusCode)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 399) statusCode: Long,
-        @LongForgery(0, 1024) size: Long
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long
     ) {
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, emptyMap())
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, emptyMap())
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -826,11 +835,12 @@ internal class RumResourceScopeTest {
     @Test
     fun `M not send related error event W handleEvent(StopResource with missing statusCode)`(
         @Forgery kind: RumResourceKind,
-        @LongForgery(0, 1024) size: Long
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long
     ) {
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, null, size, kind, emptyMap())
+        mockEvent = RumRawEvent.StopResource(fakeKey, null, uploadSize, downloadSize, kind, emptyMap())
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -847,7 +857,8 @@ internal class RumResourceScopeTest {
     fun `M send Resource with initial global attributes W handleEvent(StopResource)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -875,7 +886,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, emptyMap())
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, emptyMap())
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -932,7 +943,8 @@ internal class RumResourceScopeTest {
     fun `M send Resource with global attributes W handleEvent(StopResource)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -946,7 +958,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, emptyMap())
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, emptyMap())
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -1003,7 +1015,8 @@ internal class RumResourceScopeTest {
     fun `M send Resource with timing W handleEvent(AddResourceTiming+StopResource)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery timing: ResourceTiming,
         forge: Forge
     ) {
@@ -1017,7 +1030,7 @@ internal class RumResourceScopeTest {
         mockEvent = RumRawEvent.AddResourceTiming(fakeKey, timing)
         val resultTiming = testedScope.handleEvent(mockEvent, mockWriter)
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -1076,7 +1089,8 @@ internal class RumResourceScopeTest {
     fun `M send Resource W handleEvent(AddResourceTiming+StopResource) {unrelated timing}`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery timing: ResourceTiming,
         forge: Forge
     ) {
@@ -1090,7 +1104,7 @@ internal class RumResourceScopeTest {
         mockEvent = RumRawEvent.AddResourceTiming("not_the_$fakeKey", timing)
         val resultTiming = testedScope.handleEvent(mockEvent, mockWriter)
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val result = testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -2235,14 +2249,15 @@ internal class RumResourceScopeTest {
     fun `M do nothing W handleEvent(StopResource) with different key`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
         val expectedAttributes = mutableMapOf<String, Any?>()
         expectedAttributes.putAll(fakeAttributes)
         expectedAttributes.putAll(attributes)
-        mockEvent = RumRawEvent.StopResource("not_the_$fakeKey", statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource("not_the_$fakeKey", statusCode, uploadSize, downloadSize, kind, attributes)
 
         Thread.sleep(RESOURCE_DURATION_MS)
         val result = testedScope.handleEvent(mockEvent, mockWriter)
@@ -2307,7 +2322,8 @@ internal class RumResourceScopeTest {
     fun `M do nothing W handleEvent(WaitForResourceTiming+StopResource)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
@@ -2318,7 +2334,7 @@ internal class RumResourceScopeTest {
         mockEvent = RumRawEvent.WaitForResourceTiming(fakeKey)
         val resultWaitForTiming = testedScope.handleEvent(mockEvent, mockWriter)
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val resultStop = testedScope.handleEvent(mockEvent, mockWriter)
 
         verify(mockParentScope, atMost(1)).getRumContext()
@@ -2331,7 +2347,8 @@ internal class RumResourceScopeTest {
     fun `M send Resource W handleEvent(WaitForResourceTiming+StopResource) {unrelated wait}`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys)
@@ -2342,7 +2359,7 @@ internal class RumResourceScopeTest {
         mockEvent = RumRawEvent.WaitForResourceTiming("not_the_$fakeKey")
         val resultWaitForTiming = testedScope.handleEvent(mockEvent, mockWriter)
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val resultStop = testedScope.handleEvent(mockEvent, mockWriter)
 
         argumentCaptor<ResourceEvent> {
@@ -2395,7 +2412,8 @@ internal class RumResourceScopeTest {
     fun `M send Resource W handleEvent(WaitForResourceTiming+AddResourceTiming+StopResource)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery timing: ResourceTiming,
         forge: Forge
     ) {
@@ -2409,7 +2427,7 @@ internal class RumResourceScopeTest {
         mockEvent = RumRawEvent.AddResourceTiming(fakeKey, timing)
         val resultTiming = testedScope.handleEvent(mockEvent, mockWriter)
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val resultStop = testedScope.handleEvent(mockEvent, mockWriter)
 
         argumentCaptor<ResourceEvent> {
@@ -2463,7 +2481,8 @@ internal class RumResourceScopeTest {
     fun `M send Resource W handleEvent(WaitForResourceTiming+StopResource+AddResourceTiming)`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery timing: ResourceTiming,
         forge: Forge
     ) {
@@ -2474,7 +2493,7 @@ internal class RumResourceScopeTest {
 
         mockEvent = RumRawEvent.WaitForResourceTiming(fakeKey)
         val resultWaitForTiming = testedScope.handleEvent(mockEvent, mockWriter)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         val resultStop = testedScope.handleEvent(mockEvent, mockWriter)
         Thread.sleep(RESOURCE_DURATION_MS)
         mockEvent = RumRawEvent.AddResourceTiming(fakeKey, timing)
@@ -2532,7 +2551,8 @@ internal class RumResourceScopeTest {
     fun `M use explicit timings W handleEvent { AddResourceTiming + StopResource }`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery timing: ResourceTiming,
         forge: Forge
     ) {
@@ -2543,7 +2563,7 @@ internal class RumResourceScopeTest {
                     to forge.getForgery(ResourceTiming::class.java).asTimingsPayload()
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
 
         // When
         testedScope
@@ -2561,7 +2581,8 @@ internal class RumResourceScopeTest {
     fun `M use attributes timings W handleEvent { StopResource without AddResourceTiming  }`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery timing: ResourceTiming,
         forge: Forge
     ) {
@@ -2569,7 +2590,7 @@ internal class RumResourceScopeTest {
         val attributes = forge.exhaustiveAttributes(excludedKeys = fakeAttributes.keys) +
             mapOf("_dd.resource_timings" to timing.asTimingsPayload())
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
 
         // When
         testedScope.handleEvent(mockEvent, mockWriter)
@@ -2586,16 +2607,19 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         val fakeStatusCode = forge.aNullable { forge.aLong() }
-        val fakeSize = forge.aNullable { forge.aLong() }
+        val fakeUploadSize = forge.aNullable { forge.aLong() }
+        val fakeDownloadSize = forge.aNullable { forge.aLong() }
         val fakeKind = forge.aValueFrom(RumResourceKind::class.java)
         val fakeStopEvent = RumRawEvent.StopResource(
-            fakeKey,
-            fakeStatusCode,
-            fakeSize,
-            fakeKind,
-            emptyMap(),
-            Time(0, 0)
+            key = fakeKey,
+            statusCode = fakeStatusCode,
+            uploadSize = fakeUploadSize,
+            downloadSize = fakeDownloadSize,
+            kind = fakeKind,
+            attributes = emptyMap(),
+            eventTime = Time(0, 0)
         )
+
         // Given
         val result = testedScope.handleEvent(fakeStopEvent, mockWriter)
 
@@ -2653,16 +2677,19 @@ internal class RumResourceScopeTest {
         forge: Forge
     ) {
         val fakeStatusCode = forge.aNullable { forge.aLong() }
-        val fakeSize = forge.aNullable { forge.aLong() }
+        val fakeUploadSize = forge.aNullable { forge.aLong() }
+        val fakeDownloadSize = forge.aNullable { forge.aLong() }
         val fakeKind = forge.aValueFrom(RumResourceKind::class.java)
         val fakeStopEvent = RumRawEvent.StopResource(
-            fakeKey,
-            fakeStatusCode,
-            fakeSize,
-            fakeKind,
-            emptyMap(),
-            fakeEventTime
+            key = fakeKey,
+            statusCode = fakeStatusCode,
+            uploadSize = fakeUploadSize,
+            downloadSize = fakeDownloadSize,
+            kind = fakeKind,
+            attributes = emptyMap(),
+            eventTime = fakeEventTime
         )
+
         // Given
         val result = testedScope.handleEvent(fakeStopEvent, mockWriter)
 
@@ -2719,7 +2746,8 @@ internal class RumResourceScopeTest {
     fun `M use graphql attributes W handleEvent`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -2735,7 +2763,7 @@ internal class RumResourceScopeTest {
                 "_dd.graphql.variables" to variables
             )
 
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
 
         // When
         testedScope.handleEvent(mockEvent, mockWriter)
@@ -2753,7 +2781,8 @@ internal class RumResourceScopeTest {
     fun `M notify about success W handleEvent() { resource write succeeded }`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -2761,7 +2790,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -2773,7 +2802,8 @@ internal class RumResourceScopeTest {
     fun `M notify about error W handleEvent() { resource write failed }`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -2782,7 +2812,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then
@@ -2794,7 +2824,8 @@ internal class RumResourceScopeTest {
     fun `M notify about error W handleEvent() { resource write throws }`(
         @Forgery kind: RumResourceKind,
         @LongForgery(200, 600) statusCode: Long,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         forge: Forge
     ) {
         // Given
@@ -2805,7 +2836,7 @@ internal class RumResourceScopeTest {
 
         // When
         Thread.sleep(RESOURCE_DURATION_MS)
-        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, size, kind, attributes)
+        mockEvent = RumRawEvent.StopResource(fakeKey, statusCode, uploadSize, downloadSize, kind, attributes)
         testedScope.handleEvent(mockEvent, mockWriter)
 
         // Then

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -475,10 +475,11 @@ internal class DatadogRumMonitorTest {
     fun `M delegate event to rootScope W stopResource()`(
         @StringForgery key: String,
         @IntForgery(200, 600) statusCode: Int,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery kind: RumResourceKind
     ) {
-        testedMonitor.stopResource(key, statusCode, size, kind, fakeAttributes)
+        testedMonitor.stopResource(key, statusCode, uploadSize, downloadSize, kind, fakeAttributes)
         Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
@@ -488,7 +489,8 @@ internal class DatadogRumMonitorTest {
             assertThat(event.key).isEqualTo(key)
             assertThat(event.statusCode).isEqualTo(statusCode.toLong())
             assertThat(event.kind).isEqualTo(kind)
-            assertThat(event.size).isEqualTo(size)
+            assertThat(event.uploadSize).isEqualTo(uploadSize)
+            assertThat(event.downloadSize).isEqualTo(downloadSize)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)
@@ -499,7 +501,7 @@ internal class DatadogRumMonitorTest {
         @StringForgery key: String,
         @Forgery kind: RumResourceKind
     ) {
-        testedMonitor.stopResource(key, null, null, kind, fakeAttributes)
+        testedMonitor.stopResource(key, null, null, null, kind, fakeAttributes)
         Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
@@ -509,7 +511,8 @@ internal class DatadogRumMonitorTest {
             assertThat(event.key).isEqualTo(key)
             assertThat(event.statusCode).isNull()
             assertThat(event.kind).isEqualTo(kind)
-            assertThat(event.size).isNull()
+            assertThat(event.uploadSize).isNull()
+            assertThat(event.downloadSize).isNull()
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)
@@ -950,12 +953,13 @@ internal class DatadogRumMonitorTest {
     fun `M delegate event to rootScope with timestamp W stopResource()`(
         @StringForgery key: String,
         @IntForgery(200, 600) statusCode: Int,
-        @LongForgery(0, 1024) size: Long,
+        @LongForgery(0, 1024) uploadSize: Long,
+        @LongForgery(0, 1024) downloadSize: Long,
         @Forgery kind: RumResourceKind
     ) {
         val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
 
-        testedMonitor.stopResource(key, statusCode, size, kind, attributes)
+        testedMonitor.stopResource(key, statusCode, uploadSize, downloadSize, kind, attributes)
         Thread.sleep(PROCESSING_DELAY)
 
         argumentCaptor<RumRawEvent> {
@@ -966,7 +970,8 @@ internal class DatadogRumMonitorTest {
             assertThat(event.key).isEqualTo(key)
             assertThat(event.statusCode).isEqualTo(statusCode.toLong())
             assertThat(event.kind).isEqualTo(kind)
-            assertThat(event.size).isEqualTo(size)
+            assertThat(event.uploadSize).isEqualTo(uploadSize)
+            assertThat(event.downloadSize).isEqualTo(downloadSize)
             assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
         }
         verifyNoMoreInteractions(mockScope, mockWriter)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/RumResourceInputStreamTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/RumResourceInputStreamTest.kt
@@ -235,6 +235,7 @@ internal class RumResourceInputStreamTest {
         verify(rumMonitor.mockInstance).stopResource(
             testedInputStream.key,
             null,
+            null,
             0L,
             RumResourceKind.OTHER,
             emptyMap()
@@ -502,6 +503,7 @@ internal class RumResourceInputStreamTest {
             verify(rumMonitor.mockInstance).stopResource(
                 testedInputStream.key,
                 null,
+                null,
                 contentBytes.size.toLong(),
                 RumResourceKind.OTHER,
                 emptyMap()
@@ -549,6 +551,7 @@ internal class RumResourceInputStreamTest {
                 .addResourceTiming(eq(testedInputStream.key), any())
             verify(rumMonitor.mockInstance).stopResource(
                 testedInputStream.key,
+                null,
                 null,
                 contentBytes.size.toLong(),
                 RumResourceKind.OTHER,
@@ -601,6 +604,7 @@ internal class RumResourceInputStreamTest {
             verify(rumMonitor.mockInstance).stopResource(
                 testedInputStream.key,
                 null,
+                null,
                 (len1 + mark + mark + len2).toLong(),
                 RumResourceKind.OTHER,
                 emptyMap()
@@ -647,6 +651,7 @@ internal class RumResourceInputStreamTest {
                 .addResourceTiming(eq(testedInputStream.key), any())
             verify(rumMonitor.mockInstance).stopResource(
                 testedInputStream.key,
+                null,
                 null,
                 (len1 + len2).toLong(),
                 RumResourceKind.OTHER,
@@ -704,6 +709,7 @@ internal class RumResourceInputStreamTest {
             }
             verify(rumMonitor.mockInstance).stopResource(
                 testedInputStream.key,
+                null,
                 null,
                 contentBytes.size.toLong(),
                 RumResourceKind.OTHER,

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/security/EncryptionTest.kt
@@ -183,10 +183,11 @@ internal class EncryptionTest {
         logger.w("Action added")
 
         rumMonitor.stopResource(
-            resourceName,
-            forge.anInt(100, 600),
-            forge.aLong(min = 0L),
-            forge.aValueFrom(RumResourceKind::class.java),
+            key = resourceName,
+            statusCode = forge.anInt(100, 600),
+            uploadSize = forge.aLong(min = 0L),
+            downloadSize = forge.aLong(min = 0L),
+            kind = forge.aValueFrom(RumResourceKind::class.java),
             attributes = emptyMap()
         )
 

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -303,11 +303,12 @@ internal constructor(
             )
         }
         GlobalRumMonitor.get(sdkCore).stopResource(
-            requestId,
-            statusCode,
-            getBodyLength(response, sdkCore.internalLogger),
-            kind,
-            attributes + rumResourceAttributesProvider.onProvideAttributes(request, response, null)
+            key = requestId,
+            statusCode = statusCode,
+            uploadSize = request.body?.contentLength(),
+            downloadSize = getBodyLength(response, sdkCore.internalLogger),
+            kind = kind,
+            attributes = attributes + rumResourceAttributesProvider.onProvideAttributes(request, response, null)
         )
     }
 

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -209,6 +209,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 fakeResponseBody.toByteArray().size.toLong(),
                 kind,
                 expectedStopAttrs
@@ -254,6 +255,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 fakeResponseBody.toByteArray().size.toLong(),
                 kind,
                 expectedStopAttrs
@@ -298,6 +300,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 fakeResponseBody.toByteArray().size.toLong(),
                 kind,
                 expectedStopAttrs
@@ -346,6 +349,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 null,
                 kind,
                 expectedStopAttrs
@@ -393,6 +397,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 null,
                 kind,
                 expectedStopAttrs
@@ -439,6 +444,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 null,
                 kind,
                 expectedStopAttrs
@@ -484,6 +490,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 null,
                 kind,
                 expectedStopAttrs
@@ -545,6 +552,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 null,
                 kind,
                 expectedStopAttrs
@@ -604,6 +612,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 null,
                 kind,
                 expectedStopAttrs
@@ -644,6 +653,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 fakeResponseBody.toByteArray().size.toLong(),
                 kind,
                 expectedStopAttrs
@@ -682,6 +692,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 fakeResponseBody.toByteArray().size.toLong(),
                 kind,
                 expectedStopAttrs

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -204,6 +204,7 @@ internal class DatadogInterceptorWithoutTracesTest {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 fakeResponseBody.toByteArray().size.toLong(),
                 kind,
                 expectedStopAttrs
@@ -245,6 +246,7 @@ internal class DatadogInterceptorWithoutTracesTest {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 fakeResponseBody.toByteArray().size.toLong(),
                 kind,
                 expectedStopAttrs
@@ -287,6 +289,7 @@ internal class DatadogInterceptorWithoutTracesTest {
             verify(rumMonitor.mockInstance).stopResource(
                 requestId,
                 statusCode,
+                fakeRequest.body?.contentLength(),
                 fakeResponseBody.toByteArray().size.toLong(),
                 kind,
                 expectedStopAttrs

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -131,7 +131,9 @@ internal open class TracingInterceptorNotSendingSpanTest {
     lateinit var fakeHostIp: String
 
     lateinit var fakeMethod: RumResourceMethod
+
     var fakeBody: String? = null
+
     var fakeMediaType: MediaType? = null
 
     @StringForgery(type = StringForgeryType.ASCII)

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/ManualTrackingRumTest.kt
@@ -331,7 +331,8 @@ class ManualTrackingRumTest {
         @StringForgery resourceKey: String,
         @Forgery resourceUrl: URL,
         @IntForgery(200, 599) resourceStatus: Int,
-        @LongForgery(0) resourceSize: Long
+        @LongForgery(0) uploadSize: Long,
+        @LongForgery(0) downloadSize: Long
     ) {
         // Given
         val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
@@ -340,7 +341,14 @@ class ManualTrackingRumTest {
         rumMonitor.startView(key, name, emptyMap())
         rumMonitor.startResource(resourceKey, RumResourceMethod.GET, resourceUrl.toString())
         Thread.sleep(100)
-        rumMonitor.stopResource(resourceKey, resourceStatus, resourceSize, RumResourceKind.NATIVE, emptyMap())
+        rumMonitor.stopResource(
+            key = resourceKey,
+            statusCode = resourceStatus,
+            uploadSize = uploadSize,
+            downloadSize = downloadSize,
+            kind = RumResourceKind.NATIVE,
+            attributes = emptyMap()
+        )
         rumMonitor.stopView(key, emptyMap())
 
         // Then

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumConfigurationTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumConfigurationTest.kt
@@ -148,7 +148,8 @@ class RumConfigurationTest {
         @StringForgery mappedResourceUrl: String,
         @Forgery resourceMethod: RumResourceMethod,
         @IntForgery(200, 599) statusCode: Int,
-        @LongForgery size: Long,
+        @LongForgery uploadSize: Long,
+        @LongForgery downloadSize: Long,
         @Forgery resourceKind: RumResourceKind
     ) {
         // Given
@@ -166,7 +167,7 @@ class RumConfigurationTest {
         // When
         rumMonitor.startView(viewKey, viewName, emptyMap())
         rumMonitor.startResource(originalResourceUrl, resourceMethod, originalResourceUrl, emptyMap())
-        rumMonitor.stopResource(originalResourceUrl, statusCode, size, resourceKind, emptyMap())
+        rumMonitor.stopResource(originalResourceUrl, statusCode, uploadSize, downloadSize, resourceKind, emptyMap())
 
         // Then
         val eventsWritten = stubSdkCore.eventsWritten(Feature.RUM_FEATURE_NAME)


### PR DESCRIPTION
### What does this PR do?

Add the `upload_size` to RUM Resources (among other to track the `POST` OkHttp requests)

> [!NOTE]
> This will be part of a debug version of the SDK to help our customer regarding Incident 27794, and won't be merged into develop in the current state.