### PR TITLE
RUM-5524: Make ImagePrivacy clearer

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -3,7 +3,7 @@ interface com.datadog.android.sessionreplay.ExtensionSupport
   fun getOptionSelectorDetectors(): List<com.datadog.android.sessionreplay.recorder.OptionSelectorDetector>
 enum com.datadog.android.sessionreplay.ImagePrivacy
   - MASK_NONE
-  - MASK_CONTENT
+  - MASK_LARGE_ONLY
   - MASK_ALL
 data class com.datadog.android.sessionreplay.MapperTypeWrapper<T: android.view.View>
   constructor(Class<T>, com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper<T>)

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -5,7 +5,7 @@ public abstract interface class com/datadog/android/sessionreplay/ExtensionSuppo
 
 public final class com/datadog/android/sessionreplay/ImagePrivacy : java/lang/Enum {
 	public static final field MASK_ALL Lcom/datadog/android/sessionreplay/ImagePrivacy;
-	public static final field MASK_CONTENT Lcom/datadog/android/sessionreplay/ImagePrivacy;
+	public static final field MASK_LARGE_ONLY Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public static final field MASK_NONE Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/ImagePrivacy;

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ImagePrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ImagePrivacy.kt
@@ -9,7 +9,7 @@ package com.datadog.android.sessionreplay
 /**
  * Defines the Session Replay privacy policy when recording images.
  * @see ImagePrivacy.MASK_NONE
- * @see ImagePrivacy.MASK_CONTENT
+ * @see ImagePrivacy.MASK_LARGE_ONLY
  * @see ImagePrivacy.MASK_ALL
  */
 enum class ImagePrivacy {
@@ -19,10 +19,10 @@ enum class ImagePrivacy {
     MASK_NONE,
 
     /**
-     * Mask images that we consider to be content images.
-     * In the replay images will be replaced with placeholders with the label: Content Image.
+     * Mask images that we consider to be content images based on them being larger than 100x100 dp.
+     * In the replay such images will be replaced with placeholders with the label: Content Image.
      */
-    MASK_CONTENT,
+    MASK_LARGE_ONLY,
 
     /**
      * No images will be recorded.

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -30,7 +30,7 @@ data class SessionReplayConfiguration internal constructor(
     class Builder(@FloatRange(from = 0.0, to = 100.0) private val sampleRate: Float) {
         private var customEndpointUrl: String? = null
         private var privacy = SessionReplayPrivacy.MASK
-        private var imagePrivacy = ImagePrivacy.MASK_CONTENT
+        private var imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY
         private var extensionSupport: ExtensionSupport = NoOpExtensionSupport()
 
         /**
@@ -68,7 +68,7 @@ data class SessionReplayConfiguration internal constructor(
          * Sets the image recording level for the Session Replay feature.
          * If not specified then all images that are considered to be content images will be masked by default.
          * @see ImagePrivacy.MASK_NONE
-         * @see ImagePrivacy.MASK_CONTENT
+         * @see ImagePrivacy.MASK_LARGE_ONLY
          * @see ImagePrivacy.MASK_ALL
          */
         fun setImagePrivacy(level: ImagePrivacy): Builder {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
@@ -275,7 +275,7 @@ internal class DefaultImageWireframeHelper(
         drawable: Drawable,
         density: Float
     ): Boolean =
-        imagePrivacy == ImagePrivacy.MASK_CONTENT &&
+        imagePrivacy == ImagePrivacy.MASK_LARGE_ONLY &&
             usePIIPlaceholder &&
             imageTypeResolver.isDrawablePII(drawable, density)
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -59,7 +59,7 @@ internal class SessionReplayConfigurationBuilderTest {
         // Then
         assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
-        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_CONTENT)
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_LARGE_ONLY)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -78,7 +78,7 @@ internal class SessionReplayConfigurationBuilderTest {
         assertThat(sessionReplayConfiguration.customEndpointUrl)
             .isEqualTo(sessionReplayUrl)
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
-        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_CONTENT)
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_LARGE_ONLY)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -96,7 +96,7 @@ internal class SessionReplayConfigurationBuilderTest {
         // Then
         assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(fakePrivacy)
-        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_CONTENT)
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_LARGE_ONLY)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckableTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckableTextViewMapperTest.kt
@@ -196,7 +196,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
     fun `M create ImageWireFrame W map() { checked, above M }`() {
         // Given
         val allowedMappingContext =
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW, imagePrivacy = ImagePrivacy.MASK_CONTENT)
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW, imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY)
         whenever(mockButtonDrawable.intrinsicHeight).thenReturn(fakeIntrinsicDrawableHeight)
         whenever(mockCheckableTextView.isChecked).thenReturn(true)
 
