### PR TITLE
Speed up `IdGenerationStrategy` test

### DIFF
--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/trace/api/IdGenerationStrategyTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/trace/api/IdGenerationStrategyTest.kt
@@ -39,20 +39,20 @@ internal class IdGenerationStrategyTest {
         val highOrderLowerBound = (System.currentTimeMillis() / 1000).shl(32)
         isTid128.forEach { tId128b ->
             val strategy = IdGenerationStrategy.fromName(strategyName, tId128b)
-            val traceIds = (0..32768).map { strategy.generateTraceId() }
+            val traceIds = (0..4096).map { strategy.generateTraceId() }
             val checked = HashSet<DDTraceId>()
 
             traceIds.forEach { traceId ->
                 assertThat(traceId).isNotNull
-                assertThat(traceId.equals("foo")).isFalse()
-                assertThat(traceId.equals(DDTraceId.ZERO)).isFalse()
-                assertThat(traceId.equals(traceId)).isTrue()
+                assertThat(traceId).isNotEqualTo("foo")
+                assertThat(traceId).isNotEqualTo(DDTraceId.ZERO)
+                assertThat(traceId).isEqualTo(traceId)
                 val hashCode =
                     (
                         traceId.toHighOrderLong() xor (traceId.toHighOrderLong() ushr 32)
                             xor traceId.toLong() xor (traceId.toLong() ushr 32)
                         ).toInt()
-                assertThat(hashCode == traceId.hashCode()).isTrue()
+                assertThat(hashCode).isEqualTo(traceId.hashCode())
                 assertThat(checked).doesNotContain(traceId)
                 if (tId128b && strategyName != "SEQUENTIAL") {
                     val highOrderUpperBound = (System.currentTimeMillis() / 1000).shl(32)


### PR DESCRIPTION
### What does this PR do?

`M generate id with strategyName and tIdSize bits` test was taking almost 1 minute to run on my machine (takes even more on CI), so speeding it up by lowering down the number of trace IDs being generated.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

