### PR TITLE
RUM-5077: Fix units for dropped nodes

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandler.kt
@@ -221,6 +221,6 @@ internal class RecordedDataQueueHandler(
 
         @VisibleForTesting
         internal const val ITEM_DROPPED_EXPIRED_MESSAGE =
-            "SR RecordedDataQueueHandler: dropped item from the queue. age=%d ms"
+            "SR RecordedDataQueueHandler: dropped item from the queue. age=%d ns"
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/async/RecordedDataQueueHandlerTest.kt
@@ -252,7 +252,8 @@ internal class RecordedDataQueueHandlerTest {
         val item = testedHandler.addSnapshotItem(mockSystemInformation)
 
         // Then
-        assertThat(item!!.recordedQueuedItemContext).isEqualTo(currentRumContextData)
+        checkNotNull(item)
+        assertThat(item.recordedQueuedItemContext).isEqualTo(currentRumContextData)
         assertThat(item.systemInformation).isEqualTo(mockSystemInformation)
         assertThat(testedHandler.recordedDataQueue.size).isEqualTo(1)
     }
@@ -269,7 +270,8 @@ internal class RecordedDataQueueHandlerTest {
             testedHandler.addTouchEventItem(fakeTouchData)
 
         // Then
-        assertThat(item!!.recordedQueuedItemContext).isEqualTo(currentRumContextData)
+        checkNotNull(item)
+        assertThat(item.recordedQueuedItemContext).isEqualTo(currentRumContextData)
         assertThat(item.touchData).isEqualTo(fakeTouchData)
         assertThat(testedHandler.recordedDataQueue.size).isEqualTo(1)
     }
@@ -485,9 +487,9 @@ internal class RecordedDataQueueHandlerTest {
     @Test
     fun `M consume items in the correct order W tryToConsumeItems() { spawn multiple threads }`() {
         // Given
-        val item1 = createFakeSnapshotItemWithDelayMs(1)
-        val item2 = createFakeSnapshotItemWithDelayMs(2)
-        val item3 = createFakeSnapshotItemWithDelayMs(3)
+        val item1 = addSnapshotItemToQueue()
+        val item2 = addSnapshotItemToQueue()
+        val item3 = addSnapshotItemToQueue()
 
         item1.isFinishedTraversal = true
         item2.isFinishedTraversal = true
@@ -565,9 +567,9 @@ internal class RecordedDataQueueHandlerTest {
     @Test
     fun `M clear pending queue and stop processor W clearAndStopProcessing() { pending items }`() {
         // Given
-        createFakeSnapshotItemWithDelayMs(1)
-        createFakeSnapshotItemWithDelayMs(2)
-        createFakeSnapshotItemWithDelayMs(3)
+        addSnapshotItemToQueue()
+        addSnapshotItemToQueue()
+        addSnapshotItemToQueue()
 
         // When
         testedHandler.clearAndStopProcessingQueue()
@@ -670,9 +672,9 @@ internal class RecordedDataQueueHandlerTest {
 
     // endregion
 
-    private fun createFakeSnapshotItemWithDelayMs(delay: Int): SnapshotRecordedDataQueueItem {
+    private fun addSnapshotItemToQueue(): SnapshotRecordedDataQueueItem {
         val newRumContext = RecordedQueuedItemContext(
-            timestamp = System.nanoTime() + delay,
+            timestamp = System.currentTimeMillis(),
             newRumContext = fakeRecordedQueuedItemContext.newRumContext
         )
 
@@ -680,7 +682,8 @@ internal class RecordedDataQueueHandlerTest {
             .thenReturn(newRumContext)
 
         val item = testedHandler.addSnapshotItem(mockSystemInformation)
-        item!!.nodes = fakeNodeData
+        checkNotNull(item)
+        item.nodes = fakeNodeData
         return item
     }
 


### PR DESCRIPTION
### What does this PR do?
We're sending ns instead of ms in the error msg for dropped nodes, but still write "ms" in the message itself. This pr fixes the units in the message. 

### Motivation
Wrong units in the dropped nodes error.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

