### PR TITLE
RUM-5750 Use NO_EXPORT_FLAG for BroadcastReceiver on API above 26

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/receiver/ThreadSafeReceiver.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/receiver/ThreadSafeReceiver.kt
@@ -18,13 +18,16 @@ internal abstract class ThreadSafeReceiver : BroadcastReceiver() {
 
     val isRegistered = AtomicBoolean(false)
 
-    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    // We suppress the warning here as this method is not available on all Android versions
+    @SuppressLint("WrongConstant", "UnspecifiedRegisterReceiverFlag")
     fun registerReceiver(
         context: Context,
         filter: IntentFilter
     ): Intent? {
         val intent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
             context.registerReceiver(this, filter, Context.RECEIVER_NOT_EXPORTED)
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            context.registerReceiver(this, filter, RECEIVER_NOT_EXPORTED_COMPAT)
         } else {
             context.registerReceiver(this, filter)
         }
@@ -36,5 +39,9 @@ internal abstract class ThreadSafeReceiver : BroadcastReceiver() {
         if (isRegistered.compareAndSet(true, false)) {
             context.unregisterReceiver(this)
         }
+    }
+
+    companion object {
+        internal const val RECEIVER_NOT_EXPORTED_COMPAT: Int = 0x4
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/receiver/ThreadSafeReceiverTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/receiver/ThreadSafeReceiverTest.kt
@@ -1,0 +1,133 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.internal.receiver
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.os.Build
+import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.annotations.TestTargetApi
+import com.datadog.tools.unit.extensions.ApiLevelExtension
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.verifyNoInteractions
+import org.mockito.kotlin.verifyNoMoreInteractions
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(ApiLevelExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(Configurator::class)
+internal class ThreadSafeReceiverTest {
+    private lateinit var testedReceiver: ThreadSafeReceiver
+
+    @Mock
+    lateinit var mockContext: Context
+
+    @Mock
+    lateinit var mockIntentFilter: IntentFilter
+
+    @BeforeEach
+    fun `set up`() {
+        testedReceiver = TestableThreadSafeReceiver()
+    }
+
+    // region registerReceiver
+
+    @TestTargetApi(Build.VERSION_CODES.O)
+    @Test
+    fun `M use the no export flag W registerReceiver { API version above 26}`() {
+        // When
+        testedReceiver.registerReceiver(mockContext, mockIntentFilter)
+
+        // Then
+        verify(mockContext).registerReceiver(
+            testedReceiver,
+            mockIntentFilter,
+            ThreadSafeReceiver.RECEIVER_NOT_EXPORTED_COMPAT
+        )
+        assertThat(this.testedReceiver.isRegistered.get()).isTrue()
+    }
+
+    @TestTargetApi(Build.VERSION_CODES.TIRAMISU)
+    @Test
+    fun `M use the no export flag W registerReceiver { API version above 33}`() {
+        // When
+        testedReceiver.registerReceiver(mockContext, mockIntentFilter)
+
+        // Then
+        verify(mockContext).registerReceiver(
+            testedReceiver,
+            mockIntentFilter,
+            Context.RECEIVER_NOT_EXPORTED
+        )
+        assertThat(this.testedReceiver.isRegistered.get()).isTrue()
+    }
+
+    @SuppressLint("UnspecifiedRegisterReceiverFlag")
+    @TestTargetApi(Build.VERSION_CODES.N)
+    @Test
+    fun `M not use the no export flag W registerReceiver { API version below 26}`() {
+        // When
+        testedReceiver.registerReceiver(mockContext, mockIntentFilter)
+
+        // Then
+        verify(mockContext).registerReceiver(testedReceiver, mockIntentFilter)
+        verifyNoMoreInteractions(mockContext)
+        assertThat(this.testedReceiver.isRegistered.get()).isTrue()
+    }
+
+    // endregion
+
+    // region unregisterReceiver
+
+    @Test
+    fun `M unregister the receiver W unregisterReceiver { registered }`() {
+        // Given
+        testedReceiver.isRegistered.set(true)
+
+        // When
+        testedReceiver.unregisterReceiver(mockContext)
+
+        // Then
+        verify(mockContext).unregisterReceiver(testedReceiver)
+        assertThat(this.testedReceiver.isRegistered.get()).isFalse()
+    }
+
+    @Test
+    fun `M do nothing W unregisterReceiver { not registered }`() {
+        // Given
+        testedReceiver.isRegistered.set(false)
+
+        // When
+        testedReceiver.unregisterReceiver(mockContext)
+
+        // Then
+        verifyNoInteractions(mockContext)
+        assertThat(this.testedReceiver.isRegistered.get()).isFalse()
+    }
+
+    // endregion
+}
+
+internal class TestableThreadSafeReceiver : ThreadSafeReceiver() {
+    override fun onReceive(context: Context?, intent: Intent?) {}
+}


### PR DESCRIPTION
### What does this PR do?

This issue was reported by a customer. Their security check tool detected this issue in our SDK where we do not register a receiver with NO_EXPORT_FLAG in API 33 to 26. This method actually exists also below API 33 up to API 26 but the flag Context.NO_EXPORT_FLAG was not available so that's the reason we skipped it. 

I chose not to use the `ContextCompat.NO_EXPORT_FLAG` just to not have to introduce this new dependency just for this case and added a `0x4` local flag myself (same value as the one in Context and ContextCompat). The worse thing it could happen is that this flag to change later but I checked and the SDK is not crashing it is just ignoring it. On the other side if the flag value (logic will change under the hood) we might end up with a different access rights for this receiver exposing again a security issue. I think this is highly unlikely but reviewers please have this in mind.
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

