### PR TITLE
RUM-6400 Add warning log when initializing the SDK outside of main process

### DIFF
--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/CoreFeature.kt
@@ -626,6 +626,13 @@ internal class CoreFeature(
         } else {
             appContext.packageName == currentProcess.processName
         }
+        if (!isMainProcess) {
+            internalLogger.log(
+                InternalLogger.Level.WARN,
+                InternalLogger.Target.USER,
+                { SDK_INITIALIZED_IN_SECONDARY_PROCESS_WARNING_MESSAGE }
+            )
+        }
     }
 
     private fun shutDownExecutors() {
@@ -676,6 +683,10 @@ internal class CoreFeature(
     // endregion
 
     companion object {
+        internal const val SDK_INITIALIZED_IN_SECONDARY_PROCESS_WARNING_MESSAGE =
+            "Datadog SDK was initialized in a secondary process: although data will still be captured," +
+                " nothing will be uploaded from this process. Make sure to also initialize the SDK from the main" +
+                " process of your application."
 
         internal val DEFAULT_FLUSHABLE_EXECUTOR_SERVICE_FACTORY =
             FlushableExecutorService.Factory { logger, executorContext, backPressureStrategy ->

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/internal/CoreFeatureTest.kt
@@ -781,6 +781,11 @@ internal class CoreFeatureTest {
 
         // Then
         assertThat(testedFeature.isMainProcess).isFalse()
+        mockInternalLogger.verifyLog(
+            InternalLogger.Level.WARN,
+            InternalLogger.Target.USER,
+            CoreFeature.SDK_INITIALIZED_IN_SECONDARY_PROCESS_WARNING_MESSAGE
+        )
     }
 
     @Test


### PR DESCRIPTION
### What does this PR do?

During our escalation sessions with our clients we encountered several situations where the SDK was not initialised outside the main process. Unless the application is using 2 different processes and has 2 SDK instances (one in each process) this scenario will lead to a non - functional SDK as the data will no be uploaded as we are not initialising our schedulers in a secondary process. 

In this PR we are adding a warning log for our users when the SDK is initialised in a secondary process just to better debug this situations and avoid long escalation back and forth. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

