### PR TITLE
RUM-4822 Let GZipped requests report an accurate upoad size

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -1201,6 +1201,8 @@ datadog:
       - "okhttp3.Response.header(kotlin.String, kotlin.String?)"
       - "okhttp3.ResponseBody.contentLength()"
       - "okio.Buffer.constructor()"
+      - "okio.GzipSink.buffer()"
+      - "okio.GzipSink.constructor(okio.Sink)"
       # endregion
       # region org.json
       - "org.json.JSONArray.length()"


### PR DESCRIPTION
### What does this PR do?

Ensure gzipped requests report their actual content length and not -1

> [!NOTE]
> This will be part of a debug version of the SDK to help our customer regarding Incident 27794, and won't be merged into develop in the current state.