### PR TITLE
RUM-5977 include optional exception in Upload Status

### DIFF
--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploaderTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploaderTest.kt
@@ -514,7 +514,7 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batch, batchMetadata)
 
         // Then
-        assertThat(result).isInstanceOf(UploadStatus.UnknownError::class.java)
+        assertThat(result).isInstanceOf(UploadStatus.UnknownHttpError::class.java)
         assertThat(result.code).isEqualTo(statusCode)
         verifyRequest(fakeDatadogRequest)
         verifyResponseIsClosed()
@@ -572,7 +572,7 @@ internal class DataOkHttpUploaderTest {
         val result = testedUploader.upload(fakeContext, batch, batchMetadata)
 
         // Then
-        assertThat(result).isInstanceOf(UploadStatus.NetworkError::class.java)
+        assertThat(result).isInstanceOf(UploadStatus.UnknownException::class.java)
         assertThat(result.code).isEqualTo(UploadStatus.UNKNOWN_RESPONSE_CODE)
         verifyRequest(fakeDatadogRequest)
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/DataUploadRunnableTest.kt
@@ -19,6 +19,7 @@ import com.datadog.android.core.internal.persistence.Storage
 import com.datadog.android.core.internal.system.SystemInfo
 import com.datadog.android.core.internal.system.SystemInfoProvider
 import com.datadog.android.utils.forge.Configurator
+import com.datadog.tools.unit.forge.anException
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.IntForgery
@@ -850,7 +851,7 @@ internal class DataUploadRunnableTest {
                     batch,
                     batchMetadata[index]
                 )
-            ) doReturn UploadStatus.DNSError
+            ) doReturn UploadStatus.DNSError(forge.anException())
         }
 
         // When
@@ -1025,9 +1026,10 @@ internal class DataUploadRunnableTest {
             }
 
             return listOf(
-                forge.getForgery(UploadStatus.HttpServerError::class.java),
                 forge.getForgery(UploadStatus.HttpClientRateLimiting::class.java),
-                forge.getForgery(UploadStatus.NetworkError::class.java)
+                forge.getForgery(UploadStatus.HttpServerError::class.java),
+                forge.getForgery(UploadStatus.NetworkError::class.java),
+                forge.getForgery(UploadStatus.UnknownException::class.java)
             )
         }
 
@@ -1040,7 +1042,7 @@ internal class DataUploadRunnableTest {
             return listOf(
                 forge.getForgery(UploadStatus.HttpClientError::class.java),
                 forge.getForgery(UploadStatus.HttpRedirection::class.java),
-                forge.getForgery(UploadStatus.UnknownError::class.java),
+                forge.getForgery(UploadStatus.UnknownHttpError::class.java),
                 forge.getForgery(UploadStatus.UnknownStatus::class.java)
             )
         }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadStatusTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadStatusTest.kt
@@ -59,7 +59,7 @@ internal class UploadStatusTest {
         // Then
         mockLogger.verifyLog(
             InternalLogger.Level.INFO,
-            InternalLogger.Target.USER,
+            listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) sent successfully."
         )
         verifyNoMoreInteractions(mockLogger)
@@ -79,9 +79,9 @@ internal class UploadStatusTest {
         // Then
         mockLogger.verifyLog(
             InternalLogger.Level.WARN,
-            InternalLogger.Target.USER,
+            listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of a network error; we will retry later."
+                "because of a network error (${status.throwable!!.message}); we will retry later."
         )
         verifyNoMoreInteractions(mockLogger)
     }
@@ -100,9 +100,9 @@ internal class UploadStatusTest {
         // Then
         mockLogger.verifyLog(
             InternalLogger.Level.WARN,
-            InternalLogger.Target.USER,
+            listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of a DNS error; we will retry later."
+                "because of a DNS error (${status.throwable!!.message}); we will retry later."
         )
         verifyNoMoreInteractions(mockLogger)
     }
