### PR TITLE
RUM-6235 Handle sse request

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -1237,6 +1237,7 @@ datadog:
       - "okhttp3.Response.code()"
       - "okhttp3.Response.header(kotlin.String, kotlin.String?)"
       - "okhttp3.ResponseBody.contentLength()"
+      - "okhttp3.ResponseBody.contentType()"
       - "okio.Buffer.constructor()"
       # endregion
       # region org.json

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -89,7 +89,8 @@ timber = "5.0.1"
 coroutines = "1.4.2"
 
 # Local Server
-ktor = "1.6.0"
+ktor = "1.6.8"
+ktorServer = "3.0.0-rc-1"
 
 # Otel
 jctools = "3.3.0"
@@ -233,8 +234,10 @@ coroutinesCore = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", ver
 
 # Local Server
 ktorCore = { module = "io.ktor:ktor", version.ref = "ktor" }
-ktorNetty = { module = "io.ktor:ktor-server-netty", version.ref = "ktor" }
 ktorGson = { module = "io.ktor:ktor-gson", version.ref = "ktor" }
+ktorServerCore = { module = "io.ktor:ktor-server-core", version.ref = "ktorServer" }
+ktorServerNetty = { module = "io.ktor:ktor-server-netty", version.ref = "ktorServer" }
+ktorServerSSE = { module = "io.ktor:ktor-server-sse", version.ref = "ktorServer" }
 
 # Otel
 jctools = { module = "org.jctools:jctools-core", version.ref = "jctools" }
