### PR TITLE
RUM-5873: Update Session Replay integration test payloads

### DIFF
--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/consent_granted_sr_test_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/consent_granted_sr_test_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,17 +14,9 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 172,
-        "height": 19,
         "type": "text",
         "text": "Welcome to Session Replay",
         "textStyle": {
@@ -46,23 +38,11 @@
         }
       },
       {
-        "width": 88,
-        "height": 48,
-        "shapeStyle": {
-          "backgroundColor": "#5a595bff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 88,
-        "height": 48,
-        "border": {
-          "color": "#000000ff",
-          "width": 1
-        },
         "type": "text",
-        "text": "Click Me",
+        "text": "CLICK ME",
         "textStyle": {
           "family": "roboto, sans-serif",
           "size": 14,
@@ -72,20 +52,14 @@
           "padding": {
             "top": 14,
             "bottom": 14,
-            "left": 11,
-            "right": 11
+            "left": 12,
+            "right": 12
           },
           "alignment": {
             "horizontal": "center",
             "vertical": "center"
           }
         }
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_checkbox_and_radio_fields_allow_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_checkbox_and_radio_fields_allow_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,17 +14,9 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Default CheckBox",
         "textStyle": {
@@ -46,17 +38,10 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "border": {
-          "color": "#a538afff",
-          "width": 1
-        },
-        "type": "shape"
+        "type": "image",
+        "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "App Compat CheckBox",
         "textStyle": {
@@ -78,17 +63,10 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "border": {
-          "color": "#cc0000ff",
-          "width": 1
-        },
-        "type": "shape"
+        "type": "image",
+        "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Material CheckBox",
         "textStyle": {
@@ -110,17 +88,10 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "border": {
-          "color": "#ffbb33ff",
-          "width": 1
-        },
-        "type": "shape"
+        "type": "image",
+        "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Default Radio",
         "textStyle": {
@@ -142,21 +113,10 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "shapeStyle": {
-          "opacity": 1.0,
-          "cornerRadius": 10
-        },
-        "border": {
-          "color": "#a538afff",
-          "width": 1
-        },
-        "type": "shape"
+        "type": "image",
+        "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "App Compat Radio",
         "textStyle": {
@@ -178,21 +138,10 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "shapeStyle": {
-          "opacity": 1.0,
-          "cornerRadius": 10
-        },
-        "border": {
-          "color": "#cc0000ff",
-          "width": 1
-        },
-        "type": "shape"
+        "type": "image",
+        "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Material Radio",
         "textStyle": {
@@ -214,23 +163,8 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "shapeStyle": {
-          "opacity": 1.0,
-          "cornerRadius": 10
-        },
-        "border": {
-          "color": "#ffbb33ff",
-          "width": 1
-        },
-        "type": "shape"
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
+        "type": "image",
+        "isEmpty": false
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_checkbox_and_radio_fields_mask_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_checkbox_and_radio_fields_mask_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,17 +14,9 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "xxxxxxx xxxxxxxx",
         "textStyle": {
@@ -46,8 +38,6 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
         "border": {
           "color": "#a538afff",
           "width": 1
@@ -55,8 +45,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "xxx xxxxxx xxxxxxxx",
         "textStyle": {
@@ -78,8 +66,6 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
         "border": {
           "color": "#cc0000ff",
           "width": 1
@@ -87,8 +73,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "xxxxxxxx xxxxxxxx",
         "textStyle": {
@@ -110,8 +94,6 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
         "border": {
           "color": "#ffbb33ff",
           "width": 1
@@ -119,8 +101,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "xxxxxxx xxxxx",
         "textStyle": {
@@ -142,12 +122,6 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "shapeStyle": {
-          "opacity": 1.0,
-          "cornerRadius": 10
-        },
         "border": {
           "color": "#a538afff",
           "width": 1
@@ -155,8 +129,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "xxx xxxxxx xxxxx",
         "textStyle": {
@@ -178,12 +150,6 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "shapeStyle": {
-          "opacity": 1.0,
-          "cornerRadius": 10
-        },
         "border": {
           "color": "#cc0000ff",
           "width": 1
@@ -191,8 +157,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "xxxxxxxx xxxxx",
         "textStyle": {
@@ -214,23 +178,11 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "shapeStyle": {
-          "opacity": 1.0,
-          "cornerRadius": 10
-        },
         "border": {
           "color": "#ffbb33ff",
           "width": 1
         },
         "type": "shape"
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_checkbox_and_radio_fields_mask_user_input_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_checkbox_and_radio_fields_mask_user_input_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,17 +14,9 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Default CheckBox",
         "textStyle": {
@@ -46,8 +38,6 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
         "border": {
           "color": "#a538afff",
           "width": 1
@@ -55,8 +45,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "App Compat CheckBox",
         "textStyle": {
@@ -78,8 +66,6 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
         "border": {
           "color": "#cc0000ff",
           "width": 1
@@ -87,8 +73,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Material CheckBox",
         "textStyle": {
@@ -110,8 +94,6 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
         "border": {
           "color": "#ffbb33ff",
           "width": 1
@@ -119,8 +101,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Default Radio",
         "textStyle": {
@@ -142,12 +122,6 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "shapeStyle": {
-          "opacity": 1.0,
-          "cornerRadius": 10
-        },
         "border": {
           "color": "#a538afff",
           "width": 1
@@ -155,8 +129,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "App Compat Radio",
         "textStyle": {
@@ -178,12 +150,6 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "shapeStyle": {
-          "opacity": 1.0,
-          "cornerRadius": 10
-        },
         "border": {
           "color": "#cc0000ff",
           "width": 1
@@ -191,8 +157,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Material Radio",
         "textStyle": {
@@ -214,23 +178,11 @@
         }
       },
       {
-        "width": 16,
-        "height": 16,
-        "shapeStyle": {
-          "opacity": 1.0,
-          "cornerRadius": 10
-        },
         "border": {
           "color": "#ffbb33ff",
           "width": 1
         },
         "type": "shape"
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_allow_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_allow_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,29 +14,15 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 80,
-        "height": 80,
-        "shapeStyle": {
-          "backgroundColor": "#5a595bff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 80,
-        "height": 84,
         "clip": {
           "top": 2,
-          "bottom": 2,
+          "bottom": 3,
           "left": 0,
           "right": 0
         },
@@ -44,20 +30,12 @@
         "isEmpty": false
       },
       {
-        "width": 80,
-        "height": 80,
-        "shapeStyle": {
-          "backgroundColor": "#5a595bff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 80,
-        "height": 84,
         "clip": {
           "top": 2,
-          "bottom": 2,
+          "bottom": 3,
           "left": 0,
           "right": 0
         },
@@ -65,31 +43,17 @@
         "isEmpty": false
       },
       {
-        "width": 80,
-        "height": 80,
-        "shapeStyle": {
-          "backgroundColor": "#5a595bff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 80,
-        "height": 84,
         "clip": {
           "top": 2,
-          "bottom": 2,
+          "bottom": 3,
           "left": 0,
           "right": 0
         },
         "type": "image",
         "isEmpty": false
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_mask_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_mask_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,82 +14,37 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 80,
-        "height": 80,
-        "shapeStyle": {
-          "backgroundColor": "#5a595bff",
-          "opacity": 1.0
-        },
-        "type": "shape"
-      },
-      {
-        "width": 80,
-        "height": 84,
         "clip": {
           "top": 2,
-          "bottom": 2,
+          "bottom": 3,
           "left": 0,
           "right": 0
         },
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 80,
-        "height": 80,
-        "shapeStyle": {
-          "backgroundColor": "#5a595bff",
-          "opacity": 1.0
-        },
-        "type": "shape"
-      },
-      {
-        "width": 80,
-        "height": 84,
-        "clip": {
-          "top": 2,
-          "bottom": 2,
-          "left": 0,
-          "right": 0
-        },
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 80,
-        "height": 80,
-        "shapeStyle": {
-          "backgroundColor": "#5a595bff",
-          "opacity": 1.0
-        },
-        "type": "shape"
-      },
-      {
-        "width": 80,
-        "height": 84,
-        "clip": {
-          "top": 2,
-          "bottom": 2,
-          "left": 0,
-          "right": 0
-        },
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 411,
-        "height": 56,
         "type": "placeholder",
-        "label": "Toolbar"
+        "label": "Image"
+      },
+      {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
+        "type": "placeholder",
+        "label": "Image"
+      },
+      {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
+        "type": "placeholder",
+        "label": "Image"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_mask_user_input_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_mask_user_input_payload.json
@@ -1,103 +1,60 @@
-[
-  {
-    "type": 4,
-    "data": {
-      "width": 411,
-      "height": 914
-    }
-  },
-  {
-    "type": 6,
-    "data": {
-      "has_focus": true
-    }
-  },
-  {
-    "type": 10,
-    "data": {
-      "wireframes": [
-        {
-          "width": 411,
-          "height": 914,
-          "shapeStyle": {
-            "backgroundColor": "#303030ff",
-            "opacity": 1.0
-          },
-          "type": "shape"
-        },
-        {
-          "width": 80,
-          "height": 80,
-          "shapeStyle": {
-            "backgroundColor": "#ffffffff",
-            "opacity": 1.0
-          },
-          "type": "shape"
-        },
-        {
-          "width": 80,
-          "height": 84,
-          "clip": {
-            "top": 2,
-            "bottom": 2,
-            "left": 0,
-            "right": 0
-          },
-          "type": "image",
-          "mimeType": "image/webp",
-          "isEmpty": false
-        },
-        {
-          "width": 80,
-          "height": 80,
-          "shapeStyle": {
-            "backgroundColor": "#ffffffff",
-            "opacity": 1.0
-          },
-          "type": "shape"
-        },
-        {
-          "width": 80,
-          "height": 84,
-          "clip": {
-            "top": 2,
-            "bottom": 2,
-            "left": 0,
-            "right": 0
-          },
-          "type": "image",
-          "mimeType": "image/webp",
-          "isEmpty": false
-        },
-        {
-          "width": 80,
-          "height": 80,
-          "shapeStyle": {
-            "backgroundColor": "#ffffffff",
-            "opacity": 1.0
-          },
-          "type": "shape"
-        },
-        {
-          "width": 80,
-          "height": 84,
-          "clip": {
-            "top": 2,
-            "bottom": 2,
-            "left": 0,
-            "right": 0
-          },
-          "type": "image",
-          "mimeType": "image/webp",
-          "isEmpty": false
-        },
-        {
-          "width": 411,
-          "height": 56,
-          "type": "placeholder",
-          "label": "Toolbar"
-        }
-      ]
-    }
+[{
+  "type": 4,
+  "data": {
+    "width": 320,
+    "height": 640
   }
-]
+}, {
+  "type": 6,
+  "data": {
+    "has_focus": true
+  }
+}, {
+  "type": 10,
+  "data": {
+    "wireframes": [
+      {
+        "type": "shape"
+      },
+      {
+        "type": "shape"
+      },
+      {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
+        "type": "image",
+        "isEmpty": false
+      },
+      {
+        "type": "shape"
+      },
+      {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
+        "type": "image",
+        "isEmpty": false
+      },
+      {
+        "type": "shape"
+      },
+      {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
+        "type": "image",
+        "isEmpty": false
+      }
+    ]
+  }
+}]

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_allow_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_allow_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,20 +14,12 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 80,
-        "height": 84,
         "clip": {
           "top": 2,
-          "bottom": 2,
+          "bottom": 3,
           "left": 0,
           "right": 0
         },
@@ -35,22 +27,14 @@
         "isEmpty": false
       },
       {
-        "width": 80,
-        "height": 84,
         "clip": {
           "top": 2,
-          "bottom": 2,
+          "bottom": 3,
           "left": 0,
           "right": 0
         },
         "type": "image",
         "isEmpty": false
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,43 +14,27 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 80,
-        "height": 84,
         "clip": {
           "top": 2,
-          "bottom": 2,
+          "bottom": 3,
           "left": 0,
           "right": 0
         },
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 80,
-        "height": 84,
-        "clip": {
-          "top": 2,
-          "bottom": 2,
-          "left": 0,
-          "right": 0
-        },
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 411,
-        "height": 56,
         "type": "placeholder",
-        "label": "Toolbar"
+        "label": "Image"
+      },
+      {
+        "clip": {
+          "top": 2,
+          "bottom": 3,
+          "left": 0,
+          "right": 0
+        },
+        "type": "placeholder",
+        "label": "Image"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_user_input_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_user_input_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,20 +14,12 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 80,
-        "height": 84,
         "clip": {
           "top": 2,
-          "bottom": 2,
+          "bottom": 3,
           "left": 0,
           "right": 0
         },
@@ -35,22 +27,14 @@
         "isEmpty": false
       },
       {
-        "width": 80,
-        "height": 84,
         "clip": {
           "top": 2,
-          "bottom": 2,
+          "bottom": 3,
           "left": 0,
           "right": 0
         },
         "type": "image",
         "isEmpty": false
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_sensitive_fields_allow_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_sensitive_fields_allow_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,36 +14,26 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -52,27 +42,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -81,27 +67,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -110,27 +92,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -139,27 +117,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -168,27 +142,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -197,39 +167,29 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
             "vertical": "center"
           }
         }
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_sensitive_fields_mask_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_sensitive_fields_mask_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,222 +14,182 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "text",
-        "text": "***",
-        "textStyle": {
-          "family": "roboto, sans-serif",
-          "size": 17,
-          "color": "#ffffffff"
-        },
-        "textPosition": {
-          "padding": {
-            "top": 9,
-            "bottom": 11,
-            "left": 3,
-            "right": 3
-          },
-          "alignment": {
-            "horizontal": "left",
-            "vertical": "center"
-          }
-        }
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "text",
-        "text": "***",
-        "textStyle": {
-          "family": "roboto, sans-serif",
-          "size": 17,
-          "color": "#ffffffff"
-        },
-        "textPosition": {
-          "padding": {
-            "top": 9,
-            "bottom": 11,
-            "left": 3,
-            "right": 3
-          },
-          "alignment": {
-            "horizontal": "left",
-            "vertical": "center"
-          }
-        }
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "text",
-        "text": "***",
-        "textStyle": {
-          "family": "roboto, sans-serif",
-          "size": 17,
-          "color": "#ffffffff"
-        },
-        "textPosition": {
-          "padding": {
-            "top": 9,
-            "bottom": 11,
-            "left": 3,
-            "right": 3
-          },
-          "alignment": {
-            "horizontal": "left",
-            "vertical": "center"
-          }
-        }
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "text",
-        "text": "***",
-        "textStyle": {
-          "family": "roboto, sans-serif",
-          "size": 17,
-          "color": "#ffffffff"
-        },
-        "textPosition": {
-          "padding": {
-            "top": 9,
-            "bottom": 11,
-            "left": 3,
-            "right": 3
-          },
-          "alignment": {
-            "horizontal": "left",
-            "vertical": "center"
-          }
-        }
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "text",
-        "text": "***",
-        "textStyle": {
-          "family": "roboto, sans-serif",
-          "size": 17,
-          "color": "#ffffffff"
-        },
-        "textPosition": {
-          "padding": {
-            "top": 9,
-            "bottom": 11,
-            "left": 3,
-            "right": 3
-          },
-          "alignment": {
-            "horizontal": "left",
-            "vertical": "center"
-          }
-        }
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "text",
-        "text": "***",
-        "textStyle": {
-          "family": "roboto, sans-serif",
-          "size": 17,
-          "color": "#ffffffff"
-        },
-        "textPosition": {
-          "padding": {
-            "top": 9,
-            "bottom": 11,
-            "left": 3,
-            "right": 3
-          },
-          "alignment": {
-            "horizontal": "left",
-            "vertical": "center"
-          }
-        }
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
-      },
-      {
-        "width": 395,
-        "height": 44,
-        "type": "text",
-        "text": "***",
-        "textStyle": {
-          "family": "roboto, sans-serif",
-          "size": 17,
-          "color": "#ffffffff"
-        },
-        "textPosition": {
-          "padding": {
-            "top": 9,
-            "bottom": 11,
-            "left": 3,
-            "right": 3
-          },
-          "alignment": {
-            "horizontal": "left",
-            "vertical": "center"
-          }
-        }
-      },
-      {
-        "width": 411,
-        "height": 56,
         "type": "placeholder",
-        "label": "Toolbar"
+        "label": "Image"
+      },
+      {
+        "type": "text",
+        "text": "***",
+        "textStyle": {
+          "family": "roboto, sans-serif",
+          "size": 18,
+          "color": "#ffffffff"
+        },
+        "textPosition": {
+          "padding": {
+            "top": 10,
+            "bottom": 11,
+            "left": 4,
+            "right": 4
+          },
+          "alignment": {
+            "horizontal": "left",
+            "vertical": "center"
+          }
+        }
+      },
+      {
+        "type": "placeholder",
+        "label": "Image"
+      },
+      {
+        "type": "text",
+        "text": "***",
+        "textStyle": {
+          "family": "roboto, sans-serif",
+          "size": 18,
+          "color": "#ffffffff"
+        },
+        "textPosition": {
+          "padding": {
+            "top": 10,
+            "bottom": 11,
+            "left": 4,
+            "right": 4
+          },
+          "alignment": {
+            "horizontal": "left",
+            "vertical": "center"
+          }
+        }
+      },
+      {
+        "type": "placeholder",
+        "label": "Image"
+      },
+      {
+        "type": "text",
+        "text": "***",
+        "textStyle": {
+          "family": "roboto, sans-serif",
+          "size": 18,
+          "color": "#ffffffff"
+        },
+        "textPosition": {
+          "padding": {
+            "top": 10,
+            "bottom": 11,
+            "left": 4,
+            "right": 4
+          },
+          "alignment": {
+            "horizontal": "left",
+            "vertical": "center"
+          }
+        }
+      },
+      {
+        "type": "placeholder",
+        "label": "Image"
+      },
+      {
+        "type": "text",
+        "text": "***",
+        "textStyle": {
+          "family": "roboto, sans-serif",
+          "size": 18,
+          "color": "#ffffffff"
+        },
+        "textPosition": {
+          "padding": {
+            "top": 10,
+            "bottom": 11,
+            "left": 4,
+            "right": 4
+          },
+          "alignment": {
+            "horizontal": "left",
+            "vertical": "center"
+          }
+        }
+      },
+      {
+        "type": "placeholder",
+        "label": "Image"
+      },
+      {
+        "type": "text",
+        "text": "***",
+        "textStyle": {
+          "family": "roboto, sans-serif",
+          "size": 18,
+          "color": "#ffffffff"
+        },
+        "textPosition": {
+          "padding": {
+            "top": 10,
+            "bottom": 11,
+            "left": 4,
+            "right": 4
+          },
+          "alignment": {
+            "horizontal": "left",
+            "vertical": "center"
+          }
+        }
+      },
+      {
+        "type": "placeholder",
+        "label": "Image"
+      },
+      {
+        "type": "text",
+        "text": "***",
+        "textStyle": {
+          "family": "roboto, sans-serif",
+          "size": 18,
+          "color": "#ffffffff"
+        },
+        "textPosition": {
+          "padding": {
+            "top": 10,
+            "bottom": 11,
+            "left": 4,
+            "right": 4
+          },
+          "alignment": {
+            "horizontal": "left",
+            "vertical": "center"
+          }
+        }
+      },
+      {
+        "type": "placeholder",
+        "label": "Image"
+      },
+      {
+        "type": "text",
+        "text": "***",
+        "textStyle": {
+          "family": "roboto, sans-serif",
+          "size": 18,
+          "color": "#ffffffff"
+        },
+        "textPosition": {
+          "padding": {
+            "top": 10,
+            "bottom": 11,
+            "left": 4,
+            "right": 4
+          },
+          "alignment": {
+            "horizontal": "left",
+            "vertical": "center"
+          }
+        }
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_sensitive_fields_mask_user_input_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_sensitive_fields_mask_user_input_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,36 +14,26 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -52,27 +42,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -81,27 +67,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -110,27 +92,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -139,27 +117,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -168,27 +142,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -197,39 +167,29 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
             "vertical": "center"
           }
         }
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_text_fields_allow_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_text_fields_allow_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,17 +14,9 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "Default Text View",
         "textStyle": {
@@ -46,8 +38,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "Material Text View",
         "textStyle": {
@@ -69,8 +59,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "App Compat Text View",
         "textStyle": {
@@ -92,27 +80,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "Edit Text View",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#a538afff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -121,27 +105,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "Default Auto Complete Text View",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffbb33ff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -150,27 +130,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "App Compat Edit Text View",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffbb33ff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -179,27 +155,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "App Compat Auto Complete Text View",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#a538afff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
-            "bottom": 11,
-            "left": 3,
-            "right": 3
+            "top": 20,
+            "bottom": 21,
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -208,27 +180,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "Material Auto Complete Text View",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#a538afff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -237,8 +205,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Checked Text View",
         "textStyle": {
@@ -249,7 +215,7 @@
         "textPosition": {
           "padding": {
             "top": 0,
-            "bottom": 12,
+            "bottom": 13,
             "left": 0,
             "right": 32
           },
@@ -260,17 +226,10 @@
         }
       },
       {
-        "width": 19,
-        "height": 19,
-        "border": {
-          "color": "#ffffffff",
-          "width": 1
-        },
-        "type": "shape"
+        "type": "image",
+        "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "App Compat Checked Text View",
         "textStyle": {
@@ -281,7 +240,7 @@
         "textPosition": {
           "padding": {
             "top": 0,
-            "bottom": 12,
+            "bottom": 13,
             "left": 0,
             "right": 32
           },
@@ -292,23 +251,8 @@
         }
       },
       {
-        "width": 19,
-        "height": 19,
-        "shapeStyle": {
-          "backgroundColor": "#ffffffff",
-          "opacity": 1.0
-        },
-        "border": {
-          "color": "#ffffffff",
-          "width": 1
-        },
-        "type": "shape"
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
+        "type": "image",
+        "isEmpty": false
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_text_fields_mask_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_text_fields_mask_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,17 +14,9 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "xxxxxxx xxxx xxxx",
         "textStyle": {
@@ -46,8 +38,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "xxxxxxxx xxxx xxxx",
         "textStyle": {
@@ -69,8 +59,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "xxx xxxxxx xxxx xxxx",
         "textStyle": {
@@ -92,27 +80,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
+        "type": "placeholder",
+        "label": "Image"
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
-        "text": "***",
+        "text": "xxxx xxxx xxxx",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#a538afff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -121,27 +105,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
+        "type": "placeholder",
+        "label": "Image"
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
-        "text": "***",
+        "text": "xxxxxxx xxxx xxxxxxxx xxxx xxxx",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffbb33ff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -150,27 +130,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
+        "type": "placeholder",
+        "label": "Image"
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
-        "text": "***",
+        "text": "xxx xxxxxx xxxx xxxx xxxx",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffbb33ff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -179,27 +155,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
+        "type": "placeholder",
+        "label": "Image"
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
-        "text": "***",
+        "text": "xxx xxxxxx xxxx xxxxxxxx xxxx xxxx",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#a538afff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
-            "bottom": 11,
-            "left": 3,
-            "right": 3
+            "top": 20,
+            "bottom": 21,
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -208,27 +180,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
-        "type": "image",
-        "isEmpty": false
+        "type": "placeholder",
+        "label": "Image"
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
-        "text": "***",
+        "text": "xxxxxxxx xxxx xxxxxxxx xxxx xxxx",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#a538afff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -237,8 +205,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "xxxxxxx xxxx xxxx",
         "textStyle": {
@@ -249,7 +215,7 @@
         "textPosition": {
           "padding": {
             "top": 0,
-            "bottom": 12,
+            "bottom": 13,
             "left": 0,
             "right": 32
           },
@@ -260,8 +226,6 @@
         }
       },
       {
-        "width": 19,
-        "height": 19,
         "border": {
           "color": "#ffffffff",
           "width": 1
@@ -269,8 +233,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "xxx xxxxxx xxxxxxx xxxx xxxx",
         "textStyle": {
@@ -281,7 +243,7 @@
         "textPosition": {
           "padding": {
             "top": 0,
-            "bottom": 12,
+            "bottom": 13,
             "left": 0,
             "right": 32
           },
@@ -292,19 +254,11 @@
         }
       },
       {
-        "width": 19,
-        "height": 19,
         "border": {
           "color": "#ffffffff",
           "width": 1
         },
         "type": "shape"
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_text_fields_mask_user_input_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_text_fields_mask_user_input_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,17 +14,9 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "Default Text View",
         "textStyle": {
@@ -46,8 +38,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "Material Text View",
         "textStyle": {
@@ -69,8 +59,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "App Compat Text View",
         "textStyle": {
@@ -92,27 +80,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "Edit Text View",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#a538afff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -121,27 +105,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "Default Auto Complete Text View",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffbb33ff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -150,27 +130,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "App Compat Edit Text View",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffbb33ff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -179,27 +155,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "App Compat Auto Complete Text View",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#a538afff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
-            "bottom": 11,
-            "left": 3,
-            "right": 3
+            "top": 20,
+            "bottom": 21,
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -208,27 +180,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "Material Auto Complete Text View",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#a538afff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -237,8 +205,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Checked Text View",
         "textStyle": {
@@ -249,7 +215,7 @@
         "textPosition": {
           "padding": {
             "top": 0,
-            "bottom": 12,
+            "bottom": 13,
             "left": 0,
             "right": 32
           },
@@ -260,8 +226,6 @@
         }
       },
       {
-        "width": 19,
-        "height": 19,
         "border": {
           "color": "#ffffffff",
           "width": 1
@@ -269,8 +233,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "App Compat Checked Text View",
         "textStyle": {
@@ -281,7 +243,7 @@
         "textPosition": {
           "padding": {
             "top": 0,
-            "bottom": 12,
+            "bottom": 13,
             "left": 0,
             "right": 32
           },
@@ -292,19 +254,11 @@
         }
       },
       {
-        "width": 19,
-        "height": 19,
         "border": {
           "color": "#ffffffff",
           "width": 1
         },
         "type": "shape"
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_text_fields_with_input_mask_user_input_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_text_fields_with_input_mask_user_input_payload.json
@@ -1,8 +1,8 @@
 [{
   "type": 4,
   "data": {
-    "width": 411,
-    "height": 914
+    "width": 320,
+    "height": 640
   }
 }, {
   "type": 6,
@@ -14,17 +14,9 @@
   "data": {
     "wireframes": [
       {
-        "width": 411,
-        "height": 914,
-        "shapeStyle": {
-          "backgroundColor": "#303030ff",
-          "opacity": 1.0
-        },
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "Default Text View",
         "textStyle": {
@@ -46,8 +38,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "Material Text View",
         "textStyle": {
@@ -69,8 +59,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 19,
         "type": "text",
         "text": "App Compat Text View",
         "textStyle": {
@@ -92,27 +80,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -121,27 +105,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -150,27 +130,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -179,27 +155,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -208,27 +180,23 @@
         }
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "image",
         "isEmpty": false
       },
       {
-        "width": 395,
-        "height": 44,
         "type": "text",
         "text": "***",
         "textStyle": {
           "family": "roboto, sans-serif",
-          "size": 17,
+          "size": 18,
           "color": "#ffffffff"
         },
         "textPosition": {
           "padding": {
-            "top": 9,
+            "top": 10,
             "bottom": 11,
-            "left": 3,
-            "right": 3
+            "left": 4,
+            "right": 4
           },
           "alignment": {
             "horizontal": "left",
@@ -237,8 +205,6 @@
         }
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "Checked Text View",
         "textStyle": {
@@ -249,7 +215,7 @@
         "textPosition": {
           "padding": {
             "top": 0,
-            "bottom": 12,
+            "bottom": 13,
             "left": 0,
             "right": 32
           },
@@ -260,8 +226,6 @@
         }
       },
       {
-        "width": 19,
-        "height": 19,
         "border": {
           "color": "#ffffffff",
           "width": 1
@@ -269,8 +233,6 @@
         "type": "shape"
       },
       {
-        "width": 395,
-        "height": 32,
         "type": "text",
         "text": "App Compat Checked Text View",
         "textStyle": {
@@ -281,7 +243,7 @@
         "textPosition": {
           "padding": {
             "top": 0,
-            "bottom": 12,
+            "bottom": 13,
             "left": 0,
             "right": 32
           },
@@ -292,19 +254,11 @@
         }
       },
       {
-        "width": 19,
-        "height": 19,
         "border": {
           "color": "#ffffffff",
           "width": 1
         },
         "type": "shape"
-      },
-      {
-        "width": 411,
-        "height": 56,
-        "type": "placeholder",
-        "label": "Toolbar"
       }
     ]
   }

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayTest.kt
@@ -255,6 +255,9 @@ internal abstract class BaseSessionReplayTest<R : Activity> {
                         wireframeJson.remove("y")
                         wireframeJson.remove("base64")
                         wireframeJson.remove("resourceId")
+                        wireframeJson.remove("width")
+                        wireframeJson.remove("height")
+                        wireframeJson.remove("shapeStyle")
                         wireframeJson
                     }?.fold(JsonArray()) { acc, jsonObject ->
                         acc.add(jsonObject)
@@ -294,7 +297,7 @@ internal abstract class BaseSessionReplayTest<R : Activity> {
     }
 
     companion object {
-        internal val INITIAL_WAIT_MS = TimeUnit.SECONDS.toMillis(60)
+        internal val INITIAL_WAIT_MS = TimeUnit.SECONDS.toMillis(30)
         private const val UI_THREAD_DELAY_IN_MS = 1000L
         private const val PAYLOAD_UPDATE_REQUEST = "updateSrPayloads"
         private val SEGMENT_FORM_DATA_REGEX =

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/ConsentGrantedSrTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/ConsentGrantedSrTest.kt
@@ -6,9 +6,10 @@
 
 package com.datadog.android.sdk.integration.sessionreplay
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.rules.SessionReplayTestRule
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -21,8 +22,9 @@ internal class ConsentGrantedSrTest : BaseSessionReplayTest<SessionReplayPlaygro
         keepRequests = true
     )
 
-    @Ignore("Flakiness in CI, unsolved yet")
+    // TODO RUM-6839: Fix test on API 21
     @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsAllowTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.chekboxandradio
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayRadioCheckboxFieldsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,9 +28,9 @@ internal class SrCheckBoxAndRadioFieldsAllowTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsMaskTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.chekboxandradio
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayRadioCheckboxFieldsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,9 +28,9 @@ internal class SrCheckBoxAndRadioFieldsMaskTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsMaskUserInputTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.chekboxandradio
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayRadioCheckboxFieldsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,9 +28,9 @@ internal class SrCheckBoxAndRadioFieldsMaskUserInputTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsAllowTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.imagebuttons
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImageButtonsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,9 +28,9 @@ internal class SrImageButtonsAllowTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
-    @Ignore("Flakiness in CI, unsolved yet")
+    // TODO RUM-6839: Fix test on API 21
     @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.imagebuttons
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImageButtonsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,9 +28,9 @@ internal class SrImageButtonsMaskTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
-    @Ignore("Flakiness in CI, unsolved yet")
+    // TODO RUM-6839: Fix test on API 21
     @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskUserInputTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.imagebuttons
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImageButtonsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,9 +28,9 @@ internal class SrImageButtonsMaskUserInputTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
-    @Ignore("Flakiness in CI, unsolved yet")
+    // TODO RUM-6839: Fix test on API 21
     @Test
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesAllowTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.images
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImagesActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,9 +28,9 @@ internal class SrImagesAllowTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesMaskTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.images
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImagesActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,9 +28,9 @@ internal class SrImagesMaskTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesMaskUserInputTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.images
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImagesActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,9 +28,9 @@ internal class SrImagesMaskUserInputTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsAllowTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.sensitivefields
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplaySensitiveFieldsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,9 +27,9 @@ internal class SrSensitiveFieldsAllowTest : BaseSessionReplayTest<SessionReplayS
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsMaskTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.sensitivefields
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplaySensitiveFieldsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,9 +27,9 @@ internal class SrSensitiveFieldsMaskTest : BaseSessionReplayTest<SessionReplaySe
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsMaskUserInputTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.sensitivefields
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplaySensitiveFieldsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,9 +27,9 @@ internal class SrSensitiveFieldsMaskUserInputTest : BaseSessionReplayTest<Sessio
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsAllowTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.textfields
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayTextFieldsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,9 +27,9 @@ internal class SrTextFieldsAllowTest : BaseSessionReplayTest<SessionReplayTextFi
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsMaskTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.textfields
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayTextFieldsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,9 +27,9 @@ internal class SrTextFieldsMaskTest : BaseSessionReplayTest<SessionReplayTextFie
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsMaskUserInputTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.textfields
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayTextFieldsActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -26,9 +27,9 @@ internal class SrTextFieldsMaskUserInputTest : BaseSessionReplayTest<SessionRepl
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsWithInputMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsWithInputMaskUserInputTest.kt
@@ -6,13 +6,14 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.textfields
 
+import android.os.Build
+import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayTextFieldsWithInputActivity
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import com.datadog.android.sdk.utils.SR_PRIVACY_LEVEL
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 
@@ -27,9 +28,9 @@ internal class SrTextFieldsWithInputMaskUserInputTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO: RUM-5873 Fix these tests and remove the @Ignore annotation
+    // TODO RUM-6839: Fix test on API 21
     @Test
-    @Ignore("These tests were not maintained anymore and they need to be fixed")
+    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayActivity.kt
@@ -54,6 +54,7 @@ internal abstract class BaseSessionReplayActivity : AppCompatActivity() {
         )
         featureActivations.shuffled(Random(intent.getForgeSeed()))
             .forEach { it() }
+        supportActionBar?.hide()
     }
 
     @Suppress("DEPRECATION")


### PR DESCRIPTION
### What does this PR do?

Updates Session replay integration test payloads by using the same config of emulator as gitlab ci,
and remove all the `@ignore` for SR tests.

Some other changes:
* `@Ignore` is removed but `@SdkSuppress` is added to ignore the SR instrumented tests on legacy-min-api task,  because there is an underlying issue make test block forever.
* In test activity, toolbar is hidden now, because from API 35, `edgeToEdge` is enabled by default, which makes top content covered by the toolbar, it can lead different wireframes.

### Motivation

RUM-5873

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

