### PR TITLE
RUM-673: Log Timber tag

### DIFF
--- a/integrations/dd-sdk-android-timber/src/main/kotlin/com/datadog/android/timber/DatadogTree.kt
+++ b/integrations/dd-sdk-android-timber/src/main/kotlin/com/datadog/android/timber/DatadogTree.kt
@@ -48,6 +48,15 @@ class DatadogTree(
         message: String,
         t: Throwable?
     ) {
-        logger.log(priority, message, t)
+        val attributes = if (tag != null) {
+            mapOf(TIMBER_TAG_ATTRIBUTE to tag)
+        } else {
+            emptyMap()
+        }
+        logger.log(priority, message, t, attributes)
+    }
+
+    private companion object {
+        const val TIMBER_TAG_ATTRIBUTE = "timber.tag"
     }
 }

--- a/integrations/dd-sdk-android-timber/src/test/kotlin/com/datadog/android/timber/DatadogTreeTest.kt
+++ b/integrations/dd-sdk-android-timber/src/test/kotlin/com/datadog/android/timber/DatadogTreeTest.kt
@@ -95,4 +95,17 @@ class DatadogTreeTest {
         verify(mockLogger)
             .log(Log.ASSERT, fakeMessage, null, emptyMap())
     }
+
+    @Test
+    fun `tree logs message with tag`(
+        @StringForgery fakeTag: String
+    ) {
+        // When
+        Timber.tag(fakeTag)
+        Timber.d(fakeMessage)
+
+        // Then
+        verify(mockLogger)
+            .log(Log.DEBUG, fakeMessage, null, mapOf("timber.tag" to fakeTag))
+    }
 }


### PR DESCRIPTION
### What does this PR do?

Resolves #2195. If Timber tag is present, it will be logged as `timber.tag` attribute.

![image](https://github.com/user-attachments/assets/6c523a6b-2ed8-40cd-8c68-9981281352ef)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

