### PR TITLE
RUM-6104 ensure UploadWorker uses the sdk instance name

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/DatadogCore.kt
@@ -421,6 +421,7 @@ internal class DatadogCore(
             processLifecycleMonitor = ProcessLifecycleMonitor(
                 ProcessLifecycleCallback(
                     appContext,
+                    name,
                     internalLogger
                 )
             ).apply {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
@@ -26,7 +26,7 @@ internal class ProcessLifecycleCallback(
     override fun onStarted() {
         contextWeakRef.get()?.let {
             if (WorkManager.isInitialized()) {
-                cancelUploadWorker(it, internalLogger)
+                cancelUploadWorker(it, instanceName, internalLogger)
             }
         }
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallback.kt
@@ -16,6 +16,7 @@ import java.lang.ref.WeakReference
 
 internal class ProcessLifecycleCallback(
     appContext: Context,
+    internal val instanceName: String,
     private val internalLogger: InternalLogger
 ) :
     ProcessLifecycleMonitor.Callback {
@@ -37,7 +38,7 @@ internal class ProcessLifecycleCallback(
     override fun onStopped() {
         contextWeakRef.get()?.let {
             if (WorkManager.isInitialized()) {
-                triggerUploadWorker(it, internalLogger)
+                triggerUploadWorker(it, instanceName, internalLogger)
             }
         }
     }

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
@@ -25,10 +25,14 @@ internal const val TAG_DATADOG_UPLOAD = "DatadogBackgroundUpload"
 
 internal const val DELAY_MS: Long = 5000
 
-internal fun cancelUploadWorker(context: Context, internalLogger: InternalLogger) {
+internal fun cancelUploadWorker(
+    context: Context,
+    instanceName: String,
+    internalLogger: InternalLogger
+) {
     try {
         val workManager = WorkManager.getInstance(context)
-        workManager.cancelAllWorkByTag(TAG_DATADOG_UPLOAD)
+        workManager.cancelAllWorkByTag("$TAG_DATADOG_UPLOAD/$instanceName")
     } catch (e: IllegalStateException) {
         internalLogger.log(
             InternalLogger.Level.ERROR,
@@ -52,7 +56,7 @@ internal fun triggerUploadWorker(
             .build()
         val uploadWorkRequest = OneTimeWorkRequest.Builder(UploadWorker::class.java)
             .setConstraints(constraints)
-            .addTag(TAG_DATADOG_UPLOAD)
+            .addTag("$TAG_DATADOG_UPLOAD/$instanceName")
             .setInitialDelay(DELAY_MS, TimeUnit.MILLISECONDS)
             .setInputData(Data.Builder().putString(UploadWorker.DATADOG_INSTANCE_NAME, instanceName).build())
             .build()

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtils.kt
@@ -8,13 +8,13 @@ package com.datadog.android.core.internal.utils
 
 import android.content.Context
 import androidx.work.Constraints
+import androidx.work.Data
 import androidx.work.ExistingWorkPolicy
 import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.WorkManager
 import com.datadog.android.api.InternalLogger
 import com.datadog.android.core.internal.data.upload.UploadWorker
-import java.lang.IllegalStateException
 import java.util.concurrent.TimeUnit
 
 internal const val CANCEL_ERROR_MESSAGE = "Error cancelling the UploadWorker"
@@ -40,7 +40,11 @@ internal fun cancelUploadWorker(context: Context, internalLogger: InternalLogger
 }
 
 @Suppress("TooGenericExceptionCaught")
-internal fun triggerUploadWorker(context: Context, internalLogger: InternalLogger) {
+internal fun triggerUploadWorker(
+    context: Context,
+    instanceName: String,
+    internalLogger: InternalLogger
+) {
     try {
         val workManager = WorkManager.getInstance(context)
         val constraints = Constraints.Builder()
@@ -50,6 +54,7 @@ internal fun triggerUploadWorker(context: Context, internalLogger: InternalLogge
             .setConstraints(constraints)
             .addTag(TAG_DATADOG_UPLOAD)
             .setInitialDelay(DELAY_MS, TimeUnit.MILLISECONDS)
+            .setInputData(Data.Builder().putString(UploadWorker.DATADOG_INSTANCE_NAME, instanceName).build())
             .build()
         workManager.enqueueUniqueWork(
             UPLOAD_WORKER_NAME,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -90,7 +90,7 @@ internal class DatadogExceptionHandler(
         // trigger a task to send the logs ASAP
         contextRef.get()?.let {
             if (WorkManager.isInitialized()) {
-                triggerUploadWorker(it, sdkCore.internalLogger)
+                triggerUploadWorker(it, sdkCore.name, sdkCore.internalLogger)
             }
         }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/DatadogCoreTest.kt
@@ -19,6 +19,7 @@ import com.datadog.android.core.internal.ContextProvider
 import com.datadog.android.core.internal.CoreFeature
 import com.datadog.android.core.internal.DatadogCore
 import com.datadog.android.core.internal.SdkFeature
+import com.datadog.android.core.internal.lifecycle.ProcessLifecycleCallback
 import com.datadog.android.core.internal.lifecycle.ProcessLifecycleMonitor
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.net.info.NetworkInfoProvider
@@ -804,6 +805,20 @@ internal class DatadogCoreTest {
     }
 
     @Test
+    fun `M register process lifecycle monitor W initialize()`() {
+        // Then
+        argumentCaptor<Application.ActivityLifecycleCallbacks> {
+            verify(appContext.mockInstance)
+                .registerActivityLifecycleCallbacks(capture())
+            assertThat(lastValue).isInstanceOf(ProcessLifecycleMonitor::class.java)
+            val callback = (lastValue as ProcessLifecycleMonitor).callback
+            assertThat(callback).isInstanceOf(ProcessLifecycleCallback::class.java)
+            val processLifecycleCallback = callback as ProcessLifecycleCallback
+            assertThat(processLifecycleCallback.instanceName).isEqualTo(fakeInstanceName)
+        }
+    }
+
+    @Test
     fun `M unregister process lifecycle monitor W stop()`() {
         // Given
         val expectedInvocations = if (fakeConfiguration.crashReportsEnabled) 2 else 1
@@ -812,7 +827,7 @@ internal class DatadogCoreTest {
         testedCore.stop()
 
         // Then
-        argumentCaptor<ProcessLifecycleMonitor> {
+        argumentCaptor<Application.ActivityLifecycleCallbacks> {
             verify(appContext.mockInstance, times(expectedInvocations))
                 .unregisterActivityLifecycleCallbacks(capture())
             assertThat(lastValue).isInstanceOf(ProcessLifecycleMonitor::class.java)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
@@ -20,8 +20,10 @@ import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.setStaticValue
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -32,7 +34,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -58,9 +60,12 @@ internal class ProcessLifecycleCallbackTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
+    @StringForgery
+    lateinit var fakeInstanceName: String
+
     @BeforeEach
     fun `set up`() {
-        testedCallback = ProcessLifecycleCallback(appContext.mockInstance, mockInternalLogger)
+        testedCallback = ProcessLifecycleCallback(appContext.mockInstance, fakeInstanceName, mockInternalLogger)
     }
 
     @AfterEach
@@ -84,14 +89,17 @@ internal class ProcessLifecycleCallbackTest {
         testedCallback.onStopped()
 
         // Then
-        verify(mockWorkManager).enqueueUniqueWork(
-            eq(UPLOAD_WORKER_NAME),
-            eq(ExistingWorkPolicy.REPLACE),
-            argThat<OneTimeWorkRequest> {
-                this.workSpec.workerClassName == UploadWorker::class.java.canonicalName &&
-                    this.tags.contains(TAG_DATADOG_UPLOAD)
-            }
-        )
+        argumentCaptor<OneTimeWorkRequest> {
+            verify(mockWorkManager).enqueueUniqueWork(
+                eq(UPLOAD_WORKER_NAME),
+                eq(ExistingWorkPolicy.REPLACE),
+                capture()
+            )
+            val workSpec = lastValue.workSpec
+            assertThat(workSpec.workerClassName).isEqualTo(UploadWorker::class.java.canonicalName)
+            assertThat(workSpec.input.getString(UploadWorker.DATADOG_INSTANCE_NAME)).isEqualTo(fakeInstanceName)
+            assertThat(lastValue.tags).contains(TAG_DATADOG_UPLOAD)
+        }
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/lifecycle/ProcessLifecycleCallbackTest.kt
@@ -98,7 +98,7 @@ internal class ProcessLifecycleCallbackTest {
             val workSpec = lastValue.workSpec
             assertThat(workSpec.workerClassName).isEqualTo(UploadWorker::class.java.canonicalName)
             assertThat(workSpec.input.getString(UploadWorker.DATADOG_INSTANCE_NAME)).isEqualTo(fakeInstanceName)
-            assertThat(lastValue.tags).contains(TAG_DATADOG_UPLOAD)
+            assertThat(lastValue.tags).contains("$TAG_DATADOG_UPLOAD/$fakeInstanceName")
         }
     }
 
@@ -132,7 +132,7 @@ internal class ProcessLifecycleCallbackTest {
         testedCallback.onStarted()
 
         // Then
-        verify(mockWorkManager).cancelAllWorkByTag(TAG_DATADOG_UPLOAD)
+        verify(mockWorkManager).cancelAllWorkByTag("$TAG_DATADOG_UPLOAD/$fakeInstanceName")
     }
 
     @Test

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -8,7 +8,6 @@ package com.datadog.android.core.internal.utils
 
 import android.app.Application
 import androidx.work.ExistingWorkPolicy
-import androidx.work.NetworkType
 import androidx.work.OneTimeWorkRequest
 import androidx.work.impl.WorkManagerImpl
 import com.datadog.android.api.InternalLogger
@@ -20,8 +19,10 @@ import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.extensions.config.TestConfiguration
 import com.datadog.tools.unit.setStaticValue
+import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -32,7 +33,7 @@ import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
-import org.mockito.kotlin.argThat
+import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
@@ -55,6 +56,9 @@ internal class WorkManagerUtilsTest {
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
+
+    @StringForgery
+    lateinit var fakeInstanceName: String
 
     @BeforeEach
     fun `set up`() {
@@ -102,24 +106,26 @@ internal class WorkManagerUtilsTest {
         WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
 
         // When
-        triggerUploadWorker(appContext.mockInstance, mockInternalLogger)
+        triggerUploadWorker(appContext.mockInstance, fakeInstanceName, mockInternalLogger)
 
         // Then
-        verify(mockWorkManager).enqueueUniqueWork(
-            eq(UPLOAD_WORKER_NAME),
-            eq(ExistingWorkPolicy.REPLACE),
-            argThat<OneTimeWorkRequest> {
-                this.workSpec.workerClassName == UploadWorker::class.java.canonicalName &&
-                    this.tags.contains(TAG_DATADOG_UPLOAD) &&
-                    this.workSpec.constraints.requiredNetworkType == NetworkType.NOT_ROAMING
-            }
-        )
+        argumentCaptor<OneTimeWorkRequest> {
+            verify(mockWorkManager).enqueueUniqueWork(
+                eq(UPLOAD_WORKER_NAME),
+                eq(ExistingWorkPolicy.REPLACE),
+                capture()
+            )
+            val workSpec = lastValue.workSpec
+            assertThat(workSpec.workerClassName).isEqualTo(UploadWorker::class.java.canonicalName)
+            assertThat(workSpec.input.getString(UploadWorker.DATADOG_INSTANCE_NAME)).isEqualTo(fakeInstanceName)
+            assertThat(lastValue.tags).contains(TAG_DATADOG_UPLOAD)
+        }
     }
 
     @Test
     fun `it will handle the trigger exception if WorkManager was not correctly instantiated`() {
         // When
-        triggerUploadWorker(appContext.mockInstance, mockInternalLogger)
+        triggerUploadWorker(appContext.mockInstance, fakeInstanceName, mockInternalLogger)
 
         // Then
         verifyNoInteractions(mockWorkManager)

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/utils/WorkManagerUtilsTest.kt
@@ -85,16 +85,16 @@ internal class WorkManagerUtilsTest {
         WorkManagerImpl::class.java.setStaticValue("sDefaultInstance", mockWorkManager)
 
         // When
-        cancelUploadWorker(appContext.mockInstance, mockInternalLogger)
+        cancelUploadWorker(appContext.mockInstance, fakeInstanceName, mockInternalLogger)
 
         // Then
-        verify(mockWorkManager).cancelAllWorkByTag(eq(TAG_DATADOG_UPLOAD))
+        verify(mockWorkManager).cancelAllWorkByTag("$TAG_DATADOG_UPLOAD/$fakeInstanceName")
     }
 
     @Test
     fun `it will handle the cancel exception if WorkManager was not correctly instantiated`() {
         // When
-        cancelUploadWorker(appContext.mockInstance, mockInternalLogger)
+        cancelUploadWorker(appContext.mockInstance, fakeInstanceName, mockInternalLogger)
 
         // Then
         verifyNoInteractions(mockWorkManager)
@@ -118,7 +118,7 @@ internal class WorkManagerUtilsTest {
             val workSpec = lastValue.workSpec
             assertThat(workSpec.workerClassName).isEqualTo(UploadWorker::class.java.canonicalName)
             assertThat(workSpec.input.getString(UploadWorker.DATADOG_INSTANCE_NAME)).isEqualTo(fakeInstanceName)
-            assertThat(lastValue.tags).contains(TAG_DATADOG_UPLOAD)
+            assertThat(lastValue.tags).contains("$TAG_DATADOG_UPLOAD/$fakeInstanceName")
         }
     }
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -461,7 +461,7 @@ internal class DatadogExceptionHandlerTest {
             val workSpec = lastValue.workSpec
             assertThat(workSpec.workerClassName).isEqualTo(UploadWorker::class.java.canonicalName)
             assertThat(workSpec.input.getString(UploadWorker.DATADOG_INSTANCE_NAME)).isEqualTo(fakeInstanceName)
-            assertThat(lastValue.tags).contains(TAG_DATADOG_UPLOAD)
+            assertThat(lastValue.tags).contains("$TAG_DATADOG_UPLOAD/$fakeInstanceName")
         }
     }
 

--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -152,6 +152,7 @@ datadog:
       - "androidx.metrics.performance.JankStats.createAndTrack(android.view.Window, androidx.metrics.performance.JankStats.OnFrameListener):java.lang.IllegalStateException"
       - "androidx.navigation.Navigation.findNavController(android.app.Activity, kotlin.Int):java.lang.IllegalStateException"
       - "androidx.work.WorkManager.enqueueUniqueWork(kotlin.String, androidx.work.ExistingWorkPolicy, androidx.work.OneTimeWorkRequest):java.util.concurrent.RejectedExecutionException,java.lang.NullPointerException"
+      - "androidx.work.Data.Builder.build():java.lang.IllegalStateException"
       # endregion
       # region Java File
       - "java.io.ByteArrayOutputStream.write(kotlin.ByteArray, kotlin.Int, kotlin.Int):java.lang.IndexOutOfBoundsException"
@@ -475,6 +476,8 @@ datadog:
       - "android.graphics.Rect.width()"
       # endregion
       # region Androidx APIs
+      - "androidx.appcompat.widget.DatadogActionBarContainerAccessor.constructor(androidx.appcompat.widget.ActionBarContainer)"
+      - "androidx.appcompat.widget.DatadogActionBarContainerAccessor.getBackgroundDrawable()"
       - "androidx.compose.foundation.interaction.DragInteraction.Start.constructor()"
       - "androidx.compose.runtime.DisposableEffect(kotlin.Any?, kotlin.Any?, kotlin.Function1)"
       - "androidx.compose.runtime.DisposableEffectScope.onDispose(kotlin.Function0)"
@@ -506,6 +509,8 @@ datadog:
       - "androidx.work.Constraints.Builder.build()"
       - "androidx.work.Constraints.Builder.constructor()"
       - "androidx.work.Constraints.Builder.setRequiredNetworkType(androidx.work.NetworkType)"
+      - "androidx.work.Data.Builder.constructor()"
+      - "androidx.work.Data.Builder.putString(kotlin.String, kotlin.String?)"
       - "androidx.work.Data.getString(kotlin.String)"
       - "androidx.work.ListenableWorker.Result.success()"
       - "androidx.work.OneTimeWorkRequest.Builder(java.lang.Class)"
@@ -514,11 +519,10 @@ datadog:
       - "androidx.work.OneTimeWorkRequest.Builder.constructor(java.lang.Class)"
       - "androidx.work.OneTimeWorkRequest.Builder.setConstraints(androidx.work.Constraints)"
       - "androidx.work.OneTimeWorkRequest.Builder.setInitialDelay(kotlin.Long, java.util.concurrent.TimeUnit)"
+      - "androidx.work.OneTimeWorkRequest.Builder.setInputData(androidx.work.Data)"
       - "androidx.work.WorkManager.cancelAllWorkByTag(kotlin.String)"
       - "androidx.work.WorkManager.getInstance(android.content.Context)"
       - "androidx.work.WorkManager.isInitialized()"
-      - "androidx.appcompat.widget.DatadogActionBarContainerAccessor.constructor(androidx.appcompat.widget.ActionBarContainer)"
-      - "androidx.appcompat.widget.DatadogActionBarContainerAccessor.getBackgroundDrawable()"
       # endregion
       # region Google Material
       - "com.google.android.material.tabs.TabLayout.TabView.getChildAt(kotlin.Int)"


### PR DESCRIPTION
### What does this PR do?

When the UploadWorker is woken by the system, it reads the SDK Instance name from the WorkRequest input data, and tries to get the instance with that name. 

However, the instance name was never sent meaning that for applications specifying an instance name would never find a relevant SDK. 

### Motivation

Fixes #2252
