### PR TITLE
Fix resolveResourceId not correctly calling job finished when drawable cloning failed

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolver.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolver.kt
@@ -62,7 +62,11 @@ internal class ResourceResolver(
             return
         }
 
-        val copiedDrawable = drawableCopier.copy(originalDrawable, resources) ?: return
+        val copiedDrawable = drawableCopier.copy(originalDrawable, resources)
+        if (copiedDrawable == null) {
+            resourceResolverCallback.onFailure()
+            return
+        }
 
         val bitmapFromDrawable =
             if (copiedDrawable is BitmapDrawable && shouldUseDrawableBitmap(copiedDrawable)) {

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/ResourceResolverTest.kt
@@ -34,6 +34,7 @@ import org.mockito.junit.jupiter.MockitoExtension
 import org.mockito.junit.jupiter.MockitoSettings
 import org.mockito.kotlin.any
 import org.mockito.kotlin.anyOrNull
+import org.mockito.kotlin.doReturn
 import org.mockito.kotlin.eq
 import org.mockito.kotlin.mock
 import org.mockito.kotlin.never
@@ -252,6 +253,32 @@ internal class ResourceResolverTest {
 
         whenever(mockWebPImageCompression.compressBitmap(any()))
             .thenReturn(emptyByteArray)
+
+        // When
+        testedResourceResolver.resolveResourceId(
+            resources = mockResources,
+            applicationContext = mockApplicationContext,
+            displayMetrics = mockDisplayMetrics,
+            originalDrawable = mockDrawable,
+            drawableCopier = mockDrawableCopier,
+            drawableWidth = mockDrawable.intrinsicWidth,
+            drawableHeight = mockDrawable.intrinsicHeight,
+            resourceResolverCallback = mockSerializerCallback
+        )
+
+        // Then
+        verify(mockSerializerCallback).onFailure()
+    }
+
+    @Test
+    fun `M call onFailure W copy bitmap return null`() {
+        // Given
+        whenever(
+            mockDrawableCopier.copy(
+                originalDrawable = mockDrawable,
+                resources = mockResources
+            )
+        ).doReturn(null)
 
         // When
         testedResourceResolver.resolveResourceId(


### PR DESCRIPTION
### What does this PR do?

Snapshot item is never processed due to the fix in this [PR](https://github.com/DataDog/dd-sdk-android/pull/2351), 
this is because we call `job.started` callback but never call `job.finished` , so the snapshot is always in pending state.

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

