### PR TITLE
Resolve Semantics modifier info to background wireframes

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -924,6 +924,7 @@ datadog:
       - "kotlin.collections.MutableList.add(com.datadog.android.rum.internal.domain.scope.RumScope)"
       - "kotlin.collections.MutableList.add(com.datadog.android.rum.model.ActionEvent.Type)"
       - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.compose.internal.data.Parameter)"
+      - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.compose.internal.utils.BackgroundInfo)"
       - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.internal.processor.MutationResolver.Entry)"
       - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.model.MobileSegment.Add)"
       - "kotlin.collections.MutableList.add(com.datadog.android.sessionreplay.model.MobileSegment.MobileRecord)"

--- a/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
+++ b/features/dd-sdk-android-session-replay-compose/consumer-rules.pro
@@ -25,6 +25,9 @@
 -keep class androidx.compose.ui.node.LayoutNode {
      *;
 }
+-keepclassmembers class androidx.compose.ui.semantics.SemanticsNode {
+     <fields>;
+}
 -keepclassmembers class androidx.compose.ui.draw.PainterElement {
      <fields>;
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapper.kt
@@ -9,7 +9,9 @@ package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.semantics.SemanticsNode
+import com.datadog.android.sessionreplay.compose.internal.utils.BackgroundInfo
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
+import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
 import com.datadog.android.sessionreplay.utils.GlobalBounds
 import kotlin.math.roundToInt
@@ -21,6 +23,29 @@ internal abstract class AbstractSemanticsNodeMapper(
 
     protected fun resolveBounds(semanticsNode: SemanticsNode): GlobalBounds {
         return semanticsUtils.resolveInnerBounds(semanticsNode)
+    }
+
+    protected fun resolveModifierWireframes(semanticsNode: SemanticsNode): List<MobileSegment.Wireframe> {
+        return semanticsUtils.resolveBackgroundInfo(semanticsNode).map {
+            convertBackgroundInfoToWireframes(backgroundInfo = it)
+        }
+    }
+
+    private fun convertBackgroundInfoToWireframes(
+        backgroundInfo: BackgroundInfo
+    ): MobileSegment.Wireframe {
+        val shapeStyle = MobileSegment.ShapeStyle(
+            backgroundColor = backgroundInfo.color?.let { convertColor(it) },
+            cornerRadius = backgroundInfo.cornerRadius
+        )
+        return MobileSegment.Wireframe.ShapeWireframe(
+            id = semanticsUtils.resolveBackgroundInfoId(backgroundInfo),
+            x = backgroundInfo.globalBounds.x,
+            y = backgroundInfo.globalBounds.y,
+            width = backgroundInfo.globalBounds.width,
+            height = backgroundInfo.globalBounds.height,
+            shapeStyle = shapeStyle
+        )
     }
 
     protected fun convertColor(color: Long): String? {

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapper.kt
@@ -7,14 +7,11 @@
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
 import androidx.compose.ui.semantics.SemanticsNode
-import androidx.compose.ui.unit.Density
 import com.datadog.android.sessionreplay.compose.internal.data.SemanticsWireframe
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
 import com.datadog.android.sessionreplay.compose.internal.utils.SemanticsUtils
-import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
 import com.datadog.android.sessionreplay.utils.ColorStringFormatter
-import com.datadog.android.sessionreplay.utils.GlobalBounds
 
 internal class ButtonSemanticsNodeMapper(
     colorStringFormatter: ColorStringFormatter,
@@ -26,34 +23,9 @@ internal class ButtonSemanticsNodeMapper(
         parentContext: UiContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
     ): SemanticsWireframe {
-        val density = semanticsNode.layoutInfo.density
-        val bounds = resolveBounds(semanticsNode)
-        val buttonStyle = resolveSemanticsButtonStyle(semanticsNode, bounds, density)
         return SemanticsWireframe(
-            wireframes = MobileSegment.Wireframe.ShapeWireframe(
-                id = semanticsNode.id.toLong(),
-                x = bounds.x,
-                y = bounds.y,
-                width = bounds.width,
-                height = bounds.height,
-                shapeStyle = buttonStyle
-            ).let { listOf(it) },
-            uiContext = parentContext.copy(
-                parentContentColor = buttonStyle.backgroundColor ?: parentContext.parentContentColor
-            )
-        )
-    }
-
-    private fun resolveSemanticsButtonStyle(
-        semanticsNode: SemanticsNode,
-        globalBounds: GlobalBounds,
-        density: Density
-    ): MobileSegment.ShapeStyle {
-        val color = semanticsUtils.resolveSemanticsModifierColor(semanticsNode)
-        val cornerRadius = semanticsUtils.resolveSemanticsModifierCornerRadius(semanticsNode, globalBounds, density)
-        return MobileSegment.ShapeStyle(
-            backgroundColor = color?.let { convertColor(it) },
-            cornerRadius = cornerRadius
+            wireframes = resolveModifierWireframes(semanticsNode),
+            uiContext = parentContext
         )
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ImageSemanticsNodeMapper.kt
@@ -37,6 +37,7 @@ internal class ImageSemanticsNodeMapper(
     ): SemanticsWireframe {
         val bounds = resolveBounds(semanticsNode)
         val bitmapInfo = resolveSemanticsPainter(semanticsNode)
+        val containerFrames = resolveModifierWireframes(semanticsNode).toMutableList()
         val imageWireframe = if (bitmapInfo != null) {
             parentContext.imageWireframeHelper.createImageWireframeByBitmap(
                 id = semanticsNode.id.toLong(),
@@ -54,8 +55,11 @@ internal class ImageSemanticsNodeMapper(
         } else {
             null
         }
+        imageWireframe?.let {
+            containerFrames.add(it)
+        }
         return SemanticsWireframe(
-            wireframes = listOfNotNull(imageWireframe),
+            wireframes = containerFrames,
             uiContext = null
         )
     }

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/reflection/ComposeReflection.kt
@@ -38,6 +38,9 @@ internal object ComposeReflection {
 
     val LayoutNodeClass = getClassSafe("androidx.compose.ui.node.LayoutNode")
 
+    val SemanticsNodeClass = getClassSafe("androidx.compose.ui.semantics.SemanticsNode")
+    val LayoutNodeField = SemanticsNodeClass?.getDeclaredFieldSafe("layoutNode")
+
     val GetInnerLayerCoordinatorMethod = LayoutNodeClass?.getDeclaredMethodSafe("getInnerLayerCoordinator")
 
     val AndroidComposeViewClass = getClassSafe("androidx.compose.ui.platform.AndroidComposeView")
@@ -48,7 +51,15 @@ internal object ComposeReflection {
 
     val BackgroundElementClass = getClassSafe("androidx.compose.foundation.BackgroundElement")
     val ColorField = BackgroundElementClass?.getDeclaredFieldSafe("color")
-    val ShapeField = BackgroundElementClass?.getDeclaredFieldSafe("shape")
+
+    val PaddingElementClass = getClassSafe("androidx.compose.foundation.layout.PaddingElement")
+    val StartField = PaddingElementClass?.getDeclaredFieldSafe("start")
+    val EndField = PaddingElementClass?.getDeclaredFieldSafe("end")
+    val BottomField = PaddingElementClass?.getDeclaredFieldSafe("bottom")
+    val TopField = PaddingElementClass?.getDeclaredFieldSafe("top")
+
+    val GraphicsLayerElementClass = getClassSafe("androidx.compose.ui.graphics.GraphicsLayerElement")
+    val ClipShapeField = GraphicsLayerElementClass?.getDeclaredFieldSafe("shape")
 
     val PainterElementClass = getClassSafe("androidx.compose.ui.draw.PainterElement")
     val PainterField = PainterElementClass?.getDeclaredFieldSafe("painter")

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/BackgroundInfo.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/BackgroundInfo.kt
@@ -1,0 +1,15 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.compose.internal.utils
+
+import com.datadog.android.sessionreplay.utils.GlobalBounds
+
+internal data class BackgroundInfo(
+    val globalBounds: GlobalBounds = GlobalBounds(0L, 0L, 0L, 0L),
+    val color: Long? = null,
+    val cornerRadius: Float = 0f
+)

--- a/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/main/kotlin/com/datadog/android/sessionreplay/compose/internal/utils/SemanticsUtils.kt
@@ -6,12 +6,12 @@
 
 package com.datadog.android.sessionreplay.compose.internal.utils
 
-import android.annotation.SuppressLint
 import android.view.View
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composition
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.layout.Placeable
 import androidx.compose.ui.semantics.SemanticsNode
 import androidx.compose.ui.semantics.SemanticsOwner
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.Density
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.CompositionField
 import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.GetInnerLayerCoordinatorMethod
+import com.datadog.android.sessionreplay.compose.internal.reflection.ComposeReflection.LayoutNodeField
 import com.datadog.android.sessionreplay.compose.internal.reflection.getSafe
 import com.datadog.android.sessionreplay.utils.GlobalBounds
 
@@ -37,17 +38,86 @@ internal class SemanticsUtils {
         return null
     }
 
-    internal fun resolveSemanticsModifierColor(
-        semanticsNode: SemanticsNode
-    ): Long? {
-        val modifier = resolveSemanticsModifier(semanticsNode)
-        return ComposeReflection.ColorField?.getSafe(modifier) as? Long
+    internal fun resolveOuterBounds(semanticsNode: SemanticsNode): GlobalBounds {
+        var currentBounds = resolveInnerBounds(semanticsNode)
+        semanticsNode.layoutInfo.getModifierInfo().filter {
+            (ComposeReflection.PaddingElementClass?.isInstance(it.modifier) == true)
+        }.forEach {
+            val top = ComposeReflection.TopField?.getSafe(it.modifier) as? Float ?: 0.0f
+            val start = ComposeReflection.StartField?.getSafe(it.modifier) as? Float ?: 0.0f
+            val end = ComposeReflection.EndField?.getSafe(it.modifier) as? Float ?: 0.0f
+            val bottom = ComposeReflection.BottomField?.getSafe(it.modifier) as? Float ?: 0.0f
+            currentBounds = GlobalBounds(
+                x = currentBounds.x - start.toLong(),
+                y = currentBounds.y - top.toLong(),
+                width = currentBounds.width + (end + start).toLong(),
+                height = currentBounds.height + (bottom + top).toLong()
+            )
+        }
+        return currentBounds
+    }
+
+    internal fun resolveBackgroundInfo(semanticsNode: SemanticsNode): List<BackgroundInfo> {
+        val backgroundInfoList = mutableListOf<BackgroundInfo>()
+        // CurrentBackgroundInfo is to store bounds, color and shape information in sequence of modifiers.
+        var currentBackgroundInfo = BackgroundInfo()
+        var currentBounds: GlobalBounds = resolveOuterBounds(semanticsNode)
+        // If the currentBounds is already invalid, return with the existing wireframes
+        if (!isGlobalBoundsValid(globalBounds = currentBounds)) {
+            return backgroundInfoList
+        }
+        val density = semanticsNode.layoutInfo.density
+        // Iterate all the modifiers in user calling sequence, when meet:
+        // -> clip(): calculate the corner radius and update `currentBackgroundInfo`
+        // -> padding(): shrink the bounds from the previous bounds and update `currentBackgroundInfo`
+        // -> background(): retrieve the color and use `currentBackgroundInfo` to generate wireframes,
+        //                  then reset `currentBackgroundInfo`.
+        semanticsNode.layoutInfo.getModifierInfo().forEach { modifierInfo ->
+            if (ComposeReflection.BackgroundElementClass?.isInstance(modifierInfo.modifier) == true) {
+                val color = ComposeReflection.ColorField?.getSafe(modifierInfo.modifier) as? Long
+                currentBackgroundInfo = currentBackgroundInfo.copy(globalBounds = currentBounds, color = color)
+                backgroundInfoList.add(currentBackgroundInfo)
+                currentBackgroundInfo = BackgroundInfo()
+            } else if (ComposeReflection.PaddingElementClass?.isInstance(modifierInfo.modifier) == true) {
+                currentBounds = shrinkInnerBounds(modifierInfo.modifier, currentBounds)
+                currentBackgroundInfo = currentBackgroundInfo.copy(globalBounds = currentBounds)
+            } else if (ComposeReflection.GraphicsLayerElementClass?.isInstance(modifierInfo.modifier) == true) {
+                val cornerRadius = resolveCornerRadius(modifierInfo.modifier, currentBounds, density)
+                currentBackgroundInfo = currentBackgroundInfo.copy(cornerRadius = cornerRadius)
+            }
+        }
+        return backgroundInfoList
+    }
+
+    internal fun resolveBackgroundInfoId(backgroundInfo: BackgroundInfo): Long {
+        return System.identityHashCode(backgroundInfo).toLong()
+    }
+
+    private fun shrinkInnerBounds(
+        modifier: Modifier,
+        currentBounds: GlobalBounds
+    ): GlobalBounds {
+        val top = ComposeReflection.TopField?.getSafe(modifier) as? Float ?: 0.0f
+        val start = ComposeReflection.StartField?.getSafe(modifier) as? Float ?: 0.0f
+        val end = ComposeReflection.EndField?.getSafe(modifier) as? Float ?: 0.0f
+        val bottom = ComposeReflection.BottomField?.getSafe(modifier) as? Float ?: 0.0f
+        return GlobalBounds(
+            x = currentBounds.x + start.toLong(),
+            y = currentBounds.y + top.toLong(),
+            width = currentBounds.width - (end + start).toLong(),
+            height = currentBounds.height - (bottom + top).toLong()
+        )
+    }
+
+    private fun isGlobalBoundsValid(globalBounds: GlobalBounds): Boolean {
+        return (globalBounds.width > 0 && globalBounds.height > 0)
     }
 
     internal fun resolveInnerBounds(semanticsNode: SemanticsNode): GlobalBounds {
         val offset = semanticsNode.positionInRoot
         // Resolve the measured size.
-        val size = resolveInnerSize(semanticsNode)
+        // Some semantics node doesn't have InnerLayerCoordinator, so use boundsInRoot as a fallback.
+        val size = resolveInnerSize(semanticsNode) ?: semanticsNode.boundsInRoot.size
         val density = semanticsNode.layoutInfo.density.density
         val width = (size.width / density).toLong()
         val height = (size.height / density).toLong()
@@ -56,33 +126,34 @@ internal class SemanticsUtils {
         return GlobalBounds(x, y, width, height)
     }
 
-    private fun resolveInnerSize(semanticsNode: SemanticsNode): Size {
-        val innerLayerCoordinator = GetInnerLayerCoordinatorMethod?.invoke(semanticsNode.layoutInfo)
+    private fun resolveInnerSize(semanticsNode: SemanticsNode): Size? {
+        val layoutNode = LayoutNodeField?.getSafe(semanticsNode)
+        val innerLayerCoordinator = layoutNode?.let { GetInnerLayerCoordinatorMethod?.invoke(it) }
         val placeable = innerLayerCoordinator as? Placeable
-        val height = placeable?.height ?: 0
-        val width = placeable?.width ?: 0
-        return Size(width = width.toFloat(), height = height.toFloat())
-    }
-
-    internal fun resolveSemanticsModifierCornerRadius(
-        semanticsNode: SemanticsNode,
-        globalBounds: GlobalBounds,
-        density: Density
-    ): Float? {
-        val size = Size(globalBounds.width.toFloat(), globalBounds.height.toFloat())
-        val modifier = resolveSemanticsModifier(semanticsNode)
-        val shape = ComposeReflection.ShapeField?.getSafe(modifier) as? RoundedCornerShape
-        return shape?.let {
-            // We only have a single value for corner radius, so we default to using the
-            // top left (i.e.: topStart) corner's value and apply it to all corners
-            it.topStart.toPx(size, density) / density.density
+        val height = placeable?.height
+        val width = placeable?.width
+        return if (height != null && width != null) {
+            Size(width = width.toFloat(), height = height.toFloat())
+        } else {
+            null
         }
     }
 
-    @SuppressLint("ModifierFactoryExtensionFunction")
-    internal fun resolveSemanticsModifier(semanticsNode: SemanticsNode): Modifier? {
-        return semanticsNode.layoutInfo.getModifierInfo().firstOrNull {
-            ComposeReflection.BackgroundElementClass?.isInstance(it.modifier) == true
-        }?.modifier
+    private fun resolveCornerRadius(modifier: Modifier, currentBounds: GlobalBounds, density: Density): Float {
+        val shape = ComposeReflection.ClipShapeField?.getSafe(modifier) as? Shape
+        return shape?.let {
+            val size = Size(
+                currentBounds.width.toFloat() * density.density,
+                currentBounds.height.toFloat() * density.density
+            )
+            // We only have a single value for corner radius, so we default to using the
+            // top left (i.e.: topStart) corner's value and apply it to all corners
+            // it.topStart.toPx(size, density) / density.density
+            if (it is RoundedCornerShape) {
+                it.topStart.toPx(size, density) / density.density
+            } else {
+                0f
+            }
+        } ?: 0f
     }
 }

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/AbstractSemanticsNodeMapperTest.kt
@@ -127,7 +127,7 @@ internal open class AbstractCompositionGroupMapperTest {
     }
 
     private fun convertColorIntAlpha(color: Long): Pair<Int, Int> {
-        val c = Color(color)
+        val c = Color(color shr 32)
         return Pair(c.toArgb(), (c.alpha * MAX_ALPHA).roundToInt())
     }
 

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/ButtonSemanticsNodeMapperTest.kt
@@ -6,9 +6,9 @@
 
 package com.datadog.android.sessionreplay.compose.internal.mappers.semantics
 
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.SemanticsNode
 import com.datadog.android.sessionreplay.compose.internal.data.UiContext
+import com.datadog.android.sessionreplay.compose.internal.utils.BackgroundInfo
 import com.datadog.android.sessionreplay.compose.test.elmyr.SessionReplayComposeForgeConfigurator
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -27,9 +27,7 @@ import org.junit.jupiter.api.extension.Extensions
 import org.mockito.Mock
 import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
-import org.mockito.kotlin.any
 import org.mockito.kotlin.doReturn
-import org.mockito.kotlin.eq
 import org.mockito.kotlin.whenever
 import org.mockito.quality.Strictness
 
@@ -49,7 +47,7 @@ internal class ButtonSemanticsNodeMapperTest : AbstractCompositionGroupMapperTes
     @Mock
     private lateinit var mockAsyncJobStatusCallback: AsyncJobStatusCallback
 
-    @LongForgery(min = 0L, max = 0xffffff)
+    @LongForgery(min = 0xffffffff)
     var fakeBackgroundColor: Long = 0L
 
     @FloatForgery
@@ -82,20 +80,19 @@ internal class ButtonSemanticsNodeMapperTest : AbstractCompositionGroupMapperTes
     fun `M return the correct wireframe W map`() {
         // Given
         val mockSemanticsNode = mockSemanticsNode()
+        val fakeBackgroundInfo = BackgroundInfo(
+            globalBounds = rectToBounds(fakeBounds, fakeDensity),
+            color = fakeBackgroundColor,
+            cornerRadius = fakeCornerRadius
+        )
         whenever(mockSemanticsUtils.resolveInnerBounds(mockSemanticsNode)) doReturn rectToBounds(
             fakeBounds,
             fakeDensity
         )
-        whenever(mockSemanticsUtils.resolveSemanticsModifierColor(mockSemanticsNode)).thenReturn(
-            Color(fakeBackgroundColor).value.toLong()
+        whenever(mockSemanticsUtils.resolveBackgroundInfo(mockSemanticsNode)) doReturn listOf(
+            fakeBackgroundInfo
         )
-        whenever(
-            mockSemanticsUtils.resolveSemanticsModifierCornerRadius(
-                eq(mockSemanticsNode),
-                any(),
-                eq(mockDensity)
-            )
-        ).thenReturn(fakeCornerRadius)
+        whenever(mockSemanticsUtils.resolveBackgroundInfoId(fakeBackgroundInfo)) doReturn fakeSemanticsId.toLong()
 
         // When
         val actual = testedButtonSemanticsNodeMapper.map(

--- a/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
+++ b/features/dd-sdk-android-session-replay-compose/src/test/kotlin/com/datadog/android/sessionreplay/compose/internal/mappers/semantics/TextSemanticsNodeMapperTest.kt
@@ -74,7 +74,7 @@ internal class TextSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest(
 
     var fakeTextAlign: TextAlign = TextAlign.Left
 
-    @LongForgery(min = 0L, max = 0xffffff)
+    @LongForgery(min = 0xffffffff)
     var fakeTextColor: Long = 0x12346778L
 
     @Forgery
@@ -93,7 +93,7 @@ internal class TextSemanticsNodeMapperTest : AbstractCompositionGroupMapperTest(
         mockColorStringFormatter(fakeTextColor, fakeTextColorHexString)
 
         whenever(mockTextLayoutInput.style) doReturn TextStyle(
-            color = Color(fakeTextColor),
+            color = Color(fakeTextColor shr 32),
             fontFamily = FontFamily.Default,
             fontSize = fakeFontSize.sp,
             textAlign = fakeTextAlign


### PR DESCRIPTION
### What does this PR do?

This PR manages to resolve the background information added by `Modifier` to shape wireframes.

For example, if an icon is defined like this:
```
Icon(modifier = Modifier
        .padding(16.dp)
        .clip(Circle(16.dp))
        .background(Color.Green)
        .padding(32.dp)
        .size(128.dp)
        .clip(RoundedCornerShape(8.dp))
        .background(Color.DarkGray)
        .padding(4.dp),
     painter = painterResource(R.drawable.ic_dd_icon_red),
     tint = Color.Red,
     contentDescription = "red dog" )
```

then it will be resolved to three wireframes, one shape wire frame of green circle, one shape wire frame of black rectangle , one image wireframe with icon image.

### Demo
| Sample App | Session Replay |
| --- | --- |
| <img width="400" alt="image" src="https://github.com/user-attachments/assets/7801c3c1-12c0-4c71-b213-6643e5bc0da4">) | <img width="400" alt="image" src="https://github.com/user-attachments/assets/8741228b-1c97-4a86-8ec2-25ea525f838d">|


### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

