### PR TITLE
Remove image property from macOS-based jobs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -252,7 +252,6 @@ test-pyramid:single-fit-trace:
 
 test-pyramid:instrumented-legacy-min-api:
   tags: [ "macos:sonoma" ]
-  image: $CI_IMAGE_DOCKER
   stage: test-pyramid
   timeout: 1h
   variables:
@@ -266,7 +265,6 @@ test-pyramid:instrumented-legacy-min-api:
 
 test-pyramid:instrumented-legacy-latest-api:
   tags: [ "macos:sonoma" ]
-  image: $CI_IMAGE_DOCKER
   stage: test-pyramid
   timeout: 1h
   variables:
@@ -280,7 +278,6 @@ test-pyramid:instrumented-legacy-latest-api:
 
 test-pyramid:instrumented-legacy-median-api:
   tags: [ "macos:sonoma" ]
-  image: $CI_IMAGE_DOCKER
   stage: test-pyramid
   timeout: 1h
   variables:


### PR DESCRIPTION
### What does this PR do?

macOS runners are not using Docker, so `image` property is meaningless.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

