### PR TITLE
Add scenario attribute in benchmark metrics

### DIFF
--- a/tools/benchmark/src/main/java/com/datadog/benchmark/DatadogExporterConfiguration.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/DatadogExporterConfiguration.kt
@@ -15,6 +15,7 @@ package com.datadog.benchmark
  * @param applicationId the id of the host application.
  * @param apiKey the api key for submitting metrics to datadog end points.
  * @param run the run description of benchmark test.
+ * @param scenario the scenario of benchmark.
  * @param endPoint the endpoint to submit the metrics.
  * @param intervalInSeconds the interval of seconds of sampling and uploading vital data.
  */
@@ -26,6 +27,7 @@ data class DatadogExporterConfiguration internal constructor(
     val applicationId: String? = null,
     val apiKey: String,
     val run: String? = null,
+    val scenario: String? = null,
     val endPoint: EndPoint = EndPoint.US1,
     val intervalInSeconds: Long = DEFAULT_INTERVAL_IN_SECONDS
 ) {
@@ -41,6 +43,7 @@ data class DatadogExporterConfiguration internal constructor(
         private var applicationVersion: String? = null
         private var applicationId: String? = null
         private var run: String? = null
+        private var scenario: String? = null
         private var endPoint: EndPoint = EndPoint.US1
         private var intervalInSeconds: Long = DEFAULT_INTERVAL_IN_SECONDS
 
@@ -115,6 +118,16 @@ data class DatadogExporterConfiguration internal constructor(
         }
 
         /**
+         * Sets the benchmark scenario.
+         *
+         * @param scenario benchmark scenario.
+         */
+        fun setScenario(scenario: String): Builder {
+            this.scenario = scenario
+            return this
+        }
+
+        /**
          * Sets the end point which the metric should be uploaded to.
          *
          * @param endPoint endpoint of the metric upload.
@@ -136,6 +149,7 @@ data class DatadogExporterConfiguration internal constructor(
                 applicationId = applicationId,
                 apiKey = apiKey,
                 run = run,
+                scenario = scenario,
                 endPoint = endPoint,
                 intervalInSeconds = intervalInSeconds
             )

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/DatadogMeter.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/DatadogMeter.kt
@@ -45,7 +45,7 @@ class DatadogMeter private constructor(private val meter: Meter) {
     /**
      * Stops cpu, memory and fps gauges.
      */
-    fun stopAllGauges() {
+    fun stopGauges() {
         stopGauge(cpuVitalReader)
         stopGauge(memoryVitalReader)
         stopGauge(fpsVitalReader)

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/exporter/DatadogMetricExporter.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/exporter/DatadogMetricExporter.kt
@@ -16,6 +16,7 @@ internal class DatadogMetricExporter(datadogExporterConfiguration: DatadogExport
         deviceModel = Build.MODEL,
         osVersion = Build.VERSION.RELEASE,
         run = datadogExporterConfiguration.run ?: DEFAULT_RUN_NAME,
+        scenario = datadogExporterConfiguration.scenario,
         applicationId = datadogExporterConfiguration.applicationId ?: DEFAULT_APPLICATION_ID,
         intervalInSeconds = datadogExporterConfiguration.intervalInSeconds
     )

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/exporter/LogsMetricExporter.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/exporter/LogsMetricExporter.kt
@@ -23,6 +23,7 @@ internal class LogsMetricExporter(datadogExporterConfiguration: DatadogExporterC
         deviceModel = Build.MODEL,
         osVersion = Build.VERSION.RELEASE,
         run = datadogExporterConfiguration.run ?: DEFAULT_RUN_NAME,
+        scenario = datadogExporterConfiguration.scenario,
         applicationId = datadogExporterConfiguration.applicationId ?: DEFAULT_APPLICATION_ID,
         intervalInSeconds = datadogExporterConfiguration.intervalInSeconds
     )

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/internal/MetricRequestBodyBuilder.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/internal/MetricRequestBodyBuilder.kt
@@ -56,10 +56,13 @@ internal class MetricRequestBodyBuilder(private val metricContext: MetricContext
     }
 
     private fun resolveTags(): List<String> {
-        return listOf(
+        return listOfNotNull(
             "$KEY_TAG_DEVICE_MODEL:${metricContext.deviceModel}",
             "$KEY_TAG_OS_VERSION:${metricContext.osVersion}",
             "$KEY_TAG_RUN:${metricContext.run}",
+            metricContext.scenario?.let {
+                "$KEY_SCENARIO:$it"
+            },
             "$KEY_TAG_APPLICATION_ID:${metricContext.applicationId}"
         )
     }
@@ -101,6 +104,7 @@ internal class MetricRequestBodyBuilder(private val metricContext: MetricContext
         private const val KEY_METRIC = "metric"
         private const val KEY_TAGS = "tags"
         private const val KEY_POINTS = "points"
+        private const val KEY_SCENARIO = "scenario"
         private const val KEY_RESOURCES = "resources"
         private const val KEY_TYPE = "type"
         private const val KEY_UNIT = "unit"

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/internal/model/MetricContext.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/internal/model/MetricContext.kt
@@ -10,6 +10,7 @@ internal data class MetricContext(
     val deviceModel: String,
     val osVersion: String,
     val run: String,
+    val scenario: String?,
     val applicationId: String,
     val intervalInSeconds: Long
 )

--- a/tools/benchmark/src/test/java/forge/MetricContextForgeryFactory.kt
+++ b/tools/benchmark/src/test/java/forge/MetricContextForgeryFactory.kt
@@ -17,7 +17,8 @@ internal class MetricContextForgeryFactory : ForgeryFactory<MetricContext> {
             osVersion = forge.aString(),
             run = forge.aString(),
             applicationId = forge.aString(),
-            intervalInSeconds = forge.aLong()
+            intervalInSeconds = forge.aLong(),
+            scenario = forge.aString()
         )
     }
 }

--- a/tools/benchmark/src/test/java/internal/MetricRequestBodyBuilderTest.kt
+++ b/tools/benchmark/src/test/java/internal/MetricRequestBodyBuilderTest.kt
@@ -66,6 +66,7 @@ class MetricRequestBodyBuilderTest {
                         "device_model:${metricContext.deviceModel}",
                         "os_version:${metricContext.osVersion}",
                         "run:${metricContext.run}",
+                        "scenario:${metricContext.scenario}",
                         "application_id:${metricContext.applicationId}"
                     )
                 )


### PR DESCRIPTION
### What does this PR do?

Add "scenario" attribute in metrics payload.

### Motivation


According to the RFC of benchmark, we should have "scenario" in tags of metrics to indicate which scenario the benchmark is running with.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

