### PR TITLE
Integrate benchmark span measurements in session replay

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.UiThread
+import com.datadog.android.internal.profiler.withinBenchmarkSpan
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
@@ -54,35 +55,37 @@ internal class SnapshotProducer(
         parents: LinkedList<MobileSegment.Wireframe>,
         recordedDataQueueRefs: RecordedDataQueueRefs
     ): Node? {
-        val traversedTreeView = treeViewTraversal.traverse(view, mappingContext, recordedDataQueueRefs)
-        val nextTraversalStrategy = traversedTreeView.nextActionStrategy
-        val resolvedWireframes = traversedTreeView.mappedWireframes
-        if (nextTraversalStrategy == TraversalStrategy.STOP_AND_DROP_NODE) {
-            return null
-        }
-        if (nextTraversalStrategy == TraversalStrategy.STOP_AND_RETURN_NODE) {
-            return Node(wireframes = resolvedWireframes, parents = parents)
-        }
+        return withinBenchmarkSpan(view::class.java.simpleName) {
+            val traversedTreeView = treeViewTraversal.traverse(view, mappingContext, recordedDataQueueRefs)
+            val nextTraversalStrategy = traversedTreeView.nextActionStrategy
+            val resolvedWireframes = traversedTreeView.mappedWireframes
+            if (nextTraversalStrategy == TraversalStrategy.STOP_AND_DROP_NODE) {
+                return null
+            }
+            if (nextTraversalStrategy == TraversalStrategy.STOP_AND_RETURN_NODE) {
+                return Node(wireframes = resolvedWireframes, parents = parents)
+            }
 
-        val childNodes = LinkedList<Node>()
-        if (view is ViewGroup &&
-            view.childCount > 0 &&
-            nextTraversalStrategy == TraversalStrategy.TRAVERSE_ALL_CHILDREN
-        ) {
-            val childMappingContext = resolveChildMappingContext(view, mappingContext)
-            val parentsCopy = LinkedList(parents).apply { addAll(resolvedWireframes) }
-            for (i in 0 until view.childCount) {
-                val viewChild = view.getChildAt(i) ?: continue
-                convertViewToNode(viewChild, childMappingContext, parentsCopy, recordedDataQueueRefs)?.let {
-                    childNodes.add(it)
+            val childNodes = LinkedList<Node>()
+            if (view is ViewGroup &&
+                view.childCount > 0 &&
+                nextTraversalStrategy == TraversalStrategy.TRAVERSE_ALL_CHILDREN
+            ) {
+                val childMappingContext = resolveChildMappingContext(view, mappingContext)
+                val parentsCopy = LinkedList(parents).apply { addAll(resolvedWireframes) }
+                for (i in 0 until view.childCount) {
+                    val viewChild = view.getChildAt(i) ?: continue
+                    convertViewToNode(viewChild, childMappingContext, parentsCopy, recordedDataQueueRefs)?.let {
+                        childNodes.add(it)
+                    }
                 }
             }
+            Node(
+                children = childNodes,
+                wireframes = resolvedWireframes,
+                parents = parents
+            )
         }
-        return Node(
-            children = childNodes,
-            wireframes = resolvedWireframes,
-            parents = parents
-        )
     }
 
     private fun resolveChildMappingContext(


### PR DESCRIPTION
### What does this PR do?

Benchmark spans measurements are put in two places of session replay:
* Span with name "SnapshotProducer" when `snapshotProducer.produce` is called
* Span with name view class name when mapping the view.

### Demo

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/45b3119a-450c-4ad3-b18d-8bca67925479">


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

