### PR TITLE
Fix content placeholder wireframe using wrong image bound

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
@@ -94,10 +94,8 @@ internal class DefaultImageWireframeHelper(
         if (imagePrivacy == ImagePrivacy.MASK_ALL) {
             return createContentPlaceholderWireframe(
                 id = id,
-                x = x,
-                y = y,
+                view = view,
                 density = density,
-                drawableProperties = drawableProperties,
                 label = MASK_ALL_CONTENT_LABEL
             )
         }
@@ -106,10 +104,8 @@ internal class DefaultImageWireframeHelper(
         if (shouldMaskContextualImage(imagePrivacy, usePIIPlaceholder, drawable, density)) {
             return createContentPlaceholderWireframe(
                 id = id,
-                x = x,
-                y = y,
+                view = view,
                 density = density,
-                drawableProperties = drawableProperties,
                 label = MASK_CONTEXTUAL_CONTENT_LABEL
             )
         }
@@ -241,19 +237,23 @@ internal class DefaultImageWireframeHelper(
     }
 
     private fun createContentPlaceholderWireframe(
+        view: View,
         id: Long,
-        x: Long,
-        y: Long,
         density: Float,
-        drawableProperties: DrawableProperties,
         label: String
     ): MobileSegment.Wireframe.PlaceholderWireframe {
+        val coordinates = IntArray(2)
+        @Suppress("UnsafeThirdPartyFunctionCall") // this will always have size >= 2
+        view.getLocationOnScreen(coordinates)
+        val viewX = coordinates[0].densityNormalized(density).toLong()
+        val viewY = coordinates[1].densityNormalized(density).toLong()
+
         return MobileSegment.Wireframe.PlaceholderWireframe(
             id,
-            x,
-            y,
-            drawableProperties.drawableWidth.densityNormalized(density).toLong(),
-            drawableProperties.drawableHeight.densityNormalized(density).toLong(),
+            viewX,
+            viewY,
+            view.width.densityNormalized(density).toLong(),
+            view.height.densityNormalized(density).toLong(),
             label = label
         )
     }


### PR DESCRIPTION
### What does this PR do?

Fixes a regression of session replay while image placeholder doesn't have the correct position and bounds.

#### Cause:
in this [PR](https://github.com/DataDog/dd-sdk-android/commit/1f40138d99a4593a5ba412fa1892ee9d9ab6cac8#diff-f77bd930d8d3012f1393ff8ed0db17f7aa1f67d69e487f31feffeb0ec87d85eaL215), placeholder is using the content image bounds instead of image view bounds, which make the placeholder go beyond the image view.

#### Fix:
rollback the related function to the version prior to this PR


here is the screenshot after the fix:

<img width="283" alt="image" src="https://github.com/user-attachments/assets/9a2c96a4-2deb-4f2a-ab50-e537e986f356">

Session replay link:
https://mobile-integration.datadoghq.com/rum/replay/sessions/dc4868a1-f572-4c66-b598-e140f777f126?applicationId=8e378128-92c4-433c-bfce-0957f8abee1a&seed=a9049579-5c24-47b6-b15c-856b3317dd02&ts=1722252089784

### Motivation

Issue found before the sdk release:
![image](https://github.com/user-attachments/assets/dcbec5dc-2018-4568-97dd-72d2e7dcfb32)


Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

