### PR TITLE
Add non-blocking ITR CI jobs that run in parallel with the regular ones

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -217,6 +217,7 @@ test:tools:
       - cache/caches/
       - cache/notifications/
   script:
+    - wget -O $DD_TRACER_FOLDER/dd-java-agent.jar 'https://output.circle-artifacts.com/output/job/317e0cef-c4a6-4e15-b659-0520d386f3df/artifacts/0/libs/dd-java-agent-1.42.0-SNAPSHOT.jar'
     - pip3 install datadog
     - rm -rf ~/.gradle/daemon/
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -188,6 +188,7 @@ test:debug:itr:
   allow_failure: true
   variables:
     DD_SERVICE: "dd-sdk-android-itr"
+    DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION: "0.8.12"
 
 test:tools:
   tags: [ "arch:amd64" ]
@@ -241,6 +242,7 @@ test:kover:itr:
   allow_failure: true
   variables:
     DD_SERVICE: "dd-sdk-android-itr"
+    DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION: "0.8.12"
 
 # TEST PYRAMID
 # the steps in this section should reflect our test pyramid strategy
@@ -313,6 +315,7 @@ test-pyramid:single-fit-logs:itr:
   allow_failure: true
   variables:
     DD_SERVICE: "dd-sdk-android-itr"
+    DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION: "0.8.12"
 
 .test-pyramid-single-fit-rum-template: &test-pyramid-single-fit-rum-template
   tags: [ "arch:amd64" ]
@@ -343,6 +346,7 @@ test-pyramid:single-fit-rum:itr:
   allow_failure: true
   variables:
     DD_SERVICE: "dd-sdk-android-itr"
+    DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION: "0.8.12"
 
 .test-pyramid-single-fit-trace-template: &test-pyramid-single-fit-trace-template
   tags: [ "arch:amd64" ]
@@ -373,6 +377,7 @@ test-pyramid:single-fit-trace:itr:
   allow_failure: true
   variables:
     DD_SERVICE: "dd-sdk-android-itr"
+    DD_CIVISIBILITY_JACOCO_PLUGIN_VERSION: "0.8.12"
 
 # RUN INSTRUMENTED TESTS ON MIN API (21), LATEST API (34) and MEDIAN API (28)
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -156,7 +156,7 @@ analysis:detekt-custom:
 # TODO RUM-1622 cleanup this section
 # TESTS
 
-test:debug:
+.test-debug-template: &test-debug-template
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test
@@ -180,6 +180,15 @@ test:debug:
     reports:
       junit: "**/build/test-results/testDebugUnitTest/*.xml"
 
+test:debug:
+  <<: *test-debug-template
+
+test:debug:itr:
+  <<: *test-debug-template
+  allow_failure: true
+  variables:
+    DD_SERVICE: "dd-sdk-android-itr"
+
 test:tools:
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
@@ -196,7 +205,7 @@ test:tools:
     - export DD_AGENT_HOST="$BUILDENV_HOST_IP"
     - GRADLE_OPTS="-Xmx3072m" ./gradlew :unitTestTools --stacktrace --no-daemon --build-cache --gradle-user-home cache/
 
-test:kover:
+.test-kover-template: &test-kover-template
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test
@@ -223,6 +232,15 @@ test:kover:
     expire_in: 1 week
     reports:
       junit: "**/build/test-results/testReleaseUnitTest/*.xml"
+
+test:kover:
+  <<: *test-kover-template
+
+test:kover:itr:
+  <<: *test-kover-template
+  allow_failure: true
+  variables:
+    DD_SERVICE: "dd-sdk-android-itr"
 
 # TEST PYRAMID
 # the steps in this section should reflect our test pyramid strategy
@@ -266,7 +284,7 @@ test-pyramid:core-it-median-api:
     - !reference [.snippets, install-android-sdk]
     - !reference [.snippets, run-core-it-instrumented]
 
-test-pyramid:single-fit-logs:
+.test-pyramid-single-fit-logs-template: &test-pyramid-single-fit-logs-template
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -287,7 +305,16 @@ test-pyramid:single-fit-logs:
     reports:
       junit: "**/build/test-results/testReleaseUnitTest/*.xml"
 
-test-pyramid:single-fit-rum:
+test-pyramid:single-fit-logs:
+  <<: *test-pyramid-single-fit-logs-template
+
+test-pyramid:single-fit-logs:itr:
+  <<: *test-pyramid-single-fit-logs-template
+  allow_failure: true
+  variables:
+    DD_SERVICE: "dd-sdk-android-itr"
+
+.test-pyramid-single-fit-rum-template: &test-pyramid-single-fit-rum-template
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -308,7 +335,16 @@ test-pyramid:single-fit-rum:
     reports:
       junit: "**/build/test-results/testReleaseUnitTest/*.xml"
 
-test-pyramid:single-fit-trace:
+test-pyramid:single-fit-rum:
+  <<: *test-pyramid-single-fit-rum-template
+
+test-pyramid:single-fit-rum:itr:
+  <<: *test-pyramid-single-fit-rum-template
+  allow_failure: true
+  variables:
+    DD_SERVICE: "dd-sdk-android-itr"
+
+.test-pyramid-single-fit-trace-template: &test-pyramid-single-fit-trace-template
   tags: [ "arch:amd64" ]
   image: $CI_IMAGE_DOCKER
   stage: test-pyramid
@@ -328,6 +364,15 @@ test-pyramid:single-fit-trace:
     expire_in: 1 week
     reports:
       junit: "**/build/test-results/testReleaseUnitTest/*.xml"
+
+test-pyramid:single-fit-trace:
+  <<: *test-pyramid-single-fit-trace-template
+
+test-pyramid:single-fit-trace:itr:
+  <<: *test-pyramid-single-fit-trace-template
+  allow_failure: true
+  variables:
+    DD_SERVICE: "dd-sdk-android-itr"
 
 # RUN INSTRUMENTED TESTS ON MIN API (21), LATEST API (34) and MEDIAN API (28)
 


### PR DESCRIPTION
### What does this PR do?

For every CI job that was running tests with DD Java agent adds a "mirror" jobs that runs the same tests with ITR-enabled.
All the additional jobs are non-blocking.

### Motivation

The idea is to have ITR running in parallel with the regular CI flow for some time to evaluate that everything works correctly.
Once it is clear that ITR works as expected, the original jobs will be deleted and the new ones will take their place.

### Additional notes

The new jobs use a different Test Visibility service name (`dd-android-sdk-itr`) to avoid mixing ITR data with regular tests data.
When the switchover from the old jobs to the new ones is done, the service name will be updated.

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

