### PR TITLE
Fix SpanEventSerializerTest flakiness

### DIFF
--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/SpanEventSerializerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/SpanEventSerializerTest.kt
@@ -87,7 +87,7 @@ internal class SpanEventSerializerTest {
         forge: Forge
     ) {
         // GIVEN
-        val fakeSanitizedAttributes = forge.exhaustiveAttributes()
+        val fakeSanitizedAttributes = forge.exhaustiveAttributes(setOf(KEY_USR_ID, KEY_USR_NAME, KEY_USR_EMAIL))
         whenever(
             mockDatadogConstraints
                 .validateAttributes(


### PR DESCRIPTION
### What does this PR do?

Forgery will generate attribute key like "id" sometimes, when the attribute is serialised, the key like this will be excluded because it's already declared in the main json structure, which causes test failure.

So in unit test we should exclude them to avoid flakiness


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

