### PR TITLE
RUM-5761: Add TextAndInputPrivacy

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -252,8 +252,14 @@ internal class TelemetryEventHandler(
             as? Long
         val startRecordingImmediately =
             sessionReplayFeatureContext[SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY] as? Boolean
-        val sessionReplayPrivacy = sessionReplayFeatureContext[SESSION_REPLAY_PRIVACY_KEY]
+        val legacySessionReplayPrivacy = sessionReplayFeatureContext[SESSION_REPLAY_PRIVACY_KEY]
             as? String
+        val sessionReplayImagePrivacy =
+            sessionReplayFeatureContext[SESSION_REPLAY_IMAGE_PRIVACY_KEY] as? String
+        val sessionReplayTouchPrivacy =
+            sessionReplayFeatureContext[SESSION_REPLAY_TOUCH_PRIVACY_KEY] as? String
+        val sessionReplayTextAndInputPrivacy =
+            sessionReplayFeatureContext[SESSION_REPLAY_TEXT_AND_INPUT_PRIVACY_KEY] as? String
         val rumConfig = sdkCore.getFeature(Feature.RUM_FEATURE_NAME)
             ?.unwrap<RumFeature>()
             ?.configuration
@@ -314,7 +320,10 @@ internal class TelemetryEventHandler(
                     tracerApiVersion = openTelemetryApiVersion,
                     trackNetworkRequests = trackNetworkRequests,
                     sessionReplaySampleRate = sessionReplaySampleRate,
-                    defaultPrivacyLevel = sessionReplayPrivacy,
+                    defaultPrivacyLevel = legacySessionReplayPrivacy,
+                    imagePrivacyLevel = sessionReplayImagePrivacy,
+                    touchPrivacyLevel = sessionReplayTouchPrivacy,
+                    textAndInputPrivacyLevel = sessionReplayTextAndInputPrivacy,
                     startRecordingImmediately = startRecordingImmediately,
                     batchProcessingLevel = coreConfiguration.batchProcessingLevel.toLong()
                 )
@@ -394,6 +403,9 @@ internal class TelemetryEventHandler(
         internal const val OPENTELEMETRY_API_VERSION_CONTEXT_KEY = "opentelemetry_api_version"
         internal const val SESSION_REPLAY_SAMPLE_RATE_KEY = "session_replay_sample_rate"
         internal const val SESSION_REPLAY_PRIVACY_KEY = "session_replay_privacy"
+        internal const val SESSION_REPLAY_TEXT_AND_INPUT_PRIVACY_KEY = "session_replay_text_and_input_privacy"
+        internal const val SESSION_REPLAY_IMAGE_PRIVACY_KEY = "session_replay_image_privacy"
+        internal const val SESSION_REPLAY_TOUCH_PRIVACY_KEY = "session_replay_touch_privacy"
         internal const val SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY =
             "session_replay_start_immediate_recording"
     }

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/internal/SliderWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/internal/SliderWireframeMapper.kt
@@ -9,7 +9,7 @@ package com.datadog.android.sessionreplay.material.internal
 import android.content.res.ColorStateList
 import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper
@@ -122,7 +122,7 @@ internal open class SliderWireframeMapper(
             )
         )
 
