### PR TITLE
RUM-6096: Fix placeholder dimensions

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
@@ -90,13 +90,18 @@ internal class DefaultImageWireframeHelper(
         }
 
         val density = displayMetrics.density
+        val drawableWidthDp = drawableProperties.drawableWidth.densityNormalized(density).toLong()
+        val drawableHeightDp = drawableProperties.drawableHeight.densityNormalized(density).toLong()
 
         if (imagePrivacy == ImagePrivacy.MASK_ALL) {
             return createContentPlaceholderWireframe(
                 id = id,
-                view = view,
-                density = density,
-                label = MASK_ALL_CONTENT_LABEL
+                x = x,
+                y = y,
+                width = drawableWidthDp,
+                height = drawableHeightDp,
+                label = MASK_ALL_CONTENT_LABEL,
+                clipping = clipping
             )
         }
 
@@ -104,14 +109,14 @@ internal class DefaultImageWireframeHelper(
         if (shouldMaskContextualImage(imagePrivacy, usePIIPlaceholder, drawable, density)) {
             return createContentPlaceholderWireframe(
                 id = id,
-                view = view,
-                density = density,
-                label = MASK_CONTEXTUAL_CONTENT_LABEL
+                x = x,
+                y = y,
+                width = drawableWidthDp,
+                height = drawableHeightDp,
+                label = MASK_CONTEXTUAL_CONTENT_LABEL,
+                clipping = clipping
             )
         }
-
-        val drawableWidthDp = drawableProperties.drawableWidth.densityNormalized(density).toLong()
-        val drawableHeightDp = drawableProperties.drawableHeight.densityNormalized(density).toLong()
 
         val imageWireframe =
             MobileSegment.Wireframe.ImageWireframe(
@@ -237,24 +242,22 @@ internal class DefaultImageWireframeHelper(
     }
 
     private fun createContentPlaceholderWireframe(
-        view: View,
         id: Long,
-        density: Float,
-        label: String
+        x: Long,
+        y: Long,
+        width: Long,
+        height: Long,
+        label: String,
+        clipping: MobileSegment.WireframeClip?
     ): MobileSegment.Wireframe.PlaceholderWireframe {
-        val coordinates = IntArray(2)
-        @Suppress("UnsafeThirdPartyFunctionCall") // this will always have size >= 2
-        view.getLocationOnScreen(coordinates)
-        val viewX = coordinates[0].densityNormalized(density).toLong()
-        val viewY = coordinates[1].densityNormalized(density).toLong()
-
         return MobileSegment.Wireframe.PlaceholderWireframe(
             id,
-            viewX,
-            viewY,
-            view.width.densityNormalized(density).toLong(),
-            view.height.densityNormalized(density).toLong(),
-            label = label
+            x,
+            y,
+            width,
+            height,
+            label = label,
+            clip = clipping
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelperTest.kt
@@ -670,13 +670,6 @@ internal class DefaultImageWireframeHelperTest {
         mockDisplayMetrics.density = 1f
         whenever(mockContext.applicationContext).thenReturn(mockContext)
         val mockView: View = mock {
-            whenever(it.getLocationOnScreen(any())).thenAnswer { location ->
-                val coords = location.arguments[0] as IntArray
-                coords[0] = fakeGlobalX
-                coords[1] = fakeGlobalY
-                null
-            }
-
             whenever(it.resources).thenReturn(mockResources)
             whenever(it.context).thenReturn(mockContext)
         }
@@ -686,8 +679,8 @@ internal class DefaultImageWireframeHelperTest {
             view = mockView,
             imagePrivacy = ImagePrivacy.MASK_LARGE_ONLY,
             currentWireframeIndex = forge.aPositiveInt(),
-            x = forge.aPositiveLong(),
-            y = forge.aPositiveLong(),
+            x = fakeGlobalX.toLong(),
+            y = fakeGlobalY.toLong(),
             width = forge.aPositiveInt(),
             height = forge.aPositiveInt(),
             drawable = mockDrawable,


### PR DESCRIPTION
### What does this PR do?
Fix placeholder dimensions, which at the moment could cover the entire dimensions of the view in cases where there are compound drawables. This issue became noticeable with fine grained masking when users can mask all images. 

Before fix:
<img width="179" alt="Screenshot 2024-09-08 at 13 43 01" src="https://github.com/user-attachments/assets/f6b5e25a-963e-45e4-b7ec-7143d4882082">

After fix:
<img width="168" alt="Screenshot 2024-09-08 at 13 48 43" src="https://github.com/user-attachments/assets/5c9ad85a-230d-4b15-9a78-59865b67042e">


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

