### PR TITLE
RUM-6385: Default sample rate for session replay

### DIFF
--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -18,7 +18,7 @@ object com.datadog.android.sessionreplay.SessionReplay
   fun stopRecording(com.datadog.android.api.SdkCore = Datadog.getInstance())
 data class com.datadog.android.sessionreplay.SessionReplayConfiguration
   class Builder
-    constructor(Float)
+    constructor(Float = SAMPLE_IN_ALL_SESSIONS)
     fun addExtensionSupport(ExtensionSupport): Builder
     fun useCustomEndpoint(String): Builder
     DEPRECATED fun setPrivacy(SessionReplayPrivacy): Builder

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -48,7 +48,9 @@ public final class com/datadog/android/sessionreplay/SessionReplayConfiguration 
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayConfiguration$Builder {
+	public fun <init> ()V
 	public fun <init> (F)V
+	public synthetic fun <init> (FILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun addExtensionSupport (Lcom/datadog/android/sessionreplay/ExtensionSupport;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;
 	public final fun build ()Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public final fun setDynamicOptimizationEnabled (Z)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration$Builder;

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -31,8 +31,9 @@ data class SessionReplayConfiguration internal constructor(
      * A Builder class for a [SessionReplayConfiguration].
      * @param sampleRate must be a value between 0 and 100. A value of 0
      * means no session will be recorded, 100 means all sessions will be recorded.
+     * If this value is not provided then Session Replay will default to a 100 sample rate.
      */
-    class Builder(@FloatRange(from = 0.0, to = 100.0) private val sampleRate: Float) {
+    class Builder(@FloatRange(from = 0.0, to = 100.0) private val sampleRate: Float = SAMPLE_IN_ALL_SESSIONS) {
         private var customEndpointUrl: String? = null
         private var privacy = SessionReplayPrivacy.MASK
 
@@ -195,6 +196,10 @@ data class SessionReplayConfiguration internal constructor(
 
         private fun customMappers(): List<MapperTypeWrapper<*>> {
             return extensionSupport.getCustomViewMappers()
+        }
+
+        internal companion object {
+            internal const val SAMPLE_IN_ALL_SESSIONS = 100.0f
         }
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/SessionReplayConfigurationBuilderTest.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.sessionreplay
 
 import android.view.View
+import com.datadog.android.sessionreplay.SessionReplayConfiguration.Builder.Companion.SAMPLE_IN_ALL_SESSIONS
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
 import fr.xgouchet.elmyr.annotation.BoolForgery
 import fr.xgouchet.elmyr.annotation.FloatForgery
@@ -47,7 +48,7 @@ internal class SessionReplayConfigurationBuilderTest {
     fun `set up`() {
         fakeExpectedCustomMappers = listOf(MapperTypeWrapper(View::class.java, mock()))
         whenever(mockExtensionSupport.getCustomViewMappers()).thenReturn(fakeExpectedCustomMappers)
-        testedBuilder = SessionReplayConfiguration.Builder(fakeSampleRate)
+        testedBuilder = SessionReplayConfiguration.Builder()
     }
 
     @Test
@@ -60,9 +61,9 @@ internal class SessionReplayConfigurationBuilderTest {
         assertThat(sessionReplayConfiguration.privacy).isEqualTo(SessionReplayPrivacy.MASK)
         assertThat(sessionReplayConfiguration.imagePrivacy).isEqualTo(ImagePrivacy.MASK_ALL)
         assertThat(sessionReplayConfiguration.touchPrivacy).isEqualTo(TouchPrivacy.HIDE)
+        assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(SAMPLE_IN_ALL_SESSIONS)
         assertThat(sessionReplayConfiguration.customMappers).isEmpty()
         assertThat(sessionReplayConfiguration.customOptionSelectorDetectors).isEmpty()
-        assertThat(sessionReplayConfiguration.sampleRate).isEqualTo(fakeSampleRate)
         assertThat(sessionReplayConfiguration.dynamicOptimizationEnabled).isEqualTo(true)
     }
 
@@ -71,6 +72,7 @@ internal class SessionReplayConfigurationBuilderTest {
         @StringForgery(regex = "https://[a-z]+\\.com") sessionReplayUrl: String
     ) {
         // When
+        testedBuilder = SessionReplayConfiguration.Builder(fakeSampleRate)
         val sessionReplayConfiguration = testedBuilder
             .useCustomEndpoint(sessionReplayUrl)
             .build()


### PR DESCRIPTION
### What does this PR do?
Add a default sample rate of 100% for Session Replay (sample rate is now optional when creating the configuration).

### Motivation
Align with the other features. 

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

