### PR TITLE
RUM-5985: Add isContainer attribute to session replay span

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -4,9 +4,9 @@ interface com.datadog.android.internal.profiler.BenchmarkSpan
   fun stop()
 interface com.datadog.android.internal.profiler.BenchmarkSpanBuilder
   fun startSpan(): BenchmarkSpan
-fun <T: Any?> withinBenchmarkSpan(String, BenchmarkSpan.() -> T): T
+fun <T: Any?> withinBenchmarkSpan(String, Map<String, String> = emptyMap(), BenchmarkSpan.() -> T): T
 interface com.datadog.android.internal.profiler.BenchmarkTracer
-  fun spanBuilder(String): BenchmarkSpanBuilder
+  fun spanBuilder(String, Map<String, String> = emptyMap()): BenchmarkSpanBuilder
 object com.datadog.android.internal.profiler.GlobalBenchmark
   fun register(BenchmarkProfiler)
   fun get(): BenchmarkProfiler

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -11,11 +11,16 @@ public abstract interface class com/datadog/android/internal/profiler/BenchmarkS
 }
 
 public final class com/datadog/android/internal/profiler/BenchmarkSpanExtKt {
-	public static final fun withinBenchmarkSpan (Ljava/lang/String;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static final fun withinBenchmarkSpan (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;)Ljava/lang/Object;
+	public static synthetic fun withinBenchmarkSpan$default (Ljava/lang/String;Ljava/util/Map;Lkotlin/jvm/functions/Function1;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class com/datadog/android/internal/profiler/BenchmarkTracer {
-	public abstract fun spanBuilder (Ljava/lang/String;)Lcom/datadog/android/internal/profiler/BenchmarkSpanBuilder;
+	public abstract fun spanBuilder (Ljava/lang/String;Ljava/util/Map;)Lcom/datadog/android/internal/profiler/BenchmarkSpanBuilder;
+}
+
+public final class com/datadog/android/internal/profiler/BenchmarkTracer$DefaultImpls {
+	public static synthetic fun spanBuilder$default (Lcom/datadog/android/internal/profiler/BenchmarkTracer;Ljava/lang/String;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/internal/profiler/BenchmarkSpanBuilder;
 }
 
 public final class com/datadog/android/internal/profiler/GlobalBenchmark {

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/BenchmarkSpanExt.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/BenchmarkSpanExt.kt
@@ -11,16 +11,21 @@ package com.datadog.android.internal.profiler
  * @param T the type returned by the lambda
  * @param operationName the name of the [BenchmarkSpan] created around the lambda
  * (default is `true`)
+ * @param additionalProperties Additional properties for this span.
  * @param block the lambda function traced by this newly created [BenchmarkSpan]
  *
  */
 inline fun <T : Any?> withinBenchmarkSpan(
     operationName: String,
+    additionalProperties: Map<String, String> = emptyMap(),
     block: BenchmarkSpan.() -> T
 ): T {
     val tracer = GlobalBenchmark.get().getTracer("dd-sdk-android")
 
-    val spanBuilder = tracer.spanBuilder(operationName)
+    val spanBuilder = tracer.spanBuilder(
+        operationName,
+        additionalProperties
+    )
 
     val span = spanBuilder.startSpan()
 

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/BenchmarkTracer.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/profiler/BenchmarkTracer.kt
@@ -19,7 +19,11 @@ interface BenchmarkTracer {
      * Returns a new [BenchmarkSpanBuilder].
      *
      * @param spanName The name of the returned span.
+     * @param additionalProperties Additional properties for this span.
      * @return a new [BenchmarkSpanBuilder].
      */
-    fun spanBuilder(spanName: String): BenchmarkSpanBuilder
+    fun spanBuilder(
+        spanName: String,
+        additionalProperties: Map<String, String> = emptyMap()
+    ): BenchmarkSpanBuilder
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/BenchmarkExt.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/BenchmarkExt.kt
@@ -1,0 +1,27 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal.recorder
+
+import com.datadog.android.internal.profiler.BenchmarkSpan
+import com.datadog.android.internal.profiler.withinBenchmarkSpan
+
+private const val ATTRIBUTE_CONTAINER = "attribute.container"
+
+/**
+ * A wrap function of [withinSRBenchmarkSpan] dedicated to session replay span recording.
+ */
+internal inline fun <T : Any?> withinSRBenchmarkSpan(
+    spanName: String,
+    isContainer: Boolean = false,
+    block: BenchmarkSpan.() -> T
+): T {
+    return withinBenchmarkSpan(
+        spanName,
+        mapOf(ATTRIBUTE_CONTAINER to isContainer.toString()),
+        block
+    )
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -9,7 +9,6 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.UiThread
-import com.datadog.android.internal.profiler.withinBenchmarkSpan
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
@@ -55,7 +54,7 @@ internal class SnapshotProducer(
         parents: LinkedList<MobileSegment.Wireframe>,
         recordedDataQueueRefs: RecordedDataQueueRefs
     ): Node? {
-        return withinBenchmarkSpan(view::class.java.simpleName) {
+        return withinSRBenchmarkSpan(view::class.java.simpleName, view is ViewGroup) {
             val traversedTreeView = treeViewTraversal.traverse(view, mappingContext, recordedDataQueueRefs)
             val nextTraversalStrategy = traversedTreeView.nextActionStrategy
             val resolvedWireframes = traversedTreeView.mappedWireframes

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
@@ -12,13 +12,13 @@ import androidx.annotation.MainThread
 import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.measureMethodCallPerf
-import com.datadog.android.internal.profiler.withinBenchmarkSpan
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueHandler
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.internal.recorder.Debouncer
 import com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer
+import com.datadog.android.sessionreplay.internal.recorder.withinSRBenchmarkSpan
 import com.datadog.android.sessionreplay.internal.utils.MiscUtils
 import java.lang.ref.WeakReference
 
@@ -58,7 +58,7 @@ internal class WindowsOnDrawListener(
                 METHOD_CALL_CAPTURE_RECORD,
                 methodCallSamplingRate
             ) {
-                withinBenchmarkSpan(BENCHMARK_SPAN_SNAPSHOT_PRODUCER) {
+                withinSRBenchmarkSpan(BENCHMARK_SPAN_SNAPSHOT_PRODUCER, isContainer = true) {
                     val recordedDataQueueRefs = RecordedDataQueueRefs(recordedDataQueueHandler)
                     recordedDataQueueRefs.recordedDataQueueItem = item
                     rootViews.mapNotNull {

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/internal/BenchmarkSpanToSpanEventMapper.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/internal/BenchmarkSpanToSpanEventMapper.kt
@@ -28,19 +28,23 @@ internal class BenchmarkSpanToSpanEventMapper {
             duration = durationNanos,
             start = spanData.startEpochNanos,
             error = 0, // error is not needed in benchmark
-            meta = resolveMeta(),
+            meta = resolveMeta(spanData),
             metrics = resolveMetrics()
         )
     }
 
-    private fun resolveMeta(): SpanEvent.Meta {
-        // TODO: RUM-5985 Fill SpanEvent with useful meta data
+    private fun resolveMeta(spanData: SpanData): SpanEvent.Meta {
+        val map = mutableMapOf<String, String>()
+        spanData.attributes.forEach { attributeKey, value ->
+            map[attributeKey.key] = value.toString()
+        }
         return SpanEvent.Meta(
             version = "",
             dd = SpanEvent.Dd(),
             span = SpanEvent.Span(),
             tracer = SpanEvent.Tracer(version = ""),
-            usr = SpanEvent.Usr()
+            usr = SpanEvent.Usr(),
+            additionalProperties = map
         )
     }
 

--- a/tools/benchmark/src/main/java/com/datadog/benchmark/profiler/DDBenchmarkTracer.kt
+++ b/tools/benchmark/src/main/java/com/datadog/benchmark/profiler/DDBenchmarkTracer.kt
@@ -16,10 +16,18 @@ import io.opentelemetry.context.Context
  */
 class DDBenchmarkTracer(private val tracer: Tracer) : BenchmarkTracer {
 
-    override fun spanBuilder(spanName: String): BenchmarkSpanBuilder {
+    override fun spanBuilder(
+        spanName: String,
+        additionalProperties: Map<String, String>
+    ): BenchmarkSpanBuilder {
         return DDBenchmarkSpanBuilder(
             tracer
                 .spanBuilder(spanName)
+                .apply {
+                    additionalProperties.forEach {
+                        this.setAttribute(it.key, it.value)
+                    }
+                }
                 .setParent(Context.current())
         )
     }


### PR DESCRIPTION
### What does this PR do?

Add a "isContainer" attribute into session replay span request to differentiate the components and containers view.

### Motivation
In the benchmark dashboard, we want to have a top list graph to see which components take the leads of the time consumption in SR. here is the current graph:
<img width="778" alt="image" src="https://github.com/user-attachments/assets/d7ed8c5b-c65b-4f7f-9024-a5f331fa93fd">


As we can see the top list is occupied by the containers, which doesn't what we expect. Because containers' spans contain the children view, so we want to have only real components here.

### Demo
After adding this attributes, we can differentiate them by adding filter `@attribute.container:false `

Add we got pure components span in the list
<img width="1051" alt="image" src="https://github.com/user-attachments/assets/1ff7e6fa-fbe3-4327-9058-e14089cd3151">



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

