### PR TITLE
RUM-5830: Make no-op RUM monitor implementation returned by default to be `NoOpAdvancedRumMonitor`

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/GlobalRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/GlobalRumMonitor.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.rum.GlobalRumMonitor.get
+import com.datadog.android.rum.internal.monitor.NoOpAdvancedRumMonitor
 import java.util.Locale
 
 /**
@@ -64,7 +65,7 @@ object GlobalRumMonitor {
                         InternalLogger.Target.USER,
                         { NO_MONITOR_REGISTERED_MESSAGE.format(Locale.US, sdkCore.name) }
                     )
-                NoOpRumMonitor()
+                NoOpAdvancedRumMonitor()
             } else {
                 monitor
             }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/GlobalRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/GlobalRumMonitorTest.kt
@@ -9,6 +9,7 @@ package com.datadog.android.rum
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.FeatureSdkCore
+import com.datadog.android.rum.internal.monitor.NoOpAdvancedRumMonitor
 import com.datadog.android.rum.utils.forge.Configurator
 import com.datadog.android.rum.utils.verifyLog
 import com.datadog.tools.unit.annotations.ProhibitLeavingStaticMocksIn
@@ -131,7 +132,7 @@ internal class GlobalRumMonitorTest {
     }
 
     @Test
-    fun `M return NoOpRumMonitor W registerIfAbsent(monitor) + get() {distinct cores}`() {
+    fun `M return NoOpAdvancedRumMonitor W registerIfAbsent(monitor) + get() {distinct cores}`() {
         // Given
         val mockSdkCore2 = mock<SdkCore>()
 
@@ -140,7 +141,7 @@ internal class GlobalRumMonitorTest {
         val result = GlobalRumMonitor.get(mockSdkCore2)
 
         // Then
-        assertThat(result).isInstanceOf(NoOpRumMonitor::class.java)
+        assertThat(result).isInstanceOf(NoOpAdvancedRumMonitor::class.java)
     }
 
     @Test
@@ -154,7 +155,7 @@ internal class GlobalRumMonitorTest {
         val result = GlobalRumMonitor.get(mockSdkCore)
 
         // Then
-        check(result is NoOpRumMonitor)
+        check(result is NoOpAdvancedRumMonitor)
         mockInternalLogger.verifyLog(
             InternalLogger.Level.WARN,
             InternalLogger.Target.USER,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/RumTest.kt
@@ -15,6 +15,7 @@ import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.rum.internal.RumFeature
 import com.datadog.android.rum.internal.domain.scope.RumApplicationScope
 import com.datadog.android.rum.internal.monitor.DatadogRumMonitor
+import com.datadog.android.rum.internal.monitor.NoOpAdvancedRumMonitor
 import com.datadog.android.rum.internal.net.RumRequestFactory
 import com.datadog.android.rum.tracking.NoOpTrackingStrategy
 import com.datadog.android.rum.tracking.NoOpViewTrackingStrategy
@@ -172,7 +173,7 @@ internal class RumTest {
             Rum.UNEXPECTED_SDK_CORE_TYPE
         )
         verify(mockSdkCore, never()).registerFeature(any())
-        check(GlobalRumMonitor.get(mockSdkCore) is NoOpRumMonitor)
+        check(GlobalRumMonitor.get(mockSdkCore) is NoOpAdvancedRumMonitor)
     }
 
     @Test
@@ -197,7 +198,7 @@ internal class RumTest {
             Rum.INVALID_APPLICATION_ID_ERROR_MESSAGE
         )
         verify(mockSdkCore, never()).registerFeature(any())
-        check(GlobalRumMonitor.get(mockSdkCore) is NoOpRumMonitor)
+        check(GlobalRumMonitor.get(mockSdkCore) is NoOpAdvancedRumMonitor)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/RumFeatureTest.kt
@@ -20,13 +20,13 @@ import com.datadog.android.core.internal.system.BuildSdkVersionProvider
 import com.datadog.android.event.EventMapper
 import com.datadog.android.event.MapperSerializer
 import com.datadog.android.rum.GlobalRumMonitor
-import com.datadog.android.rum.NoOpRumMonitor
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.assertj.RumFeatureAssert
 import com.datadog.android.rum.configuration.VitalsUpdateFrequency
 import com.datadog.android.rum.internal.domain.RumDataWriter
 import com.datadog.android.rum.internal.domain.event.RumEventMapper
 import com.datadog.android.rum.internal.monitor.AdvancedRumMonitor
+import com.datadog.android.rum.internal.monitor.NoOpAdvancedRumMonitor
 import com.datadog.android.rum.internal.thread.NoOpScheduledExecutorService
 import com.datadog.android.rum.internal.tracking.NoOpInteractionPredicate
 import com.datadog.android.rum.internal.tracking.NoOpUserActionTrackingStrategy
@@ -604,7 +604,7 @@ internal class RumFeatureTest {
 
         // Then
         assertThat(GlobalRumMonitor.isRegistered(mockSdkCore)).isFalse
-        assertThat(GlobalRumMonitor.get(mockSdkCore)).isInstanceOf(NoOpRumMonitor::class.java)
+        assertThat(GlobalRumMonitor.get(mockSdkCore)).isInstanceOf(NoOpAdvancedRumMonitor::class.java)
     }
 
     @ParameterizedTest

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -247,7 +247,7 @@ internal constructor(
             val method = toHttpMethod(request.method, sdkCore.internalLogger)
             val requestId = request.buildResourceId(generateUuid = true)
 
-            (GlobalRumMonitor.get(sdkCore) as AdvancedNetworkRumMonitor).startResource(requestId, method, url)
+            (GlobalRumMonitor.get(sdkCore) as? AdvancedNetworkRumMonitor)?.startResource(requestId, method, url)
         } else {
             val prefix = if (sdkInstanceName == null) {
                 "Default SDK instance"


### PR DESCRIPTION
### What does this PR do?

Fixes https://github.com/DataDog/dd-sdk-android/issues/2183. 

https://github.com/DataDog/dd-sdk-android/pull/2126 introduced some changes and now we need to have an instance of `AdvancedRumMonitor` for OkHttp instrumentation.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

