### PR TITLE
Add Typography screen in sample application for Jetpack Compose SR

### DIFF
--- a/sample/kotlin/src/main/AndroidManifest.xml
+++ b/sample/kotlin/src/main/AndroidManifest.xml
@@ -45,7 +45,12 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
-        <activity android:name=".compose.JetpackComposeActivity" />
+        <activity
+            android:name=".compose.JetpackComposeActivity"
+            android:theme="@style/Sample.Theme.Compose" />
+        <activity
+            android:name="com.datadog.android.sample.compose.LegacyComposeActivity"
+            android:theme="@style/Sample.Theme.Compose" />
 
         <service
             android:name=".service.LogsForegroundService"

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/DimensionExt.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/DimensionExt.kt
@@ -1,0 +1,11 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sample.compose
+
+import androidx.compose.ui.unit.dp
+
+internal val DefaultPadding = 16.dp

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/JetpackComposeActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/JetpackComposeActivity.kt
@@ -9,39 +9,18 @@ package com.datadog.android.sample.compose
 import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
-import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.BottomNavigation
-import androidx.compose.material.BottomNavigationItem
-import androidx.compose.material.Icon
 import androidx.compose.material.Scaffold
-import androidx.compose.material.Tab
-import androidx.compose.material.TabRow
-import androidx.compose.material.TabRowDefaults
 import androidx.compose.material.Text
 import androidx.compose.material.TopAppBar
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material.icons.filled.Email
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalLifecycleOwner
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.LifecycleEventObserver
-import com.datadog.android.rum.GlobalRumMonitor
+import androidx.navigation.compose.NavHost
+import androidx.navigation.compose.rememberNavController
+import com.datadog.android.compose.ExperimentalTrackingApi
+import com.datadog.android.compose.NavigationViewTrackingEffect
+import com.datadog.android.rum.tracking.AcceptAllNavDestinations
 import com.google.accompanist.appcompattheme.AppCompatTheme
