### PR TITLE
RUM-6897: Fix scrolling issue

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
@@ -57,28 +57,25 @@ internal class ImageViewMapper(
         val contentYPosInDp = contentRect.top.densityNormalized(density).toLong()
         val contentWidthPx = contentRect.width()
         val contentHeightPx = contentRect.height()
-        val contentDrawable = drawable.constantState?.newDrawable(resources)
 
-        if (contentDrawable != null) {
-            // resolve foreground
-            mappingContext.imageWireframeHelper.createImageWireframe(
-                view = view,
-                imagePrivacy = mappingContext.imagePrivacy,
-                currentWireframeIndex = wireframes.size,
-                x = contentXPosInDp,
-                y = contentYPosInDp,
-                width = contentWidthPx,
-                height = contentHeightPx,
-                usePIIPlaceholder = true,
-                drawable = contentDrawable,
-                asyncJobStatusCallback = asyncJobStatusCallback,
-                clipping = clipping,
-                shapeStyle = null,
-                border = null,
-                prefix = ImageWireframeHelper.DRAWABLE_CHILD_NAME
-            )?.let {
-                wireframes.add(it)
-            }
+        // resolve foreground
+        mappingContext.imageWireframeHelper.createImageWireframe(
+            view = view,
+            imagePrivacy = mappingContext.imagePrivacy,
+            currentWireframeIndex = wireframes.size,
+            x = contentXPosInDp,
+            y = contentYPosInDp,
+            width = contentWidthPx,
+            height = contentHeightPx,
+            usePIIPlaceholder = true,
+            drawable = drawable,
+            asyncJobStatusCallback = asyncJobStatusCallback,
+            clipping = clipping,
+            shapeStyle = null,
+            border = null,
+            prefix = ImageWireframeHelper.DRAWABLE_CHILD_NAME
+        )?.let {
+            wireframes.add(it)
         }
 
         return wireframes

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
@@ -137,7 +137,7 @@ internal class DefaultImageWireframeHelper(
             resources = resources,
             applicationContext = applicationContext,
             displayMetrics = displayMetrics,
-            drawable = drawableProperties.drawable,
+            originalDrawable = drawableProperties.drawable,
             drawableWidth = width,
             drawableHeight = height,
             resourceResolverCallback = object : ResourceResolverCallback {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolver.kt
@@ -45,14 +45,14 @@ internal class ResourceResolver(
         resources: Resources,
         applicationContext: Context,
         displayMetrics: DisplayMetrics,
-        drawable: Drawable,
+        originalDrawable: Drawable,
         drawableWidth: Int,
         drawableHeight: Int,
         resourceResolverCallback: ResourceResolverCallback
     ) {
         bitmapCachesManager.registerCallbacks(applicationContext)
 
-        val resourceId = tryToGetResourceFromCache(drawable = drawable)
+        val resourceId = tryToGetResourceFromCache(drawable = originalDrawable)
 
         if (resourceId != null) {
             // if we got here it means we saw the bitmap before,
@@ -61,9 +61,11 @@ internal class ResourceResolver(
             return
         }
 
+        val copiedDrawable = originalDrawable.constantState?.newDrawable(resources) ?: return
+
         val bitmapFromDrawable =
-            if (drawable is BitmapDrawable && shouldUseDrawableBitmap(drawable)) {
-                drawable.bitmap // cannot be null - we already checked in shouldUseDrawableBitmap
+            if (copiedDrawable is BitmapDrawable && shouldUseDrawableBitmap(copiedDrawable)) {
+                copiedDrawable.bitmap // cannot be null - we already checked in shouldUseDrawableBitmap
             } else {
                 null
             }
@@ -72,7 +74,7 @@ internal class ResourceResolver(
         threadPoolExecutor.executeSafe("resolveResourceId", logger) {
             createBitmap(
                 resources = resources,
-                drawable = drawable,
+                drawable = originalDrawable,
                 drawableWidth = drawableWidth,
                 drawableHeight = drawableHeight,
                 displayMetrics = displayMetrics,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseAsyncBackgroundWireframeMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/recorder/mapper/BaseAsyncBackgroundWireframeMapper.kt
@@ -124,30 +124,23 @@ abstract class BaseAsyncBackgroundWireframeMapper<in T : View> internal construc
         mappingContext: MappingContext,
         asyncJobStatusCallback: AsyncJobStatusCallback
     ): MobileSegment.Wireframe? {
-        val resources = view.resources
-
-        val drawableCopy = view.background?.constantState?.newDrawable(resources)
-
-        return if (drawableCopy != null) {
-            mappingContext.imageWireframeHelper.createImageWireframe(
-                view = view,
-                imagePrivacy = mappingContext.imagePrivacy,
-                currentWireframeIndex = 0,
-                x = bounds.x,
-                y = bounds.y,
-                width = width,
-                height = height,
-                usePIIPlaceholder = false,
-                drawable = drawableCopy,
-                asyncJobStatusCallback = asyncJobStatusCallback,
-                clipping = MobileSegment.WireframeClip(),
-                shapeStyle = null,
-                border = null,
-                prefix = PREFIX_BACKGROUND_DRAWABLE
-            )
-        } else {
-            null
-        }
+        val background = view.background ?: return null
+        return mappingContext.imageWireframeHelper.createImageWireframe(
+            view = view,
+            imagePrivacy = mappingContext.imagePrivacy,
+            currentWireframeIndex = 0,
+            x = bounds.x,
+            y = bounds.y,
+            width = width,
+            height = height,
+            usePIIPlaceholder = false,
+            drawable = background,
+            asyncJobStatusCallback = asyncJobStatusCallback,
+            clipping = MobileSegment.WireframeClip(),
+            shapeStyle = null,
+            border = null,
+            prefix = PREFIX_BACKGROUND_DRAWABLE
+        )
     }
 
     companion object {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelperTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelperTest.kt
@@ -435,7 +435,7 @@ internal class DefaultImageWireframeHelperTest {
             resources = any(),
             applicationContext = any(),
             displayMetrics = any(),
-            drawable = any(),
+            originalDrawable = any(),
             drawableWidth = any(),
             drawableHeight = any(),
             resourceResolverCallback = any()
@@ -500,7 +500,7 @@ internal class DefaultImageWireframeHelperTest {
             resources = any(),
             applicationContext = any(),
             displayMetrics = any(),
-            drawable = any(),
+            originalDrawable = any(),
             drawableWidth = any(),
             drawableHeight = any(),
             resourceResolverCallback = argumentCaptor.capture()
@@ -613,7 +613,7 @@ internal class DefaultImageWireframeHelperTest {
             resources = any(),
             applicationContext = any(),
             displayMetrics = any(),
-            drawable = any(),
+            originalDrawable = any(),
             drawableWidth = captor.capture(),
             drawableHeight = captor.capture(),
             resourceResolverCallback = any()
@@ -645,7 +645,7 @@ internal class DefaultImageWireframeHelperTest {
             resources = any(),
             applicationContext = any(),
             displayMetrics = any(),
-            drawable = any(),
+            originalDrawable = any(),
             drawableWidth = captor.capture(),
             drawableHeight = captor.capture(),
             resourceResolverCallback = any()
@@ -722,7 +722,7 @@ internal class DefaultImageWireframeHelperTest {
             resources = any(),
             applicationContext = any(),
             displayMetrics = any(),
-            drawable = any(),
+            originalDrawable = any(),
             drawableWidth = any(),
             drawableHeight = any(),
             resourceResolverCallback = any()

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
@@ -11,6 +11,7 @@ import android.content.res.Resources
 import android.graphics.Bitmap
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
+import android.graphics.drawable.Drawable.ConstantState
 import android.graphics.drawable.LayerDrawable
 import android.graphics.drawable.StateListDrawable
 import android.util.DisplayMetrics
@@ -103,6 +104,12 @@ internal class ResourceResolverTest {
     @Mock
     lateinit var mockResources: Resources
 
+    @Mock
+    lateinit var mockConstantState: ConstantState
+
+    @Mock
+    lateinit var mockBitmapConstantState: ConstantState
+
     private var fakeBitmapWidth: Int = 1
 
     private var fakeBitmapHeight: Int = 1
@@ -117,6 +124,11 @@ internal class ResourceResolverTest {
 
     @BeforeEach
     fun setup(forge: Forge) {
+        whenever(mockBitmapDrawable.constantState).thenReturn(mockBitmapConstantState)
+        whenever(mockBitmapConstantState.newDrawable(any())).thenReturn(mockBitmapDrawable)
+
+        whenever(mockDrawable.constantState).thenReturn(mockConstantState)
+        whenever(mockConstantState.newDrawable(any())).thenReturn(mockDrawable)
         fakeImageCompressionByteArray = forge.aString().toByteArray()
 
         fakeBitmapWidth = forge.anInt(min = 1)
@@ -173,7 +185,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockDrawable,
+            originalDrawable = mockDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -209,7 +221,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -245,7 +257,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockDrawable,
+            originalDrawable = mockDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -265,7 +277,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockDrawable,
+            originalDrawable = mockDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -308,7 +320,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockDrawable,
+            originalDrawable = mockDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -356,7 +368,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockStateListDrawable,
+            originalDrawable = mockStateListDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -376,7 +388,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -405,7 +417,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -431,7 +443,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -454,7 +466,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -487,7 +499,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -521,7 +533,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -552,7 +564,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -583,7 +595,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -605,7 +617,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -619,13 +631,15 @@ internal class ResourceResolverTest {
     fun `M cache bitmap W resolveResourceId() { not a BitmapDrawable }`() {
         // Given
         val mockLayerDrawable = mock<LayerDrawable>()
+        whenever(mockLayerDrawable.constantState).thenReturn(mockConstantState)
+        whenever(mockConstantState.newDrawable()).thenReturn(mockLayerDrawable)
 
         // When
         testedResourceResolver.resolveResourceId(
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockLayerDrawable,
+            originalDrawable = mockLayerDrawable,
             drawableWidth = mockDrawable.intrinsicWidth,
             drawableHeight = mockDrawable.intrinsicHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -656,7 +670,7 @@ internal class ResourceResolverTest {
                 resources = mockResources,
                 applicationContext = mockApplicationContext,
                 displayMetrics = mockDisplayMetrics,
-                drawable = mockFirstDrawable,
+                originalDrawable = mockFirstDrawable,
                 drawableWidth = fakeBitmapWidth,
                 drawableHeight = fakeBitmapHeight,
                 resourceResolverCallback = mockFirstCallback
@@ -669,7 +683,7 @@ internal class ResourceResolverTest {
                 resources = mockResources,
                 applicationContext = mockApplicationContext,
                 displayMetrics = mockDisplayMetrics,
-                drawable = mockSecondDrawable,
+                originalDrawable = mockSecondDrawable,
                 drawableWidth = fakeBitmapWidth,
                 drawableHeight = fakeBitmapHeight,
                 resourceResolverCallback = mockSecondCallback
@@ -717,7 +731,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = fakeBitmapWidth,
             drawableHeight = fakeBitmapHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -768,7 +782,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = fakeBitmapWidth,
             drawableHeight = fakeBitmapHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -781,7 +795,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = fakeBitmapWidth,
             drawableHeight = fakeBitmapHeight,
             resourceResolverCallback = mockSerializerCallback
@@ -798,7 +812,7 @@ internal class ResourceResolverTest {
             resources = mockResources,
             applicationContext = mockApplicationContext,
             displayMetrics = mockDisplayMetrics,
-            drawable = mockBitmapDrawable,
+            originalDrawable = mockBitmapDrawable,
             drawableWidth = fakeBitmapWidth,
             drawableHeight = fakeBitmapHeight,
             resourceResolverCallback = mockSerializerCallback


### PR DESCRIPTION
### What does this PR do?
Part of fixing the frozen scrolling when MASK_NONE is selected for image privacy. We were using the copy of the drawable as the key in the resource cache and this resulted in cache misses. This pr changes the behavior to use the original drawable to generate the key.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

