### PR TITLE
RUM-6896: Add custom drawable mappers to resolve extension drawable

### DIFF
--- a/detekt_custom.yml
+++ b/detekt_custom.yml
@@ -1001,6 +1001,7 @@ datadog:
       - "kotlin.collections.listOf(com.datadog.android.rum.model.ResourceEvent.Interface)"
       - "kotlin.collections.listOf(com.datadog.android.rum.model.ViewEvent.Interface)"
       - "kotlin.collections.listOf(com.datadog.android.sessionreplay.internal.recorder.DefaultOptionSelectorDetector)"
+      - "kotlin.collections.listOf(com.datadog.android.sessionreplay.material.internal.MaterialDrawableToColorMapper)"
       - "kotlin.collections.listOf(com.datadog.android.sessionreplay.material.internal.MaterialOptionSelectorDetector)"
       - "kotlin.collections.listOf(com.datadog.android.sessionreplay.model.MobileSegment.MobileRecord.ViewEndRecord)"
       - "kotlin.collections.listOf(com.datadog.android.sessionreplay.model.MobileSegment.Wireframe)"

--- a/features/dd-sdk-android-session-replay-material/api/apiSurface
+++ b/features/dd-sdk-android-session-replay-material/api/apiSurface
@@ -1,3 +1,4 @@
 class com.datadog.android.sessionreplay.material.MaterialExtensionSupport : com.datadog.android.sessionreplay.ExtensionSupport
   override fun getCustomViewMappers(): List<com.datadog.android.sessionreplay.MapperTypeWrapper<*>>
   override fun getOptionSelectorDetectors(): List<com.datadog.android.sessionreplay.recorder.OptionSelectorDetector>
+  override fun getCustomDrawableMapper(): List<com.datadog.android.sessionreplay.utils.DrawableToColorMapper>

--- a/features/dd-sdk-android-session-replay-material/api/dd-sdk-android-session-replay-material.api
+++ b/features/dd-sdk-android-session-replay-material/api/dd-sdk-android-session-replay-material.api
@@ -1,5 +1,6 @@
 public final class com/datadog/android/sessionreplay/material/MaterialExtensionSupport : com/datadog/android/sessionreplay/ExtensionSupport {
 	public fun <init> ()V
+	public fun getCustomDrawableMapper ()Ljava/util/List;
 	public fun getCustomViewMappers ()Ljava/util/List;
 	public fun getOptionSelectorDetectors ()Ljava/util/List;
 }

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupport.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/MaterialExtensionSupport.kt
@@ -10,6 +10,7 @@ import androidx.cardview.widget.CardView
 import com.datadog.android.sessionreplay.ExtensionSupport
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.material.internal.CardWireframeMapper
+import com.datadog.android.sessionreplay.material.internal.MaterialDrawableToColorMapper
 import com.datadog.android.sessionreplay.material.internal.MaterialOptionSelectorDetector
 import com.datadog.android.sessionreplay.material.internal.SliderWireframeMapper
 import com.datadog.android.sessionreplay.material.internal.TabWireframeMapper
