### PR TITLE
Fix the decompression in SR instrumented tests for API 21

### DIFF
--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/BaseSessionReplayTest.kt
@@ -198,9 +198,10 @@ internal abstract class BaseSessionReplayTest<R : Activity> {
         val buf = ByteArray(1024)
         val decompressor = Inflater()
         decompressor.setInput(input, 0, input.size)
-        while (!decompressor.finished()) {
-            val resultLength = decompressor.inflate(buf)
-            bos.write(buf, 0, resultLength)
+        var uncompressedBytes = Int.MAX_VALUE
+        while (uncompressedBytes > 0) {
+            uncompressedBytes = decompressor.inflate(buf)
+            bos.write(buf, 0, uncompressedBytes)
         }
         decompressor.end()
         return bos.toByteArray()


### PR DESCRIPTION
### What does this PR do?

In our SR instrumented tests we need to decompress the segments intercepted through the `MockServer` in order to be able to assess them with the expected payloads.
The segments are previously compressed with a `deflate` alg and we are using an `Inflater` instance in the SR tests to deflate them.
The `Inflater` class logic is buggy in the Android API 21 JVM. For some reason the `inflater.finished` method always returns `false` having our decompression logic running in an endless loop.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

