### PR TITLE
RUM-3460: Fix padding and resizing issue for image view mapper

### DIFF
--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/mapper/ImageViewMapper.kt
@@ -52,7 +52,12 @@ internal class ImageViewMapper(
 
         val resources = view.resources
         val density = resources.displayMetrics.density
-        val clipping = imageViewUtils.calculateClipping(parentRect, contentRect, density)
+
+        val clipping = if (view.cropToPadding) {
+            imageViewUtils.calculateClipping(parentRect, contentRect, density)
+        } else {
+            null
+        }
         val contentXPosInDp = contentRect.left.densityNormalized(density).toLong()
         val contentYPosInDp = contentRect.top.densityNormalized(density).toLong()
         val contentWidthPx = contentRect.width()

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/recorder/resources/DefaultImageWireframeHelper.kt
@@ -7,7 +7,6 @@
 package com.datadog.android.sessionreplay.internal.recorder.resources
 
 import android.graphics.drawable.Drawable
-import android.graphics.drawable.GradientDrawable
 import android.graphics.drawable.InsetDrawable
 import android.graphics.drawable.LayerDrawable
 import android.view.View
@@ -238,7 +237,6 @@ internal class DefaultImageWireframeHelper(
                 }
             }
 
-            is GradientDrawable -> DrawableProperties(drawable, view.width, view.height)
             else -> DrawableProperties(drawable, width, height)
         }
     }

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/ImageViewUtils.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/utils/ImageViewUtils.kt
@@ -19,12 +19,15 @@ internal object ImageViewUtils {
         // this will always have size >= 2
         @Suppress("UnsafeThirdPartyFunctionCall")
         view.getLocationOnScreen(coords)
-
+        val leftPadding = view.paddingLeft
+        val rightPadding = view.paddingRight
+        val topPadding = view.paddingTop
+        val bottomPadding = view.paddingBottom
         return Rect(
-            coords[0],
-            coords[1],
-            coords[0] + view.width,
-            coords[1] + view.height
+            coords[0] + leftPadding,
+            coords[1] + topPadding,
+            coords[0] + view.width - rightPadding,
+            coords[1] + view.height - bottomPadding
         )
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/ImageViewUtilsTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/utils/ImageViewUtilsTest.kt
@@ -212,6 +212,10 @@ internal class ImageViewUtilsTest {
         val fakeGlobalY = forge.aPositiveInt()
         val fakeWidth = forge.aPositiveInt()
         val fakeHeight = forge.aPositiveInt()
+        val fakeTopPadding = forge.aPositiveInt()
+        val fakeBottomPadding = forge.aPositiveInt()
+        val fakeLeftPadding = forge.aPositiveInt()
+        val fakeRightPadding = forge.aPositiveInt()
         val mockView: View = mock {
             whenever(it.getLocationOnScreen(any())).thenAnswer {
                 val coords = it.arguments[0] as IntArray
@@ -221,16 +225,20 @@ internal class ImageViewUtilsTest {
             }
             whenever(it.width).thenReturn(fakeWidth)
             whenever(it.height).thenReturn(fakeHeight)
+            whenever(it.paddingTop).thenReturn(fakeTopPadding)
+            whenever(it.paddingLeft).thenReturn(fakeLeftPadding)
+            whenever(it.paddingRight).thenReturn(fakeRightPadding)
+            whenever(it.paddingBottom).thenReturn(fakeBottomPadding)
         }
 
         // When
         val result = testedImageViewUtils.resolveParentRectAbsPosition(mockView)
 
         // Then
-        assertThat(result.left).isEqualTo(fakeGlobalX)
-        assertThat(result.top).isEqualTo(fakeGlobalY)
-        assertThat(result.right).isEqualTo(fakeGlobalX + fakeWidth)
-        assertThat(result.bottom).isEqualTo(fakeGlobalY + fakeHeight)
+        assertThat(result.left).isEqualTo(fakeGlobalX + fakeLeftPadding)
+        assertThat(result.top).isEqualTo(fakeGlobalY + fakeTopPadding)
+        assertThat(result.right).isEqualTo(fakeGlobalX + fakeWidth - fakeRightPadding)
+        assertThat(result.bottom).isEqualTo(fakeGlobalY + fakeHeight - fakeBottomPadding)
     }
 
     @Test

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_allow_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_allow_payload.json
@@ -20,12 +20,6 @@
         "type": "shape"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "image",
         "isEmpty": false
       },
@@ -33,12 +27,6 @@
         "type": "shape"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "image",
         "isEmpty": false
       },
@@ -46,12 +34,6 @@
         "type": "shape"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "image",
         "isEmpty": false
       }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_mask_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_mask_payload.json
@@ -17,32 +17,23 @@
         "type": "shape"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
+        "type": "shape"
+      },
+      {
         "type": "placeholder",
         "label": "Image"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
+        "type": "shape"
+      },
+      {
         "type": "placeholder",
         "label": "Image"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
+        "type": "shape"
+      },
+      {
         "type": "placeholder",
         "label": "Image"
       }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_mask_user_input_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_image_buttons_mask_user_input_payload.json
@@ -20,12 +20,6 @@
         "type": "shape"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "image",
         "isEmpty": false
       },
@@ -33,12 +27,6 @@
         "type": "shape"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "image",
         "isEmpty": false
       },
@@ -46,12 +34,6 @@
         "type": "shape"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "image",
         "isEmpty": false
       }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_allow_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_allow_payload.json
@@ -17,22 +17,10 @@
         "type": "shape"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "image",
         "isEmpty": false
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "image",
         "isEmpty": false
       }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_payload.json
@@ -17,22 +17,10 @@
         "type": "shape"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "placeholder",
         "label": "Image"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "placeholder",
         "label": "Image"
       }

--- a/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_user_input_payload.json
+++ b/instrumented/integration/src/androidTest/assets/session_replay_payloads/sr_images_mask_user_input_payload.json
@@ -17,22 +17,10 @@
         "type": "shape"
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "image",
         "isEmpty": false
       },
       {
-        "clip": {
-          "top": 2,
-          "bottom": 3,
-          "left": 0,
-          "right": 0
-        },
         "type": "image",
         "isEmpty": false
       }

--- a/sample/kotlin/src/main/res/layout/fragment_image_components.xml
+++ b/sample/kotlin/src/main/res/layout/fragment_image_components.xml
@@ -339,7 +339,8 @@
                 <ImageView
                     android:id="@+id/imageView_remote"
                     android:layout_width="160dp"
-                    android:layout_height="wrap_content"
+                    android:layout_height="160dp"
+                    android:padding="32dp"
                     android:scaleType="fitCenter"
                     android:contentDescription="@null"
                     android:layout_marginEnd="8dp"


### PR DESCRIPTION
### What does this PR do?

In app development, clients usually use paddings to resize the content drawable in a given size image view, prior to this PR we didn't taken into account these paddings to resize our image wireframe, which leads some images/icons bigger than real.

So the updates in this PR:
* Add paddings for a demo image view in sample app
* Add paddings calculation in `resolveParentRectAbsPosition` function
* Fix the issue that  `GradientDrawable` didn't take into account the width&height after resizing.

### Motivation

RUM-3460

### Demo
![image](https://github.com/user-attachments/assets/1a3cd145-e0a5-48af-9e6a-982c61fd183b)


Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

