### PR TITLE
RUM-6293: Remove Batch metrics inner sampler to increase sample rate

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcher.kt
@@ -16,8 +16,6 @@ import com.datadog.android.core.internal.persistence.file.existsSafe
 import com.datadog.android.core.internal.persistence.file.lengthSafe
 import com.datadog.android.core.internal.time.TimeProvider
 import com.datadog.android.core.metrics.MethodCallSamplingRate
-import com.datadog.android.core.sampling.RateBasedSampler
-import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.privacy.TrackingConsent
 import java.io.File
 import java.util.Locale
@@ -28,8 +26,7 @@ internal class BatchMetricsDispatcher(
     private val uploadConfiguration: DataUploadConfiguration?,
     private val filePersistenceConfig: FilePersistenceConfig,
     private val internalLogger: InternalLogger,
-    private val dateTimeProvider: TimeProvider,
-    private val sampler: Sampler = RateBasedSampler(METRICS_DISPATCHER_DEFAULT_SAMPLING_RATE)
+    private val dateTimeProvider: TimeProvider
 
 ) : MetricsDispatcher, ProcessLifecycleMonitor.Callback {
 
@@ -39,7 +36,7 @@ internal class BatchMetricsDispatcher(
     // region MetricsDispatcher
 
     override fun sendBatchDeletedMetric(batchFile: File, removalReason: RemovalReason) {
-        if (!removalReason.includeInMetrics() || trackName == null || !sampler.sample()) {
+        if (!removalReason.includeInMetrics() || trackName == null) {
             return
         }
         resolveBatchDeletedMetricAttributes(batchFile, removalReason)?.let {
@@ -52,7 +49,7 @@ internal class BatchMetricsDispatcher(
     }
 
     override fun sendBatchClosedMetric(batchFile: File, batchMetadata: BatchClosedMetadata) {
-        if (trackName == null || !sampler.sample() || !batchFile.existsSafe(internalLogger)) {
+        if (trackName == null || !batchFile.existsSafe(internalLogger)) {
             return
         }
         resolveBatchClosedMetricAttributes(batchFile, batchMetadata)?.let {
@@ -189,8 +186,6 @@ internal class BatchMetricsDispatcher(
         internal const val TRACE_TRACK_NAME = "trace"
         internal const val SR_TRACK_NAME = "sr"
         internal const val SR_RESOURCES_TRACK_NAME = "sr-resources"
-
-        private const val METRICS_DISPATCHER_DEFAULT_SAMPLING_RATE = 1.5f
 
         internal const val WRONG_FILE_NAME_MESSAGE_FORMAT =
             "Unable to parse the file name as a timestamp: %s"

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/metrics/BatchMetricsDispatcherTest.kt
@@ -11,7 +11,6 @@ import com.datadog.android.api.feature.Feature
 import com.datadog.android.core.internal.configuration.DataUploadConfiguration
 import com.datadog.android.core.internal.persistence.file.FilePersistenceConfig
 import com.datadog.android.core.internal.time.TimeProvider
-import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.utils.forge.Configurator
 import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.Forgery
@@ -30,7 +29,6 @@ import org.mockito.kotlin.argumentCaptor
 import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
-import org.mockito.kotlin.reset
 import org.mockito.kotlin.verify
 import org.mockito.kotlin.verifyNoInteractions
 import org.mockito.kotlin.verifyNoMoreInteractions
@@ -63,15 +61,11 @@ internal class BatchMetricsDispatcherTest {
     @Mock
     lateinit var mockInternalLogger: InternalLogger
 
-    @Mock
-    lateinit var mockSampler: Sampler
-
     @Forgery
     lateinit var fakeFilePersistenceConfig: FilePersistenceConfig
 
     @BeforeEach
     fun `set up`(forge: Forge) {
-        whenever(mockSampler.sample()).doReturn(true)
         fakeFeatureName = forge.anElementFrom(
             listOf(
                 Feature.RUM_FEATURE_NAME,
@@ -87,8 +81,7 @@ internal class BatchMetricsDispatcherTest {
             fakeUploadConfiguration,
             fakeFilePersistenceConfig,
             mockInternalLogger,
-            mockDateTimeProvider,
-            mockSampler
+            mockDateTimeProvider
         )
     }
 
@@ -287,36 +280,6 @@ internal class BatchMetricsDispatcherTest {
     }
 
     @Test
-    fun `M do nothing W sendBatchDeletedMetric { sampled out }`(forge: Forge) {
-        // Given
-        reset(mockSampler)
-        whenever(mockSampler.sample()).doReturn(false)
-        val fakeReason = forge.forgeIncludeInMetricReason()
-        val fakeFile: File = forge.forgeValidFile()
-
-        // When
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
-
-        // Then
-        verifyNoInteractions(mockInternalLogger)
-    }
-
-    @Test
-    fun `M do nothing W sendBatchDeletedMetric { reason notIncludedInMetrics }`(forge: Forge) {
-        // Given
-        reset(mockSampler)
-        whenever(mockSampler.sample()).doReturn(false)
-        val fakeReason: RemovalReason.Flushed = forge.getForgery()
-        val fakeFile: File = forge.forgeValidFile()
-
-        // When
-        testedBatchMetricsDispatcher.sendBatchDeletedMetric(fakeFile, fakeReason)
-
-        // Then
-        verifyNoInteractions(mockInternalLogger)
-    }
-
-    @Test
     fun `M do nothing W sendBatchDeletedMetric { feature unknown }`(forge: Forge) {
         // Given
         val fakeUnknownFeature = forge.anAlphabeticalString()
@@ -325,8 +288,7 @@ internal class BatchMetricsDispatcherTest {
             fakeUploadConfiguration,
             fakeFilePersistenceConfig,
             mockInternalLogger,
-            mockDateTimeProvider,
-            mockSampler
+            mockDateTimeProvider
         )
         val fakeReason: RemovalReason.Flushed = forge.getForgery()
         val fakeFile: File = forge.forgeValidFile()
@@ -561,26 +523,8 @@ internal class BatchMetricsDispatcherTest {
             fakeUploadConfiguration,
             fakeFilePersistenceConfig,
             mockInternalLogger,
-            mockDateTimeProvider,
-            mockSampler
+            mockDateTimeProvider
         )
-        val fakeFile: File = forge.forgeValidClosedFile()
-
-        // When
-        testedBatchMetricsDispatcher.sendBatchClosedMetric(fakeFile, fakeMetadata)
-
-        // Then
-        verifyNoInteractions(mockInternalLogger)
-    }
-
-    @Test
-    fun `M do nothing W sendBatchClosedMetric { sampled out }`(
-        @Forgery fakeMetadata: BatchClosedMetadata,
-        forge: Forge
-    ) {
-        // Given
-        reset(mockSampler)
-        whenever(mockSampler.sample()).doReturn(false)
         val fakeFile: File = forge.forgeValidClosedFile()
 
         // When


### PR DESCRIPTION
### What does this PR do?

The whole context please check the ticket: RUM-6293

TL,DR;

The sample rate should be decreased by 10 times but wrongly decreased by 1000 times,

Since we have add sample rate option on `logMetric` method, now it doesn't make sense to have another sampler inside `BatchMetricsDispatcher`. By removing it, the sample rate is simply controlled by the parameter passed into `logMetric` and the total sample rate will be increased by (1/0.015f) = 66.6 times.


### Motivation

RUM-6293

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

