### PR TITLE
RUM-6324: Add MaterialCardView support in Material SR extension

### DIFF
--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupport.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupport.kt
@@ -6,8 +6,10 @@
 
 package com.datadog.android.sessionreplay.material
 
+import androidx.cardview.widget.CardView
 import com.datadog.android.sessionreplay.ExtensionSupport
 import com.datadog.android.sessionreplay.MapperTypeWrapper
+import com.datadog.android.sessionreplay.material.internal.CardWireframeMapper
 import com.datadog.android.sessionreplay.material.internal.MaterialOptionSelectorDetector
 import com.datadog.android.sessionreplay.material.internal.SliderWireframeMapper
 import com.datadog.android.sessionreplay.material.internal.TabWireframeMapper
@@ -52,9 +54,17 @@ class MaterialExtensionSupport : ExtensionSupport {
             )
         )
 
+        val cardWireframeMapper = CardWireframeMapper(
+            viewIdentifierResolver,
+            colorStringFormatter,
+            viewBoundsResolver,
+            drawableToColorMapper
+        )
+
         return listOf(
             MapperTypeWrapper(Slider::class.java, sliderWireframeMapper),
-            MapperTypeWrapper(TabLayout.TabView::class.java, tabWireframeMapper)
+            MapperTypeWrapper(TabLayout.TabView::class.java, tabWireframeMapper),
+            MapperTypeWrapper(CardView::class.java, cardWireframeMapper)
         )
     }
 

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/internal/CardWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/internal/CardWireframeMapper.kt
@@ -1,0 +1,87 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.material.internal
+
+import androidx.cardview.widget.CardView
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.MappingContext
+import com.datadog.android.sessionreplay.recorder.mapper.BaseViewGroupMapper
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
+import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
+import com.google.android.material.card.MaterialCardView
+
+internal class CardWireframeMapper(
+    viewIdentifierResolver: ViewIdentifierResolver,
+    colorStringFormatter: ColorStringFormatter,
+    viewBoundsResolver: ViewBoundsResolver,
+    drawableToColorMapper: DrawableToColorMapper
+) : BaseViewGroupMapper<CardView>(
+    viewIdentifierResolver,
+    colorStringFormatter,
+    viewBoundsResolver,
+    drawableToColorMapper
+) {
+    override fun map(
+        view: CardView,
+        mappingContext: MappingContext,
+        asyncJobStatusCallback: AsyncJobStatusCallback,
+        internalLogger: InternalLogger
+    ): List<MobileSegment.Wireframe> {
+        val viewGlobalBounds = viewBoundsResolver.resolveViewGlobalBounds(
+            view,
+            mappingContext.systemInformation.screenDensity
+        )
+        val shapeStyle = resolveShapeStyle(view, mappingContext)
+
+        // Only MaterialCardView can have a built-in border.
+        val shapeBorder = if (view is MaterialCardView) {
+            resolveShapeBorder(view, mappingContext)
+        } else {
+            null
+        }
+
+        return listOf(
+            MobileSegment.Wireframe.ShapeWireframe(
+                resolveViewId(view),
+                viewGlobalBounds.x,
+                viewGlobalBounds.y,
+                viewGlobalBounds.width,
+                viewGlobalBounds.height,
+                shapeStyle = shapeStyle,
+                border = shapeBorder
+            )
+        )
+    }
+
+    private fun resolveShapeBorder(
+        view: MaterialCardView,
+        mappingContext: MappingContext
+    ): MobileSegment.ShapeBorder {
+        @Suppress("DEPRECATION")
+        val strokeColor = view.strokeColorStateList?.defaultColor ?: view.strokeColor
+        return MobileSegment.ShapeBorder(
+            color = colorStringFormatter.formatColorAsHexString(strokeColor),
+            width = view.strokeWidth.toLong().densityNormalized(mappingContext.systemInformation.screenDensity)
+        )
+    }
+
+    private fun resolveShapeStyle(
+        view: CardView,
+        mappingContext: MappingContext
+    ): MobileSegment.ShapeStyle {
+        val backgroundColor = view.cardBackgroundColor.defaultColor
+        return MobileSegment.ShapeStyle(
+            backgroundColor = colorStringFormatter.formatColorAsHexString(backgroundColor),
+            opacity = view.alpha,
+            cornerRadius = view.radius.toLong().densityNormalized(mappingContext.systemInformation.screenDensity)
+        )
+    }
+}

