### PR TITLE
RUM-5780:Use SurfaceCompoitionGroupMapper to support container components in SR

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/ComposeWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/ComposeWireframeMapper.kt
@@ -44,10 +44,13 @@ internal class ComposeWireframeMapper(
 ) {
 
     private val composeMappers = mapOf<String, CompositionGroupMapper>(
-        "Text" to TextCompositionGroupMapper(colorStringFormatter),
-        "Button" to ButtonCompositionGroupMapper(colorStringFormatter),
+        "BottomNavigation" to SurfaceCompositionGroupMapper(colorStringFormatter),
+        "BottomNavigationItem" to TabCompositionGroupMapper(colorStringFormatter),
+        "TopAppBar" to SurfaceCompositionGroupMapper(colorStringFormatter),
+        "TabRow" to SurfaceCompositionGroupMapper(colorStringFormatter),
         "Tab" to TabCompositionGroupMapper(colorStringFormatter),
-        "TabRow" to TabRowCompositionGroupMapper(colorStringFormatter)
+        "Text" to TextCompositionGroupMapper(colorStringFormatter),
+        "Button" to ButtonCompositionGroupMapper(colorStringFormatter)
     )
 
     // region WireframeMapper

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/SurfaceCompositionGroupMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/SurfaceCompositionGroupMapper.kt
@@ -13,9 +13,14 @@ import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 
-internal class TabRowCompositionGroupMapper(
-    colorStringFormatter: ColorStringFormatter
-) : AbstractCompositionGroupMapper(colorStringFormatter) {
+/**
+ * This class is responsible to map the Jetpack compose components which have "backgroundColor" & "contentColor"
+ * in the parameter list, these components are mostly container components such as [BottomNavigation], [TopAppBar]
+ * and [TabRow], etc.., they usually have a [Surface] implementation under the hood, and can take other composable
+ * inside.
+ */
+internal open class SurfaceCompositionGroupMapper(colorStringFormatter: ColorStringFormatter) :
+    AbstractCompositionGroupMapper(colorStringFormatter) {
     override fun map(
         stableGroupId: Long,
         parameters: Sequence<ComposableParameter>,

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/SurfaceCompositionGroupMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/SurfaceCompositionGroupMapper.kt
@@ -14,10 +14,10 @@ import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 
 /**
- * This class is responsible to map the Jetpack compose components which have "backgroundColor" & "contentColor"
- * in the parameter list, these components are mostly container components such as [BottomNavigation], [TopAppBar]
- * and [TabRow], etc.., they usually have a [Surface] implementation under the hood, and can take other composable
- * inside.
+ * This class is responsible for the mapping of the Jetpack Compose components which have "backgroundColor"
+ * & "contentColor" in the parameter list. These components are mostly container components such as
+ * [BottomNavigation], [TopAppBar] and [TabRow], etc. They usually have a [Surface] implementation under the hood,
+ * and can take other composable inside.
  */
 internal open class SurfaceCompositionGroupMapper(colorStringFormatter: ColorStringFormatter) :
     AbstractCompositionGroupMapper(colorStringFormatter) {

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/SurfaceCompositionGroupMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/SurfaceCompositionGroupMapperTest.kt
@@ -34,9 +34,9 @@ import kotlin.math.roundToInt
 )
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(SessionReplayComposeForgeConfigurator::class)
-internal class TabRowCompositionGroupMapperTest : AbstractCompositionGroupMapperTest() {
+internal class SurfaceCompositionGroupMapperTest : AbstractCompositionGroupMapperTest() {
 
-    private lateinit var tabRowCompositionGroupMapper: TabRowCompositionGroupMapper
+    private lateinit var surfaceCompositionGroupMapper: SurfaceCompositionGroupMapper
 
     private lateinit var mockCompositionGroup: CompositionGroup
 
@@ -44,7 +44,7 @@ internal class TabRowCompositionGroupMapperTest : AbstractCompositionGroupMapper
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        tabRowCompositionGroupMapper = TabRowCompositionGroupMapper(colorStringFormatter = mockColorStringFormatter)
+        surfaceCompositionGroupMapper = SurfaceCompositionGroupMapper(colorStringFormatter = mockColorStringFormatter)
         mockCompositionGroup = mockGroupWithCoordinates(forge)
         fakeBoxWithDensity = Box(
             left = forge.aLong(),
@@ -67,7 +67,7 @@ internal class TabRowCompositionGroupMapperTest : AbstractCompositionGroupMapper
         ).thenReturn(contentColorHexStr)
 
         // When
-        val actual = tabRowCompositionGroupMapper.map(
+        val actual = surfaceCompositionGroupMapper.map(
             stableGroupId = fakeGroupId,
             parameters = listOf(
                 ComposableParameter(
@@ -98,7 +98,7 @@ internal class TabRowCompositionGroupMapperTest : AbstractCompositionGroupMapper
                 convertColorIntAlpha(backgroundColor).second
             )
         ).thenReturn(backgroundColorHexStr)
-        val actual = tabRowCompositionGroupMapper.map(
+        val actual = surfaceCompositionGroupMapper.map(
             stableGroupId = fakeGroupId,
             parameters = listOf(
                 ComposableParameter(

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/JetpackComposeActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/JetpackComposeActivity.kt
@@ -10,12 +10,23 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.BottomNavigation
+import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
 import androidx.compose.material.Tab
 import androidx.compose.material.TabRow
 import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.snapshotFlow
@@ -37,83 +48,135 @@ import kotlinx.coroutines.launch
  */
 class JetpackComposeActivity : AppCompatActivity() {
 
-    @Suppress("LongMethod")
-    @OptIn(ExperimentalPagerApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
             AppCompatTheme {
-                Column {
-                    val pages = remember {
-                        listOf(Page.Navigation, Page.Interactions)
+                AppScaffold()
+            }
+        }
+    }
+
+    @Composable
+    private fun NavigationBar() {
+        val selectedIndex = remember { mutableIntStateOf(1) }
+        BottomNavigation {
+            BottomNavigationItem(
+                selected = selectedIndex.intValue == 1,
+                onClick = {
+                    selectedIndex.intValue = 1
+                },
+                icon = {
+                    Icon(imageVector = Icons.Filled.Edit, contentDescription = null)
+                },
+                label = {
+                    Text("label 1")
+                }
+            )
+
+            BottomNavigationItem(
+                selected = selectedIndex.intValue == 2,
+                onClick = {
+                    selectedIndex.intValue = 2
+                },
+                icon = {
+                    Icon(imageVector = Icons.Filled.Email, contentDescription = null)
+                },
+                label = {
+                    Text("label 2")
+                }
+            )
+        }
+    }
+
+    @Composable
+    @OptIn(ExperimentalPagerApi::class)
+    private fun AppScaffold() {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title =
+                    {
+                        Text("Jetpack compose top bar")
                     }
+                )
+            },
+            bottomBar = {
+                NavigationBar()
+            }
+        ) {
+            AppContent(modifier = Modifier.padding(it))
+        }
+    }
 
-                    val pagerState = rememberPagerState()
+    @Composable
+    @OptIn(ExperimentalPagerApi::class)
+    @Suppress("LongMethod")
+    private fun AppContent(modifier: Modifier = Modifier) {
+        Column(modifier) {
+            val pages = remember {
+                listOf(Page.Navigation, Page.Interactions)
+            }
+            val pagerState = rememberPagerState()
+            val lifecycleOwner = LocalLifecycleOwner.current
+            DisposableEffect(lifecycleOwner) {
+                val observer = LifecycleEventObserver { _, event ->
+                    val rumMonitor = GlobalRumMonitor.get()
+                    val screen = pages[pagerState.currentPage].trackingName
+                    if (event == Lifecycle.Event.ON_RESUME) {
+                        rumMonitor.startView(screen, screen)
+                    } else if (event == Lifecycle.Event.ON_PAUSE) {
+                        rumMonitor.stopView(screen)
+                    }
+                }
+                lifecycleOwner.lifecycle.addObserver(observer)
+                onDispose {
+                    lifecycleOwner.lifecycle.removeObserver(observer)
+                }
+            }
 
-                    val lifecycleOwner = LocalLifecycleOwner.current
-                    DisposableEffect(lifecycleOwner) {
-                        val observer = LifecycleEventObserver { _, event ->
-                            val rumMonitor = GlobalRumMonitor.get()
-                            val screen = pages[pagerState.currentPage].trackingName
-                            if (event == Lifecycle.Event.ON_RESUME) {
-                                rumMonitor.startView(screen, screen)
-                            } else if (event == Lifecycle.Event.ON_PAUSE) {
-                                rumMonitor.stopView(screen)
+            LaunchedEffect(pagerState) {
+                snapshotFlow { pagerState.currentPage }
+                    // drop 1st, because it will be tracked by the lifecycle
+                    .drop(1)
+                    .collect { page ->
+                        val screen = pages[page].trackingName
+                        GlobalRumMonitor.get().startView(screen, screen)
+                    }
+            }
+
+            TabRow(
+                selectedTabIndex = pagerState.currentPage,
+                indicator = { tabPositions ->
+                    TabRowDefaults.Indicator(
+                        modifier = Modifier.pagerTabIndicatorOffset(
+                            pagerState,
+                            tabPositions
+                        ),
+                        height = TabRowDefaults.IndicatorHeight * 2
+                    )
+                }
+            ) {
+                val coroutineScope = rememberCoroutineScope()
+                pages.forEachIndexed { index, page ->
+                    Tab(
+                        text = { Text(page.name) },
+                        selected = pagerState.currentPage == index,
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(index)
                             }
                         }
-
-                        lifecycleOwner.lifecycle.addObserver(observer)
-
-                        onDispose {
-                            lifecycleOwner.lifecycle.removeObserver(observer)
-                        }
-                    }
-
-                    LaunchedEffect(pagerState) {
-                        snapshotFlow { pagerState.currentPage }
-                            // drop 1st, because it will be tracked by the lifecycle
-                            .drop(1)
-                            .collect { page ->
-                                val screen = pages[page].trackingName
-                                GlobalRumMonitor.get().startView(screen, screen)
-                            }
-                    }
-
-                    TabRow(
-                        selectedTabIndex = pagerState.currentPage,
-                        indicator = { tabPositions ->
-                            TabRowDefaults.Indicator(
-                                modifier = Modifier.pagerTabIndicatorOffset(
-                                    pagerState,
-                                    tabPositions
-                                ),
-                                height = TabRowDefaults.IndicatorHeight * 2
-                            )
-                        }
-                    ) {
-                        val coroutineScope = rememberCoroutineScope()
-                        pages.forEachIndexed { index, page ->
-                            Tab(
-                                text = { Text(page.name) },
-                                selected = pagerState.currentPage == index,
-                                onClick = {
-                                    coroutineScope.launch {
-                                        pagerState.animateScrollToPage(index)
-                                    }
-                                }
-                            )
-                        }
-                    }
-
-                    HorizontalPager(
-                        count = pages.size,
-                        state = pagerState
-                    ) { page ->
-                        when (page) {
-                            0 -> NavigationSampleView()
-                            else -> InteractionSampleView()
-                        }
-                    }
+                    )
+                }
+            }
+            HorizontalPager(
+                count = pages.size,
+                state = pagerState
+            ) { page ->
+                when (page) {
+                    0 -> NavigationSampleView()
+                    else -> InteractionSampleView()
                 }
             }
         }


### PR DESCRIPTION
### What does this PR do?

* Convert `TabRowCompositionGroupMapper` to `SurfaceCompoitionGroupMapper`, because the way it maps the wireframe can be reused in a lot of Jetpack compose container components such as BottomNavigation, TopAppBar, TabRow.


### Motivation

RUM-5780

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

