### PR TITLE
[#2163] Update link to troubleshooting documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,4 +123,4 @@ Pull requests are welcome. First, open an issue to discuss what you would like t
 [3]: https://app.datadoghq.com/logs
 [4]: https://app.datadoghq.com/apm/services
 [5]: https://app.datadoghq.com/rum/explorer
-[6]: https://docs.datadoghq.com/real_user_monitoring/android/troubleshooting/
+[6]: https://docs.datadoghq.com/real_user_monitoring/mobile_and_tv_monitoring/troubleshooting/android/


### PR DESCRIPTION
### What does this PR do?

This PR fixes a broken link to the Android SDK troubleshooting documentation.
Fixes issue:  #2163 

### Motivation

I was working through setting up a mobile device using the SDK and ran into issues. I clicked the link for troubleshooting assistance, and was met with a 404 error.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

