### PR TITLE
RUM-5540: Add stop and start apis for session replay

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -250,8 +250,8 @@ internal class TelemetryEventHandler(
             sdkCore.getFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME)
         val sessionReplaySampleRate = sessionReplayFeatureContext[SESSION_REPLAY_SAMPLE_RATE_KEY]
             as? Long
-        val startSessionReplayManually =
-            sessionReplayFeatureContext[SESSION_REPLAY_MANUAL_RECORDING_KEY] as? Boolean
+        val startSessionReplayImmediately =
+            sessionReplayFeatureContext[SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY] as? Boolean
         val sessionReplayPrivacy = sessionReplayFeatureContext[SESSION_REPLAY_PRIVACY_KEY]
             as? String
         val rumConfig = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
@@ -315,7 +315,7 @@ internal class TelemetryEventHandler(
                     trackNetworkRequests = trackNetworkRequests,
                     sessionReplaySampleRate = sessionReplaySampleRate,
                     defaultPrivacyLevel = sessionReplayPrivacy,
-                    startSessionReplayRecordingManually = startSessionReplayManually,
+                    startRecordingImmediately = startSessionReplayImmediately,
                     batchProcessingLevel = coreConfiguration.batchProcessingLevel.toLong()
                 )
             )
@@ -394,7 +394,7 @@ internal class TelemetryEventHandler(
         internal const val OPENTELEMETRY_API_VERSION_CONTEXT_KEY = "opentelemetry_api_version"
         internal const val SESSION_REPLAY_SAMPLE_RATE_KEY = "session_replay_sample_rate"
         internal const val SESSION_REPLAY_PRIVACY_KEY = "session_replay_privacy"
-        internal const val SESSION_REPLAY_MANUAL_RECORDING_KEY =
-            "session_replay_requires_manual_recording"
+        internal const val SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY =
+            "session_replay_start_immediate_recording"
     }
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -250,7 +250,7 @@ internal class TelemetryEventHandler(
             sdkCore.getFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME)
         val sessionReplaySampleRate = sessionReplayFeatureContext[SESSION_REPLAY_SAMPLE_RATE_KEY]
             as? Long
-        val startSessionReplayImmediately =
+        val startRecordingImmediately =
             sessionReplayFeatureContext[SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY] as? Boolean
         val sessionReplayPrivacy = sessionReplayFeatureContext[SESSION_REPLAY_PRIVACY_KEY]
             as? String
@@ -315,7 +315,7 @@ internal class TelemetryEventHandler(
                     trackNetworkRequests = trackNetworkRequests,
                     sessionReplaySampleRate = sessionReplaySampleRate,
                     defaultPrivacyLevel = sessionReplayPrivacy,
-                    startRecordingImmediately = startSessionReplayImmediately,
+                    startRecordingImmediately = startRecordingImmediately,
                     batchProcessingLevel = coreConfiguration.batchProcessingLevel.toLong()
                 )
             )

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryConfigurationEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryConfigurationEventAssert.kt
@@ -269,6 +269,7 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
             .isEqualTo(expected)
         return this
     }
