### PR TITLE
Lazy RUM raw event creation in event generator methods

### DIFF
--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumApplicationScopeTest.kt
@@ -379,8 +379,8 @@ internal class RumApplicationScopeTest {
         val fakeEvents = forge.aList {
             forge.anyRumEvent(
                 excluding = listOf(
-                    RumRawEvent.ApplicationStarted::class.java,
-                    RumRawEvent.SdkInit::class.java
+                    RumRawEvent.ApplicationStarted::class,
+                    RumRawEvent.SdkInit::class
                 )
             )
         }
@@ -428,8 +428,8 @@ internal class RumApplicationScopeTest {
         val fakeEvents = forge.aList {
             forge.anyRumEvent(
                 excluding = listOf(
-                    RumRawEvent.ApplicationStarted::class.java,
-                    RumRawEvent.SdkInit::class.java
+                    RumRawEvent.ApplicationStarted::class,
+                    RumRawEvent.SdkInit::class
                 )
             )
         }

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumSessionScopeTest.kt
@@ -962,14 +962,14 @@ internal class RumSessionScopeTest {
         initializeTestedScope(backgroundTrackingEnabled = false)
         val fakeNonInteractionEvent1 = forge.anyRumEvent(
             excluding = listOf(
-                RumRawEvent.StartView::class.java,
-                RumRawEvent.StartAction::class.java
+                RumRawEvent.StartView::class,
+                RumRawEvent.StartAction::class
             )
         )
         val fakeNonInteractionEvent2 = forge.anyRumEvent(
             excluding = listOf(
-                RumRawEvent.StartView::class.java,
-                RumRawEvent.StartAction::class.java
+                RumRawEvent.StartView::class,
+                RumRawEvent.StartAction::class
             )
         )
         testedScope.handleEvent(fakeNonInteractionEvent1, mockWriter)

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/rum/internal/domain/scope/RumViewScopeTest.kt
@@ -9349,14 +9349,14 @@ internal class RumViewScopeTest {
             testedScope.handleEvent(
                 forge.anyRumEvent(
                     excluding = listOf(
-                        RumRawEvent.StartView::class.java,
-                        RumRawEvent.StopView::class.java,
-                        RumRawEvent.StartAction::class.java,
-                        RumRawEvent.StopAction::class.java,
-                        RumRawEvent.StartResource::class.java,
-                        RumRawEvent.StopResource::class.java,
-                        RumRawEvent.StopResourceWithError::class.java,
-                        RumRawEvent.StopResourceWithStackTrace::class.java
+                        RumRawEvent.StartView::class,
+                        RumRawEvent.StopView::class,
+                        RumRawEvent.StartAction::class,
+                        RumRawEvent.StopAction::class,
+                        RumRawEvent.StartResource::class,
+                        RumRawEvent.StopResource::class,
+                        RumRawEvent.StopResourceWithError::class,
+                        RumRawEvent.StopResourceWithStackTrace::class
                     )
                 ),
                 mockWriter


### PR DESCRIPTION
### What does this PR do?

This PR does a bit of the optimization for the methods in `RumEventExt`: when random RUM raw event needs to be created, we are avoiding creating all of them and then selecting only one, but instead selecting the type and then creating only the selected one.

This gives a benefit for the tests where a lot of events are created. For example, for the `RumViewScopeTest#M produce event safe for serialization W handleEvent()` where there is a 1000 iterations loop to call `RumMonitor#handleEvent` this change is reducing execution time from 15s to 2s (and it will be much less redundant objects created, less work for GC).

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

