### PR TITLE
Fix the regression for the TelemetryErrorEvent with throwable

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -290,7 +290,6 @@ fun Long.toHexString(): String
 fun java.math.BigInteger.toHexString(): String
 fun Thread.State.asString(): String
 fun Array<StackTraceElement>.loggableStackTrace(): String
-fun Throwable.loggableStackTrace(): String
 enum com.datadog.android.core.metrics.MethodCallSamplingRate
   constructor(Float)
   - ALL

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -783,10 +783,6 @@ public final class com/datadog/android/core/internal/utils/ThreadExtKt {
 	public static final fun loggableStackTrace ([Ljava/lang/StackTraceElement;)Ljava/lang/String;
 }
 
-public final class com/datadog/android/core/internal/utils/ThrowableExtKt {
-	public static final fun loggableStackTrace (Ljava/lang/Throwable;)Ljava/lang/String;
-}
-
 public final class com/datadog/android/core/metrics/MethodCallSamplingRate : java/lang/Enum {
 	public static final field ALL Lcom/datadog/android/core/metrics/MethodCallSamplingRate;
 	public static final field HIGH Lcom/datadog/android/core/metrics/MethodCallSamplingRate;

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/Datadog.kt
@@ -20,8 +20,8 @@ import com.datadog.android.core.internal.HashGenerator
 import com.datadog.android.core.internal.NoOpInternalSdkCore
 import com.datadog.android.core.internal.SdkCoreRegistry
 import com.datadog.android.core.internal.Sha256HashGenerator
-import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.internal.utils.unboundInternalLogger
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.lint.InternalApi
 import com.datadog.android.privacy.TrackingConsent
 import java.util.Locale

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/error/internal/DatadogExceptionHandler.kt
@@ -18,6 +18,7 @@ import com.datadog.android.core.internal.thread.waitToIdle
 import com.datadog.android.core.internal.utils.asString
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.internal.utils.triggerUploadWorker
+import com.datadog.android.internal.utils.loggableStackTrace
 import java.lang.ref.WeakReference
 import java.util.concurrent.ThreadPoolExecutor
 

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/DatadogTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/DatadogTest.kt
@@ -19,6 +19,7 @@ import com.datadog.android.core.internal.NoOpInternalSdkCore
 import com.datadog.android.core.internal.SdkCoreRegistry
 import com.datadog.android.core.internal.Sha256HashGenerator
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.config.InternalLoggerTestConfiguration

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/error/internal/DatadogExceptionHandlerTest.kt
@@ -22,6 +22,7 @@ import com.datadog.android.core.internal.thread.waitToIdle
 import com.datadog.android.core.internal.utils.TAG_DATADOG_UPLOAD
 import com.datadog.android.core.internal.utils.UPLOAD_WORKER_NAME
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.utils.config.ApplicationContextTestConfiguration
 import com.datadog.android.utils.forge.Configurator
 import com.datadog.android.utils.verifyLog

--- a/dd-sdk-android-internal/api/apiSurface
+++ b/dd-sdk-android-internal/api/apiSurface
@@ -17,6 +17,8 @@ sealed class com.datadog.android.internal.telemetry.InternalTelemetryEvent
       constructor(String, Map<String, Any?>?)
     class Error : Log
       constructor(String, Map<String, Any?>? = null, Throwable? = null, String? = null, String? = null)
+      fun resolveKind(): String?
+      fun resolveStacktrace(): String?
   data class Configuration : InternalTelemetryEvent
     constructor(Boolean, Long, Long, Boolean, Boolean, Int)
   data class Metric : InternalTelemetryEvent
@@ -27,5 +29,6 @@ sealed class com.datadog.android.internal.telemetry.InternalTelemetryEvent
       constructor(Boolean, Boolean, Boolean, MutableMap<String, Any?> = mutableMapOf())
   object InterceptorInstantiated : InternalTelemetryEvent
 fun ByteArray.toHexString(): String
+fun Throwable.loggableStackTrace(): String
 annotation com.datadog.tools.annotation.NoOpImplementation
   constructor(Boolean = false)

--- a/dd-sdk-android-internal/api/dd-sdk-android-internal.api
+++ b/dd-sdk-android-internal/api/dd-sdk-android-internal.api
@@ -87,6 +87,8 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 	public final fun getError ()Ljava/lang/Throwable;
 	public final fun getKind ()Ljava/lang/String;
 	public final fun getStacktrace ()Ljava/lang/String;
+	public final fun resolveKind ()Ljava/lang/String;
+	public final fun resolveStacktrace ()Ljava/lang/String;
 }
 
 public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent$Metric : com/datadog/android/internal/telemetry/InternalTelemetryEvent {
@@ -104,6 +106,10 @@ public final class com/datadog/android/internal/telemetry/InternalTelemetryEvent
 
 public final class com/datadog/android/internal/utils/ByteArrayExtKt {
 	public static final fun toHexString ([B)Ljava/lang/String;
+}
+
+public final class com/datadog/android/internal/utils/ThrowableExtKt {
+	public static final fun loggableStackTrace (Ljava/lang/Throwable;)Ljava/lang/String;
 }
 
 public abstract interface annotation class com/datadog/tools/annotation/NoOpImplementation : java/lang/annotation/Annotation {

--- a/dd-sdk-android-internal/build.gradle.kts
+++ b/dd-sdk-android-internal/build.gradle.kts
@@ -47,6 +47,14 @@ dependencies {
 
     // Generate NoOp implementations
     ksp(project(":tools:noopfactory"))
+    testImplementation(project(":tools:unit")) {
+        attributes {
+            attribute(
+                com.android.build.api.attributes.ProductFlavorAttr.of("platform"),
+                objects.named("jvm")
+            )
+        }
+    }
     testImplementation(libs.bundles.jUnit5)
     testImplementation(libs.bundles.testTools)
     testFixturesImplementation(libs.kotlin)

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/InternalTelemetryEvent.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/telemetry/InternalTelemetryEvent.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.internal.telemetry
 
+import com.datadog.android.internal.utils.loggableStackTrace
+
 @Suppress("UndocumentedPublicClass", "UndocumentedPublicFunction", "UndocumentedPublicProperty")
 sealed class InternalTelemetryEvent {
 
@@ -18,7 +20,15 @@ sealed class InternalTelemetryEvent {
             val error: Throwable? = null,
             val stacktrace: String? = null,
             val kind: String? = null
-        ) : Log(message, additionalProperties)
+        ) : Log(message, additionalProperties) {
+            fun resolveKind(): String? {
+                return kind ?: error?.javaClass?.canonicalName ?: error?.javaClass?.simpleName
+            }
+
+            fun resolveStacktrace(): String? {
+                return stacktrace ?: error?.loggableStackTrace()
+            }
+        }
     }
 
     data class Configuration(

--- a/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/ThrowableExt.kt
+++ b/dd-sdk-android-internal/src/main/java/com/datadog/android/internal/utils/ThrowableExt.kt
@@ -4,16 +4,14 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.core.internal.utils
+package com.datadog.android.internal.utils
 
-import com.datadog.android.lint.InternalApi
 import java.io.PrintWriter
 import java.io.StringWriter
 
 /**
  * Converts stacktrace to string format.
  */
-@InternalApi
 fun Throwable.loggableStackTrace(): String {
     val stringWriter = StringWriter()
     @Suppress("UnsafeThirdPartyFunctionCall") // NPE cannot happen here

--- a/dd-sdk-android-internal/src/test/java/com/datadog/internal/forge/Configurator.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/internal/forge/Configurator.kt
@@ -1,0 +1,19 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.internal.forge
+
+import com.datadog.android.internal.tests.elmyr.InternalTelemetryErrorLogForgeryFactory
+import com.datadog.tools.unit.forge.BaseConfigurator
+import fr.xgouchet.elmyr.Forge
+
+internal class Configurator :
+    BaseConfigurator() {
+    override fun configure(forge: Forge) {
+        super.configure(forge)
+        forge.addFactory(InternalTelemetryErrorLogForgeryFactory())
+    }
+}

--- a/dd-sdk-android-internal/src/test/java/com/datadog/internal/telemetry/InternalTelemetryErrorEventTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/internal/telemetry/InternalTelemetryErrorEventTest.kt
@@ -1,0 +1,198 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.internal.telemetry
+
+import com.datadog.android.internal.telemetry.InternalTelemetryEvent
+import com.datadog.android.internal.utils.loggableStackTrace
+import com.datadog.tools.unit.forge.aThrowable
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.junit5.ForgeExtension
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.extension.Extensions
+import org.mockito.junit.jupiter.MockitoExtension
+import org.mockito.junit.jupiter.MockitoSettings
+import org.mockito.quality.Strictness
+
+@Extensions(
+    ExtendWith(MockitoExtension::class),
+    ExtendWith(ForgeExtension::class)
+)
+@MockitoSettings(strictness = Strictness.LENIENT)
+internal class InternalTelemetryErrorEventTest {
+
+    @Test
+    fun `M resolve the given stacktrace W resolveStacktrace { stacktrace explicitly provided }`(forge: Forge) {
+        // Given
+        val expectedStackTrace = forge.aString()
+        val errorEvent = InternalTelemetryEvent.Log.Error(
+            message = forge.aString(),
+            additionalProperties = forge.aMap { aString() to aString() },
+            error = null,
+            stacktrace = expectedStackTrace,
+            kind = forge.aNullable { aString() }
+        )
+
+        // When
+        val resolvedStackTrace = errorEvent.resolveStacktrace()
+        assertThat(resolvedStackTrace).isEqualTo(expectedStackTrace)
+    }
+
+    @Test
+    fun `M resolve the given stacktrace W resolveStacktrace { stacktrace and throwable explicitly provided }`(
+        forge: Forge
+    ) {
+        // Given
+        val expectedStackTrace = forge.aString()
+        val errorEvent = InternalTelemetryEvent.Log.Error(
+            message = forge.aString(),
+            additionalProperties = forge.aMap { aString() to aString() },
+            error = forge.aThrowable(),
+            stacktrace = expectedStackTrace,
+            kind = forge.aNullable { aString() }
+        )
+
+        // When
+        val resolvedStackTrace = errorEvent.resolveStacktrace()
+        assertThat(resolvedStackTrace).isEqualTo(expectedStackTrace)
+    }
+
+    @Test
+    fun `M resolve throwable stacktrace W resolveStacktrace { only throwable explicitly provided }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeThrowable = forge.aThrowable()
+        val expectedStackTrace = fakeThrowable.loggableStackTrace()
+        val errorEvent = InternalTelemetryEvent.Log.Error(
+            message = forge.aString(),
+            additionalProperties = forge.aMap { aString() to aString() },
+            error = fakeThrowable,
+            stacktrace = null,
+            kind = forge.aNullable { aString() }
+        )
+
+        // When
+        val resolvedStackTrace = errorEvent.resolveStacktrace()
+        assertThat(resolvedStackTrace).isEqualTo(expectedStackTrace)
+    }
+
+    @Test
+    fun `M resolve null W resolveStacktrace { stacktrace nor throwable provided }`(
+        forge: Forge
+    ) {
+        // Given
+        val errorEvent = InternalTelemetryEvent.Log.Error(
+            message = forge.aString(),
+            additionalProperties = forge.aMap { aString() to aString() },
+            error = null,
+            stacktrace = null,
+            kind = forge.aNullable { aString() }
+        )
+
+        // When
+        val resolvedStackTrace = errorEvent.resolveStacktrace()
+        assertThat(resolvedStackTrace).isNull()
+    }
+
+    @Test
+    fun `M resolve the given kind W resolveKind { kind explicitly provided }`(
+        forge: Forge
+    ) {
+        // Given
+        val expectedKind = forge.aString()
+        val errorEvent = InternalTelemetryEvent.Log.Error(
+            message = forge.aString(),
+            additionalProperties = forge.aMap { aString() to aString() },
+            error = null,
+            stacktrace = forge.aNullable { aString() },
+            kind = expectedKind
+        )
+
+        // When
+        val resolvedKind = errorEvent.resolveKind()
+        assertThat(resolvedKind).isEqualTo(expectedKind)
+    }
+
+    @Test
+    fun `M resolve the given kind W resolveKind { kind and throwable explicitly provided }`(
+        forge: Forge
+    ) {
+        // Given
+        val expectedKind = forge.aString()
+        val errorEvent = InternalTelemetryEvent.Log.Error(
+            message = forge.aString(),
+            additionalProperties = forge.aMap { aString() to aString() },
+            error = forge.aThrowable(),
+            stacktrace = forge.aNullable { aString() },
+            kind = expectedKind
+        )
+
+        // When
+        val resolvedKind = errorEvent.resolveKind()
+        assertThat(resolvedKind).isEqualTo(expectedKind)
+    }
+
+    @Test
+    fun `M resolve throwable kind W resolveKind { only throwable explicitly provided }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeThrowable = forge.aThrowable()
+        val expectedKind = fakeThrowable.javaClass.canonicalName
+        val errorEvent = InternalTelemetryEvent.Log.Error(
+            message = forge.aString(),
+            additionalProperties = forge.aMap { aString() to aString() },
+            error = fakeThrowable,
+            stacktrace = forge.aNullable { aString() },
+            kind = null
+        )
+
+        // When
+        val resolvedKind = errorEvent.resolveKind()
+        assertThat(resolvedKind).isEqualTo(expectedKind)
+    }
+
+    @Test
+    fun `M resolve throwable kind W resolveKind { only throwable explicitly provided, anonymous class }`(
+        forge: Forge
+    ) {
+        // Given
+        val fakeThrowable = object : Throwable() {}
+        val expectedKind = fakeThrowable.javaClass.simpleName
+        val errorEvent = InternalTelemetryEvent.Log.Error(
+            message = forge.aString(),
+            additionalProperties = forge.aMap { aString() to aString() },
+            error = fakeThrowable,
+            stacktrace = forge.aNullable { aString() },
+            kind = null
+        )
+
+        // When
+        val resolvedKind = errorEvent.resolveKind()
+        assertThat(resolvedKind).isEqualTo(expectedKind)
+    }
+
+    @Test
+    fun `M resolve null W resolveKind { kind nor throwable provided }`(
+        forge: Forge
+    ) {
+        // Given
+        val errorEvent = InternalTelemetryEvent.Log.Error(
+            message = forge.aString(),
+            additionalProperties = forge.aMap { aString() to aString() },
+            error = null,
+            stacktrace = forge.aNullable { aString() },
+            kind = null
+        )
+
+        // When
+        val resolvedKind = errorEvent.resolveKind()
+        assertThat(resolvedKind).isNull()
+    }
+}

--- a/dd-sdk-android-internal/src/test/java/com/datadog/internal/utils/ThrowableExtTest.kt
+++ b/dd-sdk-android-internal/src/test/java/com/datadog/internal/utils/ThrowableExtTest.kt
@@ -4,9 +4,10 @@
  * Copyright 2016-Present Datadog, Inc.
  */
 
-package com.datadog.android.core.internal.utils
+package com.datadog.internal.utils
 
-import com.datadog.android.utils.forge.Configurator
+import com.datadog.android.internal.utils.loggableStackTrace
+import com.datadog.internal.forge.Configurator
 import fr.xgouchet.elmyr.annotation.Forgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnable.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.utils.asString
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScope.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScope.kt
@@ -16,6 +16,7 @@ import com.datadog.android.core.InternalSdkCore
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -87,8 +87,8 @@ internal class TelemetryEventHandler(
                         datadogContext = datadogContext,
                         timestamp = timestamp,
                         message = event.message,
-                        stack = event.stacktrace,
-                        kind = event.kind,
+                        stack = event.resolveStacktrace(),
+                        kind = event.resolveKind(),
                         additionalProperties = event.additionalProperties
                     )
                 }

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventId.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventId.kt
@@ -17,7 +17,7 @@ internal data class TelemetryEventId(
 internal val InternalTelemetryEvent.identity: TelemetryEventId
     get() {
         return when (this) {
-            is InternalTelemetryEvent.Log.Error -> TelemetryEventId(type(), message, kind)
+            is InternalTelemetryEvent.Log.Error -> TelemetryEventId(type(), message, resolveKind())
             is InternalTelemetryEvent.Log.Debug -> TelemetryEventId(type(), message, null)
             else -> TelemetryEventId(type(), "", null)
         }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/anr/ANRDetectorRunnableTest.kt
@@ -11,6 +11,7 @@ import android.os.Handler
 import android.os.Looper
 import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.utils.config.ApplicationContextTestConfiguration

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumResourceScopeTest.kt
@@ -16,6 +16,7 @@ import com.datadog.android.api.storage.EventBatchWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource
 import com.datadog.android.rum.RumResourceKind

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -19,6 +19,7 @@ import com.datadog.android.core.feature.event.ThreadDump
 import com.datadog.android.core.internal.net.FirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.internal.telemetry.InternalTelemetryEvent
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.RumActionType
 import com.datadog.android.rum.RumAttributes
 import com.datadog.android.rum.RumErrorSource

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ErrorEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/ErrorEventForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.utils.forge
 
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.tools.unit.forge.aThrowable
 import com.datadog.tools.unit.forge.exhaustiveAttributes

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/TelemetryErrorEventForgeryFactory.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/utils/forge/TelemetryErrorEventForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.utils.forge
 
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.telemetry.model.TelemetryErrorEvent
 import com.datadog.tools.unit.forge.aThrowable
 import fr.xgouchet.elmyr.Forge

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandler.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandler.kt
@@ -10,6 +10,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.log.LogAttributes
 import com.datadog.legacy.trace.api.DDTags
 import com.datadog.opentracing.DDSpan

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandlerTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/handlers/AndroidSpanLogsHandlerTest.kt
@@ -11,6 +11,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.api.feature.FeatureScope
 import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.trace.utils.verifyLog
 import com.datadog.android.utils.forge.Configurator

--- a/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
+++ b/features/dd-sdk-android-webview/src/test/kotlin/com/datadog/android/utils/forge/ErrorEventForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.utils.forge
 
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.tools.unit.forge.aThrowable
 import com.datadog.tools.unit.forge.exhaustiveAttributes

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/trace/TracingInterceptor.kt
@@ -18,6 +18,7 @@ import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeReso
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContext
 import com.datadog.android.okhttp.TraceContextInjection
 import com.datadog.android.okhttp.internal.otel.toOpenTracingContext

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeReso
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContext
 import com.datadog.android.okhttp.TraceContextInjection
 import com.datadog.android.okhttp.internal.utils.forge.OkHttpConfigurator

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContextInjection
 import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.okhttp.utils.config.DatadogSingletonTestConfiguration

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeReso
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContextInjection
 import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.okhttp.utils.config.DatadogSingletonTestConfiguration

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeResolver
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContextInjection
 import com.datadog.android.okhttp.utils.assertj.HeadersAssert.Companion.assertThat
 import com.datadog.android.okhttp.utils.config.DatadogSingletonTestConfiguration

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -13,6 +13,7 @@ import com.datadog.android.core.internal.net.DefaultFirstPartyHostHeaderTypeReso
 import com.datadog.android.core.internal.utils.loggableStackTrace
 import com.datadog.android.core.sampling.RateBasedSampler
 import com.datadog.android.core.sampling.Sampler
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.okhttp.TraceContext
 import com.datadog.android.okhttp.TraceContextInjection
 import com.datadog.android.okhttp.internal.utils.forge.OkHttpConfigurator

--- a/reliability/single-fit/rum/build.gradle.kts
+++ b/reliability/single-fit/rum/build.gradle.kts
@@ -30,6 +30,7 @@ android {
 
 dependencies {
     implementation(project(":dd-sdk-android-core"))
+    implementation(project(":dd-sdk-android-internal"))
     implementation(project(":features:dd-sdk-android-rum"))
     implementation(libs.kotlin)
     implementation(libs.bundles.androidXNavigation)

--- a/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/ErrorEventForgeryFactory.kt
+++ b/reliability/single-fit/rum/src/test/kotlin/com/datadog/android/rum/integration/tests/elmyr/ErrorEventForgeryFactory.kt
@@ -7,6 +7,7 @@
 package com.datadog.android.rum.integration.tests.elmyr
 
 import com.datadog.android.core.internal.utils.loggableStackTrace
+import com.datadog.android.internal.utils.loggableStackTrace
 import com.datadog.android.rum.model.ErrorEvent
 import com.datadog.tools.unit.forge.aThrowable
 import com.datadog.tools.unit.forge.exhaustiveAttributes


### PR DESCRIPTION
### What does this PR do?

When we refactor the Telemetry handling logic we missed a case when the `Log.Error` is reported with a `throwable`. Main reason why we missed this is that our integration tests were not reporting the problem in the CI (they were failing but this was not visible in the CI due to an issue in the shell environment on MacOs runners). This issue was currently discovered by @ambushwork while manually running the integration tests on his end.

There were 2 main problems caused by this regression was that in case this method was used `fun error(message: String, throwable: Throwable)`:

1. The `stacktrace` and `kind` were not correctly resolved from the `Throwable`.
2. In case 2 consecutive telemetry error events would be sent: first with `kind=null` and second with `throwable` because of the way we were resolving the `identifier` they were both considered same event and second one would not be sent. 

The impact is quite high as it is affecting all our telemetry error logs that are reporting only the `Throwable`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