+
     fun hasBatchProcessingLevel(expected: Int?): TelemetryConfigurationEventAssert {
         assertThat(actual.telemetry.configuration.batchProcessingLevel)
             .overridingErrorMessage(
@@ -359,12 +360,12 @@ internal class TelemetryConfigurationEventAssert(actual: TelemetryConfigurationE
         return this
     }
 
-    fun hasSessionReplayStartManually(expected: Boolean?): TelemetryConfigurationEventAssert {
+    fun hasStartRecordingImmediately(expected: Boolean?): TelemetryConfigurationEventAssert {
         val assertErrorMessage = "Expected event data to have" +
-            " telemetry.configuration.startSessionReplayRecordingManually" +
+            " telemetry.configuration.startRecordingImmediately" +
             " $expected " +
-            "but was ${actual.telemetry.configuration.startSessionReplayRecordingManually}"
-        assertThat(actual.telemetry.configuration.startSessionReplayRecordingManually)
+            "but was ${actual.telemetry.configuration.startRecordingImmediately}"
+        assertThat(actual.telemetry.configuration.startRecordingImmediately)
             .overridingErrorMessage(assertErrorMessage)
             .isEqualTo(expected)
         return this

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -478,7 +478,7 @@ internal class TelemetryEventHandlerTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent)
             assertThat(firstValue).hasSessionReplaySampleRate(null)
-            assertThat(firstValue).hasSessionReplayStartManually(null)
+            assertThat(firstValue).hasStartRecordingImmediately(null)
             assertThat(firstValue).hasSessionReplayPrivacy(null)
         }
     }
@@ -490,11 +490,11 @@ internal class TelemetryEventHandlerTest {
         // Given
         val fakeSampleRate = forge.aPositiveLong()
         val fakeSessionReplayPrivacy = forge.aString()
-        val fakeSessionReplayIsStartManually = forge.aBool()
+        val fakeSessionReplayIsStartImmediately = forge.aBool()
         val fakeSessionReplayContext = mutableMapOf<String, Any?>(
             TelemetryEventHandler.SESSION_REPLAY_PRIVACY_KEY to fakeSessionReplayPrivacy,
-            TelemetryEventHandler.SESSION_REPLAY_MANUAL_RECORDING_KEY to
-                fakeSessionReplayIsStartManually,
+            TelemetryEventHandler.SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY to
+                fakeSessionReplayIsStartImmediately,
             TelemetryEventHandler.SESSION_REPLAY_SAMPLE_RATE_KEY to fakeSampleRate
         )
         whenever(mockSdkCore.getFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME)) doReturn
@@ -509,7 +509,7 @@ internal class TelemetryEventHandlerTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent)
             assertThat(firstValue).hasSessionReplaySampleRate(fakeSampleRate)
-            assertThat(firstValue).hasSessionReplayStartManually(fakeSessionReplayIsStartManually)
+            assertThat(firstValue).hasStartRecordingImmediately(fakeSessionReplayIsStartImmediately)
             assertThat(firstValue).hasSessionReplayPrivacy(fakeSessionReplayPrivacy)
         }
     }
@@ -521,11 +521,11 @@ internal class TelemetryEventHandlerTest {
         // Given
         val fakeSampleRate = forge.aNullable { aString() }
         val fakeSessionReplayPrivacy = forge.aNullable { aLong() }
-        val fakeSessionReplayIsStartManually = forge.aNullable { aString() }
+        val fakeSessionReplayIsStartedImmediatley = forge.aNullable { aString() }
         val fakeSessionReplayContext = mutableMapOf<String, Any?>(
             TelemetryEventHandler.SESSION_REPLAY_PRIVACY_KEY to fakeSessionReplayPrivacy,
-            TelemetryEventHandler.SESSION_REPLAY_MANUAL_RECORDING_KEY to
-                fakeSessionReplayIsStartManually,
+            TelemetryEventHandler.SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY to
+                fakeSessionReplayIsStartedImmediatley,
             TelemetryEventHandler.SESSION_REPLAY_SAMPLE_RATE_KEY to fakeSampleRate
         )
         whenever(mockSdkCore.getFeatureContext(Feature.SESSION_REPLAY_FEATURE_NAME)) doReturn
@@ -540,7 +540,7 @@ internal class TelemetryEventHandlerTest {
             verify(mockWriter).write(eq(mockEventBatchWriter), capture(), eq(EventType.TELEMETRY))
             assertConfigEventMatchesRawEvent(firstValue, configRawEvent)
             assertThat(firstValue).hasSessionReplaySampleRate(null)
-            assertThat(firstValue).hasSessionReplayStartManually(null)
+            assertThat(firstValue).hasStartRecordingImmediately(null)
             assertThat(firstValue).hasSessionReplayPrivacy(null)
         }
     }

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -10,7 +10,7 @@ data class com.datadog.android.sessionreplay.MapperTypeWrapper<T: android.view.V
   fun supportsView(android.view.View): Boolean
   fun getUnsafeMapper(): com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper<android.view.View>
 object com.datadog.android.sessionreplay.SessionReplay
