### PR TITLE
RUM-6033 Add telemetry and logs related with RumMonitor#addViewLoadigTime API

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -44,7 +44,7 @@ interface com.datadog.android.api.InternalLogger
   fun log(Level, List<Target>, () -> String, Throwable? = null, Boolean = false, Map<String, Any?>? = null)
   fun logMetric(() -> String, Map<String, Any?>, Float)
   fun startPerformanceMeasure(String, com.datadog.android.core.metrics.TelemetryMetricType, Float, String): com.datadog.android.core.metrics.PerformanceMetric?
-  fun logApiUsage(com.datadog.android.internal.telemetry.InternalTelemetryEvent.ApiUsage, Float)
+  fun logApiUsage(com.datadog.android.internal.telemetry.InternalTelemetryEvent.ApiUsage, Float = 15f)
   companion object 
     val UNBOUND: InternalLogger
 interface com.datadog.android.api.SdkCore

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -89,6 +89,7 @@ public final class com/datadog/android/api/InternalLogger$Companion {
 public final class com/datadog/android/api/InternalLogger$DefaultImpls {
 	public static synthetic fun log$default (Lcom/datadog/android/api/InternalLogger;Lcom/datadog/android/api/InternalLogger$Level;Lcom/datadog/android/api/InternalLogger$Target;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ZLjava/util/Map;ILjava/lang/Object;)V
 	public static synthetic fun log$default (Lcom/datadog/android/api/InternalLogger;Lcom/datadog/android/api/InternalLogger$Level;Ljava/util/List;Lkotlin/jvm/functions/Function0;Ljava/lang/Throwable;ZLjava/util/Map;ILjava/lang/Object;)V
+	public static synthetic fun logApiUsage$default (Lcom/datadog/android/api/InternalLogger;Lcom/datadog/android/internal/telemetry/InternalTelemetryEvent$ApiUsage;FILjava/lang/Object;)V
 }
 
 public final class com/datadog/android/api/InternalLogger$Level : java/lang/Enum {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/InternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/api/InternalLogger.kt
@@ -137,12 +137,12 @@ interface InternalLogger {
      * Logs an API usage from the internal implementation.
      * @param apiUsageEvent the API event being tracked
      * @param samplingRate value between 0-100 for sampling the event. Note that the sampling rate applied to this
-     * event will be applied in addition to the global telemetry sampling rate.
+     * event will be applied in addition to the global telemetry sampling rate. By default, the sampling rate is 15%.
      */
     @InternalApi
     fun logApiUsage(
         apiUsageEvent: InternalTelemetryEvent.ApiUsage,
-        samplingRate: Float
+        samplingRate: Float = 15f
     )
 
     companion object {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -540,7 +540,7 @@ internal class RumFeature(
         internal const val ALL_IN_SAMPLE_RATE: Float = 100f
         internal const val DEFAULT_SAMPLE_RATE: Float = 100f
         internal const val DEFAULT_TELEMETRY_SAMPLE_RATE: Float = 20f
-        internal const val DEFAULT_TELEMETRY_CONFIGURATION_SAMPLE_RATE: Float = 100f
+        internal const val DEFAULT_TELEMETRY_CONFIGURATION_SAMPLE_RATE: Float = 20f
         internal const val DEFAULT_LONG_TASK_THRESHOLD_MS = 100L
         internal const val DD_TELEMETRY_CONFIG_SAMPLE_RATE_TAG =
             "_dd.telemetry.configuration_sample_rate"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/RumFeature.kt
@@ -540,7 +540,7 @@ internal class RumFeature(
         internal const val ALL_IN_SAMPLE_RATE: Float = 100f
         internal const val DEFAULT_SAMPLE_RATE: Float = 100f
         internal const val DEFAULT_TELEMETRY_SAMPLE_RATE: Float = 20f
-        internal const val DEFAULT_TELEMETRY_CONFIGURATION_SAMPLE_RATE: Float = 20f
+        internal const val DEFAULT_TELEMETRY_CONFIGURATION_SAMPLE_RATE: Float = 100f
         internal const val DEFAULT_LONG_TASK_THRESHOLD_MS = 100L
         internal const val DD_TELEMETRY_CONFIG_SAMPLE_RATE_TAG =
             "_dd.telemetry.configuration_sample_rate"

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/event/RumEventSerializer.kt
@@ -20,6 +20,7 @@ import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.telemetry.model.TelemetryConfigurationEvent
 import com.datadog.android.telemetry.model.TelemetryDebugEvent
 import com.datadog.android.telemetry.model.TelemetryErrorEvent
+import com.datadog.android.telemetry.model.TelemetryUsageEvent
 import com.google.gson.JsonObject
 
 internal class RumEventSerializer(
@@ -53,6 +54,9 @@ internal class RumEventSerializer(
                 model.toJson().toString()
             }
             is TelemetryConfigurationEvent -> {
+                model.toJson().toString()
+            }
+            is TelemetryUsageEvent -> {
                 model.toJson().toString()
             }
             is JsonObject -> {

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -15,6 +15,7 @@ import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
@@ -242,6 +243,14 @@ internal open class RumViewScope(
     private fun onAddViewLoadingTime(event: RumRawEvent.AddViewLoadingTime, writer: DataWriter<Any>) {
         if (stopped) return
         val canAddViewLoadingTime = event.overwrite || viewLoadingTime == null
+        sdkCore.internalLogger.logApiUsage(
+            InternalTelemetryEvent.ApiUsage.AddViewLoadingTime(
+                overwrite = event.overwrite,
+                noView = viewId.isEmpty(),
+                noActiveView = !isActive()
+            ),
+            100.0f
+        )
         if (canAddViewLoadingTime) {
             viewLoadingTime = event.eventTime.nanoTime - startedNanos
             sendViewUpdate(event, writer)

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -446,7 +446,7 @@ internal class TelemetryEventHandler(
 
     companion object {
         const val MAX_EVENTS_PER_SESSION = 100
-        const val DEFAULT_CONFIGURATION_SAMPLE_RATE = 100f
+        const val DEFAULT_CONFIGURATION_SAMPLE_RATE = 20f
         const val ALREADY_SEEN_EVENT_MESSAGE =
             "Already seen telemetry event with identity=%s, rejecting."
         const val MAX_EVENT_NUMBER_REACHED_MESSAGE =

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -137,7 +137,7 @@ internal class TelemetryEventHandler(
 
         val eventIdentity = event.identity
 
-        if (event !is InternalTelemetryEvent.Metric && eventIDsSeenInCurrentSession.contains(eventIdentity)) {
+        if (isLog(event) && eventIDsSeenInCurrentSession.contains(eventIdentity)) {
             sdkCore.internalLogger.log(
                 InternalLogger.Level.INFO,
                 InternalLogger.Target.MAINTAINER,
@@ -156,6 +156,10 @@ internal class TelemetryEventHandler(
         }
 
         return true
+    }
+
+    private fun isLog(event: InternalTelemetryEvent): Boolean {
+        return event is InternalTelemetryEvent.Log
     }
 
     private fun createDebugEvent(
@@ -351,7 +355,7 @@ internal class TelemetryEventHandler(
                         datadogContext.source,
                         sdkCore.internalLogger
                     ) ?: TelemetryUsageEvent.Source.ANDROID,
-                    service = datadogContext.service,
+                    service = TELEMETRY_SERVICE_NAME,
                     version = datadogContext.sdkVersion,
                     application = TelemetryUsageEvent.Application(rumContext.applicationId),
                     session = TelemetryUsageEvent.Session(rumContext.sessionId),
@@ -442,7 +446,7 @@ internal class TelemetryEventHandler(
 
     companion object {
         const val MAX_EVENTS_PER_SESSION = 100
-        const val DEFAULT_CONFIGURATION_SAMPLE_RATE = 20f
+        const val DEFAULT_CONFIGURATION_SAMPLE_RATE = 100f
         const val ALREADY_SEEN_EVENT_MESSAGE =
             "Already seen telemetry event with identity=%s, rejecting."
         const val MAX_EVENT_NUMBER_REACHED_MESSAGE =

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumRawEventExt.kt
@@ -112,6 +112,10 @@ internal fun Forge.addErrorEvent(): RumRawEvent.AddError {
     )
 }
 
+internal fun Forge.addViewLoadingTimeEvent(): RumRawEvent.AddViewLoadingTime {
+    return RumRawEvent.AddViewLoadingTime(overwrite = aBool())
+}
+
 internal fun Forge.addLongTaskEvent(): RumRawEvent.AddLongTask {
     return RumRawEvent.AddLongTask(
         durationNs = aLong(min = 1),
@@ -178,7 +182,8 @@ internal fun Forge.invalidBackgroundEvent(): RumRawEvent {
             stopActionEvent(),
             stopResourceEvent(),
             stopResourceWithErrorEvent(),
-            stopResourceWithStacktraceEvent()
+            stopResourceWithStacktraceEvent(),
+            addViewLoadingTimeEvent()
         )
     )
 }
@@ -197,7 +202,8 @@ internal fun Forge.anyRumEvent(excluding: List<Type> = listOf()): RumRawEvent {
         addLongTaskEvent(),
         addFeatureFlagEvaluationEvent(),
         addCustomTimingEvent(),
-        updatePerformanceMetricEvent()
+        updatePerformanceMetricEvent(),
+        addViewLoadingTimeEvent()
     )
     return this.anElementFrom(
         allEvents.filter {

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -18,6 +18,7 @@ import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
@@ -44,6 +45,7 @@ import com.datadog.android.rum.model.LongTaskEvent
 import com.datadog.android.rum.model.ViewEvent
 import com.datadog.android.rum.utils.config.GlobalRumMonitorTestConfiguration
 import com.datadog.android.rum.utils.forge.Configurator
+import com.datadog.android.rum.utils.verifyApiUsage
 import com.datadog.android.rum.utils.verifyLog
 import com.datadog.tools.unit.annotations.TestConfigurationsProvider
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
@@ -7028,6 +7030,112 @@ internal class RumViewScopeTest {
                     hasSampleRate(fakeSampleRate)
                 }
         }
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.DEBUG,
+            InternalLogger.Target.USER,
+            RumViewScope.ADDING_VIEW_LOADING_TIME_DEBUG_MESSAGE_FORMAT.format(
+                expectedViewLoadingTime,
+                testedScope.key.name
+            )
+        )
+        mockInternalLogger.verifyApiUsage(
+            InternalTelemetryEvent.ApiUsage.AddViewLoadingTime(
+                overwrite = false,
+                noView = false,
+                noActiveView = false
+            ),
+            15f
+        )
+        verifyNoMoreInteractions(mockWriter)
+    }
+
+    @Test
+    fun `M overwrite view loading W handleEvent(AddViewLoadingTime, overwrite=true)`(
+        forge: Forge
+    ) {
+        // Given
+        val previousLoadingTime = forge.aPositiveLong()
+        testedScope.viewLoadingTime = previousLoadingTime
+        val newViewLoadingTime = RumRawEvent.AddViewLoadingTime(overwrite = true)
+        val expectedViewLoadingTime = newViewLoadingTime.eventTime.nanoTime - fakeEventTime.nanoTime
+
+        // When
+        testedScope.handleEvent(
+            newViewLoadingTime,
+            mockWriter
+        )
+
+        // Then
+        argumentCaptor<ViewEvent> {
+            verify(mockWriter)
+                .write(eq(mockEventBatchWriter), capture(), eq(EventType.DEFAULT))
+            assertThat(firstValue)
+                .apply {
+                    hasTimestamp(resolveExpectedTimestamp(fakeEventTime.timestamp))
+                    hasName(fakeKey.name)
+                    hasUrl(fakeUrl)
+                    hasDurationGreaterThan(1)
+                    hasLoadingType(null)
+                    hasVersion(2)
+                    hasErrorCount(0)
+                    hasResourceCount(0)
+                    hasActionCount(0)
+                    hasFrustrationCount(0)
+                    hasLongTaskCount(0)
+                    hasFrozenFrameCount(0)
+                    hasCpuMetric(null)
+                    hasMemoryMetric(null, null)
+                    hasRefreshRateMetric(null, null)
+                    isActive(true)
+                    isSlowRendered(false)
+                    hasUserInfo(fakeDatadogContext.userInfo)
+                    hasViewId(testedScope.viewId)
+                    hasApplicationId(fakeParentContext.applicationId)
+                    hasSessionId(fakeParentContext.sessionId)
+                    hasUserSession()
+                    hasNoSyntheticsTest()
+                    hasStartReason(fakeParentContext.sessionStartReason)
+                    hasReplay(fakeHasReplay)
+                    hasReplayStats(fakeReplayStats)
+                    hasSource(fakeSourceViewEvent)
+                    hasLoadingTime(expectedViewLoadingTime)
+                    hasDeviceInfo(
+                        fakeDatadogContext.deviceInfo.deviceName,
+                        fakeDatadogContext.deviceInfo.deviceModel,
+                        fakeDatadogContext.deviceInfo.deviceBrand,
+                        fakeDatadogContext.deviceInfo.deviceType.toViewSchemaType(),
+                        fakeDatadogContext.deviceInfo.architecture
+                    )
+                    hasOsInfo(
+                        fakeDatadogContext.deviceInfo.osName,
+                        fakeDatadogContext.deviceInfo.osVersion,
+                        fakeDatadogContext.deviceInfo.osMajorVersion
+                    )
+                    hasConnectivityInfo(fakeDatadogContext.networkInfo)
+                    hasServiceName(fakeDatadogContext.service)
+                    hasVersion(fakeDatadogContext.version)
+                    hasSessionActive(fakeParentContext.isSessionActive)
+                    hasSampleRate(fakeSampleRate)
+                }
+        }
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            RumViewScope.OVERWRITING_VIEW_LOADING_TIME_WARNING_MESSAGE_FORMAT.format(
+                Locale.US,
+                testedScope.key.name,
+                previousLoadingTime,
+                expectedViewLoadingTime
+            )
+        )
+        mockInternalLogger.verifyApiUsage(
+            InternalTelemetryEvent.ApiUsage.AddViewLoadingTime(
+                noActiveView = false,
+                noView = false,
+                overwrite = true
+            ),
+            15f
+        )
         verifyNoMoreInteractions(mockWriter)
     }
 
@@ -7190,6 +7298,19 @@ internal class RumViewScopeTest {
 
         // Then
         assertThat(testedScope.viewLoadingTime).isNull()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            RumViewScope.NO_ACTIVE_VIEW_FOR_LOADING_TIME_WARNING_MESSAGE
+        )
+        mockInternalLogger.verifyApiUsage(
+            InternalTelemetryEvent.ApiUsage.AddViewLoadingTime(
+                noActiveView = true,
+                noView = false,
+                overwrite = fakeOverwrite
+            ),
+            15f
+        )
         verifyNoInteractions(mockWriter)
     }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/InternalLoggerUtils.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/InternalLoggerUtils.kt
@@ -9,6 +9,8 @@
 package com.datadog.android.rum.utils
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
+import com.datadog.android.rum.utils.assertj.InternalApiUsageEventAssert
 import org.assertj.core.api.Assertions.assertThat
 import org.mockito.ArgumentMatchers.isA
 import org.mockito.kotlin.argumentCaptor
@@ -17,6 +19,17 @@ import org.mockito.kotlin.same
 import org.mockito.kotlin.times
 import org.mockito.kotlin.verify
 import org.mockito.verification.VerificationMode
+
+fun InternalLogger.verifyApiUsage(
+    apiUsage: InternalTelemetryEvent.ApiUsage,
+    samplingRate: Float
+) {
+    argumentCaptor<InternalTelemetryEvent.ApiUsage> {
+        verify(this@verifyApiUsage).logApiUsage(capture(), eq(samplingRate))
+        val event = firstValue
+        InternalApiUsageEventAssert.assertThat(event).isEqualTo(apiUsage)
+    }
+}
 
 fun InternalLogger.verifyLog(
     level: InternalLogger.Level,

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/InternalAddViewLoadingTimeEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/InternalAddViewLoadingTimeEventAssert.kt
@@ -1,0 +1,73 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.utils.assertj
+
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
+import org.assertj.core.api.AbstractAssert
+import org.assertj.core.api.Assertions.assertThat
+
+internal class InternalAddViewLoadingTimeEventAssert(actual: InternalTelemetryEvent.ApiUsage.AddViewLoadingTime) :
+    AbstractAssert<InternalAddViewLoadingTimeEventAssert, InternalTelemetryEvent.ApiUsage.AddViewLoadingTime>(
+        actual,
+        InternalAddViewLoadingTimeEventAssert::class.java
+    ) {
+
+    fun isEqualTo(expected: InternalTelemetryEvent.ApiUsage.AddViewLoadingTime) {
+        hasNoView(expected.noView)
+        hasNoActiveView(expected.noActiveView)
+        hasOverwrite(expected.overwrite)
+        hasAdditionalProperties(expected.additionalProperties)
+    }
+
+    fun hasNoView(expected: Boolean): InternalAddViewLoadingTimeEventAssert {
+        assertThat(actual.noView)
+            .overridingErrorMessage(
+                "Expected viewLoadingTimeTelemetryEvent event to" +
+                    " have noView $expected but was ${actual.noView}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasNoActiveView(expected: Boolean): InternalAddViewLoadingTimeEventAssert {
+        assertThat(actual.noActiveView)
+            .overridingErrorMessage(
+                "Expected viewLoadingTimeTelemetryEvent event to have" +
+                    " noActiveView $expected but was ${actual.noActiveView}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasOverwrite(expected: Boolean): InternalAddViewLoadingTimeEventAssert {
+        assertThat(actual.overwrite)
+            .overridingErrorMessage(
+                "Expected viewLoadingTimeTelemetryEvent event to have" +
+                    " overwrite $expected but was ${actual.overwrite}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasAdditionalProperties(expected: Map<String, Any?>): InternalAddViewLoadingTimeEventAssert {
+        assertThat(actual.additionalProperties)
+            .overridingErrorMessage(
+                "Expected viewLoadingTimeTelemetryEvent event to have" +
+                    " additionalProperties $expected but was ${actual.additionalProperties}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    companion object {
+        fun assertThat(
+            actual: InternalTelemetryEvent.ApiUsage.AddViewLoadingTime
+        ): InternalAddViewLoadingTimeEventAssert {
+            return InternalAddViewLoadingTimeEventAssert(actual)
+        }
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/InternalApiUsageEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/assertj/InternalApiUsageEventAssert.kt
@@ -1,0 +1,38 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.rum.utils.assertj
+
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
+import org.assertj.core.api.AbstractAssert
+
+class InternalApiUsageEventAssert(actual: InternalTelemetryEvent.ApiUsage) :
+    AbstractAssert<InternalApiUsageEventAssert, InternalTelemetryEvent.ApiUsage>(
+        actual,
+        InternalApiUsageEventAssert::class.java
+    ) {
+
+    fun isEqualTo(expected: InternalTelemetryEvent.ApiUsage): InternalApiUsageEventAssert {
+        when (actual) {
+            is InternalTelemetryEvent.ApiUsage.AddViewLoadingTime -> {
+                InternalAddViewLoadingTimeEventAssert
+                    .assertThat(actual as InternalTelemetryEvent.ApiUsage.AddViewLoadingTime)
+                    .isEqualTo(expected as InternalTelemetryEvent.ApiUsage.AddViewLoadingTime)
+            }
+
+            else -> {
+                failWithMessage("Unknown event type: ${actual::class.java.simpleName}")
+            }
+        }
+        return this
+    }
+
+    companion object {
+        fun assertThat(actual: InternalTelemetryEvent.ApiUsage): InternalApiUsageEventAssert {
+            return InternalApiUsageEventAssert(actual)
+        }
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryUsageEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/TelemetryUsageEventAssert.kt
@@ -1,0 +1,217 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.assertj
+
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
+import com.datadog.android.telemetry.model.TelemetryUsageEvent
+import org.assertj.core.api.AbstractObjectAssert
+import org.assertj.core.api.Assertions.assertThat
+
+internal class TelemetryUsageEventAssert(actual: TelemetryUsageEvent) :
+    AbstractObjectAssert<TelemetryUsageEventAssert, TelemetryUsageEvent>(
+        actual,
+        TelemetryUsageEventAssert::class.java
+    ) {
+
+    fun hasDate(expected: Long): TelemetryUsageEventAssert {
+        assertThat(actual.date)
+            .overridingErrorMessage(
+                "Expected event data to have date $expected but was ${actual.date}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasSource(expected: TelemetryUsageEvent.Source): TelemetryUsageEventAssert {
+        assertThat(actual.source)
+            .overridingErrorMessage(
+                "Expected event data to have source $expected but was ${actual.source}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasService(expected: String): TelemetryUsageEventAssert {
+        assertThat(actual.service)
+            .overridingErrorMessage(
+                "Expected event data to have service $expected but was ${actual.service}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasVersion(expected: String): TelemetryUsageEventAssert {
+        assertThat(actual.version)
+            .overridingErrorMessage(
+                "Expected event data to have version $expected but was ${actual.version}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasApplicationId(expected: String?): TelemetryUsageEventAssert {
+        assertThat(actual.application?.id)
+            .overridingErrorMessage(
+                "Expected event data to have" +
+                    " application.id $expected but was ${actual.application?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasSessionId(expected: String?): TelemetryUsageEventAssert {
+        assertThat(actual.session?.id)
+            .overridingErrorMessage(
+                "Expected event data to have session.id $expected but was ${actual.session?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasViewId(expected: String?): TelemetryUsageEventAssert {
+        assertThat(actual.view?.id)
+            .overridingErrorMessage(
+                "Expected event data to have view.id $expected but was ${actual.view?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasActionId(expected: String?): TelemetryUsageEventAssert {
+        assertThat(actual.action?.id)
+            .overridingErrorMessage(
+                "Expected event data to have action.id $expected but was ${actual.action?.id}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasAdditionalProperties(additionalProperties: Map<String, Any?>): TelemetryUsageEventAssert {
+        assertThat(actual.telemetry.additionalProperties)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.additionalProperties $additionalProperties" +
+                    " but was ${actual.telemetry.additionalProperties}"
+            )
+            .isEqualTo(additionalProperties)
+        return this
+    }
+
+    fun hasDeviceArchitecture(expected: String?): TelemetryUsageEventAssert {
+        assertThat(actual.telemetry.device?.architecture)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.device architecture $expected" +
+                    " but was ${actual.telemetry.device?.architecture}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasDeviceModel(expected: String?): TelemetryUsageEventAssert {
+        assertThat(actual.telemetry.device?.model)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.device model $expected" +
+                    " but was ${actual.telemetry.device?.model}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasDeviceBrand(expected: String?): TelemetryUsageEventAssert {
+        assertThat(actual.telemetry.device?.brand)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.device brand $expected" +
+                    " but was ${actual.telemetry.device?.brand}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasOsBuild(expected: String?): TelemetryUsageEventAssert {
+        assertThat(actual.telemetry.os?.build)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.os build $expected" +
+                    " but was ${actual.telemetry.os?.build}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasOsName(expected: String?): TelemetryUsageEventAssert {
+        assertThat(actual.telemetry.os?.name)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.os name $expected" +
+                    " but was ${actual.telemetry.os?.name}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasOsVersion(expected: String?): TelemetryUsageEventAssert {
+        assertThat(actual.telemetry.os?.version)
+            .overridingErrorMessage(
+                "Expected event data to have telemetry.os version $expected" +
+                    " but was ${actual.telemetry.os?.version}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasUsage(expected: InternalTelemetryEvent.ApiUsage) {
+        when (expected) {
+            is InternalTelemetryEvent.ApiUsage.AddViewLoadingTime -> {
+                val actualUsage = actual.telemetry.usage as TelemetryUsageEvent.Usage.AddViewLoadingTime
+                assertThat(actualUsage)
+                    .hasNoView(expected.noView)
+                    .hasOverwritten(actualUsage.overwritten)
+                    .hasNoActiveView(expected.noActiveView)
+            }
+        }
+    }
+
+    private class ViewLoadingTimeEventAssert(actual: TelemetryUsageEvent.Usage.AddViewLoadingTime) :
+        AbstractObjectAssert<ViewLoadingTimeEventAssert, TelemetryUsageEvent.Usage.AddViewLoadingTime>(
+            actual,
+            ViewLoadingTimeEventAssert::class.java
+        ) {
+
+        fun hasNoView(expected: Boolean): ViewLoadingTimeEventAssert {
+            assertThat(actual.noView)
+                .overridingErrorMessage(
+                    "Expected viewLoadingTimeUsage event to" +
+                        " have noView $expected but was ${actual.noView}"
+                )
+                .isEqualTo(expected)
+            return this
+        }
+
+        fun hasNoActiveView(expected: Boolean): ViewLoadingTimeEventAssert {
+            assertThat(actual.noActiveView)
+                .overridingErrorMessage(
+                    "Expected viewLoadingTimeUsage event to have" +
+                        " noActiveView $expected but was ${actual.noActiveView}"
+                )
+                .isEqualTo(expected)
+            return this
+        }
+
+        fun hasOverwritten(expected: Boolean): ViewLoadingTimeEventAssert {
+            assertThat(actual.overwritten)
+                .overridingErrorMessage(
+                    "Expected viewLoadingTimeUsage event to have" +
+                        " overwritten $expected but was ${actual.overwritten}"
+                )
+                .isEqualTo(expected)
+            return this
+        }
+    }
+
+    companion object {
+        fun assertThat(actual: TelemetryUsageEvent) = TelemetryUsageEventAssert(actual)
+        private fun assertThat(actual: TelemetryUsageEvent.Usage.AddViewLoadingTime) =
+            ViewLoadingTimeEventAssert(actual)
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/ViewLoadingTimeEventAssert.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/assertj/ViewLoadingTimeEventAssert.kt
@@ -1,0 +1,50 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.telemetry.assertj
+
+import com.datadog.android.telemetry.model.TelemetryUsageEvent
+import org.assertj.core.api.AbstractObjectAssert
+import org.assertj.core.api.Assertions.assertThat
+
+internal class ViewLoadingTimeEventAssert(actual: TelemetryUsageEvent.Usage.AddViewLoadingTime) :
+    AbstractObjectAssert<ViewLoadingTimeEventAssert, TelemetryUsageEvent.Usage.AddViewLoadingTime>(
+        actual,
+        ViewLoadingTimeEventAssert::class.java
+    ) {
+
+    fun hasNoView(expected: Boolean): ViewLoadingTimeEventAssert {
+        assertThat(actual.noView)
+            .overridingErrorMessage(
+                "Expected event data to have noView $expected but was ${actual.noView}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasNoActiveView(expected: Boolean): ViewLoadingTimeEventAssert {
+        assertThat(actual.noActiveView)
+            .overridingErrorMessage(
+                "Expected event data to have noActiveView $expected but was ${actual.noActiveView}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    fun hasOverwritten(expected: Boolean): ViewLoadingTimeEventAssert {
+        assertThat(actual.overwritten)
+            .overridingErrorMessage(
+                "Expected event data to have overwriten $expected but was ${actual.overwritten}"
+            )
+            .isEqualTo(expected)
+        return this
+    }
+
+    companion object {
+        fun assertThat(actual: TelemetryUsageEvent.Usage.AddViewLoadingTime) =
+            ViewLoadingTimeEventAssert(actual)
+    }
+}

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -661,20 +661,6 @@ internal class TelemetryEventHandlerTest {
                         rawEvent.eventTime.timestamp
                     )
                 }
-
-                is TelemetryConfigurationEvent -> {
-                    assertConfigEventMatchesInternalEvent(
-                        capturedValue,
-                        internalTelemetryEvent as InternalTelemetryEvent.Configuration,
-                        fakeRumContext,
-                        rawEvent.eventTime.timestamp
-                    )
-                }
-
-                is InternalTelemetryEvent.InterceptorInstantiated -> {
-                    assertThat(capturedValue).isEqualTo(InternalTelemetryEvent.InterceptorInstantiated)
-                }
-
                 else -> throw IllegalArgumentException(
                     "Unexpected type=${lastValue::class.jvmName} of the captured value."
                 )
@@ -884,7 +870,7 @@ internal class TelemetryEventHandlerTest {
             .hasSessionId(rumContext.sessionId)
             .hasViewId(rumContext.viewId)
             .hasActionId(rumContext.actionId)
-            .hasAdditionalProperties(internalUsageEvent.additionalProperties ?: emptyMap())
+            .hasAdditionalProperties(internalUsageEvent.additionalProperties)
             .hasDeviceArchitecture(fakeDeviceArchitecture)
             .hasDeviceBrand(fakeDeviceBrand)
             .hasDeviceModel(fakeDeviceModel)


### PR DESCRIPTION
### What does this PR do?

Following the [RFC](https://datadoghq.atlassian.net/wiki/spaces/RUMP/pages/3951001790/RFC+View+loading+time+manual+API) in this PR we are adding the logs and telemetry related with usage of the `RumMonitor#addViewLoadingTime` newly introduced API. The telemetry and log configuration will be configured accordingly with the current RUM context state and will help us understand what is the pattern for this API usage on the client side.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

