### PR TITLE
RUM-5447 Fix the racing condition in the RotatingDnsResolver logic

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -841,6 +841,7 @@ datadog:
       - "kotlin.collections.List.sumOf(kotlin.Function1)"
       - "kotlin.collections.List.take(kotlin.Int)"
       - "kotlin.collections.List.toCharArray()"
+      - "kotlin.collections.List.toList()"
       - "kotlin.collections.List.toMap()"
       - "kotlin.collections.List.toMutableList()"
       - "kotlin.collections.List.toMutableMap()"


### PR DESCRIPTION
### What does this PR do?

In this PR we are fixing the race condition problem that was caused by a concurrent access to an unprotected list in the `RotatingDnsResolver` class. This was raised by the Support team in this ticket: https://datadog.zendesk.com/agent/tickets/1761693

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