@@ -215,7 +215,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
         // Then
         verify(fakeMappingContext.imageWireframeHelper).createImageWireframe(
             view = eq(mockCheckableTextView),
-            imagePrivacy = eq(ImagePrivacy.MASK_CONTENT),
+            imagePrivacy = eq(ImagePrivacy.MASK_LARGE_ONLY),
             currentWireframeIndex = anyInt(),
             x = eq(expectedX),
             y = eq(expectedY),
@@ -237,7 +237,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
         // Given
         val allowedMappingContext = fakeMappingContext.copy(
             privacy = SessionReplayPrivacy.ALLOW,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY
         )
         whenever(mockButtonDrawable.intrinsicHeight).thenReturn(fakeIntrinsicDrawableHeight)
         whenever(mockCheckableTextView.isChecked).thenReturn(false)
@@ -258,7 +258,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
         // Then
         verify(fakeMappingContext.imageWireframeHelper).createImageWireframe(
             view = eq(mockCheckableTextView),
-            imagePrivacy = eq(ImagePrivacy.MASK_CONTENT),
+            imagePrivacy = eq(ImagePrivacy.MASK_LARGE_ONLY),
             currentWireframeIndex = anyInt(),
             x = eq(expectedX),
             y = eq(expectedY),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
@@ -76,7 +76,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext.copy(imagePrivacy = ImagePrivacy.MASK_CONTENT),
+            fakeMappingContext.copy(imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )
@@ -89,7 +89,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
 
             verify(fakeMappingContext.imageWireframeHelper, times(2)).createImageWireframe(
                 view = eq(mockSwitch),
-                imagePrivacy = eq(ImagePrivacy.MASK_CONTENT),
+                imagePrivacy = eq(ImagePrivacy.MASK_LARGE_ONLY),
                 currentWireframeIndex = ArgumentMatchers.anyInt(),
                 x = xCaptor.capture(),
                 y = yCaptor.capture(),
@@ -147,7 +147,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.MASK_CONTENT),
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )
@@ -172,7 +172,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.MASK_CONTENT),
+            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelperTest.kt
@@ -134,7 +134,7 @@ internal class DefaultImageWireframeHelperTest {
         val randomXLocation = forge.aLong(min = 1, max = (fakeScreenWidth - fakeDrawableWidth).toLong())
         val randomYLocation = forge.aLong(min = 1, max = (fakeScreenHeight - fakeDrawableHeight).toLong())
         fakeDrawableXY = Pair(randomXLocation, randomYLocation)
-        whenever(mockMappingContext.imagePrivacy).thenReturn(ImagePrivacy.MASK_CONTENT)
+        whenever(mockMappingContext.imagePrivacy).thenReturn(ImagePrivacy.MASK_LARGE_ONLY)
         whenever(mockMappingContext.systemInformation).thenReturn(mockSystemInformation)
         whenever(mockSystemInformation.screenDensity).thenReturn(0f)
         whenever(mockViewIdentifierResolver.resolveChildUniqueIdentifier(mockView, "drawable"))
@@ -229,7 +229,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -254,7 +254,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -283,7 +283,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -313,7 +313,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -336,7 +336,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -358,7 +358,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -415,7 +415,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = fakeDrawableXY.first,
             y = fakeDrawableXY.second,
@@ -593,7 +593,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -625,7 +625,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -676,7 +676,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val result = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = forge.aPositiveInt(),
             x = fakeGlobalX,
             y = fakeGlobalY,
@@ -703,7 +703,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,
@@ -736,7 +736,7 @@ internal class DefaultImageWireframeHelperTest {
         // When
         val actualWireframe = testedHelper.createImageWireframe(
             view = mockView,
-            imagePrivacy = ImagePrivacy.MASK_CONTENT,
+            imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = 0,
             x = 0,
             y = 0,


### PR DESCRIPTION
### What does this PR do?
Changes MASK_CONTENT to MASK_LARGE_ONLY, to make the ImagePrivacy api clearer about what is actually happening.

### Motivation
Clearer api for the users.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

