### PR TITLE
RUM-6316: Remove Session Replay button mapper border

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapper.kt
@@ -37,19 +37,6 @@ internal class ButtonMapper(
         asyncJobStatusCallback: AsyncJobStatusCallback,
         internalLogger: InternalLogger
     ): List<MobileSegment.Wireframe> {
-        return super.map(view, mappingContext, asyncJobStatusCallback, internalLogger).map {
-            if (it is MobileSegment.Wireframe.TextWireframe &&
-                it.shapeStyle == null && it.border == null
-            ) {
-                // we were not able to resolve the background for this button so just add a border
-                it.copy(border = MobileSegment.ShapeBorder(BLACK_COLOR, 1))
-            } else {
-                it
-            }
-        }
-    }
-
-    companion object {
-        internal const val BLACK_COLOR = "#000000ff"
+        return super.map(view, mappingContext, asyncJobStatusCallback, internalLogger)
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ButtonMapperTest.kt
@@ -127,10 +127,6 @@ internal abstract class ButtonMapperTest : BaseAsyncBackgroundWireframeMapperTes
                     height = fakeViewGlobalBounds.height,
                     clip = null,
                     shapeStyle = null,
-                    border = MobileSegment.ShapeBorder(
-                        color = "#000000ff",
-                        width = 1L
-                    ),
                     text = expectedPrivacyCompliantText(fakeText),
                     textStyle = MobileSegment.TextStyle(
                         family = expectedFontFamily,
@@ -187,10 +183,7 @@ internal abstract class ButtonMapperTest : BaseAsyncBackgroundWireframeMapperTes
                     height = fakeViewGlobalBounds.height,
                     clip = null,
                     shapeStyle = null,
-                    border = MobileSegment.ShapeBorder(
-                        color = "#000000ff",
-                        width = 1L
-                    ),
+                    border = null,
                     text = expectedPrivacyCompliantText(""),
                     textStyle = MobileSegment.TextStyle(
                         family = TextViewMapper.SANS_SERIF_FAMILY_NAME,


### PR DESCRIPTION
### What does this PR do?

Remove Session Replay button mapper border.

The logic before was adding a black border to every text view inside which doesn't have a shape or border, But text view mapper always return a wireframe without them, so the black border will always be applied, which doesn't correspond to the real UI.

### Motivation

RUM-6316

### Demo

| App Screen | Before | After |
| --- | --- | --- |
| <img width="299" alt="Screenshot 2024-09-24 at 14 21 10" src="https://github.com/user-attachments/assets/c7e30db7-433c-4ee7-8f56-4e7bb1fed734">|<img width="288" alt="image" src="https://github.com/user-attachments/assets/ccf03b39-f1ed-4192-ad9d-d1bbae3298aa"> |<img width="284" alt="image" src="https://github.com/user-attachments/assets/5b079ce4-1829-4406-9595-a2b4c4c3100d">     |
|<img width="290" alt="Screenshot 2024-09-24 at 14 22 51" src="https://github.com/user-attachments/assets/7d238d42-54e3-4548-8f21-33e2684d87df"> |<img width="284" alt="image" src="https://github.com/user-attachments/assets/6bfb6b0a-bffb-4c5c-b699-a5ac23aaa820"> |<img width="286" alt="image" src="https://github.com/user-attachments/assets/28db8c2b-1a3d-4341-b2f4-e042dbc62c42"> |



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