--- a/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/CardWireframeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-material/src/test/kotlin/com/datadog/android/sessionreplay/material/CardWireframeMapperTest.kt
@@ -1,0 +1,250 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.material
+
+import android.content.res.ColorStateList
+import androidx.cardview.widget.CardView
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.material.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.material.internal.CardWireframeMapper
+import com.datadog.android.sessionreplay.model.MobileSegment
+import com.datadog.android.sessionreplay.recorder.MappingContext
+import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
+import com.datadog.android.sessionreplay.utils.ColorStringFormatter
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.datadog.android.sessionreplay.utils.GlobalBounds
+import com.datadog.android.sessionreplay.utils.ViewBoundsResolver
+import com.datadog.android.sessionreplay.utils.ViewIdentifierResolver
+import com.google.android.material.card.MaterialCardView
+import fr.xgouchet.elmyr.annotation.FloatForgery
+import fr.xgouchet.elmyr.annotation.Forgery
+import fr.xgouchet.elmyr.annotation.IntForgery
+import fr.xgouchet.elmyr.annotation.LongForgery
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.junit5.ForgeConfiguration
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ForgeConfiguration(value = ForgeConfigurator::class)
+class CardWireframeMapperTest {
+
+    @Forgery
+    lateinit var fakeMappingContext: MappingContext
+
+    @Forgery
+    lateinit var fakeGlobalBounds: GlobalBounds
+
+    internal lateinit var testedCardWireframeMapper: CardWireframeMapper
+
+    @Mock
+    lateinit var mockCardView: CardView
+
+    @Mock
+    lateinit var mockMaterialCardView: MaterialCardView
+
+    @IntForgery(min = 0, max = 10)
+    var fakePaddingStart: Int = 0
+
+    @IntForgery(min = 0, max = 10)
+    var fakePaddingEnd: Int = 0
+
+    @FloatForgery(min = 0f, max = 10f)
+    var fakeCornerRadius: Float = 0f
+
+    @IntForgery(min = 0, max = 10)
+    var fakeStrokeWidth: Int = 0
+
+    @LongForgery
+    var fakeViewId: Long = 0L
+
+    @IntForgery(min = 0, max = 0xffffff)
+    var fakeBackgroundColor: Int = 0
+
+    @IntForgery(min = 0, max = 0xffffff)
+    var fakeStrokeColor: Int = 0
+
+    @StringForgery(regex = "#[0-9A-F]{8}")
+    lateinit var fakeBgColorHexString: String
+
+    @StringForgery(regex = "#[0-9A-F]{8}")
+    lateinit var fakeStrokeColorHexString: String
+
+    @FloatForgery(min = 0.0f, max = 1.0f)
+    var fakeAlpha: Float = 0f
+
+    @Mock
+    lateinit var mockBackgroundColorStateList: ColorStateList
+
+    @Mock
+    lateinit var mockStrokeColorStateList: ColorStateList
+
+    @Mock
+    lateinit var mockViewIdentifierResolver: ViewIdentifierResolver
+
+    @Mock
+    lateinit var mockColorStringFormatter: ColorStringFormatter
+
+    @Mock
+    lateinit var mockViewBoundsResolver: ViewBoundsResolver
+
+    @Mock
+    lateinit var mockDrawableToColorMapper: DrawableToColorMapper
+
+    @Mock
+    lateinit var mockAsyncJobStatusCallback: AsyncJobStatusCallback
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    @BeforeEach
+    fun `set up`() {
+        mockCardView = mockCardView()
+        whenever(
+            mockViewBoundsResolver.resolveViewGlobalBounds(
+                mockCardView,
+                fakeMappingContext.systemInformation.screenDensity
+            )
+        ).thenReturn(fakeGlobalBounds)
+        whenever(
+            mockViewIdentifierResolver.resolveViewId(
+                mockCardView
+            )
+        ).thenReturn(fakeViewId)
+
+        mockMaterialCardView = mockMaterialCardView()
+        whenever(
+            mockViewBoundsResolver.resolveViewGlobalBounds(
+                mockMaterialCardView,
+                fakeMappingContext.systemInformation.screenDensity
+            )
+        ).thenReturn(fakeGlobalBounds)
+        whenever(
+            mockViewIdentifierResolver.resolveViewId(
+                mockMaterialCardView
+            )
+        ).thenReturn(fakeViewId)
+        whenever(mockColorStringFormatter.formatColorAsHexString(fakeBackgroundColor))
+            .thenReturn(fakeBgColorHexString)
+        whenever(mockColorStringFormatter.formatColorAsHexString(fakeStrokeColor))
+            .thenReturn(fakeStrokeColorHexString)
+        whenever(mockBackgroundColorStateList.defaultColor).thenReturn(fakeBackgroundColor)
+        whenever(mockStrokeColorStateList.defaultColor).thenReturn(fakeStrokeColor)
+        testedCardWireframeMapper = CardWireframeMapper(
+            viewIdentifierResolver = mockViewIdentifierResolver,
+            colorStringFormatter = mockColorStringFormatter,
+            viewBoundsResolver = mockViewBoundsResolver,
+            drawableToColorMapper = mockDrawableToColorMapper
+        )
+    }
+
+    @Test
+    fun `M resolves material card view wireframe W map`() {
+        // Given
+        val expected = listOf(
+            MobileSegment.Wireframe.ShapeWireframe(
+                fakeViewId,
+                fakeGlobalBounds.x,
+                fakeGlobalBounds.y,
+                fakeGlobalBounds.width,
+                fakeGlobalBounds.height,
+                shapeStyle = MobileSegment.ShapeStyle(
+                    backgroundColor = fakeBgColorHexString,
+                    opacity = fakeAlpha,
+                    cornerRadius = (
+                        fakeCornerRadius.toLong() /
+                            fakeMappingContext.systemInformation.screenDensity
+                        ).toLong()
+                ),
+                border = MobileSegment.ShapeBorder(
+                    color = fakeStrokeColorHexString,
+                    width = (fakeStrokeWidth / fakeMappingContext.systemInformation.screenDensity).toLong()
+                )
+            )
+        )
+
+        // When
+        val actual = testedCardWireframeMapper.map(
+            mockMaterialCardView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun `M resolves card view wireframe W map`() {
+        // Given
+        val expected = listOf(
+            MobileSegment.Wireframe.ShapeWireframe(
+                fakeViewId,
+                fakeGlobalBounds.x,
+                fakeGlobalBounds.y,
+                fakeGlobalBounds.width,
+                fakeGlobalBounds.height,
+                shapeStyle = MobileSegment.ShapeStyle(
+                    backgroundColor = fakeBgColorHexString,
+                    opacity = fakeAlpha,
+                    cornerRadius = (
+                        fakeCornerRadius.toLong() /
+                            fakeMappingContext.systemInformation.screenDensity
+                        ).toLong()
+                )
+            )
+        )
+
+        // When
+        val actual = testedCardWireframeMapper.map(
+            mockCardView,
+            fakeMappingContext,
+            mockAsyncJobStatusCallback,
+            mockInternalLogger
+        )
+
+        // Then
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    private fun mockCardView(): CardView {
+        return mock {
+            whenever(it.alpha).thenReturn(fakeAlpha)
+            whenever(it.paddingStart).thenReturn(fakePaddingStart)
+            whenever(it.paddingEnd).thenReturn(fakePaddingEnd)
+            whenever(it.cardBackgroundColor).thenReturn(mockBackgroundColorStateList)
+            whenever(it.radius).thenReturn(fakeCornerRadius)
+        }
+    }
+
+    private fun mockMaterialCardView(): MaterialCardView {
+        return mock {
+            whenever(it.alpha).thenReturn(fakeAlpha)
+            whenever(it.paddingStart).thenReturn(fakePaddingStart)
+            whenever(it.paddingEnd).thenReturn(fakePaddingEnd)
+            whenever(it.cardBackgroundColor).thenReturn(mockBackgroundColorStateList)
+            whenever(it.strokeColorStateList).thenReturn(mockStrokeColorStateList)
+            whenever(it.strokeWidth).thenReturn(fakeStrokeWidth)
+            whenever(it.radius).thenReturn(fakeCornerRadius)
+        }
+    }
+}

--- a/sample/kotlin/src/main/res/layout/fragment_session_replay.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_session_replay.xml
@@ -128,7 +128,7 @@
             android:text="@string/web_view_recording"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/navigation_image_components"/>
+            app:layout_constraintTop_toBottomOf="@id/navigation_image_scaling" />
 
         <androidx.appcompat.widget.AppCompatButton
             android:id="@+id/navigation_view_group"

--- a/sample/kotlin/src/main/res/layout/fragment_view_group_components.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_view_group_components.xml
@@ -27,11 +27,32 @@
             android:layout_height="wrap_content"
             android:layout_gravity="center"
             android:padding="@dimen/default_padding"
-            android:text="@string/card_view"
+            android:text="@string/material_card_view"
             android:textAlignment="center"
             android:textColor="@android:color/holo_orange_light"
             android:textSize="18sp" />
     </com.google.android.material.card.MaterialCardView>
 
+    <androidx.cardview.widget.CardView
+        android:id="@+id/card_view_2"
+        android:layout_width="0dp"
+        android:layout_height="120dp"
+        android:layout_marginTop="@dimen/default_padding"
+        app:cardBackgroundColor="@color/datadog_violet"
+        app:cardCornerRadius="12dp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/card_view_1">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center"
+            android:padding="@dimen/default_padding"
+            android:text="@string/card_view"
+            android:textAlignment="center"
+            android:textColor="@android:color/holo_orange_light"
+            android:textSize="18sp" />
+    </androidx.cardview.widget.CardView>
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/sample/kotlin/src/main/res/values/strings.xml
+++ b/sample/kotlin/src/main/res/values/strings.xml
@@ -188,4 +188,5 @@
     <string name="linked_spans_test">Linked Spans Test</string>
     <string name="start_linked_spans_test">Start Linked Spans Test</string>
     <string name="card_view">Card view</string>
+    <string name="material_card_view">Material Card view</string>
 </resources>


### PR DESCRIPTION
### What does this PR do?

`MaterialCardView` is a widely used material component, this PR adds `MaterialCardView` support in Material SR extension

### Motivation

RUM-6324

### Demo

| Sample | Before | After |
| --- | --- | --- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/6e7b1d4d-7066-4daa-8305-c34b9194eb0c">| <img width="400" alt="image" src="https://github.com/user-attachments/assets/27add180-e272-40d9-93af-c8b54beebf1f"> | <img width="400" alt="image" src="https://github.com/user-attachments/assets/5f8fb2ca-87aa-44c1-b284-7fbbfa4993c8">|



### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

