### PR TITLE
Remove Nexus publishing plugin from buildSrc

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,7 +15,7 @@ import java.util.Properties
 
 plugins {
     `maven-publish`
-    id("io.github.gradle-nexus.publish-plugin")
+    alias(libs.plugins.nexusPublishGradlePlugin)
 }
 
 version = AndroidConfig.VERSION.name

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(libs.versionsGradlePlugin)
     implementation(libs.fuzzyWuzzy)
     implementation(libs.dokkaGradlePlugin)
-    implementation(libs.nexusPublishGradlePlugin)
     implementation(libs.kover)
 
     // check api surface

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -192,7 +192,6 @@ androidLintApi = { module = "com.android.tools.lint:lint-api", version.ref = "an
 androidLintChecks = { module = "com.android.tools.lint:lint-checks", version.ref = "androidLint" }
 
 fuzzyWuzzy = { module = "me.xdrop:fuzzywuzzy", version.ref = "fuzzyWuzzy" }
-nexusPublishGradlePlugin = { module = "io.github.gradle-nexus:publish-plugin", version.ref = "nexusPublishGradlePlugin" }
 
 kotlinPoet = { module = "com.squareup:kotlinpoet", version.ref = "kotlinPoet" }
 kotlinPoetKsp = { module = "com.squareup:kotlinpoet-ksp", version.ref = "kotlinPoet" }
@@ -305,4 +304,5 @@ traceCore = [
 
 [plugins]
 versionsGradlePlugin = { id = "com.github.ben-manes.versions", version.ref = "versionsGradlePlugin" }
+nexusPublishGradlePlugin = { id = "io.github.gradle-nexus.publish-plugin", version.ref = "nexusPublishGradlePlugin" }
 


### PR DESCRIPTION
### What does this PR do?

Tiny change: Nexus publishing plugin actually shouldn't be in the `buildSrc` classpath and so we can move it out and use it via plugin reference.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

