### PR TITLE
RUM-7085: Add compose extension in benchmark app

### DIFF
--- a/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/DatadogBenchmark.kt
+++ b/sample/benchmark/src/main/java/com/datadog/benchmark/sample/benchmark/DatadogBenchmark.kt
@@ -10,6 +10,8 @@ import android.os.Bundle
 import com.datadog.android.sessionreplay.SessionReplay
 import com.datadog.android.sessionreplay.SessionReplayConfiguration
 import com.datadog.android.sessionreplay.SessionReplayPrivacy
+import com.datadog.android.sessionreplay.compose.ComposeExtensionSupport
+import com.datadog.android.sessionreplay.compose.ExperimentalSessionReplayApi
 import com.datadog.android.sessionreplay.material.MaterialExtensionSupport
 import com.datadog.benchmark.DatadogExporterConfiguration
 import com.datadog.benchmark.DatadogMeter
@@ -53,12 +55,14 @@ internal class DatadogBenchmark(config: Config) {
         meter.stopGauges()
     }
 
+    @OptIn(ExperimentalSessionReplayApi::class)
     @Suppress("DEPRECATION")
     private fun enableSessionReplay() {
         val sessionReplayConfig = SessionReplayConfiguration
             .Builder(SAMPLE_IN_ALL_SESSIONS)
             .setPrivacy(SessionReplayPrivacy.ALLOW)
             .addExtensionSupport(MaterialExtensionSupport())
+            .addExtensionSupport(ComposeExtensionSupport())
             .build()
         SessionReplay.enable(sessionReplayConfig)
     }


### PR DESCRIPTION
### What does this PR do?

Add compose extension in benchmark app

###  Test

Benchmark can have Compose SR right now:
https://mobile-integration.datadoghq.com/rum/replay/sessions/6bad66b1-bd36-40e0-88a7-0b3b5bf5da36?applicationId=63e67473-c075-4f15-8891-04e96212f22e&seed=873a3613-936f-4040-8d5f-0c420ee7cb48&ts=1731598391352

### Review checklist (to be filled by reviewers)

- [ ] Feature or bugfix MUST have appropriate tests (unit, integration, e2e)
- [ ] Make sure you discussed the feature or bugfix with the maintaining team in an Issue
- [ ] Make sure each commit and the PR mention the Issue number (cf the [CONTRIBUTING](CONTRIBUTING.md) doc)

