### PR TITLE
Update link to the CI Docker image

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -5,7 +5,7 @@ include:
 
 variables:
   CURRENT_CI_IMAGE: "13"
-  CI_IMAGE_DOCKER: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/dd-sdk-android:$CURRENT_CI_IMAGE
+  CI_IMAGE_DOCKER: registry.ddbuild.io/ci/dd-sdk-android:$CURRENT_CI_IMAGE
   GIT_DEPTH: 5
 
   DD_SERVICE: "dd-sdk-android"


### PR DESCRIPTION
### What does this PR do?

This is needed for the cloudops -> cloud-inventory migration (see https://github.com/DataDog/cloudops/pull/40254 and https://github.com/DataDog/cloud-inventory/pull/24220), which in turn is needed in order to pick Android SDK-specific macOS Sonoma runners (see https://github.com/DataDog/ci-platform-machine-images/pull/138).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

