### PR TITLE
RUM-5814 Provide device and os info into local spans metadata

### DIFF
--- a/features/dd-sdk-android-trace/api/apiSurface
+++ b/features/dd-sdk-android-trace/api/apiSurface
@@ -44,7 +44,7 @@ data class com.datadog.android.trace.model.SpanEvent
       fun fromJson(kotlin.String): Metrics
       fun fromJsonObject(com.google.gson.JsonObject): Metrics
   data class Meta
-    constructor(kotlin.String, Dd, Span, Tracer, Usr, Network? = null, kotlin.collections.MutableMap<kotlin.String, kotlin.String> = mutableMapOf())
+    constructor(kotlin.String, Dd, Span, Tracer, Usr, Network? = null, Device, Os, kotlin.collections.MutableMap<kotlin.String, kotlin.String> = mutableMapOf())
     fun toJson(): com.google.gson.JsonElement
     companion object 
       fun fromJson(kotlin.String): Meta
@@ -79,6 +79,18 @@ data class com.datadog.android.trace.model.SpanEvent
     companion object 
       fun fromJson(kotlin.String): Network
       fun fromJsonObject(com.google.gson.JsonObject): Network
+  data class Device
+    constructor(Type, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null, kotlin.String? = null)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Device
+      fun fromJsonObject(com.google.gson.JsonObject): Device
+  data class Os
+    constructor(kotlin.String, kotlin.String, kotlin.String? = null, kotlin.String)
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Os
+      fun fromJsonObject(com.google.gson.JsonObject): Os
   data class Application
     constructor(kotlin.String? = null)
     fun toJson(): com.google.gson.JsonElement
@@ -109,3 +121,15 @@ data class com.datadog.android.trace.model.SpanEvent
     companion object 
       fun fromJson(kotlin.String): SimCarrier
       fun fromJsonObject(com.google.gson.JsonObject): SimCarrier
+  enum Type
+    constructor(kotlin.String)
+    - MOBILE
+    - DESKTOP
+    - TABLET
+    - TV
+    - GAMING_CONSOLE
+    - BOT
+    - OTHER
+    fun toJson(): com.google.gson.JsonElement
+    companion object 
+      fun fromJson(kotlin.String): Type

--- a/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
+++ b/features/dd-sdk-android-trace/api/dd-sdk-android-trace.api
@@ -188,25 +188,58 @@ public final class com/datadog/android/trace/model/SpanEvent$Dd$Companion {
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/trace/model/SpanEvent$Dd;
 }
 
