### PR TITLE
RUM-5564 increase retry delay on DNS error

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploader.kt
@@ -16,6 +16,7 @@ import okhttp3.Call
 import okhttp3.MediaType.Companion.toMediaTypeOrNull
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
+import java.net.UnknownHostException
 import java.util.Locale
 import com.datadog.android.api.net.Request as DatadogRequest
 
@@ -53,6 +54,14 @@ internal class DataOkHttpUploader(
 
         val uploadStatus = try {
             executeUploadRequest(request)
+        } catch (e: UnknownHostException) {
+            internalLogger.log(
+                InternalLogger.Level.ERROR,
+                InternalLogger.Target.USER,
+                { "Unable to find host for site ${context.site}; we will retry later." },
+                e
+            )
+            UploadStatus.DNSError
         } catch (e: Throwable) {
             internalLogger.log(
                 InternalLogger.Level.ERROR,
@@ -165,6 +174,7 @@ internal class DataOkHttpUploader(
             HTTP_UNAVAILABLE,
             HTTP_GATEWAY_TIMEOUT,
             HTTP_INSUFFICIENT_STORAGE -> UploadStatus.HttpServerError(code)
+
             else -> {
                 internalLogger.log(
                     InternalLogger.Level.WARN,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadStatus.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/UploadStatus.kt
@@ -13,6 +13,7 @@ internal sealed class UploadStatus(val shouldRetry: Boolean = false, val code: I
 
     internal class Success(responseCode: Int) : UploadStatus(shouldRetry = false, code = responseCode)
     internal object NetworkError : UploadStatus(shouldRetry = true)
+    internal object DNSError : UploadStatus(shouldRetry = true)
     internal object RequestCreationError : UploadStatus(shouldRetry = false)
     internal class InvalidTokenError(responseCode: Int) : UploadStatus(shouldRetry = false, code = responseCode)
     internal class HttpRedirection(responseCode: Int) : UploadStatus(shouldRetry = false, code = responseCode)
@@ -40,6 +41,12 @@ internal sealed class UploadStatus(val shouldRetry: Boolean = false, val code: I
                 InternalLogger.Level.WARN,
                 InternalLogger.Target.USER,
                 { "$batchInfo failed because of a network error; we will retry later." }
+            )
+
+            is DNSError -> logger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.USER,
+                { "$batchInfo failed because of a DNS error; we will retry later." }
             )
 
             is InvalidTokenError -> logger.log(

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploaderTest.kt
@@ -49,6 +49,7 @@ import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 import java.io.IOException
+import java.net.UnknownHostException
 import java.util.Locale
 import com.datadog.android.api.net.Request as DatadogRequest
 
@@ -534,6 +535,25 @@ internal class DataOkHttpUploaderTest {
 
         // Then
         assertThat(result).isInstanceOf(UploadStatus.NetworkError::class.java)
+        assertThat(result.code).isEqualTo(UploadStatus.UNKNOWN_RESPONSE_CODE)
+        verifyRequest(fakeDatadogRequest)
+    }
+
+    @Test
+    fun `M return error W upload() {UnknownHostException}`(
+        @Forgery batch: List<RawBatchEvent>,
+        @StringForgery batchMeta: String,
+        @StringForgery message: String
+    ) {
+        // Given
+        val batchMetadata = batchMeta.toByteArray()
+        whenever(mockCall.execute()) doThrow UnknownHostException(message)
+
+        // When
+        val result = testedUploader.upload(fakeContext, batch, batchMetadata)
+
+        // Then
+        assertThat(result).isInstanceOf(UploadStatus.DNSError::class.java)
         assertThat(result.code).isEqualTo(UploadStatus.UNKNOWN_RESPONSE_CODE)
         verifyRequest(fakeDatadogRequest)
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadStatusTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadStatusTest.kt
@@ -87,6 +87,27 @@ internal class UploadStatusTest {
     }
 
     @Test
+    fun `M log DNS_ERROR only to USER W logStatus()`(
+        @Forgery status: UploadStatus.DNSError
+    ) {
+        // When
+        status.logStatus(
+            fakeContext,
+            fakeByteSize,
+            mockLogger
+        )
+
+        // Then
+        mockLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
+                "because of a DNS error; we will retry later."
+        )
+        verifyNoMoreInteractions(mockLogger)
+    }
+
+    @Test
     fun `M log INVALID_TOKEN_ERROR only to USER W logStatus()`(
         @Forgery status: UploadStatus.InvalidTokenError
     ) {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -50,6 +50,7 @@ internal class Configurator :
         forge.addFactory(HttpServerErrorForgeryFactory())
         forge.addFactory(InvalidTokenErrorStatusForgeryFactory())
         forge.addFactory(NetworkErrorStatusForgeryFactory())
+        forge.addFactory(DNSErrorStatusForgeryFactory())
         forge.addFactory(RequestCreationErrorStatusForgeryFactory())
         forge.addFactory(SuccessStatusForgeryFactory())
         forge.addFactory(UnknownErrorStatusForgeryFactory())

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/DNSErrorStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/DNSErrorStatusForgeryFactory.kt
@@ -1,0 +1,18 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.utils.forge
+
+import com.datadog.android.core.internal.data.upload.UploadStatus
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class DNSErrorStatusForgeryFactory : ForgeryFactory<UploadStatus.DNSError> {
+
+    override fun getForgery(forge: Forge): UploadStatus.DNSError {
+        return UploadStatus.DNSError
+    }
+}


### PR DESCRIPTION
### What does this PR do?

When a DNS issue prevents the SDK from reaching our intake hosts, we increase the delay to avoid an infinite loop. 

### Motivation

By default our retry loop can be quite frequent, but DNS issues often take some time to be fixed. Although an actual issue in our DNS registration is unlikely, there seems to also be some issues on some networks preventing the devices from resolving the intake host address. 

### Additional Notes

Relates to #2131
