### PR TITLE
RUM-6566: Extract privacy error handling

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/PrivacyHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/PrivacyHelper.kt
@@ -1,0 +1,24 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.internal
+
+import com.datadog.android.api.InternalLogger
+
+internal class PrivacyHelper(private val internalLogger: InternalLogger) {
+    internal fun logInvalidPrivacyLevelError(e: Exception) {
+        internalLogger.log(
+            InternalLogger.Level.ERROR,
+            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
+            { INVALID_PRIVACY_LEVEL_ERROR },
+            e
+        )
+    }
+
+    internal companion object {
+        internal const val INVALID_PRIVACY_LEVEL_ERROR = "Invalid privacy level"
+    }
+}

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducer.kt
@@ -13,6 +13,7 @@ import com.datadog.android.api.InternalLogger
 import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.R
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
+import com.datadog.android.sessionreplay.internal.PrivacyHelper
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -25,7 +26,8 @@ internal class SnapshotProducer(
     private val imageWireframeHelper: ImageWireframeHelper,
     private val treeViewTraversal: TreeViewTraversal,
     private val optionSelectorDetector: OptionSelectorDetector,
-    private val internalLogger: InternalLogger
+    private val internalLogger: InternalLogger,
+    private val privacyHelper: PrivacyHelper = PrivacyHelper(internalLogger)
 ) {
 
     @UiThread
@@ -112,7 +114,7 @@ internal class SnapshotProducer(
                     ImagePrivacy.valueOf(privacy)
                 }
             } catch (e: IllegalArgumentException) {
-                logInvalidPrivacyLevelError(e)
+                privacyHelper.logInvalidPrivacyLevelError(e)
                 mappingContext.imagePrivacy
             }
 
@@ -125,7 +127,7 @@ internal class SnapshotProducer(
                     TextAndInputPrivacy.valueOf(privacy)
                 }
             } catch (e: IllegalArgumentException) {
-                logInvalidPrivacyLevelError(e)
+                privacyHelper.logInvalidPrivacyLevelError(e)
                 mappingContext.textAndInputPrivacy
             }
 
@@ -133,18 +135,5 @@ internal class SnapshotProducer(
             imagePrivacy = imagePrivacy,
             textAndInputPrivacy = textAndInputPrivacy
         )
-    }
-
-    private fun logInvalidPrivacyLevelError(e: Exception) {
-        internalLogger.log(
-            InternalLogger.Level.ERROR,
-            listOf(InternalLogger.Target.USER, InternalLogger.Target.TELEMETRY),
-            { INVALID_PRIVACY_LEVEL_ERROR },
-            e
-        )
-    }
-
-    internal companion object {
-        internal const val INVALID_PRIVACY_LEVEL_ERROR = "Invalid privacy level"
     }
 }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/SnapshotProducerTest.kt
@@ -13,8 +13,8 @@ import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.R
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.forge.ForgeConfigurator
+import com.datadog.android.sessionreplay.internal.PrivacyHelper.Companion.INVALID_PRIVACY_LEVEL_ERROR
 import com.datadog.android.sessionreplay.internal.async.RecordedDataQueueRefs
-import com.datadog.android.sessionreplay.internal.recorder.SnapshotProducer.Companion.INVALID_PRIVACY_LEVEL_ERROR
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
 import com.datadog.android.sessionreplay.recorder.SystemInformation


### PR DESCRIPTION
### What does this PR do?
Extracts the error handling for privacy into it's own class, as preparation for sharing this logic with touch privacy.

### Motivation
Part of the fine grained masking effort.

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

