### PR TITLE
Fix benchmarking metrics data upload request issue

### DIFF
--- a/tools/benchmark/src/main/java/com/datadog/benchmark/internal/DatadogHttpClient.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/internal/DatadogHttpClient.kt
@@ -13,6 +13,7 @@ import com.datadog.benchmark.internal.model.SpanEvent
 import io.opentelemetry.sdk.metrics.data.MetricData
 import okhttp3.CacheControl
 import okhttp3.Call
+import okhttp3.MediaType
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.OkHttpClient
 import okhttp3.Request
@@ -41,7 +42,8 @@ internal class DatadogHttpClient(
             operationName = OPERATION_NAME_METRICS,
             url = exporterConfiguration.endPoint.metricUrl(),
             exporterConfiguration = exporterConfiguration,
-            metricRequestBodyBuilder.build(metrics)
+            metricRequestBodyBuilder.build(metrics),
+            mediaType = CONTENT_TYPE_JSON
         )
     }
 
@@ -50,7 +52,8 @@ internal class DatadogHttpClient(
             operationName = OPERATION_NAME_TRACES,
             url = exporterConfiguration.endPoint.tracesUrl(),
             exporterConfiguration = exporterConfiguration,
-            body = spanRequestBuilder.build(spanEvents)
+            body = spanRequestBuilder.build(spanEvents),
+            mediaType = CONTENT_TYPE_TEXT_UTF8
         )
     }
 
@@ -58,7 +61,8 @@ internal class DatadogHttpClient(
         operationName: String,
         url: String,
         exporterConfiguration: DatadogExporterConfiguration,
-        body: String
+        body: String,
+        mediaType: MediaType
     ) {
         val headers = buildHeaders(
             requestId = UUID.randomUUID().toString(),
@@ -73,7 +77,7 @@ internal class DatadogHttpClient(
                 }
                 addHeader(HEADER_USER_AGENT, getUserAgent())
             }
-            .post(body.toRequestBody(CONTENT_TYPE_TEXT_UTF8))
+            .post(body.toRequestBody(mediaType))
             .cacheControl(CacheControl.Builder().noCache().build())
             .url(url)
             .build()
@@ -179,5 +183,10 @@ internal class DatadogHttpClient(
          * text/plain;charset=UTF-8 content type.
          */
         private val CONTENT_TYPE_TEXT_UTF8 = "text/plain;charset=UTF-8".toMediaType()
+
+        /**
+         * application/json;charset=UTF-8 content type.
+         */
+        private val CONTENT_TYPE_JSON = "application/json".toMediaType()
     }
 }


### PR DESCRIPTION
### What does this PR do?

Fix metrics data upload due to the modification of request body media type, 

Actually "Metrics" and "Span" require different media type as intake.

"Span" API requires plain text so several span json can be combined in the same request, while "Metrics" API requires Json format, otherwise it refuses the request with 400 Bad request response.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

