### PR TITLE
RUM-4715:SwitchCompat mapper improvement

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -992,6 +992,7 @@ datadog:
       - "kotlin.collections.listOf(kotlin.String)"
       - "kotlin.collections.listOf(okhttp3.ConnectionSpec)"
       - "kotlin.collections.listOfNotNull(com.datadog.android.sessionreplay.model.MobileSegment.Wireframe?)"
+      - "kotlin.collections.listOfNotNull(kotlin.Array)"
       - "kotlin.collections.mapOf(kotlin.Array)"
       - "kotlin.collections.mapOf(kotlin.Pair)"
       - "kotlin.collections.mutableListOf()"

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
@@ -52,7 +52,7 @@ internal abstract class CheckableTextViewMapper<T>(
         view: T,
         mappingContext: MappingContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
-    ): List<MobileSegment.Wireframe>? {
+    ): List<MobileSegment.Wireframe> {
         return listOfNotNull(
             createCheckableDrawableWireFrames(
                 view,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
@@ -71,5 +71,5 @@ internal abstract class CheckableWireframeMapper<T>(
         view: T,
         mappingContext: MappingContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
-    ): List<MobileSegment.Wireframe>?
+    ): List<MobileSegment.Wireframe>
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapper.kt
@@ -6,18 +6,17 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
-import android.graphics.Rect
 import androidx.annotation.UiThread
 import androidx.appcompat.widget.SwitchCompat
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
-import com.datadog.android.sessionreplay.recorder.SystemInformation
 import com.datadog.android.sessionreplay.recorder.mapper.TextViewMapper
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.datadog.android.sessionreplay.utils.GlobalBounds
 import com.datadog.android.sessionreplay.utils.OPAQUE_ALPHA_VALUE
 import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
 import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
@@ -47,110 +46,120 @@ internal open class SwitchCompatMapper(
         return textWireframeMapper.map(view, mappingContext, asyncJobStatusCallback, internalLogger)
     }
 
-    @Suppress("ReturnCount")
+    private fun createSwitchCompatDrawableWireFrames(
+        view: SwitchCompat,
+        mappingContext: MappingContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback
+    ): List<MobileSegment.Wireframe> {
+        var index = 0
+        val thumbWireframe = createThumbWireframe(view, index, mappingContext, asyncJobStatusCallback)
+        if (thumbWireframe != null) {
+            index++
+        }
+        val trackWireframe = createTrackWireframe(view, index, mappingContext, asyncJobStatusCallback)
+        return listOfNotNull(trackWireframe, thumbWireframe)
+    }
+
+    private fun createTrackWireframe(
+        view: SwitchCompat,
+        prevIndex: Int,
+        mappingContext: MappingContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback
+    ): MobileSegment.Wireframe? {
+        val trackBounds = resolveTrackBounds(
+            view,
+            mappingContext.systemInformation.screenDensity
+        )
+        return trackBounds?.let {
+            return view.trackDrawable.constantState?.newDrawable(view.resources)?.apply {
+                setState(view.trackDrawable.state)
+                bounds = view.trackDrawable.bounds
+                view.trackTintList?.let {
+                    setTintList(it)
+                }
+            }?.let { drawable ->
+                mappingContext.imageWireframeHelper.createImageWireframe(
+                    view = view,
+                    currentWireframeIndex = prevIndex + 1,
+                    x = trackBounds.x.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),
+                    y = trackBounds.y.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),
+                    width = trackBounds.width,
+                    height = trackBounds.height,
+                    drawable = drawable,
+                    shapeStyle = null,
+                    border = null,
+                    usePIIPlaceholder = true,
+                    asyncJobStatusCallback = asyncJobStatusCallback
+                )
+            }
+        }
+    }
+
+    private fun createThumbWireframe(
+        view: SwitchCompat,
+        prevIndex: Int,
+        mappingContext: MappingContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback
+    ): MobileSegment.Wireframe? {
+        val thumbBounds = resolveThumbBounds(
+            view,
+            mappingContext.systemInformation.screenDensity
+        )
+        return view.thumbDrawable?.let { drawable ->
+            thumbBounds?.let { thumbBounds ->
+                mappingContext.imageWireframeHelper.createImageWireframe(
+                    view = view,
+                    currentWireframeIndex = prevIndex + 1,
+                    x = thumbBounds.x.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),
+                    y = thumbBounds.y.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),
+                    width = drawable.intrinsicWidth,
+                    height = drawable.intrinsicHeight,
+                    drawable = drawable,
+                    shapeStyle = null,
+                    border = null,
+                    usePIIPlaceholder = true,
+                    clipping = null,
+                    asyncJobStatusCallback = asyncJobStatusCallback
+                )
+            }
+        }
+    }
+
+    private fun resolveThumbBounds(view: SwitchCompat, pixelsDensity: Float): GlobalBoundsInPx? {
+        val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(view, pixelsDensity)
+        val thumbDimensions = resolveThumbSizeInPx(view) ?: return null
+        val thumbLeft = (viewGlobalBounds.x * pixelsDensity).toInt() +
+            view.thumbDrawable.bounds.left
+        val thumbTop = (viewGlobalBounds.y * pixelsDensity).toInt() +
+            view.thumbDrawable.bounds.top
+        return GlobalBoundsInPx(
+            x = thumbLeft,
+            y = thumbTop,
+            width = thumbDimensions.first,
+            height = thumbDimensions.second
+        )
+    }
+
+    private fun resolveTrackBounds(view: SwitchCompat, pixelsDensity: Float): GlobalBoundsInPx? {
+        val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(view, pixelsDensity)
+        val trackSize = resolveTrackSizeInPx(view) ?: return null
+        return view.trackDrawable?.let {
+            GlobalBoundsInPx(
+                x = (viewGlobalBounds.x * pixelsDensity).toInt() + it.bounds.left,
+                y = (viewGlobalBounds.y * pixelsDensity).toInt() + it.bounds.top,
+                width = trackSize.first,
+                height = trackSize.second
+            )
+        }
+    }
+
     @UiThread
     override fun resolveCheckable(
         view: SwitchCompat,
         mappingContext: MappingContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
-    ): List<MobileSegment.Wireframe>? {
-        val trackThumbDimensions = resolveThumbAndTrackDimensions(view, mappingContext.systemInformation) ?: return null
-
-        val wireframes = mutableListOf<MobileSegment.Wireframe>()
-
-        val trackWidth = trackThumbDimensions[TRACK_WIDTH_INDEX]
-        val trackHeight = trackThumbDimensions[TRACK_HEIGHT_INDEX]
-        val thumbHeight = trackThumbDimensions[THUMB_HEIGHT_INDEX]
-        val thumbWidth = trackThumbDimensions[THUMB_WIDTH_INDEX]
-        val checkableColor = resolveCheckableColor(view)
-        val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(
-            view,
-            mappingContext.systemInformation.screenDensity
-        )
-
-        val trackId = viewIdentifierResolver.resolveChildUniqueIdentifier(view, TRACK_KEY_NAME)
-        if (trackId != null) {
-            val trackShapeStyle = resolveTrackShapeStyle(view, checkableColor)
-            val trackWireframe = MobileSegment.Wireframe.ShapeWireframe(
-                id = trackId,
-                x = viewGlobalBounds.x + viewGlobalBounds.width - trackWidth,
-                y = viewGlobalBounds.y + (viewGlobalBounds.height - trackHeight) / 2,
-                width = trackWidth,
-                height = trackHeight,
-                border = null,
-                shapeStyle = trackShapeStyle
-            )
-            wireframes.add(trackWireframe)
-        }
-
-        val thumbId = viewIdentifierResolver.resolveChildUniqueIdentifier(view, THUMB_KEY_NAME)
-        if (thumbId != null) {
-            val thumbShapeStyle = resolveThumbShapeStyle(view, checkableColor)
-            val thumbWireframe = MobileSegment.Wireframe.ShapeWireframe(
-                id = thumbId,
-                x = viewGlobalBounds.x + viewGlobalBounds.width - thumbWidth,
-                y = viewGlobalBounds.y + (viewGlobalBounds.height - thumbHeight) / 2,
-                width = thumbWidth,
-                height = thumbHeight,
-                border = null,
-                shapeStyle = thumbShapeStyle
-            )
-            wireframes.add(thumbWireframe)
-        }
-        return wireframes
-    }
-
-    @Suppress("UnusedPrivateMember")
-    // TODO RUM-4715: Improve SwitchCompatMapper
-    @UiThread
-    private fun resolveNotCheckedCheckable(
-        view: SwitchCompat,
-        mappingContext: MappingContext
-    ): List<MobileSegment.Wireframe>? {
-        val trackThumbDimensions = resolveThumbAndTrackDimensions(view, mappingContext.systemInformation) ?: return null
-
-        val wireframes = mutableListOf<MobileSegment.Wireframe>()
-
-        val trackWidth = trackThumbDimensions[TRACK_WIDTH_INDEX]
-        val trackHeight = trackThumbDimensions[TRACK_HEIGHT_INDEX]
-        val thumbHeight = trackThumbDimensions[THUMB_HEIGHT_INDEX]
-        val thumbWidth = trackThumbDimensions[THUMB_WIDTH_INDEX]
-        val checkableColor = resolveCheckableColor(view)
-        val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(
-            view,
-            mappingContext.systemInformation.screenDensity
-        )
-
-        val trackId = viewIdentifierResolver.resolveChildUniqueIdentifier(view, TRACK_KEY_NAME)
-        if (trackId != null) {
-            val trackShapeStyle = resolveTrackShapeStyle(view, checkableColor)
-            val trackWireframe = MobileSegment.Wireframe.ShapeWireframe(
-                id = trackId,
-                x = viewGlobalBounds.x + viewGlobalBounds.width - trackWidth,
-                y = viewGlobalBounds.y + (viewGlobalBounds.height - trackHeight) / 2,
-                width = trackWidth,
-                height = trackHeight,
-                border = null,
-                shapeStyle = trackShapeStyle
-            )
-            wireframes.add(trackWireframe)
-        }
-
-        val thumbId = viewIdentifierResolver.resolveChildUniqueIdentifier(view, THUMB_KEY_NAME)
-        if (thumbId != null) {
-            val thumbShapeStyle = resolveThumbShapeStyle(view, checkableColor)
-            val thumbWireframe = MobileSegment.Wireframe.ShapeWireframe(
-                id = thumbId,
-                x = viewGlobalBounds.x + viewGlobalBounds.width - trackWidth,
-                y = viewGlobalBounds.y + (viewGlobalBounds.height - thumbHeight) / 2,
-                width = thumbWidth,
-                height = thumbHeight,
-                border = null,
-                shapeStyle = thumbShapeStyle
-            )
-            wireframes.add(thumbWireframe)
-        }
-        return wireframes
+    ): List<MobileSegment.Wireframe> {
+        return createSwitchCompatDrawableWireFrames(view, mappingContext, asyncJobStatusCallback)
     }
 
     @UiThread
