### PR TITLE
RUM-6866 Allow typed Sampler

### DIFF
--- a/dd-sdk-android-core/api/apiSurface
+++ b/dd-sdk-android-core/api/apiSurface
@@ -323,14 +323,14 @@ interface com.datadog.android.core.persistence.Serializer<T: Any>
 fun <T: Any> Serializer<T>.serializeToByteArray(T, com.datadog.android.api.InternalLogger): ByteArray?
 data class com.datadog.android.core.persistence.datastore.DataStoreContent<T: Any>
   constructor(Int, T?)
-class com.datadog.android.core.sampling.RateBasedSampler : Sampler
+open class com.datadog.android.core.sampling.RateBasedSampler<T: Any> : Sampler<T>
   constructor(() -> Float)
   constructor(Float)
   constructor(Double)
-  override fun sample(): Boolean
+  override fun sample(T): Boolean
   override fun getSampleRate(): Float
-interface com.datadog.android.core.sampling.Sampler
-  fun sample(): Boolean
+interface com.datadog.android.core.sampling.Sampler<T: Any>
+  fun sample(T): Boolean
   fun getSampleRate(): Float?
 interface com.datadog.android.core.thread.FlushableExecutorService : java.util.concurrent.ExecutorService
   fun drainTo(MutableCollection<Runnable>)

--- a/dd-sdk-android-core/api/dd-sdk-android-core.api
+++ b/dd-sdk-android-core/api/dd-sdk-android-core.api
@@ -867,18 +867,18 @@ public final class com/datadog/android/core/persistence/datastore/DataStoreConte
 	public fun toString ()Ljava/lang/String;
 }
 
