### PR TITLE
Use SDK source value in Session Replay `MobileSegment.source` property

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/net/SegmentRequestFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/net/SegmentRequestFactory.kt
@@ -27,7 +27,7 @@ internal class SegmentRequestFactory(
         batchData: List<RawBatchEvent>,
         batchMetadata: ByteArray?
     ): Request {
-        val serializedSegmentPair = batchToSegmentsMapper.map(batchData.map { it.data })
+        val serializedSegmentPair = batchToSegmentsMapper.map(context, batchData.map { it.data })
         if (serializedSegmentPair.isEmpty()) {
             @Suppress("ThrowingInternalException")
             throw InvalidPayloadFormatException(

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/MobileSegmentExt.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/processor/MobileSegmentExt.kt
@@ -6,6 +6,7 @@
 
 package com.datadog.android.sessionreplay.internal.processor
 
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.model.MobileSegment
 
 internal fun MobileSegment.Wireframe.copy(clip: MobileSegment.WireframeClip?): MobileSegment.Wireframe {
@@ -17,3 +18,23 @@ internal fun MobileSegment.Wireframe.copy(clip: MobileSegment.WireframeClip?): M
         is MobileSegment.Wireframe.WebviewWireframe -> this.copy(clip = clip)
     }
 }
+
+internal fun MobileSegment.Source.Companion.tryFromSource(
+    source: String,
+    internalLogger: InternalLogger
+): MobileSegment.Source {
+    return try {
+        fromJson(source)
+    } catch (e: NoSuchElementException) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            InternalLogger.Target.MAINTAINER,
+            { UNKNOWN_MOBILE_SEGMENT_SOURCE_WARNING_MESSAGE_FORMAT.format(java.util.Locale.US, source) },
+            e
+        )
+        MobileSegment.Source.ANDROID
+    }
+}
+
+internal const val UNKNOWN_MOBILE_SEGMENT_SOURCE_WARNING_MESSAGE_FORMAT = "You are using an unknown " +
+    "source %s for MobileSegment.Source enum."

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/SegmentRequestFactoryTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/net/SegmentRequestFactoryTest.kt
@@ -87,7 +87,7 @@ internal class SegmentRequestFactoryTest {
         fakeBatchMetadata = forge.aNullable { forge.aString().toByteArray() }
         whenever(mockSegmentRequestBodyFactory.create(fakeDataGroup))
             .thenReturn(mockRequestBody)
-        whenever(mockBatchesToSegmentsMapper.map(fakeBatchData.map { it.data }))
+        whenever(mockBatchesToSegmentsMapper.map(fakeDatadogContext, fakeBatchData.map { it.data }))
             .thenReturn(fakeDataGroup)
         testedRequestFactory = SegmentRequestFactory(
             customEndpointUrl = null,
@@ -160,7 +160,7 @@ internal class SegmentRequestFactoryTest {
     @Test
     fun `M throw exception W create(){ payload is broken }`() {
         // Given
-        whenever(mockBatchesToSegmentsMapper.map(fakeBatchData.map { it.data }))
+        whenever(mockBatchesToSegmentsMapper.map(fakeDatadogContext, fakeBatchData.map { it.data }))
             .thenReturn(emptyList())
 
         // When

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/MobileSegmentExtTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/processor/MobileSegmentExtTest.kt
@@ -1,0 +1,90 @@
+package com.datadog.android.sessionreplay.internal.processor
+
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.model.MobileSegment
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.Mock
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.kotlin.argumentCaptor
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.isA
+import org.mockito.kotlin.isNull
+import org.mockito.kotlin.verify
+import java.util.Locale
+
+@Extensions(
+    ExtendWith(ForgeExtension::class),
+    ExtendWith(MockitoExtension::class)
+)
+internal class MobileSegmentExtTest {
+
+    @Mock
+    lateinit var mockInternalLogger: InternalLogger
+
+    // region MobileSegment.Source
+
+    @Test
+    fun `M resolve the MobileSegment source W tryFromSource`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeValidSource = forge.aValueFrom(MobileSegment.Source::class.java)
+
+        // When
+        val source = MobileSegment.Source.tryFromSource(fakeValidSource.toJson().asString, mockInternalLogger)
+
+        // Then
+        assertThat(source).isEqualTo(fakeValidSource)
+    }
+
+    @Test
+    fun `M return default value W tryFromSource { unknown source }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeInvalidSource = forge.aString()
+
+        // When
+        val source = MobileSegment.Source.tryFromSource(fakeInvalidSource, mockInternalLogger)
+
+        // Then
+        assertThat(source).isEqualTo(MobileSegment.Source.ANDROID)
+    }
+
+    @Test
+    fun `M send an error maintainer log W tryFromSource { unknown source }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeInvalidSource = forge.aString()
+
+        // When
+        MobileSegment.Source.tryFromSource(fakeInvalidSource, mockInternalLogger)
+
+        // Then
+        argumentCaptor<() -> String>() {
+            verify(mockInternalLogger).log(
+                level = eq(InternalLogger.Level.ERROR),
+                target = eq(InternalLogger.Target.MAINTAINER),
+                messageBuilder = capture(),
+                throwable = isA<NoSuchElementException>(),
+                onlyOnce = eq(false),
+                additionalProperties = isNull()
+            )
+
+            assertThat(firstValue()).isEqualTo(
+                UNKNOWN_MOBILE_SEGMENT_SOURCE_WARNING_MESSAGE_FORMAT.format(
+                    Locale.US,
+                    fakeInvalidSource
+                )
+            )
+        }
+    }
+
+    // endregion
+}


### PR DESCRIPTION
### What does this PR do?

This is to align with what iOS SDK has https://github.com/DataDog/dd-sdk-ios/blob/4dbdf4a10991ba65a02b02bf1fe87e4aa2765b38/DatadogSessionReplay/Sources/Feature/RequestBuilders/SegmentRequestBuilder.swift#L48

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

