### PR TITLE
RUM-5550: Parse synthetics variables to control benchmark test scenario

### DIFF
--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/BenchmarkApplication.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/BenchmarkApplication.kt
@@ -19,8 +19,6 @@ import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.rum.Rum
 import com.datadog.android.rum.RumConfiguration
 import com.datadog.android.rum.tracking.NavigationViewTrackingStrategy
-import com.datadog.benchmark.DatadogExporterConfiguration
-import com.datadog.benchmark.DatadogMeter
 import com.datadog.sample.benchmark.BuildConfig
 import com.datadog.sample.benchmark.R
 
@@ -28,23 +26,10 @@ internal class BenchmarkApplication : Application() {
 
     override fun onCreate() {
         super.onCreate()
-
-        initDatadogSessionReplay()
-        enableDatadogMeter()
+        initDatadogSdk()
     }
 
-    private fun enableDatadogMeter() {
-        DatadogMeter.create(
-            DatadogExporterConfiguration.Builder(BuildConfig.BM_API_KEY)
-                .setApplicationId(BuildConfig.APPLICATION_ID)
-                .setApplicationName("Benchmark Application")
-                .setApplicationVersion(BuildConfig.VERSION_NAME)
-                .setIntervalInSeconds(METER_INTERVAL_IN_SECONDS)
-                .build()
-        ).startGauges()
-    }
-
-    private fun initDatadogSessionReplay() {
+    private fun initDatadogSdk() {
         Datadog.initialize(
             this,
             createDatadogConfiguration(),
@@ -112,8 +97,6 @@ internal class BenchmarkApplication : Application() {
     }
 
     companion object {
-        private const val METER_INTERVAL_IN_SECONDS = 10L
-
         private const val ATTR_IS_MAPPED = "is_mapped"
         private const val SAMPLE_RATE_TELEMETRY = 100f
         private const val THRESHOLD_LONG_TASK_INTERVAL = 250L

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/MainActivity.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/MainActivity.kt
@@ -10,10 +10,7 @@ import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
-import com.datadog.android.sessionreplay.SessionReplay
-import com.datadog.android.sessionreplay.SessionReplayConfiguration
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import com.datadog.android.sessionreplay.material.MaterialExtensionSupport
+import com.datadog.benchmark.sample.benchmark.DatadogBenchmark
 import com.datadog.sample.benchmark.R
 
 /**
@@ -22,27 +19,27 @@ import com.datadog.sample.benchmark.R
 class MainActivity : AppCompatActivity() {
 
     private lateinit var navController: NavController
+    private lateinit var datadogBenchmark: DatadogBenchmark
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        enableSessionReplay()
+        datadogBenchmark = DatadogBenchmark(
+            DatadogBenchmark.Config.resolveSyntheticsBundle(intent.extras)
+        )
     }
 
-    private fun enableSessionReplay() {
-        val sessionReplayConfig = SessionReplayConfiguration
-            .Builder(SAMPLE_IN_ALL_SESSIONS)
-            .setPrivacy(SessionReplayPrivacy.ALLOW)
-            .addExtensionSupport(MaterialExtensionSupport())
-            .build()
-        SessionReplay.enable(sessionReplayConfig)
+    override fun onStart() {
+        super.onStart()
+        datadogBenchmark.start()
+    }
+
+    override fun onStop() {
+        super.onStop()
+        datadogBenchmark.stop()
     }
 
     override fun onResume() {
         super.onResume()
         navController = Navigation.findNavController(this, R.id.nav_host_fragment)
-    }
-
-    companion object {
-        private const val SAMPLE_IN_ALL_SESSIONS = 100f
     }
 }

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/DatadogBenchmark.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/DatadogBenchmark.kt
@@ -1,0 +1,104 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.benchmark.sample.benchmark
+
+import android.os.Bundle
+import com.datadog.android.sessionreplay.SessionReplay
+import com.datadog.android.sessionreplay.SessionReplayConfiguration
+import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.material.MaterialExtensionSupport
+import com.datadog.benchmark.DatadogExporterConfiguration
+import com.datadog.benchmark.DatadogMeter
+import com.datadog.benchmark.sample.benchmark.DatadogBenchmark.Config
+import com.datadog.sample.benchmark.BuildConfig
+
+/**
+ * Class to control the benchmark test in sample application. It takes the [Config] which is parsed
+ * from Synthetics variables in order to decide which scenario it should run for the benchmark test.
+ */
+internal class DatadogBenchmark(config: Config) {
+
+    private var meter: DatadogMeter = DatadogMeter.create(
+        DatadogExporterConfiguration.Builder(BuildConfig.BM_API_KEY)
+            .setApplicationId(BuildConfig.APPLICATION_ID)
+            .setApplicationName(BENCHMARK_APPLICATION_NAME)
+            .setRun(config.getRun())
+            .setScenario(config.getScenario())
+            .setApplicationVersion(BuildConfig.VERSION_NAME)
+            .setIntervalInSeconds(METER_INTERVAL_IN_SECONDS)
+            .build()
+    )
+
+    init {
+        when (config.scenario) {
+            SyntheticsScenario.SessionReplay -> enableSessionReplay()
+            else -> {} // do nothing for now
+        }
+    }
+
+    fun start() {
+        meter.startGauges()
+    }
+
+    fun stop() {
+        meter.stopGauges()
+    }
+
+    private fun enableSessionReplay() {
+        val sessionReplayConfig = SessionReplayConfiguration
+            .Builder(SAMPLE_IN_ALL_SESSIONS)
+            .setPrivacy(SessionReplayPrivacy.ALLOW)
+            .addExtensionSupport(MaterialExtensionSupport())
+            .build()
+        SessionReplay.enable(sessionReplayConfig)
+    }
+
+    internal class Config(
+        val run: SyntheticsRun? = null,
+        val scenario: SyntheticsScenario? = null
+    ) {
+        fun getRun(): String {
+            return run?.value ?: ""
+        }
+
+        fun getScenario(): String {
+            return scenario?.value ?: ""
+        }
+
+        companion object {
+            fun resolveSyntheticsBundle(bundle: Bundle?): Config {
+                val scenario = bundle?.getString(BM_SYNTHETICS_SCENARIO)
+                val run = bundle?.getString(BM_SYNTHETICS_RUN)
+                return Config(
+                    scenario = resolveScenario(scenario),
+                    run = resolveRun(run)
+                )
+            }
+
+            private fun resolveRun(run: String?): SyntheticsRun? {
+                return run?.let {
+                    SyntheticsRun.from(it)
+                }
+            }
+
+            private fun resolveScenario(scenario: String?): SyntheticsScenario? {
+                return scenario?.let {
+                    SyntheticsScenario.from(it)
+                }
+            }
+
+            private const val BM_SYNTHETICS_SCENARIO = "synthetics.benchmark.scenario"
+            private const val BM_SYNTHETICS_RUN = "synthetics.benchmark.run"
+        }
+    }
+
+    companion object {
+        private const val METER_INTERVAL_IN_SECONDS = 10L
+        private const val SAMPLE_IN_ALL_SESSIONS = 100f
+        private const val BENCHMARK_APPLICATION_NAME = "Benchmark Application"
+    }
+}

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/SyntheticsRun.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/SyntheticsRun.kt
@@ -1,0 +1,20 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.benchmark.sample.benchmark
+
+internal enum class SyntheticsRun(val value: String) {
+
+    Baseline("baseline"),
+
+    Instrumented("instrumented");
+
+    companion object {
+        fun from(value: String): SyntheticsRun? {
+            return values().firstOrNull { it.value == value }
+        }
+    }
+}

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/SyntheticsScenario.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/SyntheticsScenario.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.benchmark.sample.benchmark
+
+internal enum class SyntheticsScenario(val value: String) {
+
+    SessionReplay("sr"),
+
+    Rum("rum"),
+
+    Trace("trace"),
+
+    Logs("logs");
+
+    companion object {
+        fun from(value: String): SyntheticsScenario? {
+            return values().firstOrNull { it.value == value }
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Add `DatadogBenchmark` class to be able to parse the Synthethics variables in order to control the benchmark test scenario.


#### Explanation

1. define two local variables in synthetics test
<img width="497" alt="image" src="https://github.com/user-attachments/assets/3082018d-b810-4253-aabf-5e6e8b7ea72b">


2. define Optional Intent Arguments by using the local variables
<img width="756" alt="image" src="https://github.com/user-attachments/assets/f91ae22d-4d76-4a7e-ba46-b8ac2783c7a7">

3.On the app side, the class is able to parse the parameters in bundle, to switch the scenario in the code.



### Motivation

RUM-5550

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

