### PR TITLE
RUM-5754: Add profiling interface to internal module

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -1,2 +1,11 @@
+interface com.datadog.android.internal.profiler.BenchmarkProfiler
+  fun getTracer(String): BenchmarkTracer
+interface com.datadog.android.internal.profiler.BenchmarkSpan
+  fun stop()
+interface com.datadog.android.internal.profiler.BenchmarkTracer
+  fun startSpan(String): BenchmarkSpan
+object com.datadog.android.internal.profiler.GlobalBenchmark
+  fun register(BenchmarkProfiler)
+  fun get(): BenchmarkProfiler
 annotation com.datadog.tools.annotation.NoOpImplementation
   constructor(Boolean = false)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -1,3 +1,21 @@
+public abstract interface class com/datadog/android/internal/profiler/BenchmarkProfiler {
+	public abstract fun getTracer (Ljava/lang/String;)Lcom/datadog/android/internal/profiler/BenchmarkTracer;
+}
+
+public abstract interface class com/datadog/android/internal/profiler/BenchmarkSpan {
+	public abstract fun stop ()V
+}
+
+public abstract interface class com/datadog/android/internal/profiler/BenchmarkTracer {
+	public abstract fun startSpan (Ljava/lang/String;)Lcom/datadog/android/internal/profiler/BenchmarkSpan;
+}
+
+public final class com/datadog/android/internal/profiler/GlobalBenchmark {
+	public static final field INSTANCE Lcom/datadog/android/internal/profiler/GlobalBenchmark;
+	public final fun get ()Lcom/datadog/android/internal/profiler/BenchmarkProfiler;
+	public final fun register (Lcom/datadog/android/internal/profiler/BenchmarkProfiler;)V
+}
+
 public abstract interface annotation class com/datadog/tools/annotation/NoOpImplementation : java/lang/annotation/Annotation {
 	public abstract fun publicNoOpImplementation ()Z
 }

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/BenchmarkProfiler.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/BenchmarkProfiler.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.profiler
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+/**
+ * Interface of benchmark profiler to be implemented to provide [BenchmarkTracer].
+ * This should only used by internal benchmarking.
+ */
+@NoOpImplementation
+interface BenchmarkProfiler {
+
+    /**
+     * Returns a [BenchmarkTracer].
+     */
+    fun getTracer(operation: String): BenchmarkTracer
+}

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/BenchmarkSpan.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/BenchmarkSpan.kt
@@ -1,0 +1,21 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.profiler
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+/**
+ * Interface of benchmark span to be implemented. This should only used by internal benchmarking.
+ */
+@NoOpImplementation
+interface BenchmarkSpan {
+
+    /**
+     * Marks the end of [BenchmarkSpan] execution.
+     */
+    fun stop()
+}

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/BenchmarkTracer.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/BenchmarkTracer.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.profiler
+
+import com.datadog.tools.annotation.NoOpImplementation
+
+/**
+ * Interface of benchmark tracer to be implemented to provide [BenchmarkSpan].
+ * This should only used by internal benchmarking.
+ */
+@NoOpImplementation
+interface BenchmarkTracer {
+
+    /**
+     * Returns a new [BenchmarkSpan].
+     *
+     * @param spanName The name of the returned span.
+     * @return a new [BenchmarkSpan].
+     */
+    fun startSpan(spanName: String): BenchmarkSpan
+}

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/GlobalBenchmark.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/GlobalBenchmark.kt
@@ -1,0 +1,30 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.profiler
+
+/**
+ * A global holder of [BenchmarkProfiler], allowing to register and retrieve [BenchmarkProfiler] implementation.
+ * This should only used by internal benchmarking.
+ */
+object GlobalBenchmark {
+
+    private var benchmarkProfiler: BenchmarkProfiler = NoOpBenchmarkProfiler()
+
+    /**
+     * Registers the implementation of [BenchmarkProfiler].
+     */
+    fun register(benchmarkProfiler: BenchmarkProfiler) {
+        GlobalBenchmark.benchmarkProfiler = benchmarkProfiler
+    }
+
+    /**
+     * Returns the [BenchmarkProfiler] registered.
+     */
+    fun get(): BenchmarkProfiler {
+        return benchmarkProfiler
+    }
+}


### PR DESCRIPTION
### What does this PR do?
Adds following interface into SDK core:

* BenchmarkCounter
* BenchmarkGauge
* BenchmarkProfiler
* BenchmarkSpan
* BenchmarkTracer

Adds an object class to for BenchmarkProfiler
* GlobalBenchmark

### Motivation
RUM-5754

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

