### PR TITLE
Update the resolveBounds logic for semantics node

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -226,6 +226,7 @@ datadog:
       - "java.lang.Character.toChars(kotlin.Int):java.lang.IllegalArgumentException"
       - "java.lang.Class.forName(kotlin.String?):java.lang.LinkageError,java.lang.ExceptionInInitializerError,java.lang.ClassNotFoundException"
       - "java.lang.Class.getDeclaredField(kotlin.String?):java.lang.NoSuchFieldException,java.lang.SecurityException,java.lang.NullPointerException"
+      - "java.lang.Class.getDeclaredMethod(kotlin.String?, kotlin.Array?):java.lang.NoSuchMethodException,java.lang.SecurityException,java.lang.NullPointerException"
       - "java.lang.Class.getMethod(kotlin.String?, kotlin.Array?):java.lang.NoSuchMethodException,java.lang.SecurityException,java.lang.NullPointerException"
       - "java.lang.Class.isAssignableFrom(java.lang.Class?):java.lang.NullPointerException"
       - "java.lang.Runtime.addShutdownHook(java.lang.Thread):java.lang.IllegalArgumentException,java.lang.IllegalStateException,java.lang.SecurityException"

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapper.kt
@@ -9,22 +9,18 @@ package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.semantics.SemanticsNode
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 import com.datadog.android.sessionreplay.utils.GlobalBounds
 import kotlin.math.roundToInt
 
 internal abstract class AbstractSemanticsNodeMapper(
-    private val colorStringFormatter: ColorStringFormatter
+    private val colorStringFormatter: ColorStringFormatter,
+    private val semanticsUtils: SemanticsUtils = SemanticsUtils()
 ) : SemanticsNodeMapper {
 
     protected fun resolveBounds(semanticsNode: SemanticsNode): GlobalBounds {
-        val rect = semanticsNode.boundsInRoot
-        val density = semanticsNode.layoutInfo.density.density
-        val width = ((rect.right - rect.left) / density).toLong()
-        val height = ((rect.bottom - rect.top) / density).toLong()
-        val x = (rect.left / density).toLong()
-        val y = (rect.top / density).toLong()
-        return GlobalBounds(x, y, width, height)
+        return semanticsUtils.resolveInnerBounds(semanticsNode)
     }
 
     protected fun convertColor(color: Long): String? {

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapper.kt
@@ -19,7 +19,7 @@ import com.datadog.android.sessionreplay.utils.GlobalBounds
 internal class ButtonSemanticsNodeMapper(
     colorStringFormatter: ColorStringFormatter,
     private val semanticsUtils: SemanticsUtils = SemanticsUtils()
-) : AbstractSemanticsNodeMapper(colorStringFormatter) {
+) : AbstractSemanticsNodeMapper(colorStringFormatter, semanticsUtils) {
 
     override fun map(
         semanticsNode: SemanticsNode,

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapper.kt
@@ -21,12 +21,15 @@ import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWirefram
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection
 import com.datadog.android.sessionreplay.compose.internal.reflection.getSafe
+import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 
-internal class TextSemanticsNodeMapper(colorStringFormatter: ColorStringFormatter) :
-    AbstractSemanticsNodeMapper(colorStringFormatter) {
+internal class TextSemanticsNodeMapper(
+    colorStringFormatter: ColorStringFormatter,
+    semanticsUtils: SemanticsUtils = SemanticsUtils()
+) : AbstractSemanticsNodeMapper(colorStringFormatter, semanticsUtils) {
     override fun map(
         semanticsNode: SemanticsNode,
         parentContext: UiContext,

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapperTest.kt
@@ -9,7 +9,6 @@ package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.SemanticsNode
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
-import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -48,9 +47,6 @@ internal class ButtonSemanticsNodeMapperTest : AbstractCompositionGroupMapperTes
     private lateinit var mockSemanticsNode: SemanticsNode
 
     @Mock
-    private lateinit var mockSemanticsUtils: SemanticsUtils
-
-    @Mock
     private lateinit var mockAsyncJobStatusCallback: AsyncJobStatusCallback
 
     @LongForgery(min = 0L, max = 0xffffff)
@@ -86,6 +82,10 @@ internal class ButtonSemanticsNodeMapperTest : AbstractCompositionGroupMapperTes
     fun `M return the correct wireframe W map`() {
         // Given
         val mockSemanticsNode = mockSemanticsNode()
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn rectToBounds(
+            fakeBounds,
+            fakeDensity
+        )
         whenever(mockSemanticsUtils.resolveSemanticsModifierColor(mockSemanticsNode)).thenReturn(
             Color(fakeBackgroundColor).value.toLong()
         )

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
@@ -99,7 +99,10 @@ internal class TextSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest(
             textAlign = fakeTextAlign
         )
         whenever(mockTextLayoutResult.layoutInput) doReturn mockTextLayoutInput
-        testedTextSemanticsNodeMapper = TextSemanticsNodeMapper(colorStringFormatter = mockColorStringFormatter)
+        testedTextSemanticsNodeMapper = TextSemanticsNodeMapper(
+            colorStringFormatter = mockColorStringFormatter,
+            semanticsUtils = mockSemanticsUtils
+        )
     }
 
     @Test
@@ -112,6 +115,10 @@ internal class TextSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest(
                 AccessibilityAction("", stubTextLayoutResultAction)
             whenever(config) doReturn mockSemanticsConfiguration
         }
+        whenever(mockSemanticsUtils.resolveInnerBounds(mockNode)) doReturn rectToBounds(
+            fakeBounds,
+            fakeDensity
+        )
         val actual = testedTextSemanticsNodeMapper.map(
             mockNode,
             fakeUiContext,

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/GlobalBoundsForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/GlobalBoundsForgeryFactory.kt
@@ -1,0 +1,22 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.test.elmyr
+
+import com.datadog.android.sessionreplay.utils.GlobalBounds
+import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.ForgeryFactory
+
+internal class GlobalBoundsForgeryFactory : ForgeryFactory<GlobalBounds> {
+    override fun getForgery(forge: Forge): GlobalBounds {
+        return GlobalBounds(
+            x = forge.aLong(min = 128L, max = 65536L),
+            y = forge.aLong(min = 128L, max = 65536L),
+            width = forge.aLong(min = 32L, max = 65536L),
+            height = forge.aLong(min = 32L, max = 65536L)
+        )
+    }
+}

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/SessionReplayComposeForgeConfigurator.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/test/elmyr/SessionReplayComposeForgeConfigurator.kt
@@ -33,5 +33,6 @@ class SessionReplayComposeForgeConfigurator : BaseConfigurator() {
         forge.addFactory(ComposeWireframeForgeryFactory())
         forge.addFactory(MappingContextForgeryFactory())
         forge.addFactory(SystemInformationForgeryFactory())
+        forge.addFactory(GlobalBoundsForgeryFactory())
     }
 }


### PR DESCRIPTION
### What does this PR do?

The main updates is that we stop using `semanticsNode.boundsInRoot` to calculate the global bounds of the component, instead, we need to use the `positionInRoot` to have the top-left coordinates, and get the size of the component to have the correct global bounds, here is the explanation:

The main reason is that `semanticsNode.boundsInRoot` represents the visible bounds of the component, when it is fully visible in the screen, it is equal to the bounds that we want, but if we scroll the screen and it becomes half visible, the bounds will shrink to the visible area, which is not useful for our wireframes:

![image](https://github.com/user-attachments/assets/1badbef7-747d-4079-9dd2-1c9441c38ea6)


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

