### PR TITLE
RUM-3634: Apply privacy settings to TextCompositionGroupMapper for compose

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -1029,6 +1029,7 @@ datadog:
       - "kotlin.sequences.Sequence.groupBy(kotlin.Function1)"
       - "kotlin.sequences.Sequence.filter(kotlin.Function1)"
       - "kotlin.sequences.Sequence.firstOrNull()"
+      - "kotlin.sequences.Sequence.firstOrNull(kotlin.Function1)"
       - "kotlin.sequences.Sequence.flatMap(kotlin.Function1)"
       - "kotlin.sequences.Sequence.fold(com.google.gson.JsonArray, kotlin.Function2)"
       - "kotlin.sequences.Sequence.forEach(kotlin.Function1)"

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/data/UiContext.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/data/UiContext.kt
@@ -7,10 +7,13 @@
 package com.datadog.android.sessionreplay.compose.internal.data
 
 import androidx.compose.ui.unit.Density
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
 
 internal data class UiContext(
     val parentContentColor: String?,
-    val density: Float
+    val density: Float,
+    val privacy: SessionReplayPrivacy,
+    val isInUserInputLayout: Boolean = false
 ) {
     val composeDensity: Density
         get() = Density(density)

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/ButtonCompositionGroupMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/ButtonCompositionGroupMapper.kt
@@ -68,7 +68,7 @@ internal class ButtonCompositionGroupMapper(
                     width = 1
                 )
             ),