-        return if (mappingContext.privacy == SessionReplayPrivacy.ALLOW) {
+        return if (mappingContext.textAndInputPrivacy == TextAndInputPrivacy.MASK_SENSITIVE_INPUTS) {
             listOf(trackNonActiveWireframe, trackActiveWireframe, thumbWireframe)
         } else {
             listOf(trackNonActiveWireframe)

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/SliderWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/SliderWireframeMapperTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.material
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.material.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.material.internal.SliderWireframeMapper
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -35,7 +35,7 @@ internal class SliderWireframeMapperTest : BaseSliderWireframeMapperTest() {
     @Test
     fun `M map the Slider to a list of wireframes W map() {ALLOW}`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         val expectedInactiveTrackWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeInactiveTrackId,
             x = fakeExpectedInactiveTrackXPos,
@@ -92,7 +92,7 @@ internal class SliderWireframeMapperTest : BaseSliderWireframeMapperTest() {
     @Test
     fun `M map the Slider to a list of wireframes W map() {MASK}`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL)
         val expectedInactiveTrackWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeInactiveTrackId,
             x = fakeExpectedInactiveTrackXPos,
@@ -124,7 +124,7 @@ internal class SliderWireframeMapperTest : BaseSliderWireframeMapperTest() {
     @Test
     fun `M map the Slider to a list of wireframes W map() {MASK_USER_INPUT}`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK_USER_INPUT)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS)
         val expectedInactiveTrackWireframe = MobileSegment.Wireframe.ShapeWireframe(
             id = fakeInactiveTrackId,
             x = fakeExpectedInactiveTrackXPos,

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/MappingContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/forge/MappingContextForgeryFactory.kt
@@ -16,7 +16,7 @@ internal class MappingContextForgeryFactory : ForgeryFactory<MappingContext> {
         return MappingContext(
             systemInformation = forge.getForgery(),
             imageWireframeHelper = mock(),
-            privacy = forge.getForgery(),
+            textAndInputPrivacy = forge.getForgery(),
             imagePrivacy = forge.getForgery(),
             hasOptionSelectorParent = forge.aBool()
         )

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -18,20 +18,25 @@ data class com.datadog.android.sessionreplay.SessionReplayConfiguration
     constructor(Float)
     fun addExtensionSupport(ExtensionSupport): Builder
     fun useCustomEndpoint(String): Builder
-    fun setPrivacy(SessionReplayPrivacy): Builder
+    DEPRECATED fun setPrivacy(SessionReplayPrivacy): Builder
     fun setImagePrivacy(ImagePrivacy): Builder
     fun setTouchPrivacy(TouchPrivacy): Builder
     fun startRecordingImmediately(Boolean): Builder
+    fun setTextAndInputPrivacy(TextAndInputPrivacy): Builder
     fun build(): SessionReplayConfiguration
 enum com.datadog.android.sessionreplay.SessionReplayPrivacy
   - ALLOW
   - MASK
   - MASK_USER_INPUT
+enum com.datadog.android.sessionreplay.TextAndInputPrivacy
+  - MASK_SENSITIVE_INPUTS
+  - MASK_ALL_INPUTS
+  - MASK_ALL
 enum com.datadog.android.sessionreplay.TouchPrivacy
   - SHOW
   - HIDE
 data class com.datadog.android.sessionreplay.recorder.MappingContext
-  constructor(SystemInformation, com.datadog.android.sessionreplay.utils.ImageWireframeHelper, com.datadog.android.sessionreplay.SessionReplayPrivacy, com.datadog.android.sessionreplay.ImagePrivacy, Boolean = false)
+  constructor(SystemInformation, com.datadog.android.sessionreplay.utils.ImageWireframeHelper, com.datadog.android.sessionreplay.TextAndInputPrivacy, com.datadog.android.sessionreplay.ImagePrivacy, Boolean = false)
 interface com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
   fun isOptionSelector(android.view.ViewGroup): Boolean
 data class com.datadog.android.sessionreplay.recorder.SystemInformation
@@ -47,12 +52,12 @@ abstract class com.datadog.android.sessionreplay.recorder.mapper.BaseWireframeMa
   protected fun resolveShapeStyle(android.graphics.drawable.Drawable, Float, com.datadog.android.api.InternalLogger): com.datadog.android.sessionreplay.model.MobileSegment.ShapeStyle?
 class com.datadog.android.sessionreplay.recorder.mapper.EditTextMapper : TextViewMapper<android.widget.EditText>
   constructor(com.datadog.android.sessionreplay.utils.ViewIdentifierResolver, com.datadog.android.sessionreplay.utils.ColorStringFormatter, com.datadog.android.sessionreplay.utils.ViewBoundsResolver, com.datadog.android.sessionreplay.utils.DrawableToColorMapper)
-  override fun resolveCapturedText(android.widget.EditText, com.datadog.android.sessionreplay.SessionReplayPrivacy, Boolean): String
+  override fun resolveCapturedText(android.widget.EditText, com.datadog.android.sessionreplay.TextAndInputPrivacy, Boolean): String
   companion object 
 open class com.datadog.android.sessionreplay.recorder.mapper.TextViewMapper<T: android.widget.TextView> : BaseAsyncBackgroundWireframeMapper<T>
   constructor(com.datadog.android.sessionreplay.utils.ViewIdentifierResolver, com.datadog.android.sessionreplay.utils.ColorStringFormatter, com.datadog.android.sessionreplay.utils.ViewBoundsResolver, com.datadog.android.sessionreplay.utils.DrawableToColorMapper)
   override fun map(T, com.datadog.android.sessionreplay.recorder.MappingContext, com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback, com.datadog.android.api.InternalLogger): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
-  protected open fun resolveCapturedText(T, com.datadog.android.sessionreplay.SessionReplayPrivacy, Boolean): String
+  protected open fun resolveCapturedText(T, com.datadog.android.sessionreplay.TextAndInputPrivacy, Boolean): String
 interface com.datadog.android.sessionreplay.recorder.mapper.TraverseAllChildrenMapper<T: android.view.ViewGroup> : WireframeMapper<T>
 interface com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper<T: android.view.View>
   fun map(T, com.datadog.android.sessionreplay.recorder.MappingContext, com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback, com.datadog.android.api.InternalLogger): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -34,8 +34,8 @@ public final class com/datadog/android/sessionreplay/SessionReplay {
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayConfiguration {
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -47,6 +47,7 @@ public final class com/datadog/android/sessionreplay/SessionReplayConfiguration$
 	public final fun build ()Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public final fun setImagePrivacy (Lcom/datadog/android/sessionreplay/ImagePrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun setPrivacy (Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
+	public final fun setTextAndInputPrivacy (Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun setTouchPrivacy (Lcom/datadog/android/sessionreplay/TouchPrivacy;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun startRecordingImmediately (Z)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun useCustomEndpoint (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
@@ -58,6 +59,14 @@ public final class com/datadog/android/sessionreplay/SessionReplayPrivacy : java
 	public static final field MASK_USER_INPUT Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public static fun values ()[Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
+}
+
+public final class com/datadog/android/sessionreplay/TextAndInputPrivacy : java/lang/Enum {
+	public static final field MASK_ALL Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
+	public static final field MASK_ALL_INPUTS Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
+	public static final field MASK_SENSITIVE_INPUTS Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
+	public static fun values ()[Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 }
 
 public final class com/datadog/android/sessionreplay/TouchPrivacy : java/lang/Enum {
@@ -1350,21 +1359,21 @@ public final class com/datadog/android/sessionreplay/model/ResourceMetadata$Comp
 }
 
 public final class com/datadog/android/sessionreplay/recorder/MappingContext {
-	public fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Z)V
-	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Z)V
+	public synthetic fun <init> (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;ZILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Lcom/datadog/android/sessionreplay/recorder/SystemInformation;
 	public final fun component2 ()Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;
-	public final fun component3 ()Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
+	public final fun component3 ()Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 	public final fun component4 ()Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public final fun component5 ()Z
-	public final fun copy (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Z)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/recorder/MappingContext;Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;ZILjava/lang/Object;)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
+	public final fun copy (Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;Z)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/recorder/MappingContext;Lcom/datadog/android/sessionreplay/recorder/SystemInformation;Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Lcom/datadog/android/sessionreplay/ImagePrivacy;ZILjava/lang/Object;)Lcom/datadog/android/sessionreplay/recorder/MappingContext;
 	public fun equals (Ljava/lang/Object;)Z
 	public final fun getHasOptionSelectorParent ()Z
 	public final fun getImagePrivacy ()Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public final fun getImageWireframeHelper ()Lcom/datadog/android/sessionreplay/utils/ImageWireframeHelper;
-	public final fun getPrivacy ()Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;
 	public final fun getSystemInformation ()Lcom/datadog/android/sessionreplay/recorder/SystemInformation;
+	public final fun getTextAndInputPrivacy ()Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
 }
@@ -1416,7 +1425,7 @@ public abstract class com/datadog/android/sessionreplay/recorder/mapper/BaseWire
 public final class com/datadog/android/sessionreplay/recorder/mapper/EditTextMapper : com/datadog/android/sessionreplay/recorder/mapper/TextViewMapper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/recorder/mapper/EditTextMapper$Companion;
 	public fun <init> (Lcom/datadog/android/sessionreplay/utils/ViewIdentifierResolver;Lcom/datadog/android/sessionreplay/utils/ColorStringFormatter;Lcom/datadog/android/sessionreplay/utils/ViewBoundsResolver;Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper;)V
-	public synthetic fun resolveCapturedText (Landroid/widget/TextView;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Z)Ljava/lang/String;
+	public synthetic fun resolveCapturedText (Landroid/widget/TextView;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Z)Ljava/lang/String;
 }
 
 public final class com/datadog/android/sessionreplay/recorder/mapper/EditTextMapper$Companion {
@@ -1426,7 +1435,7 @@ public class com/datadog/android/sessionreplay/recorder/mapper/TextViewMapper : 
 	public fun <init> (Lcom/datadog/android/sessionreplay/utils/ViewIdentifierResolver;Lcom/datadog/android/sessionreplay/utils/ColorStringFormatter;Lcom/datadog/android/sessionreplay/utils/ViewBoundsResolver;Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper;)V
 	public synthetic fun map (Landroid/view/View;Lcom/datadog/android/sessionreplay/recorder/MappingContext;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;Lcom/datadog/android/api/InternalLogger;)Ljava/util/List;
 	public fun map (Landroid/widget/TextView;Lcom/datadog/android/sessionreplay/recorder/MappingContext;Lcom/datadog/android/sessionreplay/utils/AsyncJobStatusCallback;Lcom/datadog/android/api/InternalLogger;)Ljava/util/List;
-	protected fun resolveCapturedText (Landroid/widget/TextView;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Z)Ljava/lang/String;
+	protected fun resolveCapturedText (Landroid/widget/TextView;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;Z)Ljava/lang/String;
 }
 
 public abstract interface class com/datadog/android/sessionreplay/recorder/mapper/TraverseAllChildrenMapper : com/datadog/android/sessionreplay/recorder/mapper/WireframeMapper {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -36,6 +36,7 @@ object SessionReplay {
             privacy = sessionReplayConfiguration.privacy,
             imagePrivacy = sessionReplayConfiguration.imagePrivacy,
             touchPrivacy = sessionReplayConfiguration.touchPrivacy,
+            textAndInputPrivacy = sessionReplayConfiguration.textAndInputPrivacy,
             customMappers = sessionReplayConfiguration.customMappers,
             customOptionSelectorDetectors = sessionReplayConfiguration.customOptionSelectorDetectors,
             sampleRate = sessionReplayConfiguration.sampleRate,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/TextAndInputPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/TextAndInputPrivacy.kt
@@ -1,0 +1,32 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+/**
+ * Defines the Session Replay privacy policy when recording text and inputs.
+ * @see TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
+ * @see TextAndInputPrivacy.MASK_ALL_INPUTS
+ * @see TextAndInputPrivacy.MASK_ALL
+ */
+enum class TextAndInputPrivacy {
+
+    /**
+     * All text and inputs considered sensitive will be masked.
+     * Sensitive text includes passwords, emails and phone numbers.
+     */
+    MASK_SENSITIVE_INPUTS,
+
+    /**
+     * All inputs will be masked.
+     */
+    MASK_ALL_INPUTS,
+
+    /**
+     * All text and inputs will be masked.
+     */
+    MASK_ALL
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
@@ -24,7 +24,7 @@ import androidx.appcompat.widget.SwitchCompat
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.Recorder
 import com.datadog.android.sessionreplay.internal.recorder.SessionReplayRecorder
@@ -58,7 +58,7 @@ import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
 
 internal class DefaultRecorderProvider(
     private val sdkCore: FeatureSdkCore,
-    private val privacy: SessionReplayPrivacy,
+    private val textAndInputPrivacy: TextAndInputPrivacy,
     private val imagePrivacy: ImagePrivacy,
     private val touchPrivacy: TouchPrivacy,
     private val customMappers: List<MapperTypeWrapper<*>>,
@@ -76,9 +76,9 @@ internal class DefaultRecorderProvider(
             resourceDataStoreManager = resourceDataStoreManager,
             resourcesWriter = resourceWriter,
             rumContextProvider = SessionReplayRumContextProvider(sdkCore),
-            privacy = privacy,
             imagePrivacy = imagePrivacy,
             touchPrivacy = touchPrivacy,
+            textAndInputPrivacy = textAndInputPrivacy,
             recordWriter = recordWriter,
             timeProvider = SessionReplayTimeProvider(sdkCore),
             mappers = customMappers + builtInMappers(),

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -21,6 +21,7 @@ import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.internal.net.BatchesToSegmentsMapper
 import com.datadog.android.sessionreplay.internal.net.SegmentRequestFactory
@@ -45,8 +46,9 @@ internal class SessionReplayFeature(
     private val sdkCore: FeatureSdkCore,
     private val customEndpointUrl: String?,
     internal val privacy: SessionReplayPrivacy,
-    internal val imagePrivacy: ImagePrivacy,
+    internal val textAndInputPrivacy: TextAndInputPrivacy,
     internal val touchPrivacy: TouchPrivacy,
+    internal val imagePrivacy: ImagePrivacy,
     private val rateBasedSampler: Sampler,
     private val startRecordingImmediately: Boolean,
     private val recorderProvider: RecorderProvider
@@ -58,8 +60,9 @@ internal class SessionReplayFeature(
         sdkCore: FeatureSdkCore,
         customEndpointUrl: String?,
         privacy: SessionReplayPrivacy,
-        imagePrivacy: ImagePrivacy,
+        textAndInputPrivacy: TextAndInputPrivacy,
         touchPrivacy: TouchPrivacy,
+        imagePrivacy: ImagePrivacy,
         customMappers: List<MapperTypeWrapper<*>>,
         customOptionSelectorDetectors: List<OptionSelectorDetector>,
         sampleRate: Float,
@@ -68,13 +71,14 @@ internal class SessionReplayFeature(
         sdkCore,
         customEndpointUrl,
         privacy,
-        imagePrivacy,
+        textAndInputPrivacy,
         touchPrivacy,
+        imagePrivacy,
         RateBasedSampler(sampleRate),
         startRecordingImmediately,
         DefaultRecorderProvider(
             sdkCore,
-            privacy,
+            textAndInputPrivacy,
             imagePrivacy,
             touchPrivacy,
             customMappers,
@@ -136,6 +140,9 @@ internal class SessionReplayFeature(
             it[SESSION_REPLAY_SAMPLE_RATE_KEY] = rateBasedSampler.getSampleRate()?.toLong()
             it[SESSION_REPLAY_PRIVACY_KEY] = privacy.toString().lowercase(Locale.US)
             it[SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY] = startRecordingImmediately
+            it[SESSION_REPLAY_TOUCH_PRIVACY_KEY] = touchPrivacy.toString().lowercase(Locale.US)
+            it[SESSION_REPLAY_IMAGE_PRIVACY_KEY] = imagePrivacy.toString().lowercase(Locale.US)
+            it[SESSION_REPLAY_TEXT_AND_INPUT_PRIVACY_KEY] = textAndInputPrivacy.toString().lowercase(Locale.US)
         }
     }
 
@@ -393,6 +400,9 @@ internal class SessionReplayFeature(
         const val RUM_SESSION_ID_BUS_MESSAGE_KEY = "sessionId"
         internal const val SESSION_REPLAY_SAMPLE_RATE_KEY = "session_replay_sample_rate"
         internal const val SESSION_REPLAY_PRIVACY_KEY = "session_replay_privacy"
+        internal const val SESSION_REPLAY_TEXT_AND_INPUT_PRIVACY_KEY = "session_replay_text_and_input_privacy"
+        internal const val SESSION_REPLAY_IMAGE_PRIVACY_KEY = "session_replay_image_privacy"
+        internal const val SESSION_REPLAY_TOUCH_PRIVACY_KEY = "session_replay_touch_privacy"
         internal const val SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY =
             "session_replay_start_immediate_recording"
         internal const val SESSION_REPLAY_ENABLED_KEY =

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/DefaultOnDrawListenerProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/DefaultOnDrawListenerProducer.kt
@@ -11,7 +11,7 @@ import android.view.ViewTreeObserver
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener
 
@@ -23,14 +23,14 @@ internal class DefaultOnDrawListenerProducer(
 
     override fun create(
         decorViews: List<View>,
-        privacy: SessionReplayPrivacy,
+        textAndInputPrivacy: TextAndInputPrivacy,
         imagePrivacy: ImagePrivacy
     ): ViewTreeObserver.OnDrawListener {
         return WindowsOnDrawListener(
             zOrderedDecorViews = decorViews,
             recordedDataQueueHandler = recordedDataQueueHandler,
             snapshotProducer = snapshotProducer,
-            privacy = privacy,
+            textAndInputPrivacy = textAndInputPrivacy,
             imagePrivacy = imagePrivacy,
             internalLogger = sdkCore.internalLogger,
             methodCallSamplingRate = MethodCallSamplingRate.LOW.rate

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/OnDrawListenerProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/OnDrawListenerProducer.kt
@@ -9,12 +9,12 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.view.View
 import android.view.ViewTreeObserver
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 
 internal fun interface OnDrawListenerProducer {
     fun create(
         decorViews: List<View>,
-        privacy: SessionReplayPrivacy,
+        textAndInputPrivacy: TextAndInputPrivacy,
         imagePrivacy: ImagePrivacy
     ): ViewTreeObserver.OnDrawListener
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
@@ -16,7 +16,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.MapperTypeWrapper
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.internal.LifecycleCallback
 import com.datadog.android.sessionreplay.internal.SessionReplayLifecycleCallback
@@ -55,7 +55,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
 
     private val appContext: Application
     private val rumContextProvider: RumContextProvider
-    private val privacy: SessionReplayPrivacy
+    private val textAndInputPrivacy: TextAndInputPrivacy
     private val imagePrivacy: ImagePrivacy
     private val touchPrivacy: TouchPrivacy
     private val recordWriter: RecordWriter
@@ -77,7 +77,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         appContext: Application,
         resourcesWriter: ResourcesWriter,
         rumContextProvider: RumContextProvider,
-        privacy: SessionReplayPrivacy,
+        textAndInputPrivacy: TextAndInputPrivacy,
         imagePrivacy: ImagePrivacy,
         touchPrivacy: TouchPrivacy,
         recordWriter: RecordWriter,
@@ -106,7 +106,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
 
         this.appContext = appContext
         this.rumContextProvider = rumContextProvider
-        this.privacy = privacy
+        this.textAndInputPrivacy = textAndInputPrivacy
         this.imagePrivacy = imagePrivacy
         this.touchPrivacy = touchPrivacy
         this.recordWriter = recordWriter
@@ -188,9 +188,9 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
             viewOnDrawInterceptor,
             timeProvider,
             internalLogger,
-            privacy,
             imagePrivacy,
-            touchPrivacy
+            touchPrivacy,
+            textAndInputPrivacy
         )
         this.sessionReplayLifecycleCallback = SessionReplayLifecycleCallback(this)
         this.uiHandler = Handler(Looper.getMainLooper())
@@ -202,7 +202,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
     constructor(
         appContext: Application,
         rumContextProvider: RumContextProvider,
-        privacy: SessionReplayPrivacy,
+        textAndInputPrivacy: TextAndInputPrivacy,
         imagePrivacy: ImagePrivacy,
         touchPrivacy: TouchPrivacy,
         recordWriter: RecordWriter,
@@ -220,7 +220,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
     ) {
         this.appContext = appContext
         this.rumContextProvider = rumContextProvider
-        this.privacy = privacy
+        this.textAndInputPrivacy = textAndInputPrivacy
         this.imagePrivacy = imagePrivacy
         this.touchPrivacy = touchPrivacy
         this.recordWriter = recordWriter
@@ -255,7 +255,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
             val windows = sessionReplayLifecycleCallback.getCurrentWindows()
             val decorViews = windowInspector.getGlobalWindowViews(internalLogger)
             windowCallbackInterceptor.intercept(windows, appContext)
-            viewOnDrawInterceptor.intercept(decorViews, privacy, imagePrivacy)
+            viewOnDrawInterceptor.intercept(decorViews, textAndInputPrivacy, imagePrivacy)
         }
     }
 
@@ -272,7 +272,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         if (shouldRecord) {
             val decorViews = windowInspector.getGlobalWindowViews(internalLogger)
             windowCallbackInterceptor.intercept(windows, appContext)
-            viewOnDrawInterceptor.intercept(decorViews, privacy, imagePrivacy)
+            viewOnDrawInterceptor.intercept(decorViews, textAndInputPrivacy, imagePrivacy)
         }
     }
 
@@ -281,7 +281,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         if (shouldRecord) {
             val decorViews = windowInspector.getGlobalWindowViews(internalLogger)
             windowCallbackInterceptor.stopIntercepting(windows)
-            viewOnDrawInterceptor.intercept(decorViews, privacy, imagePrivacy)
+            viewOnDrawInterceptor.intercept(decorViews, textAndInputPrivacy, imagePrivacy)
         }
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -11,7 +11,7 @@ import android.view.ViewGroup
 import androidx.annotation.UiThread
 import com.datadog.android.internal.profiler.withinBenchmarkSpan
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -30,7 +30,7 @@ internal class SnapshotProducer(
     fun produce(
         rootView: View,
         systemInformation: SystemInformation,
-        privacy: SessionReplayPrivacy,
+        textAndInputPrivacy: TextAndInputPrivacy,
         imagePrivacy: ImagePrivacy,
         recordedDataQueueRefs: RecordedDataQueueRefs
     ): Node? {
@@ -39,7 +39,7 @@ internal class SnapshotProducer(
             MappingContext(
                 systemInformation = systemInformation,
                 imageWireframeHelper = imageWireframeHelper,
-                privacy = privacy,
+                textAndInputPrivacy = textAndInputPrivacy,
                 imagePrivacy = imagePrivacy
             ),
             LinkedList(),

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptor.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewTreeObserver.OnDrawListener
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import java.util.WeakHashMap
 
 internal class ViewOnDrawInterceptor(
@@ -22,11 +22,12 @@ internal class ViewOnDrawInterceptor(
 
     fun intercept(
         decorViews: List<View>,
-        sessionReplayPrivacy: SessionReplayPrivacy,
+        textAndInputPrivacy: TextAndInputPrivacy,
         imagePrivacy: ImagePrivacy
     ) {
         stopInterceptingAndRemove(decorViews)
-        val onDrawListener = onDrawListenerProducer.create(decorViews, sessionReplayPrivacy, imagePrivacy)
+        val onDrawListener =
+            onDrawListenerProducer.create(decorViews, textAndInputPrivacy, imagePrivacy)
         decorViews.forEach { decorView ->
             val viewTreeObserver = decorView.viewTreeObserver
             if (viewTreeObserver != null && viewTreeObserver.isAlive) {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptor.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptor.kt
@@ -10,7 +10,7 @@ import android.content.Context
 import android.view.Window
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.callback.NoOpWindowCallback
@@ -23,9 +23,9 @@ internal class WindowCallbackInterceptor(
     private val viewOnDrawInterceptor: ViewOnDrawInterceptor,
     private val timeProvider: TimeProvider,
     private val internalLogger: InternalLogger,
-    private val privacy: SessionReplayPrivacy,
     private val imagePrivacy: ImagePrivacy,
-    private val touchPrivacy: TouchPrivacy
+    private val touchPrivacy: TouchPrivacy,
+    private val textAndInputPrivacy: TextAndInputPrivacy
 ) {
     private val wrappedWindows: WeakHashMap<Window, Any?> = WeakHashMap()
 
@@ -59,7 +59,7 @@ internal class WindowCallbackInterceptor(
             timeProvider,
             viewOnDrawInterceptor,
             internalLogger,
-            privacy,
+            textAndInputPrivacy,
             imagePrivacy,
             touchPrivacy
         )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallback.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallback.kt
@@ -12,7 +12,7 @@ import android.view.Window
 import androidx.annotation.MainThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.recorder.ViewOnDrawInterceptor
@@ -31,7 +31,7 @@ internal class RecorderWindowCallback(
     private val timeProvider: TimeProvider,
     private val viewOnDrawInterceptor: ViewOnDrawInterceptor,
     private val internalLogger: InternalLogger,
-    private val privacy: SessionReplayPrivacy,
+    private val privacy: TextAndInputPrivacy,
     private val imagePrivacy: ImagePrivacy,
     private val touchPrivacy: TouchPrivacy,
     private val copyEvent: (MotionEvent) -> MotionEvent = {
@@ -182,7 +182,7 @@ internal class RecorderWindowCallback(
             viewOnDrawInterceptor.stopIntercepting()
             viewOnDrawInterceptor.intercept(
                 decorViews = rootViews,
-                sessionReplayPrivacy = privacy,
+                textAndInputPrivacy = privacy,
                 imagePrivacy = imagePrivacy
             )
         }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
@@ -14,7 +14,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.measureMethodCallPerf
 import com.datadog.android.internal.profiler.withinBenchmarkSpan
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.internal.recorder.Debouncer
@@ -26,7 +26,7 @@ internal class WindowsOnDrawListener(
     zOrderedDecorViews: List<View>,
     private val recordedDataQueueHandler: RecordedDataQueueHandler,
     private val snapshotProducer: SnapshotProducer,
-    private val privacy: SessionReplayPrivacy,
+    private val textAndInputPrivacy: TextAndInputPrivacy,
     private val imagePrivacy: ImagePrivacy,
     private val debouncer: Debouncer = Debouncer(),
     private val miscUtils: MiscUtils = MiscUtils,
@@ -65,7 +65,7 @@ internal class WindowsOnDrawListener(
                         snapshotProducer.produce(
                             rootView = it,
                             systemInformation = systemInformation,
-                            privacy = privacy,
+                            textAndInputPrivacy = textAndInputPrivacy,
                             imagePrivacy = imagePrivacy,
                             recordedDataQueueRefs = recordedDataQueueRefs
                         )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.widget.Checkable
 import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.recorder.mapper.BaseWireframeMapper
@@ -40,7 +40,7 @@ internal abstract class CheckableWireframeMapper<T>(
         internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
         val mainWireframes = resolveMainWireframes(view, mappingContext, asyncJobStatusCallback, internalLogger)
-        val checkableWireframes = if (mappingContext.privacy != SessionReplayPrivacy.ALLOW) {
+        val checkableWireframes = if (mappingContext.textAndInputPrivacy != TextAndInputPrivacy.MASK_SENSITIVE_INPUTS) {
             resolveMaskedCheckable(view, mappingContext)
         } else {
             // Resolves checkable view regardless the state

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/NumberPickerMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/NumberPickerMapper.kt
@@ -11,7 +11,7 @@ import android.widget.NumberPicker
 import androidx.annotation.RequiresApi
 import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.recorder.SystemInformation
@@ -73,7 +73,7 @@ internal open class NumberPickerMapper(
             return map(
                 view,
                 mappingContext.systemInformation,
-                mappingContext.privacy,
+                mappingContext.textAndInputPrivacy,
                 prevIndexLabelId,
                 topDividerId,
                 selectedIndexLabelId,
@@ -89,7 +89,7 @@ internal open class NumberPickerMapper(
     private fun map(
         view: NumberPicker,
         systemInformation: SystemInformation,
-        privacy: SessionReplayPrivacy,
+        textAndInputPrivacy: TextAndInputPrivacy,
         prevIndexLabelId: Long,
         topDividerId: Long,
         selectedIndexLabelId: Long,
@@ -167,7 +167,7 @@ internal open class NumberPickerMapper(
             nextPrevLabelTextColor
         )
 
-        return if (privacy == SessionReplayPrivacy.ALLOW) {
+        return if (textAndInputPrivacy == TextAndInputPrivacy.MASK_SENSITIVE_INPUTS) {
             listOf(
                 prevValueLabelWireframe,
                 topDividerWireframe,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ProgressBarWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ProgressBarWireframeMapper.kt
@@ -14,7 +14,7 @@ import android.widget.ProgressBar
 import androidx.annotation.RequiresApi
 import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -69,8 +69,12 @@ internal open class ProgressBarWireframeMapper<P : ProgressBar>(
         buildNonActiveTrackWireframe(view, trackBounds, trackColor)?.let(wireframes::add)
 
         val hasProgress = !view.isIndeterminate
-        val showProgress = (mappingContext.privacy == SessionReplayPrivacy.ALLOW) ||
-            (mappingContext.privacy == SessionReplayPrivacy.MASK_USER_INPUT && showProgressWhenMaskUserInput)
+        val showProgress =
+            (mappingContext.textAndInputPrivacy == TextAndInputPrivacy.MASK_SENSITIVE_INPUTS) ||
+                (
+                    mappingContext.textAndInputPrivacy == TextAndInputPrivacy.MASK_ALL_INPUTS &&
+                        showProgressWhenMaskUserInput
+                    )
 
         if (hasProgress && showProgress) {
             val normalizedProgress = normalizedProgress(view)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapper.kt
@@ -8,7 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.widget.SeekBar
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -55,7 +55,7 @@ internal open class SeekBarWireframeMapper(
             normalizedProgress
         )
 
-        if (mappingContext.privacy == SessionReplayPrivacy.ALLOW) {
+        if (mappingContext.textAndInputPrivacy == TextAndInputPrivacy.MASK_SENSITIVE_INPUTS) {
             val screenDensity = mappingContext.systemInformation.screenDensity
             val trackHeight = ProgressBarWireframeMapper.TRACK_HEIGHT_IN_PX.densityNormalized(screenDensity)
             val thumbColor = getColor(view.thumbTintList, view.drawableState) ?: getDefaultColor(view)

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/MappingContext.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/MappingContext.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.sessionreplay.recorder
 
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
 
 /**
@@ -16,7 +16,7 @@ import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
  * expected by Datadog.
  * @param systemInformation as [SystemInformation]
  * @param imageWireframeHelper a helper tool to capture images within a View
- * @param privacy the masking configuration to use when building the wireframes
+ * @param textAndInputPrivacy the text and input privacy level to use when building the wireframes
  * @param imagePrivacy the image recording configuration to use when building the wireframes
  * @param hasOptionSelectorParent tells if one of the parents of the current [android.view.View]
  * is an option selector type (e.g. time picker, date picker, drop - down list)
@@ -24,7 +24,7 @@ import com.datadog.android.sessionreplay.utils.ImageWireframeHelper
 data class MappingContext(
     val systemInformation: SystemInformation,
     val imageWireframeHelper: ImageWireframeHelper,
-    val privacy: SessionReplayPrivacy,
+    val textAndInputPrivacy: TextAndInputPrivacy,
     val imagePrivacy: ImagePrivacy,
     val hasOptionSelectorParent: Boolean = false
 )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapper.kt
@@ -9,7 +9,7 @@ package com.datadog.android.sessionreplay.recorder.mapper
 import android.text.InputType
 import android.widget.EditText
 import android.widget.TextView
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.internal.recorder.obfuscator.StringObfuscator
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
@@ -34,21 +34,25 @@ class EditTextMapper(
     drawableToColorMapper
 ) {
 
-    override fun resolveCapturedText(textView: EditText, privacy: SessionReplayPrivacy, isOption: Boolean): String {
+    override fun resolveCapturedText(
+        textView: EditText,
+        textAndInputPrivacy: TextAndInputPrivacy,
+        isOption: Boolean
+    ): String {
         val text = textView.text?.toString().orEmpty()
         val hint = textView.hint?.toString().orEmpty()
 
         return if (text.isNotEmpty()) {
-            resolveCapturedText(textView, text, privacy)
+            resolveCapturedText(textView, text, textAndInputPrivacy)
         } else {
-            resolveCapturedHint(hint, privacy)
+            resolveCapturedHint(hint, textAndInputPrivacy)
         }
     }
 
     private fun resolveCapturedText(
         textView: TextView,
         text: String,
-        privacy: SessionReplayPrivacy
+        textAndInputPrivacy: TextAndInputPrivacy
     ): String {
         val inputTypeVariation = textView.inputType and InputType.TYPE_MASK_VARIATION
         val inputTypeClass = textView.inputType and InputType.TYPE_MASK_CLASS
@@ -61,16 +65,16 @@ class EditTextMapper(
 
         val isSensitive = isSensitiveText || isSensitiveNumber || (inputTypeClass == InputType.TYPE_CLASS_PHONE)
 
-        return when (privacy) {
-            SessionReplayPrivacy.ALLOW -> if (isSensitive) FIXED_INPUT_MASK else text
+        return when (textAndInputPrivacy) {
+            TextAndInputPrivacy.MASK_SENSITIVE_INPUTS -> if (isSensitive) FIXED_INPUT_MASK else text
 
-            SessionReplayPrivacy.MASK,
-            SessionReplayPrivacy.MASK_USER_INPUT -> FIXED_INPUT_MASK
+            TextAndInputPrivacy.MASK_ALL,
+            TextAndInputPrivacy.MASK_ALL_INPUTS -> FIXED_INPUT_MASK
         }
     }
 
-    private fun resolveCapturedHint(hint: String, privacy: SessionReplayPrivacy): String {
-        return if (privacy == SessionReplayPrivacy.MASK) {
+    private fun resolveCapturedHint(hint: String, textAndInputPrivacy: TextAndInputPrivacy): String {
+        return if (textAndInputPrivacy == TextAndInputPrivacy.MASK_ALL) {
             StringObfuscator.getStringObfuscator().obfuscate(hint)
         } else {
             hint

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -85,25 +85,6 @@ internal class SessionReplayConfigurationBuilderTest {
     }
 
     @Test
-    fun `M use the given privacy rule W setSessionReplayPrivacy`(
-        @Forgery fakePrivacy: SessionReplayPrivacy
-    ) {
-        // When
-        val sessionReplayConfiguration = testedBuilder
-            .setPrivacy(fakePrivacy)
-            .build()
-
-        // Then
-        assertThat(sessionReplayConfiguration.customEndpointUrl).isNull()
-        assertThat(sessionReplayConfiguration.privacy).isEqualTo(fakePrivacy)
-        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_ALL)
-        assertThat(sessionReplayConfiguration.touchPrivacy).isEqualTo(TouchPrivacy.HIDE)
-        assertThat(sessionReplayConfiguration.customMappers).isEmpty()
-        assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
-        assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
-    }
-
-    @Test
     fun `M use the given image privacy rule W setImagePrivacy`(
         @Forgery fakeImagePrivacy: ImagePrivacy
     ) {
@@ -127,6 +108,19 @@ internal class SessionReplayConfigurationBuilderTest {
 
         // Then
         assertThat(sessionReplayConfiguration.touchPrivacy).isEqualTo(fakeTouchPrivacy)
+    }
+
+    @Test
+    fun `M use the given text and input privacy rule W setTextAndInputPrivacy`(
+        @Forgery fakeTextAndInputPrivacy: TextAndInputPrivacy
+    ) {
+        // When
+        val sessionReplayConfiguration = testedBuilder
+            .setTextAndInputPrivacy(fakeTextAndInputPrivacy)
+            .build()
+
+        // Then
+        assertThat(sessionReplayConfiguration.textAndInputPrivacy).isEqualTo(fakeTextAndInputPrivacy)
     }
 
     @Test
@@ -162,5 +156,60 @@ internal class SessionReplayConfigurationBuilderTest {
 
         // Then
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `M not overwrite fgm W setPrivacy { fgm already set }`() {
+        // When
+        val sessionReplayConfiguration = testedBuilder
+            .setImagePrivacy(ImagePrivacy.MASK_ALL)
+            .setPrivacy(SessionReplayPrivacy.ALLOW)
+            .build()
+
+        // Then
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_ALL)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `M set appropriate fgm privacy W setPrivacy { allow }`() {
+        // When
+        val sessionReplayConfiguration = testedBuilder
+            .setPrivacy(SessionReplayPrivacy.ALLOW)
+            .build()
+
+        // Then
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_NONE)
+        assertThat(sessionReplayConfiguration.touchPrivacy).isEqualTo(TouchPrivacy.SHOW)
+        assertThat(sessionReplayConfiguration.textAndInputPrivacy).isEqualTo(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `M set appropriate fgm privacy W setPrivacy { mask_user_input }`() {
+        // When
+        val sessionReplayConfiguration = testedBuilder
+            .setPrivacy(SessionReplayPrivacy.MASK_USER_INPUT)
+            .build()
+
+        // Then
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_LARGE_ONLY)
+        assertThat(sessionReplayConfiguration.touchPrivacy).isEqualTo(TouchPrivacy.HIDE)
+        assertThat(sessionReplayConfiguration.textAndInputPrivacy).isEqualTo(TextAndInputPrivacy.MASK_ALL_INPUTS)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `M set appropriate fgm privacy W setPrivacy { mask }`() {
+        // When
+        val sessionReplayConfiguration = testedBuilder
+            .setPrivacy(SessionReplayPrivacy.MASK)
+            .build()
+
+        // Then
+        assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_ALL)
+        assertThat(sessionReplayConfiguration.touchPrivacy).isEqualTo(TouchPrivacy.HIDE)
+        assertThat(sessionReplayConfiguration.textAndInputPrivacy).isEqualTo(TextAndInputPrivacy.MASK_ALL)
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayRecorderTest.kt
@@ -60,7 +60,7 @@ internal class SessionReplayRecorderTest {
     private lateinit var mockRecordWriter: RecordWriter
 
     @Forgery
-    private lateinit var fakePrivacy: SessionReplayPrivacy
+    private lateinit var fakeTextAndInputPrivacy: TextAndInputPrivacy
 
     @Forgery
     private lateinit var fakeImagePrivacy: ImagePrivacy
@@ -110,7 +110,7 @@ internal class SessionReplayRecorderTest {
         testedSessionReplayRecorder = SessionReplayRecorder(
             appContext = appContext.mockInstance,
             rumContextProvider = mockRumContextProvider,
-            privacy = fakePrivacy,
+            textAndInputPrivacy = fakeTextAndInputPrivacy,
             imagePrivacy = fakeImagePrivacy,
             touchPrivacy = fakeTouchPrivacy,
             recordWriter = mockRecordWriter,
@@ -155,7 +155,7 @@ internal class SessionReplayRecorderTest {
         verify(mockWindowCallbackInterceptor).intercept(fakeActiveWindows, appContext.mockInstance)
         verify(mockViewOnDrawInterceptor).intercept(
             decorViews = fakeActiveWindowsDecorViews,
-            sessionReplayPrivacy = fakePrivacy,
+            textAndInputPrivacy = fakeTextAndInputPrivacy,
             imagePrivacy = fakeImagePrivacy
         )
     }
@@ -186,7 +186,7 @@ internal class SessionReplayRecorderTest {
 
         // Then
         verify(mockWindowCallbackInterceptor).intercept(fakeAddedWindows, appContext.mockInstance)
-        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
+        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
     }
 
     @Test
@@ -208,7 +208,7 @@ internal class SessionReplayRecorderTest {
         verify(mockWindowCallbackInterceptor, never())
             .intercept(fakeAddedWindows, appContext.mockInstance)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
+            .intercept(fakeNewDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
     }
 
     @Test
@@ -230,7 +230,7 @@ internal class SessionReplayRecorderTest {
         verify(mockWindowCallbackInterceptor, never())
             .intercept(fakeAddedWindows, appContext.mockInstance)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
+            .intercept(fakeNewDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
     }
 
     @Test
@@ -249,7 +249,7 @@ internal class SessionReplayRecorderTest {
 
         // Then
         verify(mockWindowCallbackInterceptor).stopIntercepting(fakeAddedWindows)
-        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
+        verify(mockViewOnDrawInterceptor).intercept(fakeNewDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
     }
 
     @Test
@@ -270,7 +270,7 @@ internal class SessionReplayRecorderTest {
         // Then
         verify(mockWindowCallbackInterceptor, never()).stopIntercepting(fakeAddedWindows)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
+            .intercept(fakeNewDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
     }
 
     @Test
@@ -289,7 +289,7 @@ internal class SessionReplayRecorderTest {
         // Then
         verify(mockWindowCallbackInterceptor, never()).stopIntercepting(fakeAddedWindows)
         verify(mockViewOnDrawInterceptor, never())
-            .intercept(fakeNewDecorViews, fakePrivacy, fakeImagePrivacy)
+            .intercept(fakeNewDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MappingContextForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/MappingContextForgeryFactory.kt
@@ -17,7 +17,7 @@ internal class MappingContextForgeryFactory : ForgeryFactory<MappingContext> {
             systemInformation = forge.getForgery(),
             imageWireframeHelper = mock(),
             hasOptionSelectorParent = forge.aBool(),
-            privacy = forge.getForgery(),
+            textAndInputPrivacy = forge.getForgery(),
             imagePrivacy = forge.getForgery()
         )
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.forge
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.TouchPrivacy
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.ForgeryFactory
@@ -19,6 +20,7 @@ class SessionReplayConfigurationForgeryFactory : ForgeryFactory<SessionReplayCon
         return SessionReplayConfiguration(
             customEndpointUrl = forge.aNullable { aStringMatching("https://[a-z]+\\.com") },
             privacy = forge.aValueFrom(SessionReplayPrivacy::class.java),
+            textAndInputPrivacy = forge.aValueFrom(TextAndInputPrivacy::class.java),
             imagePrivacy = forge.aValueFrom(ImagePrivacy::class.java),
             touchPrivacy = forge.aValueFrom(TouchPrivacy::class.java),
             customMappers = forge.aList { mock() },

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -105,6 +105,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            textAndInputPrivacy = fakeConfiguration.textAndInputPrivacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
             startRecordingImmediately = true,
             touchPrivacy = fakeConfiguration.touchPrivacy,
@@ -129,6 +130,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            textAndInputPrivacy = fakeConfiguration.textAndInputPrivacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
             touchPrivacy = fakeConfiguration.touchPrivacy,
             customMappers = emptyList(),
@@ -152,6 +154,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            textAndInputPrivacy = fakeConfiguration.textAndInputPrivacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
             touchPrivacy = fakeConfiguration.touchPrivacy,
             customMappers = emptyList(),
@@ -177,6 +180,10 @@ internal class SessionReplayFeatureTest {
                 .isEqualTo(fakeConfiguration.privacy.toString().lowercase(Locale.US))
             assertThat(updatedContext[SessionReplayFeature.SESSION_REPLAY_START_IMMEDIATE_RECORDING_KEY])
                 .isEqualTo(true)
+            assertThat(updatedContext[SessionReplayFeature.SESSION_REPLAY_IMAGE_PRIVACY_KEY])
+                .isEqualTo(fakeConfiguration.imagePrivacy.toString().lowercase(Locale.US))
+            assertThat(updatedContext[SessionReplayFeature.SESSION_REPLAY_TEXT_AND_INPUT_PRIVACY_KEY])
+                .isEqualTo(fakeConfiguration.textAndInputPrivacy.toString().lowercase(Locale.US))
         }
     }
 
@@ -187,6 +194,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            textAndInputPrivacy = fakeConfiguration.textAndInputPrivacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
             startRecordingImmediately = true,
             touchPrivacy = fakeConfiguration.touchPrivacy,
@@ -1006,6 +1014,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            textAndInputPrivacy = fakeConfiguration.textAndInputPrivacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
             touchPrivacy = fakeConfiguration.touchPrivacy,
             startRecordingImmediately = scenario.startRecordingImmediately,
@@ -1044,6 +1053,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            textAndInputPrivacy = fakeConfiguration.textAndInputPrivacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
             touchPrivacy = fakeConfiguration.touchPrivacy,
             startRecordingImmediately = true,
@@ -1075,6 +1085,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            textAndInputPrivacy = fakeConfiguration.textAndInputPrivacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
             touchPrivacy = fakeConfiguration.touchPrivacy,
             startRecordingImmediately = false,
@@ -1108,6 +1119,7 @@ internal class SessionReplayFeatureTest {
             sdkCore = mockSdkCore,
             customEndpointUrl = fakeConfiguration.customEndpointUrl,
             privacy = fakeConfiguration.privacy,
+            textAndInputPrivacy = fakeConfiguration.textAndInputPrivacy,
             imagePrivacy = fakeConfiguration.imagePrivacy,
             touchPrivacy = fakeConfiguration.touchPrivacy,
             startRecordingImmediately = true,

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
@@ -9,7 +9,7 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.view.View
 import android.view.ViewGroup
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -67,7 +67,7 @@ internal class SnapshotProducerTest {
     lateinit var fakeViewWireframes: List<MobileSegment.Wireframe>
 
     @Forgery
-    lateinit var fakePrivacy: SessionReplayPrivacy
+    lateinit var fakeTextAndInputPrivacy: TextAndInputPrivacy
 
     @Forgery
     lateinit var fakeImagePrivacy: ImagePrivacy
@@ -96,7 +96,7 @@ internal class SnapshotProducerTest {
         val snapshot = testedSnapshotProducer.produce(
             mockRoot,
             fakeSystemInformation,
-            fakePrivacy,
+            fakeTextAndInputPrivacy,
             fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
@@ -123,7 +123,7 @@ internal class SnapshotProducerTest {
         val snapshot = testedSnapshotProducer.produce(
             fakeRoot,
             fakeSystemInformation,
-            fakePrivacy,
+            fakeTextAndInputPrivacy,
             fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
@@ -150,7 +150,7 @@ internal class SnapshotProducerTest {
         val snapshot = testedSnapshotProducer.produce(
             fakeRoot,
             fakeSystemInformation,
-            fakePrivacy,
+            fakeTextAndInputPrivacy,
             fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
@@ -177,7 +177,7 @@ internal class SnapshotProducerTest {
         val snapshot = testedSnapshotProducer.produce(
             fakeRoot,
             fakeSystemInformation,
-            fakePrivacy,
+            fakeTextAndInputPrivacy,
             fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
@@ -208,7 +208,7 @@ internal class SnapshotProducerTest {
         testedSnapshotProducer.produce(
             mockRoot,
             fakeSystemInformation,
-            fakePrivacy,
+            fakeTextAndInputPrivacy,
             fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
@@ -220,7 +220,7 @@ internal class SnapshotProducerTest {
         argumentCaptor.allValues.forEach {
             assertThat(it.systemInformation).isEqualTo(fakeSystemInformation)
             assertThat(it.imageWireframeHelper).isEqualTo(mockImageWireframeHelper)
-            assertThat(it.privacy).isEqualTo(fakePrivacy)
+            assertThat(it.textAndInputPrivacy).isEqualTo(fakeTextAndInputPrivacy)
         }
     }
 
@@ -245,7 +245,7 @@ internal class SnapshotProducerTest {
         testedSnapshotProducer.produce(
             mockRoot,
             fakeSystemInformation,
-            fakePrivacy,
+            fakeTextAndInputPrivacy,
             fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
@@ -280,7 +280,7 @@ internal class SnapshotProducerTest {
         testedSnapshotProducer.produce(
             mockRoot,
             fakeSystemInformation,
-            fakePrivacy,
+            fakeTextAndInputPrivacy,
             fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
@@ -324,7 +324,7 @@ internal class SnapshotProducerTest {
         val snapshot = testedSnapshotProducer.produce(
             fakeRoot,
             fakeSystemInformation,
-            fakePrivacy,
+            fakeTextAndInputPrivacy,
             fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )
@@ -357,7 +357,7 @@ internal class SnapshotProducerTest {
         val snapshot = testedSnapshotProducer.produce(
             fakeRoot,
             fakeSystemInformation,
-            fakePrivacy,
+            fakeTextAndInputPrivacy,
             fakeImagePrivacy,
             mockRecordedDataQueueRefs
         )

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/ViewOnDrawInterceptorTest.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewTreeObserver
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -54,7 +54,7 @@ internal class ViewOnDrawInterceptorTest {
     lateinit var mockOnDrawListener: ViewTreeObserver.OnDrawListener
 
     @Forgery
-    lateinit var fakePrivacy: SessionReplayPrivacy
+    lateinit var fakeTextAndInputPrivacy: TextAndInputPrivacy
 
     @Forgery
     lateinit var fakeImagePrivacy: ImagePrivacy
@@ -68,7 +68,7 @@ internal class ViewOnDrawInterceptorTest {
         whenever(
             mockOnDrawListenerProducer.create(
                 fakeDecorViews,
-                fakePrivacy,
+                fakeTextAndInputPrivacy,
                 fakeImagePrivacy
             )
         ) doReturn mockOnDrawListener
@@ -82,7 +82,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M register the OnDrawListener W intercept()`() {
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
 
         // Then
         fakeDecorViews.forEach {
@@ -99,15 +99,15 @@ internal class ViewOnDrawInterceptorTest {
         testedInterceptor = ViewOnDrawInterceptor(
             internalLogger = mockInternalLogger,
             onDrawListenerProducer = { _, privacy, _ ->
-                check(privacy == fakePrivacy) {
-                    "Expected to create an OnDrawListener with privacy $fakePrivacy but was $privacy"
+                check(privacy == fakeTextAndInputPrivacy) {
+                    "Expected to create an OnDrawListener with privacy $fakeTextAndInputPrivacy but was $privacy"
                 }
                 mock()
             }
         )
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
 
         // Then
         fakeDecorViews.forEach {
@@ -124,7 +124,7 @@ internal class ViewOnDrawInterceptorTest {
         ) { _, _, _ -> mockOnDrawListener }
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
 
         // Then
         fakeDecorViews.forEach {
@@ -136,7 +136,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M register one single listener instance W intercept()`() {
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
 
         // Then
         val captor = argumentCaptor<ViewTreeObserver.OnDrawListener>()
@@ -158,7 +158,7 @@ internal class ViewOnDrawInterceptorTest {
         }
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
 
         // Then
         assertThat(testedInterceptor.decorOnDrawListeners).isEmpty()
@@ -172,7 +172,7 @@ internal class ViewOnDrawInterceptorTest {
         }
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
 
         // Then
         assertThat(testedInterceptor.decorOnDrawListeners).isEmpty()
@@ -181,7 +181,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister and clean the listeners W stopIntercepting(decorViews)`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
 
         // When
         testedInterceptor.stopIntercepting(fakeDecorViews)
@@ -198,7 +198,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister the listeners safely W stopIntercepting(decorViews)`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
         fakeDecorViews.forEach {
             whenever(it.viewTreeObserver.removeOnDrawListener(any())) doThrow IllegalStateException()
         }
@@ -218,7 +218,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister and clean the listeners W stopIntercepting()`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
 
         // When
         testedInterceptor.stopIntercepting()
@@ -236,10 +236,10 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister first and clean the listeners W intercepting()`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
 
         // When
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
 
         // Then
         fakeDecorViews.forEach {
@@ -255,7 +255,7 @@ internal class ViewOnDrawInterceptorTest {
     @Test
     fun `M unregister the listeners safely W stopIntercepting()`() {
         // Given
-        testedInterceptor.intercept(fakeDecorViews, fakePrivacy, fakeImagePrivacy)
+        testedInterceptor.intercept(fakeDecorViews, fakeTextAndInputPrivacy, fakeImagePrivacy)
         fakeDecorViews.forEach {
             whenever(it.viewTreeObserver.removeOnDrawListener(any())) doThrow IllegalStateException()
         }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptorTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/WindowCallbackInterceptorTest.kt
@@ -13,7 +13,7 @@ import android.view.View
 import android.view.Window
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
@@ -65,7 +65,7 @@ internal class WindowCallbackInterceptorTest {
     lateinit var mockInternalLogger: InternalLogger
 
     @Forgery
-    lateinit var fakePrivacy: SessionReplayPrivacy
+    lateinit var fakeTextAndInputPrivacy: TextAndInputPrivacy
 
     @Forgery
     lateinit var fakeImagePrivacy: ImagePrivacy
@@ -82,13 +82,13 @@ internal class WindowCallbackInterceptorTest {
         mockActivity = forge.aMockedActivity()
         fakeWindowsList = forge.aMockedWindowsList()
         testedInterceptor = WindowCallbackInterceptor(
-            mockRecordedDataQueueHandler,
-            mockViewOnDrawInterceptor,
-            mockTimeProvider,
-            mockInternalLogger,
-            fakePrivacy,
-            fakeImagePrivacy,
-            fakeTouchPrivacy
+            recordedDataQueueHandler = mockRecordedDataQueueHandler,
+            viewOnDrawInterceptor = mockViewOnDrawInterceptor,
+            timeProvider = mockTimeProvider,
+            internalLogger = mockInternalLogger,
+            imagePrivacy = fakeImagePrivacy,
+            touchPrivacy = fakeTouchPrivacy,
+            textAndInputPrivacy = fakeTextAndInputPrivacy
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallbackTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/callback/RecorderWindowCallbackTest.kt
@@ -14,7 +14,7 @@ import android.view.View
 import android.view.Window
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.TouchPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
@@ -102,7 +102,7 @@ internal class RecorderWindowCallbackTest {
     lateinit var mockEventUtils: MotionEventUtils
 
     @Forgery
-    lateinit var fakePrivacy: SessionReplayPrivacy
+    lateinit var fakeTextAndInputPrivacy: TextAndInputPrivacy
 
     @BeforeEach
     fun `set up`() {
@@ -121,9 +121,9 @@ internal class RecorderWindowCallbackTest {
             timeProvider = mockTimeProvider,
             viewOnDrawInterceptor = mockViewOnDrawInterceptor,
             internalLogger = mockInternalLogger,
-            privacy = fakePrivacy,
             imagePrivacy = ImagePrivacy.MASK_NONE,
             touchPrivacy = TouchPrivacy.SHOW,
+            privacy = fakeTextAndInputPrivacy,
             copyEvent = { it },
             motionEventUtils = mockEventUtils,
             motionUpdateThresholdInNs = TEST_MOTION_UPDATE_DELAY_THRESHOLD_NS,
@@ -426,7 +426,7 @@ internal class RecorderWindowCallbackTest {
         // Then
         inOrder(mockViewOnDrawInterceptor) {
             verify(mockViewOnDrawInterceptor).stopIntercepting()
-            verify(mockViewOnDrawInterceptor).intercept(fakeDecorViews, fakePrivacy, ImagePrivacy.MASK_NONE)
+            verify(mockViewOnDrawInterceptor).intercept(fakeDecorViews, fakeTextAndInputPrivacy, ImagePrivacy.MASK_NONE)
         }
     }
 
@@ -466,7 +466,7 @@ internal class RecorderWindowCallbackTest {
             timeProvider = mockTimeProvider,
             viewOnDrawInterceptor = mockViewOnDrawInterceptor,
             internalLogger = mockInternalLogger,
-            privacy = fakePrivacy,
+            privacy = fakeTextAndInputPrivacy,
             imagePrivacy = ImagePrivacy.MASK_NONE,
             touchPrivacy = TouchPrivacy.SHOW,
             copyEvent = { it },
@@ -507,7 +507,7 @@ internal class RecorderWindowCallbackTest {
             timeProvider = mockTimeProvider,
             viewOnDrawInterceptor = mockViewOnDrawInterceptor,
             internalLogger = mockInternalLogger,
-            privacy = fakePrivacy,
+            privacy = fakeTextAndInputPrivacy,
             imagePrivacy = ImagePrivacy.MASK_NONE,
             touchPrivacy = TouchPrivacy.HIDE,
             copyEvent = { it },

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListenerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListenerTest.kt
@@ -15,7 +15,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.metrics.PerformanceMetric
 import com.datadog.android.core.metrics.TelemetryMetricType
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
@@ -108,7 +108,7 @@ internal class WindowsOnDrawListenerTest {
     lateinit var mockContext: Context
 
     @Forgery
-    lateinit var fakePrivacy: SessionReplayPrivacy
+    lateinit var fakeTextAndInputPrivacy: TextAndInputPrivacy
 
     @Forgery
     lateinit var fakeImagePrivacy: ImagePrivacy
@@ -130,7 +130,7 @@ internal class WindowsOnDrawListenerTest {
                 mockSnapshotProducer.produce(
                     eq(decorView),
                     eq(fakeSystemInformation),
-                    eq(fakePrivacy),
+                    eq(fakeTextAndInputPrivacy),
                     eq(fakeImagePrivacy),
                     any()
                 )
@@ -157,7 +157,7 @@ internal class WindowsOnDrawListenerTest {
             zOrderedDecorViews = fakeMockedDecorViews,
             recordedDataQueueHandler = mockRecordedDataQueueHandler,
             snapshotProducer = mockSnapshotProducer,
-            privacy = fakePrivacy,
+            textAndInputPrivacy = fakeTextAndInputPrivacy,
             imagePrivacy = fakeImagePrivacy,
             debouncer = mockDebouncer,
             miscUtils = mockMiscUtils,
@@ -194,7 +194,7 @@ internal class WindowsOnDrawListenerTest {
         verify(mockSnapshotProducer, times(fakeWindowsSnapshots.size)).produce(
             rootView = any(),
             systemInformation = any(),
-            privacy = eq(fakePrivacy),
+            textAndInputPrivacy = eq(fakeTextAndInputPrivacy),
             imagePrivacy = eq(fakeImagePrivacy),
             recordedDataQueueRefs = argCaptor.capture()
         )
@@ -209,7 +209,7 @@ internal class WindowsOnDrawListenerTest {
             zOrderedDecorViews = emptyList(),
             recordedDataQueueHandler = mockRecordedDataQueueHandler,
             snapshotProducer = mockSnapshotProducer,
-            privacy = fakePrivacy,
+            textAndInputPrivacy = fakeTextAndInputPrivacy,
             imagePrivacy = fakeImagePrivacy,
             debouncer = mockDebouncer,
             miscUtils = mockMiscUtils,

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckableTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckableTextViewMapperTest.kt
@@ -13,7 +13,7 @@ import android.os.Build
 import android.widget.Checkable
 import android.widget.TextView
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckableTextViewMapper.Companion.CHECK_BOX_CHECKED_DRAWABLE_INDEX
 import com.datadog.android.sessionreplay.internal.recorder.mapper.CheckableTextViewMapper.Companion.CHECK_BOX_NOT_CHECKED_DRAWABLE_INDEX
@@ -179,7 +179,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
     internal abstract fun mockCheckableTextView(): T
 
     internal open fun expectedCheckedShapeStyle(checkBoxColor: String): MobileSegment.ShapeStyle? {
-        return if (fakeMappingContext.privacy == SessionReplayPrivacy.ALLOW) {
+        return if (fakeMappingContext.textAndInputPrivacy == TextAndInputPrivacy.MASK_SENSITIVE_INPUTS) {
             MobileSegment.ShapeStyle(
                 backgroundColor = checkBoxColor,
                 opacity = mockCheckableTextView.alpha
@@ -196,7 +196,10 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
     fun `M create ImageWireFrame W map() { checked, above M }`() {
         // Given
         val allowedMappingContext =
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW, imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY)
+            fakeMappingContext.copy(
+                textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS,
+                imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY
+            )
         whenever(mockButtonDrawable.intrinsicHeight).thenReturn(fakeIntrinsicDrawableHeight)
         whenever(mockCheckableTextView.isChecked).thenReturn(true)
 
@@ -236,7 +239,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
     fun `M create ImageWireFrame W map() { not checked, above M }`() {
         // Given
         val allowedMappingContext = fakeMappingContext.copy(
-            privacy = SessionReplayPrivacy.ALLOW,
+            textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS,
             imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY
         )
         whenever(mockButtonDrawable.intrinsicHeight).thenReturn(fakeIntrinsicDrawableHeight)

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseSwitchCompatMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseSwitchCompatMapperTest.kt
@@ -11,7 +11,7 @@ import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.Drawable.ConstantState
 import androidx.appcompat.widget.SwitchCompat
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -197,7 +197,8 @@ internal abstract class BaseSwitchCompatMapperTest : LegacyBaseWireframeMapperTe
         // Given
         whenever(mockSwitch.thumbDrawable).thenReturn(null)
         whenever(mockSwitch.isChecked).thenReturn(forge.aBool())
-        val allowMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        val allowMappingContext =
+            fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
 
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
@@ -216,7 +217,8 @@ internal abstract class BaseSwitchCompatMapperTest : LegacyBaseWireframeMapperTe
         // Given
         whenever(mockSwitch.trackDrawable).thenReturn(null)
         whenever(mockSwitch.isChecked).thenReturn(forge.aBool())
-        val allowMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        val allowMappingContext =
+            fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
 
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapperTest.kt
@@ -11,7 +11,7 @@ import android.text.InputType
 import android.view.Gravity
 import android.widget.Button
 import android.widget.TextView
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.mapper.BaseAsyncBackgroundWireframeMapperTest
@@ -68,7 +68,7 @@ internal abstract class ButtonMapperTest : BaseAsyncBackgroundWireframeMapperTes
             )
         ) doReturn fakeTextColorHexString
 
-        withPrivacy(privacyOption())
+        withTextAndInputPrivacy(privacyOption())
 
         testedWireframeMapper = ButtonMapper(
             mockViewIdentifierResolver,
@@ -80,7 +80,7 @@ internal abstract class ButtonMapperTest : BaseAsyncBackgroundWireframeMapperTes
 
     abstract fun expectedPrivacyCompliantText(text: String): String
 
-    abstract fun privacyOption(): SessionReplayPrivacy
+    abstract fun privacyOption(): TextAndInputPrivacy
 
     @ParameterizedTest(name = "{index} (typeface: {0}, align:{2}, gravity:{3})")
     @MethodSource("basicParametersMatrix")

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/NumberPickerMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/NumberPickerMapperTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.internal.recorder.mapper
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -42,7 +42,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return a list of wireframes W map() {privacy=ALLOW}`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         val expectedSelectedLabelValue = fakeValue.toString()
         val expectedPrevLabelValue = (fakeValue - 1).toString()
         val expectedNextLabelValue = (fakeValue + 1).toString()
@@ -78,7 +78,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return a list of wireframes W map() {privacy=ALLOW, value=max }`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         fakeValue = fakeMaxValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val expectedSelectedLabelValue = fakeValue.toString()
@@ -116,7 +116,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return a list of wireframes W map() {privacy=ALLOW, value=min }`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         fakeValue = fakeMinValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val expectedSelectedLabelValue = fakeValue.toString()
@@ -156,7 +156,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         forge: Forge
     ) {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         val fakeDisplayedValues = forge.aList(size = (fakeMaxValue - fakeMinValue + 1)) { aString() }
             .toTypedArray()
         whenever(mockNumberPicker.displayedValues).thenReturn(fakeDisplayedValues)
@@ -198,7 +198,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         forge: Forge
     ) {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         fakeValue = fakeMaxValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val fakeDisplayedValues = forge.aList(size = (fakeMaxValue - fakeMinValue + 1)) { aString() }
@@ -241,7 +241,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         forge: Forge
     ) {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         fakeValue = fakeMinValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val fakeDisplayedValues = forge.aList(size = (fakeMaxValue - fakeMinValue + 1)) { aString() }
@@ -283,7 +283,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return empty list W map {privacy=ALLOW, prevLabelId=null}`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         whenever(
             mockViewIdentifierResolver
                 .resolveChildUniqueIdentifier(
@@ -308,7 +308,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return empty list W map {privacy=ALLOW, nextLabelId=null}`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.ALLOW)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         whenever(
             mockViewIdentifierResolver
                 .resolveChildUniqueIdentifier(
@@ -337,7 +337,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return a list of wireframes W map() {privacy=MASK}`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL)
         val expectedSelectedLabelValue = "xxx"
         val expectedTopDividerWireframe = fakeTopDividerWireframe()
         val expectedSelectedLabelWireframe = fakeSelectedLabelWireframe()
@@ -364,7 +364,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return a list of wireframes W map() {privacy=MASK, value=max}`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL)
         fakeValue = fakeMaxValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val expectedSelectedLabelValue = "xxx"
@@ -393,7 +393,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return a list of wireframes W map() {privacy=MASK, value=min }`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL)
         fakeValue = fakeMinValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val expectedSelectedLabelValue = "xxx"
@@ -425,7 +425,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         forge: Forge
     ) {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL)
         val fakeDisplayedValues = forge.aList(size = (fakeMaxValue - fakeMinValue + 1)) { aString() }
             .toTypedArray()
         whenever(mockNumberPicker.displayedValues).thenReturn(fakeDisplayedValues)
@@ -457,7 +457,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         forge: Forge
     ) {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL)
         fakeValue = fakeMaxValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val fakeDisplayedValues = forge.aList(size = (fakeMaxValue - fakeMinValue + 1)) { aString() }
@@ -491,7 +491,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         forge: Forge
     ) {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL)
         fakeValue = fakeMinValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val fakeDisplayedValues = forge.aList(size = (fakeMaxValue - fakeMinValue + 1)) { aString() }
@@ -528,7 +528,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return a list of wireframes W map() {privacy=MASK_USER_INPUT}`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK_USER_INPUT)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS)
         val expectedSelectedLabelValue = "xxx"
         val expectedTopDividerWireframe = fakeTopDividerWireframe()
         val expectedSelectedLabelWireframe = fakeSelectedLabelWireframe()
@@ -555,7 +555,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return a list of wireframes W map() {privacy=MASK_USER_INPUT, value=max}`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK_USER_INPUT)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS)
         fakeValue = fakeMaxValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val expectedSelectedLabelValue = "xxx"
@@ -584,7 +584,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
     @Test
     fun `M return a list of wireframes W map() {privacy=MASK_USER_INPUT, value=min }`() {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK_USER_INPUT)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS)
         fakeValue = fakeMinValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val expectedSelectedLabelValue = "xxx"
@@ -616,7 +616,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         forge: Forge
     ) {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK_USER_INPUT)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS)
         val fakeDisplayedValues = forge.aList(size = (fakeMaxValue - fakeMinValue + 1)) { aString() }
             .toTypedArray()
         whenever(mockNumberPicker.displayedValues).thenReturn(fakeDisplayedValues)
@@ -648,7 +648,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         forge: Forge
     ) {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK_USER_INPUT)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS)
         fakeValue = fakeMaxValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val fakeDisplayedValues = forge.aList(size = (fakeMaxValue - fakeMinValue + 1)) { aString() }
@@ -682,7 +682,7 @@ internal class NumberPickerMapperTest : BaseNumberPickerMapperTest() {
         forge: Forge
     ) {
         // Given
-        fakeMappingContext = fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK_USER_INPUT)
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS)
         fakeValue = fakeMinValue
         whenever(mockNumberPicker.value).thenReturn(fakeValue)
         val fakeDisplayedValues = forge.aList(size = (fakeMaxValue - fakeMinValue + 1)) { aString() }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ProgressBarWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ProgressBarWireframeMapperTest.kt
@@ -4,7 +4,7 @@ import android.content.res.ColorStateList
 import android.graphics.Rect
 import android.os.Build
 import android.widget.ProgressBar
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.internal.recorder.mapper.SeekBarWireframeMapper.Companion.TRACK_HEIGHT_IN_PX
@@ -96,7 +96,7 @@ internal class ProgressBarWireframeMapperTest :
     @Test
     fun `M return generic wireframes W map {indeterminate}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockProgressBar(isIndeterminate = true)
 
         // When
@@ -120,7 +120,7 @@ internal class ProgressBarWireframeMapperTest :
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return partial wireframes W map {determinate, invalid track id, Android 0+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockProgressBar(isIndeterminate = false)
         mockChildUniqueIdentifier(SeekBarWireframeMapper.ACTIVE_TRACK_KEY_NAME, null)
 
@@ -141,7 +141,7 @@ internal class ProgressBarWireframeMapperTest :
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return partial wireframes W map {determinate, invalid non active track id, Android 0+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockProgressBar(isIndeterminate = false)
         mockChildUniqueIdentifier(SeekBarWireframeMapper.NON_ACTIVE_TRACK_KEY_NAME, null)
 
@@ -162,7 +162,7 @@ internal class ProgressBarWireframeMapperTest :
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return wireframes W map {determinate, privacy=ALLOW, Android 0+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockProgressBar(isIndeterminate = false)
 
         // When
@@ -183,7 +183,7 @@ internal class ProgressBarWireframeMapperTest :
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return wireframes W map {determinate, privacy=MASK, Android 0+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.MASK)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_ALL)
         prepareMockProgressBar(isIndeterminate = false)
 
         // When
@@ -203,7 +203,7 @@ internal class ProgressBarWireframeMapperTest :
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return wireframes W map {determinate, privacy=MASK_USER_INPUT, Android 0+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.MASK_USER_INPUT)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_ALL_INPUTS)
         prepareMockProgressBar(isIndeterminate = false)
 
         // When
@@ -228,7 +228,7 @@ internal class ProgressBarWireframeMapperTest :
     fun `M return partial wireframes W map {determinate, invalid track id}`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockProgressBar(isIndeterminate = false)
         mockChildUniqueIdentifier(SeekBarWireframeMapper.ACTIVE_TRACK_KEY_NAME, null)
 
@@ -249,7 +249,7 @@ internal class ProgressBarWireframeMapperTest :
     fun `M return partial wireframes W map {determinate, invalid non active track id}`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockProgressBar(isIndeterminate = false)
         mockChildUniqueIdentifier(SeekBarWireframeMapper.NON_ACTIVE_TRACK_KEY_NAME, null)
 
@@ -270,7 +270,7 @@ internal class ProgressBarWireframeMapperTest :
     fun `M return wireframes W map {determinate, privacy=ALLOW}`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockProgressBar(isIndeterminate = false)
 
         // When
@@ -291,7 +291,7 @@ internal class ProgressBarWireframeMapperTest :
     fun `M return wireframes W map {determinate, privacy=MASK}`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.MASK)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_ALL)
         prepareMockProgressBar(isIndeterminate = false)
 
         // When
@@ -311,7 +311,7 @@ internal class ProgressBarWireframeMapperTest :
     fun `M return wireframes W map {determinate, privacy=MASK_USER_INPUT}`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.MASK_USER_INPUT)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_ALL_INPUTS)
         prepareMockProgressBar(isIndeterminate = false)
 
         // When

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SeekBarWireframeMapperTest.kt
@@ -5,7 +5,7 @@ import android.graphics.Rect
 import android.graphics.drawable.Drawable
 import android.os.Build
 import android.widget.SeekBar
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.internal.recorder.mapper.SeekBarWireframeMapper.Companion.TRACK_HEIGHT_IN_PX
@@ -119,7 +119,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return partial wireframes W map {invalid thumb id, Android O+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockSeekBar()
         mockChildUniqueIdentifier(SeekBarWireframeMapper.THUMB_KEY_NAME, null)
 
@@ -141,7 +141,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return partial wireframes W map {invalid active track id, Android O+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockSeekBar()
         mockChildUniqueIdentifier(SeekBarWireframeMapper.ACTIVE_TRACK_KEY_NAME, null)
 
@@ -163,7 +163,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return partial wireframes W map {invalid non active track id, Android O+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockSeekBar()
         mockChildUniqueIdentifier(SeekBarWireframeMapper.NON_ACTIVE_TRACK_KEY_NAME, null)
 
@@ -185,7 +185,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return wireframes W map {privacy=ALLOW, Android O+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockSeekBar()
 
         // When
@@ -207,7 +207,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return wireframes W map {privacy=MASK, Android O+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.MASK)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_ALL)
         prepareMockSeekBar()
 
         // When
@@ -227,7 +227,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     @TestTargetApi(Build.VERSION_CODES.O)
     fun `M return wireframes W map {privacy=MASK_USER_INPUT, Android O+}`() {
         // Given
-        withPrivacy(SessionReplayPrivacy.MASK_USER_INPUT)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_ALL_INPUTS)
         prepareMockSeekBar()
 
         // When
@@ -251,7 +251,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     fun `M return partial wireframes W map { invalid thumb id }`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockSeekBar()
         mockChildUniqueIdentifier(SeekBarWireframeMapper.THUMB_KEY_NAME, null)
 
@@ -273,7 +273,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     fun `M return partial wireframes W map { invalid active track id }`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockSeekBar()
         mockChildUniqueIdentifier(SeekBarWireframeMapper.ACTIVE_TRACK_KEY_NAME, null)
 
@@ -295,7 +295,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     fun `M return partial wireframes W map { invalid non active track id }`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockSeekBar()
         mockChildUniqueIdentifier(SeekBarWireframeMapper.NON_ACTIVE_TRACK_KEY_NAME, null)
 
@@ -317,7 +317,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     fun `M return wireframes W map {privacy=ALLOW}`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.ALLOW)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_SENSITIVE_INPUTS)
         prepareMockSeekBar()
 
         // When
@@ -339,7 +339,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     fun `M return wireframes W map {privacy=MASK}`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.MASK)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_ALL)
         prepareMockSeekBar()
 
         // When
@@ -359,7 +359,7 @@ internal class SeekBarWireframeMapperTest : AbstractWireframeMapperTest<SeekBar,
     fun `M return wireframes W map {privacy=MASK_USER_INPUT}`() {
         // Given
         fakeMinValue = 0
-        withPrivacy(SessionReplayPrivacy.MASK_USER_INPUT)
+        withTextAndInputPrivacy(TextAndInputPrivacy.MASK_ALL_INPUTS)
         prepareMockSeekBar()
 
         // When

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
@@ -8,7 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.graphics.drawable.Drawable
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.densityNormalized
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -82,7 +82,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         )
 
         // Then
-        if (fakeMappingContext.privacy != SessionReplayPrivacy.ALLOW) {
+        if (fakeMappingContext.textAndInputPrivacy != TextAndInputPrivacy.MASK_SENSITIVE_INPUTS) {
             assertThat(resolvedWireframes).isEqualTo(fakeTextWireframes + expectedTrackWireframe)
         } else {
             assertThat(resolvedWireframes).isEqualTo(fakeTextWireframes)
@@ -147,7 +147,10 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY),
+            fakeMappingContext.copy(
+                textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL,
+                imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY
+            ),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )
@@ -172,7 +175,10 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
         // When
         val resolvedWireframes = testedSwitchCompatMapper.map(
             mockSwitch,
-            fakeMappingContext.copy(privacy = SessionReplayPrivacy.MASK, imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY),
+            fakeMappingContext.copy(
+                textAndInputPrivacy = TextAndInputPrivacy.MASK_ALL,
+                imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY
+            ),
             mockAsyncJobStatusCallback,
             mockInternalLogger
         )

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/AbstractWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/AbstractWireframeMapperTest.kt
@@ -10,7 +10,7 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.view.View
 import com.datadog.android.api.InternalLogger
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -81,8 +81,8 @@ internal abstract class AbstractWireframeMapperTest<V : View, WM : WireframeMapp
 
     // region MappingContext
 
-    fun withPrivacy(privacy: SessionReplayPrivacy) {
-        fakeMappingContext = fakeMappingContext.copy(privacy = privacy)
+    fun withTextAndInputPrivacy(textAndInputPrivacy: TextAndInputPrivacy) {
+        fakeMappingContext = fakeMappingContext.copy(textAndInputPrivacy = textAndInputPrivacy)
     }
 
     fun withSystemThemeColor(themeColor: String?) {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonMapperAllowTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonMapperAllowTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.recorder.mapper
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapperTest
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -29,5 +29,5 @@ internal class ButtonMapperAllowTest : ButtonMapperTest() {
         return text
     }
 
-    override fun privacyOption(): SessionReplayPrivacy = SessionReplayPrivacy.ALLOW
+    override fun privacyOption(): TextAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonMapperMaskInputTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonMapperMaskInputTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.recorder.mapper
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapperTest
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -33,5 +33,5 @@ internal class ButtonMapperMaskInputTest : ButtonMapperTest() {
         }
     }
 
-    override fun privacyOption(): SessionReplayPrivacy = SessionReplayPrivacy.MASK_USER_INPUT
+    override fun privacyOption(): TextAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonMapperMaskTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/ButtonMapperMaskTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.recorder.mapper
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.mapper.ButtonMapperTest
 import com.datadog.android.sessionreplay.internal.recorder.obfuscator.StringObfuscator
@@ -34,5 +34,5 @@ internal class ButtonMapperMaskTest : ButtonMapperTest() {
         }
     }
 
-    override fun privacyOption(): SessionReplayPrivacy = SessionReplayPrivacy.MASK
+    override fun privacyOption(): TextAndInputPrivacy = TextAndInputPrivacy.MASK_ALL
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperAllowTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperAllowTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.recorder.mapper
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -36,5 +36,5 @@ internal class EditTextMapperAllowTest : EditTextMapperTest() {
         return hint
     }
 
-    override fun privacyOption(): SessionReplayPrivacy = SessionReplayPrivacy.ALLOW
+    override fun privacyOption(): TextAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperMaskInputTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperMaskInputTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.recorder.mapper
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -32,5 +32,5 @@ internal class EditTextMapperMaskInputTest : EditTextMapperTest() {
         return hint
     }
 
-    override fun privacyOption(): SessionReplayPrivacy = SessionReplayPrivacy.MASK_USER_INPUT
+    override fun privacyOption(): TextAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperMaskTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperMaskTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.recorder.mapper
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.obfuscator.StringObfuscator
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -33,5 +33,5 @@ internal class EditTextMapperMaskTest : EditTextMapperTest() {
         return StringObfuscator.getStringObfuscator().obfuscate(hint)
     }
 
-    override fun privacyOption(): SessionReplayPrivacy = SessionReplayPrivacy.MASK
+    override fun privacyOption(): TextAndInputPrivacy = TextAndInputPrivacy.MASK_ALL
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/EditTextMapperTest.kt
@@ -6,7 +6,7 @@ import android.text.InputType
 import android.view.Gravity
 import android.widget.EditText
 import android.widget.TextView
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.mapper.TextViewMapperTest.Companion.parametersMatrix
 import com.datadog.android.sessionreplay.utils.OPAQUE_ALPHA_VALUE
@@ -56,7 +56,7 @@ internal abstract class EditTextMapperTest :
 
         whenever(mockEditable.toString()) doReturn fakeText
 
-        withPrivacy(privacyOption())
+        withTextAndInputPrivacy(privacyOption())
 
         testedWireframeMapper = EditTextMapper(
             mockViewIdentifierResolver,
@@ -70,7 +70,7 @@ internal abstract class EditTextMapperTest :
 
     abstract fun expectedPrivacyCompliantHint(hint: String): String
 
-    abstract fun privacyOption(): SessionReplayPrivacy
+    abstract fun privacyOption(): TextAndInputPrivacy
 
     @ParameterizedTest(name = "{index} (typeface: {0}, align:{2}, gravity:{3})")
     @MethodSource("basicParametersMatrix")

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperAllowTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperAllowTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.recorder.mapper
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -26,5 +26,5 @@ internal class TextViewMapperAllowTest : TextViewMapperTest() {
 
     override fun expectedPrivacyCompliantText(text: String): String = text
 
-    override fun privacyOption(): SessionReplayPrivacy = SessionReplayPrivacy.ALLOW
+    override fun privacyOption(): TextAndInputPrivacy = TextAndInputPrivacy.MASK_SENSITIVE_INPUTS
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperMaskInputTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperMaskInputTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.recorder.mapper
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
@@ -32,5 +32,5 @@ internal class TextViewMapperMaskInputTest : TextViewMapperTest() {
         }
     }
 
-    override fun privacyOption(): SessionReplayPrivacy = SessionReplayPrivacy.MASK_USER_INPUT
+    override fun privacyOption(): TextAndInputPrivacy = TextAndInputPrivacy.MASK_ALL_INPUTS
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperMaskTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperMaskTest.kt
@@ -6,7 +6,7 @@
 
 package com.datadog.android.sessionreplay.recorder.mapper
 
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import com.datadog.android.sessionreplay.internal.recorder.obfuscator.StringObfuscator
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
@@ -33,5 +33,5 @@ internal class TextViewMapperMaskTest : TextViewMapperTest() {
         }
     }
 
-    override fun privacyOption(): SessionReplayPrivacy = SessionReplayPrivacy.MASK
+    override fun privacyOption(): TextAndInputPrivacy = TextAndInputPrivacy.MASK_ALL
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperTest.kt
@@ -3,7 +3,7 @@ package com.datadog.android.sessionreplay.recorder.mapper
 import android.graphics.Typeface
 import android.view.Gravity
 import android.widget.TextView
-import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.model.MobileSegment.Horizontal.LEFT
 import com.datadog.android.sessionreplay.model.MobileSegment.Horizontal.RIGHT
@@ -51,7 +51,7 @@ internal abstract class TextViewMapperTest :
             )
         ) doReturn fakeTextColorHexString
 
-        withPrivacy(privacyOption())
+        withTextAndInputPrivacy(privacyOption())
 
         testedWireframeMapper = TextViewMapper(
             mockViewIdentifierResolver,
@@ -63,7 +63,7 @@ internal abstract class TextViewMapperTest :
 
     abstract fun expectedPrivacyCompliantText(text: String): String
 
-    abstract fun privacyOption(): SessionReplayPrivacy
+    abstract fun privacyOption(): TextAndInputPrivacy
 
     @ParameterizedTest(name = "{index} (typeface: {0}, align:{2}, gravity:{3})")
     @MethodSource("parametersMatrix")

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayActivity.kt
@@ -56,6 +56,7 @@ internal abstract class BaseSessionReplayActivity : AppCompatActivity() {
             .forEach { it() }
     }
 
+    @Suppress("DEPRECATION")
     open fun sessionReplayConfiguration(privacy: SessionReplayPrivacy, sampleRate: Float): SessionReplayConfiguration {
         return RuntimeConfig.sessionReplayConfigBuilder(sampleRate)
             .setPrivacy(privacy)

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/DatadogBenchmark.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/DatadogBenchmark.kt
@@ -50,6 +50,7 @@ internal class DatadogBenchmark(config: Config) {
         meter.stopGauges()
     }
 
+    @Suppress("DEPRECATION")
     private fun enableSessionReplay() {
         val sessionReplayConfig = SessionReplayConfiguration
             .Builder(SAMPLE_IN_ALL_SESSIONS)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -157,6 +157,7 @@ class SampleApplication : Application() {
         val rumConfig = createRumConfiguration()
         Rum.enable(rumConfig)
 
+        @Suppress("DEPRECATION")
         val sessionReplayConfig = SessionReplayConfiguration.Builder(SAMPLE_IN_ALL_SESSIONS)
             .apply {
                 if (BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL.isNotBlank()) {


### PR DESCRIPTION
### What does this PR do?
(Notice that this PR is being merged into the feature branch and not yet into develop.)

Adds the new setTextAndInputPrivacy api and deprecates the setPrivacy api. 

When a user calls setPrivacy it will be converted into the new fine grained masking levels. 

allow -> text: mask_sensitive_inputs, images: mask_none, touch: show
mask_user_input -> text: mask_all_inputs, images: mask_large_only, touch: hide
mask -> text: mask_all, images: mask_all, touch: hide

When passing to the webviews the fine grained masking is converted back to the legacy privacy levels in such a way as to be at least as restrictive as necessary. In practice this means it is almost always converted to mask_all. The two exceptions are:

text: mask_sensitive_text, images: mask_none, touch: show --> allow
text: mask_user_input, images: mask_none, touch: show --> mask_input

In addition, we will send the new fine grained masking apis in the configuration telemetry.

### Motivation
Fine grained masking global configuration.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

