### PR TITLE
RUM-5389: Add API to configure the Image Privacy

### DIFF
--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/MappingContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/MappingContextForgeryFactory.kt
@@ -16,8 +16,9 @@ internal class MappingContextForgeryFactory : ForgeryFactory<MappingContext> {
         return MappingContext(
             systemInformation = forge.getForgery(),
             imageWireframeHelper = mock(),
-            hasOptionSelectorParent = forge.aBool(),
-            privacy = forge.getForgery()
+            privacy = forge.getForgery(),
+            imagePrivacy = forge.getForgery(),
+            hasOptionSelectorParent = forge.aBool()
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -2,9 +2,9 @@ interface com.datadog.android.sessionreplay.ExtensionSupport
   fun getCustomViewMappers(): List<MapperTypeWrapper<*>>
   fun getOptionSelectorDetectors(): List<com.datadog.android.sessionreplay.recorder.OptionSelectorDetector>
 enum com.datadog.android.sessionreplay.ImagePrivacy
-  - ALL
-  - CONTEXTUAL
-  - NONE
+  - MASK_NONE
+  - MASK_CONTENT
+  - MASK_ALL
 data class com.datadog.android.sessionreplay.MapperTypeWrapper<T: android.view.View>
   constructor(Class<T>, com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper<T>)
   fun supportsView(android.view.View): Boolean

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -1,6 +1,10 @@
 interface com.datadog.android.sessionreplay.ExtensionSupport
   fun getCustomViewMappers(): List<MapperTypeWrapper<*>>
   fun getOptionSelectorDetectors(): List<com.datadog.android.sessionreplay.recorder.OptionSelectorDetector>
+enum com.datadog.android.sessionreplay.ImagePrivacy
+  - ALL
+  - CONTEXTUAL
+  - NONE
 data class com.datadog.android.sessionreplay.MapperTypeWrapper<T: android.view.View>
   constructor(Class<T>, com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper<T>)
   fun supportsView(android.view.View): Boolean
@@ -13,13 +17,14 @@ data class com.datadog.android.sessionreplay.SessionReplayConfiguration
     fun addExtensionSupport(ExtensionSupport): Builder
     fun useCustomEndpoint(String): Builder
     fun setPrivacy(SessionReplayPrivacy): Builder
+    fun setImagePrivacy(ImagePrivacy): Builder
     fun build(): SessionReplayConfiguration
 enum com.datadog.android.sessionreplay.SessionReplayPrivacy
   - ALLOW
   - MASK
   - MASK_USER_INPUT
 data class com.datadog.android.sessionreplay.recorder.MappingContext
-  constructor(SystemInformation, com.datadog.android.sessionreplay.utils.ImageWireframeHelper, com.datadog.android.sessionreplay.SessionReplayPrivacy, Boolean = false)
+  constructor(SystemInformation, com.datadog.android.sessionreplay.utils.ImageWireframeHelper, com.datadog.android.sessionreplay.SessionReplayPrivacy, com.datadog.android.sessionreplay.ImagePrivacy, Boolean = false)
 interface com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
   fun isOptionSelector(android.view.ViewGroup): Boolean
 data class com.datadog.android.sessionreplay.recorder.SystemInformation
@@ -74,7 +79,7 @@ interface com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 data class com.datadog.android.sessionreplay.utils.GlobalBounds
   constructor(Long, Long, Long, Long)
 interface com.datadog.android.sessionreplay.utils.ImageWireframeHelper
-  fun createImageWireframe(android.view.View, Int, Long, Long, Int, Int, Boolean, android.graphics.drawable.Drawable, AsyncJobStatusCallback, com.datadog.android.sessionreplay.model.MobileSegment.WireframeClip? = null, com.datadog.android.sessionreplay.model.MobileSegment.ShapeStyle? = null, com.datadog.android.sessionreplay.model.MobileSegment.ShapeBorder? = null, String? = DRAWABLE_CHILD_NAME): com.datadog.android.sessionreplay.model.MobileSegment.Wireframe?
+  fun createImageWireframe(android.view.View, com.datadog.android.sessionreplay.ImagePrivacy, Int, Long, Long, Int, Int, Boolean, android.graphics.drawable.Drawable, AsyncJobStatusCallback, com.datadog.android.sessionreplay.model.MobileSegment.WireframeClip? = null, com.datadog.android.sessionreplay.model.MobileSegment.ShapeStyle? = null, com.datadog.android.sessionreplay.model.MobileSegment.ShapeBorder? = null, String? = DRAWABLE_CHILD_NAME): com.datadog.android.sessionreplay.model.MobileSegment.Wireframe?
   fun createCompoundDrawableWireframes(android.widget.TextView, com.datadog.android.sessionreplay.recorder.MappingContext, Int, AsyncJobStatusCallback): MutableList<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
   companion object 
 open class com.datadog.android.sessionreplay.utils.LegacyDrawableToColorMapper : DrawableToColorMapper

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -3,6 +3,14 @@ public abstract interface class com/datadog/android/sessionreplay/ExtensionSuppo
 	public abstract fun getOptionSelectorDetectors ()Ljava/util/List;
 }
 
+public final class com/datadog/android/sessionreplay/ImagePrivacy : java/lang/Enum {
+	public static final field ALL Lcom/datadog/android/sessionreplay/ImagePrivacy;
+	public static final field CONTEXTUAL Lcom/datadog/android/sessionreplay/ImagePrivacy;
+	public static final field NONE Lcom/datadog/android/sessionreplay/ImagePrivacy;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/ImagePrivacy;
+	public static fun values ()[Lcom/datadog/android/sessionreplay/ImagePrivacy;
+}
+
 public final class com/datadog/android/sessionreplay/MapperTypeWrapper {
 	public fun <init> (Ljava/lang/Class;Lcom/datadog/android/sessionreplay/recorder/mapper/WireframeMapper;)V
 	public final fun copy (Ljava/lang/Class;Lcom/datadog/android/sessionreplay/recorder/mapper/WireframeMapper;)Lcom/datadog/android/sessionreplay/MapperTypeWrapper;
@@ -22,8 +30,8 @@ public final class com/datadog/android/sessionreplay/SessionReplay {
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayConfiguration {
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;F)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -33,6 +41,7 @@ public final class com/datadog/android/sessionreplay/SessionReplayConfiguration$
 	public fun <init> (F)V
 	public final fun addExtensionSupport (Lcom/datadog/android/sessionreplay/ExtensionSupport;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun build ()Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public final fun setImagePrivacy (Lcom/datadog/android/sessionreplay/ImagePrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun setPrivacy (Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 }
@@ -1328,16 +1337,18 @@ public final class com/datadog/android/sessionreplay/model/ResourceMetadata$Comp
 }
 
 public final class com/datadog/android/sessionreplay/recorder/MappingContext {
-	public fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Z)V
-	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Z)V
+	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/sessionreplay/recorder/SystemInformation;
 	public final fun component2 ()Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;
 	public final fun component3 ()Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
-	public final fun component4 ()Z
-	public final fun copy (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Z)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/recorder/MappingContext;Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;ZILjava/lang/Object;)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
+	public final fun component4 ()Lcom/datadog/android/sessionreplay/ImagePrivacy;
+	public final fun component5 ()Z
+	public final fun copy (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Z)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/recorder/MappingContext;Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;ZILjava/lang/Object;)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHasOptionSelectorParent ()Z
+	public final fun getImagePrivacy ()Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public final fun getImageWireframeHelper ()Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;
 	public final fun getPrivacy ()Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public final fun getSystemInformation ()Lcom/datadog/android/sessionreplay/recorder/SystemInformation;
@@ -1489,14 +1500,14 @@ public final class com/datadog/android/sessionreplay/utils/GlobalBounds {
 public abstract interface class com/datadog/android/sessionreplay/utils/ImageWireframeHelper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper$Companion;
 	public abstract fun createCompoundDrawableWireframes (Landroid/widget/TextView;Lcom/datadog/android/sessionreplay/recorder/MappingContext;ILcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;)Ljava/util/List;
-	public abstract fun createImageWireframe (Landroid/view/View;IJJIIZLandroid/graphics/drawable/Drawable;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe;
+	public abstract fun createImageWireframe (Landroid/view/View;Lcom/datadog/android/sessionreplay/ImagePrivacy;IJJIIZLandroid/graphics/drawable/Drawable;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe;
 }
 
 public final class com/datadog/android/sessionreplay/utils/ImageWireframeHelper$Companion {
 }
 
 public final class com/datadog/android/sessionreplay/utils/ImageWireframeHelper$DefaultImpls {
-	public static synthetic fun createImageWireframe$default (Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Landroid/view/View;IJJIIZLandroid/graphics/drawable/Drawable;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe;
+	public static synthetic fun createImageWireframe$default (Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Landroid/view/View;Lcom/datadog/android/sessionreplay/ImagePrivacy;IJJIIZLandroid/graphics/drawable/Drawable;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;Lcom/datadog/android/sessionreplay/model/MobileSegment$WireframeClip;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeStyle;Lcom/datadog/android/sessionreplay/model/MobileSegment$ShapeBorder;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/model/MobileSegment$Wireframe;
 }
 
 public class com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper : com/datadog/android/sessionreplay/utils/DrawableToColorMapper {

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -4,9 +4,9 @@ public abstract interface class com/datadog/android/sessionreplay/ExtensionSuppo
 }
 
 public final class com/datadog/android/sessionreplay/ImagePrivacy : java/lang/Enum {
-	public static final field ALL Lcom/datadog/android/sessionreplay/ImagePrivacy;
-	public static final field CONTEXTUAL Lcom/datadog/android/sessionreplay/ImagePrivacy;
-	public static final field NONE Lcom/datadog/android/sessionreplay/ImagePrivacy;
+	public static final field MASK_ALL Lcom/datadog/android/sessionreplay/ImagePrivacy;
+	public static final field MASK_CONTENT Lcom/datadog/android/sessionreplay/ImagePrivacy;
+	public static final field MASK_NONE Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/ImagePrivacy;
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ImagePrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ImagePrivacy.kt
@@ -8,25 +8,25 @@ package com.datadog.android.sessionreplay
 
 /**
  * Defines the Session Replay privacy policy when recording images.
- * @see ImagePrivacy.ALL
- * @see ImagePrivacy.CONTEXTUAL
- * @see ImagePrivacy.NONE
+ * @see ImagePrivacy.MASK_NONE
+ * @see ImagePrivacy.MASK_CONTENT
+ * @see ImagePrivacy.MASK_ALL
  */
 enum class ImagePrivacy {
     /**
      * All images will be recorded, including those downloaded from the Internet during app runtime.
      */
-    ALL,
+    MASK_NONE,
 
     /**
-     * Mask images that we consider to be contextual.
+     * Mask images that we consider to be content images.
      * In the replay images will be replaced with placeholders with the label: Content Image.
      */
-    CONTEXTUAL,
+    MASK_CONTENT,
 
     /**
      * No images will be recorded.
      * In the replay images will be replaced with placeholders with the label: Image.
      */
-    NONE
+    MASK_ALL
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ImagePrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ImagePrivacy.kt
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+/**
+ * Defines the Session Replay privacy policy when recording images.
+ * @see ImagePrivacy.ALL
+ * @see ImagePrivacy.CONTEXTUAL
+ * @see ImagePrivacy.NONE
+ */
+enum class ImagePrivacy {
+    /**
+     * All images will be recorded, including those downloaded from the Internet during app runtime.
+     */
+    ALL,
+
+    /**
+     * Mask images that we consider to be contextual.
+     * In the replay images will be replaced with placeholders with the label: Content Image.
+     */
+    CONTEXTUAL,
+
+    /**
+     * No images will be recorded.
+     * In the replay images will be replaced with placeholders with the label: Image.
+     */
+    NONE
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -33,6 +33,7 @@ object SessionReplay {
             sdkCore = sdkCore as FeatureSdkCore,
             customEndpointUrl = sessionReplayConfiguration.customEndpointUrl,
             privacy = sessionReplayConfiguration.privacy,
+            imagePrivacy = sessionReplayConfiguration.imagePrivacy,
             customMappers = sessionReplayConfiguration.customMappers,
             customOptionSelectorDetectors = sessionReplayConfiguration.customOptionSelectorDetectors,
             sampleRate = sessionReplayConfiguration.sampleRate

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -30,7 +30,7 @@ data class SessionReplayConfiguration internal constructor(
     class Builder(@FloatRange(from = 0.0, to = 100.0) private val sampleRate: Float) {
         private var customEndpointUrl: String? = null
         private var privacy = SessionReplayPrivacy.MASK
-        private var imagePrivacy = ImagePrivacy.CONTEXTUAL
+        private var imagePrivacy = ImagePrivacy.MASK_CONTENT
         private var extensionSupport: ExtensionSupport = NoOpExtensionSupport()
 
         /**
@@ -66,10 +66,10 @@ data class SessionReplayConfiguration internal constructor(
 
         /**
          * Sets the image recording level for the Session Replay feature.
-         * If not specified all images larger than certain dimensions will be masked by default.
-         * @see ImagePrivacy.ALL
-         * @see ImagePrivacy.CONTEXTUAL
-         * @see ImagePrivacy.NONE
+         * If not specified then all images that are considered to be content images will be masked by default.
+         * @see ImagePrivacy.MASK_NONE
+         * @see ImagePrivacy.MASK_CONTENT
+         * @see ImagePrivacy.MASK_ALL
          */
         fun setImagePrivacy(level: ImagePrivacy): Builder {
             this.imagePrivacy = level

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -18,7 +18,8 @@ data class SessionReplayConfiguration internal constructor(
     internal val privacy: SessionReplayPrivacy,
     internal val customMappers: List<MapperTypeWrapper<*>>,
     internal val customOptionSelectorDetectors: List<OptionSelectorDetector>,
-    internal val sampleRate: Float
+    internal val sampleRate: Float,
+    internal val imagePrivacy: ImagePrivacy
 ) {
 
     /**
@@ -29,6 +30,7 @@ data class SessionReplayConfiguration internal constructor(
     class Builder(@FloatRange(from = 0.0, to = 100.0) private val sampleRate: Float) {
         private var customEndpointUrl: String? = null
         private var privacy = SessionReplayPrivacy.MASK
+        private var imagePrivacy = ImagePrivacy.CONTEXTUAL
         private var extensionSupport: ExtensionSupport = NoOpExtensionSupport()
 
         /**
@@ -63,12 +65,25 @@ data class SessionReplayConfiguration internal constructor(
         }
 
         /**
+         * Sets the image recording level for the Session Replay feature.
+         * If not specified all images larger than certain dimensions will be masked by default.
+         * @see ImagePrivacy.ALL
+         * @see ImagePrivacy.CONTEXTUAL
+         * @see ImagePrivacy.NONE
+         */
+        fun setImagePrivacy(level: ImagePrivacy): Builder {
+            this.imagePrivacy = level
+            return this
+        }
+
+        /**
          * Builds a [SessionReplayConfiguration] based on the current state of this Builder.
          */
         fun build(): SessionReplayConfiguration {
             return SessionReplayConfiguration(
                 customEndpointUrl = customEndpointUrl,
                 privacy = privacy,
+                imagePrivacy = imagePrivacy,
                 customMappers = customMappers(),
                 customOptionSelectorDetectors = extensionSupport.getOptionSelectorDetectors(),
                 sampleRate = sampleRate

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
@@ -22,6 +22,7 @@ import android.widget.TextView
 import androidx.appcompat.widget.ActionBarContainer
 import androidx.appcompat.widget.SwitchCompat
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.Recorder
@@ -57,6 +58,7 @@ import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
 internal class DefaultRecorderProvider(
     private val sdkCore: FeatureSdkCore,
     private val privacy: SessionReplayPrivacy,
+    private val imagePrivacy: ImagePrivacy,
     private val customMappers: List<MapperTypeWrapper<*>>,
     private val customOptionSelectorDetectors: List<OptionSelectorDetector>
 ) : RecorderProvider {
@@ -73,6 +75,7 @@ internal class DefaultRecorderProvider(
             resourcesWriter = resourceWriter,
             rumContextProvider = SessionReplayRumContextProvider(sdkCore),
             privacy = privacy,
+            imagePrivacy = imagePrivacy,
             recordWriter = recordWriter,
             timeProvider = SessionReplayTimeProvider(sdkCore),
             mappers = customMappers + builtInMappers(),

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -18,6 +18,7 @@ import com.datadog.android.api.net.RequestFactory
 import com.datadog.android.api.storage.FeatureStorageConfiguration
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.net.BatchesToSegmentsMapper
@@ -42,6 +43,7 @@ internal class SessionReplayFeature(
     private val sdkCore: FeatureSdkCore,
     private val customEndpointUrl: String?,
     internal val privacy: SessionReplayPrivacy,
+    internal val imagePrivacy: ImagePrivacy?,
     private val rateBasedSampler: Sampler,
     private val recorderProvider: RecorderProvider
 ) : StorageBackedFeature, FeatureEventReceiver {
@@ -52,6 +54,7 @@ internal class SessionReplayFeature(
         sdkCore: FeatureSdkCore,
         customEndpointUrl: String?,
         privacy: SessionReplayPrivacy,
+        imagePrivacy: ImagePrivacy,
         customMappers: List<MapperTypeWrapper<*>>,
         customOptionSelectorDetectors: List<OptionSelectorDetector>,
         sampleRate: Float
@@ -59,10 +62,12 @@ internal class SessionReplayFeature(
         sdkCore,
         customEndpointUrl,
         privacy,
+        imagePrivacy,
         RateBasedSampler(sampleRate),
         DefaultRecorderProvider(
             sdkCore,
             privacy,
+            imagePrivacy,
             customMappers,
             customOptionSelectorDetectors
         )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/DefaultOnDrawListenerProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/DefaultOnDrawListenerProducer.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.view.ViewTreeObserver
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.metrics.MethodCallSamplingRate
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener
@@ -20,12 +21,17 @@ internal class DefaultOnDrawListenerProducer(
     private val sdkCore: FeatureSdkCore
 ) : OnDrawListenerProducer {
 
-    override fun create(decorViews: List<View>, privacy: SessionReplayPrivacy): ViewTreeObserver.OnDrawListener {
+    override fun create(
+        decorViews: List<View>,
+        privacy: SessionReplayPrivacy,
+        imagePrivacy: ImagePrivacy
+    ): ViewTreeObserver.OnDrawListener {
         return WindowsOnDrawListener(
             zOrderedDecorViews = decorViews,
             recordedDataQueueHandler = recordedDataQueueHandler,
             snapshotProducer = snapshotProducer,
             privacy = privacy,
+            imagePrivacy = imagePrivacy,
             internalLogger = sdkCore.internalLogger,
             methodCallSamplingRate = MethodCallSamplingRate.LOW.rate
         )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/OnDrawListenerProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/OnDrawListenerProducer.kt
@@ -8,8 +8,13 @@ package com.datadog.android.sessionreplay.internal.recorder
 
 import android.view.View
 import android.view.ViewTreeObserver
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 
 internal fun interface OnDrawListenerProducer {
-    fun create(decorViews: List<View>, privacy: SessionReplayPrivacy): ViewTreeObserver.OnDrawListener
+    fun create(
+        decorViews: List<View>,
+        privacy: SessionReplayPrivacy,
+        imagePrivacy: ImagePrivacy
+    ): ViewTreeObserver.OnDrawListener
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
@@ -14,6 +14,7 @@ import androidx.annotation.MainThread
 import androidx.annotation.VisibleForTesting
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.LifecycleCallback
@@ -54,6 +55,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
     private val appContext: Application
     private val rumContextProvider: RumContextProvider
     private val privacy: SessionReplayPrivacy
+    private val imagePrivacy: ImagePrivacy
     private val recordWriter: RecordWriter
     private val timeProvider: TimeProvider
     private val mappers: List<MapperTypeWrapper<*>>
@@ -74,6 +76,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         resourcesWriter: ResourcesWriter,
         rumContextProvider: RumContextProvider,
         privacy: SessionReplayPrivacy,
+        imagePrivacy: ImagePrivacy,
         recordWriter: RecordWriter,
         timeProvider: TimeProvider,
         mappers: List<MapperTypeWrapper<*>> = emptyList(),
@@ -101,6 +104,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         this.appContext = appContext
         this.rumContextProvider = rumContextProvider
         this.privacy = privacy
+        this.imagePrivacy = imagePrivacy
         this.recordWriter = recordWriter
         this.timeProvider = timeProvider
         this.mappers = mappers
@@ -180,7 +184,8 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
             viewOnDrawInterceptor,
             timeProvider,
             internalLogger,
-            privacy
+            privacy,
+            imagePrivacy
         )
         this.sessionReplayLifecycleCallback = SessionReplayLifecycleCallback(this)
         this.uiHandler = Handler(Looper.getMainLooper())
@@ -193,6 +198,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         appContext: Application,
         rumContextProvider: RumContextProvider,
         privacy: SessionReplayPrivacy,
+        imagePrivacy: ImagePrivacy,
         recordWriter: RecordWriter,
         timeProvider: TimeProvider,
         mappers: List<MapperTypeWrapper<*>> = emptyList(),
@@ -209,6 +215,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         this.appContext = appContext
         this.rumContextProvider = rumContextProvider
         this.privacy = privacy
+        this.imagePrivacy = imagePrivacy
         this.recordWriter = recordWriter
         this.timeProvider = timeProvider
         this.mappers = mappers
@@ -241,7 +248,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
             val windows = sessionReplayLifecycleCallback.getCurrentWindows()
             val decorViews = windowInspector.getGlobalWindowViews(internalLogger)
             windowCallbackInterceptor.intercept(windows, appContext)
-            viewOnDrawInterceptor.intercept(decorViews, privacy)
+            viewOnDrawInterceptor.intercept(decorViews, privacy, imagePrivacy)
         }
     }
 
@@ -258,7 +265,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         if (shouldRecord) {
             val decorViews = windowInspector.getGlobalWindowViews(internalLogger)
             windowCallbackInterceptor.intercept(windows, appContext)
-            viewOnDrawInterceptor.intercept(decorViews, privacy)
+            viewOnDrawInterceptor.intercept(decorViews, privacy, imagePrivacy)
         }
     }
 
@@ -267,7 +274,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         if (shouldRecord) {
             val decorViews = windowInspector.getGlobalWindowViews(internalLogger)
             windowCallbackInterceptor.stopIntercepting(windows)
-            viewOnDrawInterceptor.intercept(decorViews, privacy)
+            viewOnDrawInterceptor.intercept(decorViews, privacy, imagePrivacy)
         }
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.UiThread
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -29,11 +30,17 @@ internal class SnapshotProducer(
         rootView: View,
         systemInformation: SystemInformation,
         privacy: SessionReplayPrivacy,
+        imagePrivacy: ImagePrivacy,
         recordedDataQueueRefs: RecordedDataQueueRefs
     ): Node? {
         return convertViewToNode(
             rootView,
-            MappingContext(systemInformation, imageWireframeHelper, privacy),
+            MappingContext(
+                systemInformation = systemInformation,
+                imageWireframeHelper = imageWireframeHelper,
+                privacy = privacy,
+                imagePrivacy = imagePrivacy
+            ),
             LinkedList(),
             recordedDataQueueRefs
         )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptor.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.view.View
 import android.view.ViewTreeObserver.OnDrawListener
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import java.util.WeakHashMap
 
@@ -19,9 +20,13 @@ internal class ViewOnDrawInterceptor(
     internal val decorOnDrawListeners: WeakHashMap<View, OnDrawListener> =
         WeakHashMap()
 
-    fun intercept(decorViews: List<View>, sessionReplayPrivacy: SessionReplayPrivacy) {
+    fun intercept(
+        decorViews: List<View>,
+        sessionReplayPrivacy: SessionReplayPrivacy,
+        imagePrivacy: ImagePrivacy
+    ) {
         stopInterceptingAndRemove(decorViews)
-        val onDrawListener = onDrawListenerProducer.create(decorViews, sessionReplayPrivacy)
+        val onDrawListener = onDrawListenerProducer.create(decorViews, sessionReplayPrivacy, imagePrivacy)
         decorViews.forEach { decorView ->
             val viewTreeObserver = decorView.viewTreeObserver
             if (viewTreeObserver != null && viewTreeObserver.isAlive) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptor.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.content.Context
 import android.view.Window
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.callback.NoOpWindowCallback
@@ -21,7 +22,8 @@ internal class WindowCallbackInterceptor(
     private val viewOnDrawInterceptor: ViewOnDrawInterceptor,
     private val timeProvider: TimeProvider,
     private val internalLogger: InternalLogger,
-    private val privacy: SessionReplayPrivacy
+    private val privacy: SessionReplayPrivacy,
+    private val imagePrivacy: ImagePrivacy
 ) {
     private val wrappedWindows: WeakHashMap<Window, Any?> = WeakHashMap()
 
@@ -55,7 +57,8 @@ internal class WindowCallbackInterceptor(
             timeProvider,
             viewOnDrawInterceptor,
             internalLogger,
-            privacy
+            privacy,
+            imagePrivacy
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallback.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallback.kt
@@ -11,6 +11,7 @@ import android.view.MotionEvent
 import android.view.Window
 import androidx.annotation.MainThread
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.ViewOnDrawInterceptor
@@ -30,6 +31,7 @@ internal class RecorderWindowCallback(
     private val viewOnDrawInterceptor: ViewOnDrawInterceptor,
     private val internalLogger: InternalLogger,
     private val privacy: SessionReplayPrivacy,
+    private val imagePrivacy: ImagePrivacy,
     private val copyEvent: (MotionEvent) -> MotionEvent = {
         @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here
         MotionEvent.obtain(it)
@@ -174,7 +176,11 @@ internal class RecorderWindowCallback(
             // a new window was added or removed so we stop recording the previous root views
             // and we start recording the new ones.
             viewOnDrawInterceptor.stopIntercepting()
-            viewOnDrawInterceptor.intercept(rootViews, privacy)
+            viewOnDrawInterceptor.intercept(
+                decorViews = rootViews,
+                sessionReplayPrivacy = privacy,
+                imagePrivacy = imagePrivacy
+            )
         }
     }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
@@ -12,6 +12,7 @@ import androidx.annotation.MainThread
 import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.measureMethodCallPerf
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
@@ -25,6 +26,7 @@ internal class WindowsOnDrawListener(
     private val recordedDataQueueHandler: RecordedDataQueueHandler,
     private val snapshotProducer: SnapshotProducer,
     private val privacy: SessionReplayPrivacy,
+    private val imagePrivacy: ImagePrivacy,
     private val debouncer: Debouncer = Debouncer(),
     private val miscUtils: MiscUtils = MiscUtils,
     private val internalLogger: InternalLogger,
@@ -58,7 +60,13 @@ internal class WindowsOnDrawListener(
                 val recordedDataQueueRefs = RecordedDataQueueRefs(recordedDataQueueHandler)
                 recordedDataQueueRefs.recordedDataQueueItem = item
                 rootViews.mapNotNull {
-                    snapshotProducer.produce(it, systemInformation, privacy, recordedDataQueueRefs)
+                    snapshotProducer.produce(
+                        rootView = it,
+                        systemInformation = systemInformation,
+                        privacy = privacy,
+                        imagePrivacy = imagePrivacy,
+                        recordedDataQueueRefs = recordedDataQueueRefs
+                    )
                 }
             }
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
@@ -111,6 +111,7 @@ internal abstract class CheckableTextViewMapper<T>(
             )
             mappingContext.imageWireframeHelper.createImageWireframe(
                 view = view,
+                imagePrivacy = mappingContext.imagePrivacy,
                 currentWireframeIndex = 0,
                 x = checkBoxBounds.x,
                 y = checkBoxBounds.y,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
@@ -63,6 +63,7 @@ internal class ImageViewMapper(
             // resolve foreground
             mappingContext.imageWireframeHelper.createImageWireframe(
                 view = view,
+                imagePrivacy = mappingContext.imagePrivacy,
                 currentWireframeIndex = wireframes.size,
                 x = contentXPosInDp,
                 y = contentYPosInDp,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapper.kt
@@ -80,6 +80,7 @@ internal open class SwitchCompatMapper(
             }?.let { drawable ->
                 mappingContext.imageWireframeHelper.createImageWireframe(
                     view = view,
+                    imagePrivacy = mappingContext.imagePrivacy,
                     currentWireframeIndex = prevIndex + 1,
                     x = trackBounds.x.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),
                     y = trackBounds.y.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),
@@ -105,10 +106,12 @@ internal open class SwitchCompatMapper(
             view,
             mappingContext.systemInformation.screenDensity
         )
+
         return view.thumbDrawable?.let { drawable ->
             thumbBounds?.let { thumbBounds ->
                 mappingContext.imageWireframeHelper.createImageWireframe(
                     view = view,
+                    imagePrivacy = mappingContext.imagePrivacy,
                     currentWireframeIndex = prevIndex + 1,
                     x = thumbBounds.x.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),
                     y = thumbBounds.y.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
@@ -91,7 +91,7 @@ internal class DefaultImageWireframeHelper(
 
         val density = displayMetrics.density
 
-        if (imagePrivacy == ImagePrivacy.NONE) {
+        if (imagePrivacy == ImagePrivacy.MASK_ALL) {
             return createContentPlaceholderWireframe(
                 id = id,
                 x = x,
@@ -275,7 +275,7 @@ internal class DefaultImageWireframeHelper(
         drawable: Drawable,
         density: Float
     ): Boolean =
-        imagePrivacy == ImagePrivacy.CONTEXTUAL &&
+        imagePrivacy == ImagePrivacy.MASK_CONTENT &&
             usePIIPlaceholder &&
             imageTypeResolver.isDrawablePII(drawable, density)
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
@@ -15,6 +15,7 @@ import android.widget.TextView
 import androidx.annotation.UiThread
 import androidx.annotation.VisibleForTesting
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.internal.recorder.ViewUtilsInternal
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -35,10 +36,11 @@ internal class DefaultImageWireframeHelper(
     private val imageTypeResolver: ImageTypeResolver
 ) : ImageWireframeHelper {
 
-    @Suppress("ReturnCount")
+    @Suppress("ReturnCount", "LongMethod")
     @UiThread
     override fun createImageWireframe(
         view: View,
+        imagePrivacy: ImagePrivacy,
         currentWireframeIndex: Int,
         x: Long,
         y: Long,
@@ -53,7 +55,12 @@ internal class DefaultImageWireframeHelper(
         prefix: String?
     ): MobileSegment.Wireframe? {
         val id = viewIdentifierResolver.resolveChildUniqueIdentifier(view, prefix + currentWireframeIndex)
-        val drawableProperties = resolveDrawableProperties(view, drawable)
+        val drawableProperties = resolveDrawableProperties(
+            view = view,
+            drawable = drawable,
+            width = width,
+            height = height
+        )
 
         if (id == null || !drawableProperties.isValid()) return null
 
@@ -84,13 +91,31 @@ internal class DefaultImageWireframeHelper(
 
         val density = displayMetrics.density
 
-        // in case we suspect the image is PII, return a placeholder
-        if (usePIIPlaceholder && imageTypeResolver.isDrawablePII(drawable, density)) {
-            return createContentPlaceholderWireframe(view, id, density)
+        if (imagePrivacy == ImagePrivacy.NONE) {
+            return createContentPlaceholderWireframe(
+                id = id,
+                x = x,
+                y = y,
+                density = density,
+                drawableProperties = drawableProperties,
+                label = MASK_ALL_CONTENT_LABEL
+            )
         }
 
-        val drawableWidthDp = width.densityNormalized(density).toLong()
-        val drawableHeightDp = height.densityNormalized(density).toLong()
+        // in case we suspect the image is PII, return a placeholder
+        if (shouldMaskContextualImage(imagePrivacy, usePIIPlaceholder, drawable, density)) {
+            return createContentPlaceholderWireframe(
+                id = id,
+                x = x,
+                y = y,
+                density = density,
+                drawableProperties = drawableProperties,
+                label = MASK_CONTEXTUAL_CONTENT_LABEL
+            )
+        }
+
+        val drawableWidthDp = drawableProperties.drawableWidth.densityNormalized(density).toLong()
+        val drawableHeightDp = drawableProperties.drawableHeight.densityNormalized(density).toLong()
 
         val imageWireframe =
             MobileSegment.Wireframe.ImageWireframe(
@@ -161,8 +186,10 @@ internal class DefaultImageWireframeHelper(
                     pixelsDensity = density,
                     position = compoundDrawablePosition
                 )
+
                 createImageWireframe(
                     view = textView,
+                    imagePrivacy = mappingContext.imagePrivacy,
                     currentWireframeIndex = ++wireframeIndex,
                     x = drawableCoordinates.x,
                     y = drawableCoordinates.y,
@@ -183,12 +210,12 @@ internal class DefaultImageWireframeHelper(
         return result
     }
 
-    private fun resolveDrawableProperties(view: View, drawable: Drawable): DrawableProperties {
+    private fun resolveDrawableProperties(view: View, drawable: Drawable, width: Int, height: Int): DrawableProperties {
         return when (drawable) {
             is LayerDrawable -> {
                 if (drawable.numberOfLayers > 0) {
                     @Suppress("UnsafeThirdPartyFunctionCall") // Can't be out of bounds
-                    resolveDrawableProperties(view, drawable.getDrawable(0))
+                    resolveDrawableProperties(view, drawable.getDrawable(0), width, height)
                 } else {
                     DrawableProperties(drawable, drawable.intrinsicWidth, drawable.intrinsicHeight)
                 }
@@ -197,35 +224,37 @@ internal class DefaultImageWireframeHelper(
             is InsetDrawable -> {
                 val internalDrawable = drawable.drawable
                 if (internalDrawable != null) {
-                    resolveDrawableProperties(view, internalDrawable)
+                    resolveDrawableProperties(
+                        view = view,
+                        drawable = internalDrawable,
+                        width = width,
+                        height = height
+                    )
                 } else {
                     DrawableProperties(drawable, drawable.intrinsicWidth, drawable.intrinsicHeight)
                 }
             }
 
             is GradientDrawable -> DrawableProperties(drawable, view.width, view.height)
-            else -> DrawableProperties(drawable, drawable.intrinsicWidth, drawable.intrinsicHeight)
+            else -> DrawableProperties(drawable, width, height)
         }
     }
 
     private fun createContentPlaceholderWireframe(
-        view: View,
         id: Long,
-        density: Float
+        x: Long,
+        y: Long,
+        density: Float,
+        drawableProperties: DrawableProperties,
+        label: String
     ): MobileSegment.Wireframe.PlaceholderWireframe {
-        val coordinates = IntArray(2)
-        @Suppress("UnsafeThirdPartyFunctionCall") // this will always have size >= 2
-        view.getLocationOnScreen(coordinates)
-        val viewX = coordinates[0].densityNormalized(density).toLong()
-        val viewY = coordinates[1].densityNormalized(density).toLong()
-
         return MobileSegment.Wireframe.PlaceholderWireframe(
             id,
-            viewX,
-            viewY,
-            view.width.densityNormalized(density).toLong(),
-            view.height.densityNormalized(density).toLong(),
-            label = PLACEHOLDER_CONTENT_LABEL
+            x,
+            y,
+            drawableProperties.drawableWidth.densityNormalized(density).toLong(),
+            drawableProperties.drawableHeight.densityNormalized(density).toLong(),
+            label = label
         )
     }
 
@@ -239,6 +268,16 @@ internal class DefaultImageWireframeHelper(
             else -> null
         }
     }
+
+    private fun shouldMaskContextualImage(
+        imagePrivacy: ImagePrivacy,
+        usePIIPlaceholder: Boolean,
+        drawable: Drawable,
+        density: Float
+    ): Boolean =
+        imagePrivacy == ImagePrivacy.CONTEXTUAL &&
+            usePIIPlaceholder &&
+            imageTypeResolver.isDrawablePII(drawable, density)
 
     internal enum class CompoundDrawablePositions {
         LEFT,
@@ -268,7 +307,10 @@ internal class DefaultImageWireframeHelper(
     internal companion object {
 
         @VisibleForTesting
-        internal const val PLACEHOLDER_CONTENT_LABEL = "Content Image"
+        internal const val MASK_CONTEXTUAL_CONTENT_LABEL = "Content Image"
+
+        @VisibleForTesting
+        internal const val MASK_ALL_CONTENT_LABEL = "Image"
 
         @VisibleForTesting
         internal const val APPLICATION_CONTEXT_NULL_ERROR = "Application context is null for view %s"

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/MappingContext.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/MappingContext.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sessionreplay.recorder
 
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
 
@@ -16,6 +17,7 @@ import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
  * @param systemInformation as [SystemInformation]
  * @param imageWireframeHelper a helper tool to capture images within a View
  * @param privacy the masking configuration to use when building the wireframes
+ * @param imagePrivacy the image recording configuration to use when building the wireframes
  * @param hasOptionSelectorParent tells if one of the parents of the current [android.view.View]
  * is an option selector type (e.g. time picker, date picker, drop - down list)
  */
@@ -23,5 +25,6 @@ data class MappingContext(
     val systemInformation: SystemInformation,
     val imageWireframeHelper: ImageWireframeHelper,
     val privacy: SessionReplayPrivacy,
+    val imagePrivacy: ImagePrivacy,
     val hasOptionSelectorParent: Boolean = false
 )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseAsyncBackgroundWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseAsyncBackgroundWireframeMapper.kt
@@ -127,9 +127,11 @@ abstract class BaseAsyncBackgroundWireframeMapper<in T : View> internal construc
         val resources = view.resources
 
         val drawableCopy = view.background?.constantState?.newDrawable(resources)
+
         return if (drawableCopy != null) {
             mappingContext.imageWireframeHelper.createImageWireframe(
                 view = view,
+                imagePrivacy = mappingContext.imagePrivacy,
                 currentWireframeIndex = 0,
                 x = bounds.x,
                 y = bounds.y,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/ImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/ImageWireframeHelper.kt
@@ -10,6 +10,7 @@ import android.graphics.drawable.Drawable
 import android.view.View
 import android.widget.TextView
 import androidx.annotation.UiThread
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 
@@ -21,6 +22,7 @@ interface ImageWireframeHelper {
     /**
      * Asks the helper to create an image wireframe, and process the provided drawable in the background.
      * @param view the view owning the drawable
+     * @param imagePrivacy defines which images should be hidden
      * @param currentWireframeIndex the index of the wireframe in the list of wireframes for the view
      * @param x the x position of the image
      * @param y the y position of the image
@@ -37,6 +39,7 @@ interface ImageWireframeHelper {
     // TODO RUM-3666 limit the number of params to this function
     fun createImageWireframe(
         view: View,
+        imagePrivacy: ImagePrivacy,
         currentWireframeIndex: Int,
         x: Long,
         y: Long,

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -59,7 +59,7 @@ internal class SessionReplayConfigurationBuilderTest {
         // Then
         assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
-        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.CONTEXTUAL)
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_CONTENT)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -78,7 +78,7 @@ internal class SessionReplayConfigurationBuilderTest {
         assertThat(sessionReplayConfiguration.customEndpointUrl)
             .isEqualTo(sessionReplayUrl)
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
-        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.CONTEXTUAL)
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_CONTENT)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -96,7 +96,7 @@ internal class SessionReplayConfigurationBuilderTest {
         // Then
         assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(fakePrivacy)
-        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.CONTEXTUAL)
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_CONTENT)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -59,6 +59,7 @@ internal class SessionReplayConfigurationBuilderTest {
         // Then
         assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.CONTEXTUAL)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -77,6 +78,7 @@ internal class SessionReplayConfigurationBuilderTest {
         assertThat(sessionReplayConfiguration.customEndpointUrl)
             .isEqualTo(sessionReplayUrl)
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.CONTEXTUAL)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -94,6 +96,25 @@ internal class SessionReplayConfigurationBuilderTest {
         // Then
         assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(fakePrivacy)
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.CONTEXTUAL)
+        assertThat(sessionReplayConfiguration.customMappers).isEmpty()
+        assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
+        assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
+    }
+
+    @Test
+    fun `M use the given image privacy rule W setImagePrivacy`(
+        @Forgery fakeImagePrivacy: ImagePrivacy
+    ) {
+        // When
+        val sessionReplayConfiguration = testedBuilder
+            .setImagePrivacy(fakeImagePrivacy)
+            .build()
+
+        // Then
+        assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
+        assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(fakeImagePrivacy)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
@@ -62,6 +62,9 @@ internal class SessionReplayRecorderTest {
     @Forgery
     private lateinit var fakePrivacy: SessionReplayPrivacy
 
+    @Forgery
+    private lateinit var fakeImagePrivacy: ImagePrivacy
+
     @Mock
     private lateinit var mockTimeProvider: TimeProvider
 
@@ -105,6 +108,7 @@ internal class SessionReplayRecorderTest {
             appContext = appContext.mockInstance,
             rumContextProvider = mockRumContextProvider,
             privacy = fakePrivacy,
+            imagePrivacy = fakeImagePrivacy,
             recordWriter = mockRecordWriter,
             timeProvider = mockTimeProvider,
             mappers = mock(),
@@ -146,8 +150,9 @@ internal class SessionReplayRecorderTest {
         // Then
         verify(mockWindowCallbackInterceptor).intercept(fakeActiveWindows, appContext.mockInstance)
         verify(mockViewOnDrawInterceptor).intercept(
-            fakeActiveWindowsDecorViews,
-            fakePrivacy
+            decorViews = fakeActiveWindowsDecorViews,
+            sessionReplayPrivacy = fakePrivacy,
+            imagePrivacy = fakeImagePrivacy
         )
     }
 
@@ -177,7 +182,7 @@ internal class SessionReplayRecorderTest {
 
         // Then
         verify(mockWindowCallbackInterceptor).intercept(fakeAddedWindows, appContext.mockInstance)
-        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews, fakePrivacy)
+        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
     }
 
     @Test
@@ -199,7 +204,7 @@ internal class SessionReplayRecorderTest {
         verify(mockWindowCallbackInterceptor, never())
             .intercept(fakeAddedWindows, appContext.mockInstance)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, fakePrivacy)
+            .intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
     }
 
     @Test
@@ -221,7 +226,7 @@ internal class SessionReplayRecorderTest {
         verify(mockWindowCallbackInterceptor, never())
             .intercept(fakeAddedWindows, appContext.mockInstance)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, fakePrivacy)
+            .intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
     }
 
     @Test
@@ -240,7 +245,7 @@ internal class SessionReplayRecorderTest {
 
         // Then
         verify(mockWindowCallbackInterceptor).stopIntercepting(fakeAddedWindows)
-        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews, fakePrivacy)
+        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
     }
 
     @Test
@@ -261,7 +266,7 @@ internal class SessionReplayRecorderTest {
         // Then
         verify(mockWindowCallbackInterceptor, never()).stopIntercepting(fakeAddedWindows)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, fakePrivacy)
+            .intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
     }
 
     @Test
@@ -280,7 +285,7 @@ internal class SessionReplayRecorderTest {
         // Then
         verify(mockWindowCallbackInterceptor, never()).stopIntercepting(fakeAddedWindows)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, fakePrivacy)
+            .intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MappingContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MappingContextForgeryFactory.kt
@@ -17,7 +17,8 @@ internal class MappingContextForgeryFactory : ForgeryFactory<MappingContext> {
             systemInformation = forge.getForgery(),
             imageWireframeHelper = mock(),
             hasOptionSelectorParent = forge.aBool(),
-            privacy = forge.getForgery()
+            privacy = forge.getForgery(),
+            imagePrivacy = forge.getForgery()
         )
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sessionreplay.forge
 
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import fr.xgouchet.elmyr.Forge
@@ -17,6 +18,7 @@ class SessionReplayConfigurationForgeryFactory : ForgeryFactory<SessionReplayCon
         return SessionReplayConfiguration(
             customEndpointUrl = forge.aNullable { aStringMatching("https://[a-z]+\\.com") },
             privacy = forge.aValueFrom(SessionReplayPrivacy::class.java),
+            imagePrivacy = forge.aValueFrom(ImagePrivacy::class.java),
             customMappers = forge.aList { mock() },
             customOptionSelectorDetectors = forge.aList { mock() },
             sampleRate = forge.aFloat(min = 0f, max = 100f)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -99,6 +99,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            imagePrivacy = fakeConfiguration.imagePrivacy,
             rateBasedSampler = mockSampler
         ) { _, _, _, _ -> mockRecorder }
     }
@@ -120,6 +121,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            imagePrivacy = fakeConfiguration.imagePrivacy,
             customMappers = emptyList(),
             customOptionSelectorDetectors = emptyList(),
             sampleRate = fakeConfiguration.sampleRate
@@ -140,6 +142,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            imagePrivacy = fakeConfiguration.imagePrivacy,
             customMappers = emptyList(),
             customOptionSelectorDetectors = emptyList(),
             sampleRate = fakeConfiguration.sampleRate
@@ -172,6 +175,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            imagePrivacy = fakeConfiguration.imagePrivacy,
             rateBasedSampler = mockSampler
         ) { _, _, _, _ -> mockRecorder }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 
 import android.view.View
 import android.view.ViewGroup
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
@@ -45,7 +46,7 @@ import java.util.LinkedList
 @ForgeConfiguration(ForgeConfigurator::class)
 internal class SnapshotProducerTest {
 
-    lateinit var testedSnapshotProducer: SnapshotProducer
+    private lateinit var testedSnapshotProducer: SnapshotProducer
 
     @Mock
     lateinit var mockTreeViewTraversal: TreeViewTraversal
@@ -67,6 +68,9 @@ internal class SnapshotProducerTest {
 
     @Forgery
     lateinit var fakePrivacy: SessionReplayPrivacy
+
+    @Forgery
+    lateinit var fakeImagePrivacy: ImagePrivacy
 
     @BeforeEach
     fun `set up`() {
@@ -93,6 +97,7 @@ internal class SnapshotProducerTest {
             mockRoot,
             fakeSystemInformation,
             fakePrivacy,
+            fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
 
@@ -119,6 +124,7 @@ internal class SnapshotProducerTest {
             fakeRoot,
             fakeSystemInformation,
             fakePrivacy,
+            fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
 
@@ -145,6 +151,7 @@ internal class SnapshotProducerTest {
             fakeRoot,
             fakeSystemInformation,
             fakePrivacy,
+            fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
 
@@ -171,6 +178,7 @@ internal class SnapshotProducerTest {
             fakeRoot,
             fakeSystemInformation,
             fakePrivacy,
+            fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
 
@@ -201,6 +209,7 @@ internal class SnapshotProducerTest {
             mockRoot,
             fakeSystemInformation,
             fakePrivacy,
+            fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
 
@@ -237,6 +246,7 @@ internal class SnapshotProducerTest {
             mockRoot,
             fakeSystemInformation,
             fakePrivacy,
+            fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
 
@@ -271,6 +281,7 @@ internal class SnapshotProducerTest {
             mockRoot,
             fakeSystemInformation,
             fakePrivacy,
+            fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
 
@@ -314,6 +325,7 @@ internal class SnapshotProducerTest {
             fakeRoot,
             fakeSystemInformation,
             fakePrivacy,
+            fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
 
@@ -346,6 +358,7 @@ internal class SnapshotProducerTest {
             fakeRoot,
             fakeSystemInformation,
             fakePrivacy,
+            fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptorTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.view.View
 import android.view.ViewTreeObserver
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.Forge
@@ -55,13 +56,22 @@ internal class ViewOnDrawInterceptorTest {
     @Forgery
     lateinit var fakePrivacy: SessionReplayPrivacy
 
-    lateinit var fakeDecorViews: List<View>
+    @Forgery
+    lateinit var fakeImagePrivacy: ImagePrivacy
+
+    private lateinit var fakeDecorViews: List<View>
 
     @BeforeEach
     fun `set up`(forge: Forge) {
         fakeDecorViews = forge.aMockedDecorViewsList()
 
-        whenever(mockOnDrawListenerProducer.create(fakeDecorViews, fakePrivacy)) doReturn mockOnDrawListener
+        whenever(
+            mockOnDrawListenerProducer.create(
+                fakeDecorViews,
+                fakePrivacy,
+                fakeImagePrivacy
+            )
+        ) doReturn mockOnDrawListener
 
         testedInterceptor = ViewOnDrawInterceptor(
             internalLogger = mockInternalLogger,
@@ -72,7 +82,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M register the OnDrawListener W intercept()`() {
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
 
         // Then
         fakeDecorViews.forEach {
@@ -88,7 +98,7 @@ internal class ViewOnDrawInterceptorTest {
         // Given
         testedInterceptor = ViewOnDrawInterceptor(
             internalLogger = mockInternalLogger,
-            onDrawListenerProducer = { _, privacy ->
+            onDrawListenerProducer = { _, privacy, _ ->
                 check(privacy == fakePrivacy) {
                     "Expected to create an OnDrawListener with privacy $fakePrivacy but was $privacy"
                 }
@@ -97,7 +107,7 @@ internal class ViewOnDrawInterceptorTest {
         )
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
 
         // Then
         fakeDecorViews.forEach {
@@ -111,10 +121,10 @@ internal class ViewOnDrawInterceptorTest {
         val mockOnDrawListener = mock<ViewTreeObserver.OnDrawListener>()
         testedInterceptor = ViewOnDrawInterceptor(
             internalLogger = mockInternalLogger
-        ) { _, _ -> mockOnDrawListener }
+        ) { _, _, _ -> mockOnDrawListener }
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
 
         // Then
         fakeDecorViews.forEach {
@@ -126,7 +136,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M register one single listener instance W intercept()`() {
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
 
         // Then
         val captor = argumentCaptor<ViewTreeObserver.OnDrawListener>()
@@ -148,7 +158,7 @@ internal class ViewOnDrawInterceptorTest {
         }
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
 
         // Then
         assertThat(testedInterceptor.decorOnDrawListeners).isEmpty()
@@ -162,7 +172,7 @@ internal class ViewOnDrawInterceptorTest {
         }
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
 
         // Then
         assertThat(testedInterceptor.decorOnDrawListeners).isEmpty()
@@ -171,7 +181,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister and clean the listeners W stopIntercepting(decorViews)`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
 
         // When
         testedInterceptor.stopIntercepting(fakeDecorViews)
@@ -188,7 +198,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister the listeners safely W stopIntercepting(decorViews)`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
         fakeDecorViews.forEach {
             whenever(it.viewTreeObserver.removeOnDrawListener(any())) doThrow IllegalStateException()
         }
@@ -208,7 +218,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister and clean the listeners W stopIntercepting()`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
 
         // When
         testedInterceptor.stopIntercepting()
@@ -226,10 +236,10 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister first and clean the listeners W intercepting()`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
 
         // Then
         fakeDecorViews.forEach {
@@ -245,7 +255,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister the listeners safely W stopIntercepting()`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
         fakeDecorViews.forEach {
             whenever(it.viewTreeObserver.removeOnDrawListener(any())) doThrow IllegalStateException()
         }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptorTest.kt
@@ -12,6 +12,7 @@ import android.util.DisplayMetrics
 import android.view.View
 import android.view.Window
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
@@ -48,7 +49,7 @@ import java.util.LinkedList
 @ForgeConfiguration(ForgeConfigurator::class)
 internal class WindowCallbackInterceptorTest {
 
-    lateinit var testedInterceptor: WindowCallbackInterceptor
+    private lateinit var testedInterceptor: WindowCallbackInterceptor
 
     @Mock
     lateinit var mockViewOnDrawInterceptor: ViewOnDrawInterceptor
@@ -65,9 +66,12 @@ internal class WindowCallbackInterceptorTest {
     @Forgery
     lateinit var fakePrivacy: SessionReplayPrivacy
 
-    lateinit var fakeWindowsList: List<Window>
+    @Forgery
+    lateinit var fakeImagePrivacy: ImagePrivacy
 
-    lateinit var mockActivity: Activity
+    private lateinit var fakeWindowsList: List<Window>
+
+    private lateinit var mockActivity: Activity
 
     @BeforeEach
     fun `set up`(forge: Forge) {
@@ -78,7 +82,8 @@ internal class WindowCallbackInterceptorTest {
             mockViewOnDrawInterceptor,
             mockTimeProvider,
             mockInternalLogger,
-            fakePrivacy
+            fakePrivacy,
+            fakeImagePrivacy
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallbackTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallbackTest.kt
@@ -13,6 +13,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.Window
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
@@ -50,6 +51,7 @@ import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.util.concurrent.TimeUnit
 import kotlin.jvm.internal.Intrinsics
+import kotlin.math.pow
 
 @Extensions(
     ExtendWith(MockitoExtension::class),
@@ -101,6 +103,9 @@ internal class RecorderWindowCallbackTest {
     @Forgery
     lateinit var fakePrivacy: SessionReplayPrivacy
 
+    @Forgery
+    lateinit var fakeImagePrivacy: ImagePrivacy
+
     @BeforeEach
     fun `set up`() {
         val mockResources = mock<Resources> {
@@ -119,6 +124,7 @@ internal class RecorderWindowCallbackTest {
             viewOnDrawInterceptor = mockViewOnDrawInterceptor,
             internalLogger = mockInternalLogger,
             privacy = fakePrivacy,
+            imagePrivacy = fakeImagePrivacy,
             copyEvent = { it },
             motionEventUtils = mockEventUtils,
             motionUpdateThresholdInNs = TEST_MOTION_UPDATE_DELAY_THRESHOLD_NS,
@@ -421,7 +427,7 @@ internal class RecorderWindowCallbackTest {
         // Then
         inOrder(mockViewOnDrawInterceptor) {
             verify(mockViewOnDrawInterceptor).stopIntercepting()
-            verify(mockViewOnDrawInterceptor).intercept(fakeDecorViews, fakePrivacy)
+            verify(mockViewOnDrawInterceptor).intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
         }
     }
 
@@ -498,7 +504,7 @@ internal class RecorderWindowCallbackTest {
     // endregion
 
     companion object {
-        private val FLOAT_MAX_INT_VALUE = Math.pow(2.0, 23.0).toFloat()
+        private val FLOAT_MAX_INT_VALUE = 2.0.pow(23.0).toFloat()
 
         // We need to test with higher threshold values in order to avoid flakiness
         private val TEST_MOTION_UPDATE_DELAY_THRESHOLD_NS: Long =

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListenerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListenerTest.kt
@@ -12,9 +12,9 @@ import android.content.res.Resources
 import android.content.res.Resources.Theme
 import android.view.View
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.core.metrics.PerformanceMetric
 import com.datadog.android.core.metrics.TelemetryMetricType
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
@@ -74,9 +74,6 @@ internal class WindowsOnDrawListenerTest {
     lateinit var mockRecordedDataQueueHandler: RecordedDataQueueHandler
 
     @Mock
-    lateinit var mockSessionReplayFeature: FeatureScope
-
-    @Mock
     lateinit var mockDebouncer: Debouncer
 
     @Mock
@@ -113,6 +110,9 @@ internal class WindowsOnDrawListenerTest {
     @Forgery
     lateinit var fakePrivacy: SessionReplayPrivacy
 
+    @Forgery
+    lateinit var fakeImagePrivacy: ImagePrivacy
+
     @FloatForgery
     var fakeMethodCallSamplingRate: Float = 0f
 
@@ -131,6 +131,7 @@ internal class WindowsOnDrawListenerTest {
                     eq(decorView),
                     eq(fakeSystemInformation),
                     eq(fakePrivacy),
+                    eq(fakeImagePrivacy),
                     any()
                 )
             )
@@ -157,6 +158,7 @@ internal class WindowsOnDrawListenerTest {
             recordedDataQueueHandler = mockRecordedDataQueueHandler,
             snapshotProducer = mockSnapshotProducer,
             privacy = fakePrivacy,
+            imagePrivacy = fakeImagePrivacy,
             debouncer = mockDebouncer,
             miscUtils = mockMiscUtils,
             internalLogger = mockInternalLogger,
@@ -193,6 +195,7 @@ internal class WindowsOnDrawListenerTest {
             rootView = any(),
             systemInformation = any(),
             privacy = eq(fakePrivacy),
+            imagePrivacy = eq(fakeImagePrivacy),
             recordedDataQueueRefs = argCaptor.capture()
         )
         assertThat(argCaptor.firstValue.recordedDataQueueItem).isEqualTo(fakeSnapshotQueueItem)
@@ -207,6 +210,7 @@ internal class WindowsOnDrawListenerTest {
             recordedDataQueueHandler = mockRecordedDataQueueHandler,
             snapshotProducer = mockSnapshotProducer,
             privacy = fakePrivacy,
+            imagePrivacy = fakeImagePrivacy,
             debouncer = mockDebouncer,
             miscUtils = mockMiscUtils,
             internalLogger = mockInternalLogger,
@@ -282,7 +286,7 @@ internal class WindowsOnDrawListenerTest {
                 "Capture Record"
             )
         ).thenReturn(mockPerformanceMetric)
-        whenever(mockSnapshotProducer.produce(any(), any(), any(), any())).thenReturn(null)
+        whenever(mockSnapshotProducer.produce(any(), any(), any(), any(), any())).thenReturn(null)
         whenever(mockRecordedDataQueueHandler.addSnapshotItem(any<SystemInformation>()))
             .thenReturn(fakeSnapshotQueueItem)
         fakeSnapshotQueueItem.pendingJobs.set(0)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckableTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckableTextViewMapperTest.kt
@@ -12,6 +12,7 @@ import android.graphics.drawable.DrawableContainer
 import android.os.Build
 import android.widget.Checkable
 import android.widget.TextView
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckableTextViewMapper.Companion.CHECK_BOX_CHECKED_DRAWABLE_INDEX
@@ -115,6 +116,9 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
     @IntForgery
     var mockCloneDrawableIntrinsicWidth: Int = 0
 
+    @Forgery
+    lateinit var fakeImagePrivacy: ImagePrivacy
+
     @BeforeEach
     fun `set up`() {
         mockClonedDrawable = mock {
@@ -191,7 +195,8 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
     @Test
     fun `M create ImageWireFrame W map() { checked, above M }`() {
         // Given
-        val allowedMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        val allowedMappingContext =
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW, imagePrivacy = ImagePrivacy.ALL)
         whenever(mockButtonDrawable.intrinsicHeight).thenReturn(fakeIntrinsicDrawableHeight)
         whenever(mockCheckableTextView.isChecked).thenReturn(true)
 
@@ -210,6 +215,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
         // Then
         verify(fakeMappingContext.imageWireframeHelper).createImageWireframe(
             view = eq(mockCheckableTextView),
+            imagePrivacy = eq(ImagePrivacy.ALL),
             currentWireframeIndex = anyInt(),
             x = eq(expectedX),
             y = eq(expectedY),
@@ -229,7 +235,10 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
     @Test
     fun `M create ImageWireFrame W map() { not checked, above M }`() {
         // Given
-        val allowedMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        val allowedMappingContext = fakeMappingContext.copy(
+            privacy = SessionReplayPrivacy.ALLOW,
+            imagePrivacy = ImagePrivacy.ALL
+        )
         whenever(mockButtonDrawable.intrinsicHeight).thenReturn(fakeIntrinsicDrawableHeight)
         whenever(mockCheckableTextView.isChecked).thenReturn(false)
 
@@ -249,6 +258,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
         // Then
         verify(fakeMappingContext.imageWireframeHelper).createImageWireframe(
             view = eq(mockCheckableTextView),
+            imagePrivacy = eq(ImagePrivacy.ALL),
             currentWireframeIndex = anyInt(),
             x = eq(expectedX),
             y = eq(expectedY),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckableTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckableTextViewMapperTest.kt
@@ -196,7 +196,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
     fun `M create ImageWireFrame W map() { checked, above M }`() {
         // Given
         val allowedMappingContext =
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW, imagePrivacy = ImagePrivacy.ALL)
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW, imagePrivacy = ImagePrivacy.MASK_CONTENT)
         whenever(mockButtonDrawable.intrinsicHeight).thenReturn(fakeIntrinsicDrawableHeight)
         whenever(mockCheckableTextView.isChecked).thenReturn(true)
 
@@ -215,7 +215,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
         // Then
         verify(fakeMappingContext.imageWireframeHelper).createImageWireframe(
             view = eq(mockCheckableTextView),
-            imagePrivacy = eq(ImagePrivacy.ALL),
+            imagePrivacy = eq(ImagePrivacy.MASK_CONTENT),
             currentWireframeIndex = anyInt(),
             x = eq(expectedX),
             y = eq(expectedY),
@@ -237,7 +237,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
         // Given
         val allowedMappingContext = fakeMappingContext.copy(
             privacy = SessionReplayPrivacy.ALLOW,
-            imagePrivacy = ImagePrivacy.ALL
+            imagePrivacy = ImagePrivacy.MASK_CONTENT
         )
         whenever(mockButtonDrawable.intrinsicHeight).thenReturn(fakeIntrinsicDrawableHeight)
         whenever(mockCheckableTextView.isChecked).thenReturn(false)
@@ -258,7 +258,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
         // Then
         verify(fakeMappingContext.imageWireframeHelper).createImageWireframe(
             view = eq(mockCheckableTextView),
-            imagePrivacy = eq(ImagePrivacy.ALL),
+            imagePrivacy = eq(ImagePrivacy.MASK_CONTENT),
             currentWireframeIndex = anyInt(),
             x = eq(expectedX),
             y = eq(expectedY),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapperTest.kt
@@ -16,8 +16,8 @@ import android.util.DisplayMetrics
 import android.view.View
 import android.widget.ImageView
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.internal.recorder.resources.ImageCompression
 import com.datadog.android.sessionreplay.internal.utils.ImageViewUtils
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -31,6 +31,7 @@ import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
 import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
 import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -72,9 +73,6 @@ internal class ImageViewMapperTest {
 
     @Mock
     lateinit var mockMappingContext: MappingContext
-
-    @Mock
-    lateinit var mockWebPImageCompression: ImageCompression
 
     @Mock
     lateinit var mockDrawable: Drawable
@@ -130,6 +128,9 @@ internal class ImageViewMapperTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @Forgery
+    lateinit var fakeImagePrivacy: ImagePrivacy
+
     @LongForgery
     var fakeId: Long = 0L
 
@@ -156,6 +157,7 @@ internal class ImageViewMapperTest {
         whenever(mockSystemInformation.screenDensity).thenReturn(forge.aFloat())
         whenever(mockMappingContext.systemInformation).thenReturn(mockSystemInformation)
         whenever(mockMappingContext.imageWireframeHelper).thenReturn(mockImageWireframeHelper)
+        whenever(mockMappingContext.imagePrivacy).thenReturn(fakeImagePrivacy)
 
         whenever(mockResources.displayMetrics).thenReturn(mockDisplayMetrics)
         whenever(mockImageView.resources).thenReturn(mockResources)
@@ -206,6 +208,7 @@ internal class ImageViewMapperTest {
         whenever(mockImageView.background).thenReturn(null)
         mockImageWireframeHelper(
             expectedView = mockImageView,
+            expectedImagePrivacy = fakeImagePrivacy,
             expectedDrawable = mockDrawable,
             expectedIndex = 0,
             expectedPrefix = ImageWireframeHelper.DRAWABLE_CHILD_NAME,
@@ -246,6 +249,7 @@ internal class ImageViewMapperTest {
         whenever(mockImageView.background).thenReturn(mockBackgroundDrawable)
         mockImageWireframeHelper(
             expectedView = mockImageView,
+            expectedImagePrivacy = fakeImagePrivacy,
             expectedDrawable = mockBackgroundDrawable,
             expectedIndex = 0,
             expectedPrefix = BaseAsyncBackgroundWireframeMapper.PREFIX_BACKGROUND_DRAWABLE,
@@ -254,6 +258,7 @@ internal class ImageViewMapperTest {
         )
         mockImageWireframeHelper(
             expectedView = mockImageView,
+            expectedImagePrivacy = fakeImagePrivacy,
             expectedDrawable = mockDrawable,
             expectedIndex = 1,
             expectedPrefix = ImageWireframeHelper.DRAWABLE_CHILD_NAME,
@@ -281,6 +286,7 @@ internal class ImageViewMapperTest {
         whenever(
             mockImageWireframeHelper.createImageWireframe(
                 view = any(),
+                imagePrivacy = any(),
                 currentWireframeIndex = any(),
                 x = any(),
                 y = any(),
@@ -311,6 +317,7 @@ internal class ImageViewMapperTest {
         verify(mockImageWireframeHelper)
             .createImageWireframe(
                 view = any(),
+                imagePrivacy = any(),
                 currentWireframeIndex = any(),
                 x = any(),
                 y = any(),
@@ -346,6 +353,7 @@ internal class ImageViewMapperTest {
 
         mockImageWireframeHelper(
             expectedView = mockImageView,
+            expectedImagePrivacy = fakeImagePrivacy,
             expectedDrawable = mockBackgroundDrawable,
             expectedIndex = 0,
             expectedPrefix = BaseAsyncBackgroundWireframeMapper.PREFIX_BACKGROUND_DRAWABLE,
@@ -354,6 +362,7 @@ internal class ImageViewMapperTest {
         )
         mockImageWireframeHelper(
             expectedView = mockImageView,
+            expectedImagePrivacy = fakeImagePrivacy,
             expectedDrawable = mockDrawable,
             expectedIndex = 1,
             expectedPrefix = ImageWireframeHelper.DRAWABLE_CHILD_NAME,
@@ -404,6 +413,7 @@ internal class ImageViewMapperTest {
             .thenReturn(null)
         mockImageWireframeHelper(
             expectedView = mockImageView,
+            expectedImagePrivacy = fakeImagePrivacy,
             expectedDrawable = mockDrawable,
             expectedIndex = 0,
             expectedPrefix = ImageWireframeHelper.DRAWABLE_CHILD_NAME,
@@ -426,6 +436,7 @@ internal class ImageViewMapperTest {
 
     private fun mockImageWireframeHelper(
         expectedView: View,
+        expectedImagePrivacy: ImagePrivacy,
         expectedDrawable: Drawable,
         expectedIndex: Int,
         expectedPrefix: String?,
@@ -435,6 +446,7 @@ internal class ImageViewMapperTest {
         whenever(
             mockImageWireframeHelper.createImageWireframe(
                 view = eq(expectedView),
+                imagePrivacy = eq(expectedImagePrivacy),
                 currentWireframeIndex = eq(expectedIndex),
                 x = any(),
                 y = any(),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.graphics.drawable.Drawable
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
@@ -75,7 +76,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext,
+            fakeMappingContext.copy(imagePrivacy = ImagePrivacy.ALL),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )
@@ -88,6 +89,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
 
             verify(fakeMappingContext.imageWireframeHelper, times(2)).createImageWireframe(
                 view = eq(mockSwitch),
+                imagePrivacy = eq(ImagePrivacy.ALL),
                 currentWireframeIndex = ArgumentMatchers.anyInt(),
                 x = xCaptor.capture(),
                 y = yCaptor.capture(),
@@ -145,7 +147,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK),
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.ALL),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )
@@ -170,7 +172,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK),
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.ALL),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )
@@ -179,6 +181,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         assertThat(resolvedWireframes).isEqualTo(fakeTextWireframes)
         verify(fakeMappingContext.imageWireframeHelper, never()).createImageWireframe(
             view = any(),
+            imagePrivacy = any(),
             currentWireframeIndex = any(),
             x = any(),
             y = any(),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
@@ -76,7 +76,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext.copy(imagePrivacy = ImagePrivacy.ALL),
+            fakeMappingContext.copy(imagePrivacy = ImagePrivacy.MASK_CONTENT),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )
@@ -89,7 +89,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
 
             verify(fakeMappingContext.imageWireframeHelper, times(2)).createImageWireframe(
                 view = eq(mockSwitch),
-                imagePrivacy = eq(ImagePrivacy.ALL),
+                imagePrivacy = eq(ImagePrivacy.MASK_CONTENT),
                 currentWireframeIndex = ArgumentMatchers.anyInt(),
                 x = xCaptor.capture(),
                 y = yCaptor.capture(),
@@ -147,7 +147,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.ALL),
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.MASK_CONTENT),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )
@@ -172,7 +172,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.ALL),
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.MASK_CONTENT),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelperTest.kt
@@ -134,7 +134,7 @@ internal class DefaultImageWireframeHelperTest {
         val randomXLocation = forge.aLong(min = 1, max = (fakeScreenWidth - fakeDrawableWidth).toLong())
         val randomYLocation = forge.aLong(min = 1, max = (fakeScreenHeight - fakeDrawableHeight).toLong())
         fakeDrawableXY = Pair(randomXLocation, randomYLocation)
-        whenever(mockMappingContext.imagePrivacy).thenReturn(ImagePrivacy.CONTEXTUAL)
+        whenever(mockMappingContext.imagePrivacy).thenReturn(ImagePrivacy.MASK_CONTENT)
         whenever(mockMappingContext.systemInformation).thenReturn(mockSystemInformation)
         whenever(mockSystemInformation.screenDensity).thenReturn(0f)
         whenever(mockViewIdentifierResolver.resolveChildUniqueIdentifier(mockView, "drawable"))
@@ -182,7 +182,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.NONE,
+            imagePrivacy = ImagePrivacy.MASK_ALL,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -204,7 +204,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.ALL,
+            imagePrivacy = ImagePrivacy.MASK_NONE,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -229,7 +229,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -254,7 +254,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -283,7 +283,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -313,7 +313,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -336,7 +336,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -358,7 +358,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -415,7 +415,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = fakeDrawableXY.first,
             y = fakeDrawableXY.second,
@@ -593,7 +593,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -625,7 +625,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -676,7 +676,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val result = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = forge.aPositiveInt(),
             x = fakeGlobalX,
             y = fakeGlobalY,
@@ -703,7 +703,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -736,7 +736,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val actualWireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.CONTEXTUAL,
+            imagePrivacy = ImagePrivacy.MASK_CONTENT,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,


### PR DESCRIPTION
### What does this PR do?
Link to the [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3901883432/RFC+Image+Privacy+Configuration)

Adds an ImagePrivacy api to the SessionReplayConfiguration. The api has the following values:

MASK_ALL - no images will be recorded. Images will be replaced with a placeholder labelled "Image".
MASK_CONTENT - bundled images will be recorded and contextual ones will not (the default state). Contextual images will be replaced with a placeholder labelled "Content Image".
MASK_NONE - all images will be recorded.

Usage of the api:
```
SessionReplayConfiguration.Builder()
.setImagePrivacy(ImagePrivacy.MASK_ALL)
```

MASK_NONE
<img width="361" alt="Screenshot 2024-07-17 at 9 40 31" src="https://github.com/user-attachments/assets/266034d7-dbc0-4067-a483-e4501328561a">

MASK_CONTENT
<img width="166" alt="Screenshot 2024-07-17 at 14 39 09" src="https://github.com/user-attachments/assets/82a42436-27d6-48bf-89aa-f1fdd60788ca">


MASK_ALL
<img width="171" alt="Screenshot 2024-07-17 at 14 36 48" src="https://github.com/user-attachments/assets/cb038ee2-f183-41cd-9303-aa24b6e59a98">



### Motivation
Give users the flexibility to have different image recording levels for their sessions.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