@@ -121,7 +121,7 @@ internal class UploadStatusTest {
         // Then
         mockLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
+            listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
                 "because your token is invalid; the batch was dropped. " +
                 "Make sure that the provided token still " +
@@ -144,7 +144,7 @@ internal class UploadStatusTest {
         // Then
         mockLogger.verifyLog(
             InternalLogger.Level.WARN,
-            InternalLogger.Target.USER,
+            listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
                 "because of a network redirection; the batch was dropped."
         )
@@ -188,7 +188,7 @@ internal class UploadStatusTest {
         mockLogger.verifyLog(
             InternalLogger.Level.WARN,
             listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            "Batch [$fakeByteSize bytes] ($fakeContext) not uploaded due to rate limitation; " +
+            "Batch [$fakeByteSize bytes] ($fakeContext) failed because of an intake rate limitation; " +
                 "we will retry later."
         )
     }
@@ -207,7 +207,7 @@ internal class UploadStatusTest {
         // Then
         mockLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
+            listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
                 "because of a server processing error; we will retry later."
         )
@@ -215,8 +215,8 @@ internal class UploadStatusTest {
     }
 
     @Test
-    fun `M log UNKNOWN_ERROR only to USER W logStatus()`(
-        @Forgery status: UploadStatus.UnknownError
+    fun `M log UNKNOWN_HTTP_ERROR only to USER W logStatus()`(
+        @Forgery status: UploadStatus.UnknownHttpError
     ) {
         // When
         status.logStatus(
@@ -228,9 +228,29 @@ internal class UploadStatusTest {
         // Then
         mockLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
+            listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of an unknown error (status code = ${status.code}); the batch was dropped."
+                "because of an unexpected HTTP error (status code = ${status.code}); the batch was dropped."
+        )
+    }
+
+    @Test
+    fun `M log UNKNOWN_EXCEPTION only to USER W logStatus()`(
+        @Forgery status: UploadStatus.UnknownException
+    ) {
+        // When
+        status.logStatus(
+            fakeContext,
+            fakeByteSize,
+            mockLogger
+        )
+
+        // Then
+        mockLogger.verifyLog(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER),
+            "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
+                "because of an unknown error (${status.throwable!!.message}); we will retry later."
         )
     }
 
@@ -248,9 +268,9 @@ internal class UploadStatusTest {
         // Then
         mockLogger.verifyLog(
             InternalLogger.Level.ERROR,
-            InternalLogger.Target.USER,
+            listOf(InternalLogger.Target.USER),
             "Batch [$fakeByteSize bytes] ($fakeContext) failed " +
-                "because of an error when creating the request;" +
+                "because of an error when creating the request (${status.throwable!!.message});" +
                 " the batch was dropped."
         )
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/data/upload/UploadWorkerTest.kt
@@ -687,15 +687,16 @@ internal class UploadWorkerTest {
             }
 
             return listOf(
-                forge.getForgery(UploadStatus.HttpServerError::class.java),
-                forge.getForgery(UploadStatus.NetworkError::class.java),
-                forge.getForgery(UploadStatus.HttpClientRateLimiting::class.java),
                 forge.getForgery(UploadStatus.HttpClientError::class.java),
-                forge.getForgery(UploadStatus.UnknownStatus::class.java),
-                forge.getForgery(UploadStatus.UnknownError::class.java),
+                forge.getForgery(UploadStatus.HttpClientRateLimiting::class.java),
                 forge.getForgery(UploadStatus.HttpRedirection::class.java),
+                forge.getForgery(UploadStatus.HttpServerError::class.java),
                 forge.getForgery(UploadStatus.InvalidTokenError::class.java),
-                forge.getForgery(UploadStatus.RequestCreationError::class.java)
+                forge.getForgery(UploadStatus.NetworkError::class.java),
+                forge.getForgery(UploadStatus.RequestCreationError::class.java),
+                forge.getForgery(UploadStatus.UnknownException::class.java),
+                forge.getForgery(UploadStatus.UnknownHttpError::class.java),
+                forge.getForgery(UploadStatus.UnknownStatus::class.java)
             )
         }
     }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/Configurator.kt
@@ -44,16 +44,17 @@ internal class Configurator :
         forge.addFactory(DataUploadConfigurationForgeryFactory())
 
         // UploadStatus
-        forge.addFactory(HttpRedirectStatusForgeryFactory())
-        forge.addFactory(HttpClientRateLimitingStatusForgeryFactory())
+        forge.addFactory(DNSErrorStatusForgeryFactory())
         forge.addFactory(HttpClientErrorForgeryFactory())
+        forge.addFactory(HttpClientRateLimitingStatusForgeryFactory())
+        forge.addFactory(HttpRedirectStatusForgeryFactory())
         forge.addFactory(HttpServerErrorForgeryFactory())
         forge.addFactory(InvalidTokenErrorStatusForgeryFactory())
         forge.addFactory(NetworkErrorStatusForgeryFactory())
-        forge.addFactory(DNSErrorStatusForgeryFactory())
         forge.addFactory(RequestCreationErrorStatusForgeryFactory())
         forge.addFactory(SuccessStatusForgeryFactory())
-        forge.addFactory(UnknownErrorStatusForgeryFactory())
+        forge.addFactory(UnknownExceptionStatusForgeryFactory())
+        forge.addFactory(UnknownHttpErrorStatusForgeryFactory())
         forge.addFactory(UnknownStatusForgeryFactory())
 
         // RemovalReason

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/DNSErrorStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/DNSErrorStatusForgeryFactory.kt
@@ -7,12 +7,13 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.android.core.internal.data.upload.UploadStatus
+import com.datadog.tools.unit.forge.anException
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
 internal class DNSErrorStatusForgeryFactory : ForgeryFactory<UploadStatus.DNSError> {
 
     override fun getForgery(forge: Forge): UploadStatus.DNSError {
-        return UploadStatus.DNSError
+        return UploadStatus.DNSError(forge.anException())
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/NetworkErrorStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/NetworkErrorStatusForgeryFactory.kt
@@ -7,12 +7,13 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.android.core.internal.data.upload.UploadStatus
+import com.datadog.tools.unit.forge.anException
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
 internal class NetworkErrorStatusForgeryFactory : ForgeryFactory<UploadStatus.NetworkError> {
 
     override fun getForgery(forge: Forge): UploadStatus.NetworkError {
-        return UploadStatus.NetworkError
+        return UploadStatus.NetworkError(forge.anException())
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/UnknownExceptionStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/UnknownExceptionStatusForgeryFactory.kt
@@ -7,12 +7,13 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.android.core.internal.data.upload.UploadStatus
+import com.datadog.tools.unit.forge.anException
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-internal class UnknownErrorStatusForgeryFactory : ForgeryFactory<UploadStatus.UnknownError> {
+internal class UnknownExceptionStatusForgeryFactory : ForgeryFactory<UploadStatus.UnknownException> {
 
-    override fun getForgery(forge: Forge): UploadStatus.UnknownError {
-        return UploadStatus.UnknownError(responseCode = forge.aPositiveInt())
+    override fun getForgery(forge: Forge): UploadStatus.UnknownException {
+        return UploadStatus.UnknownException(forge.anException())
     }
 }

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/UnknownHttpErrorStatusForgeryFactory.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/utils/forge/UnknownHttpErrorStatusForgeryFactory.kt
@@ -7,13 +7,12 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.android.core.internal.data.upload.UploadStatus
-import com.datadog.tools.unit.forge.anException
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
 
-internal class RequestCreationErrorStatusForgeryFactory : ForgeryFactory<UploadStatus.RequestCreationError> {
+internal class UnknownHttpErrorStatusForgeryFactory : ForgeryFactory<UploadStatus.UnknownHttpError> {
 
-    override fun getForgery(forge: Forge): UploadStatus.RequestCreationError {
-        return UploadStatus.RequestCreationError(forge.anException())
+    override fun getForgery(forge: Forge): UploadStatus.UnknownHttpError {
+        return UploadStatus.UnknownHttpError(responseCode = forge.aPositiveInt())
     }
 }

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -980,6 +980,7 @@ datadog:
       - "kotlin.collections.emptyMap()"
       - "kotlin.collections.emptySet()"
       - "kotlin.collections.listOf(android.view.Window)"
+      - "kotlin.collections.listOf(com.datadog.android.api.InternalLogger.Target)"
       - "kotlin.collections.listOf(com.datadog.android.rum.model.ActionEvent.Interface)"
       - "kotlin.collections.listOf(com.datadog.android.rum.model.ErrorEvent.Interface)"
       - "kotlin.collections.listOf(com.datadog.android.rum.model.LongTaskEvent.Interface)"


### PR DESCRIPTION
### What does this PR do?

Small improvement in our `UploadStatus` type to keep track of exceptions when those happen, and a refactoring to make the logging method easier to read. 

This is step one to create a customisable retry scheduling strategy.