@@ -34,7 +35,9 @@ class MaterialExtensionSupport : ExtensionSupport {
     private val viewIdentifierResolver: ViewIdentifierResolver = DefaultViewIdentifierResolver
     private val colorStringFormatter: ColorStringFormatter = DefaultColorStringFormatter
     private val viewBoundsResolver: ViewBoundsResolver = DefaultViewBoundsResolver
-    private val drawableToColorMapper: DrawableToColorMapper = DrawableToColorMapper.getDefault()
+    private val materialDrawableToColorMapper = MaterialDrawableToColorMapper()
+    private val drawableToColorMapper: DrawableToColorMapper =
+        DrawableToColorMapper.getDefault(listOf(materialDrawableToColorMapper))
 
     override fun getCustomViewMappers(): List<MapperTypeWrapper<*>> {
         val sliderWireframeMapper = SliderWireframeMapper(
@@ -70,5 +73,9 @@ class MaterialExtensionSupport : ExtensionSupport {
 
     override fun getOptionSelectorDetectors(): List<OptionSelectorDetector> {
         return listOf(MaterialOptionSelectorDetector())
+    }
+
+    override fun getCustomDrawableMapper(): List<DrawableToColorMapper> {
+        return listOf(materialDrawableToColorMapper)
     }
 }

--- a/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/internal/MaterialDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay-material/src/main/kotlin/com/datadog/android/sessionreplay/material/internal/MaterialDrawableToColorMapper.kt
@@ -1,0 +1,28 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.android.sessionreplay.material.internal
+
+import android.graphics.drawable.Drawable
+import com.datadog.android.api.InternalLogger
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
+import com.google.android.material.shape.MaterialShapeDrawable
+
+internal class MaterialDrawableToColorMapper : DrawableToColorMapper {
+
+    override fun mapDrawableToColor(drawable: Drawable, internalLogger: InternalLogger): Int? {
+        return when (drawable) {
+            is MaterialShapeDrawable -> resolveMaterialShapeDrawable(drawable)
+            else -> null
+        }
+    }
+
+    private fun resolveMaterialShapeDrawable(
+        shapeDrawable: MaterialShapeDrawable
+    ): Int? {
+        return shapeDrawable.fillColor?.defaultColor
+    }
+}

--- a/features/dd-sdk-android-session-replay/api/apiSurface
+++ b/features/dd-sdk-android-session-replay/api/apiSurface
@@ -1,6 +1,7 @@
 interface com.datadog.android.sessionreplay.ExtensionSupport
   fun getCustomViewMappers(): List<MapperTypeWrapper<*>>
   fun getOptionSelectorDetectors(): List<com.datadog.android.sessionreplay.recorder.OptionSelectorDetector>
+  fun getCustomDrawableMapper(): List<com.datadog.android.sessionreplay.utils.DrawableToColorMapper>
 enum com.datadog.android.sessionreplay.ImagePrivacy : PrivacyLevel
   - MASK_NONE
   - MASK_LARGE_ONLY
@@ -77,9 +78,11 @@ interface com.datadog.android.sessionreplay.recorder.mapper.TraverseAllChildrenM
 interface com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper<T: android.view.View>
   fun map(T, com.datadog.android.sessionreplay.recorder.MappingContext, com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback, com.datadog.android.api.InternalLogger): List<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
 open class com.datadog.android.sessionreplay.utils.AndroidMDrawableToColorMapper : LegacyDrawableToColorMapper
+  constructor(List<DrawableToColorMapper> = emptyList())
   override fun resolveRippleDrawable(android.graphics.drawable.RippleDrawable, com.datadog.android.api.InternalLogger): Int?
   override fun resolveInsetDrawable(android.graphics.drawable.InsetDrawable, com.datadog.android.api.InternalLogger): Int?
 open class com.datadog.android.sessionreplay.utils.AndroidQDrawableToColorMapper : AndroidMDrawableToColorMapper
+  constructor(List<DrawableToColorMapper> = emptyList())
   override fun resolveGradientDrawable(android.graphics.drawable.GradientDrawable, com.datadog.android.api.InternalLogger): Int?
   companion object 
 interface com.datadog.android.sessionreplay.utils.AsyncJobStatusCallback
@@ -102,7 +105,7 @@ object com.datadog.android.sessionreplay.utils.DefaultViewIdentifierResolver : V
 interface com.datadog.android.sessionreplay.utils.DrawableToColorMapper
   fun mapDrawableToColor(android.graphics.drawable.Drawable, com.datadog.android.api.InternalLogger): Int?
   companion object 
-    fun getDefault(): DrawableToColorMapper
+    fun getDefault(List<DrawableToColorMapper> = emptyList()): DrawableToColorMapper
 data class com.datadog.android.sessionreplay.utils.GlobalBounds
   constructor(Long, Long, Long, Long)
 interface com.datadog.android.sessionreplay.utils.ImageWireframeHelper
@@ -110,7 +113,9 @@ interface com.datadog.android.sessionreplay.utils.ImageWireframeHelper
   fun createCompoundDrawableWireframes(android.widget.TextView, com.datadog.android.sessionreplay.recorder.MappingContext, Int, AsyncJobStatusCallback): MutableList<com.datadog.android.sessionreplay.model.MobileSegment.Wireframe>
   companion object 
 open class com.datadog.android.sessionreplay.utils.LegacyDrawableToColorMapper : DrawableToColorMapper
+  constructor(List<DrawableToColorMapper> = emptyList())
   override fun mapDrawableToColor(android.graphics.drawable.Drawable, com.datadog.android.api.InternalLogger): Int?
+  protected open fun resolveShapeDrawable(android.graphics.drawable.ShapeDrawable, com.datadog.android.api.InternalLogger): Int
   protected open fun resolveColorDrawable(android.graphics.drawable.ColorDrawable): Int?
   protected open fun resolveRippleDrawable(android.graphics.drawable.RippleDrawable, com.datadog.android.api.InternalLogger): Int?
   protected open fun resolveLayerDrawable(android.graphics.drawable.LayerDrawable, com.datadog.android.api.InternalLogger, (Int, android.graphics.drawable.Drawable) -> Boolean = { _, _ -> true }): Int?

--- a/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
+++ b/features/dd-sdk-android-session-replay/api/dd-sdk-android-session-replay.api
@@ -1,4 +1,5 @@
 public abstract interface class com/datadog/android/sessionreplay/ExtensionSupport {
+	public abstract fun getCustomDrawableMapper ()Ljava/util/List;
 	public abstract fun getCustomViewMappers ()Ljava/util/List;
 	public abstract fun getOptionSelectorDetectors ()Ljava/util/List;
 }
@@ -44,8 +45,8 @@ public final class com/datadog/android/sessionreplay/SessionReplay {
 }
 
 public final class com/datadog/android/sessionreplay/SessionReplayConfiguration {
-	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;ZLcom/datadog/android/sessionreplay/SystemRequirementsConfiguration;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
-	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;ZLcom/datadog/android/sessionreplay/SystemRequirementsConfiguration;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public final fun copy (Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;ZLcom/datadog/android/sessionreplay/SystemRequirementsConfiguration;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
+	public static synthetic fun copy$default (Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;Ljava/lang/String;Lcom/datadog/android/sessionreplay/SessionReplayPrivacy;Ljava/util/List;Ljava/util/List;Ljava/util/List;FLcom/datadog/android/sessionreplay/ImagePrivacy;ZLcom/datadog/android/sessionreplay/TouchPrivacy;Lcom/datadog/android/sessionreplay/TextAndInputPrivacy;ZLcom/datadog/android/sessionreplay/SystemRequirementsConfiguration;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/SessionReplayConfiguration;
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
@@ -1478,6 +1479,8 @@ public abstract interface class com/datadog/android/sessionreplay/recorder/mappe
 
 public class com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper : com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper {
 	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected fun resolveInsetDrawable (Landroid/graphics/drawable/InsetDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
 	protected fun resolveRippleDrawable (Landroid/graphics/drawable/RippleDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
 }
@@ -1485,6 +1488,8 @@ public class com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapp
 public class com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper : com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper$Companion;
 	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	protected fun resolveGradientDrawable (Landroid/graphics/drawable/GradientDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
 }
 
@@ -1530,7 +1535,8 @@ public abstract interface class com/datadog/android/sessionreplay/utils/Drawable
 }
 
 public final class com/datadog/android/sessionreplay/utils/DrawableToColorMapper$Companion {
-	public final fun getDefault ()Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper;
+	public final fun getDefault (Ljava/util/List;)Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper;
+	public static synthetic fun getDefault$default (Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper$Companion;Ljava/util/List;ILjava/lang/Object;)Lcom/datadog/android/sessionreplay/utils/DrawableToColorMapper;
 }
 
 public final class com/datadog/android/sessionreplay/utils/GlobalBounds {
@@ -1566,6 +1572,8 @@ public final class com/datadog/android/sessionreplay/utils/ImageWireframeHelper$
 public class com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper : com/datadog/android/sessionreplay/utils/DrawableToColorMapper {
 	public static final field Companion Lcom/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper$Companion;
 	public fun <init> ()V
+	public fun <init> (Ljava/util/List;)V
+	public synthetic fun <init> (Ljava/util/List;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
 	public fun mapDrawableToColor (Landroid/graphics/drawable/Drawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
 	protected final fun mergeColorAndAlpha (II)I
 	protected fun resolveColorDrawable (Landroid/graphics/drawable/ColorDrawable;)Ljava/lang/Integer;
@@ -1574,6 +1582,7 @@ public class com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper
 	protected fun resolveLayerDrawable (Landroid/graphics/drawable/LayerDrawable;Lcom/datadog/android/api/InternalLogger;Lkotlin/jvm/functions/Function2;)Ljava/lang/Integer;
 	public static synthetic fun resolveLayerDrawable$default (Lcom/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper;Landroid/graphics/drawable/LayerDrawable;Lcom/datadog/android/api/InternalLogger;Lkotlin/jvm/functions/Function2;ILjava/lang/Object;)Ljava/lang/Integer;
 	protected fun resolveRippleDrawable (Landroid/graphics/drawable/RippleDrawable;Lcom/datadog/android/api/InternalLogger;)Ljava/lang/Integer;
+	protected fun resolveShapeDrawable (Landroid/graphics/drawable/ShapeDrawable;Lcom/datadog/android/api/InternalLogger;)I
 }
 
 public final class com/datadog/android/sessionreplay/utils/LegacyDrawableToColorMapper$Companion {

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ExtensionSupport.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/ExtensionSupport.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay
 import android.view.View
 import com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
 import com.datadog.android.sessionreplay.recorder.mapper.WireframeMapper
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 
 /**
  * In case you need to provide different configuration for a specific Android UI framework that
@@ -30,4 +31,10 @@ interface ExtensionSupport {
      * @return a list of custom [OptionSelectorDetector].
      */
     fun getOptionSelectorDetectors(): List<OptionSelectorDetector>
+
+    /**
+     * Implement this method if you need to add some specific mapper of drawable for extensions.
+     * @return a list of custom [DrawableToColorMapper] implementation.
+     */
+    fun getCustomDrawableMapper(): List<DrawableToColorMapper>
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplay.kt
@@ -56,6 +56,7 @@ object SessionReplay {
                     textAndInputPrivacy = sessionReplayConfiguration.textAndInputPrivacy,
                     customMappers = sessionReplayConfiguration.customMappers,
                     customOptionSelectorDetectors = sessionReplayConfiguration.customOptionSelectorDetectors,
+                    customDrawableMappers = sessionReplayConfiguration.customDrawableMappers,
                     sampleRate = sessionReplayConfiguration.sampleRate,
                     startRecordingImmediately = sessionReplayConfiguration.startRecordingImmediately,
                     dynamicOptimizationEnabled = sessionReplayConfiguration.dynamicOptimizationEnabled

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/SessionReplayConfiguration.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay
 import androidx.annotation.FloatRange
 import com.datadog.android.sessionreplay.internal.NoOpExtensionSupport
 import com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 
 /**
  * Describes configuration to be used for the Session Replay feature.
@@ -18,6 +19,7 @@ data class SessionReplayConfiguration internal constructor(
     internal val privacy: SessionReplayPrivacy,
     internal val customMappers: List<MapperTypeWrapper<*>>,
     internal val customOptionSelectorDetectors: List<OptionSelectorDetector>,
+    internal val customDrawableMappers: List<DrawableToColorMapper>,
     internal val sampleRate: Float,
     internal val imagePrivacy: ImagePrivacy,
     internal val startRecordingImmediately: Boolean,
@@ -187,6 +189,7 @@ data class SessionReplayConfiguration internal constructor(
                 textAndInputPrivacy = textAndInputPrivacy,
                 customMappers = customMappers(),
                 customOptionSelectorDetectors = extensionSupport.getOptionSelectorDetectors(),
+                customDrawableMappers = extensionSupport.getCustomDrawableMapper(),
                 sampleRate = sampleRate,
                 startRecordingImmediately = startRecordingImmediately,
                 dynamicOptimizationEnabled = dynamicOptimizationEnabled,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/DefaultRecorderProvider.kt
@@ -62,6 +62,7 @@ internal class DefaultRecorderProvider(
     private val touchPrivacyManager: TouchPrivacyManager,
     private val customMappers: List<MapperTypeWrapper<*>>,
     private val customOptionSelectorDetectors: List<OptionSelectorDetector>,
+    private val customDrawableMappers: List<DrawableToColorMapper>,
     private val dynamicOptimizationEnabled: Boolean
 ) : RecorderProvider {
 
@@ -83,6 +84,7 @@ internal class DefaultRecorderProvider(
             timeProvider = SessionReplayTimeProvider(sdkCore),
             mappers = customMappers + builtInMappers(),
             customOptionSelectorDetectors = customOptionSelectorDetectors,
+            customDrawableMappers = customDrawableMappers,
             sdkCore = sdkCore,
             dynamicOptimizationEnabled = dynamicOptimizationEnabled
         )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/NoOpExtensionSupport.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/NoOpExtensionSupport.kt
@@ -9,6 +9,7 @@ package com.datadog.android.sessionreplay.internal
 import com.datadog.android.sessionreplay.ExtensionSupport
 import com.datadog.android.sessionreplay.MapperTypeWrapper
 import com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 
 internal class NoOpExtensionSupport : ExtensionSupport {
 
@@ -17,6 +18,10 @@ internal class NoOpExtensionSupport : ExtensionSupport {
     }
 
     override fun getOptionSelectorDetectors(): List<OptionSelectorDetector> {
+        return emptyList()
+    }
+
+    override fun getCustomDrawableMapper(): List<DrawableToColorMapper> {
         return emptyList()
     }
 }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -34,6 +34,7 @@ import com.datadog.android.sessionreplay.internal.storage.NoOpRecordWriter
 import com.datadog.android.sessionreplay.internal.storage.RecordWriter
 import com.datadog.android.sessionreplay.internal.storage.SessionReplayRecordWriter
 import com.datadog.android.sessionreplay.recorder.OptionSelectorDetector
+import com.datadog.android.sessionreplay.utils.DrawableToColorMapper
 import java.util.Locale
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
@@ -67,6 +68,7 @@ internal class SessionReplayFeature(
         imagePrivacy: ImagePrivacy,
         customMappers: List<MapperTypeWrapper<*>>,
         customOptionSelectorDetectors: List<OptionSelectorDetector>,
+        customDrawableMappers: List<DrawableToColorMapper>,
         sampleRate: Float,
         startRecordingImmediately: Boolean,
         dynamicOptimizationEnabled: Boolean
@@ -86,6 +88,7 @@ internal class SessionReplayFeature(
             touchPrivacyManager,
             customMappers,
             customOptionSelectorDetectors,
+            customDrawableMappers,
             dynamicOptimizationEnabled
         )
     )

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/SessionReplayRecorder.kt
@@ -74,6 +74,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
     private val uiHandler: Handler
     private var shouldRecord = false
 
+    @Suppress("LongParameterList")
     constructor(
         appContext: Application,
         resourcesWriter: ResourcesWriter,
@@ -85,6 +86,7 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         timeProvider: TimeProvider,
         mappers: List<MapperTypeWrapper<*>> = emptyList(),
         customOptionSelectorDetectors: List<OptionSelectorDetector> = emptyList(),
+        customDrawableMappers: List<DrawableToColorMapper>,
         windowInspector: WindowInspector = WindowInspector,
         sdkCore: FeatureSdkCore,
         resourceDataStoreManager: ResourceDataStoreManager,
@@ -130,7 +132,8 @@ internal class SessionReplayRecorder : OnWindowRefreshedCallback, Recorder {
         val viewIdentifierResolver: ViewIdentifierResolver = DefaultViewIdentifierResolver
         val colorStringFormatter: ColorStringFormatter = DefaultColorStringFormatter
         val viewBoundsResolver: ViewBoundsResolver = DefaultViewBoundsResolver
-        val drawableToColorMapper: DrawableToColorMapper = DrawableToColorMapper.getDefault()
+        val drawableToColorMapper: DrawableToColorMapper =
+            DrawableToColorMapper.getDefault(customDrawableMappers)
 
         val defaultVWM = ViewWireframeMapper(
             viewIdentifierResolver,

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/AndroidMDrawableToColorMapper.kt
@@ -19,7 +19,9 @@ import com.datadog.android.api.InternalLogger
  * This class is meant for internal usage so please use it carefully as it might change in time.
  */
 @RequiresApi(Build.VERSION_CODES.M)
-open class AndroidMDrawableToColorMapper : LegacyDrawableToColorMapper() {
+open class AndroidMDrawableToColorMapper(
+    extensionMappers: List<DrawableToColorMapper> = emptyList()
+) : LegacyDrawableToColorMapper(extensionMappers) {
 
     override fun resolveRippleDrawable(drawable: RippleDrawable, internalLogger: InternalLogger): Int? {
         // A ripple drawable can have a layer marked as mask, and which is not drawn

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/AndroidQDrawableToColorMapper.kt
@@ -21,7 +21,9 @@ import com.datadog.android.api.InternalLogger
  * This class is meant for internal usage so please use it carefully as it might change in time.
  */
 @RequiresApi(Build.VERSION_CODES.Q)
-open class AndroidQDrawableToColorMapper : AndroidMDrawableToColorMapper() {
+open class AndroidQDrawableToColorMapper(
+    extensionMappers: List<DrawableToColorMapper> = emptyList()
+) : AndroidMDrawableToColorMapper(extensionMappers) {
 
     override fun resolveGradientDrawable(drawable: GradientDrawable, internalLogger: InternalLogger): Int? {
         @Suppress("SwallowedException")

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/DrawableToColorMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/utils/DrawableToColorMapper.kt
@@ -29,13 +29,13 @@ fun interface DrawableToColorMapper {
          * Provides a default implementation.
          * @return a default implementation based on the device API level
          */
-        fun getDefault(): DrawableToColorMapper {
+        fun getDefault(customDrawableMappers: List<DrawableToColorMapper> = emptyList()): DrawableToColorMapper {
             return if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                AndroidQDrawableToColorMapper()
+                AndroidQDrawableToColorMapper(customDrawableMappers)
             } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                AndroidMDrawableToColorMapper()
+                AndroidMDrawableToColorMapper(customDrawableMappers)
             } else {
-                LegacyDrawableToColorMapper()
+                LegacyDrawableToColorMapper(customDrawableMappers)
             }
         }
     }

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/forge/SessionReplayConfigurationForgeryFactory.kt
@@ -26,6 +26,7 @@ class SessionReplayConfigurationForgeryFactory : ForgeryFactory<SessionReplayCon
             touchPrivacy = forge.aValueFrom(TouchPrivacy::class.java),
             customMappers = forge.aList { mock() },
             customOptionSelectorDetectors = forge.aList { mock() },
+            customDrawableMappers = forge.aList { mock() },
             startRecordingImmediately = forge.aBool(),
             sampleRate = forge.aFloat(min = 0f, max = 100f),
             dynamicOptimizationEnabled = forge.aBool(),

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -139,6 +139,7 @@ internal class SessionReplayFeatureTest {
             touchPrivacyManager = mockTouchPrivacyManager,
             customMappers = emptyList(),
             customOptionSelectorDetectors = emptyList(),
+            customDrawableMappers = emptyList(),
             startRecordingImmediately = true,
             sampleRate = fakeConfiguration.sampleRate,
             dynamicOptimizationEnabled = fakeConfiguration.dynamicOptimizationEnabled
@@ -165,6 +166,7 @@ internal class SessionReplayFeatureTest {
             touchPrivacyManager = mockTouchPrivacyManager,
             customMappers = emptyList(),
             customOptionSelectorDetectors = emptyList(),
+            customDrawableMappers = emptyList(),
             sampleRate = fakeConfiguration.sampleRate,
             startRecordingImmediately = true,
             dynamicOptimizationEnabled = fakeConfiguration.dynamicOptimizationEnabled


### PR DESCRIPTION
### What does this PR do?

In Session Replay, we noticed that there are some components have transparent background in player, which make the content not visible.

After investigation, we see that it's due to the background drawable that we currently can not parse.

According to Telemetry, here is a top list of the drawable that we don't support:

<img width="500" alt="image" src="https://github.com/user-attachments/assets/0412742f-1717-4fb3-9fd4-2d2f62c40149">


On top of that, it's `MaterialShapeDrawable`, which belongs to material components, in this case we need to inject a custom mapper from `dd-sdk-android-session-replay-material` to `dd-sdk-android-session-replay`, so that when user add the extension of material, it can parse the drawable.

### Motivation

RUM-6896:

### Demo

| Before | After  |
| --- | --- |
|<img width="282" alt="Screenshot 2024-10-29 at 13 44 00" src="https://github.com/user-attachments/assets/85f31b0c-19e1-4c63-b57f-bc138adffacb"> | <img width="284" alt="Screenshot 2024-10-29 at 13 45 48" src="https://github.com/user-attachments/assets/1a4feb08-f548-4260-a4bb-53b0f36b563e">|



Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

