### PR TITLE
Prevent obfuscation of Fine Grained Masking enums

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -1,7 +1,7 @@
 interface com.datadog.android.sessionreplay.ExtensionSupport
   fun getCustomViewMappers(): List<MapperTypeWrapper<*>>
   fun getOptionSelectorDetectors(): List<com.datadog.android.sessionreplay.recorder.OptionSelectorDetector>
-enum com.datadog.android.sessionreplay.ImagePrivacy
+enum com.datadog.android.sessionreplay.ImagePrivacy : PrivacyLevel
   - MASK_NONE
   - MASK_LARGE_ONLY
   - MASK_ALL
@@ -9,6 +9,7 @@ data class com.datadog.android.sessionreplay.MapperTypeWrapper<T: android.view.V
   constructor(Class<T>, com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper<T>)
   fun supportsView(android.view.View): Boolean
   fun getUnsafeMapper(): com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper<android.view.View>
+interface com.datadog.android.sessionreplay.PrivacyLevel
 fun android.view.View.setSessionReplayHidden(Boolean)
 fun android.view.View.setSessionReplayImagePrivacy(ImagePrivacy?)
 fun android.view.View.setSessionReplayTextAndInputPrivacy(TextAndInputPrivacy?)
@@ -41,11 +42,11 @@ class com.datadog.android.sessionreplay.SystemRequirementsConfiguration
   companion object 
     val BASIC: SystemRequirementsConfiguration
     val NONE: SystemRequirementsConfiguration
-enum com.datadog.android.sessionreplay.TextAndInputPrivacy
+enum com.datadog.android.sessionreplay.TextAndInputPrivacy : PrivacyLevel
   - MASK_SENSITIVE_INPUTS
   - MASK_ALL_INPUTS
   - MASK_ALL
-enum com.datadog.android.sessionreplay.TouchPrivacy
+enum com.datadog.android.sessionreplay.TouchPrivacy : PrivacyLevel
   - SHOW
   - HIDE
 data class com.datadog.android.sessionreplay.recorder.MappingContext

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -3,7 +3,7 @@ public abstract interface class com/datadog/android/sessionreplay/ExtensionSuppo
 	public abstract fun getOptionSelectorDetectors ()Ljava/util/List;
 }
 
-public final class com/datadog/android/sessionreplay/ImagePrivacy : java/lang/Enum {
+public final class com/datadog/android/sessionreplay/ImagePrivacy : java/lang/Enum, com/datadog/android/sessionreplay/PrivacyLevel {
 	public static final field MASK_ALL Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public static final field MASK_LARGE_ONLY Lcom/datadog/android/sessionreplay/ImagePrivacy;
 	public static final field MASK_NONE Lcom/datadog/android/sessionreplay/ImagePrivacy;
@@ -20,6 +20,9 @@ public final class com/datadog/android/sessionreplay/MapperTypeWrapper {
 	public fun hashCode ()I
 	public final fun supportsView (Landroid/view/View;)Z
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/datadog/android/sessionreplay/PrivacyLevel {
 }
 
 public final class com/datadog/android/sessionreplay/PrivacyOverrideExtensionsKt {
@@ -85,7 +88,7 @@ public final class com/datadog/android/sessionreplay/SystemRequirementsConfigura
 	public final fun getNONE ()Lcom/datadog/android/sessionreplay/SystemRequirementsConfiguration;
 }
 
-public final class com/datadog/android/sessionreplay/TextAndInputPrivacy : java/lang/Enum {
+public final class com/datadog/android/sessionreplay/TextAndInputPrivacy : java/lang/Enum, com/datadog/android/sessionreplay/PrivacyLevel {
 	public static final field MASK_ALL Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 	public static final field MASK_ALL_INPUTS Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 	public static final field MASK_SENSITIVE_INPUTS Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
@@ -93,7 +96,7 @@ public final class com/datadog/android/sessionreplay/TextAndInputPrivacy : java/
 	public static fun values ()[Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;
 }
 
-public final class com/datadog/android/sessionreplay/TouchPrivacy : java/lang/Enum {
+public final class com/datadog/android/sessionreplay/TouchPrivacy : java/lang/Enum, com/datadog/android/sessionreplay/PrivacyLevel {
 	public static final field HIDE Lcom/datadog/android/sessionreplay/TouchPrivacy;
 	public static final field SHOW Lcom/datadog/android/sessionreplay/TouchPrivacy;
 	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/sessionreplay/TouchPrivacy;

--- a/features/dd-sdk-android-session-replay/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay/consumer-rules.pro
@@ -7,3 +7,6 @@
 -keepnames class com.datadog.android.sessionreplay.internal.recorder.listener.WindowsOnDrawListener
 -keepnames class * extends com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper
 -keepnames class * extends com.datadog.android.sessionreplay.internal.async.RecordedDataQueueItem
+
+# Keep the fine grained masking level enums
+-keepnames enum * extends com.datadog.android.sessionreplay.PrivacyLevel { *; }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ImagePrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ImagePrivacy.kt
@@ -12,7 +12,7 @@ package com.datadog.android.sessionreplay
  * @see ImagePrivacy.MASK_LARGE_ONLY
  * @see ImagePrivacy.MASK_ALL
  */
-enum class ImagePrivacy {
+enum class ImagePrivacy : PrivacyLevel {
     /**
      * All images will be recorded, including those downloaded from the Internet during app runtime.
      */

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/PrivacyLevel.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/PrivacyLevel.kt
@@ -1,0 +1,12 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay
+
+/**
+ * Base interface for privacy masking levels.
+ */
+interface PrivacyLevel

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/TextAndInputPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/TextAndInputPrivacy.kt
@@ -12,7 +12,7 @@ package com.datadog.android.sessionreplay
  * @see TextAndInputPrivacy.MASK_ALL_INPUTS
  * @see TextAndInputPrivacy.MASK_ALL
  */
-enum class TextAndInputPrivacy {
+enum class TextAndInputPrivacy : PrivacyLevel {
 
     /**
      * All text and inputs considered sensitive will be masked.

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/TouchPrivacy.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/TouchPrivacy.kt
@@ -11,7 +11,7 @@ package com.datadog.android.sessionreplay
  * @see TouchPrivacy.SHOW
  * @see TouchPrivacy.HIDE
  */
-enum class TouchPrivacy {
+enum class TouchPrivacy : PrivacyLevel {
     /**
      * All touch interactions will be recorded.
      */


### PR DESCRIPTION
### What does this PR do?
Adds a proguard rule to prevent the fine grained masking enums from being obfuscated. 

### Motivation
Because we [resolve](https://github.com/DataDog/dd-sdk-android/blob/develop/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt#L112) `String` --> `Enum` with `valueOf`.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

