### PR TITLE
Add sampling rate to internal metrics

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -42,7 +42,7 @@ interface com.datadog.android.api.InternalLogger
     - TELEMETRY
   fun log(Level, Target, () -> String, Throwable? = null, Boolean = false, Map<String, Any?>? = null)
   fun log(Level, List<Target>, () -> String, Throwable? = null, Boolean = false, Map<String, Any?>? = null)
-  fun logMetric(() -> String, Map<String, Any?>)
+  fun logMetric(() -> String, Map<String, Any?>, Float)
   fun startPerformanceMeasure(String, com.datadog.android.core.metrics.TelemetryMetricType, Float, String): com.datadog.android.core.metrics.PerformanceMetric?
   companion object 
     val UNBOUND: InternalLogger
@@ -280,6 +280,9 @@ fun Array<StackTraceElement>.loggableStackTrace(): String
 fun Throwable.loggableStackTrace(): String
 enum com.datadog.android.core.metrics.MethodCallSamplingRate
   constructor(Float)
+  - ALL
+  - HIGH
+  - MEDIUM
   - DEFAULT
   - REDUCED
   - RARE

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -77,7 +77,7 @@ public abstract interface class com/datadog/android/api/InternalLogger {
 	public static final field Companion Lcom/datadog/android/api/InternalLogger$Companion;
 	public abstract fun log (Lcom/datadog/android/api/InternalLogger$Level;Lcom/datadog/android/api/InternalLogger$Target;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ZLjava/util/Map;)V
 	public abstract fun log (Lcom/datadog/android/api/InternalLogger$Level;Ljava/util/List;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ZLjava/util/Map;)V
-	public abstract fun logMetric (Lkotlin/jvm/functions/Function0;Ljava/util/Map;)V
+	public abstract fun logMetric (Lkotlin/jvm/functions/Function0;Ljava/util/Map;F)V
 	public abstract fun startPerformanceMeasure (Ljava/lang/String;Lcom/datadog/android/core/metrics/TelemetryMetricType;FLjava/lang/String;)Lcom/datadog/android/core/metrics/PerformanceMetric;
 }
 
