### PR TITLE
[RUM-610] Prioritize Action-level attributes over global attributes

### DIFF
--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/rum/internal/domain/scope/RumActionScope.kt
@@ -51,7 +51,7 @@ internal class RumActionScope(
     private val networkInfo = sdkCore.networkInfo
 
     internal val attributes: MutableMap<String, Any?> = initialAttributes.toMutableMap().apply {
-        putAll(GlobalRumMonitor.get(sdkCore).getAttributes())
+        putAll(GlobalRumMonitor.get(sdkCore).getAttributes() + initialAttributes)
     }
 
     private val ongoingResourceKeys = mutableListOf<WeakReference<Any>>()
@@ -203,7 +203,7 @@ internal class RumActionScope(
         if (sent) return
 
         val actualType = type
-        attributes.putAll(GlobalRumMonitor.get(sdkCore).getAttributes())
+        attributes.putAll(GlobalRumMonitor.get(sdkCore).getAttributes() + attributes)
         val eventAttributes = attributes.toMutableMap()
         val rumContext = getRumContext()
 


### PR DESCRIPTION
### What does this PR do?

This PR modifies how Action attributes are populated. Instead of being a copy of the global attributes, the action scope now adds the action's attributes on top of the global attributes.

The following code snippet returns:
- a View with the attributes `{ attributeLevel: "global", version: "1.0" }` 
- an Action with the attributes `{ attributeLevel: "action", element: "button", version: "1.0" }`.

```kotlin
GlobalRumMonitor.get().addAttribute("attributeLevel", "global")
GlobalRumMonitor.get().addAttribute("version", "1.0")

GlobalRumMonitor.get().addAction(
    RumActionType.CLICK,
    "custom_action",
    mapOf("element" to "button", "attributeLevel" to "action")
)
```

### Motivation

[RUM-610](https://datadoghq.atlassian.net/browse/RUM-610)

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)



[RUM-610]: https://datadoghq.atlassian.net/browse/RUM-610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