### PR TITLE
Override process importance for Session Replay integration tests

### DIFF
--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/SessionReplayTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/SessionReplayTestRule.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sdk.rules
 import android.app.Activity
 import android.content.Intent
 import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.sdk.integration.sessionreplay.overrideProcessImportance
 import com.datadog.android.sdk.utils.addExtras
 
 internal open class SessionReplayTestRule<T : Activity>(
@@ -29,6 +30,7 @@ internal open class SessionReplayTestRule<T : Activity>(
         Thread.sleep(2000)
         removeCallbacks(listOf(Class.forName(SESSION_REPLAY_LIFECYCLE_CALLBACK_CLASS_NAME)))
         super.beforeActivityLaunched()
+        overrideProcessImportance()
     }
 
     override fun afterActivityFinished() {

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/ProcessImportanceExt.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/ProcessImportanceExt.kt
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.integration.sessionreplay
+
+import android.app.ActivityManager
+import com.datadog.android.rum.DdRumContentProvider
+
+/**
+ * In instrumentation tests, the process is treated as [IMPORTANCE_FOREGROUND_SERVICE],
+ * which differs from the behavior in a typical user environment. To prevent this difference
+ * from affecting test results, this function can be called to override the relevant variable
+ * inside [DdRumContentProvider], allowing the SDK to correctly identify that the application
+ * is in the foreground.
+ */
+fun overrideProcessImportance() {
+    DdRumContentProvider::class.java.declaredMethods.firstOrNull() {
+        it.name == "overrideProcessImportance"
+    }?.apply {
+        isAccessible = true
+        invoke(null, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
+    }
+}


### PR DESCRIPTION
### What does this PR do?

In integration test, the process is always treated as foreground service instead of foreground.
So when initialising the feature, `DatadogRumMonitor` consider the app is not in foreground,
which causes different test result in Rum feature.

In this case we need to force the importance of the process to have the same result of user environment.


### Motivation

Fix flaky test


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

