### PR TITLE
RUM-4822 Allow monitoring internal connection pool

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -151,6 +151,8 @@ data class com.datadog.android.api.storage.RawBatchEvent
   constructor(ByteArray, ByteArray = EMPTY_BYTE_ARRAY)
   override fun equals(Any?): Boolean
   override fun hashCode(): Int
+data class com.datadog.android.core.ConnectionPoolInfo
+  constructor(Int, Int)
 interface com.datadog.android.core.InternalSdkCore : com.datadog.android.api.feature.FeatureSdkCore
   val networkInfo: com.datadog.android.api.context.NetworkInfo
   val trackingConsent: com.datadog.android.privacy.TrackingConsent

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -462,6 +462,19 @@ public final class com/datadog/android/api/storage/RawBatchEvent {
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/datadog/android/core/ConnectionPoolInfo {
+	public fun <init> (II)V
+	public final fun component1 ()I
+	public final fun component2 ()I
+	public final fun copy (II)Lcom/datadog/android/core/ConnectionPoolInfo;
+	public static synthetic fun copy$default (Lcom/datadog/android/core/ConnectionPoolInfo;IIILjava/lang/Object;)Lcom/datadog/android/core/ConnectionPoolInfo;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getConnectionCount ()I
+	public final fun getIdleConnectionCount ()I
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface class com/datadog/android/core/InternalSdkCore : com/datadog/android/api/feature/FeatureSdkCore {
 	public abstract fun deleteLastViewEvent ()V
 	public abstract fun getAllFeatures ()Ljava/util/List;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/ConnectionPoolInfo.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/ConnectionPoolInfo.kt
@@ -1,0 +1,17 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core
+
+/**
+ * Provide information abouth the internal OkHttp Connection pool.
+ * @property connectionCount the total number of connections in the pool
+ * @property idleConnectionCount the number of idle connections in the pool
+ */
+data class ConnectionPoolInfo(
+    val connectionCount: Int,
+    val idleConnectionCount: Int
+)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumResourceAttributesProvider.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumResourceAttributesProvider.kt
@@ -15,7 +15,7 @@ import okhttp3.Response
  * offers a possibility to add custom attributes to the RUM Resource event.
  */
 @NoOpImplementation
-interface RumResourceAttributesProvider {
+fun interface RumResourceAttributesProvider {
 
     /**
      * Offers a possibility to create custom attributes collection which later will be attached to

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -13,6 +13,7 @@ import android.util.Log
 import androidx.lifecycle.ViewModelProvider
 import com.datadog.android.Datadog
 import com.datadog.android.DatadogSite
+import com.datadog.android.core.ConnectionPoolInfo
 import com.datadog.android.core.configuration.BackPressureMitigation
 import com.datadog.android.core.configuration.BackPressureStrategy
 import com.datadog.android.core.configuration.BatchSize
@@ -272,7 +273,17 @@ class SampleApplication : Application() {
             )
         )
 
-        configBuilder.addNetworkInterceptor(DatadogInterceptor())
+        configBuilder.addNetworkInterceptor(
+            DatadogInterceptor(
+                rumResourceAttributesProvider = { request, _, _ ->
+                    val connectionPoolInfo = request.tag(ConnectionPoolInfo::class.java)
+                    mapOf(
+                        "connection_pool.connection_count" to connectionPoolInfo?.connectionCount,
+                        "connection_pool.idle_connection_count" to connectionPoolInfo?.idleConnectionCount
+                    )
+                }
+            )
+        )
 
         return configBuilder.build()
     }


### PR DESCRIPTION
### What does this PR do?

Adds a way for our customer to know the number of connections used by the internal OkHttpClient

> [!NOTE]
> This will be part of a debug version of the SDK to help our customer regarding Incident 27794, and won't be merged into develop in the current state.