### PR TITLE
RUM-6314: Use layout text to display textview overflow correctly

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapper.kt
@@ -27,6 +27,7 @@ import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
 /**
  * A [WireframeMapper] implementation to map a [TextView] component.
  */
+@Suppress("TooManyFunctions")
 open class TextViewMapper<in T : TextView>(
     viewIdentifierResolver: ViewIdentifierResolver,
     colorStringFormatter: ColorStringFormatter,
@@ -90,7 +91,7 @@ open class TextViewMapper<in T : TextView>(
         textAndInputPrivacy: TextAndInputPrivacy,
         isOption: Boolean
     ): String {
-        val originalText = textView.text?.toString().orEmpty()
+        val originalText = resolveLayoutText(textView)
         return when (textAndInputPrivacy) {
             TextAndInputPrivacy.MASK_SENSITIVE_INPUTS -> originalText
             TextAndInputPrivacy.MASK_ALL -> if (isOption) {
@@ -106,6 +107,10 @@ open class TextViewMapper<in T : TextView>(
     // endregion
 
     // region Internal
+
+    private fun resolveLayoutText(textView: T): String {
+        return (textView.layout?.text ?: textView.text)?.toString().orEmpty()
+    }
 
     private fun createTextWireframe(
         textView: T,

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapperTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay.internal.recorder.mapper
 
 import android.graphics.Typeface
 import android.text.InputType
+import android.text.Layout
 import android.view.Gravity
 import android.widget.Button
 import android.widget.TextView
@@ -32,6 +33,7 @@ import org.junit.jupiter.api.extension.Extensions
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.doReturn
@@ -46,6 +48,9 @@ import java.util.stream.Stream
 @MockitoSettings(strictness = Strictness.LENIENT)
 @ForgeConfiguration(ForgeConfigurator::class)
 internal abstract class ButtonMapperTest : BaseAsyncBackgroundWireframeMapperTest<Button, ButtonMapper>() {
+
+    @Mock
+    lateinit var mockLayout: Layout
 
     @StringForgery
     lateinit var fakeText: String
@@ -67,6 +72,8 @@ internal abstract class ButtonMapperTest : BaseAsyncBackgroundWireframeMapperTes
                 OPAQUE_ALPHA_VALUE
             )
         ) doReturn fakeTextColorHexString
+
+        whenever(mockLayout.text) doReturn fakeText
 
         withTextAndInputPrivacy(privacyOption())
 
@@ -94,6 +101,7 @@ internal abstract class ButtonMapperTest : BaseAsyncBackgroundWireframeMapperTes
     ) {
         // Given
         prepareMockView<Button> { mockView ->
+            whenever(mockView.layout) doReturn mockLayout
             whenever(mockView.typeface) doReturn fakeTypeface
             whenever(mockView.textSize) doReturn fakeFontSize
             whenever(mockView.currentTextColor) doReturn fakeTextColor
@@ -155,6 +163,8 @@ internal abstract class ButtonMapperTest : BaseAsyncBackgroundWireframeMapperTes
     fun `M resolves wireframe W map {no text}`() {
         // Given
         prepareMockView<Button> { mockView ->
+            whenever(mockLayout.text) doReturn ""
+            whenever(mockView.layout) doReturn mockLayout
             whenever(mockView.typeface) doReturn null
             whenever(mockView.textSize) doReturn fakeFontSize
             whenever(mockView.currentTextColor) doReturn fakeTextColor

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/recorder/mapper/TextViewMapperTest.kt
@@ -1,6 +1,7 @@
 package com.datadog.android.sessionreplay.recorder.mapper
 
 import android.graphics.Typeface
+import android.text.Layout
 import android.view.Gravity
 import android.widget.TextView
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
+import org.mockito.Mock
 import org.mockito.Mockito.mock
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.whenever
@@ -29,6 +31,12 @@ import com.datadog.android.sessionreplay.model.MobileSegment.Vertical.CENTER as 
 
 internal abstract class TextViewMapperTest :
     BaseAsyncBackgroundWireframeMapperTest<TextView, TextViewMapper<TextView>>() {
+
+    @Mock
+    lateinit var mockLayout: Layout
+
+    @StringForgery
+    lateinit var fakeLayoutText: String
 
     @StringForgery
     lateinit var fakeText: String
@@ -44,6 +52,7 @@ internal abstract class TextViewMapperTest :
 
     @BeforeEach
     fun `set up`() {
+        whenever(mockLayout.text) doReturn fakeLayoutText
         whenever(
             mockColorStringFormatter.formatColorAndAlphaAsHexString(
                 fakeTextColor,
@@ -77,6 +86,7 @@ internal abstract class TextViewMapperTest :
     ) {
         // Given
         prepareMockView<TextView> { mockView ->
+            whenever(mockView.layout) doReturn mockLayout
             whenever(mockView.typeface) doReturn fakeTypeface
             whenever(mockView.textSize) doReturn fakeFontSize
             whenever(mockView.currentTextColor) doReturn fakeTextColor
@@ -110,7 +120,7 @@ internal abstract class TextViewMapperTest :
                     clip = null,
                     shapeStyle = null,
                     border = null,
-                    text = expectedPrivacyCompliantText(fakeText),
+                    text = expectedPrivacyCompliantText(fakeLayoutText),
                     textStyle = MobileSegment.TextStyle(
                         family = expectedFontFamily,
                         size = expectedFontSize,


### PR DESCRIPTION
### What does this PR do?

Fix the Session Replay issue that text view overflow could not be displayed properly

### Motivation

RUM-6314

### Demo

| App screen | Before | After |
| --- | --- | --- |
|<img width="600" alt="image" src="https://github.com/user-attachments/assets/80b85cec-dff1-40cd-8392-4b06c760bea2"> |![image](https://github.com/user-attachments/assets/a165b4db-94e0-42a8-a7d0-7a5659dc659f)|![image](https://github.com/user-attachments/assets/59b068e5-7382-44ae-b074-6b041ad4635f)|


Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

