### PR TITLE
Make the DataOkHttpUploader state volatile

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploader.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/data/upload/DataOkHttpUploader.kt
@@ -31,8 +31,13 @@ internal class DataOkHttpUploader(
     val androidInfoProvider: AndroidInfoProvider
 ) : DataUploader {
 
-    private var attempts = 1
+    @Volatile
+    private var attempts: Int = 1
+
+    @Volatile
     private var previousUploadStatus: UploadStatus? = null
+
+    @Volatile
     private var previousUploadedBatchId: BatchId? = null
 
     // region DataUploader


### PR DESCRIPTION
### What does this PR do?

Initially I thought that given the fact that the `DataOkHttpUploader` is being executed sequentially there is no need for thread safety in it. After a team discussion we stumbled upon this corner case where the executor could actually kill that thread and spawn a new one therefor we need to make sure these states are Volatile and kept in the Heap.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

