### PR TITLE
Update Datadog Agent to 1.41.0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ include:
 # SETUP
 
 variables:
-  CURRENT_CI_IMAGE: "12"
+  CURRENT_CI_IMAGE: "13"
   CI_IMAGE_DOCKER: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/dd-sdk-android:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 

--- a/Dockerfile.gitlab
+++ b/Dockerfile.gitlab
@@ -31,7 +31,7 @@ ENV ANDROID_BUILD_TOOLS 35.0.0
 ENV ANDROID_SDK_TOOLS 11076708
 ENV NDK_VERSION 25.1.8937393
 ENV CMAKE_VERSION 3.22.1
-ENV DD_TRACER_VERSION 1.39.0
+ENV DD_TRACER_VERSION 1.41.0
 # requires build with BuildKit to be available https://docs.docker.com/build/building/variables/#multi-platform-build-arguments
 ARG TARGETARCH
 ENV JAVA_HOME=/usr/lib/jvm/java-17-openjdk-${TARGETARCH}


### PR DESCRIPTION
### What does this PR do?

This PR updates the version of Datadog Agent used for Test Visibility from 1.39.0 to 1.41.0.

### Motivation

Updating the agent is a pre-requisite for enabling ITR, and the recent version contains related fixes and improvements.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

