### PR TITLE
RUM-6570: Fix Rum integration test verifyViewEventsOnSwipe

### DIFF
--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingTest.kt
@@ -55,7 +55,7 @@ internal abstract class FragmentTrackingTest :
         )
 
         // swipe to change the fragment
-        onView(ViewMatchers.withId(R.id.tab_layout)).perform(ViewActions.swipeLeft())
+        onView(ViewMatchers.withId(R.id.btn_next)).perform(ViewActions.click())
         instrumentation.waitForIdleSync()
         Thread.sleep(200) // give time to the view id to update
         val fragmentBViewUrl = currentFragmentViewUrl(activity)
@@ -71,7 +71,7 @@ internal abstract class FragmentTrackingTest :
         )
 
         // swipe to close the view
-        onView(ViewMatchers.withId(R.id.tab_layout)).perform(ViewActions.swipeRight())
+        onView(ViewMatchers.withId(R.id.btn_last)).perform(ViewActions.click())
         instrumentation.waitForIdleSync()
         Thread.sleep(200) // give time to the view id to update
 

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/rules/MockServerActivityTestRule.kt
@@ -19,6 +19,7 @@ import com.datadog.android.rum.GlobalRumMonitor
 import com.datadog.android.sdk.integration.RuntimeConfig
 import com.datadog.android.sdk.utils.addForgeSeed
 import com.datadog.android.sdk.utils.addTrackingConsent
+import com.datadog.android.sdk.utils.overrideProcessImportance
 import com.google.gson.JsonParser
 import fr.xgouchet.elmyr.Forge
 import okhttp3.mockwebserver.Dispatcher
@@ -92,7 +93,7 @@ internal open class MockServerActivityTestRule<T : Activity>(
             RuntimeConfig.rumEndpointUrl = "$it/$RUM_URL_SUFFIX"
             RuntimeConfig.sessionReplayEndpointUrl = "$it/$SESSION_REPlAY_URL_SUFFIX"
         }
-
+        overrideProcessImportance()
         super.beforeActivityLaunched()
     }
 

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingPlaygroundActivity.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/integration/rum/FragmentTrackingPlaygroundActivity.kt
@@ -10,6 +10,7 @@ package com.datadog.android.sdk.integration.rum
 
 import android.os.Bundle
 import android.util.Log
+import android.widget.Button
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentManager
@@ -24,6 +25,8 @@ import com.datadog.android.sdk.utils.getTrackingConsent
 
 internal class FragmentTrackingPlaygroundActivity : AppCompatActivity() {
     lateinit var viewPager: ViewPager
+    lateinit var btnNext: Button
+    lateinit var btnLast: Button
 
     @Suppress("CheckInternal")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -45,8 +48,16 @@ internal class FragmentTrackingPlaygroundActivity : AppCompatActivity() {
 
         setContentView(R.layout.fragment_tracking_layout)
         viewPager = findViewById(R.id.pager)
+        btnNext = findViewById(R.id.btn_next)
+        btnLast = findViewById(R.id.btn_last)
         viewPager.apply {
             adapter = ViewPagerAdapter(supportFragmentManager)
+        }
+        btnNext.setOnClickListener {
+            viewPager.setCurrentItem(viewPager.currentItem + 1, true)
+        }
+        btnLast.setOnClickListener {
+            viewPager.setCurrentItem(viewPager.currentItem - 1, true)
         }
 
         // attach the fragment view tracking strategy

--- a/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/utils/ProcessImportanceExt.kt
+++ b/instrumented/integration/src/main/kotlin/com/datadog/android/sdk/utils/ProcessImportanceExt.kt
@@ -1,0 +1,26 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sdk.utils
+
+import android.app.ActivityManager
+import com.datadog.android.rum.DdRumContentProvider
+
+/**
+ * In instrumentation tests, the process is treated as [IMPORTANCE_FOREGROUND_SERVICE],
+ * which differs from the behavior in a typical user environment. To prevent this difference
+ * from affecting test results, this function can be called to override the relevant variable
+ * inside [DdRumContentProvider], allowing the SDK to correctly identify that the application
+ * is in the foreground.
+ */
+fun overrideProcessImportance() {
+    DdRumContentProvider::class.java.declaredMethods.firstOrNull {
+        it.name == "overrideProcessImportance"
+    }?.apply {
+        isAccessible = true
+        invoke(null, ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND)
+    }
+}

--- a/instrumented/integration/src/main/res/layout/fragment_tracking_layout.xml
+++ b/instrumented/integration/src/main/res/layout/fragment_tracking_layout.xml
@@ -24,4 +24,23 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
     </androidx.viewpager.widget.ViewPager>
+
+    <Button
+        android:id="@+id/btn_next"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="next page"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <Button
+        android:id="@+id/btn_last"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="last page"
+        app:layout_constraintBottom_toTopOf="@id/btn_next"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
### What does this PR do?

There are two integration tests failing for very long time,

* `ConsentPendingGrantedFragmentTrackingTest.verifyViewEventsOnSwipe`

* `ConsentGrantedFragmentTrackingTest.verifyViewEventsOnSwipe`

This is due to the action we perform on the test activity never works:

```
onView(ViewMatchers.withId(R.id.tab_layout)).perform(ViewActions.swipeLeft())
```
It's a known issue of  Espresso that swipe is not working on a view pager, so we can never perform the action that we want,

to fix it, I added two buttons on the layout to go to next or last page, and replace the swipe action by clicking the buttons.

Another issue is that in integration test we need to override the importance of the process otherwise we don't receive the event of application start

### Motivation

RUM-6570

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

