### PR TITLE
RUM-6307 Make sure ConsentAwareFileOrchestrator is thread safe

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/SdkFeature.kt
@@ -351,7 +351,9 @@ internal class SdkFeature(
             fileMover = FileMover(internalLogger),
             internalLogger = internalLogger,
             filePersistenceConfig = filePersistenceConfig,
-            metricsDispatcher = metricsDispatcher
+            metricsDispatcher = metricsDispatcher,
+            coreFeature.trackingConsentProvider,
+            featureName
         )
     }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/ConsentAwareStorage.kt
@@ -19,6 +19,7 @@ import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.persistence.file.FileReaderWriter
 import com.datadog.android.core.internal.persistence.file.batch.BatchFileReaderWriter
 import com.datadog.android.core.internal.persistence.file.existsSafe
+import com.datadog.android.core.internal.privacy.ConsentProvider
 import com.datadog.android.core.internal.utils.submitSafe
 import com.datadog.android.core.metrics.MethodCallSamplingRate
 import com.datadog.android.core.metrics.TelemetryMetricType
@@ -36,7 +37,9 @@ internal class ConsentAwareStorage(
     private val fileMover: FileMover,
     private val internalLogger: InternalLogger,
     internal val filePersistenceConfig: FilePersistenceConfig,
-    private val metricsDispatcher: MetricsDispatcher
+    private val metricsDispatcher: MetricsDispatcher,
+    private val consentProvider: ConsentProvider,
+    private val featureName: String
 ) : Storage {
 
     /**
@@ -53,28 +56,27 @@ internal class ConsentAwareStorage(
         forceNewBatch: Boolean,
         callback: (EventBatchWriter) -> Unit
     ) {
-        val orchestrator = when (datadogContext.trackingConsent) {
-            TrackingConsent.GRANTED -> grantedOrchestrator
-            TrackingConsent.PENDING -> pendingOrchestrator
-            TrackingConsent.NOT_GRANTED -> null
-        }
-
         val metric = internalLogger.startPerformanceMeasure(
             callerClass = ConsentAwareStorage::class.java.name,
             metric = TelemetryMetricType.MethodCalled,
             samplingRate = MethodCallSamplingRate.RARE.rate,
-            operationName = "writeCurrentBatch[${orchestrator?.getRootDirName()}]"
+            operationName = "writeCurrentBatch[$featureName]"
         )
-
         executorService.submitSafe("Data write", internalLogger) {
+            val orchestrator = resolveOrchestrator()
+            if (orchestrator == null) {
+                callback.invoke(NoOpEventBatchWriter())
+                metric?.stopAndSend(false)
+                return@submitSafe
+            }
             synchronized(writeLock) {
-                val batchFile = orchestrator?.getWritableFile(forceNewBatch)
+                val batchFile = orchestrator.getWritableFile(forceNewBatch)
                 val metadataFile = if (batchFile != null) {
                     orchestrator.getMetadataFile(batchFile)
                 } else {
                     null
                 }
-                val writer = if (orchestrator == null || batchFile == null) {
+                val writer = if (batchFile == null) {
                     NoOpEventBatchWriter()
                 } else {
                     FileEventBatchWriter(
@@ -150,6 +152,16 @@ internal class ConsentAwareStorage(
                     deleteBatch(it, metaFile, RemovalReason.Flushed)
                 }
             }
+        }
+    }
+
+    @WorkerThread
+    private fun resolveOrchestrator(): FileOrchestrator? {
+        val consent = consentProvider.getConsent()
+        return when (consent) {
+            TrackingConsent.GRANTED -> grantedOrchestrator
+            TrackingConsent.PENDING -> pendingOrchestrator
+            TrackingConsent.NOT_GRANTED -> null
         }
     }
 

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/persistence/file/advanced/ConsentAwareFileOrchestrator.kt
@@ -27,6 +27,7 @@ internal open class ConsentAwareFileOrchestrator(
     internal val internalLogger: InternalLogger
 ) : FileOrchestrator, TrackingConsentProviderCallback {
 
+    @Volatile
     private lateinit var delegateOrchestrator: FileOrchestrator
 
     init {

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/persistence/AbstractStorageTest.kt
@@ -109,7 +109,7 @@ internal class AbstractStorageTest {
         @Forgery fakeBatchEvent: RawBatchEvent
     ) {
         // Given
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         whenever(mockGrantedPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
         var result: Boolean? = null
@@ -118,7 +118,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -138,7 +138,7 @@ internal class AbstractStorageTest {
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
         whenever(mockGrantedPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
@@ -148,7 +148,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -165,7 +165,8 @@ internal class AbstractStorageTest {
         @BoolForgery forceNewBatch: Boolean
     ) {
         // Given
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
+        whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn null
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn null
         var resultMetadata: ByteArray? = null
@@ -174,7 +175,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isNull()
@@ -192,7 +193,7 @@ internal class AbstractStorageTest {
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.GRANTED)
+        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.GRANTED
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
         whenever(mockGrantedPersistenceStrategy.currentMetadata()) doReturn batchMetadata
@@ -202,7 +203,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isEqualTo(batchMetadata)
@@ -221,7 +222,7 @@ internal class AbstractStorageTest {
         @Forgery fakeBatchEvent: RawBatchEvent
     ) {
         // Given
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.PENDING
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         whenever(mockPendingPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
         var result: Boolean? = null
@@ -230,7 +231,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -250,7 +251,7 @@ internal class AbstractStorageTest {
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.PENDING
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
         whenever(mockPendingPersistenceStrategy.write(any(), anyOrNull(), any())) doReturn fakeResult
@@ -260,7 +261,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
 
         // Then
         assertThat(result).isEqualTo(fakeResult)
@@ -277,7 +278,7 @@ internal class AbstractStorageTest {
         @BoolForgery forceNewBatch: Boolean
     ) {
         // Given
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.PENDING
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         var resultMetadata: ByteArray? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
@@ -286,7 +287,7 @@ internal class AbstractStorageTest {
         whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn null
 
         // When
-        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isNull()
@@ -304,7 +305,7 @@ internal class AbstractStorageTest {
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.PENDING)
+        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.PENDING
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
         var resultMetadata: ByteArray? = null
@@ -314,7 +315,7 @@ internal class AbstractStorageTest {
         whenever(mockPendingPersistenceStrategy.currentMetadata()) doReturn batchMetadata
 
         // When
-        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isEqualTo(batchMetadata)
@@ -333,7 +334,7 @@ internal class AbstractStorageTest {
         @StringForgery fakeBatchMetadata: String
     ) {
         // Given
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
+        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.NOT_GRANTED
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         val batchMetadata = fakeBatchMetadata.toByteArray()
         var result: Boolean? = null
@@ -342,7 +343,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
 
         // Then
         assertThat(result).isFalse()
@@ -358,7 +359,7 @@ internal class AbstractStorageTest {
         @BoolForgery forceNewBatch: Boolean
     ) {
         // Given
-        val sdkContext = fakeDatadogContext.copy(trackingConsent = TrackingConsent.NOT_GRANTED)
+        whenever(mockConsentProvider.getConsent()) doReturn TrackingConsent.NOT_GRANTED
         val mockWriteCallback = mock<(EventBatchWriter) -> Unit>()
         var resultMetadata: ByteArray? = null
         whenever(mockWriteCallback.invoke(any())) doAnswer {
@@ -366,7 +367,7 @@ internal class AbstractStorageTest {
         }
 
         // When
-        testedStorage.writeCurrentBatch(sdkContext, forceNewBatch, mockWriteCallback)
+        testedStorage.writeCurrentBatch(fakeDatadogContext, forceNewBatch, mockWriteCallback)
 
         // Then
         assertThat(resultMetadata).isNull()

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/PendingToGrantedAsyncTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/PendingToGrantedAsyncTest.kt
@@ -1,0 +1,211 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.integration.tests
+
+import androidx.test.core.app.ApplicationProvider
+import com.datadog.android.Datadog
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.stub.StubStorageBackedFeature
+import com.datadog.android.api.storage.EventType
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.integration.tests.assertj.MockWebServerAssert
+import com.datadog.android.core.integration.tests.forge.factories.ConfigurationCoreForgeryFactory
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.tools.unit.ConditionWatcher
+import com.datadog.tools.unit.forge.useToolsFactories
+import com.google.gson.JsonObject
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit4.ForgeRule
+import fr.xgouchet.elmyr.jvm.useJvmFactories
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Instrumentation tests for the feature scope for the case when the tracking consent is switched from Pending to
+ * Granted. These tests are meant to assess the correct behavior of our persistence strategy
+ * when write events are sent to the feature scope and the tracking consent is switched from Pending to Granted from
+ * 2 different threads.
+ */
+@RunWith(Parameterized::class)
+class PendingToGrantedAsyncTest(
+    private val fakeBatchData: List<RawBatchEvent>,
+    private val fakeBatchMetadata: ByteArray,
+    private val fakeConfiguration: Configuration,
+    private val eventType: EventType
+) : MockServerTest() {
+
+    @get:Rule
+    var forge = ForgeRule()
+        .useJvmFactories()
+        .useToolsFactories()
+        .withFactory(ConfigurationCoreForgeryFactory())
+
+    @StringForgery(type = StringForgeryType.ALPHABETICAL)
+    lateinit var fakeFeatureName: String
+
+    private lateinit var trackingConsent: TrackingConsent
+    private lateinit var stubFeature: Feature
+    private lateinit var testedInternalSdkCore: InternalSdkCore
+
+    @Before
+    fun setUp() {
+        stubFeature = StubStorageBackedFeature(
+            forge,
+            fakeFeatureName,
+            getMockServerWrapper().getServerUrl()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        cleanStorage()
+        Datadog.stopInstance()
+        cleanMockWebServer()
+    }
+
+    @Test
+    fun mustReceiveTheEvents_whenFeatureWrite_asynchronousAccess() {
+        // Given
+        trackingConsent = TrackingConsent.PENDING
+        testedInternalSdkCore = Datadog.initialize(
+            context = ApplicationProvider.getApplicationContext(),
+            configuration = fakeConfiguration,
+            trackingConsent = trackingConsent
+        ) as InternalSdkCore
+        testedInternalSdkCore.registerFeature(stubFeature)
+        val featureScope = testedInternalSdkCore.getFeature(fakeFeatureName)
+        checkNotNull(featureScope)
+        val countDownLatch = CountDownLatch(2)
+
+        // When
+        Thread {
+            Thread.sleep(200)
+            Datadog.setTrackingConsent(TrackingConsent.GRANTED)
+            countDownLatch.countDown()
+        }.start()
+        Thread {
+            fakeBatchData.forEach { rawBatchEvent ->
+                featureScope.withWriteContext { _, eventBatchWriter ->
+                    eventBatchWriter.write(
+                        rawBatchEvent,
+                        fakeBatchMetadata,
+                        eventType
+                    )
+                }
+            }
+            countDownLatch.countDown()
+        }.start()
+
+        // Then
+        countDownLatch.await(TimeUnit.SECONDS.toMillis(10), TimeUnit.MILLISECONDS)
+        ConditionWatcher {
+            MockWebServerAssert.assertThat(getMockServerWrapper())
+                .withConfiguration(fakeConfiguration)
+                .withTrackingConsent(TrackingConsent.GRANTED)
+                .receivedData(fakeBatchData, fakeBatchMetadata)
+            true
+        }.doWait(LONG_WAIT_MS)
+    }
+
+    // region Internal
+
+    private fun cleanStorage() {
+        val storageFolder = testedInternalSdkCore.rootStorageDir
+        storageFolder?.deleteRecursively()
+    }
+
+    companion object {
+        private val forge = ForgeRule()
+            .useJvmFactories()
+            .useToolsFactories()
+            .withFactory(ConfigurationCoreForgeryFactory())
+
+        @JvmStatic
+        @Parameters
+        fun testParameters(): Collection<Array<Any>> {
+            return listOf(
+                arrayOf(
+                    forge.aList(size = forge.anInt(min = 50, max = 100)) {
+                        val fakeEvent: JsonObject = forge.getForgery()
+                        val eventMetadata = forge.anAlphabeticalString()
+                        RawBatchEvent(
+                            fakeEvent.toString().toByteArray(),
+                            eventMetadata.toByteArray()
+                        )
+                    },
+                    forge.anAlphabeticalString().toByteArray(),
+                    forge.getForgery<Configuration>(),
+                    forge.aValueFrom(EventType::class.java)
+                ),
+                arrayOf(
+                    forge.aList(size = forge.anInt(min = 50, max = 100)) {
+                        val fakeEvent: JsonObject = forge.getForgery()
+                        val eventMetadata = forge.anAlphabeticalString()
+                        RawBatchEvent(
+                            fakeEvent.toString().toByteArray(),
+                            eventMetadata.toByteArray()
+                        )
+                    },
+                    forge.anAlphabeticalString().toByteArray(),
+                    forge.getForgery<Configuration>(),
+                    forge.aValueFrom(EventType::class.java)
+                ),
+                arrayOf(
+                    forge.aList(size = forge.anInt(min = 50, max = 100)) {
+                        val fakeEvent: JsonObject = forge.getForgery()
+                        val eventMetadata = forge.anAlphabeticalString()
+                        RawBatchEvent(
+                            fakeEvent.toString().toByteArray(),
+                            eventMetadata.toByteArray()
+                        )
+                    },
+                    forge.anAlphabeticalString().toByteArray(),
+                    forge.getForgery<Configuration>(),
+                    forge.aValueFrom(EventType::class.java)
+                ),
+                arrayOf(
+                    forge.aList(size = forge.anInt(min = 50, max = 100)) {
+                        val fakeEvent: JsonObject = forge.getForgery()
+                        val eventMetadata = forge.anAlphabeticalString()
+                        RawBatchEvent(
+                            fakeEvent.toString().toByteArray(),
+                            eventMetadata.toByteArray()
+                        )
+                    },
+                    forge.anAlphabeticalString().toByteArray(),
+                    forge.getForgery<Configuration>(),
+                    forge.aValueFrom(EventType::class.java)
+                ),
+                arrayOf(
+                    forge.aList(size = forge.anInt(min = 50, max = 100)) {
+                        val fakeEvent: JsonObject = forge.getForgery()
+                        val eventMetadata = forge.anAlphabeticalString()
+                        RawBatchEvent(
+                            fakeEvent.toString().toByteArray(),
+                            eventMetadata.toByteArray()
+                        )
+                    },
+                    forge.anAlphabeticalString().toByteArray(),
+                    forge.getForgery<Configuration>(),
+                    forge.aValueFrom(EventType::class.java)
+                )
+            )
+        }
+    }
+
+    // endregion
+}

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/PendingToGrantedCustomPersistenceAsyncTest.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/PendingToGrantedCustomPersistenceAsyncTest.kt
@@ -1,0 +1,261 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.integration.tests
+
+import androidx.test.core.app.ApplicationProvider
+import com.datadog.android.Datadog
+import com.datadog.android.DatadogSite
+import com.datadog.android._InternalProxy
+import com.datadog.android.api.feature.Feature
+import com.datadog.android.api.feature.stub.StubStorageBackedFeature
+import com.datadog.android.api.storage.EventType
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.core.InternalSdkCore
+import com.datadog.android.core.configuration.BatchProcessingLevel
+import com.datadog.android.core.configuration.BatchSize
+import com.datadog.android.core.configuration.Configuration
+import com.datadog.android.core.configuration.UploadFrequency
+import com.datadog.android.core.integration.tests.assertj.MockWebServerAssert
+import com.datadog.android.core.integration.tests.forge.factories.ConfigurationCoreForgeryFactory
+import com.datadog.android.core.integration.tests.utils.HeapBasedPersistenceStrategy
+import com.datadog.android.core.persistence.PersistenceStrategy
+import com.datadog.android.privacy.TrackingConsent
+import com.datadog.android.trace.TracingHeaderType
+import com.datadog.tools.unit.ConditionWatcher
+import com.datadog.tools.unit.forge.useToolsFactories
+import com.google.gson.JsonObject
+import fr.xgouchet.elmyr.annotation.StringForgery
+import fr.xgouchet.elmyr.annotation.StringForgeryType
+import fr.xgouchet.elmyr.junit4.ForgeRule
+import fr.xgouchet.elmyr.jvm.useJvmFactories
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
+import org.junit.runners.Parameterized.Parameters
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+/**
+ * Instrumentation tests for the feature scope for the case when the tracking consent is switched from Pending to
+ * Granted. These tests are meant to assess the correct behavior of our persistence strategy
+ * when write events are sent to the feature scope and the tracking consent is switched from Pending to Granted from
+ * 2 different threads.
+ * This test suite focuses on the custom persistence strategy configuration feature.
+ */
+@RunWith(Parameterized::class)
+class PendingToGrantedCustomPersistenceAsyncTest(
+    private val fakeBatchData: List<RawBatchEvent>,
+    private val fakeBatchMetadata: ByteArray,
+    private val fakeConfiguration: Configuration,
+    private val eventType: EventType
+) : MockServerTest() {
+
+    @get:Rule
+    var forge = ForgeRule()
+        .useJvmFactories()
+        .useToolsFactories()
+        .withFactory(ConfigurationCoreForgeryFactory())
+
+    @StringForgery(type = StringForgeryType.ALPHABETICAL)
+    lateinit var fakeFeatureName: String
+
+    private lateinit var trackingConsent: TrackingConsent
+    private lateinit var stubFeature: Feature
+    private lateinit var testedInternalSdkCore: InternalSdkCore
+
+    @Before
+    fun setUp() {
+        stubFeature = StubStorageBackedFeature(
+            forge,
+            fakeFeatureName,
+            getMockServerWrapper().getServerUrl()
+        )
+    }
+
+    @After
+    fun tearDown() {
+        cleanStorage()
+        Datadog.stopInstance()
+        cleanMockWebServer()
+    }
+
+    @Test
+    fun mustReceiveTheEvents_whenFeatureWrite_customStorage_asynchronousAccess() {
+        // Given
+        trackingConsent = TrackingConsent.PENDING
+        testedInternalSdkCore = Datadog.initialize(
+            context = ApplicationProvider.getApplicationContext(),
+            configuration = fakeConfiguration,
+            trackingConsent = trackingConsent
+        ) as InternalSdkCore
+        testedInternalSdkCore.registerFeature(stubFeature)
+        val featureScope = testedInternalSdkCore.getFeature(fakeFeatureName)
+        checkNotNull(featureScope)
+        val countDownLatch = CountDownLatch(2)
+
+        // When
+        Thread {
+            Thread.sleep(200)
+            Datadog.setTrackingConsent(TrackingConsent.GRANTED)
+            countDownLatch.countDown()
+        }.start()
+        Thread {
+            fakeBatchData.forEach { rawBatchEvent ->
+                featureScope.withWriteContext { _, eventBatchWriter ->
+                    eventBatchWriter.write(
+                        rawBatchEvent,
+                        fakeBatchMetadata,
+                        eventType
+                    )
+                }
+            }
+            countDownLatch.countDown()
+        }.start()
+
+        // Then
+        countDownLatch.await(TimeUnit.SECONDS.toMillis(10), TimeUnit.MILLISECONDS)
+        ConditionWatcher {
+            MockWebServerAssert.assertThat(getMockServerWrapper())
+                .withConfiguration(fakeConfiguration)
+                .withTrackingConsent(TrackingConsent.GRANTED)
+                .receivedData(fakeBatchData, fakeBatchMetadata)
+            true
+        }.doWait(LONG_WAIT_MS)
+    }
+
+    // region Internal
+
+    private fun cleanStorage() {
+        val storageFolder = testedInternalSdkCore.rootStorageDir
+        storageFolder?.deleteRecursively()
+    }
+
+    companion object {
+        private val forge = ForgeRule()
+            .useJvmFactories()
+            .useToolsFactories()
+            .withFactory(ConfigurationCoreForgeryFactory())
+
+        private fun ForgeRule.forgeConfigurationWithCustomStorage(): Configuration {
+            return Configuration.Builder(
+                UUID.randomUUID().toString(),
+                anHexadecimalString(),
+                anHexadecimalString(),
+                aNullable {
+                    anAlphaNumericalString()
+                }
+            )
+                .setUseDeveloperModeWhenDebuggable(aBool())
+                // this needs to be before allowing the clear text traffic as it invalidates this option
+                .useSite(aValueFrom(DatadogSite::class.java))
+                .setFirstPartyHostsWithHeaderType(
+                    aMap {
+                        val fakeUrl = aStringMatching("https://[a-z0-9]+\\.com")
+                        fakeUrl to aList {
+                            aValueFrom(
+                                TracingHeaderType::class.java
+                            )
+                        }.toSet()
+                    }
+                )
+                .apply {
+                    _InternalProxy.allowClearTextHttp(this)
+                }
+                .setBatchSize(aValueFrom(BatchSize::class.java))
+                .setUploadFrequency(aValueFrom(UploadFrequency::class.java))
+                .setBatchProcessingLevel(aValueFrom(BatchProcessingLevel::class.java))
+                .setPersistenceStrategyFactory(object : PersistenceStrategy.Factory {
+                    override fun create(
+                        identifier: String,
+                        maxItemsPerBatch: Int,
+                        maxBatchSize: Long
+                    ): PersistenceStrategy {
+                        return HeapBasedPersistenceStrategy()
+                    }
+                })
+                .build()
+        }
+
+        @JvmStatic
+        @Parameters
+        fun testParameters(): Collection<Array<Any>> {
+            return listOf(
+                arrayOf(
+                    forge.aList(size = forge.anInt(min = 50, max = 100)) {
+                        val fakeEvent: JsonObject = forge.getForgery()
+                        val eventMetadata = forge.anAlphabeticalString()
+                        RawBatchEvent(
+                            fakeEvent.toString().toByteArray(),
+                            eventMetadata.toByteArray()
+                        )
+                    },
+                    forge.anAlphabeticalString().toByteArray(),
+                    forge.forgeConfigurationWithCustomStorage(),
+                    forge.aValueFrom(EventType::class.java)
+                ),
+                arrayOf(
+                    forge.aList(size = forge.anInt(min = 50, max = 100)) {
+                        val fakeEvent: JsonObject = forge.getForgery()
+                        val eventMetadata = forge.anAlphabeticalString()
+                        RawBatchEvent(
+                            fakeEvent.toString().toByteArray(),
+                            eventMetadata.toByteArray()
+                        )
+                    },
+                    forge.anAlphabeticalString().toByteArray(),
+                    forge.forgeConfigurationWithCustomStorage(),
+                    forge.aValueFrom(EventType::class.java)
+                ),
+                arrayOf(
+                    forge.aList(size = forge.anInt(min = 50, max = 100)) {
+                        val fakeEvent: JsonObject = forge.getForgery()
+                        val eventMetadata = forge.anAlphabeticalString()
+                        RawBatchEvent(
+                            fakeEvent.toString().toByteArray(),
+                            eventMetadata.toByteArray()
+                        )
+                    },
+                    forge.anAlphabeticalString().toByteArray(),
+                    forge.getForgery<Configuration>(),
+                    forge.aValueFrom(EventType::class.java)
+                ),
+                arrayOf(
+                    forge.aList(size = forge.anInt(min = 50, max = 100)) {
+                        val fakeEvent: JsonObject = forge.getForgery()
+                        val eventMetadata = forge.anAlphabeticalString()
+                        RawBatchEvent(
+                            fakeEvent.toString().toByteArray(),
+                            eventMetadata.toByteArray()
+                        )
+                    },
+                    forge.anAlphabeticalString().toByteArray(),
+                    forge.forgeConfigurationWithCustomStorage(),
+                    forge.aValueFrom(EventType::class.java)
+                ),
+                arrayOf(
+                    forge.aList(size = forge.anInt(min = 50, max = 100)) {
+                        val fakeEvent: JsonObject = forge.getForgery()
+                        val eventMetadata = forge.anAlphabeticalString()
+                        RawBatchEvent(
+                            fakeEvent.toString().toByteArray(),
+                            eventMetadata.toByteArray()
+                        )
+                    },
+                    forge.anAlphabeticalString().toByteArray(),
+                    forge.forgeConfigurationWithCustomStorage(),
+                    forge.aValueFrom(EventType::class.java)
+                )
+            )
+        }
+    }
+
+    // endregion
+}

--- a/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/utils/HeapBasedPersistenceStrategy.kt
+++ b/reliability/core-it/src/androidTest/kotlin/com/datadog/android/core/integration/tests/utils/HeapBasedPersistenceStrategy.kt
@@ -1,0 +1,95 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.core.integration.tests.utils
+
+import com.datadog.android.api.storage.EventType
+import com.datadog.android.api.storage.RawBatchEvent
+import com.datadog.android.core.persistence.PersistenceStrategy
+import java.security.MessageDigest
+
+internal class HeapBasedPersistenceStrategy : PersistenceStrategy {
+
+    @Volatile
+    private var batchMetadata: ByteArray? = null
+    private val storedEvents = HashSet<RawBatchEvent>()
+    private val lockedBatches: MutableMap<String, PersistenceStrategy.Batch> = mutableMapOf()
+
+    override fun currentMetadata(): ByteArray? {
+        return batchMetadata
+    }
+
+    override fun write(event: RawBatchEvent, batchMetadata: ByteArray?, eventType: EventType): Boolean {
+        synchronized(storedEvents) {
+            storedEvents.add(event)
+        }
+        this.batchMetadata = batchMetadata
+        return true
+    }
+
+    override fun lockAndReadNext(): PersistenceStrategy.Batch? {
+        val currentBatch: List<RawBatchEvent>
+        synchronized(storedEvents) {
+            currentBatch = storedEvents.toList()
+        }
+        if (currentBatch.isNotEmpty()) {
+            val batchId = currentBatch.toBatchId()
+            val batch = PersistenceStrategy.Batch(batchId, batchMetadata, currentBatch)
+            lockedBatches[batchId] = batch
+            return batch
+        }
+        return null
+    }
+
+    override fun unlockAndKeep(batchId: String) {
+        synchronized(storedEvents) {
+            lockedBatches.remove(batchId)?.let {
+                storedEvents.addAll(it.events)
+            }
+        }
+    }
+
+    override fun unlockAndDelete(batchId: String) {
+        val batch = synchronized(lockedBatches) {
+            lockedBatches.remove(batchId)
+        }
+        synchronized(storedEvents) {
+            batch?.events?.forEach { event ->
+                storedEvents.remove(event)
+            }
+        }
+    }
+
+    override fun dropAll() {
+        synchronized(storedEvents) {
+            storedEvents.clear()
+        }
+        synchronized(lockedBatches) {
+            lockedBatches.clear()
+        }
+        batchMetadata = null
+    }
+
+    override fun migrateData(targetStrategy: PersistenceStrategy) {
+        val heapBasedPersistenceStrategy = targetStrategy as HeapBasedPersistenceStrategy
+        synchronized(storedEvents) {
+            heapBasedPersistenceStrategy.storedEvents.addAll(storedEvents)
+            storedEvents.clear()
+        }
+        heapBasedPersistenceStrategy.batchMetadata = batchMetadata
+    }
+
+    private fun List<RawBatchEvent>.toBatchId(): String {
+        val data = this.map { it.data }.reduce { acc, bytes -> acc + bytes }
+        return try {
+            val digest = MessageDigest.getInstance("SHA-1")
+            val hashBytes = digest.digest(data)
+            return hashBytes.toString()
+        } catch (e: Throwable) {
+            ""
+        }
+    }
+}


### PR DESCRIPTION
### What does this PR do?

- **Issue Identified**:
  - Our storage logic has a race condition issue affecting event processing.
  - This problem is visible only in a specific use case involving concurrent operations and tracking consent management.

- **Specific Use Case**:
  - The system is operating under "PENDING" tracking consent mode.
  - Events are being written via a `featureScope` by one thread.
  - At the same time, tracking consent is being changed by another thread.

- **Underlying Process**:
  - For each event written:
    - The system first resolves the `DatadogContext` to determine the current environment and configuration.
    - It then uses the `DatadogContext` to resolve the `FileOrchestrator`, which decides where events should be stored.
    - Subsequently, a task is added to the Executor queue to handle the actual writing of the event.
    
 ```java
 override fun writeCurrentBatch(
        datadogContext: DatadogContext,
        forceNewBatch: Boolean,
        callback: (EventBatchWriter) -> Unit
    ) {
        val orchestrator = when (datadogContext.trackingConsent) {
            TrackingConsent.GRANTED -> grantedOrchestrator
            TrackingConsent.PENDING -> pendingOrchestrator
            TrackingConsent.NOT_GRANTED -> null
        }

        val metric = internalLogger.startPerformanceMeasure(
            callerClass = ConsentAwareStorage::class.java.name,
            metric = TelemetryMetricType.MethodCalled,
            samplingRate = MethodCallSamplingRate.RARE.rate,
            operationName = "writeCurrentBatch[${orchestrator?.getRootDirName()}]"
        )

        executorService.submitSafe("Data write", internalLogger) {
            synchronized(writeLock) {
                val batchFile = orchestrator?.getWritableFile(forceNewBatch)
                val metadataFile = if (batchFile != null) {
                    orchestrator.getMetadataFile(batchFile)
                    ...
```

- **Race Condition Trigger**:
  - During the execution of `setTrackingConsent(Granted)`:
    - A new task is created to migrate events from the "PENDING" to the "GRANTED" consent state.
    - This task is added to the Executor queue.
  - The race condition occurs when this migration task enters the queue between the resolution of the `FileOrchestrator` and the addition of the event-writing task.
  
```mermaid
journey
    title Storge Executor Queue
    section Write Tasks
        event1InPendign: Write Event 1
        event2InPending: Write Event 2
    section SwitchConsent Tasks
        PendingToGranted: Switch Consent
    section Write Tasks
        event3InPending: Write Event 3
        event4InGranted: Write Event 4
```

- **Resulting Issue**:
  - The events, initially deemed "PENDING," get stored in the "PENDING" directory.
  - Due to the timing of the migration task:
    - These events may fail to migrate to the "GRANTED" state.
    - Consequently, they remain in the "PENDING" folder indefinitely.
  - This results in the loss of events, as they are not properly sent or processed.

- **Implications**:
  - This issue could lead to incomplete data capture and analysis.
  - It may also affect downstream processes that rely on accurate and complete event data.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