-            UiContext(contentColor, uiContext.density)
+            uiContext.copy(parentContentColor = contentColor)
         )
     }
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/AbstractCompositionGroupMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/AbstractCompositionGroupMapperTest.kt
@@ -42,15 +42,15 @@ import org.mockito.quality.Strictness
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
-internal class AbstractCompositionGroupMapperTest {
+internal open class AbstractCompositionGroupMapperTest {
 
     private lateinit var testedMapper: StubAbstractCompositionGroupMapper
 
     @Forgery
-    private lateinit var fakeComposeContext: ComposeContext
+    lateinit var fakeComposeContext: ComposeContext
 
     @Forgery
-    private lateinit var fakeUiContext: UiContext
+    lateinit var fakeUiContext: UiContext
 
     @Forgery
     private lateinit var fakeWireframe: ComposeWireframe
@@ -102,7 +102,7 @@ internal class AbstractCompositionGroupMapperTest {
         }
     }
 
-    private fun mockGroupWithCoordinates(
+    protected fun mockGroupWithCoordinates(
         forge: Forge
     ): CompositionGroup {
         val fakeOffset = Offset.Zero.copy(forge.aFloat(), forge.aFloat())

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/TextCompositionGroupMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/TextCompositionGroupMapperTest.kt
@@ -1,0 +1,85 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.mappers
+
+import androidx.compose.runtime.tooling.CompositionGroup
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.compose.internal.data.Box
+import com.datadog.android.sessionreplay.compose.internal.mappers.TextCompositionGroupMapper.Companion.DEFAULT_FONT_FAMILY
+import com.datadog.android.sessionreplay.compose.internal.mappers.TextCompositionGroupMapper.Companion.DEFAULT_FONT_SIZE
+import com.datadog.android.sessionreplay.compose.internal.mappers.TextCompositionGroupMapper.Companion.FIXED_INPUT_MASK
+import com.datadog.android.sessionreplay.compose.internal.stableId
+import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.utils.DefaultColorStringFormatter
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.RepeatedTest
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
+internal class TextCompositionGroupMapperTest : AbstractCompositionGroupMapperTest() {
+
+    private lateinit var textCompositionGroupMapper: TextCompositionGroupMapper
+
+    private lateinit var mockCompositionGroup: CompositionGroup
+
+    @BeforeEach
+    fun `set up`(forge: Forge) {
+        textCompositionGroupMapper = TextCompositionGroupMapper(colorStringFormatter = DefaultColorStringFormatter)
+        mockCompositionGroup = mockGroupWithCoordinates(forge)
+    }
+
+    @RepeatedTest(8)
+    fun `M return the correct wireframe W map`() {
+        val actual = textCompositionGroupMapper.map(
+            compositionGroup = mockCompositionGroup,
+            composeContext = fakeComposeContext,
+            uiContext = fakeUiContext
+        )
+        val expectedText = when (fakeUiContext.privacy) {
+            SessionReplayPrivacy.ALLOW -> String()
+            SessionReplayPrivacy.MASK,
+            SessionReplayPrivacy.MASK_USER_INPUT -> if (fakeUiContext.isInUserInputLayout) {
+                FIXED_INPUT_MASK
+            } else {
+                ""
+            }
+        }
+        val expectedBox = requireNotNull(Box.from(compositionGroup = mockCompositionGroup))
+        val boxWithDensity = expectedBox.withDensity(fakeUiContext.density)
+        val expected = MobileSegment.Wireframe.TextWireframe(
+            id = mockCompositionGroup.stableId(),
+            x = boxWithDensity.x,
+            y = boxWithDensity.y,
+            width = boxWithDensity.width,
+            height = boxWithDensity.height,
+            text = expectedText,
+            textStyle = MobileSegment.TextStyle(
+                family = DEFAULT_FONT_FAMILY,
+                size = DEFAULT_FONT_SIZE,
+                color = fakeUiContext.parentContentColor ?: TextCompositionGroupMapper.DEFAULT_TEXT_COLOR
+            ),
+            textPosition = MobileSegment.TextPosition(
+                alignment = MobileSegment.Alignment(horizontal = null, vertical = null)
+            )
+        )
+        Assertions.assertThat(actual?.wireframe).isEqualTo(expected)
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/UIContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/UIContextForgeryFactory.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sessionreplay.compose.test.elmyr
 
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
@@ -14,7 +15,9 @@ internal class UIContextForgeryFactory : ForgeryFactory<UiContext> {
     override fun getForgery(forge: Forge): UiContext {
         return UiContext(
             parentContentColor = forge.anAlphabeticalString(),
-            density = forge.aFloat(0.01f, 100f)
+            density = forge.aFloat(0.01f, 100f),
+            privacy = forge.aValueFrom(SessionReplayPrivacy::class.java),
+            isInUserInputLayout = forge.aBool()
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -18,6 +18,10 @@ enum com.datadog.android.sessionreplay.SessionReplayPrivacy
   - ALLOW
   - MASK
   - MASK_USER_INPUT
+interface com.datadog.android.sessionreplay.internal.recorder.obfuscator.StringObfuscator
+  fun obfuscate(String): String
+  companion object 
+    fun getStringObfuscator(): StringObfuscator
 data class com.datadog.android.sessionreplay.recorder.MappingContext
   constructor(SystemInformation, com.datadog.android.sessionreplay.utils.ImageWireframeHelper, com.datadog.android.sessionreplay.SessionReplayPrivacy, Boolean = false)
 interface com.datadog.android.sessionreplay.recorder.OptionSelectorDetector

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -45,6 +45,15 @@ public final class com/datadog/android/sessionreplay/SessionReplayPrivacy : java
 	public static fun values ()[Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 }
 
+public abstract interface class com/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator {
+	public static final field Companion Lcom/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator$Companion;
+	public abstract fun obfuscate (Ljava/lang/String;)Ljava/lang/String;
+}
+
+public final class com/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator$Companion {
+	public final fun getStringObfuscator ()Lcom/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator;
+}
+
 public final class com/datadog/android/sessionreplay/model/MobileSegment {
 	public static final field Companion Lcom/datadog/android/sessionreplay/model/MobileSegment$Companion;
 	public fun <init> (Lcom/datadog/android/sessionreplay/model/MobileSegment$Application;Lcom/datadog/android/sessionreplay/model/MobileSegment$Session;Lcom/datadog/android/sessionreplay/model/MobileSegment$View;JJJLjava/lang/Long;Ljava/lang/Boolean;Lcom/datadog/android/sessionreplay/model/MobileSegment$Source;Ljava/util/List;)V

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/obfuscator/StringObfuscator.kt
@@ -7,13 +7,34 @@
 package com.datadog.android.sessionreplay.internal.recorder.obfuscator
 
 import android.os.Build
+import com.datadog.android.lint.InternalApi
 
-internal interface StringObfuscator {
+/**
+ * Obfuscates string of text in session replay.
+ *
+ * DO NOT USE this class or its methods if you are not working on the internals of the Datadog SDK
+ * or one of the cross platform frameworks.
+ */
+@InternalApi
+interface StringObfuscator {
+
+    /**
+     * Obfuscates string of text in session replay.
+     *
+     * For Datadog internal use only.
+     */
+    @InternalApi
     fun obfuscate(stringValue: String): String
 
     companion object {
         internal const val CHARACTER_MASK = 'x'
 
+        /**
+         * Gets the instance of [StringObfuscator].
+         *
+         * For Datadog internal use only.
+         */
+        @InternalApi
         fun getStringObfuscator(): StringObfuscator {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 AndroidNStringObfuscator()


### PR DESCRIPTION
### What does this PR do?

Apply the privacy settings to `TextCompositionGroupMapper` for compose, the text masking strategy keeps same as `TextViewMapper` in Android View

### Motivation

* RUM-3634

### Screenrecord

| USER_INPUT | MASK | 
|---|---|
|https://mobile-integration.datadoghq.com/rum/replay/sessions/e55f5ad0-145d-4c2c-bc5b-1c4bbcd35ba9?applicationId=38030dde-f9f9-4e52-9443-b9804a030080&seed=70a2b95d-ba66-4083-ad43-81134787c57b&ts=1720118965911 | https://mobile-integration.datadoghq.com/rum/replay/sessions/5b0a74de-9928-4fb6-a273-e5d2a4f7ded3?applicationId=38030dde-f9f9-4e52-9443-b9804a030080&seed=49b1537e-3107-4da9-b7a6-49c24ed46145&ts=1720119348991|




### Additional Notes

* `StringObfuscator` is changed from `internal` class to `@InternalApi`, so the class can be shared between module.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