+public final class com/datadog/android/trace/model/SpanEvent$Device {
+	public static final field Companion Lcom/datadog/android/trace/model/SpanEvent$Device$Companion;
+	public fun <init> (Lcom/datadog/android/trace/model/SpanEvent$Type;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Lcom/datadog/android/trace/model/SpanEvent$Type;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun component5 ()Ljava/lang/String;
+	public final fun copy (Lcom/datadog/android/trace/model/SpanEvent$Type;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Device;
+	public static synthetic fun copy$default (Lcom/datadog/android/trace/model/SpanEvent$Device;Lcom/datadog/android/trace/model/SpanEvent$Type;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/trace/model/SpanEvent$Device;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Device;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/trace/model/SpanEvent$Device;
+	public final fun getArchitecture ()Ljava/lang/String;
+	public final fun getBrand ()Ljava/lang/String;
+	public final fun getModel ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getType ()Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/trace/model/SpanEvent$Device$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Device;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/trace/model/SpanEvent$Device;
+}
+
 public final class com/datadog/android/trace/model/SpanEvent$Meta {
 	public static final field Companion Lcom/datadog/android/trace/model/SpanEvent$Meta$Companion;
-	public fun <init> (Ljava/lang/String;Lcom/datadog/android/trace/model/SpanEvent$Dd;Lcom/datadog/android/trace/model/SpanEvent$Span;Lcom/datadog/android/trace/model/SpanEvent$Tracer;Lcom/datadog/android/trace/model/SpanEvent$Usr;Lcom/datadog/android/trace/model/SpanEvent$Network;Ljava/util/Map;)V
-	public synthetic fun <init> (Ljava/lang/String;Lcom/datadog/android/trace/model/SpanEvent$Dd;Lcom/datadog/android/trace/model/SpanEvent$Span;Lcom/datadog/android/trace/model/SpanEvent$Tracer;Lcom/datadog/android/trace/model/SpanEvent$Usr;Lcom/datadog/android/trace/model/SpanEvent$Network;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public fun <init> (Ljava/lang/String;Lcom/datadog/android/trace/model/SpanEvent$Dd;Lcom/datadog/android/trace/model/SpanEvent$Span;Lcom/datadog/android/trace/model/SpanEvent$Tracer;Lcom/datadog/android/trace/model/SpanEvent$Usr;Lcom/datadog/android/trace/model/SpanEvent$Network;Lcom/datadog/android/trace/model/SpanEvent$Device;Lcom/datadog/android/trace/model/SpanEvent$Os;Ljava/util/Map;)V
+	public synthetic fun <init> (Ljava/lang/String;Lcom/datadog/android/trace/model/SpanEvent$Dd;Lcom/datadog/android/trace/model/SpanEvent$Span;Lcom/datadog/android/trace/model/SpanEvent$Tracer;Lcom/datadog/android/trace/model/SpanEvent$Usr;Lcom/datadog/android/trace/model/SpanEvent$Network;Lcom/datadog/android/trace/model/SpanEvent$Device;Lcom/datadog/android/trace/model/SpanEvent$Os;Ljava/util/Map;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public final fun component1 ()Ljava/lang/String;
 	public final fun component2 ()Lcom/datadog/android/trace/model/SpanEvent$Dd;
 	public final fun component3 ()Lcom/datadog/android/trace/model/SpanEvent$Span;
 	public final fun component4 ()Lcom/datadog/android/trace/model/SpanEvent$Tracer;
 	public final fun component5 ()Lcom/datadog/android/trace/model/SpanEvent$Usr;
 	public final fun component6 ()Lcom/datadog/android/trace/model/SpanEvent$Network;
-	public final fun component7 ()Ljava/util/Map;
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/trace/model/SpanEvent$Dd;Lcom/datadog/android/trace/model/SpanEvent$Span;Lcom/datadog/android/trace/model/SpanEvent$Tracer;Lcom/datadog/android/trace/model/SpanEvent$Usr;Lcom/datadog/android/trace/model/SpanEvent$Network;Ljava/util/Map;)Lcom/datadog/android/trace/model/SpanEvent$Meta;
-	public static synthetic fun copy$default (Lcom/datadog/android/trace/model/SpanEvent$Meta;Ljava/lang/String;Lcom/datadog/android/trace/model/SpanEvent$Dd;Lcom/datadog/android/trace/model/SpanEvent$Span;Lcom/datadog/android/trace/model/SpanEvent$Tracer;Lcom/datadog/android/trace/model/SpanEvent$Usr;Lcom/datadog/android/trace/model/SpanEvent$Network;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/trace/model/SpanEvent$Meta;
+	public final fun component7 ()Lcom/datadog/android/trace/model/SpanEvent$Device;
+	public final fun component8 ()Lcom/datadog/android/trace/model/SpanEvent$Os;
+	public final fun component9 ()Ljava/util/Map;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/trace/model/SpanEvent$Dd;Lcom/datadog/android/trace/model/SpanEvent$Span;Lcom/datadog/android/trace/model/SpanEvent$Tracer;Lcom/datadog/android/trace/model/SpanEvent$Usr;Lcom/datadog/android/trace/model/SpanEvent$Network;Lcom/datadog/android/trace/model/SpanEvent$Device;Lcom/datadog/android/trace/model/SpanEvent$Os;Ljava/util/Map;)Lcom/datadog/android/trace/model/SpanEvent$Meta;
+	public static synthetic fun copy$default (Lcom/datadog/android/trace/model/SpanEvent$Meta;Ljava/lang/String;Lcom/datadog/android/trace/model/SpanEvent$Dd;Lcom/datadog/android/trace/model/SpanEvent$Span;Lcom/datadog/android/trace/model/SpanEvent$Tracer;Lcom/datadog/android/trace/model/SpanEvent$Usr;Lcom/datadog/android/trace/model/SpanEvent$Network;Lcom/datadog/android/trace/model/SpanEvent$Device;Lcom/datadog/android/trace/model/SpanEvent$Os;Ljava/util/Map;ILjava/lang/Object;)Lcom/datadog/android/trace/model/SpanEvent$Meta;
 	public fun equals (Ljava/lang/Object;)Z
 	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Meta;
 	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/trace/model/SpanEvent$Meta;
 	public final fun getAdditionalProperties ()Ljava/util/Map;
 	public final fun getDd ()Lcom/datadog/android/trace/model/SpanEvent$Dd;
+	public final fun getDevice ()Lcom/datadog/android/trace/model/SpanEvent$Device;
 	public final fun getNetwork ()Lcom/datadog/android/trace/model/SpanEvent$Network;
+	public final fun getOs ()Lcom/datadog/android/trace/model/SpanEvent$Os;
 	public final fun getSpan ()Lcom/datadog/android/trace/model/SpanEvent$Span;
 	public final fun getTracer ()Lcom/datadog/android/trace/model/SpanEvent$Tracer;
 	public final fun getUsr ()Lcom/datadog/android/trace/model/SpanEvent$Usr;
@@ -265,6 +298,33 @@ public final class com/datadog/android/trace/model/SpanEvent$Network {
 public final class com/datadog/android/trace/model/SpanEvent$Network$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Network;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/trace/model/SpanEvent$Network;
+}
+
+public final class com/datadog/android/trace/model/SpanEvent$Os {
+	public static final field Companion Lcom/datadog/android/trace/model/SpanEvent$Os$Companion;
+	public fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)V
+	public synthetic fun <init> (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/String;
+	public final fun component2 ()Ljava/lang/String;
+	public final fun component3 ()Ljava/lang/String;
+	public final fun component4 ()Ljava/lang/String;
+	public final fun copy (Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Os;
+	public static synthetic fun copy$default (Lcom/datadog/android/trace/model/SpanEvent$Os;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;Ljava/lang/String;ILjava/lang/Object;)Lcom/datadog/android/trace/model/SpanEvent$Os;
+	public fun equals (Ljava/lang/Object;)Z
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Os;
+	public static final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/trace/model/SpanEvent$Os;
+	public final fun getBuild ()Ljava/lang/String;
+	public final fun getName ()Ljava/lang/String;
+	public final fun getVersion ()Ljava/lang/String;
+	public final fun getVersionMajor ()Ljava/lang/String;
+	public fun hashCode ()I
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/datadog/android/trace/model/SpanEvent$Os$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Os;
+	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/trace/model/SpanEvent$Os;
 }
 
 public final class com/datadog/android/trace/model/SpanEvent$Session {
@@ -345,6 +405,25 @@ public final class com/datadog/android/trace/model/SpanEvent$Tracer {
 public final class com/datadog/android/trace/model/SpanEvent$Tracer$Companion {
 	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Tracer;
 	public final fun fromJsonObject (Lcom/google/gson/JsonObject;)Lcom/datadog/android/trace/model/SpanEvent$Tracer;
+}
+
+public final class com/datadog/android/trace/model/SpanEvent$Type : java/lang/Enum {
+	public static final field BOT Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public static final field Companion Lcom/datadog/android/trace/model/SpanEvent$Type$Companion;
+	public static final field DESKTOP Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public static final field GAMING_CONSOLE Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public static final field MOBILE Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public static final field OTHER Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public static final field TABLET Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public static final field TV Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public static final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public final fun toJson ()Lcom/google/gson/JsonElement;
+	public static fun valueOf (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Type;
+	public static fun values ()[Lcom/datadog/android/trace/model/SpanEvent$Type;
+}
+
+public final class com/datadog/android/trace/model/SpanEvent$Type$Companion {
+	public final fun fromJson (Ljava/lang/String;)Lcom/datadog/android/trace/model/SpanEvent$Type;
 }
 
 public final class com/datadog/android/trace/model/SpanEvent$Usr {

--- a/features/dd-sdk-android-trace/src/main/json/trace/span-schema.json
+++ b/features/dd-sdk-android-trace/src/main/json/trace/span-schema.json
@@ -232,6 +232,66 @@
             }
           },
           "readOnly": true
+        },
+        "device": {
+          "type": "object",
+          "description": "Device properties",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Device type info",
+              "enum": ["mobile", "desktop", "tablet", "tv", "gaming_console", "bot", "other"],
+              "readOnly": true
+            },
+            "name": {
+              "type": "string",
+              "description": "Device marketing name, e.g. Xiaomi Redmi Note 8 Pro, Pixel 5, etc.",
+              "readOnly": true
+            },
+            "model": {
+              "type": "string",
+              "description": "Device SKU model, e.g. Samsung SM-988GN, etc. Quite often name and model can be the same.",
+              "readOnly": true
+            },
+            "brand": {
+              "type": "string",
+              "description": "Device marketing brand, e.g. Apple, OPPO, Xiaomi, etc.",
+              "readOnly": true
+            },
+            "architecture": {
+              "type": "string",
+              "description": "The CPU architecture of the device that is reporting the error",
+              "readOnly": true
+            }
+          }
+        },
+        "os": {
+          "type": "object",
+          "description": "Operating system properties",
+          "required": ["name", "version", "version_major"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Operating system name, e.g. Android, iOS",
+              "readOnly": true
+            },
+            "version": {
+              "type": "string",
+              "description": "Full operating system version, e.g. 8.1.1",
+              "readOnly": true
+            },
+            "build": {
+              "type": "string",
+              "description": "Operating system build number, e.g. 15D21",
+              "readOnly": true
+            },
+            "version_major": {
+              "type": "string",
+              "description": "Major operating system version, e.g. 8",
+              "readOnly": true
+            }
+          }
         }
       },
       "required": [
@@ -239,7 +299,9 @@
         "_dd",
         "span",
         "tracer",
-        "usr"
+        "usr",
+        "device",
+        "os"
       ],
       "additionalProperties": {
         "type": "string",

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/BaseSpanEventMapper.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/BaseSpanEventMapper.kt
@@ -1,0 +1,74 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.trace.internal.domain.event
+
+import com.datadog.android.api.context.DeviceInfo
+import com.datadog.android.api.context.DeviceType
+import com.datadog.android.api.context.NetworkInfo
+import com.datadog.android.api.context.UserInfo
+import com.datadog.android.trace.model.SpanEvent
+
+internal abstract class BaseSpanEventMapper<T> : ContextAwareMapper<T, SpanEvent> {
+
+    protected fun resolveUserInfo(userInfo: UserInfo) = SpanEvent.Usr(
+        id = userInfo.id,
+        name = userInfo.name,
+        email = userInfo.email,
+        additionalProperties = userInfo.additionalProperties.toMutableMap()
+    )
+
+    protected fun resolveDeviceInfo(deviceInfo: DeviceInfo): SpanEvent.Device {
+        return SpanEvent.Device(
+            type = resolveDeviceType(deviceInfo.deviceType),
+            name = deviceInfo.deviceName,
+            model = deviceInfo.deviceModel,
+            brand = deviceInfo.deviceBrand,
+            architecture = deviceInfo.architecture
+        )
+    }
+
+    protected fun resolveNetworkInfo(networkInfo: NetworkInfo): SpanEvent.Network {
+        val simCarrier = resolveSimCarrier(networkInfo)
+        val networkInfoClient = SpanEvent.Client(
+            simCarrier = simCarrier,
+            signalStrength = networkInfo.strength?.toString(),
+            downlinkKbps = networkInfo.downKbps?.toString(),
+            uplinkKbps = networkInfo.upKbps?.toString(),
+            connectivity = networkInfo.connectivity.toString()
+        )
+        return SpanEvent.Network(networkInfoClient)
+    }
+
+    protected fun resolveOsInfo(deviceInfo: DeviceInfo): SpanEvent.Os {
+        return SpanEvent.Os(
+            name = deviceInfo.osName,
+            version = deviceInfo.osVersion,
+            versionMajor = deviceInfo.osMajorVersion
+        )
+    }
+
+    private fun resolveSimCarrier(networkInfo: NetworkInfo): SpanEvent.SimCarrier? {
+        return if (networkInfo.carrierId != null || networkInfo.carrierName != null) {
+            SpanEvent.SimCarrier(
+                id = networkInfo.carrierId?.toString(),
+                name = networkInfo.carrierName
+            )
+        } else {
+            null
+        }
+    }
+
+    private fun resolveDeviceType(deviceType: DeviceType): SpanEvent.Type {
+        return when (deviceType) {
+            DeviceType.MOBILE -> SpanEvent.Type.MOBILE
+            DeviceType.TABLET -> SpanEvent.Type.TABLET
+            DeviceType.TV -> SpanEvent.Type.TV
+            DeviceType.DESKTOP -> SpanEvent.Type.DESKTOP
+            else -> SpanEvent.Type.OTHER
+        }
+    }
+}

--- a/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/CoreTracerSpanToSpanEventMapper.kt
+++ b/features/dd-sdk-android-trace/src/main/kotlin/com/datadog/android/trace/internal/domain/event/CoreTracerSpanToSpanEventMapper.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.trace.internal.domain.event
 
 import com.datadog.android.api.context.DatadogContext
-import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.trace.model.SpanEvent
 import com.datadog.trace.api.DDSpanId
@@ -21,7 +20,7 @@ import com.google.gson.JsonObject
 @Suppress("TooManyFunctions")
 internal class CoreTracerSpanToSpanEventMapper(
     internal val networkInfoEnabled: Boolean
-) : ContextAwareMapper<DDSpan, SpanEvent> {
+) : BaseSpanEventMapper<DDSpan>() {
 
     // region Mapper
 
@@ -69,20 +68,9 @@ internal class CoreTracerSpanToSpanEventMapper(
     }
 
     private fun resolveMeta(datadogContext: DatadogContext, event: DDSpan): SpanEvent.Meta {
-        val networkInfoMeta = if (networkInfoEnabled) {
-            val networkInfo = datadogContext.networkInfo
-            val simCarrier = resolveSimCarrier(networkInfo)
-            val networkInfoClient = SpanEvent.Client(
-                simCarrier = simCarrier,
-                signalStrength = networkInfo.strength?.toString(),
-                downlinkKbps = networkInfo.downKbps?.toString(),
-                uplinkKbps = networkInfo.upKbps?.toString(),
-                connectivity = networkInfo.connectivity.toString()
-            )
-            SpanEvent.Network(networkInfoClient)
-        } else {
-            null
-        }
+        val deviceInfo = resolveDeviceInfo(datadogContext.deviceInfo)
+        val osInfo = resolveOsInfo(datadogContext.deviceInfo)
+        val networkInfoMeta = if (networkInfoEnabled) resolveNetworkInfo(datadogContext.networkInfo) else null
         val userInfo = datadogContext.userInfo
         val usrMeta = SpanEvent.Usr(
             id = userInfo.id,
@@ -113,6 +101,8 @@ internal class CoreTracerSpanToSpanEventMapper(
             ),
             usr = usrMeta,
             network = networkInfoMeta,
+            device = deviceInfo,
+            os = osInfo,
             additionalProperties = meta
         )
     }
@@ -144,17 +134,6 @@ internal class CoreTracerSpanToSpanEventMapper(
             }
         }
         return spanLink
-    }
-
-    private fun resolveSimCarrier(networkInfo: NetworkInfo): SpanEvent.SimCarrier? {
-        return if (networkInfo.carrierId != null || networkInfo.carrierName != null) {
-            SpanEvent.SimCarrier(
-                id = networkInfo.carrierId?.toString(),
-                name = networkInfo.carrierName
-            )
-        } else {
-            null
-        }
     }
 
     private fun resolveMetricsFromSpanContext(span: DDSpan): MutableMap<String, Number> {

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/assertj/SpanEventAssert.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/assertj/SpanEventAssert.kt
@@ -6,6 +6,8 @@
 
 package com.datadog.android.trace.assertj
 
+import com.datadog.android.api.context.DeviceInfo
+import com.datadog.android.api.context.DeviceType
 import com.datadog.android.api.context.NetworkInfo
 import com.datadog.android.api.context.UserInfo
 import com.datadog.android.trace.internal.domain.event.CoreTracerSpanToSpanEventMapper
@@ -312,6 +314,77 @@ internal class SpanEventAssert(actual: SpanEvent) :
         assertThat(actual.meta.usr.additionalProperties)
             .hasSameSizeAs(userInfo.additionalProperties)
             .containsAllEntriesOf(userInfo.additionalProperties)
+        return this
+    }
+
+    fun hasDeviceInfo(deviceInfo: DeviceInfo): SpanEventAssert {
+        val expectedType: SpanEvent.Type = when (deviceInfo.deviceType) {
+            DeviceType.MOBILE -> SpanEvent.Type.MOBILE
+            DeviceType.TABLET -> SpanEvent.Type.TABLET
+            DeviceType.DESKTOP -> SpanEvent.Type.DESKTOP
+            DeviceType.TV -> SpanEvent.Type.TV
+            DeviceType.OTHER -> SpanEvent.Type.OTHER
+        }
+        assertThat(actual.meta.device.type)
+            .overridingErrorMessage(
+                "Expected SpanEvent to have device type: " +
+                    "$expectedType but " +
+                    "instead was: ${actual.meta.device.type}"
+            )
+            .isEqualTo(expectedType)
+        assertThat(actual.meta.device.name)
+            .overridingErrorMessage(
+                "Expected SpanEvent to have device name: " +
+                    "${deviceInfo.deviceName} but " +
+                    "instead was: ${actual.meta.device.name}"
+            )
+            .isEqualTo(deviceInfo.deviceName)
+        assertThat(actual.meta.device.model)
+            .overridingErrorMessage(
+                "Expected SpanEvent to have device model: " +
+                    "${deviceInfo.deviceModel} but " +
+                    "instead was: ${actual.meta.device.model}"
+            )
+            .isEqualTo(deviceInfo.deviceModel)
+        assertThat(actual.meta.device.brand)
+            .overridingErrorMessage(
+                "Expected SpanEvent to have device brand: " +
+                    "${deviceInfo.deviceBrand} but " +
+                    "instead was: ${actual.meta.device.brand}"
+            )
+            .isEqualTo(deviceInfo.deviceBrand)
+        assertThat(actual.meta.device.architecture)
+            .overridingErrorMessage(
+                "Expected SpanEvent to have device architecture: " +
+                    "${deviceInfo.architecture} but " +
+                    "instead was: ${actual.meta.device.architecture}"
+            )
+            .isEqualTo(deviceInfo.architecture)
+        return this
+    }
+
+    fun hasOsInfo(deviceInfo: DeviceInfo): SpanEventAssert {
+        assertThat(actual.meta.os.name)
+            .overridingErrorMessage(
+                "Expected SpanEvent to have os name: " +
+                    "${deviceInfo.osName} but " +
+                    "instead was: ${actual.meta.os.name}"
+            )
+            .isEqualTo(deviceInfo.osName)
+        assertThat(actual.meta.os.versionMajor)
+            .overridingErrorMessage(
+                "Expected SpanEvent to have os major version: " +
+                    "${deviceInfo.osMajorVersion} but " +
+                    "instead was: ${actual.meta.os.versionMajor}"
+            )
+            .isEqualTo(deviceInfo.osMajorVersion)
+        assertThat(actual.meta.os.version)
+            .overridingErrorMessage(
+                "Expected SpanEvent to have os version: " +
+                    "${deviceInfo.osVersion} but " +
+                    "instead was: ${actual.meta.os.version}"
+            )
+            .isEqualTo(deviceInfo.osVersion)
         return this
     }
 

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/CoreTracerSpanToSpanEventMapperTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/CoreTracerSpanToSpanEventMapperTest.kt
@@ -91,6 +91,8 @@ internal class CoreTracerSpanToSpanEventMapperTest {
                     doesntHaveNetworkInfo()
                 }
             }
+            .hasDeviceInfo(fakeDatadogContext.deviceInfo)
+            .hasOsInfo(fakeDatadogContext.deviceInfo)
             .hasUserInfo(fakeDatadogContext.userInfo)
             .hasMeta(expectedMeta)
             .hasMetrics(expectedMetrics)
@@ -147,6 +149,8 @@ internal class CoreTracerSpanToSpanEventMapperTest {
                     doesntHaveNetworkInfo()
                 }
             }.hasUserInfo(fakeDatadogContext.userInfo)
+            .hasDeviceInfo(fakeDatadogContext.deviceInfo)
+            .hasOsInfo(fakeDatadogContext.deviceInfo)
             .hasMeta(expectedMeta)
             .hasMetrics(expectedMetrics)
     }

--- a/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/DdSpanToSpanEventMapperTest.kt
+++ b/features/dd-sdk-android-trace/src/test/kotlin/com/datadog/android/trace/internal/domain/event/DdSpanToSpanEventMapperTest.kt
@@ -101,6 +101,8 @@ internal class DdSpanToSpanEventMapperTest {
             }
             .hasUserInfo(fakeDatadogContext.userInfo)
             .hasMeta(fakeSpan.meta)
+            .hasDeviceInfo(fakeDatadogContext.deviceInfo)
+            .hasOsInfo(fakeDatadogContext.deviceInfo)
             .hasMetrics(fakeSpan.metrics)
     }
 
