### PR TITLE
Fix checkable mapper privacy issue

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableTextViewMapper.kt
@@ -111,7 +111,7 @@ internal abstract class CheckableTextViewMapper<T>(
             )
             mappingContext.imageWireframeHelper.createImageWireframe(
                 view = view,
-                imagePrivacy = mappingContext.imagePrivacy,
+                imagePrivacy = mapInputPrivacyToImagePrivacy(mappingContext.textAndInputPrivacy),
                 currentWireframeIndex = 0,
                 x = checkBoxBounds.x,
                 y = checkBoxBounds.y,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/CheckableWireframeMapper.kt
@@ -10,6 +10,7 @@ import android.view.View
 import android.widget.Checkable
 import androidx.annotation.UiThread
 import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.ImagePrivacy
 import com.datadog.android.sessionreplay.TextAndInputPrivacy
 import com.datadog.android.sessionreplay.model.MobileSegment
 import com.datadog.android.sessionreplay.recorder.MappingContext
@@ -50,6 +51,14 @@ internal abstract class CheckableWireframeMapper<T>(
             return mainWireframes + wireframes
         }
         return mainWireframes
+    }
+
+    protected fun mapInputPrivacyToImagePrivacy(inputPrivacy: TextAndInputPrivacy): ImagePrivacy {
+        return when (inputPrivacy) {
+            TextAndInputPrivacy.MASK_SENSITIVE_INPUTS -> ImagePrivacy.MASK_NONE
+            TextAndInputPrivacy.MASK_ALL_INPUTS,
+            TextAndInputPrivacy.MASK_ALL -> ImagePrivacy.MASK_ALL
+        }
     }
 
     @UiThread

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapper.kt
@@ -80,7 +80,7 @@ internal open class SwitchCompatMapper(
             }?.let { drawable ->
                 mappingContext.imageWireframeHelper.createImageWireframe(
                     view = view,
-                    imagePrivacy = mappingContext.imagePrivacy,
+                    imagePrivacy = mapInputPrivacyToImagePrivacy(mappingContext.textAndInputPrivacy),
                     currentWireframeIndex = prevIndex + 1,
                     x = trackBounds.x.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),
                     y = trackBounds.y.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),
@@ -111,7 +111,7 @@ internal open class SwitchCompatMapper(
             thumbBounds?.let { thumbBounds ->
                 mappingContext.imageWireframeHelper.createImageWireframe(
                     view = view,
-                    imagePrivacy = mappingContext.imagePrivacy,
+                    imagePrivacy = mapInputPrivacyToImagePrivacy(mappingContext.textAndInputPrivacy),
                     currentWireframeIndex = prevIndex + 1,
                     x = thumbBounds.x.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),
                     y = thumbBounds.y.densityNormalized(mappingContext.systemInformation.screenDensity).toLong(),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckableTextViewMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/BaseCheckableTextViewMapperTest.kt
@@ -218,7 +218,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
         // Then
         verify(fakeMappingContext.imageWireframeHelper).createImageWireframe(
             view = eq(mockCheckableTextView),
-            imagePrivacy = eq(ImagePrivacy.MASK_LARGE_ONLY),
+            imagePrivacy = eq(ImagePrivacy.MASK_NONE),
             currentWireframeIndex = anyInt(),
             x = eq(expectedX),
             y = eq(expectedY),
@@ -261,7 +261,7 @@ internal abstract class BaseCheckableTextViewMapperTest<T> :
         // Then
         verify(fakeMappingContext.imageWireframeHelper).createImageWireframe(
             view = eq(mockCheckableTextView),
-            imagePrivacy = eq(ImagePrivacy.MASK_LARGE_ONLY),
+            imagePrivacy = eq(ImagePrivacy.MASK_NONE),
             currentWireframeIndex = anyInt(),
             x = eq(expectedX),
             y = eq(expectedY),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/SwitchCompatMapperTest.kt
@@ -89,7 +89,7 @@ internal class SwitchCompatMapperTest : BaseSwitchCompatMapperTest() {
 
             verify(fakeMappingContext.imageWireframeHelper, times(2)).createImageWireframe(
                 view = eq(mockSwitch),
-                imagePrivacy = eq(ImagePrivacy.MASK_LARGE_ONLY),
+                imagePrivacy = eq(ImagePrivacy.MASK_NONE),
                 currentWireframeIndex = ArgumentMatchers.anyInt(),
                 x = xCaptor.capture(),
                 y = yCaptor.capture(),


### PR DESCRIPTION
### What does this PR do?

Before, checkable mapper was using image privacy to mask the components, `Checkbox`, `CheckedTextView`, `Switch` are affected.
We actually need to use Text & input privacy to mask them.


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

