### PR TITLE
RUM-6219: Add Image and TextAndInput privacy overrides

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -10,6 +10,8 @@ data class com.datadog.android.sessionreplay.MapperTypeWrapper<T: android.view.V
   fun supportsView(android.view.View): Boolean
   fun getUnsafeMapper(): com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper<android.view.View>
 fun android.view.View.setSessionReplayHidden(Boolean)
+fun android.view.View.setSessionReplayImagePrivacy(ImagePrivacy?)
+fun android.view.View.setSessionReplayTextAndInputPrivacy(TextAndInputPrivacy?)
 object com.datadog.android.sessionreplay.SessionReplay
   fun enable(SessionReplayConfiguration, com.datadog.android.api.SdkCore = Datadog.getInstance())
   fun startRecording(com.datadog.android.api.SdkCore = Datadog.getInstance())

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -24,6 +24,8 @@ public final class com/datadog/android/sessionreplay/MapperTypeWrapper {
 
 public final class com/datadog/android/sessionreplay/PrivacyOverrideExtensionsKt {
 	public static final fun setSessionReplayHidden (Landroid/view/View;Z)V
+	public static final fun setSessionReplayImagePrivacy (Landroid/view/View;Lcom/datadog/android/sessionreplay/ImagePrivacy;)V
+	public static final fun setSessionReplayTextAndInputPrivacy (Landroid/view/View;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;)V
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplay {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/PrivacyOverrideExtensions.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/PrivacyOverrideExtensions.kt
@@ -22,3 +22,31 @@ fun View.setSessionReplayHidden(hide: Boolean) {
         this.setTag(R.id.datadog_hidden, null)
     }
 }
+
+/**
+ * Allows overriding the image privacy for a view in Session Replay.
+ *
+ * @param privacy the new privacy level to use for the view
+ * or null to remove the override.
+ */
+fun View.setSessionReplayImagePrivacy(privacy: ImagePrivacy?) {
+    if (privacy == null) {
+        this.setTag(R.id.datadog_image_privacy, null)
+    } else {
+        this.setTag(R.id.datadog_image_privacy, privacy.toString())
+    }
+}
+
+/**
+ * Allows overriding the text and input privacy for a view in Session Replay.
+ *
+ * @param privacy the new privacy level to use for the view
+ * or null to remove the override.
+ */
+fun View.setSessionReplayTextAndInputPrivacy(privacy: TextAndInputPrivacy?) {
+    if (privacy == null) {
+        this.setTag(R.id.datadog_text_and_input_privacy, null)
+    } else {
+        this.setTag(R.id.datadog_text_and_input_privacy, privacy.toString())
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
@@ -183,7 +183,8 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
                     ),
                     ComposedOptionSelectorDetector(
                         customOptionSelectorDetectors + DefaultOptionSelectorDetector()
-                    )
+                    ),
+                    internalLogger = internalLogger
                 ),
                 recordedDataQueueHandler = recordedDataQueueHandler,
                 sdkCore = sdkCore,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -9,7 +9,9 @@ package com.datadog.android.sessionreplay.internal.recorder
 import android.view.View
 import android.view.ViewGroup
 import androidx.annotation.UiThread
+import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
+import com.datadog.android.sessionreplay.R
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -22,7 +24,8 @@ import java.util.LinkedList
 internal class SnapshotProducer(
     private val imageWireframeHelper: ImageWireframeHelper,
     private val treeViewTraversal: TreeViewTraversal,
-    private val optionSelectorDetector: OptionSelectorDetector
+    private val optionSelectorDetector: OptionSelectorDetector,
+    private val internalLogger: InternalLogger
 ) {
 
     @UiThread
@@ -55,7 +58,8 @@ internal class SnapshotProducer(
         recordedDataQueueRefs: RecordedDataQueueRefs
     ): Node? {
         return withinSRBenchmarkSpan(view::class.java.simpleName, view is ViewGroup) {
-            val traversedTreeView = treeViewTraversal.traverse(view, mappingContext, recordedDataQueueRefs)
+            val localMappingContext = resolvePrivacyOverrides(view, mappingContext)
+            val traversedTreeView = treeViewTraversal.traverse(view, localMappingContext, recordedDataQueueRefs)
             val nextTraversalStrategy = traversedTreeView.nextActionStrategy
             val resolvedWireframes = traversedTreeView.mappedWireframes
             if (nextTraversalStrategy == TraversalStrategy.STOP_AND_DROP_NODE) {
@@ -70,7 +74,7 @@ internal class SnapshotProducer(
                 view.childCount > 0 &&
                 nextTraversalStrategy == TraversalStrategy.TRAVERSE_ALL_CHILDREN
             ) {
-                val childMappingContext = resolveChildMappingContext(view, mappingContext)
+                val childMappingContext = resolveChildMappingContext(view, localMappingContext)
                 val parentsCopy = LinkedList(parents).apply { addAll(resolvedWireframes) }
                 for (i in 0 until view.childCount) {
                     val viewChild = view.getChildAt(i) ?: continue
@@ -96,5 +100,51 @@ internal class SnapshotProducer(
         } else {
             parentMappingContext
         }
+    }
+
+    private fun resolvePrivacyOverrides(view: View, mappingContext: MappingContext): MappingContext {
+        val imagePrivacy =
+            try {
+                val privacy = view.getTag(R.id.datadog_image_privacy) as? String
+                if (privacy == null) {
+                    mappingContext.imagePrivacy
+                } else {
+                    ImagePrivacy.valueOf(privacy)
+                }
+            } catch (e: IllegalArgumentException) {
+                logInvalidPrivacyLevelError(e)
+                mappingContext.imagePrivacy
+            }
+
+        val textAndInputPrivacy =
+            try {
+                val privacy = view.getTag(R.id.datadog_text_and_input_privacy) as? String
+                if (privacy == null) {
+                    mappingContext.textAndInputPrivacy
+                } else {
+                    TextAndInputPrivacy.valueOf(privacy)
+                }
+            } catch (e: IllegalArgumentException) {
+                logInvalidPrivacyLevelError(e)
+                mappingContext.textAndInputPrivacy
+            }
+
+        return mappingContext.copy(
+            imagePrivacy = imagePrivacy,
+            textAndInputPrivacy = textAndInputPrivacy
+        )
+    }
+
+    private fun logInvalidPrivacyLevelError(e: Exception) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            { INVALID_PRIVACY_LEVEL_ERROR },
+            e
+        )
+    }
+
+    internal companion object {
+        internal const val INVALID_PRIVACY_LEVEL_ERROR = "Invalid privacy level"
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/res/values/ids.xml
+++ b/features/dd-sdk-android-session-replay/src/main/res/values/ids.xml
@@ -6,4 +6,6 @@
 
 <resources>
     <item name="datadog_hidden" type="id"/>
+    <item name="datadog_image_privacy" type="id"/>
+    <item name="datadog_text_and_input_privacy" type="id"/>
 </resources>

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/PrivacyOverrideExtensionsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/PrivacyOverrideExtensionsTest.kt
@@ -8,6 +8,7 @@ package com.datadog.android.sessionreplay
 
 import android.view.View
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
 import org.junit.jupiter.api.Test
@@ -51,5 +52,59 @@ internal class PrivacyOverrideExtensionsTest {
 
         // Then
         verify(mockView).setTag(eq(R.id.datadog_hidden), isNull())
+    }
+
+    @Test
+    fun `M set tag W setSessionReplayImagePrivacy() { with privacy }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockView = mock<View>()
+        val mockPrivacy = forge.aValueFrom(ImagePrivacy::class.java)
+
+        // When
+        mockView.setSessionReplayImagePrivacy(mockPrivacy)
+
+        // Then
+        verify(mockView).setTag(eq(R.id.datadog_image_privacy), eq(mockPrivacy.toString()))
+    }
+
+    @Test
+    fun `M set tag to null W setSessionReplayImagePrivacy() { privacy is null }`() {
+        // Given
+        val mockView = mock<View>()
+
+        // When
+        mockView.setSessionReplayImagePrivacy(null)
+
+        // Then
+        verify(mockView).setTag(eq(R.id.datadog_image_privacy), isNull())
+    }
+
+    @Test
+    fun `M set tag W setSessionReplayTextAndInputPrivacy() { with privacy }`(
+        forge: Forge
+    ) {
+        // Given
+        val mockView = mock<View>()
+        val mockPrivacy = forge.aValueFrom(TextAndInputPrivacy::class.java)
+
+        // When
+        mockView.setSessionReplayTextAndInputPrivacy(mockPrivacy)
+
+        // Then
+        verify(mockView).setTag(eq(R.id.datadog_text_and_input_privacy), eq(mockPrivacy.toString()))
+    }
+
+    @Test
+    fun `M set tag to null W setSessionReplayTextAndInputPrivacy() { privacy is null }`() {
+        // Given
+        val mockView = mock<View>()
+
+        // When
+        mockView.setSessionReplayTextAndInputPrivacy(null)
+
+        // Then
+        verify(mockView).setTag(eq(R.id.datadog_text_and_input_privacy), isNull())
     }
 }


### PR DESCRIPTION
### What does this PR do?
Adds privacy overrides for images and textAndInput.
Api example:

`view.setSessionReplayImagePrivacy(privacy: ImagePrivacy?)`
`view.setSessionReplayTextAndInputPrivacy(privacy: TextAndInputPrivacy?)`

These privacy overrides work on nearest parent - so if you override the privacy on a viewgroup, it should be propagated to the children unless they have their own override.

### Motivation
Part of the fine grained masking effort. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

