### PR TITLE
Update our CI around Generated files

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -71,14 +71,6 @@ static-analysis:
     include: "https://gitlab-templates.ddbuild.io/mobile/v34714656-060be019/static-analysis.yml"
     strategy: depend
 
-analysis:licenses:
-  tags: [ "arch:amd64" ]
-  image: $CI_IMAGE_DOCKER
-  stage: analysis
-  timeout: 30m
-  script:
-    - GRADLE_OPTS="-Xmx3072m" ./gradlew checkThirdPartyLicensesAll --stacktrace --no-daemon
-
 # TODO RUM-1622 cleanup this section
 # TESTS
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -123,11 +123,15 @@ registerSubModuleAggregationTask("checkThirdPartyLicensesAll", "checkThirdPartyL
 
 registerSubModuleAggregationTask("checkApiSurfaceChangesAll", "checkApiSurfaceChanges")
 
+registerSubModuleAggregationTask("checkTransitiveDependenciesListAll", "checkTransitiveDependenciesList")
+
 /**
  * Task necessary to be compliant with the shared Android static analysis pipeline
  */
 tasks.register("checkGeneratedFiles") {
+    dependsOn("checkThirdPartyLicensesAll")
     dependsOn("checkApiSurfaceChangesAll")
+    dependsOn("checkTransitiveDependenciesListAll")
 }
 
 registerSubModuleAggregationTask("koverReportAll", "koverXmlReportRelease")

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/CheckTransitiveDependenciesTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/CheckTransitiveDependenciesTask.kt
@@ -1,0 +1,54 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.gradle.plugin.transdeps
+
+import com.datadog.gradle.utils.execShell
+import org.gradle.api.DefaultTask
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+
+open class CheckTransitiveDependenciesTask : DefaultTask() {
+
+    @InputFile
+    lateinit var dependenciesFile: File
+
+    init {
+        group = "datadog"
+        description = "Check the transitive dependencies of the library"
+    }
+
+    // region Task
+
+    @TaskAction
+    fun applyTask() {
+        val lines = project.execShell(
+            "git",
+            "diff",
+            "--color=never",
+            "HEAD",
+            "--",
+            dependenciesFile.absolutePath
+        )
+
+        val additions = lines.filter { it.matches(Regex("^\\+[^+].*$")) }
+        val removals = lines.filter { it.matches(Regex("^-[^-].*$")) }
+
+        if (additions.isNotEmpty() || removals.isNotEmpty()) {
+            error(
+                "Make sure you run the ${TransitiveDependenciesPlugin.TASK_GEN_TRANSITIVE_DEPS} task" +
+                    " before you push your PR.\n" +
+                    additions.joinToString("\n") + removals.joinToString("\n")
+            )
+        }
+    }
+
+    @InputFile
+    fun getInputFile() = dependenciesFile
+
+    // endregion
+}

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/GenerateTransitiveDependenciesTask.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/GenerateTransitiveDependenciesTask.kt
@@ -14,7 +14,7 @@ import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import java.io.File
 
-open class TransitiveDependenciesTask : DefaultTask() {
+open class GenerateTransitiveDependenciesTask : DefaultTask() {
 
     @get:Input
     var humanReadableSize: Boolean = true
@@ -23,7 +23,7 @@ open class TransitiveDependenciesTask : DefaultTask() {
     var sortByName: Boolean = true
 
     @get: OutputFile
-    lateinit var outputFile: File
+    lateinit var dependenciesFile: File
 
     init {
         group = "datadog"
@@ -34,7 +34,7 @@ open class TransitiveDependenciesTask : DefaultTask() {
 
     @TaskAction
     fun applyTask() {
-        outputFile.writeText("Dependencies List\n\n")
+        dependenciesFile.writeText("Dependencies List\n\n")
         val implementation = project.configurations.getByName("releaseCompileClasspath")
         listConfigurationDependencies(implementation)
     }
@@ -58,10 +58,10 @@ open class TransitiveDependenciesTask : DefaultTask() {
         var sum = 0L
         sortedArtifacts.forEach {
             sum += it.length()
-            outputFile.appendText(getDependencyFileDescription(it))
+            dependenciesFile.appendText(getDependencyFileDescription(it))
         }
 
-        outputFile.appendText("\n${TOTAL.padEnd(PADDING)}:${size(sum)}\n\n")
+        dependenciesFile.appendText("\n${TOTAL.padEnd(PADDING)}:${size(sum)}\n\n")
     }
 
     private fun getDependencyFileDescription(it: File): String {

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/TransitiveDependenciesPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/plugin/transdeps/TransitiveDependenciesPlugin.kt
@@ -15,18 +15,24 @@ import java.io.File
 class TransitiveDependenciesPlugin : Plugin<Project> {
 
     override fun apply(target: Project) {
-        target.tasks.register(TASK_NAME, TransitiveDependenciesTask::class.java) {
-            outputFile = File(target.projectDir, FILE_NAME)
+        target.tasks.register(TASK_GEN_TRANSITIVE_DEPS, GenerateTransitiveDependenciesTask::class.java) {
+            dependenciesFile = File(target.projectDir, FILE_NAME)
+        }
+
+        target.tasks.register(TASK_CHECK_TRANSITIVE_DEPS, CheckTransitiveDependenciesTask::class.java) {
+            dependenciesFile = File(target.projectDir, FILE_NAME)
+            dependsOn(TASK_GEN_TRANSITIVE_DEPS)
         }
 
         target.taskConfig<KotlinCompile> {
-            finalizedBy(TASK_NAME)
+            finalizedBy(TASK_GEN_TRANSITIVE_DEPS)
         }
     }
 
     companion object {
 
-        const val TASK_NAME = "listTransitiveDependencies"
+        const val TASK_GEN_TRANSITIVE_DEPS = "generateTransitiveDependenciesList"
+        const val TASK_CHECK_TRANSITIVE_DEPS = "checkTransitiveDependenciesList"
         const val FILE_NAME = "transitiveDependencies"
     }
 }

--- a/integrations/dd-sdk-android-okhttp-otel/transitiveDependencies
+++ b/integrations/dd-sdk-android-okhttp-otel/transitiveDependencies
@@ -2,13 +2,11 @@ Dependencies List
 
 com.squareup.okhttp3:okhttp:4.11.0                              :  768 Kb
 com.squareup.okio:okio-jvm:3.2.0                                :  337 Kb
-io.opentelemetry:opentelemetry-api:1.4.0                        :   78 Kb
-io.opentelemetry:opentelemetry-context:1.4.0                    :   42 Kb
 org.jetbrains.kotlin:kotlin-stdlib-common:1.8.22                :  216 Kb
 org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.22                  :  963 b 
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.22                  :  969 b 
 org.jetbrains.kotlin:kotlin-stdlib:1.8.22                       : 1631 Kb
 org.jetbrains:annotations:13.0                                  :   17 Kb
 
-Total transitive dependencies size                              :    3 Mb
+Total transitive dependencies size                              :    2 Mb
 


### PR DESCRIPTION
### What does this PR do?

- [x] Add a new task to check whether the `transitiveDependencies` file is up to date on new PRs
- [x] Use the generic `checkGeneratedFiles` to call the new task, as well as the existing ones to check the licenses and api surface files

### Motivation

Some dependency changes were not committed meaning that locally the `transitiveDependencies` for the `dd-sdk-android-okhttp-otel` is changed all the time in unrelated commits. 
