### PR TITLE
Read SR system requirement synchronously with strict mode allowance

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sessionreplay
 
-import android.os.Handler
-import android.os.Looper
 import com.datadog.android.Datadog
 import com.datadog.android.api.SdkCore
 import com.datadog.android.api.feature.Feature.Companion.SESSION_REPLAY_FEATURE_NAME
@@ -21,6 +19,8 @@ object SessionReplay {
 
     /**
      * Enables a SessionReplay feature based on the configuration provided.
+     * It is recommended to invoke this function as early as possible in the app's lifecycle,
+     * ideally within the `Application#onCreate` callback, to ensure proper initialization.
      *
      * @param sessionReplayConfiguration Configuration to use for the feature.
      * @param sdkCore SDK instance to register feature in. If not provided, default SDK instance
@@ -32,21 +32,9 @@ object SessionReplay {
         sessionReplayConfiguration: SessionReplayConfiguration,
         sdkCore: SdkCore = Datadog.getInstance()
     ) {
-        enable(sessionReplayConfiguration, Handler(Looper.getMainLooper()), sdkCore)
-    }
-
-    internal fun enable(
-        sessionReplayConfiguration: SessionReplayConfiguration,
-        uiHandler: Handler,
-        sdkCore: SdkCore = Datadog.getInstance()
-    ) {
         val featureSdkCore = sdkCore as FeatureSdkCore
-        sessionReplayConfiguration.systemRequirementsConfiguration.let {
-            it.runIfRequirementsMet(
-                sdkCore = sdkCore,
-                uiHandler = uiHandler,
-                featureSdkCore.internalLogger
-            ) {
+        sessionReplayConfiguration.systemRequirementsConfiguration
+            .runIfRequirementsMet(featureSdkCore.internalLogger) {
                 val sessionReplayFeature = SessionReplayFeature(
                     sdkCore = featureSdkCore,
                     customEndpointUrl = sessionReplayConfiguration.customEndpointUrl,
@@ -62,7 +50,6 @@ object SessionReplay {
                 )
                 sdkCore.registerFeature(sessionReplayFeature)
             }
-        }
     }
 
     /**

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/prerequisite/CPURequirementChecker.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/prerequisite/CPURequirementChecker.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.prerequisite
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.allowThreadDiskReads
 import com.datadog.android.core.internal.persistence.file.listFilesSafe
 import java.io.File
 
@@ -22,7 +23,10 @@ internal class CPURequirementChecker(
         if (minCPUCores == 0) {
             return true
         }
-        return readCPUCoreNumber() >= minCPUCores
+        val actualCPUCoreNumber = allowThreadDiskReads {
+            readCPUCoreNumber()
+        }
+        return actualCPUCoreNumber >= minCPUCores
     }
 
     override fun name(): String = CPU_CHECK_NAME

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/prerequisite/MemoryRequirementChecker.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/prerequisite/MemoryRequirementChecker.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay.internal.prerequisite
 
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.core.allowThreadDiskReads
 import com.datadog.android.core.internal.persistence.file.canReadSafe
 import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.readLinesSafe
@@ -24,7 +25,10 @@ internal class MemoryRequirementChecker(
         if (minRamSizeMb == 0) {
             return true
         }
-        return getMaxRAMSize() >= minRamSizeMb
+        val actualMaxRamSizeMb = allowThreadDiskReads {
+            getMaxRAMSize()
+        }
+        return actualMaxRamSizeMb >= minRamSizeMb
     }
 
     override fun name(): String = MEMORY_CHECK_NAME

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayTest.kt
@@ -28,7 +28,6 @@ import org.mockito.kotlin.any
 import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doAnswer
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.whenever
@@ -63,11 +62,9 @@ internal class SessionReplayTest {
             systemRequirementsConfiguration = mockSystemRequirementsConfiguration
         )
         whenever(
-            mockSystemRequirementsConfiguration.runIfRequirementsMet(
-                eq(mockSdkCore), any(), any(), any()
-            )
+            mockSystemRequirementsConfiguration.runIfRequirementsMet(any(), any())
         ) doAnswer {
-            it.getArgument<() -> Unit>(3).invoke()
+            it.getArgument<() -> Unit>(1).invoke()
         }
         SessionReplay.enable(
             fakeSessionReplayConfigurationWithMockRequirement,

--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -217,7 +217,10 @@ class SampleApplication : Application() {
 
     private fun initializeSessionReplay() {
         val shouldUseFgm = SecureRandom().nextInt(100) < USE_FGM_PCT
-        val systemRequirementsConfiguration = SystemRequirementsConfiguration.BASIC
+        val systemRequirementsConfiguration = SystemRequirementsConfiguration.Builder()
+            .setMinRAMSizeMb(1024)
+            .setMinCPUCoreNumber(1)
+            .build()
 
         @Suppress("DEPRECATION")
         val sessionReplayConfig = SessionReplayConfiguration.Builder(SAMPLE_IN_ALL_SESSIONS)


### PR DESCRIPTION
### What does this PR do?

Asynchronous enabling the session replay feature after checking the system requirement causes the dysfunction of touch recorder.
This commit fixes it by reading the files on the original thread synchronously with allowance of strict mode.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