-public final class com/datadog/android/core/sampling/RateBasedSampler : com/datadog/android/core/sampling/Sampler {
+public class com/datadog/android/core/sampling/RateBasedSampler : com/datadog/android/core/sampling/Sampler {
 	public static final field SAMPLE_ALL_RATE F
 	public fun <init> (D)V
 	public fun <init> (F)V
 	public fun <init> (Lkotlin/jvm/functions/Function0;)V
 	public fun getSampleRate ()Ljava/lang/Float;
-	public fun sample ()Z
+	public fun sample (Ljava/lang/Object;)Z
 }
 
 public abstract interface class com/datadog/android/core/sampling/Sampler {
 	public abstract fun getSampleRate ()Ljava/lang/Float;
-	public abstract fun sample ()Z
+	public abstract fun sample (Ljava/lang/Object;)Z
 }
 
 public abstract interface class com/datadog/android/core/thread/FlushableExecutorService : java/util/concurrent/ExecutorService {

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/logger/SdkInternalLogger.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/internal/logger/SdkInternalLogger.kt
@@ -98,7 +98,7 @@ internal class SdkInternalLogger(
         additionalProperties: Map<String, Any?>,
         samplingRate: Float
     ) {
-        if (!RateBasedSampler(samplingRate).sample()) return
+        if (!sample(samplingRate)) return
         val rumFeature = sdkCore?.getFeature(Feature.RUM_FEATURE_NAME) ?: return
         val metricEvent = InternalTelemetryEvent.Metric(
             message = messageBuilder(),
@@ -113,7 +113,7 @@ internal class SdkInternalLogger(
         samplingRate: Float,
         operationName: String
     ): PerformanceMetric? {
-        if (!RateBasedSampler(samplingRate).sample()) return null
+        if (!sample(samplingRate)) return null
 
         return when (metric) {
             TelemetryMetricType.MethodCalled -> {
@@ -130,7 +130,7 @@ internal class SdkInternalLogger(
         apiUsageEvent: InternalTelemetryEvent.ApiUsage,
         samplingRate: Float
     ) {
-        if (!RateBasedSampler(samplingRate).sample()) return
+        if (!sample(samplingRate)) return
         val rumFeature = sdkCore?.getFeature(Feature.RUM_FEATURE_NAME) ?: return
         rumFeature.sendEvent(apiUsageEvent)
     }
@@ -138,6 +138,10 @@ internal class SdkInternalLogger(
     // endregion
 
     // region Internal
+
+    fun sample(samplingRate: Float): Boolean {
+        return RateBasedSampler<Unit>(samplingRate).sample(Unit)
+    }
 
     private fun logToUser(
         level: InternalLogger.Level,

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/sampling/RateBasedSampler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/sampling/RateBasedSampler.kt
@@ -13,10 +13,11 @@ import java.security.SecureRandom
 /**
  * [Sampler] with the given sample rate which can be fixed or dynamic.
  *
+ * @param T the type of items to sample.
  * @param sampleRateProvider Provider for the sample rate value which will be called each time
  * the sampling decision needs to be made. All the values should be on the scale [0;100].
  */
-class RateBasedSampler(private val sampleRateProvider: () -> Float) : Sampler {
+open class RateBasedSampler<T : Any>(private val sampleRateProvider: () -> Float) : Sampler<T> {
 
     /**
      * Creates a new instance of [RateBasedSampler] with the given sample rate.
@@ -36,7 +37,7 @@ class RateBasedSampler(private val sampleRateProvider: () -> Float) : Sampler {
 
     /** @inheritDoc */
     @Suppress("MagicNumber")
-    override fun sample(): Boolean {
+    override fun sample(item: T): Boolean {
         return when (val sampleRate = getSampleRate()) {
             0f -> false
             SAMPLE_ALL_RATE -> true

--- a/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/sampling/Sampler.kt
+++ b/dd-sdk-android-core/src/main/kotlin/com/datadog/android/core/sampling/Sampler.kt
@@ -10,14 +10,15 @@ import androidx.annotation.FloatRange
 
 /**
  * Interface representing the sampling.
+ * @param T the type of items to sample.
  */
-interface Sampler {
+interface Sampler<T : Any> {
 
     /**
-     * Sampling method.
-     * @return true if you want to keep the value, false otherwise.
+     * @param item the item to sample
+     * @return true to keep the item, false to discard it
      */
-    fun sample(): Boolean
+    fun sample(item: T): Boolean
 
     /**
      * @return the sample rate if applicable, as a float between 0 and 100,

--- a/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/sampling/RateBasedSamplerTest.kt
+++ b/dd-sdk-android-core/src/test/kotlin/com/datadog/android/core/sampling/RateBasedSamplerTest.kt
@@ -30,7 +30,7 @@ import kotlin.math.sqrt
 @ForgeConfiguration(Configurator::class)
 internal class RateBasedSamplerTest {
 
-    private lateinit var testedSampler: RateBasedSampler
+    private lateinit var testedSampler: RateBasedSampler<Unit>
 
     @FloatForgery(min = 0f, max = 100f)
     var randomSampleRate: Float = 0.0f
@@ -51,7 +51,7 @@ internal class RateBasedSamplerTest {
         repeat(testRepeats) {
             var validated = 0
             repeat(dataSize) {
-                val isValid = if (testedSampler.sample()) 1 else 0
+                val isValid = if (testedSampler.sample(Unit)) 1 else 0
                 validated += isValid
             }
             val computedSampleRate = (validated.toDouble() / dataSize.toDouble()) * 100
@@ -93,7 +93,7 @@ internal class RateBasedSamplerTest {
         repeat(testRepeats) {
             var validated = 0
             repeat(dataSize) {
-                val isValid = if (testedSampler.sample()) 1 else 0
+                val isValid = if (testedSampler.sample(Unit)) 1 else 0
                 validated += isValid
             }
             val computedSampleRate = (validated.toDouble() / dataSize.toDouble()) * 100
@@ -120,7 +120,7 @@ internal class RateBasedSamplerTest {
         val dataSize = 10
 
         repeat(dataSize) {
-            val isValid = if (testedSampler.sample()) 1 else 0
+            val isValid = if (testedSampler.sample(Unit)) 1 else 0
             validated += isValid
         }
 
@@ -135,7 +135,7 @@ internal class RateBasedSamplerTest {
         val dataSize = 10
 
         repeat(dataSize) {
-            val isValid = if (testedSampler.sample()) 1 else 0
+            val isValid = if (testedSampler.sample(Unit)) 1 else 0
             validated += isValid
         }
 

--- a/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
+++ b/features/dd-sdk-android-logs/src/main/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandler.kt
@@ -27,7 +27,7 @@ internal class DatadogLogHandler(
     internal val attachNetworkInfo: Boolean,
     internal val bundleWithTraces: Boolean = true,
     internal val bundleWithRum: Boolean = true,
-    internal val sampler: Sampler = RateBasedSampler(DEFAULT_SAMPLE_RATE),
+    internal val sampler: Sampler<Unit> = RateBasedSampler(DEFAULT_SAMPLE_RATE),
     internal val minLogPriority: Int = -1
 ) : LogHandler {
 
@@ -52,7 +52,7 @@ internal class DatadogLogHandler(
             combinedAttributes.putAll(logsFeature.unwrap<LogsFeature>().getAttributes().toMutableMap())
         }
         combinedAttributes.putAll(attributes)
-        if (sampler.sample()) {
+        if (sampler.sample(Unit)) {
             if (logsFeature != null) {
                 val threadName = Thread.currentThread().name
                 logsFeature.withWriteContext { datadogContext, eventBatchWriter ->
@@ -123,7 +123,7 @@ internal class DatadogLogHandler(
         }
         combinedAttributes.putAll(attributes)
 
-        if (sampler.sample()) {
+        if (sampler.sample(Unit)) {
             if (logsFeature != null) {
                 val threadName = Thread.currentThread().name
                 logsFeature.withWriteContext { datadogContext, eventBatchWriter ->

--- a/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
+++ b/features/dd-sdk-android-logs/src/test/kotlin/com/datadog/android/log/internal/logger/DatadogLogHandlerTest.kt
@@ -106,7 +106,7 @@ internal class DatadogLogHandlerTest {
     lateinit var mockWriter: DataWriter<LogEvent>
 
     @Mock
-    lateinit var mockSampler: Sampler
+    lateinit var mockSampler: Sampler<Unit>
 
     @BeforeEach
     fun `set up`(forge: Forge) {
@@ -937,7 +937,7 @@ internal class DatadogLogHandlerTest {
     @Test
     fun `it will sample out the logs when required`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(false)
+        whenever(mockSampler.sample(Unit)).thenReturn(false)
         testedHandler = DatadogLogHandler(
             loggerName = fakeLoggerName,
             logGenerator = DatadogLogGenerator(
@@ -967,7 +967,7 @@ internal class DatadogLogHandlerTest {
     fun `it will sample in the logs when required`() {
         // Given
         val now = System.currentTimeMillis()
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(Unit)).thenReturn(true)
         testedHandler = DatadogLogHandler(
             loggerName = fakeLoggerName,
             logGenerator = DatadogLogGenerator(

--- a/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
+++ b/features/dd-sdk-android-rum/src/main/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandler.kt
@@ -35,8 +35,9 @@ import com.datadog.android.telemetry.model.TelemetryConfigurationEvent.ViewTrack
 @Suppress("TooManyFunctions")
 internal class TelemetryEventHandler(
     internal val sdkCore: InternalSdkCore,
-    internal val eventSampler: Sampler,
-    internal val configurationExtraSampler: Sampler = RateBasedSampler(DEFAULT_CONFIGURATION_SAMPLE_RATE),
+    internal val eventSampler: Sampler<InternalTelemetryEvent>,
+    internal val configurationExtraSampler: Sampler<InternalTelemetryEvent> =
+        RateBasedSampler(DEFAULT_CONFIGURATION_SAMPLE_RATE),
     private val sessionEndedMetricDispatcher: SessionMetricDispatcher,
     private val maxEventCountPerSession: Int = MAX_EVENTS_PER_SESSION
 ) : RumSessionListener {
@@ -125,13 +126,13 @@ internal class TelemetryEventHandler(
         totalEventsSeenInCurrentSession = 0
     }
 
-    // region private
+    // region Internal
 
     @Suppress("ReturnCount")
     private fun canWrite(event: InternalTelemetryEvent): Boolean {
-        if (!eventSampler.sample()) return false
+        if (!eventSampler.sample(event)) return false
 
-        if (event is InternalTelemetryEvent.Configuration && !configurationExtraSampler.sample()) {
+        if (event is InternalTelemetryEvent.Configuration && !configurationExtraSampler.sample(event)) {
             return false
         }
 

--- a/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
+++ b/features/dd-sdk-android-rum/src/test/kotlin/com/datadog/android/telemetry/internal/TelemetryEventHandlerTest.kt
@@ -90,10 +90,10 @@ internal class TelemetryEventHandlerTest {
     lateinit var mockWriter: DataWriter<Any>
 
     @Mock
-    lateinit var mockSampler: Sampler
+    lateinit var mockSampler: Sampler<InternalTelemetryEvent>
 
     @Mock
-    lateinit var mockConfigurationSampler: Sampler
+    lateinit var mockConfigurationSampler: Sampler<InternalTelemetryEvent>
 
     @Mock
     lateinit var mockSdkCore: InternalSdkCore
@@ -170,8 +170,8 @@ internal class TelemetryEventHandlerTest {
             deviceInfo = mockDeviceInfo
         )
 
-        whenever(mockSampler.sample()) doReturn true
-        whenever(mockConfigurationSampler.sample()) doReturn true
+        whenever(mockSampler.sample(any())) doReturn true
+        whenever(mockConfigurationSampler.sample(any())) doReturn true
 
         whenever(
             mockSdkCore.getFeature(Feature.RUM_FEATURE_NAME)
@@ -744,7 +744,7 @@ internal class TelemetryEventHandlerTest {
         // Given
         val fakeInternalTelemetryEvent = forge.forgeWritableInternalTelemetryEvent()
         val rawEvent = RumRawEvent.TelemetryEventWrapper(fakeInternalTelemetryEvent)
-        whenever(mockSampler.sample()) doReturn false
+        whenever(mockSampler.sample(any())) doReturn false
 
         // When
         testedTelemetryHandler.handleEvent(rawEvent, mockWriter)
@@ -763,8 +763,8 @@ internal class TelemetryEventHandlerTest {
             forge.getForgery<InternalTelemetryEvent.Log.Debug>()
         )
         val rawEvent = RumRawEvent.TelemetryEventWrapper(logeEvent)
-        whenever(mockSampler.sample()) doReturn true
-        whenever(mockConfigurationSampler.sample()) doReturn false
+        whenever(mockSampler.sample(any())) doReturn true
+        whenever(mockConfigurationSampler.sample(any())) doReturn false
 
         // When
         testedTelemetryHandler.handleEvent(rawEvent, mockWriter)
@@ -786,8 +786,8 @@ internal class TelemetryEventHandlerTest {
     ) {
         // Given
         val rawEvent = RumRawEvent.TelemetryEventWrapper(fakeConfiguration)
-        whenever(mockSampler.sample()) doReturn true
-        whenever(mockConfigurationSampler.sample()) doReturn false
+        whenever(mockSampler.sample(any())) doReturn true
+        whenever(mockConfigurationSampler.sample(any())) doReturn false
 
         // When
         testedTelemetryHandler.handleEvent(rawEvent, mockWriter)
@@ -930,7 +930,7 @@ internal class TelemetryEventHandlerTest {
     fun `M count the limit only after the sampling W handleEvent()`(forge: Forge) {
         // Given
         // sample out 50%
-        whenever(mockSampler.sample()) doAnswer object : Answer<Boolean> {
+        whenever(mockSampler.sample(any())) doAnswer object : Answer<Boolean> {
             var invocationCount = 0
             override fun answer(invocation: InvocationOnMock): Boolean {
                 invocationCount++
@@ -1008,8 +1008,8 @@ internal class TelemetryEventHandlerTest {
         }
     }
 
-// endregion
-// region Api Usage
+    // endregion
+    // region Api Usage
 
     @Test
     fun `M create api usage event W handleEvent(api usage event)`(
@@ -1081,9 +1081,10 @@ internal class TelemetryEventHandlerTest {
             message = TelemetryEventHandler.MAX_EVENT_NUMBER_REACHED_MESSAGE
         )
     }
-// endregion
 
-// region Assertions
+    // endregion
+
+    // region Assertions
 
     private fun assertApiUsageMatchesInternalEvent(
         actual: TelemetryUsageEvent,
@@ -1257,7 +1258,7 @@ internal class TelemetryEventHandlerTest {
         )
     }
 
-// endregion
+    // endregion
 
     companion object {
 

--- a/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
+++ b/features/dd-sdk-android-session-replay/src/main/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeature.kt
@@ -50,7 +50,7 @@ internal class SessionReplayFeature(
     internal val textAndInputPrivacy: TextAndInputPrivacy,
     internal val touchPrivacy: TouchPrivacy,
     internal val imagePrivacy: ImagePrivacy,
-    private val rateBasedSampler: Sampler,
+    private val rateBasedSampler: Sampler<Unit>,
     private val startRecordingImmediately: Boolean,
     private val recorderProvider: RecorderProvider
 ) : StorageBackedFeature, FeatureEventReceiver {
@@ -261,7 +261,7 @@ internal class SessionReplayFeature(
 
     private fun applySampling(alreadySeenSession: Boolean) {
         if (!alreadySeenSession) {
-            isSessionSampledIn.set(rateBasedSampler.sample())
+            isSessionSampledIn.set(rateBasedSampler.sample(Unit))
         }
     }
 

--- a/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
+++ b/features/dd-sdk-android-session-replay/src/test/kotlin/com/datadog/android/sessionreplay/internal/SessionReplayFeatureTest.kt
@@ -90,7 +90,7 @@ internal class SessionReplayFeatureTest {
     lateinit var mockExecutorService: ExecutorService
 
     @Mock
-    lateinit var mockSampler: Sampler
+    lateinit var mockSampler: Sampler<Unit>
 
     private lateinit var fakeSessionId: String
 
@@ -450,7 +450,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M startRecording W rum session updated { keep, sampled in }`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
         testedFeature.onInitialize(appContext.mockInstance)
         testedFeature.stopRecording()
         val rumSessionUpdateBusMessage = mapOf(
@@ -475,7 +475,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M doNothing W rum session updated { keep, sessionId is null }`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
         testedFeature.onInitialize(appContext.mockInstance)
         testedFeature.stopRecording()
         val rumSessionUpdateBusMessage = mapOf(
@@ -496,7 +496,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M do nothing W rum session updated { keep false, sampled in }`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
         testedFeature.onInitialize(appContext.mockInstance)
         testedFeature.stopRecording()
         val rumSessionUpdateBusMessage = mapOf(
@@ -523,7 +523,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M only startRecording once W rum session updated { same session Id }`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
         testedFeature.onInitialize(appContext.mockInstance)
         val rumSessionUpdateBusMessage1 = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
@@ -557,7 +557,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M do nothing W rum session updated { keep true, sampled out }`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(false)
+        whenever(mockSampler.sample(any())).thenReturn(false)
         testedFeature.onInitialize(appContext.mockInstance)
         testedFeature.stopRecording()
         val rumSessionUpdateBusMessage = mapOf(
@@ -585,7 +585,7 @@ internal class SessionReplayFeatureTest {
     fun `M stopRecording W rum session updated { keep false, sample in }`() {
         // Given
         val fakeSessionId2 = UUID.randomUUID().toString()
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
         testedFeature.onInitialize(appContext.mockInstance)
         val rumSessionUpdateBusMessage1 = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
@@ -626,7 +626,7 @@ internal class SessionReplayFeatureTest {
     fun `M stopRecording W rum session updated { keep true, sample out }`() {
         // Given
         val fakeSessionId2 = UUID.randomUUID().toString()
-        whenever(mockSampler.sample()).thenReturn(true).thenReturn(false)
+        whenever(mockSampler.sample(any())).thenReturn(true).thenReturn(false)
         testedFeature.onInitialize(appContext.mockInstance)
         val rumSessionUpdateBusMessage1 = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
@@ -665,7 +665,7 @@ internal class SessionReplayFeatureTest {
     fun `M stopRecording W rum session updated { keep false, sample out }`() {
         // Given
         val fakeSessionId2 = UUID.randomUUID().toString()
-        whenever(mockSampler.sample()).thenReturn(true).thenReturn(false)
+        whenever(mockSampler.sample(any())).thenReturn(true).thenReturn(false)
         testedFeature.onInitialize(appContext.mockInstance)
         val rumSessionUpdateBusMessage1 = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
@@ -705,7 +705,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M log warning W rum session updated before initialization { keep true, sample in }`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
         val rumSessionUpdateBusMessage = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
                 SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
@@ -729,7 +729,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M log warning W rum session updated before initialization { keep true, sample out }`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(false)
+        whenever(mockSampler.sample(any())).thenReturn(false)
         val rumSessionUpdateBusMessage = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
                 SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
@@ -753,7 +753,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M log warning W rum session updated before initialization { keep false, sample in }`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
         val rumSessionUpdateBusMessage = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
                 SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
@@ -777,7 +777,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M log warning W rum session updated before initialization { keep false, sample out }`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(false)
+        whenever(mockSampler.sample(any())).thenReturn(false)
         val rumSessionUpdateBusMessage = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
                 SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
@@ -801,7 +801,7 @@ internal class SessionReplayFeatureTest {
     @Test
     fun `M start recording W rum session is initialized after first message`() {
         // Given
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
         val rumSessionUpdateBusMessage1 = mapOf(
             SessionReplayFeature.SESSION_REPLAY_BUS_MESSAGE_TYPE_KEY to
                 SessionReplayFeature.RUM_SESSION_RENEWED_BUS_MESSAGE,
@@ -1016,7 +1016,7 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.RUM_SESSION_ID_BUS_MESSAGE_KEY to fakeSessionId
         )
 
-        whenever(mockSampler.sample()).thenReturn(scenario.sampleInSession)
+        whenever(mockSampler.sample(any())).thenReturn(scenario.sampleInSession)
 
         // When
         testedFeature = SessionReplayFeature(
@@ -1055,7 +1055,7 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to true,
             SessionReplayFeature.RUM_SESSION_ID_BUS_MESSAGE_KEY to fakeSessionId
         )
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
 
         // When
         testedFeature = SessionReplayFeature(
@@ -1087,7 +1087,7 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.RUM_KEEP_SESSION_BUS_MESSAGE_KEY to true,
             SessionReplayFeature.RUM_SESSION_ID_BUS_MESSAGE_KEY to fakeSessionId
         )
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
 
         // When
         testedFeature = SessionReplayFeature(
@@ -1121,7 +1121,7 @@ internal class SessionReplayFeatureTest {
             SessionReplayFeature.RUM_SESSION_ID_BUS_MESSAGE_KEY to fakeSessionId
         )
 
-        whenever(mockSampler.sample()).thenReturn(true)
+        whenever(mockSampler.sample(any())).thenReturn(true)
 
         // When
         testedFeature = SessionReplayFeature(

--- a/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
+++ b/features/dd-sdk-android-webview/src/main/kotlin/com/datadog/android/webview/internal/log/WebViewLogEventConsumer.kt
@@ -12,6 +12,7 @@ import com.datadog.android.api.feature.FeatureSdkCore
 import com.datadog.android.api.storage.DataWriter
 import com.datadog.android.api.storage.EventType
 import com.datadog.android.core.sampling.RateBasedSampler
+import com.datadog.android.core.sampling.Sampler
 import com.datadog.android.log.LogAttributes
 import com.datadog.android.webview.internal.WebViewEventConsumer
 import com.datadog.android.webview.internal.rum.WebViewRumEventContextProvider
@@ -25,11 +26,11 @@ internal class WebViewLogEventConsumer(
     sampleRate: Float
 ) : WebViewEventConsumer<Pair<JsonObject, String>> {
 
-    val sampler = RateBasedSampler(sampleRate)
+    val sampler: Sampler<Unit> = RateBasedSampler(sampleRate)
 
     override fun consume(event: Pair<JsonObject, String>) {
         if (event.second == USER_LOG_EVENT_TYPE) {
-            if (sampler.sample()) {
+            if (sampler.sample(Unit)) {
                 sdkCore.getFeature(WebViewLogsFeature.WEB_LOGS_FEATURE_NAME)
                     ?.withWriteContext { datadogContext, eventBatchWriter ->
                         val rumContext = rumContextProvider.getRumContext(datadogContext)

--- a/integrations/dd-sdk-android-okhttp/api/apiSurface
+++ b/integrations/dd-sdk-android-okhttp/api/apiSurface
@@ -16,9 +16,9 @@ class com.datadog.android.okhttp.DatadogEventListener : okhttp3.EventListener
     constructor(String? = null)
     override fun create(okhttp3.Call): okhttp3.EventListener
 open class com.datadog.android.okhttp.DatadogInterceptor : com.datadog.android.okhttp.trace.TracingInterceptor
-  DEPRECATED constructor(String? = null, Map<String, Set<com.datadog.android.trace.TracingHeaderType>>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), com.datadog.android.core.sampling.Sampler = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
-  DEPRECATED constructor(String? = null, List<String>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), com.datadog.android.core.sampling.Sampler = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
-  DEPRECATED constructor(String? = null, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), com.datadog.android.core.sampling.Sampler = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
+  DEPRECATED constructor(String? = null, Map<String, Set<com.datadog.android.trace.TracingHeaderType>>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), com.datadog.android.core.sampling.Sampler<io.opentracing.Span> = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
+  DEPRECATED constructor(String? = null, List<String>, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), com.datadog.android.core.sampling.Sampler<io.opentracing.Span> = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
+  DEPRECATED constructor(String? = null, com.datadog.android.okhttp.trace.TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.rum.RumResourceAttributesProvider = NoOpRumResourceAttributesProvider(), com.datadog.android.core.sampling.Sampler<io.opentracing.Span> = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
   override fun onRequestIntercepted(com.datadog.android.api.feature.FeatureSdkCore, okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
   override fun canSendSpan(): Boolean
@@ -37,9 +37,9 @@ fun okhttp3.Request.Builder.parentSpan(io.opentracing.Span): okhttp3.Request.Bui
 interface com.datadog.android.okhttp.trace.TracedRequestListener
   fun onRequestIntercepted(okhttp3.Request, io.opentracing.Span, okhttp3.Response?, Throwable?)
 open class com.datadog.android.okhttp.trace.TracingInterceptor : okhttp3.Interceptor
-  DEPRECATED constructor(String? = null, List<String>, TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.core.sampling.Sampler = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
-  DEPRECATED constructor(String? = null, Map<String, Set<com.datadog.android.trace.TracingHeaderType>>, TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.core.sampling.Sampler = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
-  DEPRECATED constructor(String? = null, TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.core.sampling.Sampler = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
+  DEPRECATED constructor(String? = null, List<String>, TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.core.sampling.Sampler<io.opentracing.Span> = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
+  DEPRECATED constructor(String? = null, Map<String, Set<com.datadog.android.trace.TracingHeaderType>>, TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.core.sampling.Sampler<io.opentracing.Span> = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
+  DEPRECATED constructor(String? = null, TracedRequestListener = NoOpTracedRequestListener(), com.datadog.android.core.sampling.Sampler<io.opentracing.Span> = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE))
   override fun intercept(okhttp3.Interceptor.Chain): okhttp3.Response
   protected open fun onRequestIntercepted(com.datadog.android.api.feature.FeatureSdkCore, okhttp3.Request, io.opentracing.Span?, okhttp3.Response?, Throwable?)
   class Builder : BaseBuilder<TracingInterceptor, Builder>
@@ -51,6 +51,7 @@ open class com.datadog.android.okhttp.trace.TracingInterceptor : okhttp3.Interce
     constructor(Map<String, Set<com.datadog.android.trace.TracingHeaderType>>)
     fun setSdkInstanceName(String): R
     fun setTracedRequestListener(TracedRequestListener): R
-    fun setTraceSampler(com.datadog.android.core.sampling.Sampler): R
+    fun setTraceSampleRate(Float): R
+    fun setTraceSampler(com.datadog.android.core.sampling.Sampler<io.opentracing.Span>): R
     fun setTraceContextInjection(com.datadog.android.okhttp.TraceContextInjection): R
     abstract fun build(): T

--- a/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
+++ b/integrations/dd-sdk-android-okhttp/api/dd-sdk-android-okhttp.api
@@ -108,6 +108,7 @@ public abstract class com/datadog/android/okhttp/trace/TracingInterceptor$BaseBu
 	public abstract fun build ()Lcom/datadog/android/okhttp/trace/TracingInterceptor;
 	public final fun setSdkInstanceName (Ljava/lang/String;)Lcom/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder;
 	public final fun setTraceContextInjection (Lcom/datadog/android/okhttp/TraceContextInjection;)Lcom/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder;
+	public final fun setTraceSampleRate (F)Lcom/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder;
 	public final fun setTraceSampler (Lcom/datadog/android/core/sampling/Sampler;)Lcom/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder;
 	public final fun setTracedRequestListener (Lcom/datadog/android/okhttp/trace/TracedRequestListener;)Lcom/datadog/android/okhttp/trace/TracingInterceptor$BaseBuilder;
 }

--- a/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
+++ b/integrations/dd-sdk-android-okhttp/src/main/kotlin/com/datadog/android/okhttp/DatadogInterceptor.kt
@@ -72,13 +72,12 @@ import java.util.Locale
  *         .build()
  * ```
  */
-open class DatadogInterceptor
-internal constructor(
+open class DatadogInterceptor internal constructor(
     sdkInstanceName: String?,
     tracedHosts: Map<String, Set<TracingHeaderType>>,
     tracedRequestListener: TracedRequestListener,
     internal val rumResourceAttributesProvider: RumResourceAttributesProvider,
-    traceSampler: Sampler,
+    traceSampler: Sampler<Span>,
     traceContextInjection: TraceContextInjection,
     localTracerFactory: (SdkCore, Set<TracingHeaderType>) -> Tracer
 ) : TracingInterceptor(
@@ -128,7 +127,7 @@ internal constructor(
         tracedRequestListener: TracedRequestListener = NoOpTracedRequestListener(),
         rumResourceAttributesProvider: RumResourceAttributesProvider =
             NoOpRumResourceAttributesProvider(),
-        traceSampler: Sampler = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE)
+        traceSampler: Sampler<Span> = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE)
     ) : this(
         sdkInstanceName = sdkInstanceName,
         tracedHosts = firstPartyHostsWithHeaderType,
@@ -177,7 +176,7 @@ internal constructor(
         tracedRequestListener: TracedRequestListener = NoOpTracedRequestListener(),
         rumResourceAttributesProvider: RumResourceAttributesProvider =
             NoOpRumResourceAttributesProvider(),
-        traceSampler: Sampler = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE)
+        traceSampler: Sampler<Span> = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE)
     ) : this(
         sdkInstanceName = sdkInstanceName,
         tracedHosts = firstPartyHosts.associateWith {
@@ -222,7 +221,7 @@ internal constructor(
         tracedRequestListener: TracedRequestListener = NoOpTracedRequestListener(),
         rumResourceAttributesProvider: RumResourceAttributesProvider =
             NoOpRumResourceAttributesProvider(),
-        traceSampler: Sampler = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE)
+        traceSampler: Sampler<Span> = RateBasedSampler(DEFAULT_TRACE_SAMPLE_RATE)
     ) : this(
         sdkInstanceName = sdkInstanceName,
         tracedHosts = emptyMap(),

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorBuilderTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorBuilderTest.kt
@@ -16,9 +16,11 @@ import com.datadog.android.trace.TracingHeaderType
 import com.datadog.tools.unit.extensions.TestConfigurationExtension
 import com.datadog.tools.unit.forge.BaseConfigurator
 import fr.xgouchet.elmyr.Forge
+import fr.xgouchet.elmyr.annotation.FloatForgery
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.opentracing.Span
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -54,7 +56,7 @@ internal class DatadogInterceptorBuilderTest {
     private lateinit var fakeTracedHosts: List<String>
 
     @Mock
-    lateinit var mockSampler: Sampler
+    lateinit var mockSampler: Sampler<Span>
 
     @BeforeEach
     fun `set up`(forge: Forge) {
@@ -185,6 +187,29 @@ internal class DatadogInterceptorBuilderTest {
         assertThat(interceptor.rumResourceAttributesProvider).isSameAs(mockRumResourceAttributesProvider)
         assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
         assertThat(interceptor.traceSampler).isInstanceOf(RateBasedSampler::class.java)
+        assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
+        assertThat(interceptor.localTracerFactory).isNotNull()
+    }
+
+    @Test
+    fun `M set traceSampler W build { setTraceSampleRate }`(
+        @FloatForgery(0f, 100f) fakeSampleRate: Float
+    ) {
+        // When
+        val interceptor = DatadogInterceptor.Builder(fakeTracedHostsWithHeaderType)
+            .setTraceSampleRate(fakeSampleRate)
+            .build()
+
+        // Then
+        assertThat(interceptor.tracedHosts).isEqualTo(fakeTracedHostsWithHeaderType)
+        assertThat(interceptor.traceContextInjection).isEqualTo(TraceContextInjection.All)
+        assertThat(interceptor.sdkInstanceName).isNull()
+        assertThat(
+            interceptor.rumResourceAttributesProvider
+        ).isInstanceOf(NoOpRumResourceAttributesProvider::class.java)
+        assertThat(interceptor.tracedRequestListener).isInstanceOf(NoOpTracedRequestListener::class.java)
+        assertThat(interceptor.traceSampler).isInstanceOf(RateBasedSampler::class.java)
+        assertThat(interceptor.traceSampler.getSampleRate()).isEqualTo(fakeSampleRate)
         assertThat(interceptor.traceOrigin).isEqualTo(DatadogInterceptor.ORIGIN_RUM)
         assertThat(interceptor.localTracerFactory).isNotNull()
     }

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorTest.kt
@@ -366,7 +366,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(any())).thenReturn(false)
         stubChain(mockChain, statusCode)
         val expectedStartAttrs = emptyMap<String, Any?>()
         // no span -> shouldn't have trace/spans IDs
@@ -505,7 +505,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(any())).thenReturn(false)
         stubChain(mockChain) {
             Response.Builder()
                 .request(fakeRequest)
@@ -553,7 +553,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         @IntForgery(min = 200, max = 300) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(any())).thenReturn(false)
         stubChain(mockChain) {
             Response.Builder()
                 .request(fakeRequest)
@@ -664,7 +664,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(any())).thenReturn(false)
         stubChain(mockChain) {
             Response.Builder()
                 .request(fakeRequest)
@@ -766,7 +766,7 @@ internal class DatadogInterceptorTest : TracingInterceptorNotSendingSpanTest() {
         @IntForgery(min = 400, max = 500) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(any())).thenReturn(false)
         stubChain(mockChain, statusCode)
         val expectedStartAttrs = emptyMap<String, Any?>()
         // no span -> shouldn't have trace/spans IDs

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/DatadogInterceptorWithoutTracesTest.kt
@@ -37,6 +37,7 @@ import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.annotation.StringForgeryType
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.opentracing.Span
 import io.opentracing.SpanContext
 import io.opentracing.Tracer
 import okhttp3.HttpUrl.Companion.toHttpUrl
@@ -108,7 +109,7 @@ internal class DatadogInterceptorWithoutTracesTest {
     lateinit var mockSpan: DDSpan
 
     @Mock
-    lateinit var mockTraceSampler: Sampler
+    lateinit var mockTraceSampler: Sampler<Span>
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
@@ -148,7 +149,7 @@ internal class DatadogInterceptorWithoutTracesTest {
         whenever(mockSpan.context()) doReturn mockSpanContext
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId
-        whenever(mockTraceSampler.sample()) doReturn true
+        whenever(mockTraceSampler.sample(any())) doReturn true
 
         val mediaType = forge.anElementFrom("application", "image", "text", "model") +
             "/" + forge.anAlphabeticalString()

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/TracingInterceptorBuilderTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/TracingInterceptorBuilderTest.kt
@@ -18,6 +18,7 @@ import fr.xgouchet.elmyr.Forge
 import fr.xgouchet.elmyr.annotation.StringForgery
 import fr.xgouchet.elmyr.junit5.ForgeConfiguration
 import fr.xgouchet.elmyr.junit5.ForgeExtension
+import io.opentracing.Span
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
@@ -48,7 +49,7 @@ internal class TracingInterceptorBuilderTest {
     lateinit var mockTracedRequestListener: TracedRequestListener
 
     @Mock
-    lateinit var mockSampler: Sampler
+    lateinit var mockSampler: Sampler<Span>
 
     @StringForgery
     lateinit var fakeOrigin: String

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorContextInjectionSampledTest.kt
@@ -125,7 +125,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
     lateinit var mockResolver: DefaultFirstPartyHostHeaderTypeResolver
 
     @Mock
-    lateinit var mockTraceSampler: Sampler
+    lateinit var mockTraceSampler: Sampler<Span>
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
@@ -175,7 +175,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId).thenReturn(fakeTraceId)
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId.toString()
-        whenever(mockTraceSampler.sample()) doReturn true
+        whenever(mockTraceSampler.sample(mockSpan)) doReturn true
         val mediaType = forge.anElementFrom("application", "image", "text", "model") +
             "/" + forge.anAlphabeticalString()
         fakeLocalHosts =
@@ -318,7 +318,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         val datadogContextKeyValue = forge.anAlphabeticalString()
         val nonDatadogContextKey = forge.anAlphabeticalString()
         val nonDatadogContextKeyValue = forge.anAlphabeticalString()
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -353,7 +353,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -381,7 +381,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -406,7 +406,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -661,7 +661,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -694,7 +694,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -728,7 +728,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -762,7 +762,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -819,7 +819,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -853,7 +853,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -890,7 +890,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -922,7 +922,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1097,6 +1097,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         whenever(localSpanBuilder.withOrigin(getExpectedOrigin())) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockTraceSampler.sample(localSpan)).thenReturn(true)
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceIdAsString
         whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
@@ -1131,6 +1132,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         whenever(localSpanBuilder.withOrigin(getExpectedOrigin())) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockTraceSampler.sample(localSpan)).thenReturn(true)
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceIdAsString
         whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
@@ -1227,7 +1229,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
@@ -1276,7 +1278,7 @@ internal class TracingInterceptorContextInjectionSampledTest {
         @Forgery throwable: Throwable
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerNotSendingSpanTest.kt
@@ -121,7 +121,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
     lateinit var mockResolver: DefaultFirstPartyHostHeaderTypeResolver
 
     @Mock
-    lateinit var mockTraceSampler: Sampler
+    lateinit var mockTraceSampler: Sampler<Span>
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
@@ -171,7 +171,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         whenever(mockSpan.context()) doReturn mockSpanContext
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId) doReturn fakeTraceId
-        whenever(mockTraceSampler.sample()) doReturn true
+        whenever(mockTraceSampler.sample(mockSpan)) doReturn true
 
         fakeOrigin = forge.aNullable { anAlphabeticalString() }
         fakeMediaType = if (forge.aBool()) {
@@ -250,7 +250,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -278,7 +278,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -306,7 +306,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -332,7 +332,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -393,7 +393,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
@@ -419,7 +419,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
             forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN) to setOf(
                 TracingHeaderType.B3MULTI
@@ -451,7 +451,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
             forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN) to setOf(
                 TracingHeaderType.B3
@@ -481,7 +481,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
             forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN) to setOf(
                 TracingHeaderType.TRACECONTEXT
@@ -592,7 +592,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -625,7 +625,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -658,7 +658,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -691,7 +691,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -731,7 +731,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -767,7 +767,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -806,7 +806,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -840,7 +840,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -868,7 +868,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
@@ -999,6 +999,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockTraceSampler.sample(localSpan)).thenReturn(true)
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId) doReturn fakeTraceId
         whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
@@ -1030,6 +1031,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockTraceSampler.sample(localSpan)).thenReturn(true)
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId) doReturn fakeTraceId
         whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
@@ -1119,7 +1121,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
@@ -1167,7 +1169,7 @@ internal open class TracingInterceptorNonDdTracerNotSendingSpanTest {
         @Forgery throwable: Throwable
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNonDdTracerTest.kt
@@ -120,7 +120,7 @@ internal open class TracingInterceptorNonDdTracerTest {
     lateinit var mockResolver: DefaultFirstPartyHostHeaderTypeResolver
 
     @Mock
-    lateinit var mockTraceSampler: Sampler
+    lateinit var mockTraceSampler: Sampler<Span>
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
@@ -167,7 +167,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         whenever(mockSpan.context()) doReturn mockSpanContext
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId) doReturn fakeTraceId
-        whenever(mockTraceSampler.sample()) doReturn true
+        whenever(mockTraceSampler.sample(mockSpan)) doReturn true
 
         fakeOrigin = forge.aNullable { anAlphabeticalString() }
         val mediaType = forge.anElementFrom("application", "image", "text", "model") +
@@ -279,7 +279,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -308,7 +308,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -336,7 +336,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -362,7 +362,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -423,7 +423,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
@@ -450,7 +450,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
             forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN) to setOf(
                 TracingHeaderType.B3MULTI
@@ -482,7 +482,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
             forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN) to setOf(
                 TracingHeaderType.B3
@@ -512,7 +512,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
             forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN) to setOf(
                 TracingHeaderType.TRACECONTEXT
@@ -696,7 +696,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -734,7 +734,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -772,7 +772,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -810,7 +810,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -850,7 +850,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -887,7 +887,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -926,7 +926,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -960,7 +960,7 @@ internal open class TracingInterceptorNonDdTracerTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1125,6 +1125,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockTraceSampler.sample(localSpan)).thenReturn(true)
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId) doReturn fakeTraceId
         whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
@@ -1156,6 +1157,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockTraceSampler.sample(localSpan)).thenReturn(true)
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId) doReturn fakeTraceId
         whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
@@ -1245,7 +1247,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
@@ -1293,7 +1295,7 @@ internal open class TracingInterceptorNonDdTracerTest {
         @Forgery throwable: Throwable
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorNotSendingSpanTest.kt
@@ -119,7 +119,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
     lateinit var mockResolver: DefaultFirstPartyHostHeaderTypeResolver
 
     @Mock
-    lateinit var mockTraceSampler: Sampler
+    lateinit var mockTraceSampler: Sampler<Span>
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
@@ -169,7 +169,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         whenever(mockSpan.context()) doReturn mockSpanContext
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId) doReturn fakeTraceId
-        whenever(mockTraceSampler.sample()) doReturn true
+        whenever(mockTraceSampler.sample(mockSpan)) doReturn true
 
         fakeOrigin = forge.aNullable { anAlphabeticalString() }
         fakeMediaType = if (forge.aBool()) {
@@ -265,7 +265,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -294,7 +294,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -322,7 +322,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -348,7 +348,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -383,7 +383,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -459,7 +459,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeUrl = forgeUrl(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
@@ -486,7 +486,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
             forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN) to setOf(
                 TracingHeaderType.B3MULTI
@@ -518,7 +518,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
             forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN) to setOf(
                 TracingHeaderType.B3
@@ -548,7 +548,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
             forge.aStringMatching(TracingInterceptorTest.HOSTNAME_PATTERN) to setOf(
                 TracingHeaderType.TRACECONTEXT
@@ -661,7 +661,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -694,7 +694,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -727,7 +727,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -760,7 +760,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -799,7 +799,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -835,7 +835,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -873,7 +873,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -906,7 +906,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1064,6 +1064,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockTraceSampler.sample(localSpan)).thenReturn(true)
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId) doReturn fakeTraceId
         whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
@@ -1097,6 +1098,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         whenever(localSpanBuilder.asChildOf(null as SpanContext?)) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockTraceSampler.sample(localSpan)).thenReturn(true)
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId) doReturn fakeTraceId
         whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
@@ -1198,7 +1200,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
@@ -1249,7 +1251,7 @@ internal open class TracingInterceptorNotSendingSpanTest {
         @Forgery throwable: Throwable
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable

--- a/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
+++ b/integrations/dd-sdk-android-okhttp/src/test/kotlin/com/datadog/android/okhttp/trace/TracingInterceptorTest.kt
@@ -121,7 +121,7 @@ internal open class TracingInterceptorTest {
     lateinit var mockResolver: DefaultFirstPartyHostHeaderTypeResolver
 
     @Mock
-    lateinit var mockTraceSampler: Sampler
+    lateinit var mockTraceSampler: Sampler<Span>
 
     @Mock
     lateinit var mockInternalLogger: InternalLogger
@@ -170,7 +170,7 @@ internal open class TracingInterceptorTest {
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.traceId).thenReturn(fakeTraceId)
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceId.toString()
-        whenever(mockTraceSampler.sample()) doReturn true
+        whenever(mockTraceSampler.sample(mockSpan)) doReturn true
 
         fakeOrigin = forge.aNullable { anAlphabeticalString() }
         val mediaType = forge.anElementFrom("application", "image", "text", "model") +
@@ -305,7 +305,7 @@ internal open class TracingInterceptorTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -333,7 +333,7 @@ internal open class TracingInterceptorTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -359,7 +359,7 @@ internal open class TracingInterceptorTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -409,7 +409,7 @@ internal open class TracingInterceptorTest {
             carrier.put(datadogContextKey, datadogContextKeyValue)
             carrier.put(nonDatadogContextKey, nonDatadogContextKeyValue)
         }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockResolver.headerTypesForUrl(fakeUrl.toHttpUrl())).thenReturn(
             setOf(
@@ -497,7 +497,7 @@ internal open class TracingInterceptorTest {
             carrier.put(datadogContextKey, datadogContextKeyValue)
             carrier.put(nonDatadogContextKey, nonDatadogContextKeyValue)
         }.whenever(mockTracer).inject<TextMapInject>(any(), any(), any())
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeUrl = forgeUrlWithQueryParams(forge, forge.anElementFrom(fakeLocalHosts.keys))
         fakeRequest = forgeRequest(forge)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(false)
@@ -523,7 +523,7 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts =
             forge.aMap { forge.aStringMatching(HOSTNAME_PATTERN) to setOf(TracingHeaderType.B3MULTI) }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
@@ -552,7 +552,7 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts =
             forge.aMap { forge.aStringMatching(HOSTNAME_PATTERN) to setOf(TracingHeaderType.B3) }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
@@ -580,7 +580,7 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts =
             forge.aMap { forge.aStringMatching(HOSTNAME_PATTERN) to setOf(TracingHeaderType.TRACECONTEXT) }
         testedInterceptor = instantiateTestedInterceptor(fakeLocalHosts) { _, _ -> mockLocalTracer }
@@ -618,7 +618,7 @@ internal open class TracingInterceptorTest {
         forge: Forge
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         fakeLocalHosts = forge.aMap {
             forge.aStringMatching(HOSTNAME_PATTERN) to setOf(
                 TracingHeaderType.DATADOG,
@@ -854,7 +854,7 @@ internal open class TracingInterceptorTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -887,7 +887,7 @@ internal open class TracingInterceptorTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -921,7 +921,7 @@ internal open class TracingInterceptorTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -955,7 +955,7 @@ internal open class TracingInterceptorTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         doAnswer { invocation ->
             val carrier = invocation.arguments[2] as TextMapInject
             carrier.put(key, value)
@@ -994,7 +994,7 @@ internal open class TracingInterceptorTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1030,7 +1030,7 @@ internal open class TracingInterceptorTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1068,7 +1068,7 @@ internal open class TracingInterceptorTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1101,7 +1101,7 @@ internal open class TracingInterceptorTest {
             )
         }
         stubChain(mockChain, statusCode)
-        whenever(mockTraceSampler.sample()).thenReturn(true)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(true)
 
         // When
         val response = testedInterceptor.intercept(mockChain)
@@ -1283,6 +1283,7 @@ internal open class TracingInterceptorTest {
         whenever(localSpanBuilder.withOrigin(getExpectedOrigin())) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockTraceSampler.sample(localSpan)).thenReturn(true)
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceIdAsString
         whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
@@ -1317,6 +1318,7 @@ internal open class TracingInterceptorTest {
         whenever(localSpanBuilder.withOrigin(getExpectedOrigin())) doReturn localSpanBuilder
         whenever(localSpanBuilder.start()) doReturn localSpan
         whenever(localSpan.context()) doReturn mockSpanContext
+        whenever(mockTraceSampler.sample(localSpan)).thenReturn(true)
         whenever(mockSpanContext.toSpanId()) doReturn fakeSpanId
         whenever(mockSpanContext.toTraceId()) doReturn fakeTraceIdAsString
         whenever(mockLocalTracer.buildSpan(TracingInterceptor.SPAN_NAME)) doReturn localSpanBuilder
@@ -1413,7 +1415,7 @@ internal open class TracingInterceptorTest {
         @IntForgery(min = 200, max = 600) statusCode: Int
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         stubChain(mockChain, statusCode)
 
@@ -1462,7 +1464,7 @@ internal open class TracingInterceptorTest {
         @Forgery throwable: Throwable
     ) {
         // Given
-        whenever(mockTraceSampler.sample()).thenReturn(false)
+        whenever(mockTraceSampler.sample(mockSpan)).thenReturn(false)
         whenever(mockResolver.isFirstPartyUrl(fakeUrl.toHttpUrl())).thenReturn(true)
         whenever(mockChain.request()) doReturn fakeRequest
         whenever(mockChain.proceed(any())) doThrow throwable


### PR DESCRIPTION
### What does this PR do?

Preparing for a new implementation of a sampler for the TracingInterceptor, add a type to the sampler to allow adapting the sampling decision to the event being sampled.
