### PR TITLE
RUM-5763: Add TouchPrivacy to Session Replay

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -20,12 +20,16 @@ data class com.datadog.android.sessionreplay.SessionReplayConfiguration
     fun useCustomEndpoint(String): Builder
     fun setPrivacy(SessionReplayPrivacy): Builder
     fun setImagePrivacy(ImagePrivacy): Builder
+    fun setTouchPrivacy(TouchPrivacy): Builder
     fun startRecordingImmediately(Boolean): Builder
     fun build(): SessionReplayConfiguration
 enum com.datadog.android.sessionreplay.SessionReplayPrivacy
   - ALLOW
   - MASK
   - MASK_USER_INPUT
+enum com.datadog.android.sessionreplay.TouchPrivacy
+  - SHOW
+  - HIDE
 data class com.datadog.android.sessionreplay.recorder.MappingContext
   constructor(SystemInformation, com.datadog.android.sessionreplay.utils.ImageWireframeHelper, com.datadog.android.sessionreplay.SessionReplayPrivacy, com.datadog.android.sessionreplay.ImagePrivacy, Boolean = false)
 interface com.datadog.android.sessionreplay.recorder.OptionSelectorDetector

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -34,8 +34,8 @@ public final class com/datadog/android/sessionreplay/SessionReplay {
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayConfiguration {
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;Z)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -47,6 +47,7 @@ public final class com/datadog/android/sessionreplay/SessionReplayConfiguration$
 	public final fun build ()Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public final fun setImagePrivacy (Lcom/datadog/android/sessionreplay/ImagePrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun setPrivacy (Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
+	public final fun setTouchPrivacy (Lcom/datadog/android/sessionreplay/TouchPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun startRecordingImmediately (Z)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 }
@@ -57,6 +58,13 @@ public final class com/datadog/android/sessionreplay/SessionReplayPrivacy : java
 	public static final field MASK_USER_INPUT Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
+}
+
+public final class com/datadog/android/sessionreplay/TouchPrivacy : java/lang/Enum {
+	public static final field HIDE Lcom/datadog/android/sessionreplay/TouchPrivacy;
+	public static final field SHOW Lcom/datadog/android/sessionreplay/TouchPrivacy;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/TouchPrivacy;
+	public static fun values ()[Lcom/datadog/android/sessionreplay/TouchPrivacy;
 }
 
 public final class com/datadog/android/sessionreplay/model/MobileSegment {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -35,6 +35,7 @@ object SessionReplay {
             customEndpointUrl = sessionReplayConfiguration.customEndpointUrl,
             privacy = sessionReplayConfiguration.privacy,
             imagePrivacy = sessionReplayConfiguration.imagePrivacy,
+            touchPrivacy = sessionReplayConfiguration.touchPrivacy,
             customMappers = sessionReplayConfiguration.customMappers,
             customOptionSelectorDetectors = sessionReplayConfiguration.customOptionSelectorDetectors,
             sampleRate = sessionReplayConfiguration.sampleRate,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -20,7 +20,8 @@ data class SessionReplayConfiguration internal constructor(
     internal val customOptionSelectorDetectors: List<OptionSelectorDetector>,
     internal val sampleRate: Float,
     internal val imagePrivacy: ImagePrivacy,
-    internal val startRecordingImmediately: Boolean
+    internal val startRecordingImmediately: Boolean,
+    internal val touchPrivacy: TouchPrivacy
 ) {
 
     /**
@@ -33,6 +34,7 @@ data class SessionReplayConfiguration internal constructor(
         private var privacy = SessionReplayPrivacy.MASK
         private var imagePrivacy = ImagePrivacy.MASK_ALL
         private var startRecordingImmediately = true
+        private var touchPrivacy = TouchPrivacy.HIDE
         private var extensionSupport: ExtensionSupport = NoOpExtensionSupport()
 
         /**
@@ -79,6 +81,17 @@ data class SessionReplayConfiguration internal constructor(
         }
 
         /**
+         * Sets the touch recording level for the Session Replay feature.
+         * If not specified then all touches will be hidden by default.
+         * @see TouchPrivacy.HIDE
+         * @see TouchPrivacy.SHOW
+         */
+        fun setTouchPrivacy(level: TouchPrivacy): Builder {
+            this.touchPrivacy = level
+            return this
+        }
+
+        /**
          * Should recording start automatically (or be manually started).
          * If not specified then by default it starts automatically.
          * @param enabled whether recording should start automatically or not.
@@ -96,6 +109,7 @@ data class SessionReplayConfiguration internal constructor(
                 customEndpointUrl = customEndpointUrl,
                 privacy = privacy,
                 imagePrivacy = imagePrivacy,
+                touchPrivacy = touchPrivacy,
                 customMappers = customMappers(),
                 customOptionSelectorDetectors = extensionSupport.getOptionSelectorDetectors(),
                 sampleRate = sampleRate,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/TouchPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/TouchPrivacy.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+/**
+ * Defines the Session Replay privacy policy when recording touch interactions.
+ * @see TouchPrivacy.SHOW
+ * @see TouchPrivacy.HIDE
+ */
+enum class TouchPrivacy {
+    /**
+     * All touch interactions will be recorded.
+     */
+    SHOW,
+
+    /**
+     * No touch interactions will be recorded.
+     */
+    HIDE
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
@@ -25,6 +25,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.Recorder
 import com.datadog.android.sessionreplay.internal.recorder.SessionReplayRecorder
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ActionBarContainerMapper
@@ -59,6 +60,7 @@ internal class DefaultRecorderProvider(
     private val sdkCore: FeatureSdkCore,
     private val privacy: SessionReplayPrivacy,
     private val imagePrivacy: ImagePrivacy,
+    private val touchPrivacy: TouchPrivacy,
     private val customMappers: List<MapperTypeWrapper<*>>,
     private val customOptionSelectorDetectors: List<OptionSelectorDetector>
 ) : RecorderProvider {
@@ -76,6 +78,7 @@ internal class DefaultRecorderProvider(
             rumContextProvider = SessionReplayRumContextProvider(sdkCore),
             privacy = privacy,
             imagePrivacy = imagePrivacy,
+            touchPrivacy = touchPrivacy,
             recordWriter = recordWriter,
             timeProvider = SessionReplayTimeProvider(sdkCore),
             mappers = customMappers + builtInMappers(),

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -21,6 +21,7 @@ import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.internal.net.BatchesToSegmentsMapper
 import com.datadog.android.sessionreplay.internal.net.SegmentRequestFactory
 import com.datadog.android.sessionreplay.internal.recorder.NoOpRecorder
@@ -44,7 +45,8 @@ internal class SessionReplayFeature(
     private val sdkCore: FeatureSdkCore,
     private val customEndpointUrl: String?,
     internal val privacy: SessionReplayPrivacy,
-    internal val imagePrivacy: ImagePrivacy?,
+    internal val imagePrivacy: ImagePrivacy,
+    internal val touchPrivacy: TouchPrivacy,
     private val rateBasedSampler: Sampler,
     private val startRecordingImmediately: Boolean,
     private val recorderProvider: RecorderProvider
@@ -57,6 +59,7 @@ internal class SessionReplayFeature(
         customEndpointUrl: String?,
         privacy: SessionReplayPrivacy,
         imagePrivacy: ImagePrivacy,
+        touchPrivacy: TouchPrivacy,
         customMappers: List<MapperTypeWrapper<*>>,
         customOptionSelectorDetectors: List<OptionSelectorDetector>,
         sampleRate: Float,
@@ -66,12 +69,14 @@ internal class SessionReplayFeature(
         customEndpointUrl,
         privacy,
         imagePrivacy,
+        touchPrivacy,
         RateBasedSampler(sampleRate),
         startRecordingImmediately,
         DefaultRecorderProvider(
             sdkCore,
             privacy,
             imagePrivacy,
+            touchPrivacy,
             customMappers,
             customOptionSelectorDetectors
         )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
@@ -17,6 +17,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.internal.LifecycleCallback
 import com.datadog.android.sessionreplay.internal.SessionReplayLifecycleCallback
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
@@ -56,6 +57,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
     private val rumContextProvider: RumContextProvider
     private val privacy: SessionReplayPrivacy
     private val imagePrivacy: ImagePrivacy
+    private val touchPrivacy: TouchPrivacy
     private val recordWriter: RecordWriter
     private val timeProvider: TimeProvider
     private val mappers: List<MapperTypeWrapper<*>>
@@ -77,6 +79,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         rumContextProvider: RumContextProvider,
         privacy: SessionReplayPrivacy,
         imagePrivacy: ImagePrivacy,
+        touchPrivacy: TouchPrivacy,
         recordWriter: RecordWriter,
         timeProvider: TimeProvider,
         mappers: List<MapperTypeWrapper<*>> = emptyList(),
@@ -105,6 +108,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         this.rumContextProvider = rumContextProvider
         this.privacy = privacy
         this.imagePrivacy = imagePrivacy
+        this.touchPrivacy = touchPrivacy
         this.recordWriter = recordWriter
         this.timeProvider = timeProvider
         this.mappers = mappers
@@ -185,7 +189,8 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
             timeProvider,
             internalLogger,
             privacy,
-            imagePrivacy
+            imagePrivacy,
+            touchPrivacy
         )
         this.sessionReplayLifecycleCallback = SessionReplayLifecycleCallback(this)
         this.uiHandler = Handler(Looper.getMainLooper())
@@ -199,6 +204,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         rumContextProvider: RumContextProvider,
         privacy: SessionReplayPrivacy,
         imagePrivacy: ImagePrivacy,
+        touchPrivacy: TouchPrivacy,
         recordWriter: RecordWriter,
         timeProvider: TimeProvider,
         mappers: List<MapperTypeWrapper<*>> = emptyList(),
@@ -216,6 +222,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         this.rumContextProvider = rumContextProvider
         this.privacy = privacy
         this.imagePrivacy = imagePrivacy
+        this.touchPrivacy = touchPrivacy
         this.recordWriter = recordWriter
         this.timeProvider = timeProvider
         this.mappers = mappers

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptor.kt
@@ -11,6 +11,7 @@ import android.view.Window
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.callback.NoOpWindowCallback
 import com.datadog.android.sessionreplay.internal.recorder.callback.RecorderWindowCallback
@@ -23,7 +24,8 @@ internal class WindowCallbackInterceptor(
     private val timeProvider: TimeProvider,
     private val internalLogger: InternalLogger,
     private val privacy: SessionReplayPrivacy,
-    private val imagePrivacy: ImagePrivacy
+    private val imagePrivacy: ImagePrivacy,
+    private val touchPrivacy: TouchPrivacy
 ) {
     private val wrappedWindows: WeakHashMap<Window, Any?> = WeakHashMap()
 
@@ -58,7 +60,8 @@ internal class WindowCallbackInterceptor(
             viewOnDrawInterceptor,
             internalLogger,
             privacy,
-            imagePrivacy
+            imagePrivacy,
+            touchPrivacy
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.sessionreplay
 
 import android.view.View
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
-import com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper
 import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
@@ -34,12 +33,11 @@ import org.mockito.quality.Strictness
 @ForgeConfiguration(value = ForgeConfigurator::class)
 internal class SessionReplayConfigurationBuilderTest {
 
-    lateinit var testedBuilder: SessionReplayConfiguration.Builder
+    private lateinit var testedBuilder: SessionReplayConfiguration.Builder
 
     @Mock
     lateinit var mockExtensionSupport: ExtensionSupport
-    lateinit var fakeCustomViewMappers: Map<Class<*>, WireframeMapper<*>>
-    lateinit var fakeExpectedCustomMappers: List<MapperTypeWrapper<*>>
+    private lateinit var fakeExpectedCustomMappers: List<MapperTypeWrapper<*>>
 
     @FloatForgery
     var fakeSampleRate: Float = 0f
@@ -60,6 +58,7 @@ internal class SessionReplayConfigurationBuilderTest {
         assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
         assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_ALL)
+        assertThat(sessionReplayConfiguration.touchPrivacy).isEqualTo(TouchPrivacy.HIDE)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -79,6 +78,7 @@ internal class SessionReplayConfigurationBuilderTest {
             .isEqualTo(sessionReplayUrl)
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
         assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_ALL)
+        assertThat(sessionReplayConfiguration.touchPrivacy).isEqualTo(TouchPrivacy.HIDE)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -97,6 +97,7 @@ internal class SessionReplayConfigurationBuilderTest {
         assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(fakePrivacy)
         assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_ALL)
+        assertThat(sessionReplayConfiguration.touchPrivacy).isEqualTo(TouchPrivacy.HIDE)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
         assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
@@ -112,12 +113,20 @@ internal class SessionReplayConfigurationBuilderTest {
             .build()
 
         // Then
-        assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
-        assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
         assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(fakeImagePrivacy)
-        assertThat(sessionReplayConfiguration.customMappers).isEmpty()
-        assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
-        assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
+    }
+
+    @Test
+    fun `M use the given touch privacy rule W setTouchPrivacy`(
+        @Forgery fakeTouchPrivacy: TouchPrivacy
+    ) {
+        // When
+        val sessionReplayConfiguration = testedBuilder
+            .setTouchPrivacy(fakeTouchPrivacy)
+            .build()
+
+        // Then
+        assertThat(sessionReplayConfiguration.touchPrivacy).isEqualTo(fakeTouchPrivacy)
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
@@ -65,6 +65,9 @@ internal class SessionReplayRecorderTest {
     @Forgery
     private lateinit var fakeImagePrivacy: ImagePrivacy
 
+    @Forgery
+    private lateinit var fakeTouchPrivacy: TouchPrivacy
+
     @Mock
     private lateinit var mockTimeProvider: TimeProvider
 
@@ -109,6 +112,7 @@ internal class SessionReplayRecorderTest {
             rumContextProvider = mockRumContextProvider,
             privacy = fakePrivacy,
             imagePrivacy = fakeImagePrivacy,
+            touchPrivacy = fakeTouchPrivacy,
             recordWriter = mockRecordWriter,
             timeProvider = mockTimeProvider,
             mappers = mock(),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.forge
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 import org.mockito.kotlin.mock
@@ -19,6 +20,7 @@ class SessionReplayConfigurationForgeryFactory : ForgeryFactory<SessionReplayCon
             customEndpointUrl = forge.aNullable { aStringMatching("https://[a-z]+\\.com") },
             privacy = forge.aValueFrom(SessionReplayPrivacy::class.java),
             imagePrivacy = forge.aValueFrom(ImagePrivacy::class.java),
+            touchPrivacy = forge.aValueFrom(TouchPrivacy::class.java),
             customMappers = forge.aList { mock() },
             customOptionSelectorDetectors = forge.aList { mock() },
             startRecordingImmediately = forge.aBool(),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -107,6 +107,7 @@ internal class SessionReplayFeatureTest {
             privacy = fakeConfiguration.privacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
             startRecordingImmediately = true,
+            touchPrivacy = fakeConfiguration.touchPrivacy,
             rateBasedSampler = mockSampler
         ) { _, _, _, _ -> mockRecorder }
     }
@@ -129,6 +130,7 @@ internal class SessionReplayFeatureTest {
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
+            touchPrivacy = fakeConfiguration.touchPrivacy,
             customMappers = emptyList(),
             customOptionSelectorDetectors = emptyList(),
             startRecordingImmediately = true,
@@ -151,6 +153,7 @@ internal class SessionReplayFeatureTest {
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
+            touchPrivacy = fakeConfiguration.touchPrivacy,
             customMappers = emptyList(),
             customOptionSelectorDetectors = emptyList(),
             sampleRate = fakeConfiguration.sampleRate,
@@ -186,6 +189,7 @@ internal class SessionReplayFeatureTest {
             privacy = fakeConfiguration.privacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
             startRecordingImmediately = true,
+            touchPrivacy = fakeConfiguration.touchPrivacy,
             rateBasedSampler = mockSampler
         ) { _, _, _, _ -> mockRecorder }
 
@@ -1003,6 +1007,7 @@ internal class SessionReplayFeatureTest {
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
+            touchPrivacy = fakeConfiguration.touchPrivacy,
             startRecordingImmediately = scenario.startRecordingImmediately,
             rateBasedSampler = mockSampler
         ) { _, _, _, _ -> mockRecorder }
@@ -1040,6 +1045,7 @@ internal class SessionReplayFeatureTest {
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
+            touchPrivacy = fakeConfiguration.touchPrivacy,
             startRecordingImmediately = true,
             rateBasedSampler = mockSampler
         ) { _, _, _, _ -> mockRecorder }
@@ -1070,6 +1076,7 @@ internal class SessionReplayFeatureTest {
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
+            touchPrivacy = fakeConfiguration.touchPrivacy,
             startRecordingImmediately = false,
             rateBasedSampler = mockSampler
         ) { _, _, _, _ -> mockRecorder }
@@ -1102,6 +1109,7 @@ internal class SessionReplayFeatureTest {
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
+            touchPrivacy = fakeConfiguration.touchPrivacy,
             startRecordingImmediately = true,
             rateBasedSampler = mockSampler
         ) { _, _, _, _ -> mockRecorder }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptorTest.kt
@@ -14,6 +14,7 @@ import android.view.Window
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.callback.NoOpWindowCallback
@@ -69,6 +70,9 @@ internal class WindowCallbackInterceptorTest {
     @Forgery
     lateinit var fakeImagePrivacy: ImagePrivacy
 
+    @Forgery
+    lateinit var fakeTouchPrivacy: TouchPrivacy
+
     private lateinit var fakeWindowsList: List<Window>
 
     private lateinit var mockActivity: Activity
@@ -83,7 +87,8 @@ internal class WindowCallbackInterceptorTest {
             mockTimeProvider,
             mockInternalLogger,
             fakePrivacy,
-            fakeImagePrivacy
+            fakeImagePrivacy,
+            fakeTouchPrivacy
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelperTest.kt
@@ -179,7 +179,7 @@ internal class DefaultImageWireframeHelperTest {
     // region createImageWireframe
 
     @Test
-    fun `M return content placeholder W createImageWireframe() { ImagePrivacy NONE }`() {
+    fun `M return content placeholder W createImageWireframe() { ImagePrivacy MASK_ALL }`() {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,
@@ -201,7 +201,7 @@ internal class DefaultImageWireframeHelperTest {
     }
 
     @Test
-    fun `M not return image wireframe W createImageWireframe() { ImagePrivacy ALL }`() {
+    fun `M return image wireframe W createImageWireframe() { ImagePrivacy MASK_NONE }`() {
         // When
         val wireframe = testedHelper.createImageWireframe(
             view = mockView,


### PR DESCRIPTION
### What does this PR do?
Adds a public TouchPrivacy api

Possible values for touch:
`SHOW` - record all touch interactions
`HIDE` - do not record touch interactions

Default value will be HIDE.

Usage example:
```
SessionReplayConfiguration.Builder() 
  .setTouchPrivacy(TouchPrivacy.SHOW)
```

Note: At the moment this will not hide the change in a button background that occurs as a result of a click (or other view hierarchy side effects). 


### Motivation
Part of the move to fine grained privacy options.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