-  fun enable(SessionReplayConfiguration, com.datadog.android.api.SdkCore = Datadog.getInstance(), Boolean = true)
+  fun enable(SessionReplayConfiguration, com.datadog.android.api.SdkCore = Datadog.getInstance())
   fun startRecording(com.datadog.android.api.SdkCore = Datadog.getInstance())
   fun stopRecording(com.datadog.android.api.SdkCore = Datadog.getInstance())
 data class com.datadog.android.sessionreplay.SessionReplayConfiguration
@@ -19,6 +19,7 @@ data class com.datadog.android.sessionreplay.SessionReplayConfiguration
     fun addExtensionSupport(ExtensionSupport): Builder
     fun useCustomEndpoint(String): Builder
     fun setPrivacy(SessionReplayPrivacy): Builder
+    fun startRecordingImmediately(Boolean): Builder
     fun build(): SessionReplayConfiguration
 enum com.datadog.android.sessionreplay.SessionReplayPrivacy
   - ALLOW

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -10,7 +10,9 @@ data class com.datadog.android.sessionreplay.MapperTypeWrapper<T: android.view.V
   fun supportsView(android.view.View): Boolean
   fun getUnsafeMapper(): com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper<android.view.View>
 object com.datadog.android.sessionreplay.SessionReplay
