### PR TITLE
Remove unnecessary legacy privacy line from the sampleApplication

### DIFF
--- a/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
+++ b/sample/kotlin/src/main/kotlin/com/datadog/android/sample/SampleApplication.kt
@@ -222,7 +222,6 @@ class SampleApplication : Application() {
             .setMinCPUCoreNumber(1)
             .build()
 
-        @Suppress("DEPRECATION")
         val sessionReplayConfig = SessionReplayConfiguration.Builder(SAMPLE_IN_ALL_SESSIONS)
             .apply {
                 if (BuildConfig.DD_OVERRIDE_SESSION_REPLAY_URL.isNotBlank()) {
@@ -235,7 +234,6 @@ class SampleApplication : Application() {
                     useLegacyConfiguration(this)
                 }
             }
-            .setPrivacy(SessionReplayPrivacy.MASK_USER_INPUT)
             .addExtensionSupport(MaterialExtensionSupport())
             .setSystemRequirements(systemRequirementsConfiguration)
             .build()


### PR DESCRIPTION
### What does this PR do?
I noticed a problem in the sampleApplication - we had a line there setting the legacy privacy. This is overwriting the value from the useLegacyConfiguration method.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

