### PR TITLE
RUM-5188: Add session replay skipped frames count in session ended metrics

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -277,6 +277,7 @@ internal class RumFeature(
             TELEMETRY_DEBUG_MESSAGE_TYPE -> logTelemetryDebug(event)
             MOBILE_METRIC_MESSAGE_TYPE -> logMetric(event)
             TELEMETRY_CONFIG_MESSAGE_TYPE -> logTelemetryConfiguration(event)
+            TELEMETRY_SESSION_REPLAY_SKIP_FRAME -> addSessionReplaySkippedFrame()
             FLUSH_AND_STOP_MONITOR_MESSAGE_TYPE -> {
                 (GlobalRumMonitor.get(sdkCore) as? DatadogRumMonitor)?.let {
                     it.stopKeepAliveCallback()
@@ -564,6 +565,10 @@ internal class RumFeature(
         }
     }
 
+    private fun addSessionReplaySkippedFrame() {
+        (GlobalRumMonitor.get(sdkCore) as? AdvancedRumMonitor)?.addSessionReplaySkippedFrame()
+    }
+
     // endregion
 
     internal data class Configuration(
@@ -600,6 +605,7 @@ internal class RumFeature(
         internal const val TELEMETRY_DEBUG_MESSAGE_TYPE = "telemetry_debug"
         internal const val MOBILE_METRIC_MESSAGE_TYPE = "mobile_metric"
         internal const val TELEMETRY_CONFIG_MESSAGE_TYPE = "telemetry_configuration"
+        internal const val TELEMETRY_SESSION_REPLAY_SKIP_FRAME = "sr_skipped_frame"
         internal const val FLUSH_AND_STOP_MONITOR_MESSAGE_TYPE = "flush_and_stop_monitor"
 
         internal const val ALL_IN_SAMPLE_RATE: Float = 100f

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionEndedMetricDispatcher.kt
@@ -72,6 +72,10 @@ internal class SessionEndedMetricDispatcher(private val internalLogger: Internal
         metricsBySessionId[sessionId]?.onMissedEventTracked(missedEventType)
     }
 
+    override fun onSessionReplaySkippedFrameTracked(sessionId: String) {
+        metricsBySessionId[sessionId]?.onSessionReplaySkippedFrameTracked()
+    }
+
     private fun buildSdkErrorTrackError(sessionId: String, errorKind: String?): String {
         return "Failed to track $errorKind error, session $sessionId has ended"
     }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionMetricDispatcher.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/metric/SessionMetricDispatcher.kt
@@ -50,4 +50,9 @@ internal interface SessionMetricDispatcher {
      * Called when a missed event is tracked by this session metric.
      */
     fun onMissedEventTracked(sessionId: String, missedEventType: SessionEndedMetric.MissedEventType)
+
+    /**
+     * Called when skipped frame is tracked by this session metric.
+     */
+    fun onSessionReplaySkippedFrameTracked(sessionId: String)
 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/AdvancedRumMonitor.kt
@@ -29,6 +29,8 @@ internal interface AdvancedRumMonitor : RumMonitor, AdvancedNetworkRumMonitor {
 
     fun addLongTask(durationNs: Long, target: String)
 
+    fun addSessionReplaySkippedFrame()
+
     fun addCrash(
         message: String,
         source: RumErrorSource,

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitor.kt
@@ -65,7 +65,7 @@ internal class DatadogRumMonitor(
     private val writer: DataWriter<Any>,
     internal val handler: Handler,
     internal val telemetryEventHandler: TelemetryEventHandler,
-    sessionEndedMetricDispatcher: SessionMetricDispatcher,
+    private val sessionEndedMetricDispatcher: SessionMetricDispatcher,
     firstPartyHostHeaderTypeResolver: FirstPartyHostHeaderTypeResolver,
     cpuVitalMonitor: VitalMonitor,
     memoryVitalMonitor: VitalMonitor,
@@ -609,6 +609,14 @@ internal class DatadogRumMonitor(
                 isMetric = true
             )
         )
+    }
+
+    override fun addSessionReplaySkippedFrame() {
+        getCurrentSessionId { sessionId ->
+            sessionId?.let {
+                sessionEndedMetricDispatcher.onSessionReplaySkippedFrameTracked(it)
+            }
+        }
     }
 
     override fun sendErrorTelemetryEvent(

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/RumSessionEndedMetricTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/metric/RumSessionEndedMetricTest.kt
@@ -437,7 +437,7 @@ class RumSessionEndedMetricTest {
     }
 
     @Test
-    fun `M have correct 'no_view_events_count' W toMetricAttributes()`(
+    fun `M have correct no_view_events_count W toMetricAttributes()`(
         @BoolForgery fakeBackgroundEventTracking: Boolean,
         @IntForgery(min = 0, max = 5) randomActionCount: Int,
         @IntForgery(min = 0, max = 5) randomResourceCount: Int,
@@ -474,7 +474,7 @@ class RumSessionEndedMetricTest {
     }
 
     @Test
-    fun `M have correct 'has_background_events_tracking_enabled' W toMetricAttributes()`(
+    fun `M have correct has_background_events_tracking_enabled W toMetricAttributes()`(
         @BoolForgery fakeBackgroundEventTracking: Boolean
     ) {
         // Given
@@ -492,7 +492,7 @@ class RumSessionEndedMetricTest {
     }
 
     @Test
-    fun `M have correct 'ntp_offset' W toMetricAttributes()`(
+    fun `M have correct ntp_offset W toMetricAttributes()`(
         @LongForgery ntpOffsetAtStart: Long,
         @LongForgery ntpOffsetAtEnd: Long
     ) {
@@ -512,6 +512,30 @@ class RumSessionEndedMetricTest {
         val ntpOffset = rse[SessionEndedMetric.NTP_OFFSET_KEY] as Map<*, *>
         assertThat(ntpOffset[SessionEndedMetric.NTP_OFFSET_AT_START_KEY]).isEqualTo(ntpOffsetAtStart)
         assertThat(ntpOffset[SessionEndedMetric.NTP_OFFSET_AT_END_KEY]).isEqualTo(ntpOffsetAtEnd)
+    }
+
+    @Test
+    fun `M have correct sr_skipped_frames_count W toMetricAttributes()`(
+        @IntForgery(min = 0, max = 100) count: Int
+    ) {
+        // Given
+        val sessionEndedMetric = SessionEndedMetric(
+            fakeSessionId,
+            fakeStartReason,
+            fakeNtpOffsetAtStart,
+            backgroundEventTracking
+        )
+
+        // When
+        repeat(count) {
+            sessionEndedMetric.onSessionReplaySkippedFrameTracked()
+        }
+        val attributes = sessionEndedMetric.toMetricAttributes(fakeNtpOffsetAtEnd)
+
+        // Then
+        val rse = attributes[SessionEndedMetric.RSE_KEY] as Map<*, *>
+        val skippedFramesCount = rse[SessionEndedMetric.SESSION_REPLAY_SKIPPED_FRAMES_COUNT] as Int
+        assertThat(skippedFramesCount).isEqualTo(count)
     }
 
     @Test

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/monitor/DatadogRumMonitorTest.kt
@@ -80,6 +80,7 @@ import org.mockito.kotlin.inOrder
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
 import org.mockito.kotlin.same
+import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -132,7 +133,7 @@ internal class DatadogRumMonitorTest {
     lateinit var mockTelemetryEventHandler: TelemetryEventHandler
 
     @Mock
-    lateinit var sessionEndedMetricDispatcher: SessionMetricDispatcher
+    lateinit var mockSessionEndedMetricDispatcher: SessionMetricDispatcher
 
     @Mock
     lateinit var mockSdkCore: InternalSdkCore
@@ -183,7 +184,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
-            sessionEndedMetricDispatcher,
+            mockSessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -205,7 +206,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
-            sessionEndedMetricDispatcher,
+            mockSessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -264,7 +265,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
-            sessionEndedMetricDispatcher,
+            mockSessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -301,7 +302,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
-            sessionEndedMetricDispatcher,
+            mockSessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -1617,7 +1618,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
-            sessionEndedMetricDispatcher,
+            mockSessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -1662,7 +1663,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
-            sessionEndedMetricDispatcher,
+            mockSessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -1694,7 +1695,7 @@ internal class DatadogRumMonitorTest {
             mockWriter,
             mockHandler,
             mockTelemetryEventHandler,
-            sessionEndedMetricDispatcher,
+            mockSessionEndedMetricDispatcher,
             mockResolver,
             mockCpuVitalMonitor,
             mockMemoryVitalMonitor,
@@ -1869,6 +1870,43 @@ internal class DatadogRumMonitorTest {
             assertThat(lastValue.isMetric).isFalse
             assertThat(lastValue.additionalProperties).isEqualTo(fakeAdditionalProperties)
         }
+    }
+
+    @Test
+    fun `M call sessionEndedMetricDispatcher W addSkippedFrame`(
+        @IntForgery(min = 0, max = 100) count: Int,
+        @StringForgery(type = StringForgeryType.ASCII) key: String,
+        @StringForgery name: String
+    ) {
+        val attributes = fakeAttributes + (RumAttributes.INTERNAL_TIMESTAMP to fakeTimestamp)
+
+        testedMonitor.startView(key, name, attributes)
+        // Given
+        testedMonitor = DatadogRumMonitor(
+            fakeApplicationId,
+            mockSdkCore,
+            100.0f,
+            fakeBackgroundTrackingEnabled,
+            fakeTrackFrustrations,
+            mockWriter,
+            mockHandler,
+            mockTelemetryEventHandler,
+            mockSessionEndedMetricDispatcher,
+            mockResolver,
+            mockCpuVitalMonitor,
+            mockMemoryVitalMonitor,
+            mockFrameRateVitalMonitor,
+            mockSessionListener,
+            mockExecutorService
+        )
+        testedMonitor.startView(key, name, attributes)
+        // When
+        repeat(count) {
+            testedMonitor.addSessionReplaySkippedFrame()
+        }
+
+        // Then
+        verify(mockSessionEndedMetricDispatcher, times(count)).onSessionReplaySkippedFrameTracked(any())
     }
 
     @Test

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/DefaultOnDrawListenerProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/DefaultOnDrawListenerProducer.kt
@@ -32,7 +32,7 @@ internal class DefaultOnDrawListenerProducer(
             snapshotProducer = snapshotProducer,
             privacy = privacy,
             imagePrivacy = imagePrivacy,
-            internalLogger = sdkCore.internalLogger,
+            sdkCore = sdkCore,
             methodCallSamplingRate = MethodCallSamplingRate.LOW.rate
         )
     }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListener.kt
@@ -10,7 +10,7 @@ import android.view.View
 import android.view.ViewTreeObserver
 import androidx.annotation.MainThread
 import androidx.annotation.UiThread
-import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.feature.measureMethodCallPerf
 import com.datadog.android.internal.profiler.withinBenchmarkSpan
 import com.datadog.android.sessionreplay.ImagePrivacy
@@ -29,8 +29,8 @@ internal class WindowsOnDrawListener(
     private val privacy: SessionReplayPrivacy,
     private val imagePrivacy: ImagePrivacy,
     private val miscUtils: MiscUtils = MiscUtils,
-    private val internalLogger: InternalLogger,
-    private val debouncer: Debouncer = Debouncer(internalLogger = internalLogger),
+    private val sdkCore: FeatureSdkCore,
+    private val debouncer: Debouncer = Debouncer(sdkCore = sdkCore),
     private val methodCallSamplingRate: Float
 ) : ViewTreeObserver.OnDrawListener {
 
@@ -53,7 +53,7 @@ internal class WindowsOnDrawListener(
             val systemInformation = miscUtils.resolveSystemInformation(context)
             val item = recordedDataQueueHandler.addSnapshotItem(systemInformation) ?: return
 
-            val nodes = internalLogger.measureMethodCallPerf(
+            val nodes = sdkCore.internalLogger.measureMethodCallPerf(
                 METHOD_CALL_CALLER_CLASS,
                 METHOD_CALL_CAPTURE_RECORD,
                 methodCallSamplingRate

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListenerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/listener/WindowsOnDrawListenerTest.kt
@@ -12,6 +12,7 @@ import android.content.res.Resources
 import android.content.res.Resources.Theme
 import android.view.View
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.metrics.PerformanceMetric
 import com.datadog.android.core.metrics.TelemetryMetricType
 import com.datadog.android.sessionreplay.ImagePrivacy
@@ -80,6 +81,9 @@ internal class WindowsOnDrawListenerTest {
     lateinit var mockInternalLogger: InternalLogger
 
     @Mock
+    lateinit var mockSdkCore: FeatureSdkCore
+
+    @Mock
     lateinit var mockPerformanceMetric: PerformanceMetric
 
     @IntForgery(min = 0)
@@ -118,6 +122,7 @@ internal class WindowsOnDrawListenerTest {
 
     @BeforeEach
     fun `set up`(forge: Forge) {
+        whenever(mockSdkCore.internalLogger).thenReturn(mockInternalLogger)
         whenever(mockMiscUtils.resolveSystemInformation(mockContext))
             .thenReturn(fakeSystemInformation)
         fakeMockedDecorViews = forge.aMockedDecorViewList().onEach {
@@ -161,7 +166,7 @@ internal class WindowsOnDrawListenerTest {
             imagePrivacy = fakeImagePrivacy,
             debouncer = mockDebouncer,
             miscUtils = mockMiscUtils,
-            internalLogger = mockInternalLogger,
+            sdkCore = mockSdkCore,
             methodCallSamplingRate = fakeMethodCallSamplingRate
         )
     }
@@ -213,7 +218,7 @@ internal class WindowsOnDrawListenerTest {
             imagePrivacy = fakeImagePrivacy,
             debouncer = mockDebouncer,
             miscUtils = mockMiscUtils,
-            internalLogger = mockInternalLogger,
+            sdkCore = mockSdkCore,
             methodCallSamplingRate = fakeMethodCallSamplingRate
         )
         testedListener.onDraw()


### PR DESCRIPTION
### What does this PR do?

Add session replay skipped frames count in session ended metrics, so that we can have a visibility in RUM telemetry how many frames are optimised by the time bank.

### Motivation

RUM-5188

### Demo
<img width="313" alt="Screenshot 2024-09-09 at 15 40 14" src="https://github.com/user-attachments/assets/1e0cacf3-3739-413a-9e82-cb9f5bab8812">



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