@@ -158,27 +167,20 @@ internal open class SwitchCompatMapper(
         view: SwitchCompat,
         mappingContext: MappingContext
     ): List<MobileSegment.Wireframe>? {
-        val trackThumbDimensions = resolveThumbAndTrackDimensions(view, mappingContext.systemInformation) ?: return null
-
+        val pixelsDensity = mappingContext.systemInformation.screenDensity
         val wireframes = mutableListOf<MobileSegment.Wireframe>()
-
-        val trackWidth = trackThumbDimensions[TRACK_WIDTH_INDEX]
-        val trackHeight = trackThumbDimensions[TRACK_HEIGHT_INDEX]
+        val trackBounds = resolveTrackBounds(view, pixelsDensity) ?: return null
         val checkableColor = resolveCheckableColor(view)
-        val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(
-            view,
-            mappingContext.systemInformation.screenDensity
-        )
 
         val trackId = viewIdentifierResolver.resolveChildUniqueIdentifier(view, TRACK_KEY_NAME)
         if (trackId != null) {
             val trackShapeStyle = resolveTrackShapeStyle(view, checkableColor)
             val trackWireframe = MobileSegment.Wireframe.ShapeWireframe(
                 id = trackId,
-                x = viewGlobalBounds.x + viewGlobalBounds.width - trackWidth,
-                y = viewGlobalBounds.y + (viewGlobalBounds.height - trackHeight) / 2,
-                width = trackWidth,
-                height = trackHeight,
+                x = trackBounds.x.densityNormalized(pixelsDensity).toLong(),
+                y = trackBounds.y.densityNormalized(pixelsDensity).toLong(),
+                width = trackBounds.width.densityNormalized(pixelsDensity).toLong(),
+                height = trackBounds.height.densityNormalized(pixelsDensity).toLong(),
                 border = null,
                 shapeStyle = trackShapeStyle
             )
@@ -192,71 +194,47 @@ internal open class SwitchCompatMapper(
 
     // region Internal
 
-    protected fun resolveCheckableColor(view: SwitchCompat): String {
+    private fun resolveCheckableColor(view: SwitchCompat): String {
         return colorStringFormatter.formatColorAndAlphaAsHexString(view.currentTextColor, OPAQUE_ALPHA_VALUE)
     }
 
-    private fun resolveThumbShapeStyle(view: SwitchCompat, checkBoxColor: String): MobileSegment.ShapeStyle {
-        return MobileSegment.ShapeStyle(
-            backgroundColor = checkBoxColor,
-            view.alpha,
-            cornerRadius = THUMB_CORNER_RADIUS
-        )
-    }
-
-    protected fun resolveTrackShapeStyle(view: SwitchCompat, checkBoxColor: String): MobileSegment.ShapeStyle {
+    private fun resolveTrackShapeStyle(view: SwitchCompat, checkBoxColor: String): MobileSegment.ShapeStyle {
         return MobileSegment.ShapeStyle(
             backgroundColor = checkBoxColor,
             view.alpha
         )
     }
 
-    protected fun resolveThumbAndTrackDimensions(
-        view: SwitchCompat,
-        systemInformation: SystemInformation
-    ): LongArray? {
-        val density = systemInformation.screenDensity
-        val thumbWidth: Long
-        val trackHeight: Long
-        // based on the implementation there is nothing drawn in the switcher area if one of
-        // these are null
-        val thumbDrawable = view.thumbDrawable
-        val trackDrawable = view.trackDrawable
-        if (thumbDrawable == null || trackDrawable == null) {
-            return null
+    private fun resolveThumbSizeInPx(view: SwitchCompat): Pair<Width, Height>? {
+        return view.thumbDrawable?.let {
+            Pair(it.intrinsicWidth, it.intrinsicHeight)
         }
-        val paddingRect = Rect()
-        thumbDrawable.getPadding(paddingRect)
-        val totalHorizontalPadding =
-            paddingRect.left.densityNormalized(systemInformation.screenDensity) +
-                paddingRect.right.densityNormalized(systemInformation.screenDensity)
-        thumbWidth = thumbDrawable.intrinsicWidth.densityNormalized(density).toLong() -
-            totalHorizontalPadding
-        val thumbHeight: Long = thumbWidth
-        // for some reason there is no padding added in the trackDrawable
-        // in order to normalise with the padding applied to the width we will have to
-        // use the horizontal padding applied.
-        trackHeight = trackDrawable.intrinsicHeight.densityNormalized(density).toLong() -
-            totalHorizontalPadding
-        val trackWidth = thumbWidth * 2
-        val dimensions = LongArray(NUMBER_OF_DIMENSIONS)
-        dimensions[THUMB_WIDTH_INDEX] = thumbWidth
-        dimensions[THUMB_HEIGHT_INDEX] = thumbHeight
-        dimensions[TRACK_WIDTH_INDEX] = trackWidth
-        dimensions[TRACK_HEIGHT_INDEX] = trackHeight
-        return dimensions
     }
+
+    private fun resolveTrackSizeInPx(view: SwitchCompat): Pair<Width, Height>? {
+        return view.trackDrawable?.let {
+            // NinePatchDrawable optical size depends on its size
+            Pair(it.bounds.width(), it.bounds.height())
+        }
+    }
+
+    /**
+     * Similar to [GlobalBounds] but in pixel.
+     */
+    data class GlobalBoundsInPx(
+        val x: Int,
+        val y: Int,
+        val width: Int,
+        val height: Int
+    )
 
     // endregion
 
     companion object {
-        private const val NUMBER_OF_DIMENSIONS = 4
-        internal const val THUMB_WIDTH_INDEX = 0
-        internal const val THUMB_HEIGHT_INDEX = 1
-        internal const val TRACK_WIDTH_INDEX = 2
-        internal const val TRACK_HEIGHT_INDEX = 3
         internal const val THUMB_KEY_NAME = "thumb"
         internal const val TRACK_KEY_NAME = "track"
-        internal const val THUMB_CORNER_RADIUS = 10
     }
 }
+
+private typealias Width = Int
+private typealias Height = Int

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
@@ -6,19 +6,28 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
+import android.graphics.drawable.Drawable
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.assertj.core.api.Assertions.assertThat
-import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.RepeatedTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.ExtendWith
 import org.junit.jupiter.api.extension.Extensions
+import org.mockito.ArgumentMatchers
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.any
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.never
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
@@ -30,6 +39,11 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(ForgeConfigurator::class)
 internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
 
+    private val xCaptor = argumentCaptor<Long>()
+    private val yCaptor = argumentCaptor<Long>()
+    private val widthCaptor = argumentCaptor<Int>()
+    private val heightCaptor = argumentCaptor<Int>()
+    private val drawableCaptor = argumentCaptor<Drawable>()
     override fun setupTestedMapper(): SwitchCompatMapper {
         return SwitchCompatMapper(
             mockTextWireframeMapper,
@@ -40,38 +54,21 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         )
     }
 
-    @Test
-    fun `M resolve the switch as wireframes W map() { checked }`() {
+    @RepeatedTest(8)
+    fun `M resolve the switch as wireframes W map()`(forge: Forge) {
         // Given
-        whenever(mockSwitch.isChecked).thenReturn(true)
-        val expectedThumbWidth =
-            normalizedThumbWidth - normalizedThumbRightPadding - normalizedThumbLeftPadding
-        val expectedTrackWidth = expectedThumbWidth * 2
-        val expectedTrackHeight =
-            normalizedTrackHeight - normalizedThumbRightPadding - normalizedThumbLeftPadding
+        whenever(mockSwitch.isChecked).thenReturn(forge.aBool())
+        val density = fakeMappingContext.systemInformation.screenDensity
         val expectedTrackWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeTrackIdentifier,
-            x = fakeViewGlobalBounds.x + fakeViewGlobalBounds.width - expectedTrackWidth,
-            y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - expectedTrackHeight) / 2,
-            width = expectedTrackWidth,
-            height = expectedTrackHeight,
+            x = expectedTrackLeft,
+            y = expectedTrackTop,
+            width = fakeTrackBounds.width().toLong().densityNormalized(density),
+            height = fakeTrackBounds.height().toLong().densityNormalized(density),
             border = null,
             shapeStyle = MobileSegment.ShapeStyle(
                 backgroundColor = fakeCurrentTextColorString,
                 mockSwitch.alpha
-            )
-        )
-        val expectedThumbWireframe = MobileSegment.Wireframe.ShapeWireframe(
-            id = fakeThumbIdentifier,
-            x = fakeViewGlobalBounds.x + fakeViewGlobalBounds.width - expectedThumbWidth,
-            y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - expectedThumbWidth) / 2,
-            width = expectedThumbWidth,
-            height = expectedThumbWidth,
-            border = null,
-            shapeStyle = MobileSegment.ShapeStyle(
-                backgroundColor = fakeCurrentTextColorString,
-                mockSwitch.alpha,
-                cornerRadius = SwitchCompatMapper.THUMB_CORNER_RADIUS
             )
         )
 
@@ -84,71 +81,43 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         )
 
         // Then
-        if (fakeMappingContext.privacy == SessionReplayPrivacy.ALLOW) {
-            assertThat(resolvedWireframes)
-                .isEqualTo(fakeTextWireframes + expectedTrackWireframe + expectedThumbWireframe)
+        if (fakeMappingContext.privacy != SessionReplayPrivacy.ALLOW) {
+            assertThat(resolvedWireframes).isEqualTo(fakeTextWireframes + expectedTrackWireframe)
         } else {
-            assertThat(resolvedWireframes)
-                .isEqualTo(fakeTextWireframes + expectedTrackWireframe)
+            assertThat(resolvedWireframes).isEqualTo(fakeTextWireframes)
+
+            verify(fakeMappingContext.imageWireframeHelper, times(2)).createImageWireframe(
+                view = eq(mockSwitch),
+                currentWireframeIndex = ArgumentMatchers.anyInt(),
+                x = xCaptor.capture(),
+                y = yCaptor.capture(),
+                width = widthCaptor.capture(),
+                height = heightCaptor.capture(),
+                usePIIPlaceholder = ArgumentMatchers.anyBoolean(),
+                drawable = drawableCaptor.capture(),
+                asyncJobStatusCallback = eq(mockAsyncJobStatusCallback),
+                clipping = eq(null),
+                shapeStyle = eq(null),
+                border = eq(null),
+                prefix = ArgumentMatchers.anyString()
+            )
+
+            assertThat(xCaptor.allValues).containsOnly(expectedThumbLeft, expectedTrackLeft)
+            assertThat(yCaptor.allValues).containsOnly(expectedThumbTop, expectedTrackTop)
+            assertThat(widthCaptor.allValues).containsOnly(
+                mockThumbDrawable.intrinsicWidth,
+                (fakeTrackBounds.width())
+            )
+            assertThat(heightCaptor.allValues).containsOnly(
+                mockThumbDrawable.intrinsicHeight,
+                (fakeTrackBounds.height())
+            )
+            assertThat(drawableCaptor.allValues).containsOnly(mockThumbDrawable, mockCloneDrawable)
         }
     }
 
     @Test
-    @Disabled("TODO RUM-4715, will be immediately fixed in next commit")
-    fun `M resolve the switch as wireframes W map() { not checked }`() {
-        // Given
-        whenever(mockSwitch.isChecked).thenReturn(false)
-        val expectedThumbWidth =
-            normalizedThumbWidth - normalizedThumbRightPadding - normalizedThumbLeftPadding
-        val expectedTrackWidth = expectedThumbWidth * 2
-        val expectedTrackHeight =
-            normalizedTrackHeight - normalizedThumbRightPadding - normalizedThumbLeftPadding
-        val expectedTrackWireframe = MobileSegment.Wireframe.ShapeWireframe(
-            id = fakeTrackIdentifier,
-            x = fakeViewGlobalBounds.x + fakeViewGlobalBounds.width - expectedTrackWidth,
-            y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - expectedTrackHeight) / 2,
-            width = expectedTrackWidth,
-            height = expectedTrackHeight,
-            border = null,
-            shapeStyle = MobileSegment.ShapeStyle(
-                backgroundColor = fakeCurrentTextColorString,
-                mockSwitch.alpha
-            )
-        )
-        val expectedThumbWireframe = MobileSegment.Wireframe.ShapeWireframe(
-            id = fakeThumbIdentifier,
-            x = fakeViewGlobalBounds.x + fakeViewGlobalBounds.width - expectedTrackWidth,
-            y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - expectedThumbWidth) / 2,
-            width = expectedThumbWidth,
-            height = expectedThumbWidth,
-            border = null,
-            shapeStyle = MobileSegment.ShapeStyle(
-                backgroundColor = fakeCurrentTextColorString,
-                mockSwitch.alpha,
-                cornerRadius = SwitchCompatMapper.THUMB_CORNER_RADIUS
-            )
-        )
-
-        // When
-        val resolvedWireframes = testedSwitchCompatMapper.map(
-            mockSwitch,
-            fakeMappingContext,
-            mockAsyncJobStatusCallback,
-            mockInternalLogger
-        )
-
-        // Then
-        if (fakeMappingContext.privacy == SessionReplayPrivacy.ALLOW) {
-            assertThat(resolvedWireframes)
-                .isEqualTo(fakeTextWireframes + expectedTrackWireframe + expectedThumbWireframe)
-        } else {
-            assertThat(resolvedWireframes)
-                .isEqualTo(fakeTextWireframes + expectedTrackWireframe)
-        }
-    }
-
-    @Test
-    fun `M resolve the switch as wireframes W map() { can't generate id for thumbWireframe }`(
+    fun `M resolve the switch as wireframes W map() { can't generate id for thumbWireframe for masked view }`(
         forge: Forge
     ) {
         // Given
@@ -159,15 +128,13 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
             )
         ).thenReturn(null)
         whenever(mockSwitch.isChecked).thenReturn(forge.aBool())
-        val expectedThumbWidth = normalizedThumbWidth - normalizedThumbRightPadding - normalizedThumbLeftPadding
-        val expectedTrackWidth = expectedThumbWidth * 2
-        val expectedTrackHeight = normalizedTrackHeight - normalizedThumbRightPadding - normalizedThumbLeftPadding
+        val density = fakeMappingContext.systemInformation.screenDensity
         val expectedTrackWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeTrackIdentifier,
-            x = fakeViewGlobalBounds.x + fakeViewGlobalBounds.width - expectedTrackWidth,
-            y = fakeViewGlobalBounds.y + (fakeViewGlobalBounds.height - expectedTrackHeight) / 2,
-            width = expectedTrackWidth,
-            height = expectedTrackHeight,
+            x = expectedTrackLeft,
+            y = expectedTrackTop,
+            width = fakeTrackBounds.width().toLong().densityNormalized(density),
+            height = fakeTrackBounds.height().toLong().densityNormalized(density),
             border = null,
             shapeStyle = MobileSegment.ShapeStyle(
                 backgroundColor = fakeCurrentTextColorString,
@@ -178,13 +145,52 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext,
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )
 
         // Then
-        assertThat(resolvedWireframes)
-            .isEqualTo(fakeTextWireframes + expectedTrackWireframe)
+        assertThat(resolvedWireframes).isEqualTo(fakeTextWireframes + expectedTrackWireframe)
+    }
+
+    @RepeatedTest(8)
+    fun `M resolve the switch as wireframes W map() { can't generate id for trackWireframe }`(
+        forge: Forge
+    ) {
+        // Given
+        whenever(
+            mockViewIdentifierResolver.resolveChildUniqueIdentifier(
+                mockSwitch,
+                SwitchCompatMapper.TRACK_KEY_NAME
+            )
+        ).thenReturn(null)
+        whenever(mockSwitch.isChecked).thenReturn(forge.aBool())
+
+        // When
+        val resolvedWireframes = testedSwitchCompatMapper.map(
+            mockSwitch,
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK),
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(resolvedWireframes).isEqualTo(fakeTextWireframes)
+        verify(fakeMappingContext.imageWireframeHelper, never()).createImageWireframe(
+            view = any(),
+            currentWireframeIndex = any(),
+            x = any(),
+            y = any(),
+            width = any(),
+            height = any(),
+            usePIIPlaceholder = any(),
+            drawable = any(),
+            asyncJobStatusCallback = any(),
+            clipping = any(),
+            shapeStyle = any(),
+            border = any(),
+            prefix = any()
+        )
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/DropDownSwitchersFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/DropDownSwitchersFragment.kt
@@ -12,6 +12,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.Spinner
+import androidx.appcompat.widget.SwitchCompat
 import androidx.fragment.app.Fragment
 import com.datadog.android.sample.R
 
@@ -19,6 +20,20 @@ internal class DropDownSwitchersFragment : Fragment() {
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
         val root = inflater.inflate(R.layout.fragment_drop_down_switchers_components, container, false)
+        val disabledSwitchCompat = root.findViewById<SwitchCompat>(R.id.app_compat_switcher_disabled)
+        root.findViewById<SwitchCompat>(R.id.app_compat_switcher).apply {
+            setOnCheckedChangeListener { _, isChecked ->
+                disabledSwitchCompat.isEnabled = isChecked
+            }
+        }
+
+        val disabledSwitchMaterial = root.findViewById<SwitchCompat>(R.id.material_switcher_disabled)
+        root.findViewById<SwitchCompat>(R.id.material_switcher).apply {
+            setOnCheckedChangeListener { _, isChecked ->
+                disabledSwitchMaterial.isEnabled = isChecked
+            }
+        }
+
         root.findViewById<Spinner>(R.id.default_spinner)?.let { spinner ->
             ArrayAdapter.createFromResource(
                 requireContext(),

--- a/sample/kotlin/src/main/res/layout/fragment_drop_down_switchers_components.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_drop_down_switchers_components.xml
@@ -20,8 +20,18 @@
         android:textColor="@color/datadog_violet"
         android:text="@string/app_compat_switch" />
 
+    <androidx.appcompat.widget.SwitchCompat
+        android:id="@+id/app_compat_switcher_disabled"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:enabled="false"
+        android:text="@string/app_compat_switch_disabled"
+        android:textColor="@color/datadog_violet"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/app_compat_switcher" />
+
     <com.google.android.material.switchmaterial.SwitchMaterial
-        app:layout_constraintTop_toBottomOf="@id/app_compat_switcher"
+        app:layout_constraintTop_toBottomOf="@id/app_compat_switcher_disabled"
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginTop="@dimen/default_padding"
         android:id="@+id/material_switcher"
@@ -30,8 +40,19 @@
         android:textColor="@android:color/holo_red_dark"
         android:text="@string/material_switch" />
 
+    <com.google.android.material.switchmaterial.SwitchMaterial
+        android:id="@+id/material_switcher_disabled"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/default_padding"
+        android:enabled="false"
+        android:text="@string/material_switch_disabled"
+        android:textColor="@android:color/holo_red_dark"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/material_switcher" />
+
     <Spinner
-        app:layout_constraintTop_toBottomOf="@id/material_switcher"
+        app:layout_constraintTop_toBottomOf="@id/material_switcher_disabled"
         app:layout_constraintStart_toStartOf="parent"
         android:layout_marginTop="@dimen/default_padding"
         android:id="@+id/default_spinner"

--- a/sample/kotlin/src/main/res/values/strings.xml
+++ b/sample/kotlin/src/main/res/values/strings.xml
@@ -154,7 +154,9 @@
     <string name="default_spinner">Default spinner</string>
     <string name="app_compat_spinner">App Compat Spinner</string>
     <string name="app_compat_switch">App Compat Switch</string>
+    <string name="app_compat_switch_disabled">App Compat Switch (Disabled)</string>
     <string name="material_switch">Material Switch</string>
+    <string name="material_switch_disabled">Material Switch (Disabled)</string>
     <string name="dropdowns_and_switchers_components">Dropdowns and Switchers Components</string>
     <string name="planet">Planet</string>
     <string name="sliders_and_steppers_components">Sliders and Steppers Components</string>


### PR DESCRIPTION
### What does this PR do?

Improve the `SwitchCompatMapper` to make `SwitchCompat` have similar replay with the real UI.

#### Main Changes
* Same as previous PR, the `SwitchCompatMapper` doesn't create `ShapeWireframe` any more for checked or unchecked state, instead, we extract the track drawable and thumb drawable to show the real graphic of the component.
* Sample application is updated to demonstrate more state of switch buttons 

### Motivation

* RUM-4715

What inspired you to submit this pull request?


### Session replay demo

https://mobile-integration.datadoghq.com/rum/replay/sessions/128703cf-1202-45c6-a34a-8a8a2df7275d?applicationId=38030dde-f9f9-4e52-9443-b9804a030080&seed=bd9e3c7b-fbbf-4a75-89b7-a323624f0cd2&ts=1719931750249

### New implementation overhead

Since the new implementation of `SwitchCompatMapper` create `ImageWireframe` other than `ShapeWireframe`, some overhead is in the expectation, to measure this, `Method called` metric is used to measure the total duration of creating a wire frame of each `map` method, here is the result

|old implementation (Shape wireframe) | new implementation (Image wireframe)  |
| ------ | ------ |
|<img width="1051" alt="image" src="https://github.com/DataDog/dd-sdk-android/assets/15606345/85d5a315-68a4-479c-8150-90c06061ad8f">  |<img width="1033" alt="image" src="https://github.com/DataDog/dd-sdk-android/assets/15606345/49ed9dee-8296-477b-a1c1-e3be06e013f1"> |


As we can see the new implementation takes 180us on average, and old implementation takes 120~140us on average, the overhead is nearly 50% percent.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

