### PR TITLE
RUM-6324: Add View Groups Session Replay demo screen in sample app

### DIFF
--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/SessionReplayFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/SessionReplayFragment.kt
@@ -63,7 +63,7 @@ internal class SessionReplayFragment :
             R.id.navigation_image_components -> R.id.fragment_image_components
             R.id.navigation_image_scaling -> R.id.fragment_image_scaling
             R.id.navigation_webview_recording -> R.id.fragment_webview_record
-
+            R.id.navigation_view_group -> R.id.fragment_view_group_components
             else -> null
         }
         if (destination != null) {

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/ViewGroupComponentsFragment.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/sessionreplay/ViewGroupComponentsFragment.kt
@@ -1,0 +1,25 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sample.sessionreplay
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.datadog.android.sample.R
+
+internal class ViewGroupComponentsFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_view_group_components, container, false)
+    }
+}

--- a/sample/kotlin/src/main/res/layout/fragment_session_replay.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_session_replay.xml
@@ -130,5 +130,15 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toBottomOf="@id/navigation_image_components"/>
 
+        <androidx.appcompat.widget.AppCompatButton
+            android:id="@+id/navigation_view_group"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_margin="8dp"
+            android:text="@string/view_group_button"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/navigation_webview_recording" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </ScrollView>

--- a/sample/kotlin/src/main/res/layout/fragment_view_group_components.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_view_group_components.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?><!--
+  ~ Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+  ~ This product includes software developed at Datadog (https://www.datadoghq.com/).
+  ~ Copyright 2016-Present Datadog, Inc.
+  -->
+
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="@dimen/default_padding">
+
+    <com.google.android.material.card.MaterialCardView
+        android:id="@+id/card_view_1"
+        android:layout_width="0dp"
+        android:layout_height="120dp"
+        app:cardBackgroundColor="@color/datadog_violet"
+        app:cardCornerRadius="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:strokeColor="@android:color/black"
+        app:strokeWidth="2dp">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:padding="@dimen/default_padding"
+            android:text="@string/card_view"
+            android:textAlignment="center"
+            android:textColor="@android:color/holo_orange_light"
+            android:textSize="18sp" />
+    </com.google.android.material.card.MaterialCardView>
+
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/kotlin/src/main/res/navigation/nav_graph.xml
+++ b/sample/kotlin/src/main/res/navigation/nav_graph.xml
@@ -68,6 +68,11 @@
         android:name="com.datadog.android.sample.sessionreplay.TextViewComponentsFragment"
         android:label="@string/text_view_components"/>
 
+    <fragment
+        android:id="@+id/fragment_view_group_components"
+        android:name="com.datadog.android.sample.sessionreplay.ViewGroupComponentsFragment"
+        android:label="@string/text_view_components" />
+
     <fragment android:id="@+id/fragment_picker_components"
         android:name="com.datadog.android.sample.sessionreplay.PickerComponentsFragment"
         android:label="@string/picker_components"/>

--- a/sample/kotlin/src/main/res/values/strings.xml
+++ b/sample/kotlin/src/main/res/values/strings.xml
@@ -182,8 +182,10 @@
     <string name="start_async_operation">Start Async Operation</string>
     <string name="chained_contexts_test">Chained Otel Contexts Test</string>
     <string name="web_view_recording">Web View Recording</string>
+    <string name="view_group_button">View Groups</string>
     <string name="start_custom_rum_view">Start Custom Rum View</string>
     <string name="webview_recording">WebView Recording</string>
     <string name="linked_spans_test">Linked Spans Test</string>
     <string name="start_linked_spans_test">Start Linked Spans Test</string>
+    <string name="card_view">Card view</string>
 </resources>


### PR DESCRIPTION
### What does this PR do?

When testing SR with some other applications, we noticed that the card view is not correctly display in the player, before fixing the issue, we need to add an showcase screen for this kind of view groups.

### Motivation

RUM-6324

### Additional Notes

| Sample App| Player |
| --- | --- |
| ![Screenshot_20240925_135133](https://github.com/user-attachments/assets/c5c28505-b570-4a40-ba7e-34e58e49b79e)|![image](https://github.com/user-attachments/assets/821b059b-7afe-4f7e-b502-d40173a96105)|

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

