### PR TITLE
Add SpanEvent serializer in benchmark module

### DIFF
--- a/tools/benchmark/src/main/java/com/datadog/benchmark/internal/SpanEventSerializer.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/internal/SpanEventSerializer.kt
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.benchmark.internal
+
+import com.datadog.benchmark.internal.model.SpanEvent
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+
+internal class SpanEventSerializer {
+    // region Serializer
+
+    fun serialize(env: String, spanEvents: List<SpanEvent>): String {
+        val spans = JsonArray(spanEvents.size)
+        spanEvents.forEach {
+            spans.add(it.toJson())
+        }
+        val jsonObject = JsonObject()
+        jsonObject.add(TAG_SPANS, spans)
+        jsonObject.addProperty(TAG_ENV, env)
+
+        return jsonObject.toString()
+    }
+
+    // end region
+
+    companion object {
+
+        // PAYLOAD TAGS
+        internal const val TAG_SPANS = "spans"
+        internal const val TAG_ENV = "env"
+    }
+}


### PR DESCRIPTION
### What does this PR do?

Add SpanEvent serializer in benchmark module


### Additional Notes

* `DatadogDataConstraints` constructor is assigned with default value of `internalLogger`, so that in benchmark module, it doesn't have to provide an implementation of `InternalLogger`

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

