### PR TITLE
Fix: use Java 11 bytecode for public modules

### DIFF
--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -1,7 +1,7 @@
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
 import com.datadog.gradle.config.detektCustomConfig
-import com.datadog.gradle.config.java17
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.javadocConfig
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
@@ -34,7 +34,7 @@ plugins {
 android {
     namespace = "com.datadog.android.internal"
     compileOptions {
-        java17()
+        java11()
     }
 
     testFixtures {

--- a/tools/benchmark/build.gradle.kts
+++ b/tools/benchmark/build.gradle.kts
@@ -7,7 +7,7 @@
 import com.datadog.gradle.config.AndroidConfig
 import com.datadog.gradle.config.androidLibraryConfig
 import com.datadog.gradle.config.dependencyUpdateConfig
-import com.datadog.gradle.config.java17
+import com.datadog.gradle.config.java11
 import com.datadog.gradle.config.junitConfig
 import com.datadog.gradle.config.kotlinConfig
 import com.datadog.gradle.config.publishingConfig
@@ -28,7 +28,7 @@ android {
     }
     namespace = "com.datadog.tools.benchmark"
     compileOptions {
-        java17()
+        java11()
     }
 }
 


### PR DESCRIPTION
### What does this PR do?

I noticed that some public modules were inconsistent in terms of the Java bytecode version produced, they had Java 17. Fixing it to align with other modules, to use Java 11.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