-import com.google.accompanist.pager.ExperimentalPagerApi
-import com.google.accompanist.pager.HorizontalPager
-import com.google.accompanist.pager.pagerTabIndicatorOffset
-import com.google.accompanist.pager.rememberPagerState
-import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.launch
 
 /**
  * An activity to showcase Jetpack Compose instrumentation.
@@ -58,39 +37,6 @@ class JetpackComposeActivity : AppCompatActivity() {
     }
 
     @Composable
-    private fun NavigationBar() {
-        val selectedIndex = remember { mutableIntStateOf(1) }
-        BottomNavigation {
-            BottomNavigationItem(
-                selected = selectedIndex.intValue == 1,
-                onClick = {
-                    selectedIndex.intValue = 1
-                },
-                icon = {
-                    Icon(imageVector = Icons.Filled.Edit, contentDescription = null)
-                },
-                label = {
-                    Text("label 1")
-                }
-            )
-
-            BottomNavigationItem(
-                selected = selectedIndex.intValue == 2,
-                onClick = {
-                    selectedIndex.intValue = 2
-                },
-                icon = {
-                    Icon(imageVector = Icons.Filled.Email, contentDescription = null)
-                },
-                label = {
-                    Text("label 2")
-                }
-            )
-        }
-    }
-
-    @Composable
-    @OptIn(ExperimentalPagerApi::class)
     private fun AppScaffold() {
         Scaffold(
             topBar = {
@@ -100,9 +46,6 @@ class JetpackComposeActivity : AppCompatActivity() {
                         Text("Jetpack compose top bar")
                     }
                 )
-            },
-            bottomBar = {
-                NavigationBar()
             }
         ) {
             AppContent(modifier = Modifier.padding(it))
@@ -110,75 +53,22 @@ class JetpackComposeActivity : AppCompatActivity() {
     }
 
     @Composable
-    @OptIn(ExperimentalPagerApi::class)
-    @Suppress("LongMethod")
+    @OptIn(ExperimentalTrackingApi::class)
     private fun AppContent(modifier: Modifier = Modifier) {
-        Column(modifier) {
-            val pages = remember {
-                listOf(Page.Navigation, Page.Interactions)
-            }
-            val pagerState = rememberPagerState()
-            val lifecycleOwner = LocalLifecycleOwner.current
-            DisposableEffect(lifecycleOwner) {
-                val observer = LifecycleEventObserver { _, event ->
-                    val rumMonitor = GlobalRumMonitor.get()
-                    val screen = pages[pagerState.currentPage].trackingName
-                    if (event == Lifecycle.Event.ON_RESUME) {
-                        rumMonitor.startView(screen, screen)
-                    } else if (event == Lifecycle.Event.ON_PAUSE) {
-                        rumMonitor.stopView(screen)
-                    }
-                }
-                lifecycleOwner.lifecycle.addObserver(observer)
-                onDispose {
-                    lifecycleOwner.lifecycle.removeObserver(observer)
-                }
-            }
-
-            LaunchedEffect(pagerState) {
-                snapshotFlow { pagerState.currentPage }
-                    // drop 1st, because it will be tracked by the lifecycle
-                    .drop(1)
-                    .collect { page ->
-                        val screen = pages[page].trackingName
-                        GlobalRumMonitor.get().startView(screen, screen)
-                    }
-            }
-
-            TabRow(
-                selectedTabIndex = pagerState.currentPage,
-                indicator = { tabPositions ->
-                    TabRowDefaults.Indicator(
-                        modifier = Modifier.pagerTabIndicatorOffset(
-                            pagerState,
-                            tabPositions
-                        ),
-                        height = TabRowDefaults.IndicatorHeight * 2
-                    )
-                }
-            ) {
-                val coroutineScope = rememberCoroutineScope()
-                pages.forEachIndexed { index, page ->
-                    Tab(
-                        text = { Text(page.name) },
-                        selected = pagerState.currentPage == index,
-                        onClick = {
-                            coroutineScope.launch {
-                                pagerState.animateScrollToPage(index)
-                            }
-                        }
-                    )
-                }
-            }
-            HorizontalPager(
-                count = pages.size,
-                state = pagerState
-            ) { page ->
-                when (page) {
-                    0 -> NavigationSampleView()
-                    else -> InteractionSampleView()
-                }
-            }
+        val navController = rememberNavController()
+        NavigationViewTrackingEffect(
+            navController = navController,
+            trackArguments = true,
+            destinationPredicate = AcceptAllNavDestinations()
+        )
+        NavHost(
+            navController = navController,
+            startDestination = SampleScreen.Root.navigationRoute,
+            modifier = modifier
+        ) {
+            selectionNavigation(
+                navController = navController
+            )
         }
     }
 }

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/LegacyComposeActivity.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/LegacyComposeActivity.kt
@@ -1,0 +1,180 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sample.compose
+
+import android.os.Bundle
+import androidx.activity.compose.setContent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.BottomNavigation
+import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material.Icon
+import androidx.compose.material.Scaffold
+import androidx.compose.material.Tab
+import androidx.compose.material.TabRow
+import androidx.compose.material.TabRowDefaults
+import androidx.compose.material.Text
+import androidx.compose.material.TopAppBar
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Email
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLifecycleOwner
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
+import com.datadog.android.rum.GlobalRumMonitor
+import com.google.accompanist.appcompattheme.AppCompatTheme
+import com.google.accompanist.pager.ExperimentalPagerApi
+import com.google.accompanist.pager.HorizontalPager
+import com.google.accompanist.pager.pagerTabIndicatorOffset
+import com.google.accompanist.pager.rememberPagerState
+import kotlinx.coroutines.flow.drop
+import kotlinx.coroutines.launch
+
+internal class LegacyComposeActivity : AppCompatActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        actionBar?.hide()
+        setContent {
+            AppCompatTheme {
+                AppScaffold()
+            }
+        }
+    }
+
+    @Composable
+    private fun AppScaffold() {
+        Scaffold(
+            topBar = {
+                TopAppBar(
+                    title = {
+                        Text("Jetpack compose top bar")
+                    }
+                )
+            },
+            bottomBar = {
+                NavigationBar()
+            }
+        ) {
+            AppContent(modifier = Modifier.padding(it))
+        }
+    }
+
+    @Composable
+    private fun NavigationBar() {
+        val selectedIndex = remember { mutableIntStateOf(1) }
+        BottomNavigation {
+            BottomNavigationItem(
+                selected = selectedIndex.intValue == 1,
+                onClick = {
+                    selectedIndex.intValue = 1
+                },
+                icon = {
+                    Icon(imageVector = Icons.Filled.Edit, contentDescription = null)
+                },
+                label = {
+                    Text("label 1")
+                }
+            )
+
+            BottomNavigationItem(
+                selected = selectedIndex.intValue == 2,
+                onClick = {
+                    selectedIndex.intValue = 2
+                },
+                icon = {
+                    Icon(imageVector = Icons.Filled.Email, contentDescription = null)
+                },
+                label = {
+                    Text("label 2")
+                }
+            )
+        }
+    }
+
+    @Composable
+    @OptIn(ExperimentalPagerApi::class)
+    @Suppress("LongMethod")
+    private fun AppContent(modifier: Modifier = Modifier) {
+        Column(modifier) {
+            val pages = remember {
+                listOf(Page.Navigation, Page.Interactions)
+            }
+            val pagerState = rememberPagerState()
+            val lifecycleOwner = LocalLifecycleOwner.current
+            DisposableEffect(lifecycleOwner) {
+                val observer = LifecycleEventObserver { _, event ->
+                    val rumMonitor = GlobalRumMonitor.get()
+                    val screen = pages[pagerState.currentPage].trackingName
+                    if (event == Lifecycle.Event.ON_RESUME) {
+                        rumMonitor.startView(screen, screen)
+                    } else if (event == Lifecycle.Event.ON_PAUSE) {
+                        rumMonitor.stopView(screen)
+                    }
+                }
+                lifecycleOwner.lifecycle.addObserver(observer)
+                onDispose {
+                    lifecycleOwner.lifecycle.removeObserver(observer)
+                }
+            }
+
+            LaunchedEffect(pagerState) {
+                snapshotFlow { pagerState.currentPage }
+                    // drop 1st, because it will be tracked by the lifecycle
+                    .drop(1)
+                    .collect { page ->
+                        val screen = pages[page].trackingName
+                        GlobalRumMonitor.get().startView(screen, screen)
+                    }
+            }
+
+            TabRow(
+                selectedTabIndex = pagerState.currentPage,
+                indicator = { tabPositions ->
+                    TabRowDefaults.Indicator(
+                        modifier = Modifier.pagerTabIndicatorOffset(
+                            pagerState,
+                            tabPositions
+                        ),
+                        height = TabRowDefaults.IndicatorHeight * 2
+                    )
+                }
+            ) {
+                val coroutineScope = rememberCoroutineScope()
+                pages.forEachIndexed { index, page ->
+                    Tab(
+                        text = { Text(page.name) },
+                        selected = pagerState.currentPage == index,
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(index)
+                            }
+                        }
+                    )
+                }
+            }
+            HorizontalPager(
+                count = pages.size,
+                state = pagerState
+            ) { page ->
+                when (page) {
+                    0 -> NavigationSampleView()
+                    else -> InteractionSampleView()
+                }
+            }
+        }
+    }
+}

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/SampleSelectionScreen.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/SampleSelectionScreen.kt
@@ -1,0 +1,109 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sample.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.Button
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.navigation.NavGraphBuilder
+import androidx.navigation.NavHostController
+import androidx.navigation.activity
+import androidx.navigation.compose.composable
+
+@Composable
+internal fun SampleSelectionScreen(
+    onTypographyClicked: () -> Unit,
+    onLegacyClicked: () -> Unit
+) {
+    Column(
+        modifier = Modifier.fillMaxSize(),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            modifier = Modifier.padding(DefaultPadding),
+            text = "Jetpack Compose Sample",
+            style = MaterialTheme.typography.h6
+        )
+        StyledButton(
+            text = "Typography Sample",
+            onClick = onTypographyClicked
+        )
+        StyledButton(
+            text = "Legacy Sample",
+            onClick = onLegacyClicked
+        )
+    }
+}
+
+@Composable
+private fun StyledButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    text: String
+) {
+    Button(
+        modifier = modifier.fillMaxWidth().padding(DefaultPadding),
+        content = {
+            Text(text)
+        },
+        onClick = onClick
+    )
+}
+
+internal fun NavGraphBuilder.selectionNavigation(navController: NavHostController) {
+    composable(SampleScreen.Root.navigationRoute) {
+        SampleSelectionScreen(
+            onTypographyClicked = {
+                navController.navigate(SampleScreen.Typography.navigationRoute)
+            },
+            onLegacyClicked = {
+                navController.navigate(SampleScreen.Legacy.navigationRoute)
+            }
+        )
+    }
+
+    composable(SampleScreen.Typography.navigationRoute) {
+        TypographySample()
+    }
+
+    activity(SampleScreen.Legacy.navigationRoute) {
+        activityClass = LegacyComposeActivity::class
+    }
+}
+
+internal sealed class SampleScreen(
+    val navigationRoute: String
+) {
+
+    object Root : SampleScreen(COMPOSE_ROOT)
+    object Typography : SampleScreen("$COMPOSE_ROOT/typography")
+    object Legacy : SampleScreen("$COMPOSE_ROOT/legacy")
+
+    companion object {
+        private const val COMPOSE_ROOT = "compose"
+    }
+}
+
+@Preview
+@Composable
+@Suppress("UnusedPrivateMember")
+private fun PreviewSampleSelectionScreen() {
+    SampleSelectionScreen(
+        onLegacyClicked = {
+        },
+        onTypographyClicked = {
+        }
+    )
+}

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/TypographySample.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/compose/TypographySample.kt
@@ -1,0 +1,67 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sample.compose
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.MaterialTheme
+import androidx.compose.material.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+internal fun TypographySample() {
+    Column {
+        Text(
+            text = "Material H3 - onBackground",
+            style = MaterialTheme.typography.h3,
+            modifier = Modifier.padding(16.dp),
+            color = MaterialTheme.colors.onBackground
+        )
+
+        Text(
+            text = "Material H4 - onSurface",
+            style = MaterialTheme.typography.h4,
+            modifier = Modifier.padding(16.dp),
+            color = MaterialTheme.colors.onSurface
+        )
+
+        Text(
+            text = "Material H6 - Red",
+            style = MaterialTheme.typography.h6,
+            modifier = Modifier.padding(16.dp),
+            color = Color.Red
+        )
+
+        Text(
+            text = "Material Body 1 - Green",
+            style = MaterialTheme.typography.body1.copy(
+                color = Color.Blue
+            ),
+            modifier = Modifier.padding(16.dp),
+            color = Color.Green
+        )
+
+        Text(
+            text = "Material Caption - Blue",
+            style = MaterialTheme.typography.caption.copy(
+                color = Color.Blue
+            ),
+            modifier = Modifier.padding(16.dp)
+        )
+    }
+}
+
+@Preview
+@Composable
+@Suppress("UnusedPrivateMember")
+private fun PreviewTypographySample() {
+    TypographySample()
+}

--- a/sample/kotlin/src/main/res/values/themes.xml
+++ b/sample/kotlin/src/main/res/values/themes.xml
@@ -14,6 +14,12 @@
         <item name="colorPrimaryDark">@color/datadog_violet_dark</item>
     </style>
 
+    <style name="Sample.Theme.Compose" parent="Theme.MaterialComponents.Light.NoActionBar">
+        <item name="android:windowBackground">@color/white</item>
+
+        <item name="colorPrimary">@color/datadog_violet</item>
+        <item name="colorPrimaryDark">@color/datadog_violet_dark</item>
+    </style>
 
 
     <style name="Sample.Theme.Custom" parent="Theme.MaterialComponents.Light.DarkActionBar">


### PR DESCRIPTION
### What does this PR do?

* Add a selection screen for Jetpack Compose session replay
* Add a Typography screen to demo the text as Jetpack Compose
* Move to the current demo screen to `LegacyActivity`.

### Motivation

Prepare to demonstrate the Jetpack compose session replay improvement on text mapper.

### Screenshots
| selection screen | typography screen|
| ----- | ----- |
|![Screenshot_20240813_133607](https://github.com/user-attachments/assets/3ecd9ad2-3b35-4fc9-85df-c78b27940036)|![Screenshot_20240813_133626](https://github.com/user-attachments/assets/1336337f-e288-413d-863c-74cd3142607a)|



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

