### PR TITLE
Detekt the api coverage in Integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -370,6 +370,22 @@ test-pyramid:legacy-integration-instrumented-median-api:
     - !reference [.snippets, install-android-sdk]
     - !reference [.snippets, run-legacy-integration-instrumented]
 
+test-pyramid:detekt-api-coverage:
+  tags: [ "arch:amd64" ]
+  image: $CI_IMAGE_DOCKER
+  stage: test-pyramid
+  timeout: 1h
+  script:
+    - mkdir -p ./config/
+    - aws ssm get-parameter --region us-east-1 --name ci.dd-sdk-android.gradle-properties --with-decryption --query "Parameter.Value" --out text >> ./gradle.properties
+    - GRADLE_OPTS="-Xmx4096M" ./gradlew assembleLibrariesDebug --stacktrace --no-daemon
+    - GRADLE_OPTS="-Xmx4096M" ./gradlew printSdkDebugRuntimeClasspath --stacktrace --no-daemon
+    - GRADLE_OPTS="-Xmx4096M" ./gradlew :tools:detekt:jar --stacktrace --no-daemon
+    - curl -sSLO https://github.com/detekt/detekt/releases/download/v1.23.4/detekt-cli-1.23.4-all.jar
+    - java -jar detekt-cli-1.23.4-all.jar --config detekt_test_pyramid.yml --plugins tools/detekt/build/libs/detekt.jar -ex "**/*.kts" --jvm-target 11 -cp $(cat sdk_classpath)
+    # For now we just print the uncovered apis, eventually we will fail if it's not empty
+    - grep -v -f apiUsage.log apiSurface.log
+
 test-pyramid:publish-e2e-synthetics:
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
@@ -423,7 +439,6 @@ test-pyramid:publish-webview-synthetics:
     expire_in: 1 week
     paths:
       - sample/kotlin/build/outputs/apk/us1/release/kotlin-us1-release.apk
-
 
 test-pyramid:publish-staging-synthetics:
   tags: [ "arch:amd64" ]

--- a/buildSrc/src/main/kotlin/com/datadog/gradle/config/TestPyramidConfig.kt
+++ b/buildSrc/src/main/kotlin/com/datadog/gradle/config/TestPyramidConfig.kt
@@ -19,7 +19,6 @@ fun Project.registerSubModuleAggregationTask(
 ) {
     tasks.register(taskName) {
         project.subprojects.forEach { subProject ->
-            println("SubProject ${subProject.name} / ${subProject.path}")
             if (!exceptions.contains(subProject.name) &&
                 subProject.name.startsWith(subModuleNamePrefix) &&
                 subProject.path.startsWith(subModulePathPrefix)

--- a/detekt_test_pyramid.yml
+++ b/detekt_test_pyramid.yml
@@ -82,9 +82,27 @@ datadog-test-pyramid:
   active: true
   ApiUsage:
     active: true
-    includes: ['**/reliability/**']
+    includes: [ '**/reliability/**' ]
+    internalPackagePrefix: 'com.datadog'
   ApiSurface:
     active: true
-    includes: ['**/dd-sdk-android-*/**']
-    excludes: ['**/build/**', '**/test/**', '**/testDebug/**','**/testRelease/**', '**/androidTest/**', '**/testFixtures/**', '**/buildSrc/**', '**/*.kts', '**/instrumented/**', '**/sample/**', '**/tools/**']
-
+    includes: [ '**/dd-sdk-android-*/**' ]
+    excludes:
+      - '**/build/**'
+      - '**/test/**'
+      - '**/testDebug/**'
+      - '**/testRelease/**'
+      - '**/androidTest/**'
+      - '**/testFixtures/**'
+      - '**/buildSrc/**'
+      - '**/*.kts'
+      - '**/instrumented/**'
+      - '**/sample/**'
+      - '**/tools/**'
+      - '**/dd-sdk-android-internal/**'
+    internalPackagePrefix: 'com.datadog'
+    ignoredAnnotations:
+      - "com.datadog.android.lint.InternalApi"
+    ignoredClasses:
+      - "com.datadog.android._InternalProxy"
+      - "com.datadog.android.rum._RumInternalProxy"

--- a/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/pyramid/ApiUsage.kt
+++ b/tools/detekt/src/main/kotlin/com/datadog/tools/detekt/rules/pyramid/ApiUsage.kt
@@ -28,6 +28,8 @@ class ApiUsage(
     private val outputFileName: String by config(defaultValue = "apiUsage.log")
     private val outputFile: File by lazy { File(outputFileName) }
 
+    private val internalPackagePrefix: String by config(defaultValue = "")
+
     private var visitingTestFunction = false
 
     // region Rule
@@ -63,8 +65,10 @@ class ApiUsage(
         expression: KtCallExpression,
         resolvedCall: ResolvedFunCall
     ) {
-        outputFile.appendText(resolvedCall.call)
-        outputFile.appendText("\n")
+        if (internalPackagePrefix.isBlank() || resolvedCall.containerFqName.startsWith(internalPackagePrefix)) {
+            outputFile.appendText(resolvedCall.call)
+            outputFile.appendText("\n")
+        }
     }
 
     // endregion


### PR DESCRIPTION
### What does this PR do?

This updates how we compute our API coverage through Integration tests, by ignoring methods flagged with `@Internal` and Extension methods we use for non Datadog classes. 

### Motivation

Improve our visibility on integration test coverage