@@ -755,7 +755,10 @@ public final class com/datadog/android/core/internal/utils/ThrowableExtKt {
 }
 
 public final class com/datadog/android/core/metrics/MethodCallSamplingRate : java/lang/Enum {
+	public static final field ALL Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
 	public static final field DEFAULT Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
+	public static final field HIGH Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
+	public static final field MEDIUM Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
 	public static final field RARE Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
 	public static final field REDUCED Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
 	public final fun getRate ()F

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/InternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/InternalLogger.kt
@@ -105,9 +105,15 @@ interface InternalLogger {
      * [com.datadog.android.telemetry.model.TelemetryDebugEvent.Telemetry] event.
      * @param messageBuilder the lambda building the metric message
      * @param additionalProperties additional properties to add to the metric
+     * @param samplingRate value between 0-100 for sampling the event. Note that the sampling rate applied to this
+     * metric will be applied in addition to the global telemetry sampling rate.
      */
     @InternalApi
-    fun logMetric(messageBuilder: () -> String, additionalProperties: Map<String, Any?>)
+    fun logMetric(
+        messageBuilder: () -> String,
+        additionalProperties: Map<String, Any?>,
+        samplingRate: Float
+    )
 
     /**
      * Start measuring a performance metric.

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/logger/SdkInternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/logger/SdkInternalLogger.kt
@@ -92,7 +92,13 @@ internal class SdkInternalLogger(
         }
     }
 
-    override fun logMetric(messageBuilder: () -> String, additionalProperties: Map<String, Any?>) {
+    override fun logMetric(
+        messageBuilder: () -> String,
+        additionalProperties: Map<String, Any?>,
+        samplingRate: Float
+    ) {
+        if (!RateBasedSampler(samplingRate).sample()) return
+
         val rumFeature = sdkCore?.getFeature(Feature.RUM_FEATURE_NAME) ?: return
         val message = messageBuilder()
         val telemetryEvent =

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
@@ -15,6 +15,7 @@ import com.datadog.android.core.internal.persistence.file.advanced.FeatureFileOr
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.lengthSafe
 import com.datadog.android.core.internal.time.TimeProvider
+import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.privacy.TrackingConsent
@@ -44,7 +45,8 @@ internal class BatchMetricsDispatcher(
         resolveBatchDeletedMetricAttributes(batchFile, removalReason)?.let {
             internalLogger.logMetric(
                 messageBuilder = { BATCH_DELETED_MESSAGE },
-                additionalProperties = it
+                additionalProperties = it,
+                samplingRate = MethodCallSamplingRate.DEFAULT.rate
             )
         }
     }
@@ -56,7 +58,8 @@ internal class BatchMetricsDispatcher(
         resolveBatchClosedMetricAttributes(batchFile, batchMetadata)?.let {
             internalLogger.logMetric(
                 messageBuilder = { BATCH_CLOSED_MESSAGE },
-                additionalProperties = it
+                additionalProperties = it,
+                samplingRate = MethodCallSamplingRate.DEFAULT.rate
             )
         }
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/MethodCalledTelemetry.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/MethodCalledTelemetry.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.core.internal.metrics
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.core.metrics.PerformanceMetric
 import com.datadog.android.core.metrics.PerformanceMetric.Companion.METRIC_TYPE
 
@@ -36,7 +37,8 @@ internal class MethodCalledTelemetry(
 
         internalLogger.logMetric(
             messageBuilder = { METHOD_CALLED_METRIC_NAME },
-            additionalProperties = additionalProperties
+            additionalProperties = additionalProperties,
+            samplingRate = MethodCallSamplingRate.ALL.rate // sampling is performed on start
         )
     }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/metrics/MethodCallSamplingRate.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/metrics/MethodCallSamplingRate.kt
@@ -8,9 +8,12 @@ package com.datadog.android.core.metrics
 
 /**
  * Sampling rates for Method Call telemetry.
- * @param rate the rate to sample at.
+ * @param rate the rate to sample at (between 0 and 100).
  */
 enum class MethodCallSamplingRate(val rate: Float) {
+    ALL(rate = 100.0f),
+    HIGH(rate = 10.0f),
+    MEDIUM(rate = 1.0f),
     DEFAULT(rate = 0.1f),
     REDUCED(rate = 0.01f),
     RARE(rate = 0.001f)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/logger/SdkInternalLoggerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/logger/SdkInternalLoggerTest.kt
@@ -24,7 +24,6 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import org.assertj.core.api.Assertions
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.data.Offset.offset
 import org.junit.jupiter.api.BeforeEach
@@ -37,6 +36,7 @@ import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.mock
+import org.mockito.kotlin.mockingDetails
 import org.mockito.kotlin.never
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -166,9 +166,9 @@ internal class SdkInternalLoggerTest {
         val predicate = testedInternalLogger.userLogger.predicate
         for (i in 0..10) {
             if (i >= sdkVerbosity) {
-                Assertions.assertThat(predicate(i)).isTrue
+                assertThat(predicate(i)).isTrue
             } else {
-                Assertions.assertThat(predicate(i)).isFalse
+                assertThat(predicate(i)).isFalse
             }
         }
     }
@@ -458,7 +458,7 @@ internal class SdkInternalLoggerTest {
     }
 
     @Test
-    fun `M send metric W metric()`(
+    fun `M send metric W metric() {sampling 100 percent}`(
         @StringForgery fakeMessage: String,
         forge: Forge
     ) {
@@ -472,7 +472,8 @@ internal class SdkInternalLoggerTest {
         // When
         testedInternalLogger.logMetric(
             mockLambda,
-            fakeAdditionalProperties
+            fakeAdditionalProperties,
+            100.0f
         )
 
         // Then
@@ -487,8 +488,62 @@ internal class SdkInternalLoggerTest {
     }
 
     @Test
+    fun `M send metric W metric() {sampling x percent}`(
+        @StringForgery fakeMessage: String,
+        @FloatForgery(25f, 75f) fakeSampleRate: Float,
+        forge: Forge
+    ) {
+        // Given
+        val mockRumFeatureScope = mock<FeatureScope>()
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+        val fakeAdditionalProperties = forge.exhaustiveAttributes()
+        val mockLambda: () -> String = mock()
+        whenever(mockLambda.invoke()) doReturn fakeMessage
+        val repeatCount = 100
+        val expectedCallCount = (repeatCount * fakeSampleRate / 100f).toInt()
+        val marginOfError = (repeatCount * 0.25f).toInt()
+
+        // When
+        repeat(100) {
+            testedInternalLogger.logMetric(
+                mockLambda,
+                fakeAdditionalProperties,
+                fakeSampleRate
+            )
+        }
+
+        // Then
+        val count = mockingDetails(mockRumFeatureScope).invocations.filter { it.method.name == "sendEvent" }.size
+        assertThat(count).isCloseTo(expectedCallCount, offset(marginOfError))
+    }
+
+    @Test
+    fun `M send metric W metric() {sampling 0 percent}`(
+        @StringForgery fakeMessage: String,
+        forge: Forge
+    ) {
+        // Given
+        val mockRumFeatureScope = mock<FeatureScope>()
+        whenever(mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)) doReturn mockRumFeatureScope
+        val fakeAdditionalProperties = forge.exhaustiveAttributes()
+        val mockLambda: () -> String = mock()
+        whenever(mockLambda.invoke()) doReturn fakeMessage
+
+        // When
+        testedInternalLogger.logMetric(
+            mockLambda,
+            fakeAdditionalProperties,
+            0.0f
+        )
+
+        // Then
+        verify(mockRumFeatureScope, never()).sendEvent(any())
+    }
+
+    @Test
     fun `M do nothing metric W metric { rum feature not initialized }`(
         @StringForgery fakeMessage: String,
+        @FloatForgery(0f, 100f) fakeSampleRate: Float,
         forge: Forge
     ) {
         // Given
@@ -501,7 +556,8 @@ internal class SdkInternalLoggerTest {
         assertDoesNotThrow {
             testedInternalLogger.logMetric(
                 mockLambda,
-                fakeAdditionalProperties
+                fakeAdditionalProperties,
+                fakeSampleRate
             )
         }
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
@@ -108,7 +108,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }
@@ -147,7 +148,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }
@@ -171,7 +173,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }
@@ -197,7 +200,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }
@@ -222,7 +226,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }
@@ -247,7 +252,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_DELETED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }
@@ -351,7 +357,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_CLOSED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }
@@ -396,7 +403,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_CLOSED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }
@@ -426,7 +434,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_CLOSED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }
@@ -456,7 +465,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_CLOSED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }
@@ -486,7 +496,8 @@ internal class BatchMetricsDispatcherTest {
         argumentCaptor<Map<String, Any?>> {
             verify(mockInternalLogger).logMetric(
                 argThat { this.invoke() == BatchMetricsDispatcher.BATCH_CLOSED_MESSAGE },
-                capture()
+                capture(),
+                eq(0.1f)
             )
             assertThat(firstValue).containsExactlyInAnyOrderEntriesOf(expectedAdditionalProperties)
         }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/MethodCalledTelemetryTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/MethodCalledTelemetryTest.kt
@@ -31,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
@@ -114,7 +115,7 @@ internal class MethodCalledTelemetryTest {
         testedMethodCalledTelemetry.stopAndSend(false)
 
         // Then
-        verify(mockInternalLogger).logMetric(lambdaCaptor.capture(), any())
+        verify(mockInternalLogger).logMetric(lambdaCaptor.capture(), any(), eq(100.0f))
         lambdaCaptor.firstValue.run {
             val title = this()
             assertThat(title).isEqualTo(METHOD_CALLED_METRIC_NAME)
@@ -127,7 +128,7 @@ internal class MethodCalledTelemetryTest {
         testedMethodCalledTelemetry.stopAndSend(false)
 
         // Then
-        verify(mockInternalLogger).logMetric(any(), mapCaptor.capture())
+        verify(mockInternalLogger).logMetric(any(), mapCaptor.capture(), eq(100.0f))
         val executionTime = mapCaptor.firstValue[EXECUTION_TIME] as Long
 
         assertThat(executionTime).isLessThan(System.nanoTime() - fakeStartTime)
@@ -139,7 +140,7 @@ internal class MethodCalledTelemetryTest {
         testedMethodCalledTelemetry.stopAndSend(false)
 
         // Then
-        verify(mockInternalLogger).logMetric(any(), mapCaptor.capture())
+        verify(mockInternalLogger).logMetric(any(), mapCaptor.capture(), eq(100.0f))
         val operationName = mapCaptor.firstValue[OPERATION_NAME] as String
 
         assertThat(operationName).isEqualTo(fakeOperationName)
@@ -151,7 +152,7 @@ internal class MethodCalledTelemetryTest {
         testedMethodCalledTelemetry.stopAndSend(false)
 
         // Then
-        verify(mockInternalLogger).logMetric(any(), mapCaptor.capture())
+        verify(mockInternalLogger).logMetric(any(), mapCaptor.capture(), eq(100.0f))
         val callerClass = mapCaptor.firstValue[CALLER_CLASS] as String
 
         assertThat(callerClass).isEqualTo(fakeCallerClass)
@@ -163,7 +164,7 @@ internal class MethodCalledTelemetryTest {
         testedMethodCalledTelemetry.stopAndSend(fakeStatus)
 
         // Then
-        verify(mockInternalLogger).logMetric(any(), mapCaptor.capture())
+        verify(mockInternalLogger).logMetric(any(), mapCaptor.capture(), eq(100.0f))
         val isSuccessful = mapCaptor.firstValue[IS_SUCCESSFUL] as Boolean
 
         assertThat(isSuccessful).isEqualTo(fakeStatus)
@@ -175,7 +176,7 @@ internal class MethodCalledTelemetryTest {
         testedMethodCalledTelemetry.stopAndSend(fakeStatus)
 
         // Then
-        verify(mockInternalLogger).logMetric(any(), mapCaptor.capture())
+        verify(mockInternalLogger).logMetric(any(), mapCaptor.capture(), eq(100.0f))
         val metricTypeValue = mapCaptor.firstValue[METRIC_TYPE] as String
 
         assertThat(metricTypeValue).isEqualTo(METRIC_TYPE_VALUE)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScope.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
+import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.rum.DdRumContentProvider
 import com.datadog.android.rum.internal.anr.ANRException
 import com.datadog.android.rum.internal.domain.RumContext
@@ -21,6 +22,7 @@ import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.vitals.NoOpVitalMonitor
 import com.datadog.android.rum.internal.vitals.VitalMonitor
 import java.util.Locale
+import java.util.concurrent.TimeUnit
 
 @Suppress("LongParameterList")
 internal class RumViewManagerScope(
@@ -60,11 +62,13 @@ internal class RumViewManagerScope(
             startForegroundView(event, writer)
             lastStoppedViewTime?.let {
                 val gap = event.eventTime.nanoTime - it.nanoTime
-                sdkCore.internalLogger.log(
-                    InternalLogger.Level.INFO,
-                    listOf(InternalLogger.Target.TELEMETRY, InternalLogger.Target.MAINTAINER),
-                    { MESSAGE_GAP_BETWEEN_VIEWS.format(Locale.US, gap) }
-                )
+                if (gap in 1 until THREE_SECONDS_GAP) {
+                    sdkCore.internalLogger.logMetric(
+                        messageBuilder = { MESSAGE_GAP_BETWEEN_VIEWS.format(Locale.US, gap) },
+                        additionalProperties = mapOf(ATTR_GAP_BETWEEN_VIEWS to gap),
+                        samplingRate = MethodCallSamplingRate.MEDIUM.rate
+                    )
+                }
             }
             lastStoppedViewTime = null
         } else if (event is RumRawEvent.StopSession) {
@@ -292,7 +296,9 @@ internal class RumViewManagerScope(
         internal const val RUM_APP_LAUNCH_VIEW_URL = "com/datadog/application-launch/view"
         internal const val RUM_APP_LAUNCH_VIEW_NAME = "ApplicationLaunch"
 
-        private const val MESSAGE_GAP_BETWEEN_VIEWS = "Gap between views was %d nanoseconds"
+        private const val MESSAGE_GAP_BETWEEN_VIEWS = "[Mobile Metric] Gap between views"
+        internal const val ATTR_GAP_BETWEEN_VIEWS = "view_gap"
+
         internal const val MESSAGE_MISSING_VIEW =
             "A RUM event was detected, but no view is active. " +
                 "To track views automatically, try calling the " +
@@ -302,5 +308,7 @@ internal class RumViewManagerScope(
 
         internal const val MESSAGE_UNKNOWN_MISSED_TYPE = "An RUM event was detected, but no view is active, " +
             "its missed type is unknown"
+
+        internal val THREE_SECONDS_GAP = TimeUnit.SECONDS.toNanos(3)
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.internal.metric
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.rum.internal.domain.scope.RumSessionScope
 import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.model.ViewEvent
@@ -38,7 +39,8 @@ internal class SessionEndedMetricDispatcher(private val internalLogger: Internal
         metric?.let {
             internalLogger.logMetric(
                 messageBuilder = { SessionEndedMetric.RUM_SESSION_ENDED_METRIC_NAME },
-                additionalProperties = it.toMetricAttributes(ntpOffsetAtEndMs)
+                additionalProperties = it.toMetricAttributes(ntpOffsetAtEndMs),
+                samplingRate = MethodCallSamplingRate.ALL.rate
             )
         }
     }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewManagerScopeTest.kt
@@ -32,6 +32,7 @@ import com.datadog.android.rum.utils.verifyLog
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions
@@ -56,6 +57,7 @@ import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
+import java.util.concurrent.TimeUnit
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -285,6 +287,7 @@ internal class RumViewManagerScopeTest {
 
     @Test
     fun `M send gap message W handleEvent(StopView) + handleEvent(StartView)`(
+        @LongForgery(10, 30) fakeSleepMs: Long,
         forge: Forge
     ) {
         // Given
@@ -295,16 +298,26 @@ internal class RumViewManagerScopeTest {
         testedScope.handleEvent(stopFirstViewEvent, mockWriter)
 
         // When
-        Thread.sleep(15)
+        Thread.sleep(fakeSleepMs)
         val secondViewEvent = forge.startViewEvent()
         testedScope.handleEvent(secondViewEvent, mockWriter)
 
         // Then
-        mockInternalLogger.verifyLog(
-            InternalLogger.Level.INFO,
-            listOf(InternalLogger.Target.TELEMETRY, InternalLogger.Target.MAINTAINER),
-            { it.matches(Regex("Gap between views was \\d+ nanoseconds")) }
+        val messageBuilderCaptor = argumentCaptor<() -> String>()
+        val additionalPropertiesCaptor = argumentCaptor<Map<String, Any?>>()
+
+        verify(mockInternalLogger).logMetric(
+            messageBuilderCaptor.capture(),
+            additionalPropertiesCaptor.capture(),
+            eq(1f)
         )
+
+        assertThat(additionalPropertiesCaptor.firstValue).containsKey(RumViewManagerScope.ATTR_GAP_BETWEEN_VIEWS)
+        val gapNs = additionalPropertiesCaptor.firstValue[RumViewManagerScope.ATTR_GAP_BETWEEN_VIEWS] as Long
+        val minNs = TimeUnit.MILLISECONDS.toNanos(fakeSleepMs)
+        val maxNs = TimeUnit.MILLISECONDS.toNanos(fakeSleepMs + 15)
+        assertThat(gapNs).isBetween(minNs, maxNs)
+        assertThat(messageBuilderCaptor.firstValue()).isEqualTo("[Mobile Metric] Gap between views")
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/FakeInternalLogger.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/FakeInternalLogger.kt
@@ -38,10 +38,7 @@ class FakeInternalLogger : InternalLogger {
         // do nothing
     }
 
-    override fun logMetric(
-        messageBuilder: () -> String,
-        additionalProperties: Map<String, Any?>
-    ) {
+    override fun logMetric(messageBuilder: () -> String, additionalProperties: Map<String, Any?>, samplingRate: Float) {
         lastMetric = Pair(messageBuilder(), additionalProperties)
     }
 

--- a/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubInternalLogger.kt
+++ b/reliability/stub-core/src/main/kotlin/com/datadog/android/core/stub/StubInternalLogger.kt
@@ -40,11 +40,8 @@ internal class StubInternalLogger : InternalLogger {
         throwable?.printStackTrace()
     }
 
-    override fun logMetric(
-        messageBuilder: () -> String,
-        additionalProperties: Map<String, Any?>
-    ) {
-        println("M [T]: ${messageBuilder()}")
+    override fun logMetric(messageBuilder: () -> String, additionalProperties: Map<String, Any?>, samplingRate: Float) {
+        println("M [T]: ${messageBuilder()} | $samplingRate%")
         additionalProperties.log()
         val message = messageBuilder()
         val telemetryEvent =


### PR DESCRIPTION
### What does this PR do?

- [x] Add sampling rate option for internal metrics
- [x] Reduce the amount of "Gap between view" telemetry, and discarding gaps above 3 seconds (which most probably denote an app being sent to background instead of an actual gap while navigating inside the tracked app).

> [!NOTE]
> This metric will be applied in addition to the telemetry sampling rate, so if a logMetric is created with a sampling rate of 10%, with the global telemetry sampling rate being sampled at 20%, it has a 2% chance of being kept.