### PR TITLE
RUM-7085:Add compose session replay scenario for benchmark sample application

### DIFF
--- a/sample/benchmark/build.gradle.kts
+++ b/sample/benchmark/build.gradle.kts
@@ -34,6 +34,12 @@ android {
         java17()
     }
 
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = libs.versions.androidXComposeRuntime.get()
+    }
     val bmPassword = System.getenv("BM_STORE_PASSWD")
     signingConfigs {
         if (bmPassword != null) {
@@ -76,6 +82,8 @@ dependencies {
     implementation(libs.googleMaterial)
     implementation(libs.glideCore)
     implementation(libs.timber)
+    implementation(platform(libs.androidXComposeBom))
+    implementation(libs.bundles.androidXCompose)
     implementation(project(":features:dd-sdk-android-logs"))
     implementation(project(":features:dd-sdk-android-rum"))
     implementation(project(":features:dd-sdk-android-trace"))

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/MainActivity.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/MainActivity.kt
@@ -7,10 +7,12 @@
 package com.datadog.benchmark.sample
 
 import android.os.Bundle
+import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.navigation.NavController
 import androidx.navigation.Navigation
 import com.datadog.benchmark.sample.benchmark.DatadogBenchmark
+import com.datadog.benchmark.sample.compose.MainView
 import com.datadog.sample.benchmark.R
 
 /**
@@ -22,10 +24,17 @@ class MainActivity : AppCompatActivity() {
     private lateinit var datadogBenchmark: DatadogBenchmark
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
+
         datadogBenchmark = DatadogBenchmark(
             DatadogBenchmark.Config.resolveSyntheticsBundle(intent.extras)
         )
+        if (datadogBenchmark.isComposeEnabled) {
+            setContent {
+                MainView()
+            }
+        } else {
+            setContentView(R.layout.activity_main)
+        }
     }
 
     override fun onStart() {
@@ -40,6 +49,8 @@ class MainActivity : AppCompatActivity() {
 
     override fun onResume() {
         super.onResume()
-        navController = Navigation.findNavController(this, R.id.nav_host_fragment)
+        if (!datadogBenchmark.isComposeEnabled) {
+            navController = Navigation.findNavController(this, R.id.nav_host_fragment)
+        }
     }
 }

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/DatadogBenchmark.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/DatadogBenchmark.kt
@@ -33,9 +33,12 @@ internal class DatadogBenchmark(config: Config) {
             .build()
     )
 
+    val isComposeEnabled = config.scenario == SyntheticsScenario.SessionReplayCompose
+
     init {
         if (config.run == SyntheticsRun.Instrumented) {
             when (config.scenario) {
+                SyntheticsScenario.SessionReplayCompose,
                 SyntheticsScenario.SessionReplay -> enableSessionReplay()
                 else -> {} // do nothing for now
             }

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/SyntheticsScenario.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/SyntheticsScenario.kt
@@ -10,6 +10,8 @@ internal enum class SyntheticsScenario(val value: String) {
 
     SessionReplay("sr"),
 
+    SessionReplayCompose("sr_compose"),
+
     Rum("rum"),
 
     Trace("trace"),

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/compose/MainView.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/compose/MainView.kt
@@ -1,0 +1,14 @@
+/*
+ * Unless explicitly stated otherwise all files in this repository are licensed under the Apache License Version 2.0.
+ * This product includes software developed at Datadog (https://www.datadoghq.com/).
+ * Copyright 2016-Present Datadog, Inc.
+ */
+
+package com.datadog.benchmark.sample.compose
+
+import androidx.compose.runtime.Composable
+
+@Composable
+internal fun MainView() {
+    // TODO RUM-7085: Add compose view
+}

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/fragment/SessionReplayAppcompatFragment.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/fragment/SessionReplayAppcompatFragment.kt
@@ -20,7 +20,7 @@ import android.widget.ImageView
 import android.widget.NumberPicker
 import android.widget.Spinner
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.NavHostFragment.findNavController
+import androidx.navigation.fragment.NavHostFragment.Companion.findNavController
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition

--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/fragment/SessionReplayMaterialFragment.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/fragment/SessionReplayMaterialFragment.kt
@@ -20,7 +20,7 @@ import android.widget.ImageView
 import android.widget.NumberPicker
 import android.widget.Spinner
 import androidx.fragment.app.Fragment
-import androidx.navigation.fragment.NavHostFragment.findNavController
+import androidx.navigation.fragment.NavHostFragment.Companion.findNavController
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.target.CustomTarget
 import com.bumptech.glide.request.transition.Transition

--- a/sample/benchmark/src/test/java/com/datadog/benchmark/sample/benchmark/DatadogBenchmarkTest.kt
+++ b/sample/benchmark/src/test/java/com/datadog/benchmark/sample/benchmark/DatadogBenchmarkTest.kt
@@ -52,6 +52,16 @@ class DatadogBenchmarkTest {
     }
 
     @Test
+    fun `M build correct config W resolve bundle {scenario = 'sr_compose', run = 'instrumented'}`() {
+        whenever(mockedBundle.getString("synthetics.benchmark.scenario")).thenReturn("sr_compose")
+        whenever(mockedBundle.getString("synthetics.benchmark.run")).thenReturn("instrumented")
+
+        val config = DatadogBenchmark.Config.resolveSyntheticsBundle(mockedBundle)
+        Assertions.assertThat(config.scenario).isEqualTo(SyntheticsScenario.SessionReplayCompose)
+        Assertions.assertThat(config.run).isEqualTo(SyntheticsRun.Instrumented)
+    }
+
+    @Test
     fun `M build empty config W resolve invalid bundle`() {
         whenever(mockedBundle.getString("synthetics.benchmark.scenario")).thenReturn("")
         whenever(mockedBundle.getString("synthetics.benchmark.run")).thenReturn("")


### PR DESCRIPTION
### What does this PR do?

Add session replay compose scenario, so that the application can switch to compose view when receive the bundle argument, and also in metrics we can filter with `scenario:sr_compose` for compose session replay.


### Motivation

RUM-7085


### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

