### PR TITLE
RUM-648 Add request id in okhttp request

### DIFF
--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -96,11 +96,11 @@ interface com.datadog.android.rum.RumMonitor
   fun addAction(RumActionType, String, Map<String, Any?>)
   fun startAction(RumActionType, String, Map<String, Any?>)
   fun stopAction(RumActionType, String, Map<String, Any?> = emptyMap())
-  DEPRECATED fun startResource(String, String, String, Map<String, Any?> = emptyMap())
-  fun startResource(String, RumResourceMethod, String, Map<String, Any?> = emptyMap())
-  fun stopResource(String, Int?, Long?, RumResourceKind, Map<String, Any?>)
-  fun stopResourceWithError(String, Int?, String, RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
-  fun stopResourceWithError(String, Int?, String, RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
+  DEPRECATED fun startResource(Any, String, String, Map<String, Any?> = emptyMap())
+  fun startResource(Any, RumResourceMethod, String, Map<String, Any?> = emptyMap())
+  fun stopResource(Any, Int?, Long?, RumResourceKind, Map<String, Any?>)
+  fun stopResourceWithError(Any, Int?, String, RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
+  fun stopResourceWithError(Any, Int?, String, RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
   fun addError(String, RumErrorSource, Throwable?, Map<String, Any?>)
   fun addErrorWithStacktrace(String, RumErrorSource, String?, Map<String, Any?>)
   fun addTiming(String)
@@ -164,8 +164,8 @@ interface com.datadog.android.rum.event.ViewEventMapper : com.datadog.android.ev
 data class com.datadog.android.rum.internal.domain.event.ResourceTiming
   constructor(Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L, Long = 0L)
 interface com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor
-  fun waitForResourceTiming(String)
-  fun addResourceTiming(String, com.datadog.android.rum.internal.domain.event.ResourceTiming)
+  fun waitForResourceTiming(Any)
+  fun addResourceTiming(Any, com.datadog.android.rum.internal.domain.event.ResourceTiming)
   fun notifyInterceptorInstantiated()
 fun android.content.Context.getAssetAsRumResource(String, Int = AssetManager.ACCESS_STREAMING, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun android.content.Context.getRawResAsRumResource(Int, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -170,6 +170,10 @@ interface com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor
 fun android.content.Context.getAssetAsRumResource(String, Int = AssetManager.ACCESS_STREAMING, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun android.content.Context.getRawResAsRumResource(Int, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun java.io.InputStream.asRumResource(String, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream
+class com.datadog.android.rum.resource.ResourceId
+  constructor(String, String?)
+  override fun equals(Any?): Boolean
+  override fun hashCode(): Int
 class com.datadog.android.rum.resource.RumResourceInputStream : java.io.InputStream
   constructor(java.io.InputStream, String, com.datadog.android.api.SdkCore = Datadog.getInstance())
   override fun read(): Int

--- a/features/dd-sdk-android-rum/api/apiSurface
+++ b/features/dd-sdk-android-rum/api/apiSurface
@@ -96,11 +96,11 @@ interface com.datadog.android.rum.RumMonitor
   fun addAction(RumActionType, String, Map<String, Any?>)
   fun startAction(RumActionType, String, Map<String, Any?>)
   fun stopAction(RumActionType, String, Map<String, Any?> = emptyMap())
-  DEPRECATED fun startResource(Any, String, String, Map<String, Any?> = emptyMap())
-  fun startResource(Any, RumResourceMethod, String, Map<String, Any?> = emptyMap())
-  fun stopResource(Any, Int?, Long?, RumResourceKind, Map<String, Any?>)
-  fun stopResourceWithError(Any, Int?, String, RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
-  fun stopResourceWithError(Any, Int?, String, RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
+  DEPRECATED fun startResource(String, String, String, Map<String, Any?> = emptyMap())
+  fun startResource(String, RumResourceMethod, String, Map<String, Any?> = emptyMap())
+  fun stopResource(String, Int?, Long?, RumResourceKind, Map<String, Any?>)
+  fun stopResourceWithError(String, Int?, String, RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
+  fun stopResourceWithError(String, Int?, String, RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
   fun addError(String, RumErrorSource, Throwable?, Map<String, Any?>)
   fun addErrorWithStacktrace(String, RumErrorSource, String?, Map<String, Any?>)
   fun addTiming(String)
@@ -167,6 +167,10 @@ interface com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor
   fun waitForResourceTiming(Any)
   fun addResourceTiming(Any, com.datadog.android.rum.internal.domain.event.ResourceTiming)
   fun notifyInterceptorInstantiated()
+  fun startResource(com.datadog.android.rum.resource.ResourceId, com.datadog.android.rum.RumResourceMethod, String, Map<String, Any?> = emptyMap())
+  fun stopResource(com.datadog.android.rum.resource.ResourceId, Int?, Long?, com.datadog.android.rum.RumResourceKind, Map<String, Any?>)
+  fun stopResourceWithError(com.datadog.android.rum.resource.ResourceId, Int?, String, com.datadog.android.rum.RumErrorSource, Throwable, Map<String, Any?> = emptyMap())
+  fun stopResourceWithError(com.datadog.android.rum.resource.ResourceId, Int?, String, com.datadog.android.rum.RumErrorSource, String, String?, Map<String, Any?> = emptyMap())
 fun android.content.Context.getAssetAsRumResource(String, Int = AssetManager.ACCESS_STREAMING, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun android.content.Context.getRawResAsRumResource(Int, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream
 fun java.io.InputStream.asRumResource(String, com.datadog.android.api.SdkCore = Datadog.getInstance()): java.io.InputStream

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -148,24 +148,24 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun removeAttribute (Ljava/lang/String;)V
 	public abstract fun setDebug (Z)V
 	public abstract fun startAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun startResource (Ljava/lang/Object;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun startResource (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun startResource (Ljava/lang/String;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun startResource (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun startView (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun stopAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun stopResource (Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/Long;Lcom/datadog/android/rum/RumResourceKind;Ljava/util/Map;)V
-	public abstract fun stopResourceWithError (Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun stopResourceWithError (Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;)V
+	public abstract fun stopResource (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Lcom/datadog/android/rum/RumResourceKind;Ljava/util/Map;)V
+	public abstract fun stopResourceWithError (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun stopResourceWithError (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public abstract fun stopSession ()V
 	public abstract fun stopView (Ljava/lang/Object;Ljava/util/Map;)V
 }
 
 public final class com/datadog/android/rum/RumMonitor$DefaultImpls {
-	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
-	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun startView$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun stopAction$default (Lcom/datadog/android/rum/RumMonitor;Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
-	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
-	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun stopView$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)V
 }
 
@@ -285,7 +285,17 @@ public abstract class com/datadog/android/rum/internal/instrumentation/gestures/
 public abstract interface class com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor {
 	public abstract fun addResourceTiming (Ljava/lang/Object;Lcom/datadog/android/rum/internal/domain/event/ResourceTiming;)V
 	public abstract fun notifyInterceptorInstantiated ()V
+	public abstract fun startResource (Lcom/datadog/android/rum/resource/ResourceId;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun stopResource (Lcom/datadog/android/rum/resource/ResourceId;Ljava/lang/Integer;Ljava/lang/Long;Lcom/datadog/android/rum/RumResourceKind;Ljava/util/Map;)V
+	public abstract fun stopResourceWithError (Lcom/datadog/android/rum/resource/ResourceId;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun stopResourceWithError (Lcom/datadog/android/rum/resource/ResourceId;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public abstract fun waitForResourceTiming (Ljava/lang/Object;)V
+}
+
+public final class com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor$DefaultImpls {
+	public static synthetic fun startResource$default (Lcom/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor;Lcom/datadog/android/rum/resource/ResourceId;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor;Lcom/datadog/android/rum/resource/ResourceId;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor;Lcom/datadog/android/rum/resource/ResourceId;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/rum/model/ActionChildProperties {

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -148,24 +148,24 @@ public abstract interface class com/datadog/android/rum/RumMonitor {
 	public abstract fun removeAttribute (Ljava/lang/String;)V
 	public abstract fun setDebug (Z)V
 	public abstract fun startAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun startResource (Ljava/lang/String;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun startResource (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun startResource (Ljava/lang/Object;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun startResource (Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun startView (Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;)V
 	public abstract fun stopAction (Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun stopResource (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/Long;Lcom/datadog/android/rum/RumResourceKind;Ljava/util/Map;)V
-	public abstract fun stopResourceWithError (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
-	public abstract fun stopResourceWithError (Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;)V
+	public abstract fun stopResource (Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/Long;Lcom/datadog/android/rum/RumResourceKind;Ljava/util/Map;)V
+	public abstract fun stopResourceWithError (Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;)V
+	public abstract fun stopResourceWithError (Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;)V
 	public abstract fun stopSession ()V
 	public abstract fun stopView (Ljava/lang/Object;Ljava/util/Map;)V
 }
 
 public final class com/datadog/android/rum/RumMonitor$DefaultImpls {
-	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
-	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Lcom/datadog/android/rum/RumResourceMethod;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun startResource$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun startView$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun stopAction$default (Lcom/datadog/android/rum/RumMonitor;Lcom/datadog/android/rum/RumActionType;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
-	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
-	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/String;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun stopResourceWithError$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/lang/Integer;Ljava/lang/String;Lcom/datadog/android/rum/RumErrorSource;Ljava/lang/Throwable;Ljava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun stopView$default (Lcom/datadog/android/rum/RumMonitor;Ljava/lang/Object;Ljava/util/Map;ILjava/lang/Object;)V
 }
 
@@ -283,9 +283,9 @@ public abstract class com/datadog/android/rum/internal/instrumentation/gestures/
 }
 
 public abstract interface class com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor {
-	public abstract fun addResourceTiming (Ljava/lang/String;Lcom/datadog/android/rum/internal/domain/event/ResourceTiming;)V
+	public abstract fun addResourceTiming (Ljava/lang/Object;Lcom/datadog/android/rum/internal/domain/event/ResourceTiming;)V
 	public abstract fun notifyInterceptorInstantiated ()V
-	public abstract fun waitForResourceTiming (Ljava/lang/String;)V
+	public abstract fun waitForResourceTiming (Ljava/lang/Object;)V
 }
 
 public final class com/datadog/android/rum/model/ActionChildProperties {

--- a/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
+++ b/features/dd-sdk-android-rum/api/dd-sdk-android-rum.api
@@ -5129,6 +5129,14 @@ public final class com/datadog/android/rum/resource/InputStreamExtKt {
 	public static synthetic fun asRumResource$default (Ljava/io/InputStream;Ljava/lang/String;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)Ljava/io/InputStream;
 }
 
+public final class com/datadog/android/rum/resource/ResourceId {
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;)V
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getKey ()Ljava/lang/String;
+	public final fun getUuid ()Ljava/lang/String;
+	public fun hashCode ()I
+}
+
 public final class com/datadog/android/rum/resource/RumResourceInputStream : java/io/InputStream {
 	public fun <init> (Ljava/io/InputStream;Ljava/lang/String;)V
 	public fun <init> (Ljava/io/InputStream;Ljava/lang/String;Lcom/datadog/android/api/SdkCore;)V

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -126,7 +126,7 @@ interface RumMonitor {
             " Use `startResource` method which takes `RumHttpMethod` as `method` parameter instead."
     )
     fun startResource(
-        key: String,
+        key: Any,
         method: String,
         url: String,
         attributes: Map<String, Any?> = emptyMap()
@@ -144,7 +144,7 @@ interface RumMonitor {
      * @see [stopResourceWithError]
      */
     fun startResource(
-        key: String,
+        key: Any,
         method: RumResourceMethod,
         url: String,
         attributes: Map<String, Any?> = emptyMap()
@@ -163,7 +163,7 @@ interface RumMonitor {
      * @see [stopResourceWithError]
      */
     fun stopResource(
-        key: String,
+        key: Any,
         statusCode: Int?,
         size: Long?,
         kind: RumResourceKind,
@@ -186,7 +186,7 @@ interface RumMonitor {
      * @see [stopResource]
      */
     fun stopResourceWithError(
-        key: String,
+        key: Any,
         statusCode: Int?,
         message: String,
         source: RumErrorSource,
@@ -215,7 +215,7 @@ interface RumMonitor {
      */
     @SuppressWarnings("LongParameterList")
     fun stopResourceWithError(
-        key: String,
+        key: Any,
         statusCode: Int?,
         message: String,
         source: RumErrorSource,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/RumMonitor.kt
@@ -126,7 +126,7 @@ interface RumMonitor {
             " Use `startResource` method which takes `RumHttpMethod` as `method` parameter instead."
     )
     fun startResource(
-        key: Any,
+        key: String,
         method: String,
         url: String,
         attributes: Map<String, Any?> = emptyMap()
@@ -144,7 +144,7 @@ interface RumMonitor {
      * @see [stopResourceWithError]
      */
     fun startResource(
-        key: Any,
+        key: String,
         method: RumResourceMethod,
         url: String,
         attributes: Map<String, Any?> = emptyMap()
@@ -163,7 +163,7 @@ interface RumMonitor {
      * @see [stopResourceWithError]
      */
     fun stopResource(
-        key: Any,
+        key: String,
         statusCode: Int?,
         size: Long?,
         kind: RumResourceKind,
@@ -181,12 +181,12 @@ interface RumMonitor {
      * @param attributes additional custom attributes to attach to the error. Attributes can be
      * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK. Users
      * that want to supply a custom fingerprint for this error can add a value under the key
-     * [RumAttributes.ERROR_CUSTOM_FINGERPRINT]
+     * [RumAttributes.ERROR_FINGERPRINT]
      * @see [startResource]
      * @see [stopResource]
      */
     fun stopResourceWithError(
-        key: Any,
+        key: String,
         statusCode: Int?,
         message: String,
         source: RumErrorSource,
@@ -209,13 +209,13 @@ interface RumMonitor {
      * @param attributes additional custom attributes to attach to the error. Attributes can be
      * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK. Users
      * that want to supply a custom fingerprint for this error can add a value under the key
-     * [RumAttributes.ERROR_CUSTOM_FINGERPRINT]
+     * [RumAttributes.ERROR_FINGERPRINT]
      * @see [startResource]
      * @see [stopResource]
      */
     @SuppressWarnings("LongParameterList")
     fun stopResourceWithError(
-        key: Any,
+        key: String,
         statusCode: Int?,
         message: String,
         source: RumErrorSource,
@@ -232,7 +232,7 @@ interface RumMonitor {
      * @param attributes additional custom attributes to attach to the error. Attributes can be
      * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK. Users
      * that want to supply a custom fingerprint for this error can add a value under the key
-     * [RumAttributes.ERROR_CUSTOM_FINGERPRINT]
+     * [RumAttributes.ERROR_FINGERPRINT]
      */
     fun addError(
         message: String,
@@ -253,7 +253,7 @@ interface RumMonitor {
      * @param stacktrace the error stacktrace information
      * @param attributes additional custom attributes to attach to the error. Users
      * that want to supply a custom fingerprint for this error can add a value under the key
-     * [RumAttributes.ERROR_CUSTOM_FINGERPRINT]
+     * [RumAttributes.ERROR_FINGERPRINT]
      */
     fun addErrorWithStacktrace(
         message: String,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -180,7 +180,7 @@ internal class RumActionScope(
         }
     }
 
-    private fun onResourceError(eventKey: String, now: Long) {
+    private fun onResourceError(eventKey: Any, now: Long) {
         val keyRef = ongoingResourceKeys.firstOrNull { it.get() == eventKey }
         if (keyRef != null) {
             ongoingResourceKeys.remove(keyRef)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEvent.kt
@@ -50,7 +50,7 @@ internal sealed class RumRawEvent {
     ) : RumRawEvent()
 
     internal data class StartResource(
-        val key: String,
+        val key: Any,
         val url: String,
         val method: RumResourceMethod,
         val attributes: Map<String, Any?>,
@@ -58,18 +58,18 @@ internal sealed class RumRawEvent {
     ) : RumRawEvent()
 
     internal data class WaitForResourceTiming(
-        val key: String,
+        val key: Any,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class AddResourceTiming(
-        val key: String,
+        val key: Any,
         val timing: ResourceTiming,
         override val eventTime: Time = Time()
     ) : RumRawEvent()
 
     internal data class StopResource(
-        val key: String,
+        val key: Any,
         val statusCode: Long?,
         val size: Long?,
         val kind: RumResourceKind,
@@ -78,7 +78,7 @@ internal sealed class RumRawEvent {
     ) : RumRawEvent()
 
     internal data class StopResourceWithError(
-        val key: String,
+        val key: Any,
         val statusCode: Long?,
         val message: String,
         val source: RumErrorSource,
@@ -88,7 +88,7 @@ internal sealed class RumRawEvent {
     ) : RumRawEvent()
 
     internal data class StopResourceWithStackTrace(
-        val key: String,
+        val key: Any,
         val statusCode: Long?,
         val message: String,
         val source: RumErrorSource,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -37,7 +37,7 @@ internal class RumResourceScope(
     internal val sdkCore: InternalSdkCore,
     internal val url: String,
     internal val method: RumResourceMethod,
-    internal val key: String,
+    internal val key: Any,
     eventTime: Time,
     initialAttributes: Map<String, Any?>,
     serverTimeOffsetInMs: Long,
@@ -500,16 +500,16 @@ internal class RumResourceScope(
             sampleRate: Float
         ): RumScope {
             return RumResourceScope(
-                parentScope,
-                sdkCore,
-                event.url,
-                event.method,
-                event.key,
-                event.eventTime,
-                event.attributes,
-                timestampOffset,
-                firstPartyHostHeaderTypeResolver,
-                featuresContextResolver,
+                parentScope = parentScope,
+                sdkCore = sdkCore,
+                url = event.url,
+                method = event.method,
+                key = event.key,
+                eventTime = event.eventTime,
+                initialAttributes = event.attributes,
+                serverTimeOffsetInMs = timestampOffset,
+                firstPartyHostHeaderTypeResolver = firstPartyHostHeaderTypeResolver,
+                featuresContextResolver = featuresContextResolver,
                 sampleRate = sampleRate
             )
         }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -84,7 +84,7 @@ internal open class RumViewScope(
     internal val eventTimestamp = eventTime.timestamp + serverTimeOffsetInMs
 
     internal var activeActionScope: RumScope? = null
-    internal val activeResourceScopes = mutableMapOf<String, RumScope>()
+    internal val activeResourceScopes = mutableMapOf<Any, RumScope>()
 
     private var resourceCount: Long = 0
     private var actionCount: Long = 0

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor.kt
@@ -7,7 +7,12 @@
 package com.datadog.android.rum.internal.monitor
 
 import com.datadog.android.lint.InternalApi
+import com.datadog.android.rum.RumAttributes
+import com.datadog.android.rum.RumErrorSource
+import com.datadog.android.rum.RumResourceKind
+import com.datadog.android.rum.RumResourceMethod
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
+import com.datadog.android.rum.resource.ResourceId
 
 /**
  * FOR INTERNAL USAGE ONLY.
@@ -24,4 +29,100 @@ interface AdvancedNetworkRumMonitor {
 
     @InternalApi
     fun notifyInterceptorInstantiated()
+
+    /**
+     * Notify that a new Resource is being loaded, linked with the [key] instance.
+     * @param key the instance that represents the resource being loaded (usually your
+     * request or network call instance).
+     * @param method the method used to load the resource (E.g., for network: "GET" or "POST")
+     * @param url the url or local path of the resource being loaded
+     * @param attributes additional custom attributes to attach to the resource. Attributes can be
+     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
+     * @see [stopResource]
+     * @see [stopResourceWithError]
+     */
+    @InternalApi
+    fun startResource(
+        key: ResourceId,
+        method: RumResourceMethod,
+        url: String,
+        attributes: Map<String, Any?> = emptyMap()
+    )
+
+    /**
+     * Stops a previously started Resource, linked with the [key] instance.
+     * @param key the instance that represents the active view (usually your
+     * request or network call instance).
+     * @param statusCode the status code of the resource (if any)
+     * @param size the size of the resource, in bytes
+     * @param kind the type of resource loaded
+     * @param attributes additional custom attributes to attach to the resource. Attributes can be
+     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK.
+     * @see [startResource]
+     * @see [stopResourceWithError]
+     */
+    @InternalApi
+    fun stopResource(
+        key: ResourceId,
+        statusCode: Int?,
+        size: Long?,
+        kind: RumResourceKind,
+        attributes: Map<String, Any?>
+    )
+
+    /**
+     * Stops a previously started Resource that failed loading, linked with the [key] instance.
+     * @param key the instance that represents the active view (usually your
+     * request or network call instance).
+     * @param statusCode the status code of the resource (if any)
+     * @param message a message explaining the error
+     * @param source the source of the error
+     * @param throwable the throwable
+     * @param attributes additional custom attributes to attach to the error. Attributes can be
+     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK. Users
+     * that want to supply a custom fingerprint for this error can add a value under the key
+     * [RumAttributes.ERROR_FINGERPRINT]
+     * @see [startResource]
+     * @see [stopResource]
+     */
+    @InternalApi
+    fun stopResourceWithError(
+        key: ResourceId,
+        statusCode: Int?,
+        message: String,
+        source: RumErrorSource,
+        throwable: Throwable,
+        attributes: Map<String, Any?> = emptyMap()
+    )
+
+    /**
+     * Stops a previously started Resource that failed loading, linked with the [key] instance by
+     * providing the intercepted stacktrace.
+     * Note: This method should only be used from hybrid application.
+     * @param key the instance that represents the active view (usually your
+     * request or network call instance).
+     * @param statusCode the status code of the resource (if any)
+     * @param message a message explaining the error
+     * @param source the source of the error
+     * @param stackTrace the error stacktrace
+     * @param errorType the type of the error. Usually it should be the canonical name of the
+     * of the Exception class.
+     * @param attributes additional custom attributes to attach to the error. Attributes can be
+     * nested up to 9 levels deep. Keys using more than 9 levels will be sanitized by SDK. Users
+     * that want to supply a custom fingerprint for this error can add a value under the key
+     * [RumAttributes.ERROR_FINGERPRINT]
+     * @see [startResource]
+     * @see [stopResource]
+     */
+    @InternalApi
+    @SuppressWarnings("LongParameterList")
+    fun stopResourceWithError(
+        key: ResourceId,
+        statusCode: Int?,
+        message: String,
+        source: RumErrorSource,
+        stackTrace: String,
+        errorType: String?,
+        attributes: Map<String, Any?> = emptyMap()
+    )
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedNetworkRumMonitor.kt
@@ -17,10 +17,10 @@ import com.datadog.android.rum.internal.domain.event.ResourceTiming
 interface AdvancedNetworkRumMonitor {
 
     @InternalApi
-    fun waitForResourceTiming(key: String)
+    fun waitForResourceTiming(key: Any)
 
     @InternalApi
-    fun addResourceTiming(key: String, timing: ResourceTiming)
+    fun addResourceTiming(key: Any, timing: ResourceTiming)
 
     @InternalApi
     fun notifyInterceptorInstantiated()

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -196,7 +196,7 @@ internal class DatadogRumMonitor(
             " Use `startResource` method which takes `RumHttpMethod` as `method` parameter instead."
     )
     override fun startResource(
-        key: String,
+        key: Any,
         method: String,
         url: String,
         attributes: Map<String, Any?>
@@ -230,7 +230,7 @@ internal class DatadogRumMonitor(
     }
 
     override fun startResource(
-        key: String,
+        key: Any,
         method: RumResourceMethod,
         url: String,
         attributes: Map<String, Any?>
@@ -242,7 +242,7 @@ internal class DatadogRumMonitor(
     }
 
     override fun stopResource(
-        key: String,
+        key: Any,
         statusCode: Int?,
         size: Long?,
         kind: RumResourceKind,
@@ -262,7 +262,7 @@ internal class DatadogRumMonitor(
     }
 
     override fun stopResourceWithError(
-        key: String,
+        key: Any,
         statusCode: Int?,
         message: String,
         source: RumErrorSource,
@@ -282,7 +282,7 @@ internal class DatadogRumMonitor(
     }
 
     override fun stopResourceWithError(
-        key: String,
+        key: Any,
         statusCode: Int?,
         message: String,
         source: RumErrorSource,
@@ -423,13 +423,13 @@ internal class DatadogRumMonitor(
         )
     }
 
-    override fun waitForResourceTiming(key: String) {
+    override fun waitForResourceTiming(key: Any) {
         handleEvent(
             RumRawEvent.WaitForResourceTiming(key)
         )
     }
 
-    override fun addResourceTiming(key: String, timing: ResourceTiming) {
+    override fun addResourceTiming(key: Any, timing: ResourceTiming) {
         handleEvent(
             RumRawEvent.AddResourceTiming(key, timing)
         )

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/resource/ResourceId.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/resource/ResourceId.kt
@@ -1,0 +1,41 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.resource
+
+import java.util.UUID
+
+/**
+ * Describes a Resource being tracked in RUM.
+ *
+ * A resource will first try to be matched with the UUID if possible, and if missing will use the key property.
+ * The UUID should be unique (based off of [UUID] class). If missing, because key could have duplicates,
+ * this can lead to unpredictable behaviors and erroneous Resource timings.
+ *
+ * @param key a key to identify the resource
+ * @param uuid a UUID based unique identifier (optional)
+ */
+class ResourceId(
+    val key: String,
+    val uuid: String?
+) {
+
+    override fun equals(other: Any?): Boolean {
+        return if (other is ResourceId) {
+            if (uuid.isNullOrBlank() || other.uuid.isNullOrBlank()) {
+                key == other.key
+            } else {
+                (uuid == other.uuid) && (key == other.key)
+            }
+        } else {
+            false
+        }
+    }
+
+    override fun hashCode(): Int {
+        return key.hashCode()
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -30,6 +30,7 @@ import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
 import com.datadog.android.rum.internal.monitor.StorageEvent
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.android.rum.model.ResourceEvent
+import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.rum.utils.asTimingsPayload
 import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator
@@ -49,7 +50,6 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
-import okhttp3.internal.format
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -110,7 +110,9 @@ internal class RumResourceScopeTest {
 
     @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+")
     lateinit var fakeUrl: String
-    lateinit var fakeKey: String
+
+    @Forgery
+    lateinit var fakeKey: ResourceId
 
     @Forgery
     lateinit var fakeMethod: RumResourceMethod
@@ -174,7 +176,6 @@ internal class RumResourceScopeTest {
         fakeServerOffset =
             forge.aLong(min = minLimit, max = maxLimit)
         fakeAttributes = forge.exhaustiveAttributes()
-        fakeKey = forge.anAsciiString()
         mockEvent = mockEvent()
         fakeSampleRate = forge.aFloat(min = 0.0f, max = 100.0f)
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -41,6 +41,7 @@ import com.datadog.android.rum.internal.domain.scope.RumViewManagerScope
 import com.datadog.android.rum.internal.domain.scope.RumViewScope
 import com.datadog.android.rum.internal.metric.SessionMetricDispatcher
 import com.datadog.android.rum.internal.vitals.VitalMonitor
+import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.rum.utils.verifyLog
 import com.datadog.android.telemetry.internal.TelemetryCoreConfiguration
@@ -593,6 +594,162 @@ internal class DatadogRumMonitorTest {
     @Test
     fun `M delegate event to rootScope W stopResourceWithError() {without status code}`(
         @StringForgery key: String,
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @Forgery throwable: Throwable
+    ) {
+        testedMonitor.stopResourceWithError(key, null, message, source, throwable, fakeAttributes)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.StopResourceWithError
+            assertThat(event.key).isEqualTo(key)
+            assertThat(event.statusCode).isNull()
+            assertThat(event.message).isEqualTo(message)
+            assertThat(event.source).isEqualTo(source)
+            assertThat(event.throwable).isEqualTo(throwable)
+            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W startResource()`(
+        @Forgery key: ResourceId,
+        @Forgery method: RumResourceMethod,
+        @StringForgery(regex = "http(s?)://[a-z]+\\.com/[a-z]+") url: String
+    ) {
+        testedMonitor.startResource(key, method, url, fakeAttributes)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.StartResource
+            assertThat(event.key).isEqualTo(key)
+            assertThat(event.method).isEqualTo(method)
+            assertThat(event.url).isEqualTo(url)
+            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W stopResource()`(
+        @Forgery key: ResourceId,
+        @IntForgery(200, 600) statusCode: Int,
+        @LongForgery(0, 1024) size: Long,
+        @Forgery kind: RumResourceKind
+    ) {
+        testedMonitor.stopResource(key, statusCode, size, kind, fakeAttributes)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.StopResource
+            assertThat(event.key).isEqualTo(key)
+            assertThat(event.statusCode).isEqualTo(statusCode.toLong())
+            assertThat(event.kind).isEqualTo(kind)
+            assertThat(event.size).isEqualTo(size)
+            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W stopResource() {without status code nor size}`(
+        @Forgery key: ResourceId,
+        @Forgery kind: RumResourceKind
+    ) {
+        testedMonitor.stopResource(key, null, null, kind, fakeAttributes)
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.StopResource
+            assertThat(event.key).isEqualTo(key)
+            assertThat(event.statusCode).isNull()
+            assertThat(event.kind).isEqualTo(kind)
+            assertThat(event.size).isNull()
+            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W stopResourceWithError() {throwable}`(
+        @Forgery key: ResourceId,
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @IntForgery(200, 600) statusCode: Int,
+        @Forgery throwable: Throwable
+    ) {
+        testedMonitor.stopResourceWithError(
+            key,
+            statusCode,
+            message,
+            source,
+            throwable,
+            fakeAttributes
+        )
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.StopResourceWithError
+            assertThat(event.key).isEqualTo(key)
+            assertThat(event.statusCode).isEqualTo(statusCode.toLong())
+            assertThat(event.message).isEqualTo(message)
+            assertThat(event.source).isEqualTo(source)
+            assertThat(event.throwable).isEqualTo(throwable)
+            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W stopResourceWithError() {stacktrace}`(
+        @Forgery key: ResourceId,
+        @StringForgery message: String,
+        @Forgery source: RumErrorSource,
+        @IntForgery(200, 600) statusCode: Int,
+        @StringForgery(type = StringForgeryType.ASCII_EXTENDED) stackTrace: String,
+        @StringForgery errorType: String
+    ) {
+        testedMonitor.stopResourceWithError(
+            key,
+            statusCode,
+            message,
+            source,
+            stackTrace,
+            errorType,
+            fakeAttributes
+        )
+        Thread.sleep(PROCESSING_DELAY)
+
+        argumentCaptor<RumRawEvent> {
+            verify(mockScope).handleEvent(capture(), same(mockWriter))
+
+            val event = firstValue as RumRawEvent.StopResourceWithStackTrace
+            assertThat(event.key).isEqualTo(key)
+            assertThat(event.statusCode).isEqualTo(statusCode.toLong())
+            assertThat(event.message).isEqualTo(message)
+            assertThat(event.source).isEqualTo(source)
+            assertThat(event.stackTrace).isEqualTo(stackTrace)
+            assertThat(event.errorType).isEqualTo(errorType)
+            assertThat(event.attributes).containsAllEntriesOf(fakeAttributes)
+        }
+        verifyNoMoreInteractions(mockScope, mockWriter)
+    }
+
+    @Test
+    fun `M delegate event to rootScope W stopResourceWithError() {without status code}`(
+        @Forgery key: ResourceId,
         @StringForgery message: String,
         @Forgery source: RumErrorSource,
         @Forgery throwable: Throwable

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceIdTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/resource/ResourceIdTest.kt
@@ -1,0 +1,179 @@
+package com.datadog.android.rum.resource
+
+import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.tools.unit.extensions.TestConfigurationExtension
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.util.UUID
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(TestConfigurationExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+class ResourceIdTest {
+
+    @Test
+    fun `M return true W equals (same key, same uuid)`(
+        @StringForgery key: String,
+        @Forgery uuid: UUID
+    ) {
+        // Given
+        val requestId = ResourceId(key, uuid.toString())
+        val otherRequestId = ResourceId(key, uuid.toString())
+
+        // When
+        val areEqual = requestId == otherRequestId
+        val areHashCodeEqual = requestId.hashCode() == otherRequestId.hashCode()
+
+        // Then
+        assertThat(areEqual).isTrue()
+        assertThat(areHashCodeEqual).isTrue()
+    }
+
+    @Test
+    fun `M return false W equals (different key, same uuid)`(
+        @StringForgery key: String,
+        @StringForgery otherKey: String,
+        @Forgery uuid: UUID
+    ) {
+        // Given
+        val requestId = ResourceId(key, uuid.toString())
+        val otherRequestId = ResourceId(otherKey, uuid.toString())
+
+        // When
+        val areEqual = requestId == otherRequestId
+        val areHashCodeEqual = requestId.hashCode() == otherRequestId.hashCode()
+
+        // Then
+        assertThat(areEqual).isFalse()
+        assertThat(areHashCodeEqual).isFalse()
+    }
+
+    @Test
+    fun `M return false W equals (same key, different uuid)`(
+        @StringForgery key: String,
+        @Forgery uuid: UUID,
+        @Forgery otherUuid: UUID
+    ) {
+        // Given
+        val requestId = ResourceId(key, uuid.toString())
+        val otherRequestId = ResourceId(key, otherUuid.toString())
+
+        // When
+        val areEqual = requestId == otherRequestId
+        val areHashCodeEqual = requestId.hashCode() == otherRequestId.hashCode()
+
+        // Then
+        assertThat(areEqual).isFalse()
+        assertThat(areHashCodeEqual).isTrue()
+    }
+
+    @Test
+    fun `M return false W equals (different key, different uuid)`(
+        @StringForgery key: String,
+        @StringForgery otherKey: String,
+        @Forgery uuid: UUID,
+        @Forgery otherUuid: UUID
+    ) {
+        // Given
+        val requestId = ResourceId(key, uuid.toString())
+        val otherRequestId = ResourceId(otherKey, otherUuid.toString())
+
+        // When
+        val areEqual = requestId == otherRequestId
+        val areHashCodeEqual = requestId.hashCode() == otherRequestId.hashCode()
+
+        // Then
+        assertThat(areEqual).isFalse()
+        assertThat(areHashCodeEqual).isFalse()
+    }
+
+    @Test
+    fun `M return true W equals (same key, different uuid one is null)`(
+        @StringForgery key: String,
+        @Forgery uuid: UUID
+    ) {
+        // Given
+        val requestId = ResourceId(key, uuid.toString())
+        val otherRequestId = ResourceId(key, null)
+
+        // When
+        val areEqual = requestId == otherRequestId
+        val areHashCodeEqual = requestId.hashCode() == otherRequestId.hashCode()
+
+        // Then
+        assertThat(areEqual).isTrue()
+        assertThat(areHashCodeEqual).isTrue()
+    }
+
+    @Test
+    fun `M return false W equals (different key, different uuid one is null)`(
+        @StringForgery key: String,
+        @Forgery uuid: UUID,
+        @StringForgery otherKey: String
+    ) {
+        // Given
+        val requestId = ResourceId(key, uuid.toString())
+        val otherRequestId = ResourceId(otherKey, null)
+
+        // When
+        val areEqual = requestId == otherRequestId
+        val areHashCodeEqual = requestId.hashCode() == otherRequestId.hashCode()
+
+        // Then
+        assertThat(areEqual).isFalse()
+        assertThat(areHashCodeEqual).isFalse()
+    }
+
+    @Test
+    fun `M return true W equals (same key, different uuid one is blank)`(
+        @StringForgery key: String,
+        @Forgery uuid: UUID,
+        @StringForgery(StringForgeryType.WHITESPACE) blankUuid: String
+    ) {
+        // Given
+        val requestId = ResourceId(key, uuid.toString())
+        val otherRequestId = ResourceId(key, blankUuid)
+
+        // When
+        val areEqual = requestId == otherRequestId
+        val areHashCodeEqual = requestId.hashCode() == otherRequestId.hashCode()
+
+        // Then
+        assertThat(areEqual).isTrue()
+        assertThat(areHashCodeEqual).isTrue()
+    }
+
+    @Test
+    fun `M return false W equals (different key, different uuid one is blank)`(
+        @StringForgery key: String,
+        @StringForgery otherKey: String,
+        @Forgery uuid: UUID,
+        @StringForgery(StringForgeryType.WHITESPACE) blankUuid: String
+    ) {
+        // Given
+        val requestId = ResourceId(key, uuid.toString())
+        val otherRequestId = ResourceId(otherKey, blankUuid)
+
+        // When
+        val areEqual = requestId == otherRequestId
+        val areHashCodeEqual = requestId.hashCode() == otherRequestId.hashCode()
+
+        // Then
+        assertThat(areEqual).isFalse()
+        assertThat(areHashCodeEqual).isFalse()
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tests/elmyr/ResourceIdForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/tests/elmyr/ResourceIdForgeryFactory.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.tests.elmyr
+
+import com.datadog.android.rum.resource.ResourceId
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
+
+internal class ResourceIdForgeryFactory : ForgeryFactory<ResourceId> {
+    override fun getForgery(forge: Forge): ResourceId {
+        return ResourceId(
+            forge.aStringMatching("https://[a-z]+.[a-z]{3}/[a-z0-9_/]+/[a-z0-9_/]+"),
+            forge.aNullable { getForgery<UUID>().toString() }
+        )
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/Configurator.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.rum.utils.forge
 
+import com.datadog.android.rum.tests.elmyr.ResourceIdForgeryFactory
 import com.datadog.android.rum.tests.elmyr.RumScopeKeyForgeryFactory
 import com.datadog.android.tests.elmyr.useCoreFactories
 import com.datadog.tools.unit.forge.BaseConfigurator
@@ -38,6 +39,7 @@ internal class Configurator : BaseConfigurator() {
         forge.addFactory(RumEventMetaForgeryFactory())
         forge.addFactory(ViewEventMetaForgeryFactory())
         forge.addFactory(RumScopeKeyForgeryFactory())
+        forge.addFactory(ResourceIdForgeryFactory())
 
         // Telemetry
         forge.addFactory(TelemetryDebugEventForgeryFactory())

--- a/integrations/dd-sdk-android-okhttp/build.gradle.kts
+++ b/integrations/dd-sdk-android-okhttp/build.gradle.kts
@@ -39,6 +39,11 @@ plugins {
 
 android {
     namespace = "com.datadog.android.okhttp"
+
+    sourceSets.named("test") {
+        // Required because AGP doesn't support kotlin test fixtures :/
+        java.srcDir("${project.rootDir.path}/dd-sdk-android-core/src/testFixtures/kotlin")
+    }
 }
 
 dependencies {
@@ -59,6 +64,7 @@ dependencies {
             )
         }
     }
+    testImplementation(testFixtures(project(":dd-sdk-android-core")))
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testImplementation(libs.okHttpMock)

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogEventListener.kt
@@ -10,10 +10,11 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.core.SdkReference
 import com.datadog.android.okhttp.DatadogEventListener.Factory
-import com.datadog.android.okhttp.internal.utils.identifyRequest
+import com.datadog.android.okhttp.internal.rum.buildResourceId
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
 import com.datadog.android.rum.internal.monitor.AdvancedNetworkRumMonitor
+import com.datadog.android.rum.resource.ResourceId
 import okhttp3.Call
 import okhttp3.EventListener
 import okhttp3.Handshake
@@ -47,7 +48,7 @@ import java.net.Proxy
 class DatadogEventListener
 internal constructor(
     internal val sdkCore: SdkCore,
-    internal val key: String
+    internal val key: ResourceId
 ) : EventListener() {
 
     private var callStart = 0L
@@ -243,10 +244,10 @@ internal constructor(
 
         /** @inheritdoc */
         override fun create(call: Call): EventListener {
-            val key = identifyRequest(call.request())
+            val resourceId = call.request().buildResourceId(generateUuid = true)
             val sdkCore = sdkCoreReference.get()
             return if (sdkCore != null) {
-                DatadogEventListener(sdkCore, key)
+                DatadogEventListener(sdkCore, resourceId)
             } else {
                 InternalLogger.UNBOUND.log(
                     InternalLogger.Level.INFO,

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -222,7 +222,7 @@ internal constructor(
             val method = toHttpMethod(request.method, sdkCore.internalLogger)
             val requestId = request.buildResourceId(generateUuid = true)
 
-            GlobalRumMonitor.get(sdkCore).startResource(requestId, method, url)
+            (GlobalRumMonitor.get(sdkCore) as AdvancedNetworkRumMonitor).startResource(requestId, method, url)
         } else {
             val prefix = if (sdkInstanceName == null) {
                 "Default SDK instance"
@@ -303,7 +303,7 @@ internal constructor(
                 RumAttributes.RULE_PSR to traceSampler.getSampleRate()
             )
         }
-        GlobalRumMonitor.get(sdkCore).stopResource(
+        (GlobalRumMonitor.get(sdkCore) as? AdvancedNetworkRumMonitor)?.stopResource(
             requestId,
             statusCode,
             getBodyLength(response, sdkCore.internalLogger),
@@ -320,7 +320,7 @@ internal constructor(
         val requestId = request.buildResourceId(generateUuid = false)
         val method = request.method
         val url = request.url.toString()
-        GlobalRumMonitor.get(sdkCore).stopResourceWithError(
+        (GlobalRumMonitor.get(sdkCore) as? AdvancedNetworkRumMonitor)?.stopResourceWithError(
             requestId,
             null,
             ERROR_MSG_FORMAT.format(Locale.US, method, url),

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -15,7 +15,7 @@ import com.datadog.android.core.configuration.Configuration
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.okhttp.internal.rum.NoOpRumResourceAttributesProvider
-import com.datadog.android.okhttp.internal.utils.identifyRequest
+import com.datadog.android.okhttp.internal.rum.buildResourceId
 import com.datadog.android.okhttp.internal.utils.traceIdAsHexString
 import com.datadog.android.okhttp.trace.NoOpTracedRequestListener
 import com.datadog.android.okhttp.trace.TracedRequestListener
@@ -220,7 +220,7 @@ internal constructor(
             val request = chain.request()
             val url = request.url.toString()
             val method = toHttpMethod(request.method, sdkCore.internalLogger)
-            val requestId = identifyRequest(request)
+            val requestId = request.buildResourceId(generateUuid = true)
 
             GlobalRumMonitor.get(sdkCore).startResource(requestId, method, url)
         } else {
@@ -288,7 +288,7 @@ internal constructor(
         span: Span?,
         isSampled: Boolean
     ) {
-        val requestId = identifyRequest(request)
+        val requestId = request.buildResourceId(generateUuid = false)
         val statusCode = response.code
         val kind = when (val mimeType = response.header(HEADER_CT)) {
             null -> RumResourceKind.NATIVE
@@ -317,7 +317,7 @@ internal constructor(
         request: Request,
         throwable: Throwable
     ) {
-        val requestId = identifyRequest(request)
+        val requestId = request.buildResourceId(generateUuid = false)
         val method = request.method
         val url = request.url.toString()
         GlobalRumMonitor.get(sdkCore).stopResourceWithError(

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/rum/RequestExt.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/internal/rum/RequestExt.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp.internal.rum
+
+import com.datadog.android.okhttp.internal.utils.identifyRequest
+import com.datadog.android.rum.resource.ResourceId
+import okhttp3.Request
+import java.util.UUID
+
+internal fun Request.buildResourceId(generateUuid: Boolean): ResourceId {
+    val uuid = tag(UUID::class.java) ?: (if (generateUuid) UUID.randomUUID() else null)
+    val key = identifyRequest(this)
+
+    return ResourceId(key, uuid?.toString())
+}

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerFactoryTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerFactoryTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.okhttp
 
-import com.datadog.android.okhttp.internal.utils.identifyRequest
+import com.datadog.android.okhttp.internal.rum.buildResourceId
 import com.datadog.android.okhttp.utils.config.DatadogSingletonTestConfiguration
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -66,7 +66,7 @@ internal class DatadogEventListenerFactoryTest {
 
         // Then
         check(result is DatadogEventListener)
-        assertThat(result.key).isEqualTo(identifyRequest(fakeRequest))
+        assertThat(result.key).isEqualTo(fakeRequest.buildResourceId(false))
     }
 
     @Test

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogEventListenerTest.kt
@@ -6,18 +6,19 @@
 
 package com.datadog.android.okhttp
 
+import com.datadog.android.okhttp.test.elmyr.OkHttpIntegrationForgeConfigurator
 import com.datadog.android.okhttp.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.okhttp.utils.reset
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.internal.domain.event.ResourceTiming
+import com.datadog.android.rum.resource.ResourceId
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
-import com.datadog.tools.unit.forge.BaseConfigurator
+import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
 import fr.xgouchet.elmyr.annotation.LongForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
-import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import okhttp3.Call
@@ -52,7 +53,7 @@ import java.util.concurrent.TimeUnit
     ExtendWith(TestConfigurationExtension::class)
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
-@ForgeConfiguration(BaseConfigurator::class)
+@ForgeConfiguration(OkHttpIntegrationForgeConfigurator::class)
 internal class DatadogEventListenerTest {
 
     lateinit var testedListener: EventListener
@@ -60,8 +61,8 @@ internal class DatadogEventListenerTest {
     @Mock
     lateinit var mockCall: Call
 
-    @StringForgery(type = StringForgeryType.ASCII)
-    lateinit var fakeKey: String
+    @Forgery
+    lateinit var fakeKey: ResourceId
 
     @StringForgery(regex = "[a-z]+\\.[a-z]{3}")
     lateinit var fakeDomain: String

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -11,7 +11,6 @@ import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.okhttp.internal.rum.NoOpRumResourceAttributesProvider
-import com.datadog.android.okhttp.internal.utils.identifyRequest
 import com.datadog.android.okhttp.trace.NoOpTracedRequestListener
 import com.datadog.android.okhttp.trace.TracingInterceptor
 import com.datadog.android.okhttp.trace.TracingInterceptorNotSendingSpanTest
@@ -51,8 +50,10 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.spy
@@ -188,7 +189,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.SPAN_ID to fakeSpanId,
             RumAttributes.RULE_PSR to fakeTracingSampleRate
         ) + fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -200,19 +200,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                fakeResponseBody.toByteArray().size.toLong(),
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(fakeResponseBody.toByteArray().size.toLong()),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -233,7 +236,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.SPAN_ID to fakeSpanId,
             RumAttributes.RULE_PSR to fakeTracingSampleRate
         ) + fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -245,19 +247,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                RumResourceMethod.GET,
-                fakeUrl,
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                fakeResponseBody.toByteArray().size.toLong(),
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(RumResourceMethod.GET),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(fakeResponseBody.toByteArray().size.toLong()),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
 
         mockInternalLogger.verifyLog(
@@ -277,7 +282,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStartAttrs = emptyMap<String, Any?>()
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -289,19 +293,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                fakeResponseBody.toByteArray().size.toLong(),
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(fakeResponseBody.toByteArray().size.toLong()),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -325,7 +332,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.SPAN_ID to fakeSpanId,
             RumAttributes.RULE_PSR to fakeTracingSampleRate
         ) + fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -337,19 +343,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                emptyMap()
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                null,
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(emptyMap())
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(null),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -372,7 +381,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.SPAN_ID to fakeSpanId,
             RumAttributes.RULE_PSR to fakeTracingSampleRate
         ) + fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -384,19 +392,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                emptyMap()
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                null,
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(emptyMap())
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(null),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -418,7 +429,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         }
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -430,19 +440,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                emptyMap()
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                null,
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(emptyMap())
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(null),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -463,7 +476,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         }
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -475,19 +487,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                emptyMap()
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                null,
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(emptyMap())
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(null),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -524,7 +539,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.SPAN_ID to fakeSpanId,
             RumAttributes.RULE_PSR to fakeTracingSampleRate
         ) + fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -536,19 +550,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                null,
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(null),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -583,7 +600,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStartAttrs = emptyMap<String, Any?>()
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -595,19 +611,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                null,
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(null),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -623,7 +642,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
             RumAttributes.SPAN_ID to fakeSpanId,
             RumAttributes.RULE_PSR to fakeTracingSampleRate
         ) + fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -635,19 +653,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                fakeResponseBody.toByteArray().size.toLong(),
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(fakeResponseBody.toByteArray().size.toLong()),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -661,7 +682,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         val expectedStartAttrs = emptyMap<String, Any?>()
         // no span -> shouldn't have trace/spans IDs
         val expectedStopAttrs = fakeAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -673,19 +693,22 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                fakeResponseBody.toByteArray().size.toLong(),
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(fakeResponseBody.toByteArray().size.toLong()),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -695,7 +718,6 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
     ) {
         // Given
         val expectedStartAttrs = emptyMap<String, Any?>()
-        val requestId = identifyRequest(fakeRequest)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable
 
@@ -706,20 +728,23 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl,
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResourceWithError(
-                requestId,
-                null,
-                "OkHttp request error $fakeMethod $fakeUrl",
-                RumErrorSource.NETWORK,
-                throwable,
-                fakeAttributes
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResourceWithError(
+                    capture(),
+                    eq(null),
+                    eq("OkHttp request error $fakeMethod $fakeUrl"),
+                    eq(RumErrorSource.NETWORK),
+                    eq(throwable),
+                    eq(fakeAttributes)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -20,6 +20,7 @@ import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceAttributesProvider
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum.resource.ResourceId
 import com.datadog.android.trace.TracingHeaderType
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.forge.BaseConfigurator
@@ -200,7 +201,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -247,7 +248,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(RumResourceMethod.GET),
@@ -293,7 +294,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -343,7 +344,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -392,7 +393,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -440,7 +441,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -487,7 +488,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -550,7 +551,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -611,7 +612,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -653,7 +654,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -693,7 +694,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -728,7 +729,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -20,6 +20,7 @@ import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceAttributesProvider
 import com.datadog.android.rum.RumResourceKind
 import com.datadog.android.rum.RumResourceMethod
+import com.datadog.android.rum.resource.ResourceId
 import com.datadog.legacy.trace.api.interceptor.MutableSpan
 import com.datadog.opentracing.DDSpan
 import com.datadog.opentracing.DDSpanContext
@@ -195,7 +196,7 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -238,7 +239,7 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(RumResourceMethod.GET),
@@ -282,7 +283,7 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),
@@ -318,7 +319,7 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            argumentCaptor<Any> {
+            argumentCaptor<ResourceId> {
                 verify(rumMonitor.mockInstance).startResource(
                     capture(),
                     eq(fakeMethod),

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -10,7 +10,6 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.sampling.Sampler
-import com.datadog.android.okhttp.internal.utils.identifyRequest
 import com.datadog.android.okhttp.trace.TracedRequestListener
 import com.datadog.android.okhttp.trace.TracingInterceptor
 import com.datadog.android.okhttp.trace.TracingInterceptorTest
@@ -48,7 +47,7 @@ import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
 import okhttp3.Response
 import okhttp3.ResponseBody.Companion.toResponseBody
-import org.assertj.core.api.Assertions
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -59,8 +58,10 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.doThrow
+import org.mockito.kotlin.eq
 import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
@@ -183,7 +184,6 @@ internal class DatadogInterceptorWithoutTracesTest {
         stubChain(mockChain, statusCode)
         val expectedStartAttrs = emptyMap<String, Any?>()
         val expectedStopAttrs = fakeResourceAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -195,19 +195,22 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl.lowercase(Locale.US),
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                fakeResponseBody.toByteArray().size.toLong(),
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(fakeResponseBody.toByteArray().size.toLong()),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -224,7 +227,6 @@ internal class DatadogInterceptorWithoutTracesTest {
         stubChain(mockChain, statusCode)
         val expectedStartAttrs = emptyMap<String, Any?>()
         val expectedStopAttrs = fakeResourceAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -236,19 +238,22 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                RumResourceMethod.GET,
-                fakeUrl.lowercase(Locale.US),
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                fakeResponseBody.toByteArray().size.toLong(),
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(RumResourceMethod.GET),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(fakeResponseBody.toByteArray().size.toLong()),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
 
         mockInternalLogger.verifyLog(
@@ -266,7 +271,6 @@ internal class DatadogInterceptorWithoutTracesTest {
         stubChain(mockChain, statusCode)
         val expectedStartAttrs = emptyMap<String, Any?>()
         val expectedStopAttrs = fakeResourceAttributes
-        val requestId = identifyRequest(fakeRequest)
         val mimeType = fakeMediaType?.type
         val kind = when {
             mimeType != null -> RumResourceKind.fromMimeType(mimeType)
@@ -278,19 +282,22 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl.lowercase(Locale.US),
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResource(
-                requestId,
-                statusCode,
-                fakeResponseBody.toByteArray().size.toLong(),
-                kind,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(fakeResponseBody.toByteArray().size.toLong()),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -301,7 +308,6 @@ internal class DatadogInterceptorWithoutTracesTest {
         // Given
         val expectedStartAttrs = emptyMap<String, Any?>()
         val expectedStopAttrs = fakeResourceAttributes
-        val requestId = identifyRequest(fakeRequest)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable
 
@@ -312,20 +318,23 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         // Then
         inOrder(rumMonitor.mockInstance) {
-            verify(rumMonitor.mockInstance).startResource(
-                requestId,
-                fakeMethod,
-                fakeUrl.lowercase(Locale.US),
-                expectedStartAttrs
-            )
-            verify(rumMonitor.mockInstance).stopResourceWithError(
-                requestId,
-                null,
-                "OkHttp request error $fakeMethod ${fakeUrl.lowercase(Locale.US)}",
-                RumErrorSource.NETWORK,
-                throwable,
-                expectedStopAttrs
-            )
+            argumentCaptor<Any> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResourceWithError(
+                    capture(),
+                    eq(null),
+                    eq("OkHttp request error $fakeMethod ${fakeUrl.lowercase(Locale.US)}"),
+                    eq(RumErrorSource.NETWORK),
+                    eq(throwable),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
         }
     }
 
@@ -340,7 +349,7 @@ internal class DatadogInterceptorWithoutTracesTest {
 
         verify(mockSpanBuilder).withOrigin(DatadogInterceptor.ORIGIN_RUM)
         verify(mockSpan).drop()
-        Assertions.assertThat(response).isSameAs(fakeResponse)
+        assertThat(response).isSameAs(fakeResponse)
     }
 
     @Test
@@ -356,7 +365,7 @@ internal class DatadogInterceptorWithoutTracesTest {
         verify(mockSpan as MutableSpan).setResourceName(fakeUrl.lowercase(Locale.US))
         verify(mockSpan as MutableSpan).setError(true)
         verify(mockSpan).drop()
-        Assertions.assertThat(response).isSameAs(fakeResponse)
+        assertThat(response).isSameAs(fakeResponse)
     }
 
     // region Internal
@@ -373,7 +382,9 @@ internal class DatadogInterceptorWithoutTracesTest {
         configure: (Request.Builder) -> Unit = {}
     ): Request {
         val protocol = forge.anElementFrom("http", "https")
-        val host = forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN)
+        // RUMM-2900 host is by definition case insensitive,
+        // and OkHttp lowercases it when building the request
+        val host = forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN).lowercase(Locale.US)
         val path = forge.anAlphaNumericalString()
         fakeUrl = "$protocol://$host/$path"
         val builder = Request.Builder().url(fakeUrl)

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/test/elmyr/OkHttpIntegrationForgeConfigurator.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/test/elmyr/OkHttpIntegrationForgeConfigurator.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp.test.elmyr
+
+import com.datadog.android.tests.elmyr.useCoreFactories
+import com.datadog.tools.unit.forge.BaseConfigurator
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.jvm.useJvmFactories
+
+class OkHttpIntegrationForgeConfigurator : BaseConfigurator() {
+    override fun configure(forge: Forge) {
+        super.configure(forge)
+        forge.useJvmFactories()
+        forge.useCoreFactories()
+
+        forge.addFactory(ResourceIdForgeryFactory())
+    }
+}

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/test/elmyr/ResourceIdForgeryFactory.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/test/elmyr/ResourceIdForgeryFactory.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.okhttp.test.elmyr
+
+import com.datadog.android.rum.resource.ResourceId
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+import java.util.UUID
+
+internal class ResourceIdForgeryFactory : ForgeryFactory<ResourceId> {
+    override fun getForgery(forge: Forge): ResourceId {
+        return ResourceId(
+            forge.aStringMatching("https://[a-z]+.[a-z]{3}/[a-z0-9_/]+/[a-z0-9_/]+"),
+            forge.aNullable { getForgery<UUID>().toString() }
+        )
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds a better way to track OkHttp requests as resources avoiding key collisions. Our keys used to only take into account the url, now we generate a UUID attached to the request to have a more accurate resource representation.