### PR TITLE
RUM-6256: Optimize MD5 byte array to hex string conversion

### DIFF
--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -26,5 +26,6 @@ sealed class com.datadog.android.internal.telemetry.InternalTelemetryEvent
     class AddViewLoadingTime : ApiUsage
       constructor(Boolean, Boolean, Boolean, MutableMap<String, Any?> = mutableMapOf())
   object InterceptorInstantiated : InternalTelemetryEvent
+fun ByteArray.toHexString(): String
 annotation com.datadog.tools.annotation.NoOpImplementation
   constructor(Boolean = false)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -102,6 +102,10 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 	public fun toString ()Ljava/lang/String;
 }
 
+public final class com/datadog/android/internal/utils/ByteArrayExtKt {
+	public static final fun toHexString ([B)Ljava/lang/String;
+}
+
 public abstract interface annotation class com/datadog/tools/annotation/NoOpImplementation : java/lang/annotation/Annotation {
 	public abstract fun publicNoOpImplementation ()Z
 }

--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -47,7 +47,8 @@ dependencies {
 
     // Generate NoOp implementations
     ksp(project(":tools:noopfactory"))
-
+    testImplementation(libs.bundles.jUnit5)
+    testImplementation(libs.bundles.testTools)
     testFixturesImplementation(libs.kotlin)
     testFixturesImplementation(libs.bundles.jUnit5)
     testFixturesImplementation(libs.bundles.testTools)

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/ByteArrayExt.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/ByteArrayExt.kt
@@ -1,0 +1,36 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.internal.utils
+
+private const val BYTE_MASK = 0xff
+private const val HEX_SHIFT = 4
+private const val LOWER_NIBBLE_MASK = 0x0f
+private const val HEX_CHARS = "0123456789abcdef"
+
+/**
+ * Converts a ByteArray to its corresponding hexadecimal String representation.
+ *
+ * Each byte in the array is converted into two hexadecimal characters.
+ * For example, the byte array `[0xA, 0x1F]` will be converted to the string `"0a1f"`.
+ *
+ * This method avoids performance overhead by using bitwise operations and
+ * minimizing object allocations compared to alternatives like `joinToString`.
+ *
+ * @receiver ByteArray The byte array to be converted.
+ * @return A hexadecimal [String] representation of the byte array.
+ *
+ */
+fun ByteArray.toHexString(): String {
+    @Suppress("UnsafeThirdPartyFunctionCall") // byte array size is always positive.
+    val result = StringBuilder(size * 2)
+    for (byte in this) {
+        val intVal = byte.toInt() and BYTE_MASK
+        result.append(HEX_CHARS[intVal ushr HEX_SHIFT]) // Append first half of byte
+        result.append(HEX_CHARS[intVal and LOWER_NIBBLE_MASK]) // Append second half of byte
+    }
+    return result.toString()
+}

--- a/dd-sdk-android-internal/src/test/java/com/datadog/internal/utils/ByteArrayExtTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/internal/utils/ByteArrayExtTest.kt
@@ -1,0 +1,66 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.internal.utils
+
+import com.datadog.android.internal.utils.toHexString
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+import java.util.Locale
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ByteArrayExtTest {
+
+    @Test
+    fun `M return correct hex string W convert {0x00, 0x00}`() {
+        // Given
+        val byteArray = byteArrayOf(0x00, 0x00) // 0xA is 10 in decimal
+
+        // When
+        val result = byteArray.toHexString()
+
+        // Then
+        val expectedHex = "0000"
+        assertThat(result).isEqualTo(expectedHex)
+    }
+
+    @Test
+    fun `M return correct hex string W convert {0xFF, 0xFF}`() {
+        // Given
+        val byteArray = byteArrayOf(0xFF.toByte(), 0xFF.toByte()) // 0xA is 10 in decimal
+
+        // When
+        val result = byteArray.toHexString()
+
+        // Then
+        val expectedHex = "ffff"
+        assertThat(result).isEqualTo(expectedHex)
+    }
+
+    @Test
+    fun `M return correct hex string W call toHexString()`(@StringForgery fakeInput: String) {
+        // Given
+        val fakeByteArray = fakeInput.toByteArray()
+
+        // When
+        val result = fakeByteArray.toHexString()
+
+        // Then
+        val expected = fakeByteArray.joinToString(separator = "") { "%02x".format(Locale.US, it) }
+        assertThat(result).isEqualTo(expected)
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/MD5HashGenerator.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/MD5HashGenerator.kt
@@ -7,9 +7,9 @@
 package com.datadog.android.sessionreplay.internal.recorder.resources
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.internal.utils.toHexString
 import java.security.MessageDigest
 import java.security.NoSuchAlgorithmException
-import java.util.Locale
 
 internal class MD5HashGenerator(
     private val logger: InternalLogger
@@ -21,7 +21,7 @@ internal class MD5HashGenerator(
 
             val hashBytes = messageDigest.digest()
 
-            hashBytes.joinToString(separator = "") { "%02x".format(Locale.US, it) }
+            hashBytes.toHexString()
         } catch (e: NoSuchAlgorithmException) {
             logger.log(
                 InternalLogger.Level.ERROR,


### PR DESCRIPTION
### What does this PR do?

This PR changes the way to convert MD5 bytes to HEX string.

### Motivation

When we broke down the steps of generating image wireframe, we noticed that `joinToString` function takes a huge amount of time when generating the MD5 resource id:

<img width="834" alt="Screenshot 2024-09-20 at 11 48 11" src="https://github.com/user-attachments/assets/4561a4cc-6b04-4c86-9342-9b11fba54901">

#### Suspicious reasons: 

* String Concatenation Overhead:
joinToString internally uses StringBuilder, but string concatenation inside the lambda (using `"%02x".format(it)`) could be inefficient. If format() is invoked for each byte, it involves repeated function calls, which adds to overhead.

* Repeated Memory Allocations:
`"%02x".format(it)` creates a new string for each byte, which leads to multiple temporary objects being created. This puts pressure on the garbage collector.

### Outcome

After using the new function to convert the byte arrays, we can see the duration optimisation rate is up to **99%**

#### Span list
| joinToString |  convertToHexString |
| --- | ---- |
| ![image](https://github.com/user-attachments/assets/70af0346-fd38-4d71-923f-adf4ca9e2047) | ![image](https://github.com/user-attachments/assets/ca1ac641-711e-4165-bf69-600fa8c4a423)|

#### Time series


<img width="1475" alt="Screenshot 2024-09-20 at 11 46 55" src="https://github.com/user-attachments/assets/62d89713-9b0c-4766-a224-84605eed776a">


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

