### PR TITLE
Fix Benchmark Span request issue

### DIFF
--- a/tools/benchmark/src/main/java/com/datadog/benchmark/EndPoint.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/EndPoint.kt
@@ -31,7 +31,7 @@ enum class EndPoint(
         traces = "https://public-trace-http-intake.logs.datadoghq.eu/"
     ),
     AP1(
-        metrics = "https://ap1.datadoghq.com",
+        metrics = "https://ap1.datadoghq.com/",
         traces = "https://browser-intake-ap1-datadoghq.com/"
     );
 

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/exporter/DatadogSpanExporter.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/exporter/DatadogSpanExporter.kt
@@ -7,7 +7,6 @@
 package com.datadog.benchmark.exporter
 
 import android.os.Build
-import android.util.Log
 import com.datadog.android.BuildConfig
 import com.datadog.benchmark.DatadogExporterConfiguration
 import com.datadog.benchmark.internal.BenchmarkSpanToSpanEventMapper
@@ -37,8 +36,6 @@ internal class DatadogSpanExporter(datadogExporterConfiguration: DatadogExporter
     private val benchmarkSpanToSpanEventMapper = BenchmarkSpanToSpanEventMapper()
 
     override fun export(spans: MutableCollection<SpanData>): CompletableResultCode {
-        Log.i("DatadogSpanExporter", "Span exported!")
-        Log.i("DatadogSpanExporter", spans.toString())
         spans.map {
             benchmarkSpanToSpanEventMapper.map(benchmarkContext, it)
         }.apply {

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/internal/DatadogHttpClient.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/internal/DatadogHttpClient.kt
@@ -13,7 +13,7 @@ import com.datadog.benchmark.internal.model.SpanEvent
 import io.opentelemetry.sdk.metrics.data.MetricData
 import okhttp3.CacheControl
 import okhttp3.Call
-import okhttp3.MediaType.Companion.toMediaTypeOrNull
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
 import okhttp3.RequestBody.Companion.toRequestBody
@@ -48,7 +48,7 @@ internal class DatadogHttpClient(
     internal fun uploadSpanEvent(spanEvents: List<SpanEvent>) {
         postRequest(
             operationName = OPERATION_NAME_TRACES,
-            url = exporterConfiguration.endPoint.metricUrl(),
+            url = exporterConfiguration.endPoint.tracesUrl(),
             exporterConfiguration = exporterConfiguration,
             body = spanRequestBuilder.build(spanEvents)
         )
@@ -73,7 +73,7 @@ internal class DatadogHttpClient(
                 }
                 addHeader(HEADER_USER_AGENT, getUserAgent())
             }
-            .post(body.toRequestBody(TYPE_JSON))
+            .post(body.toRequestBody(CONTENT_TYPE_TEXT_UTF8))
             .cacheControl(CacheControl.Builder().noCache().build())
             .url(url)
             .build()
@@ -151,8 +151,6 @@ internal class DatadogHttpClient(
 
         private const val SYSTEM_UA = "http.agent"
 
-        private val TYPE_JSON = "application/json".toMediaTypeOrNull()
-
         private const val OPERATION_NAME_METRICS = "metrics"
 
         private const val OPERATION_NAME_TRACES = "traces"
@@ -176,5 +174,10 @@ internal class DatadogHttpClient(
          * Datadog Request ID header, used for debugging purposes.
          */
         private const val HEADER_REQUEST_ID: String = "DD-REQUEST-ID"
+
+        /**
+         * text/plain;charset=UTF-8 content type.
+         */
+        private val CONTENT_TYPE_TEXT_UTF8 = "text/plain;charset=UTF-8".toMediaType()
     }
 }

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/internal/SpanEventSerializer.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/internal/SpanEventSerializer.kt
@@ -14,15 +14,17 @@ internal class SpanEventSerializer {
     // region Serializer
 
     fun serialize(env: String, spanEvents: List<SpanEvent>): String {
-        val spans = JsonArray(spanEvents.size)
-        spanEvents.forEach {
-            spans.add(it.toJson())
+        val stringBuilder = StringBuilder()
+        spanEvents.forEach { spanEvent ->
+            val spans = JsonArray(1)
+            spans.add(spanEvent.toJson())
+            val jsonObject = JsonObject()
+            jsonObject.add(TAG_SPANS, spans)
+            jsonObject.addProperty(TAG_ENV, env)
+            stringBuilder.append(jsonObject.toString())
+            stringBuilder.append("\n")
         }
-        val jsonObject = JsonObject()
-        jsonObject.add(TAG_SPANS, spans)
-        jsonObject.addProperty(TAG_ENV, env)
-
-        return jsonObject.toString()
+        return stringBuilder.toString()
     }
 
     // end region


### PR DESCRIPTION
### What does this PR do?
* Fix the base url for `AP1` Endpoint
* Remove the logs for spans exporter
* Fix the trace id of the span event
* Fix some attributes for the span
* Fix the post request url of trace
* Fix the content type of request, which led to the failure of combined json request body.
* Fix `SpanEventSerializer`, the request body should be like this:
```
// span 1
{
    "spans": [
        {
           ...
        }
    ],
    "env": "debug"
}
// span 2
{
    "spans": [
        {
           ...
        }
    ],
    "env": "debug"
}
```
instead of 
```
{
    "spans": [
        // span 1
        {
           ...
        },
       // span 2
        {
           ...
        }
    ],
    "env": "debug"
}

```

A brief description of the change being made with this pull request.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