-  fun enable(SessionReplayConfiguration, com.datadog.android.api.SdkCore = Datadog.getInstance())
+  fun enable(SessionReplayConfiguration, com.datadog.android.api.SdkCore = Datadog.getInstance(), Boolean = true)
+  fun startRecording(com.datadog.android.api.SdkCore = Datadog.getInstance())
+  fun stopRecording(com.datadog.android.api.SdkCore = Datadog.getInstance())
 data class com.datadog.android.sessionreplay.SessionReplayConfiguration
   class Builder
     constructor(Float)

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -26,8 +26,7 @@ public final class com/datadog/android/sessionreplay/SessionReplay {
 	public static final field INSTANCE Lcom/datadog/android/sessionreplay/SessionReplay;
 	public static final fun enable (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;)V
 	public static final fun enable (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Lcom/datadog/android/api/SdkCore;)V
-	public static final fun enable (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Lcom/datadog/android/api/SdkCore;Z)V
-	public static synthetic fun enable$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Lcom/datadog/android/api/SdkCore;ZILjava/lang/Object;)V
+	public static synthetic fun enable$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
 	public final fun startRecording (Lcom/datadog/android/api/SdkCore;)V
 	public static synthetic fun startRecording$default (Lcom/datadog/android/sessionreplay/SessionReplay;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
 	public final fun stopRecording (Lcom/datadog/android/api/SdkCore;)V
@@ -35,8 +34,8 @@ public final class com/datadog/android/sessionreplay/SessionReplay {
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayConfiguration {
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;Z)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -47,6 +46,7 @@ public final class com/datadog/android/sessionreplay/SessionReplayConfiguration$
 	public final fun addExtensionSupport (Lcom/datadog/android/sessionreplay/ExtensionSupport;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun build ()Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public final fun setPrivacy (Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
+	public final fun startRecordingImmediately (Z)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 }
 

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -26,7 +26,12 @@ public final class com/datadog/android/sessionreplay/SessionReplay {
 	public static final field INSTANCE Lcom/datadog/android/sessionreplay/SessionReplay;
 	public static final fun enable (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;)V
 	public static final fun enable (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Lcom/datadog/android/api/SdkCore;)V
-	public static synthetic fun enable$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
+	public static final fun enable (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Lcom/datadog/android/api/SdkCore;Z)V
+	public static synthetic fun enable$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Lcom/datadog/android/api/SdkCore;ZILjava/lang/Object;)V
+	public final fun startRecording (Lcom/datadog/android/api/SdkCore;)V
+	public static synthetic fun startRecording$default (Lcom/datadog/android/sessionreplay/SessionReplay;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
+	public final fun stopRecording (Lcom/datadog/android/api/SdkCore;)V
+	public static synthetic fun stopRecording$default (Lcom/datadog/android/sessionreplay/SessionReplay;Lcom/datadog/android/api/SdkCore;ILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayConfiguration {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay
 
 import com.datadog.android.Datadog
 import com.datadog.android.api.SdkCore
+import com.datadog.android.api.feature.Feature.Companion.SESSION_REPLAY_FEATURE_NAME
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.sessionreplay.internal.SessionReplayFeature
 
@@ -22,12 +23,15 @@ object SessionReplay {
      * @param sessionReplayConfiguration Configuration to use for the feature.
      * @param sdkCore SDK instance to register feature in. If not provided, default SDK instance
      * will be used.
+     * @param startRecordingImmediately whether to start recording immediately or wait for manual start.
+     * If not provided, the default is to start immediately.
      */
     @JvmOverloads
     @JvmStatic
     fun enable(
         sessionReplayConfiguration: SessionReplayConfiguration,
-        sdkCore: SdkCore = Datadog.getInstance()
+        sdkCore: SdkCore = Datadog.getInstance(),
+        startRecordingImmediately: Boolean = true
     ) {
         val sessionReplayFeature = SessionReplayFeature(
             sdkCore = sdkCore as FeatureSdkCore,
@@ -36,9 +40,42 @@ object SessionReplay {
             imagePrivacy = sessionReplayConfiguration.imagePrivacy,
             customMappers = sessionReplayConfiguration.customMappers,
             customOptionSelectorDetectors = sessionReplayConfiguration.customOptionSelectorDetectors,
-            sampleRate = sessionReplayConfiguration.sampleRate
+            sampleRate = sessionReplayConfiguration.sampleRate,
+            startRecordingImmediately = startRecordingImmediately
         )
 
         sdkCore.registerFeature(sessionReplayFeature)
+    }
+
+    /**
+     * Start recording session replay data.
+     * @param sdkCore SDK instance to get the feature from. If not provided, default SDK instance
+     * will be used.
+     */
+    fun startRecording(
+        sdkCore: SdkCore = Datadog.getInstance()
+    ) {
+        val sessionReplayFeature = (sdkCore as? FeatureSdkCore)
+            ?.getFeature(SESSION_REPLAY_FEATURE_NAME)?.let {
+                it.unwrap() as? SessionReplayFeature
+            }
+
+        sessionReplayFeature?.startRecording()
+    }
+
+    /**
+     * Stop recording session replay data.
+     * @param sdkCore SDK instance to get the feature from. If not provided, default SDK instance
+     * will be used.
+     */
+    fun stopRecording(
+        sdkCore: SdkCore = Datadog.getInstance()
+    ) {
+        val sessionReplayFeature = (sdkCore as? FeatureSdkCore)
+            ?.getFeature(SESSION_REPLAY_FEATURE_NAME)?.let {
+                it.unwrap() as? SessionReplayFeature
+            }
+
+        sessionReplayFeature?.stopRecording()
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -23,15 +23,12 @@ object SessionReplay {
      * @param sessionReplayConfiguration Configuration to use for the feature.
      * @param sdkCore SDK instance to register feature in. If not provided, default SDK instance
      * will be used.
-     * @param startRecordingImmediately whether to start recording immediately or wait for manual start.
-     * If not provided, the default is to start immediately.
      */
     @JvmOverloads
     @JvmStatic
     fun enable(
         sessionReplayConfiguration: SessionReplayConfiguration,
-        sdkCore: SdkCore = Datadog.getInstance(),
-        startRecordingImmediately: Boolean = true
+        sdkCore: SdkCore = Datadog.getInstance()
     ) {
         val sessionReplayFeature = SessionReplayFeature(
             sdkCore = sdkCore as FeatureSdkCore,
@@ -41,7 +38,7 @@ object SessionReplay {
             customMappers = sessionReplayConfiguration.customMappers,
             customOptionSelectorDetectors = sessionReplayConfiguration.customOptionSelectorDetectors,
             sampleRate = sessionReplayConfiguration.sampleRate,
-            startRecordingImmediately = startRecordingImmediately
+            startRecordingImmediately = sessionReplayConfiguration.startRecordingImmediately
         )
 
         sdkCore.registerFeature(sessionReplayFeature)
@@ -60,7 +57,7 @@ object SessionReplay {
                 it.unwrap() as? SessionReplayFeature
             }
 
-        sessionReplayFeature?.startRecording()
+        sessionReplayFeature?.manuallyStartRecording()
     }
 
     /**
@@ -76,6 +73,6 @@ object SessionReplay {
                 it.unwrap() as? SessionReplayFeature
             }
 
-        sessionReplayFeature?.stopRecording()
+        sessionReplayFeature?.manuallyStopRecording()
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -19,7 +19,8 @@ data class SessionReplayConfiguration internal constructor(
     internal val customMappers: List<MapperTypeWrapper<*>>,
     internal val customOptionSelectorDetectors: List<OptionSelectorDetector>,
     internal val sampleRate: Float,
-    internal val imagePrivacy: ImagePrivacy
+    internal val imagePrivacy: ImagePrivacy,
+    internal val startRecordingImmediately: Boolean
 ) {
 
     /**
@@ -31,6 +32,7 @@ data class SessionReplayConfiguration internal constructor(
         private var customEndpointUrl: String? = null
         private var privacy = SessionReplayPrivacy.MASK
         private var imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY
+        private var startRecordingImmediately = true
         private var extensionSupport: ExtensionSupport = NoOpExtensionSupport()
 
         /**
@@ -77,6 +79,16 @@ data class SessionReplayConfiguration internal constructor(
         }
 
         /**
+         * Should recording start automatically (or be manually started).
+         * If not specified then by default it starts automatically.
+         * @param enabled whether recording should start automatically or not.
+         */
+        fun startRecordingImmediately(enabled: Boolean): Builder {
+            this.startRecordingImmediately = enabled
+            return this
+        }
+
+        /**
          * Builds a [SessionReplayConfiguration] based on the current state of this Builder.
          */
         fun build(): SessionReplayConfiguration {
@@ -86,7 +98,8 @@ data class SessionReplayConfiguration internal constructor(
                 imagePrivacy = imagePrivacy,
                 customMappers = customMappers(),
                 customOptionSelectorDetectors = extensionSupport.getOptionSelectorDetectors(),
-                sampleRate = sampleRate
+                sampleRate = sampleRate,
+                startRecordingImmediately = startRecordingImmediately
             )
         }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -121,6 +121,17 @@ internal class SessionReplayConfigurationBuilderTest {
     }
 
     @Test
+    fun `M pass startRecordingImmediately W startRecordingImmediately`() {
+        // When
+        val sessionReplayConfiguration = testedBuilder
+            .startRecordingImmediately(true)
+            .build()
+
+        // Then
+        assertThat(sessionReplayConfiguration.startRecordingImmediately).isTrue()
+    }
+
+    @Test
     fun `M use the provided custom Mappers W addExtensionSupport()`() {
         // Given
         val sessionReplayConfiguration = testedBuilder

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.sessionreplay
 
+import com.datadog.android.api.feature.Feature.Companion.SESSION_REPLAY_FEATURE_NAME
+import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.SessionReplayFeature
@@ -64,5 +66,41 @@ internal class SessionReplayTest {
             assertThat((lastValue.requestFactory as SegmentRequestFactory).customEndpointUrl)
                 .isEqualTo(fakeSessionReplayConfiguration.customEndpointUrl)
         }
+    }
+
+    @Test
+    fun `M call startRecording on feature W startRecording`(
+        @Mock mockFeatureScope: FeatureScope,
+        @Mock mockSessionReplayFeature: SessionReplayFeature
+    ) {
+        // Given
+        whenever(mockSdkCore.getFeature(SESSION_REPLAY_FEATURE_NAME))
+            .thenReturn(mockFeatureScope)
+
+        whenever(mockFeatureScope.unwrap<SessionReplayFeature>()) doReturn mockSessionReplayFeature
+
+        // When
+        SessionReplay.startRecording(mockSdkCore)
+
+        // Then
+        verify(mockSessionReplayFeature).startRecording()
+    }
+
+    @Test
+    fun `M call stopRecording on feature W stopRecording`(
+        @Mock mockFeatureScope: FeatureScope,
+        @Mock mockSessionReplayFeature: SessionReplayFeature
+    ) {
+        // Given
+        whenever(mockSdkCore.getFeature(SESSION_REPLAY_FEATURE_NAME))
+            .thenReturn(mockFeatureScope)
+
+        whenever(mockFeatureScope.unwrap<SessionReplayFeature>()) doReturn mockSessionReplayFeature
+
+        // When
+        SessionReplay.stopRecording(mockSdkCore)
+
+        // Then
+        verify(mockSessionReplayFeature).stopRecording()
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
@@ -69,7 +69,7 @@ internal class SessionReplayTest {
     }
 
     @Test
-    fun `M call startRecording on feature W startRecording`(
+    fun `M call manuallyStartRecording on feature W startRecording`(
         @Mock mockFeatureScope: FeatureScope,
         @Mock mockSessionReplayFeature: SessionReplayFeature
     ) {
@@ -83,11 +83,11 @@ internal class SessionReplayTest {
         SessionReplay.startRecording(mockSdkCore)
 
         // Then
-        verify(mockSessionReplayFeature).startRecording()
+        verify(mockSessionReplayFeature).manuallyStartRecording()
     }
 
     @Test
-    fun `M call stopRecording on feature W stopRecording`(
+    fun `M call manuallyStopRecording on feature W stopRecording`(
         @Mock mockFeatureScope: FeatureScope,
         @Mock mockSessionReplayFeature: SessionReplayFeature
     ) {
@@ -101,6 +101,6 @@ internal class SessionReplayTest {
         SessionReplay.stopRecording(mockSdkCore)
 
         // Then
-        verify(mockSessionReplayFeature).stopRecording()
+        verify(mockSessionReplayFeature).manuallyStopRecording()
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
@@ -21,6 +21,7 @@ class SessionReplayConfigurationForgeryFactory : ForgeryFactory<SessionReplayCon
             imagePrivacy = forge.aValueFrom(ImagePrivacy::class.java),
             customMappers = forge.aList { mock() },
             customOptionSelectorDetectors = forge.aList { mock() },
+            startRecordingImmediately = forge.aBool(),
             sampleRate = forge.aFloat(min = 0f, max = 100f)
         )
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -829,7 +829,8 @@ internal class SessionReplayFeatureTest {
 
     @Test
     fun `M log warning and do nothing W onReceive() { unknown type property value }`(
-        forge: Forge
+        forge: Forge,
+        @Mock fakeContext: Application
     ) {
         // Given
         val event = mapOf(
@@ -838,6 +839,7 @@ internal class SessionReplayFeatureTest {
         )
 
         // When
+        testedFeature.onInitialize(fakeContext)
         testedFeature.onReceive(event)
 
         // Then
@@ -849,11 +851,13 @@ internal class SessionReplayFeatureTest {
             expectedMessage
         )
 
-        verifyNoInteractions(mockRecorder)
+        verify(mockRecorder, never()).resumeRecorders()
     }
 
     @Test
-    fun `M log warning and do nothing W onReceive() { missing mandatory fields }`() {
+    fun `M log warning and do nothing W onReceive() { missing mandatory fields }`(
+        @Mock fakeContext: Application
+    ) {
         // Given
         val event = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
@@ -861,6 +865,7 @@ internal class SessionReplayFeatureTest {
         )
 
         // When
+        testedFeature.onInitialize(fakeContext)
         testedFeature.onReceive(event)
 
         // Then
@@ -870,11 +875,13 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.EVENT_MISSING_MANDATORY_FIELDS
         )
 
-        verifyNoInteractions(mockRecorder)
+        verify(mockRecorder, never()).resumeRecorders()
     }
 
     @Test
-    fun `M log warning and do nothing W onReceive() { missing keep  state field }`() {
+    fun `M log warning and do nothing W onReceive() { missing keep  state field }`(
+        @Mock fakeContext: Application
+    ) {
         // Given
         val event = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
@@ -883,6 +890,7 @@ internal class SessionReplayFeatureTest {
         )
 
         // When
+        testedFeature.onInitialize(fakeContext)
         testedFeature.onReceive(event)
 
         // Then
@@ -892,12 +900,13 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.EVENT_MISSING_MANDATORY_FIELDS
         )
 
-        verifyNoInteractions(mockRecorder)
+        verify(mockRecorder, never()).resumeRecorders()
     }
 
     @Test
     fun `M log warning and do nothing W onReceive() { missing session id field }`(
-        @BoolForgery fakeKeep: Boolean
+        @BoolForgery fakeKeep: Boolean,
+        @Mock fakeContext: Application
     ) {
         // Given
         val event = mapOf(
@@ -907,6 +916,7 @@ internal class SessionReplayFeatureTest {
         )
 
         // When
+        testedFeature.onInitialize(fakeContext)
         testedFeature.onReceive(event)
 
         // Then
@@ -916,12 +926,13 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.EVENT_MISSING_MANDATORY_FIELDS
         )
 
-        verifyNoInteractions(mockRecorder)
+        verify(mockRecorder, never()).resumeRecorders()
     }
 
     @Test
     fun `M log warning and do nothing W onReceive() { mandatory fields have wrong format }`(
-        forge: Forge
+        forge: Forge,
+        @Mock fakeContext: Application
     ) {
         // Given
         val event = mapOf(
@@ -934,6 +945,7 @@ internal class SessionReplayFeatureTest {
         )
 
         // When
+        testedFeature.onInitialize(fakeContext)
         testedFeature.onReceive(event)
 
         // Then
@@ -943,7 +955,7 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.EVENT_MISSING_MANDATORY_FIELDS
         )
 
-        verifyNoInteractions(mockRecorder)
+        verify(mockRecorder, never()).resumeRecorders()
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -100,6 +100,7 @@ internal class SessionReplayFeatureTest {
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
+            startRecordingImmediately = true,
             rateBasedSampler = mockSampler
         ) { _, _, _, _ -> mockRecorder }
     }
@@ -124,6 +125,7 @@ internal class SessionReplayFeatureTest {
             imagePrivacy = fakeConfiguration.imagePrivacy,
             customMappers = emptyList(),
             customOptionSelectorDetectors = emptyList(),
+            startRecordingImmediately = true,
             sampleRate = fakeConfiguration.sampleRate
         )
 
@@ -145,7 +147,8 @@ internal class SessionReplayFeatureTest {
             imagePrivacy = fakeConfiguration.imagePrivacy,
             customMappers = emptyList(),
             customOptionSelectorDetectors = emptyList(),
-            sampleRate = fakeConfiguration.sampleRate
+            sampleRate = fakeConfiguration.sampleRate,
+            startRecordingImmediately = true
         )
 
         // When
@@ -163,8 +166,8 @@ internal class SessionReplayFeatureTest {
                 .isEqualTo(fakeConfiguration.sampleRate.toLong())
             assertThat(updatedContext[SessionReplayFeature.SESSION_REPLAY_PRIVACY_KEY])
                 .isEqualTo(fakeConfiguration.privacy.toString().lowercase(Locale.US))
-            assertThat(updatedContext[SessionReplayFeature.SESSION_REPLAY_MANUAL_RECORDING_KEY])
-                .isEqualTo(false)
+            assertThat(updatedContext[SessionReplayFeature.SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY])
+                .isEqualTo(true)
         }
     }
 
@@ -176,6 +179,7 @@ internal class SessionReplayFeatureTest {
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
+            startRecordingImmediately = true,
             rateBasedSampler = mockSampler
         ) { _, _, _, _ -> mockRecorder }
 


### PR DESCRIPTION
### What does this PR do?
• Adds apis to manually start and stop session replay

SessionReplay.stopRecording()
SessionReplay.startRecording

• Adds an option to SessionReplayConfiguration so that users can choose to not start recording automatically

SessionReplayConfiguration..
    .startRecordingImmediately(false)

- webviews will not be recorded when SR is stopped
- has_replay will be sent as 'false' to the backend when SR is stopped
- startRecordingImmediately will be sent to the backend in the config telemetry

### Motivation
Give users the option to stop and start recordings manually.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

