### PR TITLE
RUM-5873: Reactivate Session Replay instrumented test for API 21

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper.kt
@@ -121,7 +121,9 @@ open class LegacyDrawableToColorMapper : DrawableToColorMapper {
 
         if (fillPaint == null) return null
         val filterColor = try {
-            mColorField?.get(fillPaint.colorFilter) as? Int ?: fillPaint.color
+            fillPaint.colorFilter?.let {
+                mColorField?.get(it) as? Int
+            } ?: fillPaint.color
         } catch (e: IllegalArgumentException) {
             internalLogger.log(
                 InternalLogger.Level.WARN,
@@ -155,7 +157,7 @@ open class LegacyDrawableToColorMapper : DrawableToColorMapper {
      * @return the color to map to or null if not applicable
      */
     protected open fun resolveInsetDrawable(drawable: InsetDrawable, internalLogger: InternalLogger): Int? {
-        return null
+        return drawable.drawable?.let { mapDrawableToColor(it, internalLogger) }
     }
 
     /**

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/ConsentGrantedSrTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/ConsentGrantedSrTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.rules.SessionReplayTestRule
 import org.junit.Rule
@@ -22,9 +20,7 @@ internal class ConsentGrantedSrTest : BaseSessionReplayTest<SessionReplayPlaygro
         keepRequests = true
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsAllowTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.chekboxandradio
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayRadioCheckboxFieldsActivity
@@ -28,9 +26,7 @@ internal class SrCheckBoxAndRadioFieldsAllowTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsMaskTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.chekboxandradio
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayRadioCheckboxFieldsActivity
@@ -28,9 +26,7 @@ internal class SrCheckBoxAndRadioFieldsMaskTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/chekboxandradio/SrCheckBoxAndRadioFieldsMaskUserInputTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.chekboxandradio
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayRadioCheckboxFieldsActivity
@@ -28,9 +26,7 @@ internal class SrCheckBoxAndRadioFieldsMaskUserInputTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsAllowTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.imagebuttons
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImageButtonsActivity
@@ -28,9 +26,7 @@ internal class SrImageButtonsAllowTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.imagebuttons
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImageButtonsActivity
@@ -28,9 +26,7 @@ internal class SrImageButtonsMaskTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/imagebuttons/SrImageButtonsMaskUserInputTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.imagebuttons
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImageButtonsActivity
@@ -28,9 +26,7 @@ internal class SrImageButtonsMaskUserInputTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesAllowTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.images
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImagesActivity
@@ -28,9 +26,7 @@ internal class SrImagesAllowTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesMaskTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.images
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImagesActivity
@@ -28,9 +26,7 @@ internal class SrImagesMaskTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/images/SrImagesMaskUserInputTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.images
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayImagesActivity
@@ -28,9 +26,7 @@ internal class SrImagesMaskUserInputTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsAllowTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.sensitivefields
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplaySensitiveFieldsActivity
@@ -27,9 +25,7 @@ internal class SrSensitiveFieldsAllowTest : BaseSessionReplayTest<SessionReplayS
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsMaskTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.sensitivefields
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplaySensitiveFieldsActivity
@@ -27,9 +25,7 @@ internal class SrSensitiveFieldsMaskTest : BaseSessionReplayTest<SessionReplaySe
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/sensitivefields/SrSensitiveFieldsMaskUserInputTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.sensitivefields
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplaySensitiveFieldsActivity
@@ -27,9 +25,7 @@ internal class SrSensitiveFieldsMaskUserInputTest : BaseSessionReplayTest<Sessio
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsAllowTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsAllowTest.kt
@@ -27,7 +27,9 @@ internal class SrTextFieldsAllowTest : BaseSessionReplayTest<SessionReplayTextFi
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.ALLOW)
     )
 
-    // TODO RUM-6839: Fix test on API 21
+    // TODO RUM-6839: Fix test on API 21, the test failure is caused by different drawable
+    //  on the text background among API versions. the background wireframes on higher version are
+    //  images, on lower version are shapes.
     @Test
     @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsMaskTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsMaskTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.textfields
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayTextFieldsActivity
@@ -27,9 +25,7 @@ internal class SrTextFieldsMaskTest : BaseSessionReplayTest<SessionReplayTextFie
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsMaskUserInputTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.textfields
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayTextFieldsActivity
@@ -27,9 +25,7 @@ internal class SrTextFieldsMaskUserInputTest : BaseSessionReplayTest<SessionRepl
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)

--- a/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsWithInputMaskUserInputTest.kt
+++ b/instrumented/integration/src/androidTest/kotlin/com/datadog/android/sdk/integration/sessionreplay/textfields/SrTextFieldsWithInputMaskUserInputTest.kt
@@ -6,8 +6,6 @@
 
 package com.datadog.android.sdk.integration.sessionreplay.textfields
 
-import android.os.Build
-import androidx.test.filters.SdkSuppress
 import com.datadog.android.privacy.TrackingConsent
 import com.datadog.android.sdk.integration.sessionreplay.BaseSessionReplayTest
 import com.datadog.android.sdk.integration.sessionreplay.SessionReplayTextFieldsWithInputActivity
@@ -28,9 +26,7 @@ internal class SrTextFieldsWithInputMaskUserInputTest :
         intentExtras = mapOf(SR_PRIVACY_LEVEL to SessionReplayPrivacy.MASK_USER_INPUT)
     )
 
-    // TODO RUM-6839: Fix test on API 21
     @Test
-    @SdkSuppress(minSdkVersion = Build.VERSION_CODES.P)
     fun assessRecordedScreenPayload() {
         runInstrumentationScenario()
         assessSrPayload(EXPECTED_PAYLOAD_FILE_NAME, rule)


### PR DESCRIPTION
### What does this PR do?

Reactive Session Replay instrumented test for API 21, 
Fix a drawable resolving issue due to the different behavior on lower API.

### Motivation

RUM-5873


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

