### PR TITLE
Add SemanticsWireframe to wrap the collection of the wireframes

### DIFF
--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/data/SemanticsWireframe.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/data/SemanticsWireframe.kt
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.data
+
+import com.datadog.android.sessionreplay.model.MobileSegment
+
+internal data class SemanticsWireframe(
+    val wireframes: List<MobileSegment.Wireframe>,
+    val uiContext: UiContext?
+)

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapper.kt
@@ -8,7 +8,7 @@ package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.unit.Density
-import com.datadog.android.sessionreplay.compose.internal.data.ComposeWireframe
+import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.model.MobileSegment
@@ -25,19 +25,19 @@ internal class ButtonSemanticsNodeMapper(
         semanticsNode: SemanticsNode,
         parentContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
-    ): ComposeWireframe {
+    ): SemanticsWireframe {
         val density = semanticsNode.layoutInfo.density
         val bounds = resolveBounds(semanticsNode)
         val buttonStyle = resolveSemanticsButtonStyle(semanticsNode, bounds, density)
-        return ComposeWireframe(
-            MobileSegment.Wireframe.ShapeWireframe(
+        return SemanticsWireframe(
+            wireframes = MobileSegment.Wireframe.ShapeWireframe(
                 id = semanticsNode.id.toLong(),
                 x = bounds.x,
                 y = bounds.y,
                 width = bounds.width,
                 height = bounds.height,
                 shapeStyle = buttonStyle
-            ),
+            ).let { listOf(it) },
             uiContext = parentContext.copy(
                 parentContentColor = buttonStyle.backgroundColor ?: parentContext.parentContentColor
             )

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
@@ -12,7 +12,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.VectorPainter
 import androidx.compose.ui.semantics.SemanticsNode
 import com.datadog.android.sessionreplay.ImagePrivacy
-import com.datadog.android.sessionreplay.compose.internal.data.ComposeWireframe
+import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.BitmapField
@@ -34,7 +34,7 @@ internal class ImageSemanticsNodeMapper(
         semanticsNode: SemanticsNode,
         parentContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
-    ): ComposeWireframe? {
+    ): SemanticsWireframe {
         val bounds = resolveBounds(semanticsNode)
         val bitmapInfo = resolveSemanticsPainter(semanticsNode)
         val imageWireframe = if (bitmapInfo != null) {
@@ -54,12 +54,10 @@ internal class ImageSemanticsNodeMapper(
         } else {
             null
         }
-        return imageWireframe?.let {
-            ComposeWireframe(
-                imageWireframe,
-                null
-            )
-        }
+        return SemanticsWireframe(
+            wireframes = listOfNotNull(imageWireframe),
+            uiContext = null
+        )
     }
 
     private fun resolveSemanticsPainter(

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SemanticsNodeMapper.kt
@@ -7,7 +7,7 @@
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import androidx.compose.ui.semantics.SemanticsNode
-import com.datadog.android.sessionreplay.compose.internal.data.ComposeWireframe
+import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 
@@ -17,5 +17,5 @@ internal interface SemanticsNodeMapper {
         semanticsNode: SemanticsNode,
         parentContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
-    ): ComposeWireframe?
+    ): SemanticsWireframe?
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SemanticsWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/SemanticsWireframeMapper.kt
@@ -32,7 +32,7 @@ internal class SemanticsWireframeMapper(
     private val semanticsUtils: SemanticsUtils = SemanticsUtils(),
     private val semanticsNodeMapper: Map<Role, SemanticsNodeMapper> = mapOf(
         // TODO RUM-6189 Add Mappers for each Semantics Role
-        Role.Button to ButtonSemanticsNodeMapper(colorStringFormatter),
+        Role.Button to ButtonSemanticsNodeMapper(colorStringFormatter, semanticsUtils),
         Role.Image to ImageSemanticsNodeMapper(colorStringFormatter)
     ),
     // Text doesn't have a role in semantics, so it should be a fallback mapper.
@@ -95,8 +95,8 @@ internal class SemanticsWireframeMapper(
             semanticsNode = semanticsNode,
             parentContext = parentUiContext,
             asyncJobStatusCallback = asyncJobStatusCallback
-        )?.wireframe?.let {
-            wireframes.add(it)
+        )?.wireframes?.let {
+            wireframes.addAll(it)
         }
         val children = semanticsNode.children
         children.forEach {

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.text.TextLayoutResult
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.GenericFontFamily
 import androidx.compose.ui.text.style.TextAlign
-import com.datadog.android.sessionreplay.compose.internal.data.ComposeWireframe
+import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection
 import com.datadog.android.sessionreplay.compose.internal.reflection.getSafe
@@ -31,12 +31,12 @@ internal class TextSemanticsNodeMapper(colorStringFormatter: ColorStringFormatte
         semanticsNode: SemanticsNode,
         parentContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
-    ): ComposeWireframe {
+    ): SemanticsWireframe {
         val text = resolveText(semanticsNode.config)
         val textStyle = resolveTextStyle(semanticsNode, parentContext) ?: defaultTextStyle
         val bounds = resolveBounds(semanticsNode)
-        return ComposeWireframe(
-            MobileSegment.Wireframe.TextWireframe(
+        return SemanticsWireframe(
+            wireframes = MobileSegment.Wireframe.TextWireframe(
                 id = semanticsNode.id.toLong(),
                 x = bounds.x,
                 y = bounds.y,
@@ -45,7 +45,7 @@ internal class TextSemanticsNodeMapper(colorStringFormatter: ColorStringFormatte
                 text = text ?: "",
                 textStyle = textStyle,
                 textPosition = resolveTextAlign(semanticsNode)
-            ),
+            ).let { listOf(it) },
             null
         )
     }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapperTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.layout.LayoutInfo
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.unit.Density
 import com.datadog.android.sessionreplay.compose.internal.data.ComposeWireframe
+import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -136,7 +137,7 @@ internal class StubAbstractSemanticsNodeMapper(
         semanticsNode: SemanticsNode,
         parentContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
-    ): ComposeWireframe? {
+    ): SemanticsWireframe? {
         return null
     }
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapperTest.kt
@@ -116,6 +116,6 @@ internal class ButtonSemanticsNodeMapperTest : AbstractCompositionGroupMapperTes
                 cornerRadius = fakeCornerRadius
             )
         )
-        assertThat(actual.wireframe).isEqualTo(expected)
+        assertThat(actual.wireframes).contains(expected)
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
@@ -135,7 +135,7 @@ internal class TextSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest(
             )
         )
 
-        assertThat(actual.wireframe).isEqualTo(expected)
+        assertThat(actual.wireframes).contains(expected)
     }
 
     private fun resolveTextAlign(textAlign: TextAlign): MobileSegment.Alignment {


### PR DESCRIPTION
### What does this PR do?

A small update on the return value of each semantics node mapper,

since one semantic node can return several wireframes such as image, shape for background, we need a wrapper to contain the list of the wireframes.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

