### PR TITLE
Fix UserInfoProvider flaky test

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProviderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/user/DatadogUserInfoProviderTest.kt
@@ -142,7 +142,7 @@ internal class DatadogUserInfoProviderTest {
         testedProvider.addUserProperties(fakeMutableProperties)
 
         // When
-        repeat(forge.anInt(1, fakeMutableProperties.size)) {
+        repeat(forge.anInt(1, fakeMutableProperties.size + 1)) {
             fakeMutableProperties.remove(fakeMutableProperties.keys.random())
         }
 
@@ -240,7 +240,7 @@ internal class DatadogUserInfoProviderTest {
         testedProvider.setUserInfo(id, name, email, fakeMutableUserProperties)
 
         // When
-        repeat(forge.anInt(1, fakeMutableUserProperties.size)) {
+        repeat(forge.anInt(1, fakeMutableUserProperties.size + 1)) {
             fakeMutableUserProperties.remove(fakeMutableUserProperties.keys.random())
         }
 


### PR DESCRIPTION
### What does this PR do?

Increases the max bound of `forge.anInt` to avoid that `min` and `max` are equal.

### Motivation

Following error is thrown by the test:
```
The ‘min’ boundary (1) of the range should be less than the ‘max’ boundary (1)
java.lang.IllegalArgumentException: The ‘min’ boundary (1) of the range should be less than the ‘max’ boundary (1)
	at fr.xgouchet.elmyr.Forge.anInt(Forge.kt:124)
	at com.datadog.android.core.internal.user.DatadogUserInfoProviderTest.M use immutable values W setUserInfo { removing properties }()(DatadogUserInfoProviderTest.kt:244)

```


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

