### PR TITLE
RUM-5831: Speed up generated files/licenses checks

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -118,7 +118,7 @@ tasks.register("unitTestAll") {
 registerSubModuleAggregationTask("lintCheckAll", "lintRelease") {
     dependsOn(":tools:lint:lint")
 }
-registerSubModuleAggregationTask("checkDependencyLicencesAll", "checkDependencyLicences")
+registerSubModuleAggregationTask("checkDependencyLicencesAll", "checkDependencyLicenses")
 
 registerSubModuleAggregationTask("checkApiSurfaceChangesAll", "checkApiSurfaceChanges")
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -70,7 +70,7 @@ kotlinPoet = "1.14.2"
 kotlinGrammarParser = "9b264ee"
 jsonSchemaValidator = "1.12.1"
 binaryCompatibility = "0.13.2"
-dependencyLicense = "0.2"
+dependencyLicense = "0.3"
 
 # Integrations
 realm = "1.11.0"


### PR DESCRIPTION
### What does this PR do?

`generated-files-check` job takes 30+ minutes on the CI ([link](https://gitlab.ddbuild.io/DataDog/dd-sdk-android/-/jobs/602898072)). It is essentially a gradle task `checkGeneratedFiles` in our case which runs licenses check, API surface check and transitive dependencies check. The main bottleneck is the task to check licenses.

With https://github.com/DataDog/gradle-dependency-license-plugin/pull/19 merged and released the job now takes only 8 minutes, so it is 4 times faster.

It is essentially possible to improve the change in the PR mentioned above by sharing the cache between the projects, but the current gain is already good enough for our needs (Detekt run with custom rules in the same stage takes 7+ minutes).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