@@ -306,8 +309,12 @@ glide = [
 
 ktor = [
     "ktorCore",
-    "ktorNetty",
-    "ktorGson"
+    "ktorGson",
+]
+ktorServer = [
+    "ktorServerCore",
+    "ktorServerNetty",
+    "ktorServerSSE"
 ]
 
 traceCore = [

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -34,6 +34,7 @@ import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import io.opentracing.Tracer
 import okhttp3.MediaType
+import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.Protocol
 import okhttp3.Response
 import okhttp3.ResponseBody
@@ -213,6 +214,47 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
                     capture(),
                     eq(statusCode),
                     eq(fakeResponseBody.toByteArray().size.toLong()),
+                    eq(kind),
+                    eq(expectedStopAttrs)
+                )
+                assertThat(firstValue).isEqualTo(secondValue)
+            }
+        }
+    }
+
+    @Test
+    fun `M start and stop RUM Resource W intercept() {successful streaming request}`(
+        @IntForgery(min = 200, max = 300) statusCode: Int,
+        forge: Forge
+    ) {
+        // Given
+        val mimeType = forge.anElementFrom(*DatadogInterceptor.STREAM_CONTENT_TYPES)
+        fakeMediaType = mimeType.toMediaType()
+        stubChain(mockChain, statusCode)
+        val expectedStartAttrs = emptyMap<String, Any?>()
+        val expectedStopAttrs = mapOf(
+            RumAttributes.TRACE_ID to fakeTraceIdAsString,
+            RumAttributes.SPAN_ID to fakeSpanId,
+            RumAttributes.RULE_PSR to fakeTracingSampleRate
+        ) + fakeAttributes
+        val kind = RumResourceKind.NATIVE
+
+        // When
+        testedInterceptor.intercept(mockChain)
+
+        // Then
+        inOrder(rumMonitor.mockInstance) {
+            argumentCaptor<ResourceId> {
+                verify(rumMonitor.mockInstance).startResource(
+                    capture(),
+                    eq(fakeMethod),
+                    eq(fakeUrl),
+                    eq(expectedStartAttrs)
+                )
+                verify(rumMonitor.mockInstance).stopResource(
+                    capture(),
+                    eq(statusCode),
+                    eq(null),
                     eq(kind),
                     eq(expectedStopAttrs)
                 )

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -1346,8 +1346,12 @@ internal open class TracingInterceptorNotSendingSpanTest {
 
     // region Internal
 
-    internal fun stubChain(chain: Interceptor.Chain, statusCode: Int) {
-        return stubChain(chain) { forgeResponse(statusCode) }
+    internal fun stubChain(
+        chain: Interceptor.Chain,
+        statusCode: Int,
+        responseBuilder: Response.Builder.() -> Unit = {}
+    ) {
+        return stubChain(chain) { forgeResponse(statusCode, responseBuilder) }
     }
 
     internal fun stubChain(
@@ -1400,7 +1404,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         return builder.build()
     }
 
-    private fun forgeResponse(statusCode: Int): Response {
+    private fun forgeResponse(statusCode: Int, additionalConfig: Response.Builder.() -> Unit = {}): Response {
         val builder = Response.Builder()
             .request(fakeRequest)
             .protocol(Protocol.HTTP_2)
@@ -1410,6 +1414,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         if (fakeMediaType != null) {
             builder.header(TracingInterceptor.HEADER_CT, fakeMediaType?.type.orEmpty())
         }
+        builder.additionalConfig()
         return builder.build()
     }
 

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -195,7 +195,6 @@ dependencies {
     implementation("io.opentracing.contrib:opentracing-rxjava-3:0.1.4") {
         exclude(group = "io.opentracing")
     }
-    implementation("com.launchdarkly:okhttp-eventsource:2.5.0")
 
     // Image Loading Library
     implementation(libs.coil)

--- a/sample/kotlin/build.gradle.kts
+++ b/sample/kotlin/build.gradle.kts
@@ -195,6 +195,7 @@ dependencies {
     implementation("io.opentracing.contrib:opentracing-rxjava-3:0.1.4") {
         exclude(group = "io.opentracing")
     }
+    implementation("com.launchdarkly:okhttp-eventsource:2.5.0")
 
     // Image Loading Library
     implementation(libs.coil)
@@ -220,6 +221,7 @@ dependencies {
     implementation("com.squareup.retrofit2:converter-gson:2.9.0")
     implementation(libs.okHttp)
     implementation(libs.gson)
+    implementation("com.launchdarkly:okhttp-eventsource:2.5.0")
 
     // Misc
     implementation(libs.timber)

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/traces/TracesFragment.kt
@@ -39,6 +39,7 @@ internal class TracesFragment : Fragment(), View.OnClickListener {
         rootView.findViewById<Button>(R.id.start_coroutine_operation).setOnClickListener(this)
         rootView.findViewById<Button>(R.id.start_request).setOnClickListener(this)
         rootView.findViewById<Button>(R.id.start_404_request).setOnClickListener(this)
+        rootView.findViewById<Button>(R.id.start_sse_request).setOnClickListener(this)
         progressBarAsync = rootView.findViewById(R.id.spinner_async)
         progressBarCoroutine = rootView.findViewById(R.id.spinner_coroutine)
         progressBarRequest = rootView.findViewById(R.id.spinner_request)
@@ -73,6 +74,7 @@ internal class TracesFragment : Fragment(), View.OnClickListener {
 
     // region View.OnClickListener
 
+    @Suppress("LongMethod")
     override fun onClick(v: View?) {
         when (v?.id) {
             R.id.start_async_operation -> {
@@ -120,6 +122,17 @@ internal class TracesFragment : Fragment(), View.OnClickListener {
                     },
                     onCancel = {
                         setCompleteStatus(R.drawable.ic_cancel_red_24dp)
+                    }
+                )
+            }
+            R.id.start_sse_request -> {
+                setInProgress()
+                viewModel.startSseRequest(
+                    onResponse = {
+                        setCompleteStatus(R.drawable.ic_check_circle_green_24dp)
+                    },
+                    onException = {
+                        setCompleteStatus(R.drawable.ic_error_red_24dp)
                     }
                 )
             }

--- a/sample/kotlin/src/main/res/layout/fragment_traces.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_traces.xml
@@ -116,6 +116,16 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintTop_toBottomOf="@id/start_request"/>
 
+    <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/start_sse_request"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="16dp"
+            android:text="@string/button_start_sse"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/start_404_request"/>
+
     <ProgressBar
         android:id="@+id/spinner_request"
         android:layout_width="48dp"
@@ -125,7 +135,7 @@
         app:layout_constraintHorizontal_chainStyle="packed"
         app:layout_constraintEnd_toStartOf="@+id/request_status"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/start_404_request"
+        app:layout_constraintTop_toBottomOf="@id/start_sse_request"
         android:visibility="invisible"/>
 
     <androidx.appcompat.widget.AppCompatImageView

--- a/sample/kotlin/src/main/res/values/strings.xml
+++ b/sample/kotlin/src/main/res/values/strings.xml
@@ -60,7 +60,7 @@
     <string name="button_async_operation">Async Operation</string>
     <string name="button_network_request">Network Request</string>
     <string name="button_start">Start</string>
-    <string name="button_start_sse">Start SSE Request</string>
+    <string name="button_start_sse">Start Server Sent Event Request</string>
     <string name="button_start_404">Start 404 Request</string>
     <string name="button_save">Save</string>
     <string name="button_long_task">Long Task</string>

--- a/sample/kotlin/src/main/res/values/strings.xml
+++ b/sample/kotlin/src/main/res/values/strings.xml
@@ -60,6 +60,7 @@
     <string name="button_async_operation">Async Operation</string>
     <string name="button_network_request">Network Request</string>
     <string name="button_start">Start</string>
+    <string name="button_start_sse">Start SSE Request</string>
     <string name="button_start_404">Start 404 Request</string>
     <string name="button_save">Save</string>
     <string name="button_long_task">Long Task</string>

--- a/sample/vendor-lib/build.gradle.kts
+++ b/sample/vendor-lib/build.gradle.kts
@@ -81,6 +81,7 @@ dependencies {
 
     // Ktor (local web server)
     implementation(libs.bundles.ktor)
+    implementation(libs.bundles.ktorServer)
 }
 
 kotlinConfig(evaluateWarningsAsErrors = false)

--- a/sample/vendor-lib/src/main/kotlin/com/datadog/android/vendor/sample/SseEvent.kt
+++ b/sample/vendor-lib/src/main/kotlin/com/datadog/android/vendor/sample/SseEvent.kt
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.vendor.sample
+
+internal data class SseEvent(val data: String) {
+
+    fun toJson(): String {
+        return "{\"data\":\"$data\"}"
+    }
+}


### PR DESCRIPTION
### What does this PR do?

This PR Handles properly SSE (Server Sent Event) network request instrumented with our OkHttp interceptor. 
In order to report the size of a downloaded resource, we use the `peekBody()` method which tries to read the whole content of the network request. In case of a SSE request, it would wait until the end of the stream to eventually complete the interception and forward the content to the receiver, blocking the server messages. 

ServerSent events should have the `text/server-event` Mime Type, which we can use to detect such use case. 

### Motivation

Fixes #2266