### PR TITLE
RUM-6307 Make sure ConsentAwareFileOrchestrator is thread safe

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
@@ -27,6 +27,7 @@ internal open class ConsentAwareFileOrchestrator(
     internal val internalLogger: InternalLogger
 ) : FileOrchestrator, TrackingConsentProviderCallback {
 
+    @Volatile
     private lateinit var delegateOrchestrator: FileOrchestrator
 
     init {


### PR DESCRIPTION
### What does this PR do?

We had an issue in iOS where switching from `PENDING` to `GRANTED` in the tracking consent asynchronously causes the loss of some events that are about to be written from a different queue. In this PR we are making sure we are covering this use case with integration tests and also that we mark the `delegateOrchestrator` as `Volatile` in the `ConsentAwareFileOrchestrator` in case the Executor is re - spawning the worker thread.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