@@ -146,6 +148,8 @@ internal class DdSpanToSpanEventMapperTest {
             }
             .hasUserInfo(fakeDatadogContext.userInfo)
             .hasMeta(fakeSpan.meta)
+            .hasDeviceInfo(fakeDatadogContext.deviceInfo)
+            .hasOsInfo(fakeDatadogContext.deviceInfo)
             .hasMetrics(fakeSpan.metrics)
     }
 

--- a/tools/benchmark/src/main/json/span-schema.json
+++ b/tools/benchmark/src/main/json/span-schema.json
@@ -232,8 +232,69 @@
             }
           },
           "readOnly": true
+        },
+        "device": {
+          "type": "object",
+          "description": "Device properties",
+          "required": ["type"],
+          "properties": {
+            "type": {
+              "type": "string",
+              "description": "Device type info",
+              "enum": ["mobile", "desktop", "tablet", "tv", "gaming_console", "bot", "other"],
+              "readOnly": true
+            },
+            "name": {
+              "type": "string",
+              "description": "Device marketing name, e.g. Xiaomi Redmi Note 8 Pro, Pixel 5, etc.",
+              "readOnly": true
+            },
+            "model": {
+              "type": "string",
+              "description": "Device SKU model, e.g. Samsung SM-988GN, etc. Quite often name and model can be the same.",
+              "readOnly": true
+            },
+            "brand": {
+              "type": "string",
+              "description": "Device marketing brand, e.g. Apple, OPPO, Xiaomi, etc.",
+              "readOnly": true
+            },
+            "architecture": {
+              "type": "string",
+              "description": "The CPU architecture of the device that is reporting the error",
+              "readOnly": true
+            }
+          }
+        },
+        "os": {
+          "type": "object",
+          "description": "Operating system properties",
+          "required": ["name", "version", "version_major"],
+          "properties": {
+            "name": {
+              "type": "string",
+              "description": "Operating system name, e.g. Android, iOS",
+              "readOnly": true
+            },
+            "version": {
+              "type": "string",
+              "description": "Full operating system version, e.g. 8.1.1",
+              "readOnly": true
+            },
+            "build": {
+              "type": "string",
+              "description": "Operating system build number, e.g. 15D21",
+              "readOnly": true
+            },
+            "version_major": {
+              "type": "string",
+              "description": "Major operating system version, e.g. 8",
+              "readOnly": true
+            }
+          }
         }
       },
+
       "required": [
         "version",
         "_dd",


### PR DESCRIPTION
### What does this PR do?

After a short analysis on our local traces vs the traces created by RUM backend based on our RUM resource events we realized that we are missing some content for the local ones: `device` and `os` informations.
In this PR we are aligning the information in the local traces vs RUM backend traces by adding the `device` and `os` information into the local traces `meta`. 

Please note that in order to keep schemas aligned I added these new properties also into the `benchmark` module `span-schema.json` but made them optional as right now the benchmark module is not using these (we might need it later).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

