### PR TITLE
RUM-4592: Add diagnostic attributes to "RUM Session Ended" metric

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionMetricDispatcher.kt
@@ -19,12 +19,17 @@ internal interface SessionMetricDispatcher {
     /**
      * Starts a session metric with given session id and start reason of this session.
      */
-    fun startMetric(sessionId: String, startReason: RumSessionScope.StartReason)
+    fun startMetric(
+        sessionId: String,
+        startReason: RumSessionScope.StartReason,
+        ntpOffsetAtStartMs: Long,
+        backgroundEventTracking: Boolean
+    )
 
     /**
      * Ends the session metric with given session id.
      */
-    fun endMetric(sessionId: String)
+    fun endMetric(sessionId: String, ntpOffsetAtEndMs: Long)
 
     /**
      * Called when the session is stopped.
@@ -40,4 +45,9 @@ internal interface SessionMetricDispatcher {
      * Called when a sdk error is tracked by this session metric.
      */
     fun onSdkErrorTracked(sessionId: String, errorKind: String?)
+
+    /**
+     * Called when a missed event is tracked by this session metric.
+     */
+    fun onMissedEventTracked(sessionId: String, missedEventType: SessionEndedMetric.MissedEventType)
 }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.internal.domain.scope
 
+import com.datadog.android.api.context.TimeInfo
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.storage.DataWriter
@@ -101,6 +102,9 @@ internal class RumSessionScopeTest {
     @BoolForgery
     var fakeTrackFrustrations: Boolean = true
 
+    @Forgery
+    lateinit var fakeTimeInfo: TimeInfo
+
     lateinit var fakeInitialViewEvent: RumRawEvent
 
     @Mock
@@ -114,6 +118,7 @@ internal class RumSessionScopeTest {
         whenever(mockChildScope.handleEvent(any(), any())) doReturn mockChildScope
         whenever(mockSdkCore.getFeature(Feature.SESSION_REPLAY_FEATURE_NAME)) doReturn
             mockSessionReplayFeatureScope
+        whenever(mockSdkCore.time) doReturn (fakeTimeInfo)
 
         initializeTestedScope()
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcherTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcherTest.kt
@@ -10,7 +10,9 @@ import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -29,22 +31,31 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(Configurator::class)
-class SessionEndedMetricDispatcherTest {
+internal class SessionEndedMetricDispatcherTest {
 
     private val fakeInternalLogger = FakeInternalLogger()
 
     @Forgery
     private lateinit var fakeStartReason: RumSessionScope.StartReason
 
+    @LongForgery
+    private var fakeNtpOffsetAtStart: Long = 0L
+
+    @LongForgery
+    private var fakeNtpOffsetAtEnd: Long = 0L
+
+    @BoolForgery
+    private var backgroundEventTracking: Boolean = false
+
     @Test
     fun `M register session stop W call onSessionStopped()`(@StringForgery fakeSessionId: String) {
         // Given
         val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
-        dispatcher.startMetric(fakeSessionId, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
 
         // When
         dispatcher.onSessionStopped(fakeSessionId)
-        dispatcher.endMetric(fakeSessionId)
+        dispatcher.endMetric(fakeSessionId, fakeNtpOffsetAtEnd)
 
         // Then
         assertThat(fakeInternalLogger.isSessionStopped()).isTrue()
@@ -60,14 +71,14 @@ class SessionEndedMetricDispatcherTest {
         val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
 
         // When
-        dispatcher.startMetric(fakeSessionId1, fakeStartReason)
-        dispatcher.startMetric(fakeSessionId2, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId1, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+        dispatcher.startMetric(fakeSessionId2, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
         viewEvent.copy(session = viewEvent.session.copy(id = fakeSessionId2)).apply {
             dispatcher.onViewTracked(fakeSessionId1, this)
         }
 
-        dispatcher.endMetric(fakeSessionId1)
-        dispatcher.endMetric(fakeSessionId2)
+        dispatcher.endMetric(fakeSessionId1, fakeNtpOffsetAtEnd)
+        dispatcher.endMetric(fakeSessionId2, fakeNtpOffsetAtEnd)
 
         // Then
         assertThat(fakeInternalLogger.errorLog).isNotNull()
@@ -85,10 +96,10 @@ class SessionEndedMetricDispatcherTest {
         val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
 
         // When
-        dispatcher.startMetric(fakeSessionId1, fakeStartReason)
-        dispatcher.startMetric(fakeSessionId2, fakeStartReason)
-        dispatcher.startMetric(fakeSessionId3, fakeStartReason)
-        dispatcher.startMetric(fakeSessionId4, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId1, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+        dispatcher.startMetric(fakeSessionId2, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+        dispatcher.startMetric(fakeSessionId3, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+        dispatcher.startMetric(fakeSessionId4, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
 
         viewEvents.map {
             it.copy(session = it.session.copy(id = fakeSessionId2))
@@ -97,16 +108,16 @@ class SessionEndedMetricDispatcherTest {
         }
 
         // Then
-        dispatcher.endMetric(fakeSessionId1)
+        dispatcher.endMetric(fakeSessionId1, fakeNtpOffsetAtEnd)
         assertThat(fakeInternalLogger.getViewCounts()).isEqualTo(0)
 
-        dispatcher.endMetric(fakeSessionId2)
+        dispatcher.endMetric(fakeSessionId2, fakeNtpOffsetAtEnd)
         assertThat(fakeInternalLogger.getViewCounts()).isEqualTo(fakeInternalLogger.getViewCounts())
 
-        dispatcher.endMetric(fakeSessionId3)
+        dispatcher.endMetric(fakeSessionId3, fakeNtpOffsetAtEnd)
         assertThat(fakeInternalLogger.getViewCounts()).isEqualTo(0)
 
-        dispatcher.endMetric(fakeSessionId1)
+        dispatcher.endMetric(fakeSessionId1, fakeNtpOffsetAtEnd)
         assertThat(fakeInternalLogger.getViewCounts()).isEqualTo(0)
     }
 
@@ -122,27 +133,179 @@ class SessionEndedMetricDispatcherTest {
         val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
 
         // When
-        dispatcher.startMetric(fakeSessionId1, fakeStartReason)
-        dispatcher.startMetric(fakeSessionId2, fakeStartReason)
-        dispatcher.startMetric(fakeSessionId3, fakeStartReason)
-        dispatcher.startMetric(fakeSessionId4, fakeStartReason)
+        dispatcher.startMetric(fakeSessionId1, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+        dispatcher.startMetric(fakeSessionId2, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+        dispatcher.startMetric(fakeSessionId3, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+        dispatcher.startMetric(fakeSessionId4, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
 
         // Ends the last started session
-        dispatcher.endMetric(fakeSessionId4)
+        dispatcher.endMetric(fakeSessionId4, fakeNtpOffsetAtEnd)
         // Ends a middle session
-        dispatcher.endMetric(fakeSessionId2)
+        dispatcher.endMetric(fakeSessionId2, fakeNtpOffsetAtEnd)
 
         errorKinds.forEach {
             dispatcher.onSdkErrorTracked(fakeSessionId3, it)
         }
 
         // Then
-        dispatcher.endMetric(fakeSessionId1)
+        dispatcher.endMetric(fakeSessionId1, fakeNtpOffsetAtEnd)
         assertThat(fakeInternalLogger.getErrorCounts()).isEqualTo(0)
 
         // Errors can is reported by the last session when they are tracked
-        dispatcher.endMetric(fakeSessionId3)
+        dispatcher.endMetric(fakeSessionId3, fakeNtpOffsetAtEnd)
         assertThat(fakeInternalLogger.getErrorCounts()).isEqualTo(errorKinds.size)
+    }
+
+    @Test
+    fun `M has correct 'with_has_replay' W track multiple views`(
+        @StringForgery fakeSessionId: String,
+        @Forgery viewEvents: List<ViewEvent>
+    ) {
+        // Given
+        val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
+
+        // When
+        dispatcher.startMetric(fakeSessionId, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+
+        viewEvents.map { it.copy(session = it.session.copy(id = fakeSessionId)) }.forEach {
+            dispatcher.onViewTracked(fakeSessionId, it)
+        }
+        dispatcher.endMetric(fakeSessionId, fakeNtpOffsetAtEnd)
+
+        // Then
+        assertThat(fakeInternalLogger.getHasReplayCount()).isEqualTo(viewEvents.count { it.session.hasReplay == true })
+    }
+
+    @Test
+    fun `M has correct 'no_view_events_count' W track missed event`(
+        @StringForgery fakeSessionId: String,
+        @Forgery missedTypes: List<SessionEndedMetric.MissedEventType>
+    ) {
+        // Given
+        val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
+
+        // When
+        dispatcher.startMetric(fakeSessionId, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+        missedTypes.forEach {
+            dispatcher.onMissedEventTracked(fakeSessionId, it)
+        }
+        dispatcher.endMetric(fakeSessionId, fakeNtpOffsetAtEnd)
+
+        // Then
+        assertThat(
+            fakeInternalLogger.getMissedTypeCount(SessionEndedMetric.MissedEventType.ACTION)
+        ).isEqualTo(
+            missedTypes.count {
+                it == SessionEndedMetric.MissedEventType.ACTION
+            }
+        )
+        assertThat(
+            fakeInternalLogger.getMissedTypeCount(SessionEndedMetric.MissedEventType.RESOURCE)
+        ).isEqualTo(
+            missedTypes.count {
+                it == SessionEndedMetric.MissedEventType.RESOURCE
+            }
+        )
+        assertThat(
+            fakeInternalLogger.getMissedTypeCount(SessionEndedMetric.MissedEventType.ERROR)
+        ).isEqualTo(
+            missedTypes.count {
+                it == SessionEndedMetric.MissedEventType.ERROR
+            }
+        )
+        assertThat(
+            fakeInternalLogger.getMissedTypeCount(SessionEndedMetric.MissedEventType.LONG_TASK)
+        ).isEqualTo(
+            missedTypes.count {
+                it == SessionEndedMetric.MissedEventType.LONG_TASK
+            }
+        )
+    }
+
+    @Test
+    fun `M has correct 'has_background_events_tracking_enabled' W start metric`(
+        @StringForgery fakeSessionId: String,
+        @BoolForgery backgroundEventTracking:
+        Boolean
+    ) {
+        // Given
+        val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
+
+        // When
+        dispatcher.startMetric(fakeSessionId, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+        dispatcher.endMetric(fakeSessionId, fakeNtpOffsetAtEnd)
+
+        // Then
+        assertThat(fakeInternalLogger.getBackgroundEventTracking()).isEqualTo(backgroundEventTracking)
+    }
+
+    @Test
+    fun `M has correct ntp attribute W start and end metric`(
+        @StringForgery fakeSessionId: String,
+        @LongForgery fakeNtpOffsetAtStart: Long,
+        @LongForgery fakeNtpOffsetAtEnd: Long
+    ) {
+        // Given
+        val dispatcher = SessionEndedMetricDispatcher(fakeInternalLogger)
+
+        // When
+        dispatcher.startMetric(fakeSessionId, fakeStartReason, fakeNtpOffsetAtStart, backgroundEventTracking)
+        dispatcher.endMetric(fakeSessionId, fakeNtpOffsetAtEnd)
+
+        // Then
+        assertThat(fakeInternalLogger.getNtpAtStartOffset()).isEqualTo(fakeNtpOffsetAtStart)
+        assertThat(fakeInternalLogger.getNtpAtEndOffset()).isEqualTo(fakeNtpOffsetAtEnd)
+    }
+
+    private fun FakeInternalLogger.getNtpAtStartOffset(): Long {
+        return lastMetric?.second?.let { attributes ->
+            val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+            val ntpOffset = rse[SessionEndedMetric.NTP_OFFSET_KEY] as Map<*, *>
+            ntpOffset[SessionEndedMetric.NTP_OFFSET_AT_START_KEY] as Long
+        } ?: -1
+    }
+
+    private fun FakeInternalLogger.getNtpAtEndOffset(): Long {
+        return lastMetric?.second?.let { attributes ->
+            val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+            val ntpOffset = rse[SessionEndedMetric.NTP_OFFSET_KEY] as Map<*, *>
+            ntpOffset[SessionEndedMetric.NTP_OFFSET_AT_END_KEY] as Long
+        } ?: -1
+    }
+
+    private fun FakeInternalLogger.getBackgroundEventTracking(): Boolean? {
+        return lastMetric?.second?.let { attributes ->
+            val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+            rse[SessionEndedMetric.HAS_BACKGROUND_EVENTS_TRACKING_ENABLED_KEY] as? Boolean
+        }
+    }
+
+    private fun FakeInternalLogger.getMissedTypeCount(missedEventType: SessionEndedMetric.MissedEventType): Int {
+        return lastMetric?.second?.let { attributes ->
+            val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+            val noViewEventCount = rse[SessionEndedMetric.NO_VIEW_EVENTS_COUNT_KEY] as Map<*, *>
+            when (missedEventType) {
+                SessionEndedMetric.MissedEventType.ACTION ->
+                    noViewEventCount[SessionEndedMetric.NO_VIEW_EVENTS_COUNT_ACTIONS_KEY]
+
+                SessionEndedMetric.MissedEventType.RESOURCE ->
+                    noViewEventCount[SessionEndedMetric.NO_VIEW_EVENTS_COUNT_RESOURCES_KEY]
+
+                SessionEndedMetric.MissedEventType.ERROR ->
+                    noViewEventCount[SessionEndedMetric.NO_VIEW_EVENTS_COUNT_ERRORS_KEY]
+
+                SessionEndedMetric.MissedEventType.LONG_TASK ->
+                    noViewEventCount[SessionEndedMetric.NO_VIEW_EVENTS_COUNT_LONG_TASKS_KEY]
+            } as Int
+        } ?: -1
+    }
+
+    private fun FakeInternalLogger.getHasReplayCount(): Int {
+        return lastMetric?.second?.let { attributes ->
+            val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+            val viewCount = rse[SessionEndedMetric.VIEW_COUNTS_KEY] as Map<*, *>
+            viewCount[SessionEndedMetric.VIEW_COUNT_WITH_HAS_REPLAY] as Int
+        } ?: -1
     }
 
     private fun FakeInternalLogger.isSessionStopped(): Boolean? {
@@ -155,8 +318,8 @@ class SessionEndedMetricDispatcherTest {
     private fun FakeInternalLogger.getErrorCounts(): Int {
         return lastMetric?.second?.let { attributes ->
             val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
-            val viewCount = rse[SessionEndedMetric.SDK_ERRORS_COUNT_KEY] as Map<*, *>
-            viewCount[SessionEndedMetric.SDK_ERRORS_COUNT_TOTAL_KEY] as Int
+            val errorCount = rse[SessionEndedMetric.SDK_ERRORS_COUNT_KEY] as Map<*, *>
+            errorCount[SessionEndedMetric.SDK_ERRORS_COUNT_TOTAL_KEY] as Int
         } ?: -1
     }
 

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumSessionEndedIntegrationTelemetryTest.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/RumSessionEndedIntegrationTelemetryTest.kt
@@ -9,7 +9,10 @@ package com.datadog.android.rum.integration
 import com.datadog.android.core.stub.StubSDKCore
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.Rum
+import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumConfiguration
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.integration.tests.assertj.TelemetryMetricAssert.Companion.assertThat
 import com.datadog.android.rum.integration.tests.elmyr.RumIntegrationForgeConfigurator
 import com.datadog.android.rum.integration.tests.utils.MainLooperTestConfiguration
@@ -17,7 +20,9 @@ import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -27,6 +32,7 @@ import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
 @Extensions(
@@ -52,6 +58,28 @@ class RumSessionEndedIntegrationTelemetryTest {
             .trackNonFatalAnrs(false)
             .setTelemetrySampleRate(100f)
             .build()
+    }
+
+    @Test
+    fun `M not receive an event W the session is not sampled`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String
+    ) {
+        // Given
+        val configuration = RumConfiguration.Builder(fakeApplicationId)
+            .trackNonFatalAnrs(false)
+            .setSessionSampleRate(0f)
+            .build()
+        Rum.enable(configuration, stubSdkCore)
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        rumMonitor.startView(key = viewKey, name = viewName)
+
+        // When
+        rumMonitor.stopSession()
+
+        // Then
+        assertThat(stubSdkCore.lastMetric()).isEmpty()
     }
 
     @Test
@@ -94,6 +122,101 @@ class RumSessionEndedIntegrationTelemetryTest {
         // Then
         assertThat(stubSdkCore.lastMetric())
             .hasViewCount(repeatCount)
+    }
+
+    @Test
+    fun `M have correct 'has_background_events_tracking_enabled' W stopSession()`(
+        @BoolForgery trackBackgroundEvents: Boolean,
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String
+    ) {
+        val fakeRumConfiguration = RumConfiguration.Builder(fakeApplicationId)
+            .trackNonFatalAnrs(false)
+            .setTelemetrySampleRate(100f)
+            .trackBackgroundEvents(trackBackgroundEvents)
+            .build()
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        rumMonitor.startView(key = viewKey, name = viewName)
+
+        // When
+        rumMonitor.stopSession()
+
+        // Then
+        assertThat(stubSdkCore.lastMetric())
+            .hasBackgroundEventsTrackingEnable(trackBackgroundEvents)
+    }
+
+    @Test
+    fun `M receive an event with correct 'ntp_offset' W stopSession()`(
+
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @LongForgery ntpOffsetAtStart: Long,
+        @LongForgery ntpOffsetAtEnd: Long
+    ) {
+        // Given
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        whenever(stubSdkCore.time.serverTimeOffsetMs).thenReturn(ntpOffsetAtStart)
+        rumMonitor.startView(key = viewKey, name = viewName)
+
+        // When
+        whenever(stubSdkCore.time.serverTimeOffsetMs).thenReturn(ntpOffsetAtEnd)
+        rumMonitor.stopSession()
+
+        // Then
+        assertThat(stubSdkCore.lastMetric())
+            .hasNtpOffsetAtStart(ntpOffsetAtStart)
+            .hasNtpOffsetAtEnd(ntpOffsetAtEnd)
+    }
+
+    @Test
+    fun `M have correct missed type W events are recorded with no view active`(
+        @StringForgery viewKey: String,
+        @StringForgery viewName: String,
+        @IntForgery(min = 1, max = 5) missedActionCount: Int,
+        @IntForgery(min = 1, max = 5) missedErrorCount: Int,
+        @IntForgery(min = 1, max = 5) missedResourceCount: Int,
+        forge: Forge
+    ) {
+        // Given
+        Rum.enable(fakeRumConfiguration, stubSdkCore)
+        val rumMonitor = GlobalRumMonitor.get(stubSdkCore)
+
+        // When
+        rumMonitor.startView(viewKey, viewName)
+        rumMonitor.stopView(viewKey)
+
+        repeat(missedActionCount) {
+            val actionType = forge.aValueFrom(RumActionType::class.java)
+            val name = forge.aString()
+            rumMonitor.addAction(type = actionType, name = name, attributes = mapOf())
+        }
+
+        repeat(missedErrorCount) {
+            val source = forge.aValueFrom(RumErrorSource::class.java)
+            val message = forge.aString()
+            rumMonitor.addError(message = message, source = source, throwable = null, attributes = mapOf())
+        }
+
+        repeat(missedResourceCount) {
+            val key = forge.aString()
+            val url = forge.aString()
+            val method = forge.aValueFrom(RumResourceMethod::class.java)
+            rumMonitor.startResource(key = key, method = method, url = url, attributes = mapOf())
+        }
+        // Integration test for long task is skipped since we can not trigger long task of main thread in unit test.
+
+        rumMonitor.stopSession()
+
+        // Then
+        assertThat(stubSdkCore.lastMetric())
+            .hasNoViewActionEventCounts(missedActionCount)
+            .hasNoViewErrorEventCounts(missedErrorCount)
+            .hasNoViewResourceEventCounts(missedResourceCount)
     }
 
     companion object {

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/assertj/TelemetryMetricAssert.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/assertj/TelemetryMetricAssert.kt
@@ -22,6 +22,41 @@ class TelemetryMetricAssert(actual: JsonObject) : JsonObjectAssert(actual, true)
         return this
     }
 
+    fun hasBackgroundEventsTrackingEnable(enable: Boolean): TelemetryMetricAssert {
+        hasField("additionalProperties.rse.has_background_events_tracking_enabled", enable)
+        return this
+    }
+
+    fun hasNtpOffsetAtStart(ntpOffsetAtStart: Long): TelemetryMetricAssert {
+        hasField("additionalProperties.rse.ntp_offset.at_start", ntpOffsetAtStart)
+        return this
+    }
+
+    fun hasNtpOffsetAtEnd(ntpOffsetAtEnd: Long): TelemetryMetricAssert {
+        hasField("additionalProperties.rse.ntp_offset.at_end", ntpOffsetAtEnd)
+        return this
+    }
+
+    fun hasNoViewActionEventCounts(count: Int): TelemetryMetricAssert {
+        hasField("additionalProperties.rse.no_view_events_count.actions", count)
+        return this
+    }
+
+    fun hasNoViewErrorEventCounts(count: Int): TelemetryMetricAssert {
+        hasField("additionalProperties.rse.no_view_events_count.errors", count)
+        return this
+    }
+
+    fun hasNoViewResourceEventCounts(count: Int): TelemetryMetricAssert {
+        hasField("additionalProperties.rse.no_view_events_count.resources", count)
+        return this
+    }
+
+    fun hasNoViewLongTaskEventCounts(count: Int): TelemetryMetricAssert {
+        hasField("additionalProperties.rse.no_view_events_count.long_tasks", count)
+        return this
+    }
+
     companion object {
         fun assertThat(actual: Map<*, *>?): TelemetryMetricAssert {
             return TelemetryMetricAssert(Gson().toJsonTree(actual).asJsonObject)

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubSDKCore.kt
@@ -75,9 +75,9 @@ class StubSDKCore(
     /**
      * Returns the last metric is sent by [StubInternalLogger].
      */
-    fun lastMetric(): Map<String, Any>? {
+    fun lastMetric(): Map<String, Any> {
         return (internalLogger as StubInternalLogger)
-            .telemetryEventsWritten.lastOrNull { it["type"] == "mobile_metric" }
+            .telemetryEventsWritten.lastOrNull { it["type"] == "mobile_metric" }.orEmpty()
     }
 
     /**
@@ -173,16 +173,7 @@ class StubSDKCore(
             return datadogContext.service
         }
 
-    override val time: TimeInfo
-        get() {
-            val nanos = System.nanoTime()
-            return TimeInfo(
-                deviceTimeNs = nanos,
-                serverTimeNs = nanos,
-                serverTimeOffsetMs = 0L,
-                serverTimeOffsetNs = 0L
-            )
-        }
+    override val time: TimeInfo = mock()
 
     override fun setUserInfo(
         id: String?,


### PR DESCRIPTION
### What does this PR do?

Add following attributes into "Rum Session Ended Metric"

```
“rse” : {

   “views_count”: { 

      “with_has_replay”: <int>,

   },

   “no_view_events_count”: { “actions”: <int>, “resources”: <int>, “errors”: <int>, “long_tasks”: <int> },

   “has_background_events_tracking_enabled”: <bool>,

   “ntp_offset”: { “at_start”: <int>, “at_end”: <int> }

 }

}
```

### Motivation

As Required in RUM-4592

### Additional Notes

* Following attribute is not added on Android,

```
 “by_instrumentation”: { “<instrumentation type>”: <int> },
```

* Long task count is skipped in integration test since it's not possible to simulate with unit test env.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

